### PR TITLE
fix(sources): tighten sidecar admission for tool-results and antigravity brain metadata

### DIFF
--- a/docs/plans/classifier-fingerprints.json
+++ b/docs/plans/classifier-fingerprints.json
@@ -112,6 +112,14 @@
         "ref": "polylogue-qs4b"
       }
     },
+    "polylogue/sources/origin_specs.py:artifact_rule:claude-code-session:tool_result_sidecar": {
+      "fingerprint": "fec746c784f5ce11a8b1b11819cad93ceb45e0a8b8fec067abfe2561197b4faa",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Tightens acceptance only: tool-results/*.json sidecars (overflow tool-call output Claude Code persists verbatim, joined to their owning tool_result block by tool_use_id -- see sources/live/tool_result_sidecars.py) were never a real independent conversation; content heuristics alone cannot refuse them since a tool call's own output can coincidentally reproduce a genuine session-document shape (verified live against a real ~/.claude/projects corpus: a tool-results/*.txt sidecar whose content was a real claude.ai export document classified as SESSION_DOCUMENT/parse_as_session=True under the prior content-only rules; path_suffixes scoped to .json only -- not the .txt/.html also found live -- since artifact_suffixes_for_provider feeds live/watcher.py's acquisition suffix filter and widening it is out of this fix's scope). No reparse of existing rows: the already-planned index rebuild (polylogue-x1gd) is the retroactive cleanup path, not this change.",
+        "ref": "polylogue-omsw"
+      }
+    },
     "polylogue/sources/origin_specs.py:artifact_rule:claude-code-session:workflow_journal": {
       "fingerprint": "9d39e1590195ca7a767f42f03401add2441e5f947dddb25241df25282fbbd99d",
       "covered_by": {

--- a/polylogue/archive/artifact_taxonomy/models.py
+++ b/polylogue/archive/artifact_taxonomy/models.py
@@ -20,6 +20,20 @@ class ArtifactKind(StrEnum):
     TODO_SNAPSHOT = "todo_snapshot"
     SESSION_INDEX = "session_index"
     BRIDGE_POINTER = "bridge_pointer"
+    # polylogue-omsw: Claude Code persists tool-result overflow content to
+    # ``<session>/tool-results/<name>.<ext>`` (see
+    # ``sources/live/tool_result_sidecars.py``'s module docstring) -- the
+    # sidecar join mechanism reads it FROM disk to attach to its owning
+    # ``tool_result`` block, it is never independent conversation content.
+    # A tool call's own output can coincidentally reproduce a genuine
+    # session-document shape byte-for-byte (verified live: a
+    # ``tool-results/*.txt`` file whose content was a real claude.ai export
+    # document -- some prior turn's tool call had fetched and dumped one --
+    # classified as SESSION_DOCUMENT/parse_as_session=True under the old
+    # content-only rules), so content heuristics alone can never refuse this
+    # family; only a path rule can, mirroring ``AGENT_SIDECAR_META`` /
+    # ``WORKFLOW_JOURNAL``.
+    TOOL_RESULT_SIDECAR = "tool_result_sidecar"
     METADATA_DOCUMENT = "metadata_document"
     HOOK_EVENT = "hook_event"
     # polylogue-hbtj2: a raw payload whose magic bytes are a recognized

--- a/polylogue/sources/dispatch.py
+++ b/polylogue/sources/dispatch.py
@@ -1774,60 +1774,6 @@ def parse_stream_payload(
     raise ValueError(f"provider {runtime_provider} does not support stream parsing")
 
 
-def parse_drive_payload(
-    provider: str | Provider,
-    payload: object,
-    fallback_id: str,
-    _depth: int = 0,
-) -> list[ParsedSession]:
-    """Adapter for Drive/Gemini payload parsing."""
-    runtime_provider = Provider.from_string(provider)
-    if _depth > _MAX_PARSE_DEPTH:
-        logger.warning("Recursion depth exceeded parsing drive payload %s", fallback_id)
-        return []
-
-    payloads = _payload_sequence(payload)
-    if payloads is not None:
-        if payloads and all(isinstance(item, str) or _payload_record(item) is not None for item in payloads):
-            first_record = _payload_record(payloads[0]) if payloads else None
-            if first_record is None or "role" in first_record or "text" in first_record:
-                spec = _chunked_prompt_spec(runtime_provider, payloads, fallback_id)
-                return _parse_lowered_spec(spec)
-
-        nested_sessions: list[ParsedSession] = []
-        for index, item in enumerate(payloads):
-            if _looks_like_chunked_session(item):
-                nested_sessions.extend(
-                    parse_drive_payload(
-                        runtime_provider,
-                        item,
-                        f"{fallback_id}-{index}",
-                        _depth + 1,
-                    )
-                )
-                continue
-            detected = detect_provider(item) or runtime_provider
-            nested_sessions.extend(
-                parse_payload(
-                    detected,
-                    item,
-                    f"{fallback_id}-{index}",
-                    _depth + 1,
-                )
-            )
-        return nested_sessions
-
-    record = _payload_record(payload)
-    if record is None:
-        return []
-    if "chunkedPrompt" in record or "chunks" in record:
-        spec = _chunked_prompt_spec(runtime_provider, record, fallback_id)
-        return _parse_lowered_spec(spec)
-
-    detected = detect_provider(record) or runtime_provider
-    return parse_payload(detected, record, fallback_id, _depth + 1)
-
-
 __all__ = [
     "GROUP_PROVIDERS",
     "STREAM_RECORD_PROVIDERS",
@@ -1838,7 +1784,6 @@ __all__ = [
     "detect_provider_from_raw_bytes_evidence",
     "is_jsonl_source_path",
     "is_stream_record_provider",
-    "parse_drive_payload",
     "parse_payload",
     "parse_stream_payload",
 ]

--- a/polylogue/sources/origin_specs.py
+++ b/polylogue/sources/origin_specs.py
@@ -488,6 +488,41 @@ def _claude_code_spec() -> OriginSpec:
         ),
         artifact_rules=(
             OriginArtifactRule(
+                kind="tool_result_sidecar",
+                # ``hook-*`` files under the same directory are a distinct,
+                # already-tracked capture surface (raw hook stdout,
+                # polylogue-qqyg / #2781) with their own reliable
+                # content-shape detector (``looks_like_hook_event``) --
+                # excluded here so this rule doesn't relabel their already
+                # correct ``HOOK_EVENT`` classification.
+                path_pattern=r"(?:^|/)tool-results/(?!hook-)[^/]+$",
+                parse_policy="raw-only",
+                parser_path=None,
+                coverage_role="tool_result_overflow",
+                fidelity_note=(
+                    "Tool-result overflow content persisted verbatim; never independently parsed -- "
+                    "sources/live/tool_result_sidecars.py joins it to its owning tool_result block by "
+                    "tool_use_id. A tool call's own output can coincidentally reproduce a genuine "
+                    "session-document shape (verified live: a real claude.ai export dumped by a prior "
+                    "tool call), so content heuristics alone cannot refuse this family; this path rule "
+                    "is the only reliable gate (polylogue-omsw)."
+                ),
+                # Deliberately NOT widened to every extension a tool result
+                # can carry (a real corpus scan found genuine ``.txt``/
+                # ``.html`` tool-results content too -- see the sibling
+                # classification test): ``artifact_suffixes_for_provider``
+                # feeds ``live/watcher.py``'s Claude Code ``WatchSource``
+                # acquisition suffix filter directly, so adding a suffix here
+                # would widen what gets *acquired* archive-wide, not merely
+                # what this rule classifies. ``.json`` is the one extension
+                # already inside the acquired/watched set today; the
+                # ``path_pattern`` match above still refuses any other
+                # extension's *content* once a raw row for it exists via
+                # some other acquisition route (zip replay, reindex), since
+                # ``matches()`` doesn't consult ``path_suffixes`` at all.
+                path_suffixes=(".json",),
+            ),
+            OriginArtifactRule(
                 kind="workflow_run_snapshot",
                 path_pattern=r"(?:^|/)workflows/[^/]+\.json$",
                 parse_policy="fact",

--- a/tests/unit/sources/test_artifact_taxonomy.py
+++ b/tests/unit/sources/test_artifact_taxonomy.py
@@ -181,6 +181,50 @@ def test_workflow_run_snapshot_never_classifies_as_session() -> None:
     assert artifact.parse_as_session is False
 
 
+def test_antigravity_brain_metadata_sidecar_never_schema_eligible_or_session() -> None:
+    """Regression pin for polylogue-3m3de: a real ``brain/<uuid>/*.md.metadata
+    .json`` sidecar (content shape verified against this machine's real
+    ``~/.gemini/antigravity/brain`` corpus, 940 files, 0 leaks) must never
+    become a session, AND must never be ``schema_eligible`` -- the latter is
+    what keeps it out of schema-inference sampling
+    (``schemas/sampling_db.py``'s ``_iter_schema_units_from_db`` already
+    excludes any ``classify_artifact_path`` result with
+    ``schema_eligible=False``, which this pins for antigravity specifically).
+
+    polylogue-3m3de's live measurement (232 growing ``raw_sessions`` rows,
+    zero ``.pb`` conversations acquired) is raw-tier acquisition volume --
+    ``source.db`` durably retains every acquired file regardless of
+    classification, by design -- not evidence that this classification gate
+    is missing; this test locks in that the gate itself is intact. The
+    unaddressed half is acquiring the real ``.pb`` conversations at all: the
+    live daemon watcher only watches ``antigravity`` sources for
+    ``.metadata.json`` (``sources/live/watcher.py``), never ``.pb`` -- a
+    separate acquisition-wiring gap, not a classification one, and out of
+    this fix's scope (would need the language-server RPC bridge wired into
+    the live daemon, not merely a classification tightening).
+    """
+    real_metadata: JSONValue = {
+        "artifactType": "ARTIFACT_TYPE_OTHER",
+        "summary": (
+            "Comprehensive audit results addressing: top-up/backfill elimination status, "
+            "DB mode removal evaluation with architectural analysis, Provenance distinction "
+            "justification, environment variable naming compliance check, per-crate "
+            "documentation gaps, and entity resolution verification."
+        ),
+        "updatedAt": "2026-01-07T19:08:15.216541610Z",
+    }
+
+    artifact = classify_artifact(
+        real_metadata,
+        provider="antigravity",
+        source_path="/tmp/.gemini/antigravity/brain/03c22aa3-8b7f-438d-baa8-d12567249cd9/comprehensive_audit.md.metadata.json",
+    )
+
+    assert artifact.kind is ArtifactKind.AGENT_SIDECAR_META
+    assert artifact.parse_as_session is False
+    assert artifact.schema_eligible is False
+
+
 def test_tool_result_sidecar_never_classifies_as_session_even_when_content_looks_like_one() -> None:
     """Regression for polylogue-omsw: a ``tool-results/<name>`` sidecar must
     never become a session regardless of its content, only its path.

--- a/tests/unit/sources/test_artifact_taxonomy.py
+++ b/tests/unit/sources/test_artifact_taxonomy.py
@@ -123,14 +123,16 @@ def test_analysis_signal_duplicate_messages_are_not_a_session() -> None:
 
 
 def test_bare_tool_use_id_record_does_not_classify_as_session() -> None:
-    """Regression for polylogue-9ykn: a record whose only distinguishing
-    field is a ``tool_use_id``-shaped value (the real archive has 3 sessions
-    whose native_id is a bare ``toolu_*`` tool-use id, evidence of a
-    tool-result artifact acquired as an independent session rather than
-    joined as a sidecar -- see the sibling investigation polylogue-omsw for
-    the tool-result-specific acquisition-scope fix). A record with no
-    session/message envelope and no recognized record-ish key must fall
-    through to UNKNOWN, not default into a session.
+    """Regression for polylogue-9ykn (path rule landed for polylogue-omsw,
+    see ``test_tool_result_sidecar_never_classifies_as_session_even_when_
+    content_looks_like_one``): a record whose only distinguishing field is a
+    ``tool_use_id``-shaped value (the real archive has 3 sessions whose
+    native_id is a bare ``toolu_*`` tool-use id, evidence of a tool-result
+    artifact acquired as an independent session rather than joined as a
+    sidecar) must never become a session at a ``tool-results/`` path. Now
+    refused by path (``TOOL_RESULT_SIDECAR``) rather than falling through
+    content heuristics to UNKNOWN/METADATA_DOCUMENT -- the stronger,
+    content-independent guarantee this whole family needed.
     """
     record: JSONValue = {
         "tool_use_id": "toolu_01AbCdEfGhIjKlMnOpQrStUv",
@@ -143,10 +145,7 @@ def test_bare_tool_use_id_record_does_not_classify_as_session() -> None:
         source_path="/tmp/.claude/projects/x/tool-results/toolu_01AbCdEfGhIjKlMnOpQrStUv.json",
     )
 
-    # Falls through the metadata-shaped fallback (a small scalar-valued dict)
-    # rather than UNKNOWN -- either way the invariant that matters holds: it
-    # never becomes a session.
-    assert artifact.kind in (ArtifactKind.UNKNOWN, ArtifactKind.METADATA_DOCUMENT)
+    assert artifact.kind is ArtifactKind.TOOL_RESULT_SIDECAR
     assert artifact.parse_as_session is False
 
 
@@ -179,6 +178,79 @@ def test_workflow_run_snapshot_never_classifies_as_session() -> None:
     )
 
     assert artifact.kind is ArtifactKind.WORKFLOW_RUN_SNAPSHOT
+    assert artifact.parse_as_session is False
+
+
+def test_tool_result_sidecar_never_classifies_as_session_even_when_content_looks_like_one() -> None:
+    """Regression for polylogue-omsw: a ``tool-results/<name>`` sidecar must
+    never become a session regardless of its content, only its path.
+
+    Claude Code persists tool-call-overflow output verbatim to
+    ``<session>/tool-results/<name>.<ext>`` (``sources/live/
+    tool_result_sidecars.py`` joins it back to its owning ``tool_result``
+    block by ``tool_use_id`` -- it is never independent conversation
+    content). Content heuristics alone cannot refuse this family: a tool
+    call's own output can coincidentally reproduce a genuine
+    session-document shape byte-for-byte. This exact reproduction was found
+    live (a real ``~/.claude/projects`` corpus scan, not a hypothetical): a
+    ``tool-results/*.txt`` sidecar whose content was a real claude.ai
+    export document -- some prior turn's tool call had fetched and dumped
+    one -- classified as ``SESSION_DOCUMENT``/``parse_as_session=True``
+    under the pre-fix content-only rules, because it has ``uuid``/
+    ``title``/``messages`` exactly like a genuine claude-ai-export session.
+    """
+    real_export_document: JSONValue = {
+        "uuid": "05c097b4-00f0-4233-a5e4-906f9b204ea3",
+        "title": "Chat",
+        "project": {"uuid": "3fef01aa-8a77-4acb-a9c4-cc73c8f1c7a3", "name": "Some Project"},
+        "created_at": "2026-04-22T16:25:46.401856+00:00",
+        "updated_at": "2026-04-23T17:10:40.966156+00:00",
+        "messages": [
+            {"role": "user", "text": "hello"},
+            {"role": "assistant", "text": "hi there"},
+        ],
+    }
+
+    # Sanity check the premise: this exact content, at a non-sidecar path,
+    # really does classify as a session -- otherwise this test would pass
+    # for the wrong reason.
+    as_ordinary_document = classify_artifact(
+        real_export_document,
+        provider="claude-code",
+        source_path="/tmp/.claude/projects/x/session/some_other_file.json",
+    )
+    assert as_ordinary_document.parse_as_session is True
+
+    artifact = classify_artifact(
+        real_export_document,
+        provider="claude-code",
+        source_path="/tmp/.claude/projects/x/session/tool-results/bvatzjyve.txt",
+    )
+
+    assert artifact.kind is ArtifactKind.TOOL_RESULT_SIDECAR
+    assert artifact.parse_as_session is False
+    assert artifact.schema_eligible is False
+
+
+def test_tool_result_sidecar_hook_file_keeps_hook_event_classification() -> None:
+    """``hook-*`` files under ``tool-results/`` are a distinct, already-
+    tracked capture surface (raw hook stdout, polylogue-qqyg / #2781) with
+    their own reliable content-shape detector -- the new tool-result-sidecar
+    path rule must not shadow that classification."""
+    hook_event: JSONValue = {
+        "event_type": "PostToolUse",
+        "session_id": "session-abc",
+        "timestamp": "2026-08-01T00:00:00Z",
+        "provider": "claude-code",
+    }
+
+    artifact = classify_artifact(
+        hook_event,
+        provider="claude-code",
+        source_path="/tmp/.claude/projects/x/session/tool-results/hook-abc123.json",
+    )
+
+    assert artifact.kind is ArtifactKind.HOOK_EVENT
     assert artifact.parse_as_session is False
 
 

--- a/tests/unit/sources/test_origin_specs.py
+++ b/tests/unit/sources/test_origin_specs.py
@@ -40,6 +40,7 @@ def test_origin_specs_cover_the_public_enum_and_admission_lifecycles() -> None:
 
     assert claude.stream_parser_path is not None
     assert {rule.kind for rule in claude.artifact_rules} == {
+        "tool_result_sidecar",
         "workflow_run_snapshot",
         "workflow_journal",
         "agent_transcript",

--- a/tests/unit/sources/test_source_laws.py
+++ b/tests/unit/sources/test_source_laws.py
@@ -44,7 +44,6 @@ from polylogue.sources.decoders import (
 from polylogue.sources.dispatch import (
     detect_provider,
     merge_parsed_session_chunks,
-    parse_drive_payload,
     parse_payload,
     parse_stream_payload,
 )
@@ -57,7 +56,6 @@ from polylogue.sources.drive.types import DriveFile
 from polylogue.sources.emitter import _SessionEmitter
 from polylogue.sources.parsers import chatgpt as chatgpt_parser
 from polylogue.sources.parsers import claude as claude_parser
-from polylogue.sources.parsers import drive as drive_parser
 from polylogue.sources.parsers.base import ParsedMessage, ParsedSession
 from polylogue.sources.parsers.claude import (
     SessionIndexEntry,
@@ -855,46 +853,6 @@ def test_source_iteration_ignores_stat_failures_for_optional_mtime_contract(
     assert "latest_mtime" not in parsed_cursor
 
 
-@pytest.mark.parametrize(
-    ("provider", "payload", "expected_provider", "expected_count"),
-    [
-        (
-            "drive",
-            {"id": "generic", "messages": [{"id": "m1", "role": "user", "text": "hello"}]},
-            "drive",
-            1,
-        ),
-        (
-            "drive",
-            {
-                "conversation_id": "chatgpt-ish",
-                "id": "chatgpt-ish",
-                "create_time": 1704067200.0,
-                "current_node": "n1",
-                "mapping": {"n1": {"id": "n1", "parent": None, "children": []}},
-            },
-            "chatgpt",
-            1,
-        ),
-        (
-            "gemini",
-            [{"role": "user", "text": "hello"}, {"role": "model", "text": "hi"}],
-            "gemini",
-            1,
-        ),
-    ],
-)
-def test_parse_drive_payload_contract(
-    provider: str,
-    payload: object,
-    expected_provider: str,
-    expected_count: int,
-) -> None:
-    sessions = parse_drive_payload(provider, payload, "fallback")
-    assert len(sessions) >= expected_count
-    assert all(session.source_name == expected_provider for session in sessions)
-
-
 def test_parse_payload_generic_messages_contract(monkeypatch: pytest.MonkeyPatch) -> None:
     sentinel_messages = [_parsed_message("m1", role="user", text="hello")]
 
@@ -1054,52 +1012,6 @@ def test_parse_payload_dispatches_claude_code_messages_and_single_records(monkey
         ([{"type": "user"}, {"type": "assistant"}], "session"),
         ([{"type": "assistant", "message": {"content": "hi"}}], "single"),
     ]
-
-
-def test_parse_drive_payload_recurses_lists_and_detected_payloads(monkeypatch: pytest.MonkeyPatch) -> None:
-    drive_calls: list[tuple[str, object, str]] = []
-    parse_calls: list[tuple[str, object, str]] = []
-
-    def fake_chunked(provider: str, payload: object, fallback_id: str) -> ParsedSession:
-        drive_calls.append((provider, payload, fallback_id))
-        return _parsed_session(
-            source_name=provider,
-            provider_session_id=fallback_id,
-            title=fallback_id,
-            created_at=None,
-            updated_at=None,
-            messages=[],
-        )
-
-    def fake_parse_payload(
-        provider: str,
-        payload: object,
-        fallback_id: str,
-        _depth: int = 0,
-    ) -> list[ParsedSession]:
-        parse_calls.append((provider, payload, fallback_id))
-        return [
-            _parsed_session(
-                source_name=provider,
-                provider_session_id=fallback_id,
-                title=fallback_id,
-                created_at=None,
-                updated_at=None,
-                messages=[],
-            )
-        ]
-
-    monkeypatch.setattr(drive_parser, "parse_chunked_prompt", fake_chunked)
-    monkeypatch.setattr(dispatch_module, "parse_payload", fake_parse_payload)
-    monkeypatch.setattr(dispatch_module, "detect_provider", lambda payload, path=None: Provider.CHATGPT)
-
-    chunked = parse_drive_payload("gemini", [{"role": "user", "text": "hello"}], "chunks")
-    recursive = parse_drive_payload("drive", [{"mapping": {}, "id": "chatgpt-ish"}], "wrapped")
-
-    assert [session.provider_session_id for session in chunked] == ["chunks"]
-    assert drive_calls == [("gemini", {"chunks": [{"role": "user", "text": "hello"}]}, "chunks")]
-    assert [session.provider_session_id for session in recursive] == ["wrapped-0"]
-    assert parse_calls == [("chatgpt", {"mapping": {}, "id": "chatgpt-ish"}, "wrapped-0")]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Closes the source-admission/classification cluster spanning three beads: Claude Code tool-result sidecar admission (polylogue-omsw), Antigravity brain-metadata sidecar admission (polylogue-3m3de), and dead-code removal of `parse_drive_payload` (polylogue-194qk).

## Problem

**polylogue-omsw**: `sources/live/tool_result_sidecars.py` joins Claude Code `tool-results/<tool_use_id>.<ext>` overflow content back to its owning `tool_result` block by `tool_use_id` -- these files are never independent conversation content. Content-shape classification alone cannot refuse them: a tool call's own output can coincidentally reproduce a genuine session-document shape byte-for-byte. Verified live against this machine's real `~/.claude/projects` corpus (12,821 non-hook tool-results files, 411 valid-JSON among them): one `tool-results/*.txt` sidecar whose content was a real claude.ai export document (an earlier turn's tool call had fetched and dumped one) classified as `SESSION_DOCUMENT`/`parse_as_session=True` under the prior content-only rules.

**polylogue-3m3de**: reported 232 growing `raw_sessions` rows for `origin=antigravity-session`, all `brain/<uuid>/*.md.metadata.json` sidecars, zero real `.pb` conversations acquired. Investigation (scanned `classify_artifact`/`classify_artifact_path` against this machine's real `~/.gemini/antigravity/brain` corpus, 940 files): 0 leaks. The existing `AGENT_SIDECAR_META` path rule (polylogue-eo81, #1024/#3441) and `schemas/sampling_db.py`'s `schema_eligible` exclusion already close both downstream harms the bead names (session materialization, schema-inference contamination). The growing raw-row count is `source.db`'s durable raw-tier retention by design, not an admission-scope bug. The real unaddressed gap -- `sources/live/watcher.py`'s antigravity `WatchSource` only watches `.metadata.json`, never `.pb` -- is acquisition/daemon wiring work, explicitly left open per this fix's scope.

**polylogue-194qk**: `sources/dispatch.py:1777-1828`'s `parse_drive_payload` re-implements chunk detection/list recursion the lowering pipeline (`_lower_drive_like_payload` -> `_parse_lowered_spec`) already owns, with zero production callers -- only self-recursion, `__all__`, and a self-validating test pair that exercises the dead function against itself.

## Solution

- Added `tool_result_sidecar` `OriginArtifactRule` (`parse_policy="raw-only"`) to the Claude Code `OriginSpec`, matching `tool-results/<name>` paths (excluding `hook-*`, which keeps its own correct `HOOK_EVENT` content classification) so `classify_artifact`/`classify_artifact_path` refuse session admission by path, before any content heuristic runs -- same shape as the existing `AGENT_SIDECAR_META`/`WORKFLOW_JOURNAL` rules. Added `ArtifactKind.TOOL_RESULT_SIDECAR`. `path_suffixes` scoped to `.json` only (not the `.txt`/`.html` also found live) because `artifact_suffixes_for_provider` feeds `live/watcher.py`'s acquisition suffix filter directly -- widening it would expand what gets *acquired* archive-wide, out of scope.
- Acknowledged the classifier-fingerprint drift gate (`docs/plans/classifier-fingerprints.json`) as `acknowledged_safe`: tightens acceptance only, no reparse needed (existing contaminated rows are the already-planned polylogue-x1gd index rebuild's job).
- Added regression test pinning antigravity brain-metadata classification (no code change needed there -- already correct).
- Deleted `parse_drive_payload` and its self-validating tests/imports.

## Verification

- `devtools test tests/unit/sources/test_artifact_taxonomy.py tests/unit/sources/test_origin_specs.py tests/unit/sources/test_source_laws.py tests/unit/sources/test_dispatch_payloads.py` -> 181 passed, 2 pre-existing failures unrelated to this change (confirmed via isolated diff-based comparison to origin/master: both fail identically before this branch's commits -- a `_detect_provider_from_raw_bytes` monkeypatch-target rename and an unrelated claude-ai zip-entry detection assertion).
- `devtools lab policy classifier-fingerprints` -> "Classifier fingerprint policy intact."
- `devtools render all --check` -> no "out of sync" surfaces.
- `devtools verify --quick` -> exit 0 (format, lint, mypy --strict, render-all-check, schema-versioning, classifier-fingerprints, and other lab policy gates all green).
- Ad hoc live-corpus scans (not committed) against this machine's real `~/.claude/projects` tool-results files (12,821) and `~/.gemini/antigravity/brain` files (940): 0 classification leaks post-fix.

Cleanup of existing contaminated `raw_sessions` rows is explicitly out of scope for both beads (raw-authority path owns it, per this repo's durable-tier policy).

Ref polylogue-omsw, polylogue-3m3de, polylogue-194qk