### PR TITLE
refactor(storage): generate revision_authority CHECK from one enum

### DIFF
--- a/polylogue/archive/revision_authority.py
+++ b/polylogue/archive/revision_authority.py
@@ -8,6 +8,8 @@ from enum import StrEnum
 from hashlib import sha256
 from typing import BinaryIO, Literal
 
+from polylogue.core.enums import PolylogueStrEnum
+
 
 class RawRevisionKind(StrEnum):
     FULL = "full"
@@ -15,7 +17,19 @@ class RawRevisionKind(StrEnum):
     UNKNOWN = "unknown"
 
 
-class RawRevisionAuthority(StrEnum):
+class RawRevisionAuthority(PolylogueStrEnum):
+    """Closed vocabulary for ``revision_authority``/``previous_revision_authority``.
+
+    ``PolylogueStrEnum`` (not a plain ``StrEnum``) so this generates its SQL
+    CHECK via ``archive_tiers/common.py``'s ``check()``/``nullable_check()``
+    at every column sharing the full 3-value domain, instead of each site
+    hand-copying the literal list (polylogue-h57ic). ``raw_session_
+    memberships.revision_authority`` is a genuinely narrower 2-value domain
+    (``ASSERTED`` never applies there) and uses the separate
+    ``ProvenRevisionAuthority`` literal alias in
+    ``storage/sqlite/archive_tiers/types.py`` instead of this enum.
+    """
+
     ASSERTED = "asserted"
     BYTE_PROVEN = "byte_proven"
     QUARANTINED = "quarantined"

--- a/polylogue/storage/sqlite/archive_tiers/source.py
+++ b/polylogue/storage/sqlite/archive_tiers/source.py
@@ -6,8 +6,12 @@ live in index.db and are rebuilt from this tier.
 
 from __future__ import annotations
 
+from typing import get_args
+
+from polylogue.archive.revision_authority import RawRevisionAuthority
 from polylogue.core.enums import ArtifactSupportStatus, Origin, Provider, ValidationMode, ValidationStatus
-from polylogue.storage.sqlite.archive_tiers.common import check, nullable_check
+from polylogue.storage.sqlite.archive_tiers.common import check, literal_check, nullable_check
+from polylogue.storage.sqlite.archive_tiers.types import ProvenRevisionAuthority
 
 SOURCE_SCHEMA_VERSION = 21
 
@@ -42,7 +46,7 @@ CREATE TABLE IF NOT EXISTS raw_sessions (
     ,append_end_offset       INTEGER CHECK(append_end_offset > append_start_offset)
     ,acquisition_generation  INTEGER CHECK(acquisition_generation >= 0)
     ,revision_authority      TEXT NOT NULL DEFAULT 'quarantined'
-        CHECK(revision_authority IN ('asserted', 'byte_proven', 'quarantined'))
+        CHECK ({check("revision_authority", RawRevisionAuthority)})
     ,revision_authority_evidence TEXT
         CHECK(revision_authority_evidence IS NULL OR revision_authority_evidence IN ('live_source_verification_v1'))
 ) STRICT;
@@ -114,8 +118,12 @@ CREATE TABLE IF NOT EXISTS raw_session_memberships (
     message_count           INTEGER NOT NULL CHECK(message_count >= 0),
     predecessor_raw_id      TEXT,
     acquisition_generation  INTEGER NOT NULL DEFAULT 0 CHECK(acquisition_generation >= 0),
+    -- Narrower than every other revision_authority/previous_revision_authority
+    -- column: this value is always an OUTPUT of membership classification
+    -- (revision_governance.py's writeback), which never emits ASSERTED --
+    -- see ProvenRevisionAuthority in archive_tiers/types.py (polylogue-h57ic).
     revision_authority      TEXT NOT NULL DEFAULT 'quarantined'
-        CHECK(revision_authority IN ('byte_proven', 'quarantined')),
+        CHECK ({literal_check("revision_authority", *get_args(ProvenRevisionAuthority))}),
     decision                TEXT CHECK(decision IN (
                                 'applied', 'superseded_equivalent', 'superseded_prefix',
                                 'ambiguous', 'deferred'
@@ -150,7 +158,7 @@ CREATE TABLE IF NOT EXISTS raw_membership_census (
 CREATE TABLE IF NOT EXISTS raw_live_source_reconciliation_receipts (
     raw_id                      TEXT PRIMARY KEY REFERENCES raw_sessions(raw_id) ON DELETE CASCADE,
     verdict                     TEXT NOT NULL CHECK(verdict IN ('exact_match', 'codex_header_strip_match')),
-    previous_revision_authority TEXT NOT NULL CHECK(previous_revision_authority IN ('asserted', 'byte_proven', 'quarantined')),
+    previous_revision_authority TEXT NOT NULL CHECK ({check("previous_revision_authority", RawRevisionAuthority)}),
     source_path                 TEXT NOT NULL,
     blob_hash                   BLOB NOT NULL CHECK(length(blob_hash) = 32),
     blob_size                   INTEGER NOT NULL CHECK(blob_size >= 0),
@@ -176,7 +184,7 @@ CREATE TABLE IF NOT EXISTS raw_membership_writeback_receipts (
     membership_decision         TEXT NOT NULL CHECK(membership_decision IN (
                                     'applied', 'superseded_equivalent', 'superseded_prefix'
                                 )),
-    previous_revision_authority TEXT NOT NULL CHECK(previous_revision_authority IN ('asserted', 'byte_proven', 'quarantined')),
+    previous_revision_authority TEXT NOT NULL CHECK ({check("previous_revision_authority", RawRevisionAuthority)}),
     promoted_at_ms              INTEGER NOT NULL CHECK(promoted_at_ms >= 0),
     tool_version                TEXT NOT NULL,
     backup_manifest_path        TEXT NOT NULL,
@@ -207,7 +215,7 @@ CREATE TABLE IF NOT EXISTS raw_append_chain_backfill_receipts (
     append_start_offset              INTEGER NOT NULL CHECK(append_start_offset >= 0),
     append_end_offset                INTEGER NOT NULL CHECK(append_end_offset > append_start_offset),
     matched_after_codex_header_strip INTEGER NOT NULL CHECK(matched_after_codex_header_strip IN (0, 1)),
-    previous_revision_authority      TEXT NOT NULL CHECK(previous_revision_authority IN ('asserted', 'byte_proven', 'quarantined')),
+    previous_revision_authority      TEXT NOT NULL CHECK ({check("previous_revision_authority", RawRevisionAuthority)}),
     compared_at_ms                    INTEGER NOT NULL CHECK(compared_at_ms >= 0),
     tool_version                      TEXT NOT NULL,
     backup_manifest_path              TEXT NOT NULL,

--- a/polylogue/storage/sqlite/archive_tiers/types.py
+++ b/polylogue/storage/sqlite/archive_tiers/types.py
@@ -28,5 +28,23 @@ class ArchiveTier(StrEnum):
 DelegationMappingState = Literal["resolved", "unresolved", "edge_only", "quarantined"]
 DelegationResultStatus = Literal["ok", "error", "unknown"]
 
+# polylogue-h57ic: raw_session_memberships.revision_authority is a genuinely
+# narrower domain than polylogue.archive.revision_authority.RawRevisionAuthority
+# (asserted/byte_proven/quarantined) used by every other revision_authority /
+# previous_revision_authority column. A membership row's authority is always
+# an OUTPUT of classify_historical_full_revisions/_classify_deduped_nodes
+# (storage/sqlite/archive_tiers/revision_governance.py's membership-decision
+# writeback), which only ever emits BYTE_PROVEN or QUARANTINED -- ASSERTED is
+# an externally-captured claim about a raw's own revision identity and never
+# describes a derived membership-classification verdict. Kept as an explicit,
+# separately-named literal (this module, not the 3-value enum) so the
+# narrowing is visible in code instead of only in the CHECK clause text.
+ProvenRevisionAuthority = Literal["byte_proven", "quarantined"]
 
-__all__ = ["ArchiveTier", "DelegationMappingState", "DelegationResultStatus"]
+
+__all__ = [
+    "ArchiveTier",
+    "DelegationMappingState",
+    "DelegationResultStatus",
+    "ProvenRevisionAuthority",
+]


### PR DESCRIPTION
## Summary

Unify all 8 hand-copied `revision_authority`/`previous_revision_authority` CHECK-constraint sites in `source.db`'s DDL (`polylogue/storage/sqlite/archive_tiers/source.py`) so they generate from one Python vocabulary instead of independently typed literal lists.

## Problem

`polylogue/archive/revision_authority.py`'s `RawRevisionAuthority` (asserted/byte_proven/quarantined) was hand-typed as `CHECK(... IN ('asserted', 'byte_proven', 'quarantined'))` independently at 8 call sites: `raw_sessions.revision_authority`, three receipt tables' `previous_revision_authority` columns, and `raw_session_memberships.revision_authority`. None used the generator-tied `check()`/`nullable_check()` helpers (`archive_tiers/common.py`) even though the enum already existed — `check()` only accepts `PolylogueStrEnum`, and `RawRevisionAuthority` was a plain `StrEnum`, so it was never wired up.

One site, `raw_session_memberships.revision_authority`, silently narrowed the list to 2 values (`byte_proven`, `quarantined`) with no comment or type-level signal explaining the narrower domain — a future edit copy-pasting the 3-value list, as every other site already did, would silently widen this column's accepted domain with nothing but a full-file diff review to catch it.

I traced every write site touching this column (`revision_governance.py`'s membership-classification writeback) and confirmed the narrowing is deliberate, not drift: a membership row's authority is always an *output* of `classify_historical_full_revisions`/`_classify_deduped_nodes`, which only ever emits `BYTE_PROVEN` or `QUARANTINED` — `ASSERTED` describes an externally-captured claim about a raw's own revision identity and never applies to a derived classification verdict.

## Solution

- Promoted `RawRevisionAuthority` to `PolylogueStrEnum` (`polylogue/archive/revision_authority.py`) so the 5 sites sharing the full 3-value domain (`raw_sessions.revision_authority` and the three receipt tables' `previous_revision_authority`) generate their CHECK via `check("...", RawRevisionAuthority)`.
- Added an explicit, separately named `ProvenRevisionAuthority` `Literal` alias (`polylogue/storage/sqlite/archive_tiers/types.py`, same pattern as the existing `DelegationMappingState`/`DelegationResultStatus`) for the genuinely narrower `raw_session_memberships.revision_authority` column, with a comment documenting the classification-writeback invariant that makes the narrowing correct, generated via `literal_check("revision_authority", *get_args(ProvenRevisionAuthority))`.
- No durable migration: verified the generated SQL text is byte-for-byte identical to the prior hand-written CHECK clauses at all 8 sites (same values, same order) — this is a metadata-only DDL-source refactor with no constraint-semantics change, so `SOURCE_SCHEMA_VERSION` stays at 21.

## Verification

- `devtools test polylogue/storage/sqlite/archive_tiers/source.py polylogue/archive/revision_authority.py polylogue/storage/sqlite/archive_tiers/types.py tests/unit/storage/test_raw_revision_authority.py tests/unit/storage/test_durable_migrations.py` — `67 passed`
- `devtools verify --quick` — 24/24 steps passed (ruff format/check, `mypy --strict`, `render all --check`, layering, `lab policy schema-versioning`, schema promotion audit)
- Manual check: built the generated `SOURCE_DDL` in-memory and confirmed the resulting `CHECK` clause text for all 8 sites matches the original hand-written literals exactly (only cosmetic `CHECK (` vs `CHECK(` whitespace differs).

Ref polylogue-h57ic.