### PR TITLE
fix: generator-tie the two raw-revision decision vocabularies

### DIFF
--- a/polylogue/archive/revision_replay.py
+++ b/polylogue/archive/revision_replay.py
@@ -3,12 +3,21 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import StrEnum
 
 from polylogue.archive.revision_authority import RawRevisionAuthority, RawRevisionKind
+from polylogue.core.enums import PolylogueStrEnum
 
 
-class ApplicationDecision(StrEnum):
+class ApplicationDecision(PolylogueStrEnum):
+    """Closed vocabulary for ``raw_revision_applications.decision`` (index.db).
+
+    The replay-time outcome recorded when a raw revision is applied against
+    a logical source's replay plan. Distinct from :class:`polylogue.archive.
+    session_revision_membership.MembershipDecision` (the source-tier
+    membership-classification verdict for the same underlying event) --
+    kept separate rather than merged; see polylogue-z22ml.
+    """
+
     SELECTED_BASELINE = "selected_baseline"
     APPLIED_APPEND = "applied_append"
     SUPERSEDED = "superseded"

--- a/polylogue/archive/session_revision_membership.py
+++ b/polylogue/archive/session_revision_membership.py
@@ -5,8 +5,29 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal, TypeAlias
 
+from polylogue.core.enums import PolylogueStrEnum
 from polylogue.core.timestamps import parse_timestamp
 from polylogue.pipeline.ids import SessionRevisionProjection
+
+
+class MembershipDecision(PolylogueStrEnum):
+    """Closed vocabulary for ``raw_session_memberships.decision`` (source.db).
+
+    The membership-classification pipeline's own verdict on a raw revision's
+    fate within its logical-source cohort, persisted in the durable source
+    tier. Distinct from :class:`polylogue.archive.revision_replay.
+    ApplicationDecision` (the index-tier replay outcome for the same
+    underlying event) -- the two vocabularies model related but genuinely
+    different axes (pipeline verdict vs. replay-time application) and are
+    kept separate rather than merged; see polylogue-z22ml.
+    """
+
+    APPLIED = "applied"
+    SUPERSEDED_EQUIVALENT = "superseded_equivalent"
+    SUPERSEDED_PREFIX = "superseded_prefix"
+    AMBIGUOUS = "ambiguous"
+    DEFERRED = "deferred"
+
 
 #: One content axis's relation between two revisions: total and decidable,
 #: no residual category (polylogue-aggz). ``equal`` is the same identity set
@@ -464,4 +485,9 @@ def _browser_snapshot_dominates(older: MembershipRevision, newer: MembershipRevi
     )
 
 
-__all__ = ["MembershipClassification", "MembershipRevision", "classify_membership_revisions"]
+__all__ = [
+    "MembershipClassification",
+    "MembershipDecision",
+    "MembershipRevision",
+    "classify_membership_revisions",
+]

--- a/polylogue/storage/raw_authority.py
+++ b/polylogue/storage/raw_authority.py
@@ -18,6 +18,8 @@ from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 
+from polylogue.archive.revision_replay import ApplicationDecision
+from polylogue.archive.session_revision_membership import MembershipDecision
 from polylogue.core.json import JSONDocument, json_document
 from polylogue.logging import get_logger
 from polylogue.storage.archive_identity import ArchiveLocation
@@ -1309,10 +1311,18 @@ def validate_raw_replay_application_receipt(
     observed_memberships = {(str(row.get("raw_id")), str(row.get("logical_source_key"))) for row in membership_rows}
     if observed_memberships != expected_memberships:
         problems.append("membership receipt pairs do not match the immutable authority witness")
-    terminal_membership_decisions = {"applied", "superseded_equivalent", "superseded_prefix"}
+    terminal_membership_decisions = {
+        MembershipDecision.APPLIED,
+        MembershipDecision.SUPERSEDED_EQUIVALENT,
+        MembershipDecision.SUPERSEDED_PREFIX,
+    }
     if any(row.get("decision") not in terminal_membership_decisions for row in membership_rows):
         problems.append("membership receipt contains a non-terminal decision")
-    terminal_application_decisions = {"selected_baseline", "applied_append", "superseded"}
+    terminal_application_decisions = {
+        ApplicationDecision.SELECTED_BASELINE,
+        ApplicationDecision.APPLIED_APPEND,
+        ApplicationDecision.SUPERSEDED,
+    }
     application_pairs = {(str(row.get("raw_id")), str(row.get("logical_source_key"))) for row in application_rows}
     if any(row.get("decision") not in terminal_application_decisions for row in application_rows):
         problems.append("application receipt contains a non-terminal decision")

--- a/polylogue/storage/raw_membership_writeback.py
+++ b/polylogue/storage/raw_membership_writeback.py
@@ -21,13 +21,22 @@ from __future__ import annotations
 import sqlite3
 from dataclasses import dataclass
 
+from polylogue.archive.session_revision_membership import MembershipDecision
+
 #: The only membership decisions this write-back ever acts on. Every one of
 #: these means the membership pipeline already established this raw's
 #: content is either the accepted revision or a proven-superseded prior
 #: revision of it -- never ``ambiguous`` (a real, unresolved conflict) or
 #: ``deferred`` (not yet decided) or ``NULL`` (no membership evidence at all,
-#: see item 3 / append-chain backfill for that population instead).
-WRITE_BACK_DECISIONS: tuple[str, ...] = ("applied", "superseded_equivalent", "superseded_prefix")
+#: see item 3 / append-chain backfill for that population instead). Tied to
+#: :class:`MembershipDecision` (polylogue-z22ml) rather than hand-typed, so
+#: this can no longer silently drift from the enum or the CHECK constraints
+#: generated from it.
+WRITE_BACK_DECISIONS: tuple[str, ...] = (
+    MembershipDecision.APPLIED,
+    MembershipDecision.SUPERSEDED_EQUIVALENT,
+    MembershipDecision.SUPERSEDED_PREFIX,
+)
 
 #: SQLite ``CASE`` ordering matching the report's own precedence when a raw
 #: has more than one membership row (rare: a retired-sibling reparse under a
@@ -35,9 +44,9 @@ WRITE_BACK_DECISIONS: tuple[str, ...] = ("applied", "superseded_equivalent", "su
 #: Prefer the strongest, most-specific decision deterministically.
 _DECISION_PRECEDENCE_SQL = (
     "CASE m.decision "
-    "WHEN 'applied' THEN 0 "
-    "WHEN 'superseded_equivalent' THEN 1 "
-    "WHEN 'superseded_prefix' THEN 2 "
+    f"WHEN '{MembershipDecision.APPLIED}' THEN 0 "
+    f"WHEN '{MembershipDecision.SUPERSEDED_EQUIVALENT}' THEN 1 "
+    f"WHEN '{MembershipDecision.SUPERSEDED_PREFIX}' THEN 2 "
     "ELSE 3 END"
 )
 
@@ -49,7 +58,7 @@ class WriteBackCandidate:
     raw_id: str
     logical_source_key: str
     provider_session_id: str
-    decision: str
+    decision: MembershipDecision
     blob_size: int
 
 
@@ -104,7 +113,7 @@ def plan_raw_membership_writeback(conn: sqlite3.Connection, *, limit: int | None
             raw_id=str(raw_id),
             logical_source_key=str(logical_source_key),
             provider_session_id=str(provider_session_id),
-            decision=str(decision),
+            decision=MembershipDecision(str(decision)),
             blob_size=int(blob_size),
         )
         for raw_id, logical_source_key, provider_session_id, decision, blob_size in rows

--- a/polylogue/storage/sqlite/archive_tiers/index.py
+++ b/polylogue/storage/sqlite/archive_tiers/index.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import get_args
 
+from polylogue.archive.revision_replay import ApplicationDecision
 from polylogue.core.enums import (
     BlockType,
     BranchType,
@@ -368,10 +369,7 @@ CREATE TABLE IF NOT EXISTS raw_revision_applications (
     logical_source_key       TEXT NOT NULL,
     source_revision          TEXT NOT NULL,
     acquisition_generation  INTEGER NOT NULL CHECK(acquisition_generation >= 0),
-    decision                 TEXT NOT NULL CHECK(decision IN (
-                                 'selected_baseline', 'applied_append', 'superseded',
-                                 'ambiguous', 'deferred'
-                             )),
+    decision                 TEXT NOT NULL CHECK ({check("decision", ApplicationDecision)}),
     accepted_raw_id          TEXT,
     accepted_source_revision TEXT,
     accepted_content_hash    BLOB CHECK(

--- a/polylogue/storage/sqlite/archive_tiers/revision_governance.py
+++ b/polylogue/storage/sqlite/archive_tiers/revision_governance.py
@@ -117,7 +117,7 @@ from polylogue.archive.revision_replay import (
     RevisionReplayPlan,
     plan_revision_replay,
 )
-from polylogue.archive.session_revision_membership import MembershipClassification
+from polylogue.archive.session_revision_membership import MembershipClassification, MembershipDecision
 from polylogue.core.enums import Origin, Provider
 from polylogue.core.sources import origin_from_provider, provider_from_origin
 from polylogue.pipeline.ids import SessionRevisionProjection, session_content_hash, session_revision_projection
@@ -2248,6 +2248,26 @@ def apply_raw_revision_replay(
     return session_id, plan.accepted_raw_ids
 
 
+def _application_decision_for(decision: MembershipDecision) -> ApplicationDecision:
+    """Translate a source-tier membership verdict into an index-tier replay decision.
+
+    ``MembershipDecision`` (source.db, written by the membership-
+    classification pipeline) and ``ApplicationDecision`` (index.db, written
+    by replay) model the same underlying event -- a raw revision's fate
+    within its logical-source cohort -- at two different tiers with two
+    different, non-superset vocabularies; see both enums' docstrings and
+    polylogue-z22ml for why they stay distinct rather than collapsing to
+    one. This is the sole typed translation point between them, replacing a
+    prior comment-only, string-``startswith``-based mapping with no
+    compiler signal if either vocabulary changed.
+    """
+    if decision is MembershipDecision.AMBIGUOUS:
+        return ApplicationDecision.AMBIGUOUS
+    if decision in (MembershipDecision.SUPERSEDED_EQUIVALENT, MembershipDecision.SUPERSEDED_PREFIX):
+        return ApplicationDecision.SUPERSEDED
+    return ApplicationDecision.SELECTED_BASELINE
+
+
 def apply_raw_membership_classification(
     store: RawRevisionGovernanceHost,
     logical_source_key: str,
@@ -2279,7 +2299,9 @@ def apply_raw_membership_classification(
     """
     conn = store._ensure_source_conn()
     decided_at_ms = int(datetime.now(UTC).timestamp() * 1000)
-    decisions: dict[str, str] = dict.fromkeys(classification.ambiguous_raw_ids, "ambiguous")
+    decisions: dict[str, MembershipDecision] = dict.fromkeys(
+        classification.ambiguous_raw_ids, MembershipDecision.AMBIGUOUS
+    )
     # "superseded_equivalent" asserts an accepted chain superseded the
     # member. With no accepted head, equivalence collapses back into the
     # unresolved cohort: labeling it superseded (and, downstream,
@@ -2289,11 +2311,13 @@ def apply_raw_membership_classification(
     decisions.update(
         dict.fromkeys(
             classification.equivalent_raw_ids,
-            "superseded_equivalent" if classification.accepted_raw_ids else "ambiguous",
+            MembershipDecision.SUPERSEDED_EQUIVALENT
+            if classification.accepted_raw_ids
+            else MembershipDecision.AMBIGUOUS,
         )
     )
     for raw_id in classification.accepted_raw_ids[:-1]:
-        decisions[raw_id] = "superseded_prefix"
+        decisions[raw_id] = MembershipDecision.SUPERSEDED_PREFIX
     session_id: str | None = None
     # Ambiguous evidence is debt, not deletion authority. A later branch
     # must not erase the last accepted session/head; a cold rebuild simply
@@ -2500,7 +2524,7 @@ def apply_raw_membership_classification(
                 )
                 for generation, raw_id in enumerate(cohort_raw_ids):
                     projection = projections_by_raw_id[raw_id]
-                    decisions[raw_id] = "superseded_equivalent"
+                    decisions[raw_id] = MembershipDecision.SUPERSEDED_EQUIVALENT
                     record_revision_application_sync(
                         store._conn,
                         RevisionApplicationReceipt(
@@ -2572,7 +2596,8 @@ def apply_raw_membership_classification(
                 )
                 for generation, raw_id in enumerate(cohort_raw_ids):
                     projection = projections_by_raw_id[raw_id]
-                    decision = decisions.get(raw_id, "applied")
+                    decision = decisions.get(raw_id, MembershipDecision.APPLIED)
+                    is_ambiguous = decision is MembershipDecision.AMBIGUOUS
                     record_revision_application_sync(
                         store._conn,
                         RevisionApplicationReceipt(
@@ -2581,26 +2606,20 @@ def apply_raw_membership_classification(
                             logical_source_key=logical_source_key,
                             source_revision=projection.session_hash.hex(),
                             acquisition_generation=generation,
-                            decision=(
-                                ApplicationDecision.AMBIGUOUS
-                                if decision == "ambiguous"
-                                else ApplicationDecision.SUPERSEDED
-                                if decision.startswith("superseded")
-                                else ApplicationDecision.SELECTED_BASELINE
-                            ),
-                            accepted_raw_id=accepted_raw_id if decision != "ambiguous" else None,
+                            decision=_application_decision_for(decision),
+                            accepted_raw_id=accepted_raw_id if not is_ambiguous else None,
                             accepted_source_revision=(
-                                accepted_projection.session_hash.hex() if decision != "ambiguous" else None
+                                accepted_projection.session_hash.hex() if not is_ambiguous else None
                             ),
-                            accepted_content_hash=stored[0] if decision != "ambiguous" else None,
-                            accepted_frontier_kind="semantic" if decision != "ambiguous" else None,
-                            accepted_frontier=semantic_frontier if decision != "ambiguous" else None,
+                            accepted_content_hash=stored[0] if not is_ambiguous else None,
+                            accepted_frontier_kind="semantic" if not is_ambiguous else None,
+                            accepted_frontier=semantic_frontier if not is_ambiguous else None,
                             detail=f"membership:{decision}",
                         ),
                         decided_at_ms=decided_at_ms,
                     )
         if yield_to_head_raw_id is None:
-            decisions[accepted_raw_id] = "applied"
+            decisions[accepted_raw_id] = MembershipDecision.APPLIED
 
     with conn if manage_transaction else nullcontext():
         for raw_id, decision in decisions.items():
@@ -2615,7 +2634,9 @@ def apply_raw_membership_classification(
                 (
                     decision,
                     decided_at_ms,
-                    "quarantined" if decision in {"ambiguous", "deferred"} else "byte_proven",
+                    "quarantined"
+                    if decision in {MembershipDecision.AMBIGUOUS, MembershipDecision.DEFERRED}
+                    else "byte_proven",
                     classification.accepted_raw_ids.index(raw_id) if raw_id in classification.accepted_raw_ids else 0,
                     raw_id,
                     logical_source_key,

--- a/polylogue/storage/sqlite/archive_tiers/source.py
+++ b/polylogue/storage/sqlite/archive_tiers/source.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import get_args
 
 from polylogue.archive.revision_authority import RawRevisionAuthority
+from polylogue.archive.session_revision_membership import MembershipDecision
 from polylogue.core.enums import ArtifactSupportStatus, Origin, Provider, ValidationMode, ValidationStatus
 from polylogue.storage.sqlite.archive_tiers.common import check, literal_check, nullable_check
 from polylogue.storage.sqlite.archive_tiers.types import ProvenRevisionAuthority
@@ -124,10 +125,7 @@ CREATE TABLE IF NOT EXISTS raw_session_memberships (
     -- see ProvenRevisionAuthority in archive_tiers/types.py (polylogue-h57ic).
     revision_authority      TEXT NOT NULL DEFAULT 'quarantined'
         CHECK ({literal_check("revision_authority", *get_args(ProvenRevisionAuthority))}),
-    decision                TEXT CHECK(decision IN (
-                                'applied', 'superseded_equivalent', 'superseded_prefix',
-                                'ambiguous', 'deferred'
-                            )),
+    decision                TEXT CHECK ({nullable_check("decision", MembershipDecision)}),
     decided_at_ms           INTEGER CHECK(decided_at_ms >= 0),
     PRIMARY KEY(raw_id, logical_source_key),
     CHECK((decision IS NULL) = (decided_at_ms IS NULL))
@@ -181,9 +179,14 @@ CREATE TABLE IF NOT EXISTS raw_membership_writeback_receipts (
     raw_id                      TEXT PRIMARY KEY REFERENCES raw_sessions(raw_id) ON DELETE CASCADE,
     logical_source_key          TEXT NOT NULL,
     provider_session_id         TEXT NOT NULL,
-    membership_decision         TEXT NOT NULL CHECK(membership_decision IN (
-                                    'applied', 'superseded_equivalent', 'superseded_prefix'
-                                )),
+    membership_decision         TEXT NOT NULL CHECK ({
+    literal_check(
+        "membership_decision",
+        MembershipDecision.APPLIED,
+        MembershipDecision.SUPERSEDED_EQUIVALENT,
+        MembershipDecision.SUPERSEDED_PREFIX,
+    )
+}),
     previous_revision_authority TEXT NOT NULL CHECK ({check("previous_revision_authority", RawRevisionAuthority)}),
     promoted_at_ms              INTEGER NOT NULL CHECK(promoted_at_ms >= 0),
     tool_version                TEXT NOT NULL,


### PR DESCRIPTION
## Summary

Ties both hand-typed raw-revision "decision" CHECK constraint vocabularies (source.db `raw_session_memberships.decision` and index.db `raw_revision_applications.decision`) to Python enums via `check()`/`literal_check()`, and replaces a comment-only, string-prefix-matching translation between them with a typed function.

## Problem

`raw_session_memberships.decision` (source.db, durable tier) and `raw_revision_applications.decision` (index.db, rebuildable tier) each had a hand-written `CHECK(decision IN (...))` list, neither generated from a shared Python enum. A third hand-typed subset existed on `raw_membership_writeback_receipts.membership_decision` (3 of the 5 source-tier values). The cross-vocabulary translation in `apply_raw_membership_classification` (`revision_governance.py`) was a comment-only `decision.startswith("superseded")` string match. None of these four spots had any compiler/schema signal that the others needed a matching update if a value was added, renamed, or typo'd.

## Solution

- Added `MembershipDecision(PolylogueStrEnum)` beside `MembershipClassification` in `polylogue/archive/session_revision_membership.py` for the source-tier vocabulary (`applied` / `superseded_equivalent` / `superseded_prefix` / `ambiguous` / `deferred`).
- Promoted `ApplicationDecision` (`polylogue/archive/revision_replay.py`) from a plain `StrEnum` to `PolylogueStrEnum` for the index-tier vocabulary (`selected_baseline` / `applied_append` / `superseded` / `ambiguous` / `deferred`).
- `raw_session_memberships.decision`'s CHECK now renders via `nullable_check("decision", MembershipDecision)`; `raw_revision_applications.decision`'s via `check("decision", ApplicationDecision)`; `raw_membership_writeback_receipts.membership_decision`'s 3-value subset via `literal_check(...)` against the same enum members. Verified all three render byte-identical SQL to the prior hand-typed lists.
- Replaced the string-`startswith` translation with a typed `_application_decision_for(MembershipDecision) -> ApplicationDecision` function in `revision_governance.py`.
- Updated the writer (`revision_governance.py`), the write-back plan (`raw_membership_writeback.py`, including `WRITE_BACK_DECISIONS` and the SQL CASE precedence), and the replay-plan verification sets (`raw_authority.py`) to use the enums instead of bare strings throughout.

The two vocabularies are kept **distinct**, not merged: they model related but genuinely different axes (source-tier membership-pipeline verdict vs. index-tier replay outcome) — matching the finding's own suggested resolution.

### Handoff note re: polylogue-w6hql

polylogue-w6hql (raw-authority verdict collapse for the separate 6-table blocker/census cluster, `RawAuthorityVerdict`) targets a different axis entirely and has no scope overlap with this change — its own notes already record this distinction, so nothing further to hand off there.

## Verification

- `devtools test tests/unit/archive/test_session_revision_membership.py tests/unit/storage/test_revision_replay.py tests/unit/storage/test_revision_application.py tests/unit/maintenance/test_raw_membership_writeback_apply.py tests/unit/storage/test_raw_authority_ledger.py tests/unit/storage/test_raw_authority_verdict_projection.py tests/unit/archive/test_raw_authority_verdict.py` — `139 passed`
- `devtools verify --quick` — `exit_code: 0` (ruff format/check, mypy --strict, render all --check, all lab-policy checks including schema-versioning)
- Direct DDL round-trip check (fresh in-memory sqlite, `SOURCE_DDL` + `INDEX_DDL`) confirmed the generated CHECK constraints for `raw_session_memberships.decision`, `raw_revision_applications.decision`, and `raw_membership_writeback_receipts.membership_decision` are byte-identical to the prior hand-typed lists.

Ref polylogue-z22ml