### PR TITLE
chore(agents): make the verify-timeout rule mechanical, not prose

### DIFF
--- a/.claude/agents/lane.md
+++ b/.claude/agents/lane.md
@@ -61,10 +61,23 @@ by construction.
 
 ## Verification
 
+- **Every `devtools test`/`devtools verify`/build invocation MUST pass an
+  explicit `timeout` of `600000` (600s) on the Bash tool call.** The
+  harness's Bash default (2 minutes) is shorter than these commands
+  routinely take under fleet contention; when a command exceeds the default
+  it gets silently auto-backgrounded, and the failure mode every lane hits
+  is then idle-waiting on that background task instead of continuing. Fix
+  it at the call site — pass the long timeout up front — rather than
+  discovering the backgrounding after the fact. This is not optional
+  guidance, it is the mechanical fix for a bug that has independently hit
+  this fleet 3+ times.
 - Inner loop: `devtools test <files>` (or `devtools test -k <expr>`) against
   the exact files/behavior you changed. Do not run whole test directories or
   blanket `pytest tests/unit` — that reruns tests your change never touched
-  and burns minutes for no signal.
+  and burns minutes for no signal. Verify your `-k`/file selector actually
+  matches tests before trusting a green/red result — pytest exits 5 ("no
+  tests ran") on a selector typo or wrong filename, which is easy to
+  mistake for "nothing to check" instead of "the check never ran".
 - Before finishing: `devtools verify --quick` (format + lint + mypy +
   `render all --check`) is the fast repo gate and must pass. Note that
   `render all --check` can print per-surface `sync OK` and still exit 1 —


### PR DESCRIPTION
## Summary
Strengthens `.claude/agents/lane.md`'s verify-timeout guidance from prose to a mechanical requirement.

## Problem
Lanes have idle-waited on auto-backgrounded `devtools verify`/`devtools test` runs 3+ times across this fleet despite an existing prose warning in lane.md. The harness backgrounds any Bash call exceeding its 2-minute default, which routinely happens under fleet contention; the fix is to always pass an explicit long timeout, not to remember not to background.

## Solution
Adds an explicit `timeout: 600000` requirement as the first bullet under Verification, plus a note on the pytest exit-5 "no tests ran" selector-typo trap (hit once this session when a merge-gate receipt was recorded against a nonexistent test file/filter).

## Verification
Markdown-only change to an agent-definition file; no code/test surface affected.