### PR TITLE
fix: keep embedding failure ledger row when origin lookup fails

### DIFF
--- a/polylogue/storage/embeddings/materialization.py
+++ b/polylogue/storage/embeddings/materialization.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Protocol, cast
 
 from polylogue.config import load_polylogue_config
+from polylogue.core.enums import Origin
 from polylogue.storage.embeddings.identity import (
     EMBEDDING_DERIVATION_KEY_SQL_FUNCTION,
     EMBEDDING_INPUT_HASH_SQL_FUNCTION,
@@ -1562,32 +1563,43 @@ def embed_archive_session_sync(
     except Exception as exc:
         from polylogue.storage.sqlite.archive_tiers.embedding_write import record_embedding_failure
 
-        origin_row = None
-        with contextlib.suppress(sqlite3.Error):
-            origin_row = index_conn.execute(
-                "SELECT origin FROM sessions WHERE session_id = ?", (session_id,)
-            ).fetchone()
-        if origin_row is not None:
-            if isinstance(exc, _ProviderRequestError):
-                provider = "voyage"
-                error_class = embedding_error_class(exc)
-                retryable = not is_terminal_embedding_provider_error(str(exc))
-            else:
-                provider = "local"
-                error_class = "internal_error"
-                retryable = True
-            record_embedding_failure(
-                embeddings_conn,
-                session_id=session_id,
-                origin=str(origin_row["origin"]),
-                message_refs=attempted_message_refs,
-                provider=provider,
-                model=text_provider.model,
-                error_class=error_class,
-                error_message=str(exc),
-                retryable=retryable,
-                attempt=attempt,
-            )
+        # The failure ledger must never lose a row merely because the origin
+        # lookup itself failed (polylogue-es7b) -- ``session`` already carries
+        # ``origin`` when it was fetched successfully at the top of this
+        # function; only when the failure predates that fetch (or the
+        # connection is otherwise unusable) do we fall back to a fresh,
+        # best-effort re-read, and finally to an explicit unknown sentinel so
+        # ``record_embedding_failure`` is always called.
+        if session is not None:
+            origin_value = str(session["origin"])
+        else:
+            origin_value = str(Origin.UNKNOWN_EXPORT)
+            with contextlib.suppress(sqlite3.Error):
+                origin_row = index_conn.execute(
+                    "SELECT origin FROM sessions WHERE session_id = ?", (session_id,)
+                ).fetchone()
+                if origin_row is not None:
+                    origin_value = str(origin_row["origin"])
+        if isinstance(exc, _ProviderRequestError):
+            provider = "voyage"
+            error_class = embedding_error_class(exc)
+            retryable = not is_terminal_embedding_provider_error(str(exc))
+        else:
+            provider = "local"
+            error_class = "internal_error"
+            retryable = True
+        record_embedding_failure(
+            embeddings_conn,
+            session_id=session_id,
+            origin=origin_value,
+            message_refs=attempted_message_refs,
+            provider=provider,
+            model=text_provider.model,
+            error_class=error_class,
+            error_message=str(exc),
+            retryable=retryable,
+            attempt=attempt,
+        )
         return EmbedSessionOutcome(status="error", session_id=session_id, error=str(exc))
     finally:
         with contextlib.suppress(sqlite3.Error):

--- a/tests/unit/storage/test_embedding_contracts.py
+++ b/tests/unit/storage/test_embedding_contracts.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import sqlite3
 from collections.abc import Callable
 from pathlib import Path
-from typing import TypeAlias
+from typing import Any, TypeAlias, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -1612,3 +1612,72 @@ def test_archive_provider_fault_keeps_provider_attribution(tmp_path: Path) -> No
         conn.close()
     assert recorded_provider == "voyage"
     assert error_class == "provider_http_429"
+
+
+def test_archive_failure_ledger_survives_origin_lookup_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failed origin lookup must degrade the ledger row, never drop it.
+
+    Anti-vacuity: the production handler used to wrap the origin re-read in
+    ``contextlib.suppress(sqlite3.Error)`` and skip ``record_embedding_failure``
+    entirely when that lookup raised, so a session that fails before ``session``
+    is ever fetched (e.g. the sqlite-vec load check) left no forensic trace at
+    all beyond an aggregate error count (polylogue-es7b). Forcing that early
+    failure plus a raising origin SELECT reproduces the drop; the fix must
+    still land a row, falling back to an explicit unknown-origin sentinel.
+    """
+    from polylogue.storage.sqlite import sqlite_vec_extension as sqlite_vec_extension_module
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+    from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+    archive_root = tmp_path / "archive"
+    session_id = _write_archive_session(archive_root, native_id="embed-origin-lookup-fault", embeddable=True)
+    index_db = archive_root / "index.db"
+    embeddings_db = archive_root / "embeddings.db"
+    initialize_archive_database(embeddings_db, ArchiveTier.EMBEDDINGS)
+
+    def _fail_vec_load(conn: sqlite3.Connection) -> tuple[bool, Exception | None]:
+        # Raise before `session` is ever fetched, so the except-handler must
+        # take the origin-unknown fallback path rather than the already
+        # -fetched `session["origin"]` fast path.
+        return False, RuntimeError("sqlite-vec unavailable")
+
+    monkeypatch.setattr(sqlite_vec_extension_module, "try_load_sqlite_vec", _fail_vec_load)
+
+    # sqlite3.Connection is a builtin type and doesn't accept monkeypatched
+    # instance/class attributes, so route the index-db connection through a
+    # `factory=` subclass whose `execute` raises for the specific origin
+    # lookup, leaving every other query (including the embeddings.db
+    # connection opened by the same call site) untouched.
+    class _FlakyConnection(sqlite3.Connection):
+        def execute(self, sql: str, parameters: Any = (), /) -> sqlite3.Cursor:
+            if "SELECT origin FROM sessions" in sql:
+                raise sqlite3.OperationalError("simulated origin lookup failure")
+            return super().execute(sql, parameters)
+
+    real_connect = sqlite3.connect
+    index_db_marker = str(index_db)
+
+    def _patched_connect(database: Any, *args: Any, **kwargs: Any) -> sqlite3.Connection:
+        if index_db_marker in str(database):
+            kwargs["factory"] = _FlakyConnection
+        return cast(sqlite3.Connection, real_connect(database, *args, **kwargs))
+
+    monkeypatch.setattr(sqlite3, "connect", _patched_connect)
+
+    outcome = embed_archive_session_sync(index_db, _FakeV1VectorProvider(), session_id)
+    assert outcome.status == "error"
+
+    monkeypatch.undo()
+    conn = sqlite3.connect(embeddings_db)
+    try:
+        row = conn.execute(
+            "SELECT origin, error_class, error_message FROM embedding_failures WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None, "origin-lookup failure must not silently drop the ledger row"
+    origin, error_class, error_message = row
+    assert origin == "unknown-export"
+    assert error_class == "internal_error"
+    assert "sqlite-vec" in error_message


### PR DESCRIPTION
## Summary
Fixes a silent-drop bug in the archive embedding failure ledger: when the fallback origin lookup in `embed_archive_session_sync`'s exception handler itself failed, the entire ledger row was skipped instead of just degrading gracefully.

## Problem
Silent-degradation audit (polylogue-es7b) found that `storage/embeddings/materialization.py`'s exception handler wrapped the origin re-read (`SELECT origin FROM sessions WHERE session_id = ?`) in `contextlib.suppress(sqlite3.Error)`, and only called `record_embedding_failure()` when that lookup succeeded. If the lookup itself raised, the per-session failure (message refs, provider, error class/message, retryable state) was dropped entirely — only the aggregate error count in `embedding_catchup_runs` survived, leaving nothing to diagnose which session failed or why.

## Solution
`polylogue/storage/embeddings/materialization.py`:
- Reuse the `origin` already present on the `session` row fetched earlier in the same function whenever it's available (the common case — this also removes a redundant re-query for every recorded failure).
- Fall back to a best-effort re-read from `index_conn` only when the failure predates that fetch (e.g. the sqlite-vec load check raising before `session` is assigned).
- Fall back further to `Origin.UNKNOWN_EXPORT` ("unknown-export") when even that re-read fails, so `record_embedding_failure` is now called unconditionally — the ledger row is always written.

No schema change: `embedding_failures.origin` is a plain `TEXT` column with no CHECK constraint, so the `unknown-export` sentinel is a valid value already.

## Verification
- `devtools test tests/unit/storage/test_embedding_contracts.py` — 40 passed.
- New regression test `test_archive_failure_ledger_survives_origin_lookup_failure` forces the sqlite-vec load check to fail before `session` is fetched, and makes the origin `SELECT` itself raise via a `factory=`-based flaky connection subclass (sqlite3.Connection doesn't support monkeypatching directly). Confirmed red against the pre-fix handler (`assert None is not None` — no ledger row at all) and green against the fix (`origin="unknown-export"`, `error_class="internal_error"`).
- `devtools verify --quick` — 23/23 steps passed (ruff format/check, mypy --strict, render all --check, layering/closure/manifest/lab-policy gates), both pre-push and standalone.

## Scope
This addresses part (a) of polylogue-es7b (the embedding-failure ledger drop specifically). The bead's other findings are separate call sites left untouched, out of scope for this conservative P3 fix:
- (b)/(c): detached background-writer exception/hang handling in `daemon/write_coordinator.py`.
- (d): the missing-sibling-`source.db` warning gap in `schemas/sampling_db.py`.

Ref polylogue-es7b