### PR TITLE
chore(agents): add verify-timeout rule to triage.md

### DIFF
--- a/.claude/agents/triage.md
+++ b/.claude/agents/triage.md
@@ -23,6 +23,16 @@ to produce evidence and a verdict, never a code change.
   `git show`), and run read-only queries (`rg`, `sqlite3 ... SELECT`,
   `devtools status`, etc.). Never run anything that mutates repo state,
   the archive DB, or bead state.
+- **If confirming a finding needs `devtools test`/`devtools verify` or a
+  long `sqlite3 ... SELECT` against the live archive, pass an explicit
+  `timeout` of `600000` (600s) on the Bash tool call.** The harness's Bash
+  default (2 minutes) is shorter than these commands routinely take under
+  fleet contention; a call that exceeds the default gets silently
+  auto-backgrounded, and the failure mode is then idle-waiting on that
+  background task instead of continuing. Fix it at the call site rather
+  than discovering the backgrounding after the fact — this is the same
+  mechanical rule the `lane` agent definition carries for its (write-mode)
+  verification calls.
 
 ## Evidence standard
 


### PR DESCRIPTION
## Summary
Adds the same mechanical explicit-Bash-timeout rule that lane.md got in #3620 to triage.md, scoped to the read-only commands triage lanes actually run.

## Problem
lane.md was fixed to require an explicit `timeout: 600000` on every `devtools test`/`devtools verify` Bash call, because the harness's 2-minute default silently auto-backgrounds slower calls under fleet contention, and lanes then idle-wait on the background task instead of continuing (hit 3+ times, eddc7e8c1). triage.md's Scope section explicitly permits `devtools status`-style confirmation commands and long `sqlite3 ... SELECT` queries against the live archive as part of read-only investigation. Both are exactly the kind of command that can exceed the 2-minute default, so the same silent-backgrounding trap applies to triage lanes even though they never write code or beads.

## Solution
Added one bullet to triage.md's Scope section requiring the explicit `timeout: 600000` on any `devtools test`/`devtools verify` or long `sqlite3` call, referencing the identical rule already carried by lane.md rather than duplicating the write-mode framing.

## Verification
Markdown-only change to an agent-definition file; no code or test surface touched. `git diff` reviewed manually; no other agent-definition files needed the same fix (checked triage.md was the only remaining read-only lane definition referencing devtools/sqlite commands).