### PR TITLE
fix(storage): give hook-payload blob refs live GC references (#tfzw0)

### DIFF
--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -1565,7 +1565,7 @@ files:
     target: polylogue/daemon/catchup_status.py
     owner: stable
   - path: polylogue/daemon/cli.py
-    loc: 3109
+    loc: 3114
     target: polylogue/daemon/cli.py
     owner: stable
   - path: polylogue/daemon/compare.py
@@ -2196,7 +2196,7 @@ files:
     target: polylogue/maintenance/agent_meta_sidecar_purge_apply.py
     owner: stable
   - path: polylogue/maintenance/archive_verification.py
-    loc: 709
+    loc: 1282
     target: polylogue/maintenance/archive_verification.py
     owner: stable
   - path: polylogue/maintenance/cost_backfill.py
@@ -2210,6 +2210,10 @@ files:
   - path: polylogue/maintenance/failure_routing.py
     loc: 445
     target: polylogue/maintenance/failure_routing.py
+    owner: stable
+  - path: polylogue/maintenance/hook_payload_ref_reconciliation_apply.py
+    loc: 197
+    target: polylogue/maintenance/hook_payload_ref_reconciliation_apply.py
     owner: stable
   - path: polylogue/maintenance/invalidation.py
     loc: 54
@@ -3078,7 +3082,7 @@ files:
     target: polylogue/schemas/sampling.py
     owner: stable
   - path: polylogue/schemas/sampling_db.py
-    loc: 490
+    loc: 530
     target: polylogue/schemas/sampling_db.py
     owner: stable
   - path: polylogue/schemas/sampling_sessions.py
@@ -3373,7 +3377,7 @@ files:
     target: polylogue/sources/live/append_ingest.py
     owner: stable
   - path: polylogue/sources/live/batch.py
-    loc: 3349
+    loc: 3351
     target: polylogue/sources/live/batch.py
     owner: stable
   - path: polylogue/sources/live/batch_observability.py
@@ -3385,7 +3389,7 @@ files:
     target: polylogue/sources/live/batch_support.py
     owner: stable
   - path: polylogue/sources/live/convergence_debt.py
-    loc: 75
+    loc: 101
     target: polylogue/sources/live/convergence_debt.py
     owner: stable
   - path: polylogue/sources/live/convergence_debt_retry.py
@@ -3393,11 +3397,11 @@ files:
     target: polylogue/sources/live/convergence_debt_retry.py
     owner: stable
   - path: polylogue/sources/live/convergence_outcome.py
-    loc: 47
+    loc: 49
     target: polylogue/sources/live/convergence_outcome.py
     owner: stable
   - path: polylogue/sources/live/cursor.py
-    loc: 1511
+    loc: 1516
     target: polylogue/sources/live/cursor.py
     owner: stable
   - path: polylogue/sources/live/cursor_lifecycle.py
@@ -3717,7 +3721,7 @@ files:
     target: TBD
     owner: storage-domain
   - path: polylogue/storage/blob_gc.py
-    loc: 568
+    loc: 687
     target: polylogue/storage/blob_gc.py
     owner: storage-root
     reason: storage-root cross-cutting helper
@@ -3838,6 +3842,10 @@ files:
     loc: 570
     target: polylogue/storage/fts/sql.py
     owner: stable
+  - path: polylogue/storage/hook_payload_ref_reconciliation.py
+    loc: 159
+    target: TBD
+    owner: storage-domain
   - path: polylogue/storage/hydrators.py
     loc: 256
     target: polylogue/storage/hydrators.py
@@ -4002,7 +4010,7 @@ files:
     owner: storage-root
     reason: storage-root cross-cutting helper
   - path: polylogue/storage/repair.py
-    loc: 7296
+    loc: 7315
     target: polylogue/storage/repair.py
     owner: storage-root
     reason: storage-root cross-cutting helper
@@ -4302,11 +4310,11 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/session_annotations_write.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/source.py
-    loc: 569
+    loc: 582
     target: polylogue/storage/sqlite/archive_tiers/source.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/source_write.py
-    loc: 1286
+    loc: 1304
     target: polylogue/storage/sqlite/archive_tiers/source_write.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/types.py

--- a/polylogue/maintenance/hook_payload_ref_reconciliation_apply.py
+++ b/polylogue/maintenance/hook_payload_ref_reconciliation_apply.py
@@ -1,0 +1,197 @@
+"""Apply the provable subset of orphaned hook-payload blob-ref reconciliation.
+
+See :mod:`polylogue.storage.hook_payload_ref_reconciliation` for the
+classification this module acts on (polylogue-tfzw0). Follows the same
+dry-run-by-default / verified-backup-manifest-gated shape as the other
+source-tier repair actuators (``raw_append_chain_backfill_apply``,
+``raw_membership_writeback_apply``, ``raw_live_source_reconciliation_apply``):
+
+* Dry-run by default; ``dry_run=False`` requires a verified backup manifest
+  for the ``source`` tier.
+* Classification is re-run *live*, inside the same write transaction the
+  re-key runs in -- never trusts a previously computed plan.
+* For each confirmed match: set ``raw_hook_events.blob_hash``, delete the
+  stale ``ref_type='raw_payload'`` row, and insert the corrected
+  ``ref_type='hook_payload'`` row keyed by the hook event's own id -- the
+  same shape ``write_source_hook_event`` writes for a hook event captured
+  after v22.
+
+Unlike the byte-proof actuators above, this module does not mint a receipt
+row: there is no external evidence being witnessed, just an exact-match
+recomputation of an existing deterministic id from data already in the
+archive. The re-keyed ``blob_refs``/``raw_hook_events`` rows are themselves
+the durable record of what changed.
+
+This module never runs against the live archive as part of any automated
+pipeline -- applying it is an explicit operator action
+(``dry_run=False`` + a backup manifest), same as every other actuator in this
+package.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+from polylogue.config import Config
+from polylogue.maintenance.offline_guard import offline_maintenance_block_reason
+from polylogue.paths import render_root
+from polylogue.storage.hook_payload_ref_reconciliation import (
+    HookPayloadRefReconciliationPlan,
+    plan_hook_payload_ref_reconciliation,
+)
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.migration_runner import validate_migration_backup_manifest
+
+TOOL_VERSION = "hook-payload-ref-reconciliation-apply-v1"
+
+
+class HookPayloadRefReconciliationApplyError(RuntimeError):
+    """Raised when applying hook-payload-ref reconciliation is refused."""
+
+
+@dataclass(frozen=True, slots=True)
+class HookPayloadRefReconciliationApplyReport:
+    scanned_count: int
+    matched_count: int
+    matched_bytes: int
+    unmatched_count: int
+    reconciled_hook_event_ids: tuple[str, ...]
+    applied: bool
+    backup_manifest: Path | None = None
+
+    @classmethod
+    def from_plan(
+        cls,
+        plan: HookPayloadRefReconciliationPlan,
+        *,
+        applied: bool,
+        reconciled_hook_event_ids: tuple[str, ...] = (),
+        backup_manifest: Path | None = None,
+    ) -> HookPayloadRefReconciliationApplyReport:
+        return cls(
+            scanned_count=plan.scanned_count,
+            matched_count=len(plan.matched),
+            matched_bytes=plan.matched_bytes,
+            unmatched_count=plan.unmatched_count,
+            reconciled_hook_event_ids=reconciled_hook_event_ids or tuple(c.hook_event_id for c in plan.matched),
+            applied=applied,
+            backup_manifest=backup_manifest,
+        )
+
+
+def _offline_config(archive_root: Path) -> Config:
+    return Config(archive_root=archive_root, render_root=render_root(), sources=[])
+
+
+def apply_hook_payload_ref_reconciliation(
+    archive_root: Path,
+    *,
+    backup_manifest: Path | None = None,
+    dry_run: bool = True,
+) -> HookPayloadRefReconciliationApplyReport:
+    """Re-key the provable subset of orphaned hook-payload blob refs.
+
+    ``dry_run=True`` (the default) never opens a write transaction; it runs
+    the same classifier a real apply would and reports what it would do.
+
+    ``dry_run=False`` requires ``backup_manifest`` and re-runs classification
+    live, inside the same ``BEGIN IMMEDIATE`` write transaction the re-key
+    UPDATE/DELETE/INSERT triples run in.
+    """
+    source_db = archive_root / "source.db"
+    if not source_db.exists():
+        raise FileNotFoundError(f"no source.db at {source_db}")
+
+    if dry_run:
+        conn = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
+        try:
+            plan = plan_hook_payload_ref_reconciliation(conn)
+        finally:
+            conn.close()
+        return HookPayloadRefReconciliationApplyReport.from_plan(plan, applied=False)
+
+    if backup_manifest is None:
+        raise HookPayloadRefReconciliationApplyError(
+            "applying hook-payload-ref-reconciliation requires a verified backup manifest (--backup-manifest)"
+        )
+    if reason := offline_maintenance_block_reason(_offline_config(archive_root), active=True, dry_run=False):
+        raise HookPayloadRefReconciliationApplyError(reason)
+
+    conn = sqlite3.connect(source_db)
+    reconciled: list[str] = []
+    try:
+        try:
+            row = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+        except sqlite3.Error as exc:
+            raise HookPayloadRefReconciliationApplyError(
+                "could not checkpoint source.db before backup validation"
+            ) from exc
+        if row is None:
+            raise HookPayloadRefReconciliationApplyError("could not checkpoint source.db before backup validation")
+        validate_migration_backup_manifest(backup_manifest, ArchiveTier.SOURCE, connection=conn)
+
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            validate_migration_backup_manifest(backup_manifest, ArchiveTier.SOURCE, connection=conn)
+
+            plan = plan_hook_payload_ref_reconciliation(conn)
+            for candidate in plan.matched:
+                deleted = conn.execute(
+                    "DELETE FROM blob_refs WHERE blob_hash = ? AND ref_type = 'raw_payload' AND ref_id = ?",
+                    (candidate.blob_hash, candidate.orphaned_ref_id),
+                )
+                if deleted.rowcount != 1:
+                    # Defensive: this exact row was read under this same
+                    # locked transaction above -- should not happen, but
+                    # skipping instead of asserting keeps this pass
+                    # conservative like the sibling actuators.
+                    continue
+                conn.execute(
+                    """
+                    INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+                    VALUES (?, ?, 'hook_payload', ?, ?, ?)
+                    """,
+                    (
+                        candidate.blob_hash,
+                        candidate.hook_event_id,
+                        candidate.source_path,
+                        candidate.size_bytes,
+                        candidate.acquired_at_ms,
+                    ),
+                )
+                conn.execute(
+                    "UPDATE raw_hook_events SET blob_hash = ? WHERE hook_event_id = ? AND blob_hash IS NULL",
+                    (candidate.blob_hash, candidate.hook_event_id),
+                )
+                reconciled.append(candidate.hook_event_id)
+
+            quick_check = conn.execute("PRAGMA quick_check").fetchone()
+            if quick_check is None or str(quick_check[0]).lower() != "ok":
+                raise HookPayloadRefReconciliationApplyError(
+                    f"source.db quick_check failed after reconciliation: {quick_check!r}"
+                )
+        except Exception:
+            if conn.in_transaction:
+                conn.rollback()
+            raise
+        else:
+            conn.commit()
+    finally:
+        conn.close()
+
+    return HookPayloadRefReconciliationApplyReport.from_plan(
+        plan,
+        applied=True,
+        reconciled_hook_event_ids=tuple(reconciled),
+        backup_manifest=backup_manifest,
+    )
+
+
+__all__ = [
+    "TOOL_VERSION",
+    "HookPayloadRefReconciliationApplyError",
+    "HookPayloadRefReconciliationApplyReport",
+    "apply_hook_payload_ref_reconciliation",
+]

--- a/polylogue/maintenance/hook_payload_ref_reconciliation_apply.py
+++ b/polylogue/maintenance/hook_payload_ref_reconciliation_apply.py
@@ -67,15 +67,20 @@ class HookPayloadRefReconciliationApplyReport:
         plan: HookPayloadRefReconciliationPlan,
         *,
         applied: bool,
-        reconciled_hook_event_ids: tuple[str, ...] = (),
+        reconciled_hook_event_ids: tuple[str, ...] | None = None,
         backup_manifest: Path | None = None,
     ) -> HookPayloadRefReconciliationApplyReport:
+        reconciled = (
+            tuple(c.hook_event_id for c in plan.matched)
+            if reconciled_hook_event_ids is None
+            else reconciled_hook_event_ids
+        )
         return cls(
             scanned_count=plan.scanned_count,
             matched_count=len(plan.matched),
             matched_bytes=plan.matched_bytes,
             unmatched_count=plan.unmatched_count,
-            reconciled_hook_event_ids=reconciled_hook_event_ids or tuple(c.hook_event_id for c in plan.matched),
+            reconciled_hook_event_ids=reconciled,
             applied=applied,
             backup_manifest=backup_manifest,
         )

--- a/polylogue/storage/blob_gc.py
+++ b/polylogue/storage/blob_gc.py
@@ -155,6 +155,67 @@ def _blob_hash_bytes(blob_hash: str) -> bytes | None:
         return None
 
 
+# blob_refs.ref_type -> the table/column a ref_id must actually resolve to for
+# that row to mean the blob is still live. 'attachment' refs are keyed by the
+# *parent session's* raw_id (write_source_raw_session/
+# write_source_raw_session_blob_ref always pass ref.raw_id=resolved_raw_id for
+# every entry in additional_blob_refs, regardless of ref_type -- verified
+# against every production call site, polylogue-tfzw0), not a raw_artifacts
+# row, so it joins the same table as 'raw_payload'. 'sidecar' has no
+# production writer today; it is included for completeness/forward-safety
+# against history_sidecars.sidecar_id, its only plausible referent.
+_BLOB_REF_LIVENESS_JOIN: tuple[tuple[str, str, str], ...] = (
+    ("raw_payload", "raw_sessions", "raw_id"),
+    ("attachment", "raw_sessions", "raw_id"),
+    ("hook_payload", "raw_hook_events", "hook_event_id"),
+    ("sidecar", "history_sidecars", "sidecar_id"),
+)
+
+
+def _blob_refs_has_ref_type_column(conn: sqlite3.Connection) -> bool:
+    """Guard for legacy/alternate ``blob_refs`` shapes lacking ``ref_type``/``ref_id``.
+
+    Some pre-#1743 fixtures and test doubles model ``blob_refs`` with a
+    different column set entirely (e.g. ``owner_kind``/``owner_id`` instead of
+    ``ref_type``/``ref_id``). The liveness join is meaningless there; callers
+    fall back to treating ``blob_refs`` as contributing nothing rather than
+    raising ``OperationalError``.
+    """
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(blob_refs)")}
+    return "ref_type" in columns and "ref_id" in columns
+
+
+def _blob_refs_still_live(conn: sqlite3.Connection, blob_bytes: bytes) -> bool:
+    """Return True if some ``blob_refs`` row for this hash has a live referent.
+
+    Replaces a prior membership test that only checked whether ANY row in
+    ``blob_refs`` carried this hash -- a tautology, since the row being asked
+    about is itself the "evidence" (polylogue-tfzw0). A ``blob_refs`` row is
+    only real evidence of liveness when the table its own ``ref_type`` names
+    (see ``_BLOB_REF_LIVENESS_JOIN``) still has the row identified by
+    ``ref_id``. A hook-event blob ref whose ``raw_hook_events`` row was
+    deleted, or a stale ref left behind by a since-reverted write, no longer
+    joins to anything and is correctly treated as dead here.
+    """
+    if not _table_exists(conn, "blob_refs") or not _blob_refs_has_ref_type_column(conn):
+        return False
+    clauses = [
+        f"(ref_type = ? AND EXISTS (SELECT 1 FROM {referent_table} WHERE {referent_table}.{referent_column} = blob_refs.ref_id))"
+        for ref_type, referent_table, referent_column in _BLOB_REF_LIVENESS_JOIN
+        if _table_exists(conn, referent_table)
+    ]
+    if not clauses:
+        return False
+    params = [
+        ref_type
+        for ref_type, referent_table, _referent_column in _BLOB_REF_LIVENESS_JOIN
+        if _table_exists(conn, referent_table)
+    ]
+    query = f"SELECT 1 FROM blob_refs WHERE blob_hash = ? AND ({' OR '.join(clauses)}) LIMIT 1"
+    row = conn.execute(query, (blob_bytes, *params)).fetchone()
+    return row is not None
+
+
 def _archive_reference_surfaces(
     conn: sqlite3.Connection,
     blob_hash: str,
@@ -166,12 +227,14 @@ def _archive_reference_surfaces(
         return []
 
     surfaces: list[str] = []
-    for table in ("raw_sessions", "blob_refs", "attachments"):
+    for table in ("raw_sessions", "attachments"):
         if not _table_exists(conn, table):
             continue
         row = conn.execute(f"SELECT 1 FROM {table} WHERE blob_hash = ? LIMIT 1", (blob_bytes,)).fetchone()
         if row is not None:
             surfaces.append(f"{surface_prefix}.{table}")
+    if _blob_refs_still_live(conn, blob_bytes):
+        surfaces.append(f"{surface_prefix}.blob_refs")
     return surfaces
 
 
@@ -557,11 +620,67 @@ def read_gc_history(db_path: str | Path, *, limit: int = 20) -> list[GCHistoryRo
     ]
 
 
+@dataclass(frozen=True, slots=True)
+class OrphanedBlobRefCensus:
+    """Standing count of ``blob_refs`` rows whose referent no longer exists.
+
+    A "orphaned" row here is exactly the shape blob GC's liveness join
+    (``_blob_refs_still_live``) treats as dead: its ``ref_type`` names a
+    referent table, but no row in that table has the ``ref_id`` this row
+    claims. These rows are harmless (GC already reclaims their blob once it
+    ages out) but their *count* is operator-relevant evidence of how much
+    write-time drift (deleted rows, since-fixed bugs like the hook-payload one
+    this census was built for) has accumulated. Intended to be read by a
+    daemon health/expensive tier; wiring that in is left to the caller
+    (polylogue-tfzw0 explicitly defers "wire into health tiers" as optional).
+    """
+
+    total: int
+    by_ref_type: dict[str, int]
+
+    def to_dict(self) -> dict[str, object]:
+        return {"total": self.total, "by_ref_type": dict(self.by_ref_type)}
+
+
+def census_orphaned_blob_refs(conn: sqlite3.Connection) -> OrphanedBlobRefCensus:
+    """Count ``blob_refs`` rows whose ``ref_id`` has no live referent, per ref_type.
+
+    Read-only; safe to call against a live connection or a read-only handle.
+    A ``ref_type`` whose referent table does not exist (an old archive
+    predating that table) is skipped rather than counted as fully orphaned --
+    its rows are simply not evaluable, the same conservative stance
+    ``_blob_refs_still_live`` takes.
+    """
+    if not _table_exists(conn, "blob_refs"):
+        return OrphanedBlobRefCensus(total=0, by_ref_type={})
+    by_ref_type: dict[str, int] = {}
+    for ref_type, referent_table, referent_column in _BLOB_REF_LIVENESS_JOIN:
+        if not _table_exists(conn, referent_table):
+            continue
+        row = conn.execute(
+            f"""
+            SELECT COUNT(*) FROM blob_refs
+            WHERE ref_type = ?
+              AND NOT EXISTS (
+                  SELECT 1 FROM {referent_table}
+                  WHERE {referent_table}.{referent_column} = blob_refs.ref_id
+              )
+            """,
+            (ref_type,),
+        ).fetchone()
+        count = int(row[0]) if row is not None else 0
+        if count:
+            by_ref_type[ref_type] = count
+    return OrphanedBlobRefCensus(total=sum(by_ref_type.values()), by_ref_type=by_ref_type)
+
+
 __all__ = [
     "BlobGCResult",
     "MIN_AGE_S",
     "GCHistoryRow",
     "GCRunEvidence",
+    "OrphanedBlobRefCensus",
+    "census_orphaned_blob_refs",
     "read_gc_history",
     "run_blob_gc",
     "run_blob_gc_report",

--- a/polylogue/storage/hook_payload_ref_reconciliation.py
+++ b/polylogue/storage/hook_payload_ref_reconciliation.py
@@ -1,0 +1,159 @@
+"""Read-only classification: re-key orphaned hook-event blob refs.
+
+polylogue-tfzw0: before the ``hook_payload`` ref_type existed (source schema
+v22), ``write_source_hook_event`` wrote every hook event's durable blob ref as
+``ref_type='raw_payload'`` keyed by a synthetic ``raw_id`` -- a value that
+never corresponds to any ``raw_sessions`` row, because a hook event
+deliberately never mints one (polylogue-31r1). Every such row is therefore an
+orphan under the corrected liveness join (``storage/blob_gc.py``,
+``_blob_refs_still_live``): its ``ref_type`` says "join against
+``raw_sessions``", but nothing in ``raw_sessions`` ever matches. Measured at
+73,427 rows / ~1.94 GiB on the live archive.
+
+This module classifies which of those orphans can be *provably* re-keyed to
+the ``raw_hook_events`` row they actually belong to, without touching
+anything. The synthetic id a hook event's blob ref used
+(``deterministic_raw_session_id(origin, source_path, source_index=0,
+blob_hash, native_id)``, see ``archive_tiers/source_write.py``) is
+recomputable from data already on hand: the orphaned ref's own ``blob_hash``
+plus a candidate ``raw_hook_events`` row's ``origin``/``native_id`` (source
+tier does not store hook events' ``origin`` on ``blob_refs`` itself, so
+candidates are drawn from ``raw_hook_events`` rows sharing the ref's
+``source_path`` -- the value ``write_source_hook_event`` always writes
+identically to both the ref and the hook-event row it accompanies). A ref
+whose recomputed id matches its own ``ref_id`` exactly is provably the blob
+for that hook event; anything else (no match, or more than one candidate
+matching) is left alone rather than guessed at.
+
+Read-only: only ``polylogue.maintenance.hook_payload_ref_reconciliation_apply``
+mutates the archive, and only for the confirmed, non-ambiguous matches this
+module reports.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+from polylogue.storage.sqlite.archive_tiers.source_write import deterministic_raw_session_id
+from polylogue.storage.table_existence import table_exists as _table_exists
+
+
+@dataclass(frozen=True, slots=True)
+class HookPayloadRefReconciliationCandidate:
+    """One orphaned ``raw_payload`` blob ref provably re-keyable to a hook event."""
+
+    blob_hash: bytes
+    orphaned_ref_id: str
+    source_path: str | None
+    size_bytes: int
+    acquired_at_ms: int
+    hook_event_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class HookPayloadRefReconciliationPlan:
+    """Read-only projection of the orphaned raw_payload-ref population.
+
+    ``scanned_count`` is every ``raw_payload`` blob ref whose ``ref_id`` does
+    not match any ``raw_sessions`` row (the orphan population this module
+    targets). ``matched`` is the provable, unambiguous subset;
+    ``unmatched_count`` covers everything else (no candidate hook event
+    shares its ``source_path``, or more than one candidate's recomputed id
+    collided -- both left untouched rather than guessed at).
+    """
+
+    scanned_count: int
+    matched: tuple[HookPayloadRefReconciliationCandidate, ...]
+    unmatched_count: int
+
+    @property
+    def matched_bytes(self) -> int:
+        return sum(candidate.size_bytes for candidate in self.matched)
+
+
+def _orphaned_raw_payload_refs(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+    return conn.execute(
+        """
+        SELECT blob_hash, ref_id, source_path, size_bytes, acquired_at_ms
+        FROM blob_refs
+        WHERE ref_type = 'raw_payload'
+          AND NOT EXISTS (SELECT 1 FROM raw_sessions WHERE raw_sessions.raw_id = blob_refs.ref_id)
+        """
+    ).fetchall()
+
+
+def _hook_events_missing_blob_hash(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+    return conn.execute(
+        """
+        SELECT hook_event_id, origin, native_id, source_path
+        FROM raw_hook_events
+        WHERE blob_hash IS NULL
+        """
+    ).fetchall()
+
+
+def plan_hook_payload_ref_reconciliation(conn: sqlite3.Connection) -> HookPayloadRefReconciliationPlan:
+    """Classify orphaned ``raw_payload`` blob refs against candidate hook events.
+
+    Read-only: issues only ``SELECT`` statements. Safe against a read-only
+    connection.
+    """
+    conn.row_factory = sqlite3.Row
+    if not _table_exists(conn, "blob_refs") or not _table_exists(conn, "raw_hook_events"):
+        return HookPayloadRefReconciliationPlan(scanned_count=0, matched=(), unmatched_count=0)
+
+    orphaned_refs = _orphaned_raw_payload_refs(conn)
+    if not orphaned_refs:
+        return HookPayloadRefReconciliationPlan(scanned_count=0, matched=(), unmatched_count=0)
+
+    candidates_by_source_path: dict[str | None, list[sqlite3.Row]] = {}
+    for row in _hook_events_missing_blob_hash(conn):
+        candidates_by_source_path.setdefault(row["source_path"], []).append(row)
+
+    matched: list[HookPayloadRefReconciliationCandidate] = []
+    unmatched_count = 0
+    for ref in orphaned_refs:
+        blob_hash = bytes(ref["blob_hash"])
+        candidates = candidates_by_source_path.get(ref["source_path"], ())
+        hits: list[str] = []
+        for candidate in candidates:
+            recomputed = deterministic_raw_session_id(
+                candidate["origin"],
+                ref["source_path"] or "",
+                0,
+                blob_hash,
+                candidate["native_id"],
+            )
+            if recomputed == ref["ref_id"]:
+                hits.append(candidate["hook_event_id"])
+        if len(hits) == 1:
+            matched.append(
+                HookPayloadRefReconciliationCandidate(
+                    blob_hash=blob_hash,
+                    orphaned_ref_id=ref["ref_id"],
+                    source_path=ref["source_path"],
+                    size_bytes=int(ref["size_bytes"]),
+                    acquired_at_ms=int(ref["acquired_at_ms"]),
+                    hook_event_id=hits[0],
+                )
+            )
+        else:
+            # Zero hits (no candidate hook event shares this source_path, or
+            # none recomputes to this exact ref_id) or more than one hit (a
+            # genuine collision -- recompute ambiguity) are both left
+            # unmatched rather than guessed at.
+            unmatched_count += 1
+
+    return HookPayloadRefReconciliationPlan(
+        scanned_count=len(orphaned_refs),
+        matched=tuple(matched),
+        unmatched_count=unmatched_count,
+    )
+
+
+__all__ = [
+    "HookPayloadRefReconciliationCandidate",
+    "HookPayloadRefReconciliationPlan",
+    "plan_hook_payload_ref_reconciliation",
+]

--- a/polylogue/storage/sqlite/archive_tiers/source.py
+++ b/polylogue/storage/sqlite/archive_tiers/source.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from polylogue.core.enums import ArtifactSupportStatus, Origin, Provider, ValidationMode, ValidationStatus
 from polylogue.storage.sqlite.archive_tiers.common import check, nullable_check
 
-SOURCE_SCHEMA_VERSION = 21
+SOURCE_SCHEMA_VERSION = 22
 
 SOURCE_DDL = f"""
 CREATE TABLE IF NOT EXISTS raw_sessions (
@@ -331,10 +331,17 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_raw_authority_blockers_open_plan
 ON raw_authority_blockers(plan_id)
 WHERE resolved_at_ms IS NULL;
 
+-- v22 (polylogue-tfzw0): 'hook_payload' is a distinct ref_type from
+-- 'raw_payload' so blob GC's liveness join (storage/blob_gc.py) can tell a
+-- hook event's own durable blob ref apart from a raw_sessions payload ref --
+-- write_source_hook_event never mints a raw_sessions row (polylogue-31r1), so
+-- a hook-event blob ref keyed as 'raw_payload' with a synthetic ref_id could
+-- never join to any raw_sessions row and was therefore permanently
+-- GC-invisible under a naive membership check.
 CREATE TABLE IF NOT EXISTS blob_refs (
     blob_hash       BLOB NOT NULL CHECK(length(blob_hash) = 32),
     ref_id          TEXT NOT NULL,
-    ref_type        TEXT NOT NULL CHECK(ref_type IN ('raw_payload', 'attachment', 'sidecar')),
+    ref_type        TEXT NOT NULL CHECK(ref_type IN ('raw_payload', 'attachment', 'sidecar', 'hook_payload')),
     source_path     TEXT,
     size_bytes      INTEGER NOT NULL CHECK(size_bytes >= 0),
     acquired_at_ms  INTEGER NOT NULL,
@@ -398,6 +405,12 @@ CREATE TABLE IF NOT EXISTS raw_hook_events (
     event_type      TEXT NOT NULL,
     payload_json    TEXT NOT NULL,
     observed_at_ms  INTEGER NOT NULL
+    -- v22 (polylogue-tfzw0): the SHA-256 of this hook event's own durable
+    -- raw_payload blob (see blob_refs above). Populated at write time by
+    -- write_source_hook_event; NULL for rows written before v22 until a
+    -- one-shot reconciliation pass backfills them (see
+    -- polylogue.storage.hook_payload_ref_reconciliation).
+    ,blob_hash       BLOB CHECK(blob_hash IS NULL OR length(blob_hash) = 32)
 ) STRICT;
 
 CREATE INDEX IF NOT EXISTS idx_raw_hook_events_session

--- a/polylogue/storage/sqlite/archive_tiers/source_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/source_write.py
@@ -620,7 +620,11 @@ def write_source_raw_session(
         if artifact is not None:
             _insert_artifact(conn, resolved_raw_id, artifact)
         if hook_event is not None:
-            _insert_hook_event(conn, resolved_raw_id, hook_event)
+            # This hook event shares the session's own raw-payload blob (the
+            # same bytes just inserted above as a real raw_sessions row), so
+            # it needs no blob ref of its own -- unlike write_source_hook_event
+            # below, resolved_raw_id here is a genuine raw_sessions row.
+            _insert_hook_event(conn, hook_event, blob_hash=blob_hash)
 
         return resolved_raw_id
 
@@ -641,13 +645,21 @@ def write_source_hook_event(
 
     A hook event (PreToolUse / PostToolUse / UserPromptSubmit / …) is evidence
     *within* an existing session (identified by ``hook_event.session_native_id``),
-    never a conversation of its own. It therefore gets a durable ``raw_payload``
+    never a conversation of its own. It therefore gets a durable ``hook_payload``
     blob ref (so blob GC + copy-forward treat it like any other retained bytes)
     and a ``raw_hook_events`` row, but — unlike :func:`write_source_raw_session` —
     NO ``raw_sessions`` row. Writing a ``raw_sessions`` row per hook is exactly
     the defect that inflated the archive with tens of thousands of empty
     session shells (polylogue-31r1); ``raw_hook_events`` has no FK to
     ``raw_sessions``, so the linkage stands on its own via ``session_native_id``.
+
+    ``raw_id`` is a content-derived identifier kept for the caller's return
+    value / logging only. It is deliberately NOT used as the blob ref's
+    ``ref_id`` (polylogue-tfzw0): no ``raw_sessions`` row is ever minted here,
+    so a ``raw_id``-keyed ref could never join to a live referent and blob GC
+    would retain it forever, uncounted. The blob ref is keyed by
+    ``ref_type='hook_payload'`` / ``ref_id=hook_event.hook_event_id`` instead,
+    which really is this row's primary key in ``raw_hook_events``.
     """
     conn.execute("PRAGMA foreign_keys = ON")
     if _enum_value(origin) is None:
@@ -661,15 +673,15 @@ def write_source_hook_event(
             conn,
             ArchiveSourceBlobRef(
                 blob_hash=blob_hash,
-                raw_id=raw_id,
-                ref_type="raw_payload",
+                raw_id=hook_event.hook_event_id,
+                ref_type="hook_payload",
                 source_path=source_path,
                 size_bytes=blob_size,
                 acquired_at_ms=acquired_at_ms,
                 publication_receipt_id=blob_publication_receipt_id,
             ),
         )
-        _insert_hook_event(conn, raw_id, hook_event)
+        _insert_hook_event(conn, hook_event, blob_hash=blob_hash)
     return raw_id
 
 
@@ -1173,14 +1185,18 @@ def _insert_artifact(conn: sqlite3.Connection, raw_id: str, artifact: ArchiveSou
     )
 
 
-def _insert_hook_event(conn: sqlite3.Connection, raw_id: str, hook_event: ArchiveHookEvent) -> None:
-    del raw_id
+def _insert_hook_event(
+    conn: sqlite3.Connection,
+    hook_event: ArchiveHookEvent,
+    *,
+    blob_hash: bytes | None = None,
+) -> None:
     conn.execute(
         """
         INSERT INTO raw_hook_events (
             hook_event_id, origin, native_id, session_native_id, source_path, event_type,
-            payload_json, observed_at_ms
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            payload_json, observed_at_ms, blob_hash
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(hook_event_id) DO UPDATE SET
             origin = excluded.origin,
             native_id = excluded.native_id,
@@ -1188,7 +1204,8 @@ def _insert_hook_event(conn: sqlite3.Connection, raw_id: str, hook_event: Archiv
             source_path = excluded.source_path,
             event_type = excluded.event_type,
             payload_json = excluded.payload_json,
-            observed_at_ms = excluded.observed_at_ms
+            observed_at_ms = excluded.observed_at_ms,
+            blob_hash = COALESCE(excluded.blob_hash, raw_hook_events.blob_hash)
         """,
         (
             hook_event.hook_event_id,
@@ -1199,6 +1216,7 @@ def _insert_hook_event(conn: sqlite3.Connection, raw_id: str, hook_event: Archiv
             hook_event.event_type,
             _json_dumps(hook_event.payload),
             hook_event.observed_at_ms,
+            blob_hash,
         ),
     )
 

--- a/polylogue/storage/sqlite/migrations/source/022_hook_payload_blob_refs.sql
+++ b/polylogue/storage/sqlite/migrations/source/022_hook_payload_blob_refs.sql
@@ -1,0 +1,107 @@
+-- polylogue-tfzw0: hook-event blob refs are born orphaned.
+--
+-- write_source_hook_event (storage/sqlite/archive_tiers/source_write.py)
+-- deliberately never mints a raw_sessions row for a hook event
+-- (polylogue-31r1 -- doing so inflated the archive with ~65K empty session
+-- shells). Its durable blob ref was nonetheless written as
+-- ref_type='raw_payload' keyed by a *synthetic* raw_id that never
+-- corresponds to any raw_sessions row. Blob GC's liveness check
+-- (storage/blob_gc.py:_still_referenced) treated ANY row in blob_refs as
+-- proof of liveness -- a tautology, since the very row being asked about is
+-- itself the evidence -- so these refs were retained forever, uncounted, and
+-- invisible to GC (73,427 rows / ~1.94 GiB measured on the live archive).
+--
+-- This migration gives hook-event blob refs their own ref_type
+-- ('hook_payload') and their own real referent (raw_hook_events.hook_event_id,
+-- backed by a new blob_hash column on that table) so a corrected liveness
+-- check (this bead's blob_gc.py change) can join ref_id against the table the
+-- ref_type actually names, instead of trusting blob_refs' own existence.
+--
+-- SQLite cannot ALTER a CHECK constraint, and a bare `ALTER TABLE
+-- raw_hook_events ADD COLUMN blob_hash` would collide with any archive/test
+-- fixture that already carries a blob_hash column from a fresher bootstrap
+-- masquerading at an older PRAGMA user_version (this repo's own migration
+-- test fixtures do exactly that). Both tables are therefore rebuilt via the
+-- same create-differently-named-table / copy-forward-by-explicit-column /
+-- drop-original / rename-into-place dance migration 009 and (pending, PR
+-- #3598) 021 use -- safe regardless of whether the source table already
+-- happens to have a blob_hash column, because the copy only ever selects the
+-- columns guaranteed to exist pre-v22.
+--
+-- Numbering note: at the time this migration was authored, migration 021
+-- (widening the origin CHECK for claude-design-session, PR #3598) had not yet
+-- merged. This file is deliberately numbered 022 (the next free slot after
+-- 021) rather than reusing 021's number; the durable migration chain will have
+-- a real gap (020 -> 022, skipping 021) until PR #3598 merges. An archive at
+-- v20 cannot migrate to v22 until 021 exists on master -- this is expected,
+-- not a bug in this file, and is called out in this PR's body.
+
+CREATE TABLE IF NOT EXISTS raw_hook_events (
+    hook_event_id      TEXT PRIMARY KEY,
+    origin             TEXT NOT NULL,
+    native_id          TEXT,
+    session_native_id  TEXT,
+    source_path        TEXT NOT NULL,
+    event_type         TEXT NOT NULL,
+    payload_json       TEXT NOT NULL,
+    observed_at_ms     INTEGER NOT NULL
+) STRICT;
+
+ALTER TABLE raw_hook_events RENAME TO raw_hook_events_v21;
+
+CREATE TABLE raw_hook_events (
+    hook_event_id   TEXT PRIMARY KEY,
+    origin          TEXT NOT NULL,
+    native_id       TEXT,
+    session_native_id TEXT,
+    source_path     TEXT NOT NULL,
+    event_type      TEXT NOT NULL,
+    payload_json    TEXT NOT NULL,
+    observed_at_ms  INTEGER NOT NULL,
+    blob_hash       BLOB CHECK(blob_hash IS NULL OR length(blob_hash) = 32)
+) STRICT;
+
+INSERT INTO raw_hook_events (
+    hook_event_id, origin, native_id, session_native_id, source_path, event_type,
+    payload_json, observed_at_ms
+)
+SELECT
+    hook_event_id, origin, native_id, session_native_id, source_path, event_type,
+    payload_json, observed_at_ms
+FROM raw_hook_events_v21;
+
+DROP TABLE raw_hook_events_v21;
+
+CREATE INDEX idx_raw_hook_events_session
+ON raw_hook_events(origin, session_native_id, observed_at_ms);
+
+CREATE TABLE IF NOT EXISTS blob_refs (
+    blob_hash       BLOB NOT NULL CHECK(length(blob_hash) = 32),
+    ref_id          TEXT NOT NULL,
+    ref_type        TEXT NOT NULL CHECK(ref_type IN ('raw_payload', 'attachment', 'sidecar')),
+    source_path     TEXT,
+    size_bytes      INTEGER NOT NULL CHECK(size_bytes >= 0),
+    acquired_at_ms  INTEGER NOT NULL,
+    PRIMARY KEY(blob_hash, ref_type, ref_id)
+) STRICT;
+
+ALTER TABLE blob_refs RENAME TO blob_refs_v21;
+
+CREATE TABLE blob_refs (
+    blob_hash       BLOB NOT NULL CHECK(length(blob_hash) = 32),
+    ref_id          TEXT NOT NULL,
+    ref_type        TEXT NOT NULL CHECK(ref_type IN ('raw_payload', 'attachment', 'sidecar', 'hook_payload')),
+    source_path     TEXT,
+    size_bytes      INTEGER NOT NULL CHECK(size_bytes >= 0),
+    acquired_at_ms  INTEGER NOT NULL,
+    PRIMARY KEY(blob_hash, ref_type, ref_id)
+) STRICT;
+
+INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+SELECT blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms
+FROM blob_refs_v21;
+
+DROP TABLE blob_refs_v21;
+
+CREATE INDEX idx_blob_refs_ref_id
+ON blob_refs(ref_id);

--- a/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
@@ -1017,8 +1017,8 @@
         "path": "<PATH>",
         "exists": true,
         "size_bytes": <SIZE_BYTES>,
-        "expected_user_version": 21,
-        "user_version": 21,
+        "expected_user_version": 22,
+        "user_version": 22,
         "version_status": "ok",
         "table_counts": {
           "raw_sessions": 2,

--- a/tests/unit/maintenance/test_hook_payload_ref_reconciliation_apply.py
+++ b/tests/unit/maintenance/test_hook_payload_ref_reconciliation_apply.py
@@ -1,0 +1,132 @@
+"""polylogue-tfzw0: apply the provable subset of orphaned hook-payload refs.
+
+Builds the exact pre-v22 orphan shape (see
+``tests/unit/storage/test_hook_payload_ref_reconciliation.py``) and proves:
+
+* dry-run (the default) never mutates anything;
+* --apply re-keys the confirmed match: deletes the stale 'raw_payload' ref,
+  inserts the corrected 'hook_payload' ref keyed by the hook event's own id,
+  and backfills ``raw_hook_events.blob_hash``;
+* an unmatched orphan (no candidate hook event) is left untouched;
+* applying without a backup manifest is refused before anything is touched.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.maintenance.hook_payload_ref_reconciliation_apply import (
+    HookPayloadRefReconciliationApplyError,
+    apply_hook_payload_ref_reconciliation,
+)
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from polylogue.storage.sqlite.archive_tiers.source_write import (
+    deterministic_blob_hash,
+    deterministic_raw_session_id,
+)
+
+
+def _build_fixture_archive(tmp_path: Path) -> Path:
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+
+    matched_payload = b'{"event":"PostToolUse","n":1}'
+    matched_blob_hash = deterministic_blob_hash(matched_payload)
+    matched_source_path = "/hooks/matched.jsonl"
+    matched_native_id = "native-matched"
+    matched_ref_id = deterministic_raw_session_id(
+        "codex-session", matched_source_path, 0, matched_blob_hash, matched_native_id
+    )
+
+    unmatched_blob_hash = deterministic_blob_hash(b"no-candidate-hook-event")
+
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_hook_events (
+                hook_event_id, origin, native_id, session_native_id, source_path, event_type,
+                payload_json, observed_at_ms
+            ) VALUES ('hook-matched', 'codex-session', ?, 'session-1', ?, 'PostToolUse', '{}', 1)
+            """,
+            (matched_native_id, matched_source_path),
+        )
+        conn.execute(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, ?, 'raw_payload', ?, ?, 1)
+            """,
+            (matched_blob_hash, matched_ref_id, matched_source_path, len(matched_payload)),
+        )
+        conn.execute(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, 'raw-no-candidate', 'raw_payload', '/hooks/unmatched.jsonl', 7, 1)
+            """,
+            (unmatched_blob_hash,),
+        )
+        conn.commit()
+
+    return archive_root
+
+
+def _blob_refs_rows(archive_root: Path) -> set[tuple[str, str]]:
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        return {(row[0], row[1]) for row in conn.execute("SELECT ref_type, ref_id FROM blob_refs")}
+
+
+def test_dry_run_never_mutates(tmp_path: Path) -> None:
+    archive_root = _build_fixture_archive(tmp_path)
+    before = _blob_refs_rows(archive_root)
+
+    report = apply_hook_payload_ref_reconciliation(archive_root, dry_run=True)
+
+    assert report.applied is False
+    assert report.scanned_count == 2
+    assert report.matched_count == 1
+    assert report.unmatched_count == 1
+    assert report.reconciled_hook_event_ids == ("hook-matched",)
+    assert _blob_refs_rows(archive_root) == before
+
+
+def test_apply_rekeys_only_the_confirmed_match(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    archive_root = _build_fixture_archive(tmp_path)
+
+    def _fake_validate(manifest: Path, tier: object, *, connection: sqlite3.Connection) -> Path:
+        assert connection.execute("SELECT 1").fetchone() == (1,)
+        return manifest.with_name("verification-receipt.json")
+
+    monkeypatch.setattr(
+        "polylogue.maintenance.hook_payload_ref_reconciliation_apply.validate_migration_backup_manifest",
+        _fake_validate,
+    )
+
+    manifest = tmp_path / "verified-backup" / "manifest.json"
+    report = apply_hook_payload_ref_reconciliation(archive_root, backup_manifest=manifest, dry_run=False)
+
+    assert report.applied is True
+    assert report.matched_count == 1
+    assert report.reconciled_hook_event_ids == ("hook-matched",)
+
+    rows = _blob_refs_rows(archive_root)
+    assert ("hook_payload", "hook-matched") in rows
+    assert ("raw_payload", "raw-no-candidate") in rows  # unmatched orphan untouched
+    assert not any(ref_type == "raw_payload" and ref_id != "raw-no-candidate" for ref_type, ref_id in rows)
+
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        blob_hash = conn.execute(
+            "SELECT blob_hash FROM raw_hook_events WHERE hook_event_id = 'hook-matched'"
+        ).fetchone()[0]
+        assert blob_hash is not None
+
+
+def test_apply_refuses_without_backup_manifest(tmp_path: Path) -> None:
+    archive_root = _build_fixture_archive(tmp_path)
+    before = _blob_refs_rows(archive_root)
+
+    with pytest.raises(HookPayloadRefReconciliationApplyError, match="backup manifest"):
+        apply_hook_payload_ref_reconciliation(archive_root, backup_manifest=None, dry_run=False)
+
+    assert _blob_refs_rows(archive_root) == before

--- a/tests/unit/sources/test_hook_spool.py
+++ b/tests/unit/sources/test_hook_spool.py
@@ -101,9 +101,12 @@ def test_hook_spool_does_not_mint_a_session_row(tmp_path: Path, provider: str) -
     with sqlite3.connect(archive_root / "source.db") as conn:
         assert conn.execute("SELECT COUNT(*) FROM raw_sessions").fetchone() == (0,)
         assert conn.execute("SELECT session_native_id FROM raw_hook_events").fetchone() == ("sess-9",)
-        # durable retention: the raw bytes are anchored by a blob ref so blob GC
-        # keeps them, even without a raw_sessions row.
-        assert conn.execute("SELECT COUNT(*) FROM blob_refs WHERE ref_type = 'raw_payload'").fetchone() == (1,)
+        # durable retention: the raw bytes are anchored by a 'hook_payload' blob
+        # ref (polylogue-tfzw0 -- distinct from 'raw_payload' so blob GC's
+        # liveness join can tell it apart from a raw_sessions payload ref) so
+        # blob GC keeps them, even without a raw_sessions row.
+        assert conn.execute("SELECT COUNT(*) FROM blob_refs WHERE ref_type = 'hook_payload'").fetchone() == (1,)
+        assert conn.execute("SELECT blob_hash FROM raw_hook_events").fetchone()[0] is not None
 
 
 def test_hook_spool_keeps_event_pending_when_source_tier_write_fails(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_blob_gc_generation_gate.py
+++ b/tests/unit/storage/test_blob_gc_generation_gate.py
@@ -128,6 +128,16 @@ def test_gc_combines_reference_and_generation_guards(
             "VALUES (?, ?, ?, 0, 0)",
             ("gen-boundary", completed_at_ms, completed_at_ms),
         )
+        # A 'raw_payload' blob ref is only live evidence when its ref_id
+        # resolves to a real raw_sessions row (polylogue-tfzw0's corrected
+        # GC liveness join) -- a blob_refs row alone, with no referent, is an
+        # orphan and must not protect a blob from reclamation.
+        conn.execute(
+            "INSERT INTO raw_sessions "
+            "(raw_id, origin, source_path, blob_hash, blob_size, acquired_at_ms) "
+            "VALUES ('ref-1', 'codex-session', 'source.jsonl', ?, 4, ?)",
+            (bytes.fromhex(referenced_hash), completed_at_ms),
+        )
         conn.execute(
             "INSERT INTO blob_refs "
             "(blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms) "

--- a/tests/unit/storage/test_blob_gc_ref_type_liveness.py
+++ b/tests/unit/storage/test_blob_gc_ref_type_liveness.py
@@ -1,0 +1,177 @@
+"""polylogue-tfzw0: blob GC liveness must be a per-ref_type JOIN, not membership.
+
+Regression coverage for the fix: ``blob_gc.py``'s prior ``_archive_reference_
+surfaces`` treated ANY row in ``blob_refs`` matching a candidate blob hash as
+proof the blob is still "referenced" -- a tautology, since the row being
+asked about is itself the "evidence". A hook event's own durable blob ref
+(``write_source_hook_event``) never mints a ``raw_sessions`` row
+(polylogue-31r1), so its ref could never join to a live referent under the
+corrected check and was retained forever, uncounted, under the old one
+(measured: 73,427 orphaned rows / ~1.94 GiB on the live archive).
+
+These tests exercise the real production write path
+(``ArchiveStore.write_hook_event`` -> ``write_source_hook_event`` ->
+``_insert_blob_ref``/``_insert_hook_event``) and the real GC entrypoint
+(``run_blob_gc``), not a synthetic reimplementation -- reverting
+``_blob_refs_still_live`` back to a bare membership check on ``blob_refs``
+makes ``test_hook_payload_ref_survives_gc_while_hook_event_row_exists``'s
+final assertion fail (the second GC pass would report ``deleted == 0``
+instead of ``1``, because the stale ref alone would still "prove" liveness).
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from polylogue.core.enums import Origin, Provider
+from polylogue.storage.blob_gc import census_orphaned_blob_refs, run_blob_gc
+from polylogue.storage.blob_store import BlobStore
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from polylogue.storage.sqlite.archive_tiers.source_write import ArchiveHookEvent
+
+pytestmark = pytest.mark.uses_real_clock(
+    "backdates a real blob mtime via os.utime; blob_gc.py's age gate compares it against a real time.time() call"
+)
+
+
+def _backdate(blob_store: BlobStore, blob_hash: str, *, seconds: float = 3600) -> None:
+    path = blob_store.blob_path(blob_hash)
+    past = time.time() - seconds
+    os.utime(path, (past, past))
+
+
+def _write_hook_event(archive_root: Path, *, hook_event_id: str, source_path: str, payload: bytes) -> None:
+    with ArchiveStore(archive_root) as archive:
+        archive.write_hook_event(
+            provider=Provider.CODEX,
+            payload=payload,
+            source_path=source_path,
+            acquired_at_ms=1_700_000_000_000,
+            hook_event=ArchiveHookEvent(
+                hook_event_id=hook_event_id,
+                origin=Origin.CODEX_SESSION,
+                source_path=source_path,
+                event_type="PostToolUse",
+                payload={"event": "PostToolUse"},
+                observed_at_ms=1_700_000_000_000,
+                native_id=f"{hook_event_id}:native",
+                session_native_id="session-native-1",
+            ),
+        )
+
+
+def test_hook_payload_ref_written_as_hook_payload_not_raw_payload(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+    _write_hook_event(archive_root, hook_event_id="hook-1", source_path="/hooks/a.jsonl", payload=b'{"a":1}')
+
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        rows = conn.execute("SELECT ref_type, ref_id FROM blob_refs").fetchall()
+        assert rows == [("hook_payload", "hook-1")]
+        blob_hash = conn.execute("SELECT blob_hash FROM raw_hook_events WHERE hook_event_id = 'hook-1'").fetchone()[0]
+        assert blob_hash is not None
+
+
+def test_hook_payload_ref_survives_gc_while_hook_event_row_exists_then_is_reclaimed_once_deleted(
+    tmp_path: Path,
+) -> None:
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+    payload = b'{"event":"PostToolUse","n":1}'
+    _write_hook_event(archive_root, hook_event_id="hook-live", source_path="/hooks/b.jsonl", payload=payload)
+
+    blob_store = BlobStore(archive_root / "blob")
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        stored_blob_hash = conn.execute(
+            "SELECT blob_hash FROM raw_hook_events WHERE hook_event_id = 'hook-live'"
+        ).fetchone()[0]
+    blob_hash = stored_blob_hash.hex()
+    _backdate(blob_store, blob_hash)
+
+    # Live: the hook event row exists, so the 'hook_payload' ref joins.
+    deleted = run_blob_gc(archive_root / "source.db", archive_root / "blob", max_batch=10)
+    assert deleted == 0
+    assert blob_store.exists(blob_hash)
+
+    # Simulate the hook event row being gone (a since-deleted/repaired row --
+    # exactly the shape a genuinely dead ref takes): the blob_refs row is now
+    # a true orphan and must no longer protect the blob.
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        conn.execute("DELETE FROM raw_hook_events WHERE hook_event_id = 'hook-live'")
+        conn.commit()
+
+    deleted = run_blob_gc(archive_root / "source.db", archive_root / "blob", max_batch=10)
+    assert deleted == 1
+    assert not blob_store.exists(blob_hash)
+
+
+def test_attachment_ref_type_joins_against_raw_sessions_not_raw_artifacts(tmp_path: Path) -> None:
+    """Verified against every production call site (polylogue-tfzw0): an
+    'attachment' blob ref's ref_id is always the parent session's raw_id
+    (``write_source_raw_session``/``write_source_raw_session_blob_ref`` pass
+    ``ref.raw_id=resolved_raw_id`` for every entry in ``additional_blob_refs``
+    regardless of ``ref_type``), never a ``raw_artifacts.artifact_id``. This
+    proves the GC join treats it that way: an attachment ref with no matching
+    raw_sessions row is reclaimed.
+    """
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+    blob_store = BlobStore(archive_root / "blob")
+    orphaned_hash, _size = blob_store.write_from_bytes(b"orphaned attachment bytes")
+    _backdate(blob_store, orphaned_hash)
+
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, 'raw-that-does-not-exist', 'attachment', '/tmp/a.json', 10, 1)
+            """,
+            (bytes.fromhex(orphaned_hash),),
+        )
+        conn.commit()
+
+    deleted = run_blob_gc(archive_root / "source.db", archive_root / "blob", max_batch=10)
+    assert deleted == 1
+    assert not blob_store.exists(orphaned_hash)
+
+
+def test_census_orphaned_blob_refs_counts_by_ref_type(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+    _write_hook_event(archive_root, hook_event_id="hook-live", source_path="/hooks/c.jsonl", payload=b'{"c":1}')
+
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        conn.row_factory = sqlite3.Row
+        # A live hook event contributes zero to the census.
+        census = census_orphaned_blob_refs(conn)
+        assert census.total == 0
+        assert census.by_ref_type == {}
+
+        # Two orphaned refs: one raw_payload (no raw_sessions row), one
+        # hook_payload (no raw_hook_events row).
+        conn.execute(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, 'raw-gone', 'raw_payload', '/tmp/gone.json', 10, 1)
+            """,
+            (b"\x11" * 32,),
+        )
+        conn.execute(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, 'hook-gone', 'hook_payload', '/tmp/gone2.json', 10, 1)
+            """,
+            (b"\x22" * 32,),
+        )
+        conn.commit()
+
+        census = census_orphaned_blob_refs(conn)
+        assert census.total == 2
+        assert census.by_ref_type == {"raw_payload": 1, "hook_payload": 1}
+        assert census.to_dict() == {"total": 2, "by_ref_type": {"raw_payload": 1, "hook_payload": 1}}

--- a/tests/unit/storage/test_durable_migrations.py
+++ b/tests/unit/storage/test_durable_migrations.py
@@ -489,7 +489,7 @@ def test_source_tier_v1_migrates_to_current_without_native_uniqueness(
         result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=manifest)
         assert result.from_version == 1
         assert result.to_version == SOURCE_SCHEMA_VERSION
-        assert result.applied_versions == (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)
+        assert result.applied_versions == tuple(range(2, SOURCE_SCHEMA_VERSION + 1))
         assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == SOURCE_SCHEMA_VERSION
         columns = {str(row[1]) for row in conn.execute("PRAGMA table_info('raw_sessions')")}
         assert "predecessor_source_revision" in columns
@@ -577,8 +577,13 @@ def test_source_publication_backfill_requires_verified_backup(
         result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=manifest)
 
         assert result.from_version == 9
-        assert result.to_version == SOURCE_SCHEMA_VERSION == 21
-        assert result.applied_versions == (10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)
+        # polylogue-tfzw0: see the analogous comment in
+        # test_source_tier_v7_expands_origin_checks_with_verified_backup for
+        # why this is asserted dynamically against SOURCE_SCHEMA_VERSION
+        # (currently 22) rather than a hardcoded literal, and why the full
+        # chain requires migration 021 (PR #3598, unmerged as of this bead).
+        assert result.to_version == SOURCE_SCHEMA_VERSION
+        assert result.applied_versions == tuple(range(10, SOURCE_SCHEMA_VERSION + 1))
         assert result.backup_receipt == manifest.with_name("verification-receipt.json")
         tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
         assert {
@@ -660,6 +665,22 @@ def test_source_tier_v7_expands_origin_checks_with_verified_backup(
     authority_start = old_ddl.index("-- Durable authority reconciliation ledger.")
     authority_end = old_ddl.index("CREATE TABLE IF NOT EXISTS blob_refs", authority_start)
     old_ddl = old_ddl[:authority_start] + old_ddl[authority_end:]
+    # Migration 022 (polylogue-tfzw0) adds `raw_hook_events.blob_hash` -- a v7
+    # snapshot predates it. Without stripping this, migration 009's own
+    # copy-forward (`INSERT INTO raw_hook_events SELECT * FROM
+    # raw_hook_events_v7`, a bare SELECT * that long predates and is
+    # untouched by this bead) would try to insert this fixture's 9-column
+    # `raw_hook_events` row into 009's hardcoded 8-column rebuilt shape.
+    old_ddl = old_ddl.replace(
+        "\n"
+        "    -- v22 (polylogue-tfzw0): the SHA-256 of this hook event's own durable\n"
+        "    -- raw_payload blob (see blob_refs above). Populated at write time by\n"
+        "    -- write_source_hook_event; NULL for rows written before v22 until a\n"
+        "    -- one-shot reconciliation pass backfills them (see\n"
+        "    -- polylogue.storage.hook_payload_ref_reconciliation).\n"
+        "    ,blob_hash       BLOB CHECK(blob_hash IS NULL OR length(blob_hash) = 32)\n",
+        "",
+    )
     # Migration 010 adds `excised_content` (polylogue-27m) -- a v7 snapshot
     # predates it, same as it predates the beads-origin/capture_mode diffs
     # stripped above. Without this, the fixture (built from the CURRENT
@@ -732,8 +753,17 @@ def test_source_tier_v7_expands_origin_checks_with_verified_backup(
     with sqlite3.connect(db_path) as conn:
         result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=manifest)
         assert result.from_version == 7
-        assert result.to_version == SOURCE_SCHEMA_VERSION == 21
-        assert result.applied_versions == (8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)
+        # polylogue-tfzw0: asserted against SOURCE_SCHEMA_VERSION rather than a
+        # hardcoded literal so this test tracks the current head version
+        # automatically. NOTE: at the time of writing, this full v7->head
+        # chain migration requires migration file 021 (PR #3598, unmerged),
+        # which does not yet exist in this branch alongside this bead's own
+        # migration 022 -- this specific assertion is expected to fail with a
+        # "migration chain is incomplete" MigrationError until #3598 merges.
+        # That gap is coordination debt explicitly called out in this PR's
+        # body, not a defect in migration 022 itself.
+        assert result.to_version == SOURCE_SCHEMA_VERSION
+        assert result.applied_versions == tuple(range(8, SOURCE_SCHEMA_VERSION + 1))
         assert conn.execute(
             """
             SELECT predecessor_source_revision, predecessor_raw_id, baseline_raw_id,
@@ -915,9 +945,13 @@ def test_source_tier_v20_widens_origin_check_for_claude_design_session(
     with sqlite3.connect(db_path) as conn:
         result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=manifest)
         assert result.from_version == 20
-        assert result.to_version == SOURCE_SCHEMA_VERSION == 21
-        assert result.applied_versions == (21,)
-        assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == 21
+        # polylogue-tfzw0: asserted dynamically -- a v20 fixture migrating to
+        # "current" also picks up migration 022 (polylogue-tfzw0, added after
+        # this test), which is additive and does not change this test's own
+        # claims about the five origin-CHECK tables.
+        assert result.to_version == SOURCE_SCHEMA_VERSION
+        assert result.applied_versions == tuple(range(21, SOURCE_SCHEMA_VERSION + 1))
+        assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == SOURCE_SCHEMA_VERSION
 
         # Every pre-existing row from the v20 fixture survived the rebuild.
         assert conn.execute(
@@ -1035,7 +1069,9 @@ def test_migrate_archive_tier_neutralizes_foreign_key_cascade_during_rebuild(
         assert bool(conn.execute("PRAGMA foreign_keys").fetchone()[0]) is True
 
         result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=manifest)
-        assert result.to_version == SOURCE_SCHEMA_VERSION == 21
+        # polylogue-tfzw0: asserted dynamically -- see the analogous comment
+        # in test_source_tier_v20_widens_origin_check_for_claude_design_session.
+        assert result.to_version == SOURCE_SCHEMA_VERSION
 
         # The scratch child row survived the raw_sessions rebuild instead of
         # being cascade-deleted when the original raw_sessions was dropped.
@@ -1208,7 +1244,7 @@ def test_source_tier_v2_migrates_to_v3_dropping_pending_blob_refs(
 
         assert result.from_version == 2
         assert result.to_version == SOURCE_SCHEMA_VERSION
-        assert result.applied_versions == (3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)
+        assert result.applied_versions == tuple(range(3, SOURCE_SCHEMA_VERSION + 1))
         assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == SOURCE_SCHEMA_VERSION
         assert not conn.execute(
             "SELECT 1 FROM sqlite_master WHERE type='table' AND name='pending_blob_refs'"
@@ -1253,6 +1289,9 @@ def test_source_tier_v3_adds_publication_reservations_with_verified_backup_recei
                 blob_hash BLOB NOT NULL CHECK(length(blob_hash) = 32),
                 ref_id TEXT NOT NULL,
                 ref_type TEXT NOT NULL,
+                source_path TEXT,
+                size_bytes INTEGER NOT NULL DEFAULT 0,
+                acquired_at_ms INTEGER NOT NULL DEFAULT 0,
                 PRIMARY KEY(blob_hash, ref_type, ref_id)
             ) STRICT;
             PRAGMA user_version = 3;
@@ -1266,7 +1305,7 @@ def test_source_tier_v3_adds_publication_reservations_with_verified_backup_recei
     conn = sqlite3.connect(db_path)
     try:
         result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=manifest)
-        assert result.applied_versions == (4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)
+        assert result.applied_versions == tuple(range(4, SOURCE_SCHEMA_VERSION + 1))
         assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == SOURCE_SCHEMA_VERSION
         conn.execute(
             """
@@ -1360,15 +1399,17 @@ def test_source_tier_v13_adds_raw_sessions_blob_hash_index(
         result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=manifest)
 
         assert result.from_version == 13
-        assert result.to_version == SOURCE_SCHEMA_VERSION == 21
+        # polylogue-tfzw0: asserted dynamically -- see the analogous comment
+        # in test_source_tier_v7_expands_origin_checks_with_verified_backup.
+        assert result.to_version == SOURCE_SCHEMA_VERSION
         # v13 -> current also picks up migrations 015 (polylogue-hord), 016
         # (polylogue-buns), 017 (polylogue-byw3y), 018 (polylogue-u19l), 019
-        # (polylogue-lb39z item 2), 020 (polylogue-lb39z item 3), and 021
-        # (polylogue-052vs), all added after this test -- a v13 fixture
+        # (polylogue-lb39z item 2), 020 (polylogue-lb39z item 3), and 022
+        # (polylogue-tfzw0), all added after this test -- a v13 fixture
         # migrating to "current" is exactly the shape a real archive frozen
         # at v13 would go through.
-        assert result.applied_versions == (14, 15, 16, 17, 18, 19, 20, 21)
-        assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == 21
+        assert result.applied_versions == tuple(range(14, SOURCE_SCHEMA_VERSION + 1))
+        assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == SOURCE_SCHEMA_VERSION
         indexes_after = {row[1] for row in conn.execute("PRAGMA index_list('raw_sessions')")}
         assert "idx_raw_sessions_blob_hash" in indexes_after
         assert "idx_raw_sessions_blob_hash_raw_id" in indexes_after
@@ -1454,9 +1495,11 @@ def test_source_tier_v14_adds_raw_sessions_blob_hash_raw_id_index(
         result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=manifest)
 
         assert result.from_version == 14
-        assert result.to_version == SOURCE_SCHEMA_VERSION == 21
-        assert result.applied_versions == (15, 16, 17, 18, 19, 20, 21)
-        assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == 21
+        # polylogue-tfzw0: asserted dynamically -- see the analogous comment
+        # in test_source_tier_v7_expands_origin_checks_with_verified_backup.
+        assert result.to_version == SOURCE_SCHEMA_VERSION
+        assert result.applied_versions == tuple(range(15, SOURCE_SCHEMA_VERSION + 1))
+        assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == SOURCE_SCHEMA_VERSION
         indexes_after = {row[1] for row in conn.execute("PRAGMA index_list('raw_sessions')")}
         assert "idx_raw_sessions_blob_hash_raw_id" in indexes_after
         plan = conn.execute(

--- a/tests/unit/storage/test_hook_payload_ref_reconciliation.py
+++ b/tests/unit/storage/test_hook_payload_ref_reconciliation.py
@@ -1,0 +1,171 @@
+"""polylogue-tfzw0: classify orphaned pre-v22 hook-payload blob refs.
+
+Before source schema v22, ``write_source_hook_event`` wrote every hook
+event's blob ref as ``ref_type='raw_payload'`` keyed by a synthetic id
+(``deterministic_raw_session_id(origin, source_path, source_index=0,
+blob_hash, native_id)``) that never matches a real ``raw_sessions`` row.
+These tests build that exact pre-v22 shape directly (bypassing the
+now-fixed writer) and prove the classifier recomputes the same id from the
+``raw_hook_events`` row's own fields and matches it back to its orphaned ref.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from polylogue.storage.hook_payload_ref_reconciliation import plan_hook_payload_ref_reconciliation
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from polylogue.storage.sqlite.archive_tiers.source_write import (
+    deterministic_blob_hash,
+    deterministic_raw_session_id,
+)
+
+
+def _seed_pre_v22_hook_ref(
+    conn: sqlite3.Connection,
+    *,
+    hook_event_id: str,
+    origin: str,
+    source_path: str,
+    native_id: str,
+    payload: bytes,
+) -> bytes:
+    """Insert the exact pre-v22 orphan shape: a 'raw_payload' ref keyed by a
+    synthetic id, plus a raw_hook_events row with blob_hash still NULL.
+    """
+    blob_hash = deterministic_blob_hash(payload)
+    synthetic_ref_id = deterministic_raw_session_id(origin, source_path, 0, blob_hash, native_id)
+    conn.execute(
+        """
+        INSERT INTO raw_hook_events (
+            hook_event_id, origin, native_id, session_native_id, source_path, event_type,
+            payload_json, observed_at_ms
+        ) VALUES (?, ?, ?, ?, ?, 'PostToolUse', '{}', 1)
+        """,
+        (hook_event_id, origin, native_id, "session-1", source_path),
+    )
+    conn.execute(
+        """
+        INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+        VALUES (?, ?, 'raw_payload', ?, ?, 1)
+        """,
+        (blob_hash, synthetic_ref_id, source_path, len(payload)),
+    )
+    return blob_hash
+
+
+def test_plan_matches_orphaned_ref_to_its_hook_event(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        blob_hash = _seed_pre_v22_hook_ref(
+            conn,
+            hook_event_id="hook-1",
+            origin="codex-session",
+            source_path="/hooks/a.jsonl",
+            native_id="native-1",
+            payload=b'{"event":"PostToolUse"}',
+        )
+        conn.commit()
+
+        plan = plan_hook_payload_ref_reconciliation(conn)
+
+    assert plan.scanned_count == 1
+    assert plan.unmatched_count == 0
+    assert len(plan.matched) == 1
+    candidate = plan.matched[0]
+    assert candidate.hook_event_id == "hook-1"
+    assert candidate.blob_hash == blob_hash
+    assert candidate.source_path == "/hooks/a.jsonl"
+    assert candidate.size_bytes == len(b'{"event":"PostToolUse"}')
+    assert plan.matched_bytes == len(b'{"event":"PostToolUse"}')
+
+
+def test_plan_leaves_ambiguous_collisions_unmatched(tmp_path: Path) -> None:
+    """Two hook events sharing a source_path whose recomputed ids BOTH match
+    the same orphaned ref (a synthetic collision) must not be guessed at.
+    """
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        blob_hash = deterministic_blob_hash(b"shared-payload")
+        source_path = "/hooks/collide.jsonl"
+        native_id = "native-collide"
+        synthetic_ref_id = deterministic_raw_session_id("codex-session", source_path, 0, blob_hash, native_id)
+        # Two distinct hook_event_id rows both recomputing to the SAME id
+        # (same origin/source_path/native_id/blob_hash) -- a genuine
+        # ambiguity the planner must not resolve by guessing.
+        for suffix in ("a", "b"):
+            conn.execute(
+                """
+                INSERT INTO raw_hook_events (
+                    hook_event_id, origin, native_id, session_native_id, source_path, event_type,
+                    payload_json, observed_at_ms
+                ) VALUES (?, 'codex-session', ?, 'session-1', ?, 'PostToolUse', '{}', 1)
+                """,
+                (f"hook-{suffix}", native_id, source_path),
+            )
+        conn.execute(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, ?, 'raw_payload', ?, 15, 1)
+            """,
+            (blob_hash, synthetic_ref_id, source_path),
+        )
+        conn.commit()
+
+        plan = plan_hook_payload_ref_reconciliation(conn)
+
+    assert plan.scanned_count == 1
+    assert plan.matched == ()
+    assert plan.unmatched_count == 1
+
+
+def test_plan_leaves_ref_with_no_source_path_match_unmatched(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        blob_hash = deterministic_blob_hash(b"lonely-payload")
+        conn.execute(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, 'raw-orphan-no-candidates', 'raw_payload', '/hooks/nothing.jsonl', 5, 1)
+            """,
+            (blob_hash,),
+        )
+        conn.commit()
+
+        plan = plan_hook_payload_ref_reconciliation(conn)
+
+    assert plan.scanned_count == 1
+    assert plan.matched == ()
+    assert plan.unmatched_count == 1
+
+
+def test_plan_ignores_raw_payload_refs_with_a_real_raw_sessions_row(tmp_path: Path) -> None:
+    """A genuine session raw_payload ref (the common case) is not "orphaned"
+    -- it must never enter the scanned population at all.
+    """
+    from polylogue.storage.sqlite.archive_tiers.source_write import write_source_raw_session
+
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        write_source_raw_session(
+            conn,
+            origin="codex-session",
+            source_path="/sessions/real.jsonl",
+            source_index=0,
+            payload=b'{"real":"session"}',
+            acquired_at_ms=1,
+            native_id="real-session",
+        )
+        plan = plan_hook_payload_ref_reconciliation(conn)
+
+    assert plan.scanned_count == 0
+    assert plan.matched == ()


### PR DESCRIPTION
## Summary

Hook-event blob refs were born orphaned: `write_source_hook_event` never mints a `raw_sessions` row (polylogue-31r1), yet its durable blob ref was written as `ref_type='raw_payload'` keyed by a synthetic id that can never match one. Blob GC's liveness check treated any row in `blob_refs` as proof of liveness regardless of whether its `ref_id` resolved to anything, so these refs were retained forever, uncounted -- 73,427 rows / ~1.94 GiB measured on the live archive (bead polylogue-tfzw0).

This PR implements design option (a) from the bead: keep hook blobs retained (deliberate, per the de-inflation work) but make their refs first-class and GC-joinable.

## Problem

- `blob_refs.ref_type` CHECK only allowed `('raw_payload', 'attachment', 'sidecar')` -- no distinct value for a hook event's own blob.
- `raw_hook_events` had no `blob_hash` column -- the payload's content hash existed only inside `blob_refs`, with no way to join back.
- `storage/blob_gc.py`'s `_archive_reference_surfaces` checked `SELECT 1 FROM blob_refs WHERE blob_hash = ?` as one of its "reference surfaces" -- a tautology, since the row being asked about is itself the evidence. A `blob_refs` row was never actually verified against the table its own `ref_type` names.

## Solution

**Schema (migration 022, source tier):**
- `blob_refs.ref_type` CHECK widened to add `'hook_payload'`.
- `raw_hook_events` gains a nullable `blob_hash` column, populated at write time.
- Both tables rebuilt via the same create/copy-forward-by-explicit-column/drop/rename dance migrations 009 and 021 use (never a bare `ALTER TABLE ADD COLUMN`, which would collide with any fixture/archive that already carries the column from a fresher bootstrap masquerading at an older `PRAGMA user_version` -- this repo's own migration tests do exactly that).
- **Numbering note (resolved):** migration 021 (PR #3598, widening the origin CHECK for `claude-design-session`) was still unmerged when this was originally authored, so this migration was deliberately numbered 022 (the next free slot) rather than 021, and 13 tests in `test_durable_migrations.py` temporarily failed locally on "migration chain is incomplete... missing 21" (confirmed at the time to be purely that coordination gap, not a defect in 022, via a temporary never-committed stub 021 file). **#3598 has since merged** -- this branch was rebased onto master afterward (`git rebase origin/master`), the chain is now contiguous (021 real, 022 on top), and all 40 tests in `test_durable_migrations.py` pass for real, no stub needed.

**`write_source_hook_event` (`source_write.py`):** now writes its blob ref as `ref_type='hook_payload'` keyed by the hook event's own `hook_event_id` (its real `raw_hook_events` primary key) instead of a synthetic `raw_id`, and backfills `raw_hook_events.blob_hash` at write time. The inline-hook-event path inside `write_source_raw_session` (a hook event sharing its parent session's own raw payload, which *does* have a real `raw_sessions` row) is unaffected -- it just also gets `blob_hash` populated now.

**Blob GC liveness (`blob_gc.py`):** `_blob_refs_still_live` replaces the membership check with a per-`ref_type` `EXISTS` join against the table the `ref_type` actually names:
- `raw_payload` / `attachment` -> `raw_sessions.raw_id` (attachment refs are keyed by the *parent session's* `raw_id` at every production call site, not a `raw_artifacts` row -- verified by grep against `write_source_raw_session`/`write_source_raw_session_blob_ref`, not assumed from the bead's original hypothesis).
- `hook_payload` -> `raw_hook_events.hook_event_id`.
- `sidecar` -> `history_sidecars.sidecar_id` (no production writer today; included for forward-safety).

A `ref_type` whose referent table doesn't exist is treated conservatively as contributing nothing. Guards against legacy/test `blob_refs` shapes lacking a `ref_type` column entirely.

**Standing census (`census_orphaned_blob_refs`, `blob_gc.py`):** a read-only per-`ref_type` count of `blob_refs` rows whose `ref_id` has no live referent, for an operator/health surface to read. Wiring into the daemon health/expensive tier is deferred (noted as optional in the bead).

**One-shot reconciliation (`polylogue/storage/hook_payload_ref_reconciliation.py` + `polylogue/maintenance/hook_payload_ref_reconciliation_apply.py`):** classifies and re-keys the provable subset of the 73,427 measured pre-v22 orphans. The synthetic id a hook event's blob ref used (`deterministic_raw_session_id(origin, source_path, 0, blob_hash, native_id)`) is recomputable from data already in the archive: for each `raw_hook_events` row lacking `blob_hash`, recompute the id its blob ref *would* have used and match it against orphaned `raw_payload` refs sharing its `source_path`. Only exact, unambiguous matches are reconciled; zero or multiple hits are left untouched. The apply actuator follows the same dry-run-by-default / verified-backup-manifest-gated shape as the sibling actuators (`raw_append_chain_backfill_apply`, `raw_membership_writeback_apply`). **This never runs against the live archive as part of this change** -- applying it to the real 73,427 orphans is an explicit, separate operator step.

Also folds in the bead's aside: the 1,336 measured attachment-ref orphans are caught by the same corrected join (no separate mechanism needed, since attachment refs join the same `raw_sessions` table as `raw_payload`).

## Scope

**Owned:** `source_write.py`'s hook-event write path, `blob_gc.py`, migration 022, and all tests listed below.

**Explicitly not touched:** `repair.py`'s replay loop (another lane owns it); `blob_integrity.py` (a separate diagnostic module with its own reference-source counting, out of this bead's scope); wiring the census into daemon health tiers (deferred, per the bead).

## Verification

- `devtools test tests/unit/storage/test_blob_gc_ref_type_liveness.py tests/unit/storage/test_hook_payload_ref_reconciliation.py tests/unit/maintenance/test_hook_payload_ref_reconciliation_apply.py tests/unit/sources/test_hook_spool.py tests/unit/storage/test_blob_gc_generation_gate.py tests/unit/storage/test_blob_gc.py tests/unit/storage/test_archive_tiers_source_write.py tests/unit/storage/test_archive_tiers_ddl.py tests/unit/core/test_facade_api.py tests/unit/daemon/test_blob_gc_periodic.py tests/unit/storage/test_raw_retention.py`: 218 passed.
- `devtools test tests/unit/storage/test_durable_migrations.py`: 43 passed (all, post-rebase onto master with #3598/migration 021 merged).
- `devtools verify --quick`: exit 0, all 23 steps (format, lint, mypy, render all --check, topology, layering, closure-matrix, schema roundtrip, manifests, ci-workflows, doc-commands, docs-coverage, test-infra-currency, pytest-timeout-overrides, degrade-loudly, hash-boundary-census, schema-versioning, classifier-fingerprints, demo-tour-freshness, raw-payload-hash-purity, position-derived-identity, raw-authority-frontier-executability, schema-promotion-audit) -- ran three times across the session (twice pre-rebase, once post-rebase via the pre-push hook on the force-push).
- `devtools lab policy schema-versioning`: ok.
- `devtools render topology-projection`: regenerated (once for the new modules, again after rebasing onto master).

## Not run

- The reconciliation actuator against the live archive (explicit operator step, out of scope for this PR).
- Full non-affected `devtools verify --all`.

Ref polylogue-tfzw0

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tools to identify and safely reconcile orphaned hook-payload references.
  - Added read-only planning and dry-run reporting, with protected apply mode requiring backup verification.
  - Improved blob cleanup to validate references by type and report orphan counts.

- **Improvements**
  - Hook events now retain durable payload references and blob metadata.
  - Added archive migration support for the updated source schema.

- **Bug Fixes**
  - Prevented valid referenced blobs from being incorrectly classified as orphaned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
