### PR TITLE
fix(daemon): classify genuine convergence-debt deferrals as deferred

### DIFF
--- a/docs/plans/layering-surface-baseline.json
+++ b/docs/plans/layering-surface-baseline.json
@@ -722,6 +722,11 @@
   {
     "target": "polylogue/daemon",
     "file": "polylogue/daemon/cli.py",
+    "import": "polylogue.sources.live.convergence_debt"
+  },
+  {
+    "target": "polylogue/daemon",
+    "file": "polylogue/daemon/cli.py",
     "import": "polylogue.sources.live.cursor"
   },
   {

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -1679,6 +1679,7 @@ def _drain_convergence_debt_once(db: Path, *, limit: int = 100) -> int:
     """
     from polylogue.daemon.convergence import DaemonConverger
     from polylogue.daemon.convergence_stages import make_default_convergence_stages
+    from polylogue.sources.live.convergence_debt import is_deferred_stage_state
     from polylogue.sources.live.cursor import CursorStore
 
     cursor = CursorStore(db)
@@ -1766,6 +1767,8 @@ def _drain_convergence_debt_once(db: Path, *, limit: int = 100) -> int:
 
         last_error = getattr(state, "last_error", None)
         retry_error = last_error if isinstance(last_error, str) and last_error else "retry did not converge"
+        stages_map = getattr(state, "stages", None)
+        stages_map = stages_map if isinstance(stages_map, dict) else {}
         if debt.stage != "convergence":
             cursor.record_convergence_debt(
                 stage=debt.stage,
@@ -1773,13 +1776,14 @@ def _drain_convergence_debt_once(db: Path, *, limit: int = 100) -> int:
                 subject_id=debt.subject_id,
                 error=retry_error,
                 materializer_version=debt.materializer_version,
+                deferred=is_deferred_stage_state(stages_map.get(debt.stage)),
             )
             continue
 
         # Generic rows predate stage-scoped retry identity. Preserve the old
         # migration behavior by replacing only that generic row with the exact
         # stages that remain pending; other stage rows for the subject survive.
-        failed_stages = _failed_convergence_stage_names(getattr(state, "stages", {})) or ("convergence",)
+        failed_stages = _failed_convergence_stage_names(stages_map) or ("convergence",)
         cursor.clear_convergence_debt(
             stage=debt.stage,
             subject_type=debt.subject_type,
@@ -1792,6 +1796,7 @@ def _drain_convergence_debt_once(db: Path, *, limit: int = 100) -> int:
                 subject_id=debt.subject_id,
                 error=retry_error,
                 materializer_version=debt.materializer_version,
+                deferred=is_deferred_stage_state(stages_map.get(stage)),
             )
     return retried
 

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -2307,6 +2307,7 @@ class LiveBatchProcessor:
                                     subject_type="session_id",
                                     subject_id=session_id,
                                     error="live full ingest deferred FTS to preserve writer availability",
+                                    deferred=True,
                                 )
                                 record_session_ids.append(session_id)
                                 record_session_count = 1
@@ -2631,6 +2632,7 @@ class LiveBatchProcessor:
                     subject_type="session_id",
                     subject_id=membership_session_id,
                     error="live membership ingest deferred FTS to preserve writer availability",
+                    deferred=True,
                 )
                 session_count += 1
                 message_count += len(member_sessions[classification.accepted_raw_ids[-1]].messages)

--- a/polylogue/sources/live/convergence_debt.py
+++ b/polylogue/sources/live/convergence_debt.py
@@ -12,6 +12,12 @@ class ConvergenceDebt:
     path: Path
     stage: str
     error: str | None = None
+    # True when this row reflects a stage's deliberate bounded-backpressure
+    # deferral (``ConvergenceStage.false_means_pending``, e.g. "insights
+    # deferred until quiet") rather than a genuine check/execute failure.
+    # Drives ``convergence_debt.status`` ("deferred" vs "failed") so daemon
+    # health/alerting doesn't mistake normal backpressure for breakage.
+    deferred: bool = False
 
 
 def debt_by_path(debts: Iterable[ConvergenceDebt]) -> dict[Path, tuple[ConvergenceDebt, ...]]:
@@ -38,6 +44,23 @@ def convergence_debt_from_states(paths: Iterable[Path], states: object) -> list[
     return debt
 
 
+def stage_state_value(value: object) -> str:
+    """Normalize a ``StageState`` (or its plain string mirror) to its value."""
+    return str(getattr(value, "value", value))
+
+
+def is_deferred_stage_state(value: object) -> bool:
+    """Return whether ``value`` reflects a deliberate backpressure deferral.
+
+    ``StageState.PENDING`` (``daemon/convergence.py``) is set only for two
+    non-failure reasons: a ``false_means_pending`` stage returned ``False``
+    after doing bounded successful work, or a downstream stage is queued
+    behind an unfinished barrier stage. Neither is an error, so debt rows
+    carrying this state should read as "deferred", not "failed".
+    """
+    return stage_state_value(value) == "pending"
+
+
 def convergence_debt_from_state(path: Path, state: object) -> list[ConvergenceDebt]:
     stages = getattr(state, "stages", None)
     last_error = getattr(state, "last_error", None)
@@ -45,7 +68,7 @@ def convergence_debt_from_state(path: Path, state: object) -> list[ConvergenceDe
         return [ConvergenceDebt(path=path, stage="convergence", error=optional_error(last_error))]
     debts: list[ConvergenceDebt] = []
     for stage_name, stage_state in stages.items():
-        state_value = getattr(stage_state, "value", stage_state)
+        state_value = stage_state_value(stage_state)
         if state_value in {"done", "skipped"}:
             continue
         debts.append(
@@ -53,6 +76,7 @@ def convergence_debt_from_state(path: Path, state: object) -> list[ConvergenceDe
                 path=path,
                 stage=str(stage_name),
                 error=optional_error(last_error) or f"stage state: {state_value}",
+                deferred=state_value == "pending",
             )
         )
     if not debts:
@@ -71,5 +95,7 @@ __all__ = [
     "convergence_debt_from_state",
     "convergence_debt_from_states",
     "debt_by_path",
+    "is_deferred_stage_state",
     "optional_error",
+    "stage_state_value",
 ]

--- a/polylogue/sources/live/convergence_outcome.py
+++ b/polylogue/sources/live/convergence_outcome.py
@@ -37,6 +37,7 @@ def record_convergence_outcome(
                     subject_type="session_id",
                     subject_id=session_id,
                     error=debt.error,
+                    deferred=debt.deferred,
                 )
         else:
             cursor.record_convergence_debt(
@@ -44,4 +45,5 @@ def record_convergence_outcome(
                 subject_type="source_path",
                 subject_id=str(path),
                 error=debt.error,
+                deferred=debt.deferred,
             )

--- a/polylogue/sources/live/cursor.py
+++ b/polylogue/sources/live/cursor.py
@@ -48,7 +48,6 @@ from polylogue.storage.sqlite.archive_tiers.ops_write import (
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.connection_profile import open_connection
 
-_INSIGHT_DEFERRED_UNTIL_QUIET = "insights deferred until source quiet"
 _MAX_CURSOR_FAILURES_BEFORE_EXCLUDE = 5
 _FULL_CURSOR_RECONCILIATION_RETRY_DELAY_S = 60
 
@@ -230,12 +229,6 @@ def _storage_route_from_payload(payload: dict[str, object] | None) -> str | None
 
 def _table_has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:
     return any(str(row[1]) == column for row in conn.execute(f"PRAGMA table_info({table})"))
-
-
-def _convergence_debt_status(*, stage: str, error: str | None) -> str:
-    if stage == "insights" and error == _INSIGHT_DEFERRED_UNTIL_QUIET:
-        return "deferred"
-    return "failed"
 
 
 def _convergence_debt_priority(*, stage: str, subject_type: str, subject_id: str) -> int:
@@ -463,6 +456,7 @@ class CursorStore:
         error: str | None,
         materializer_version: str | None,
         now: str,
+        deferred: bool = False,
     ) -> None:
         """Read the current debt row and write the updated one inside ONE
         connection/transaction (``BEGIN IMMEDIATE`` before the read), so a
@@ -512,7 +506,7 @@ class CursorStore:
                     stage=stage,
                     target_type=subject_type,
                     target_id=subject_id,
-                    status=_convergence_debt_status(stage=stage, error=error),
+                    status="deferred" if deferred else "failed",
                     priority=_convergence_debt_priority(
                         stage=stage,
                         subject_type=subject_type,
@@ -1426,8 +1420,18 @@ class CursorStore:
         subject_id: str,
         error: str | None = None,
         materializer_version: str | None = None,
+        deferred: bool = False,
     ) -> None:
-        """Record derived convergence debt without marking source ingest failed."""
+        """Record derived convergence debt without marking source ingest failed.
+
+        ``deferred`` should be ``True`` only when this row reflects a
+        deliberate bounded-backpressure deferral (a ``false_means_pending``
+        convergence stage, or an explicit "deferred to preserve writer
+        availability" policy choice) rather than a genuine check/execute
+        failure -- it drives whether the row lands as
+        ``convergence_debt.status = 'deferred'`` (excluded from
+        failure-count alerting) or ``'failed'``.
+        """
         now = datetime.now(UTC).isoformat()
         self._sync_convergence_debt_to_ops(
             stage=stage,
@@ -1436,6 +1440,7 @@ class CursorStore:
             error=error,
             materializer_version=materializer_version,
             now=now,
+            deferred=deferred,
         )
 
     def clear_convergence_debt_except(

--- a/tests/unit/sources/test_convergence_debt_deferred_vocabulary.py
+++ b/tests/unit/sources/test_convergence_debt_deferred_vocabulary.py
@@ -1,0 +1,104 @@
+"""Unit coverage for the deferred-vs-failed convergence-debt classification.
+
+polylogue-6krh: ``convergence_debt.status`` declares a two-value vocabulary
+(``'failed'``, ``'deferred'``, ``storage/sqlite/archive_tiers/ops.py``'s
+CHECK constraint) but every live ``false_means_pending`` deferral -- a
+convergence stage doing bounded successful work and deferring the rest,
+per ``daemon.convergence.ConvergenceStage.false_means_pending`` -- landed as
+``'failed'`` for every stage except ``insights``, which had its exact error
+string hardcoded into a one-off check. ``StageState.PENDING`` is the actual,
+general signal for "this stage did not fail, it deferred": it is set only
+by a ``false_means_pending`` stage's non-exceptional ``False`` return or by
+downstream-barrier queuing (``daemon/convergence.py``), never by a
+check/execute exception. These tests exercise
+``polylogue.sources.live.convergence_debt`` directly against that signal,
+independent of any one stage's error text.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from polylogue.daemon.convergence import FileState, StageState
+from polylogue.sources.live.convergence_debt import (
+    ConvergenceDebt,
+    convergence_debt_from_state,
+    convergence_debt_from_states,
+    is_deferred_stage_state,
+)
+
+
+def test_is_deferred_stage_state_true_only_for_pending() -> None:
+    assert is_deferred_stage_state(StageState.PENDING) is True
+    assert is_deferred_stage_state("pending") is True
+    assert is_deferred_stage_state(StageState.FAILED) is False
+    assert is_deferred_stage_state(StageState.IN_PROGRESS) is False
+    assert is_deferred_stage_state(StageState.DONE) is False
+    assert is_deferred_stage_state(StageState.SKIPPED) is False
+
+
+def test_convergence_debt_from_state_marks_false_means_pending_stage_deferred() -> None:
+    """A stage other than 'insights' deferring via false_means_pending must
+    still produce ``deferred=True`` -- this is the exact bug: only the
+    'insights' stage's specific error string was special-cased before.
+    """
+    path = Path("/tmp/source.jsonl")
+    state = FileState(
+        path=path,
+        stages={"fts": StageState.PENDING},
+        last_error="stage fts returned False",
+    )
+
+    debts = convergence_debt_from_state(path, state)
+
+    assert len(debts) == 1
+    assert debts[0] == ConvergenceDebt(
+        path=path,
+        stage="fts",
+        error="stage fts returned False",
+        deferred=True,
+    )
+
+
+def test_convergence_debt_from_state_keeps_genuine_failure_as_failed() -> None:
+    path = Path("/tmp/source.jsonl")
+    state = FileState(
+        path=path,
+        stages={"fts": StageState.FAILED},
+        last_error="boom",
+    )
+
+    debts = convergence_debt_from_state(path, state)
+
+    assert len(debts) == 1
+    assert debts[0].deferred is False
+    assert debts[0].stage == "fts"
+
+
+def test_convergence_debt_from_state_mixed_stages_classify_independently() -> None:
+    path = Path("/tmp/source.jsonl")
+    state = FileState(
+        path=path,
+        stages={
+            "fts": StageState.PENDING,
+            "embed": StageState.FAILED,
+            "insights": StageState.DONE,
+        },
+        last_error="stage embed returned False",
+    )
+
+    debts = {debt.stage: debt for debt in convergence_debt_from_state(path, state)}
+
+    assert set(debts) == {"fts", "embed"}
+    assert debts["fts"].deferred is True
+    assert debts["embed"].deferred is False
+
+
+def test_convergence_debt_from_states_propagates_deferred_flag() -> None:
+    path = Path("/tmp/source.jsonl")
+    state = FileState(path=path, stages={"sinex_publication": StageState.PENDING})
+
+    debts = convergence_debt_from_states((path,), {path: state})
+
+    assert len(debts) == 1
+    assert debts[0].deferred is True

--- a/tests/unit/sources/test_live_catchup_planning.py
+++ b/tests/unit/sources/test_live_catchup_planning.py
@@ -581,6 +581,7 @@ def test_hot_insight_convergence_debt_uses_quiet_window_retry(
         subject_type="session_id",
         subject_id="conv-hot",
         error="insights deferred until source quiet",
+        deferred=True,
     )
     frozen_clock.advance(1)
     cursor.record_convergence_debt(
@@ -588,6 +589,7 @@ def test_hot_insight_convergence_debt_uses_quiet_window_retry(
         subject_type="session_id",
         subject_id="conv-hot",
         error="insights deferred until source quiet",
+        deferred=True,
     )
 
     debt = cursor.list_convergence_debt(limit=1)[0]
@@ -609,6 +611,7 @@ def test_hot_insight_convergence_debt_advances_after_retry_is_due(
         subject_type="session_id",
         subject_id="conv-hot",
         error="insights deferred until source quiet",
+        deferred=True,
     )
     frozen_clock.advance(61)
     cursor.record_convergence_debt(
@@ -616,6 +619,7 @@ def test_hot_insight_convergence_debt_advances_after_retry_is_due(
         subject_type="session_id",
         subject_id="conv-hot",
         error="insights deferred until source quiet",
+        deferred=True,
     )
 
     debt = cursor.list_convergence_debt(limit=1)[0]
@@ -668,6 +672,7 @@ def test_hot_insight_convergence_debt_uses_source_quiet_deadline(
         subject_type="session_id",
         subject_id="codex-session:conv-hot",
         error="insights deferred until source quiet",
+        deferred=True,
     )
 
     debt = cursor.list_convergence_debt(limit=1)[0]
@@ -718,6 +723,7 @@ def test_hot_insight_convergence_debt_uses_archive_source_quiet_deadline(
         subject_type="session_id",
         subject_id="codex-session:conv-hot-v1",
         error="insights deferred until source quiet",
+        deferred=True,
     )
 
     debt = cursor.list_convergence_debt(limit=1)[0]

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -446,6 +446,35 @@ def test_cursor_syncs_convergence_debt_to_archive_ops_db(tmp_path: Path) -> None
     assert count == 0
 
 
+def test_cursor_records_genuine_deferral_as_deferred_not_failed(tmp_path: Path) -> None:
+    """A ``false_means_pending`` stage's deliberate backpressure deferral
+    (polylogue-6krh) must land as ``status = 'deferred'``, not ``'failed'``
+    -- otherwise daemon health/alerting treats routine backpressure as a
+    stage that is broken.
+    """
+    store = CursorStore(tmp_path / "live.sqlite")
+
+    store.record_convergence_debt(
+        stage="insights",
+        subject_type="session_id",
+        subject_id="conv-1",
+        error="insights deferred until source quiet",
+        deferred=True,
+    )
+    store.record_convergence_debt(
+        stage="session_profile",
+        subject_type="session_id",
+        subject_id="conv-2",
+        error="boom",
+    )
+
+    with sqlite3.connect(tmp_path / "ops.db") as conn:
+        rows = dict(
+            conn.execute("SELECT target_id, status FROM convergence_debt WHERE target_type = 'session_id'").fetchall()
+        )
+    assert rows == {"conv-1": "deferred", "conv-2": "failed"}
+
+
 @pytest.mark.frozen_clock_modules("polylogue.sources.live.cursor", "polylogue.sources.live.convergence_debt_retry")
 def test_cursor_records_messages_fts_surface_debt_as_immediately_due(
     tmp_path: Path,


### PR DESCRIPTION
## Summary

`convergence_debt.status` was written as `'failed'` for essentially every deliberate backpressure deferral (`false_means_pending` stages), even though the schema's CHECK constraint has declared a two-value vocabulary (`'failed'`, `'deferred'`) all along.

## Problem

Live measurement of `ops.db`'s `convergence_debt` table showed a status distribution of `{failed: 3}` with `'deferred'` never observed, despite `false_means_pending` being a documented, deliberate daemon pattern (a stage does bounded successful work and returns `False` so the remaining backlog is retried as debt, not treated as an error).

Root cause: `sources/live/cursor.py`'s `_convergence_debt_status()` special-cased exactly one condition to `'deferred'` — `stage == "insights"` *and* `error` matching the literal string `"insights deferred until source quiet"`. Every other `false_means_pending` stage (`fts`, `embed`, `sinex_publication`, `raw_parse_recovery`) fell through to `'failed'`, as did the two explicit "deferred FTS to preserve writer availability" backpressure writes in `batch.py`. Daemon health/alerting (`convergence_debt_status.py`, `convergence_debt_alert.py`) filters on `status == 'failed'`, so a stage doing exactly what it was designed to do (defer bounded work under backpressure) looked like a broken stage that had failed repeatedly.

## Solution

Replaced the stage-name/error-text sniffing with the signal that was already present and reliable: `StageState.PENDING` (`daemon/convergence.py`). That state is set only for a `false_means_pending` stage's non-exceptional `False` return or downstream-barrier queuing — never for a check/execute exception, which always produces `StageState.FAILED`.

- Added `ConvergenceDebt.deferred: bool` and `sources/live/convergence_debt.py::is_deferred_stage_state()`, computed from the real `StageState` value rather than parsing error text.
- Threaded an explicit `deferred: bool` through `CursorStore.record_convergence_debt` → `_sync_convergence_debt_to_ops` → `add_convergence_debt`'s `status` argument, replacing (and removing) the dead `_convergence_debt_status()` special-case.
- Updated the two explicit "deferred FTS" call sites in `sources/live/batch.py` and the debt-retry replay path in `daemon/cli.py::_drain_convergence_debt_once` (which reconstructs rows from retried `StageState` directly) to pass the same signal.
- `storage/sqlite/archive_tiers/index_fast_forward_executor.py`'s direct `add_convergence_debt(..., status="deferred")` call for targeted-reprocess debt was already correct and untouched.

**Read-side audit** (per the mission's alerting-safety requirement): `convergence_debt_status.py::_archive_convergence_debt_summary_info` already filters strictly on `status == "failed"` for its `failed_count`/`stage_summaries`/`recent` projection, and `convergence_debt_alert.py` consumes only that filtered view. So genuinely-deferred rows are now correctly excluded from alerting *because* the write side got them right — no separate read-side change needed, and no risk of masking real failures since only rows whose underlying `StageState` was `PENDING` (never used for exceptions) get relabeled. `api/archive.py`'s one site that reads both statuses together (`status IN ('failed', 'deferred')` for standing-queries producer-debt count) already unions them and needed no change.

## Verification

- `devtools test` on the touched daemon/cursor/batch/convergence_debt files plus the new `tests/unit/sources/test_convergence_debt_deferred_vocabulary.py` (8 unit tests directly exercising `is_deferred_stage_state` and `convergence_debt_from_state`'s classification, independent of any one stage's error text) and a `CursorStore`-level test asserting a genuine deferral writes `status='deferred'` against a genuine failure writing `status='failed'`: **322 passed**.
- `devtools verify --quick`: green. Required a new `docs/plans/layering-surface-baseline.json` entry for `daemon/cli.py`'s new `sources.live.convergence_debt` import (the layering ratchet's existing ~302-entry ledger already contains the same shape of import for `daemon/cli.py` → `sources.live.cursor`/`sources.live.batch`).
- `tests/unit/sources/test_live_watcher.py::test_end_to_end_hidden_root_file_creation_triggers_ingest` failed once under parallel load and passed on immediate retry, reproduced identically on the unmodified tree — pre-existing filesystem-watcher timing flake, unrelated to this diff.

## Scope note

One pre-existing stale baseline entry (`polylogue/mcp/server_prompts.py` → `polylogue.storage.sqlite.archive_tiers.write`) was found during this audit but is unrelated to convergence-debt and left untouched to keep this PR focused.

Ref polylogue-6krh