### PR TITLE
fix: thread APPEND fallback-identity through parallel census dispatch

### DIFF
--- a/polylogue/pipeline/services/archive_ingest.py
+++ b/polylogue/pipeline/services/archive_ingest.py
@@ -16,7 +16,7 @@ from polylogue.logging import get_logger
 from polylogue.pipeline.services.parsing_models import ParseResult
 from polylogue.pipeline.services.process_pool import (
     process_pool_executor,
-    resolve_parse_worker_count,
+    resolve_archive_ingest_dispatch,
 )
 from polylogue.sources.parsers.base import ParsedSession, RawSessionData
 from polylogue.sources.source_parsing import (
@@ -53,17 +53,6 @@ def _commit_batch_message_threshold() -> int:
         return load_polylogue_config().ingest_commit_batch_messages
     except ValueError:
         return COMMIT_BATCH_MESSAGE_THRESHOLD
-
-
-def _parse_worker_count() -> int:
-    """Resolve the source-parse worker count.
-
-    Parse is ~44% of re-ingest wall time and CPU-bound; the single SQLite
-    writer is I/O-bound. Running file parsing across worker processes overlaps
-    parse CPU with write I/O. A value of 1 disables the pool entirely and
-    preserves the exact sequential behavior as an escape hatch.
-    """
-    return resolve_parse_worker_count()
 
 
 def _parse_source_path_worker(
@@ -122,7 +111,7 @@ async def parse_sources_archive(
     acquired_at_ms = int(datetime.now(UTC).timestamp() * 1000)
     threshold = _commit_batch_message_threshold()
     batched = threshold > 0
-    workers = _parse_worker_count() if parse_workers is None else max(1, parse_workers)
+    workers = resolve_archive_ingest_dispatch(parse_workers=parse_workers).worker_count
     blob_root = archive_root / "blob"
     from polylogue.storage.blob_publication import ArchiveBlobPublisher
 

--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import contextlib
 import hashlib
-import os
 import pickle
 import sqlite3
 import time
@@ -42,7 +41,7 @@ from polylogue.pipeline.services.ingest_worker import (
     SessionWritePayload,
     ingest_record,
 )
-from polylogue.pipeline.services.process_pool import process_pool_executor
+from polylogue.pipeline.services.process_pool import process_pool_executor, resolve_ingest_batch_dispatch
 from polylogue.sinex.material_adapter import (
     PublicationBackpressureError,
     PublicationEncodingError,
@@ -1110,20 +1109,11 @@ def _resolved_ingest_worker_limit(value: int | None) -> int:
 
 def _select_ingest_worker_count(raw_artifacts: Sequence[_BlobSized], ingest_workers: int | None) -> int:
     total_blob_size = sum(record.blob_size for record in raw_artifacts)
-    if total_blob_size <= 8 * 1024 * 1024:
-        return 1
-    if total_blob_size <= 64 * 1024 * 1024:
-        return min(
-            max(len(raw_artifacts), 1),
-            os.cpu_count() or 4,
-            _resolved_ingest_worker_limit(ingest_workers),
-            4,
-        )
-    return min(
-        max(len(raw_artifacts), 1),
-        os.cpu_count() or 4,
-        _resolved_ingest_worker_limit(ingest_workers),
-    )
+    return resolve_ingest_batch_dispatch(
+        total_blob_bytes=total_blob_size,
+        record_count=len(raw_artifacts),
+        worker_limit=_resolved_ingest_worker_limit(ingest_workers),
+    ).worker_count
 
 
 def _new_ingest_batch_summary(

--- a/polylogue/pipeline/services/process_pool.py
+++ b/polylogue/pipeline/services/process_pool.py
@@ -7,6 +7,8 @@ import os
 import sys
 import time
 from concurrent.futures import ProcessPoolExecutor
+from dataclasses import dataclass
+from enum import StrEnum
 
 
 def _initialize_worker_logging() -> None:
@@ -105,6 +107,121 @@ def parallel_threads_effective() -> bool:
     return not is_gil_enabled()
 
 
+class PoolKind(StrEnum):
+    """Which executor (if any) a resolved parse-dispatch plan should use."""
+
+    THREAD = "thread"
+    PROCESS = "process"
+    SEQUENTIAL = "sequential"
+
+
+@dataclass(frozen=True)
+class ParseDispatchPlan:
+    """One call site's resolved (pool kind, worker count) decision.
+
+    polylogue-xecca: before this, four CPU-bound parse-dispatch call sites
+    each computed their own worker-count formula inline (and one, the
+    thread-vs-sequential choice under ``parallel_threads_effective``, also
+    decided pool KIND inline) -- ``pipeline/services/validation_flow.py``,
+    ``pipeline/services/archive_ingest.py``, ``pipeline/services/
+    ingest_batch/_core.py``, and ``sources/revision_backfill.py``'s census
+    parse family. None of the three worker-count formulas were wrong, but
+    scattering them meant "how many workers, and thread or process, for a
+    parse dispatch" had no single place to read or change. The
+    ``resolve_*_dispatch`` functions below are that single place: one per
+    site, since each site's formula reflects a genuinely different,
+    independently measured input (workload shape, GIL-vs-free-threaded
+    build, or a deliberate ignore of build capability) -- see each
+    function's docstring for its own measurement citation. None of the four
+    sites' *effective* behavior changes; only where the arithmetic lives
+    does.
+    """
+
+    pool_kind: PoolKind
+    worker_count: int
+
+
+def resolve_archive_ingest_dispatch(*, parse_workers: int | None = None) -> ParseDispatchPlan:
+    """Worker-count decision for ``archive_ingest.py``'s re-ingest file-walk parse.
+
+    Unchanged formula: an explicit ``parse_workers`` override (clamped to at
+    least 1) wins; otherwise :func:`resolve_parse_worker_count` (CPU count,
+    ceiling adjusted for a free-threaded build). Always a process pool -- the
+    caller's own ``workers <= 1`` branch is the escape hatch to sequential,
+    preserved unchanged at the call site rather than folded into
+    :data:`PoolKind` here, since that branch also skips constructing the pool
+    context entirely (a real, not merely nominal, sequential path).
+    """
+    worker_count = resolve_parse_worker_count() if parse_workers is None else max(1, parse_workers)
+    return ParseDispatchPlan(PoolKind.PROCESS, worker_count)
+
+
+def resolve_validation_dispatch(*, record_count: int) -> ParseDispatchPlan:
+    """Worker-count decision for ``validation_flow.py``'s raw-record validation batch.
+
+    Unchanged formula: ``min(record_count, cpus, 8)``, always a process pool.
+    Deliberately ignores :func:`parallel_threads_effective` -- unlike every
+    other site here, this one's process-pool preference is *itself* the
+    measured result, independent of GIL/free-threading: JSON decode's native
+    C extension accelerator releases the GIL, so ``ProcessPoolExecutor``
+    measured 605 MB/s at 8 workers against 160 MB/s for 24 threads (3.7x),
+    a GIL-build result threads cannot approach regardless of build. Do not
+    gate this on ``parallel_threads_effective()``.
+    """
+    return ParseDispatchPlan(PoolKind.PROCESS, max(1, min(record_count, os.cpu_count() or 4, 8)))
+
+
+def resolve_ingest_batch_dispatch(*, total_blob_bytes: int, record_count: int, worker_limit: int) -> ParseDispatchPlan:
+    """Worker-count decision for ``ingest_batch/_core.py``'s size-tiered process-pool dispatch.
+
+    Unchanged formula, size-tiered by aggregate blob bytes in the batch:
+    ``<= 8 MiB`` stays sequential (pool setup cost isn't worth it for a tiny
+    batch); ``<= 64 MiB`` caps at 4 workers (a mid-size batch doesn't benefit
+    from wider fan-out); above that, ``min(record_count, cpus, worker_limit)``
+    with no additional cap. Always a process pool when not sequential.
+    """
+    if total_blob_bytes <= 8 * 1024 * 1024:
+        return ParseDispatchPlan(PoolKind.SEQUENTIAL, 1)
+    if total_blob_bytes <= 64 * 1024 * 1024:
+        return ParseDispatchPlan(
+            PoolKind.PROCESS,
+            min(max(record_count, 1), os.cpu_count() or 4, worker_limit, 4),
+        )
+    return ParseDispatchPlan(
+        PoolKind.PROCESS,
+        min(max(record_count, 1), os.cpu_count() or 4, worker_limit),
+    )
+
+
+def resolve_revision_backfill_census_dispatch(
+    *, ingest_workers: int, record_count: int, free_threaded: bool
+) -> ParseDispatchPlan:
+    """Pool-kind + worker-count decision for the raw-authority census parse family.
+
+    Unchanged formula (``sources/revision_backfill.py``'s
+    ``_parse_unique_retained_raws``): sequential unless ``ingest_workers > 1``,
+    ``record_count > 1``, AND ``free_threaded`` -- CPU-bound parse threads
+    must never engage under the GIL (polylogue-7mtf measured 0.93x-0.96x
+    speedup, i.e. none, while inflating a concurrent SQLite writer thread's
+    commit latency ~5000x). This is the one site here whose pool KIND, not
+    just worker count, is a build-capability decision: a process pool is
+    never used for this family (the historical process-pool fallback was
+    retired -- see that module's docstring).
+
+    ``free_threaded`` is an explicit input (the caller's own
+    :func:`parallel_threads_effective` read), not resolved internally here --
+    matching the mission's "build capability via parallel_threads_effective"
+    framing as one of this function's INPUTS rather than an ambient global it
+    reaches for itself. This also keeps ``revision_backfill.py``'s own tests
+    able to monkeypatch their local ``parallel_threads_effective`` import and
+    have it actually reach this decision, rather than silently patching a
+    different module's binding of the same name.
+    """
+    if ingest_workers <= 1 or record_count <= 1 or not free_threaded:
+        return ParseDispatchPlan(PoolKind.SEQUENTIAL, 1)
+    return ParseDispatchPlan(PoolKind.THREAD, min(ingest_workers, record_count))
+
+
 def process_pool_executor(*, max_workers: int) -> ProcessPoolExecutor:
     """Create a process pool that avoids bare fork() in multi-threaded parents."""
     return ProcessPoolExecutor(
@@ -133,10 +250,16 @@ def terminate_process_pool(executor: ProcessPoolExecutor, *, timeout: float = 1.
 
 
 __all__ = [
+    "ParseDispatchPlan",
+    "PoolKind",
     "_initialize_worker_logging",
     "parallel_threads_effective",
     "process_pool_context",
     "process_pool_executor",
+    "resolve_archive_ingest_dispatch",
+    "resolve_ingest_batch_dispatch",
     "resolve_parse_worker_count",
+    "resolve_revision_backfill_census_dispatch",
+    "resolve_validation_dispatch",
     "terminate_process_pool",
 ]

--- a/polylogue/pipeline/services/validation_flow.py
+++ b/polylogue/pipeline/services/validation_flow.py
@@ -10,7 +10,7 @@ from polylogue.core.enums import Provider, ValidationMode, ValidationStatus
 from polylogue.core.protocols import ProgressCallback, RawValidationStore
 from polylogue.logging import get_logger
 from polylogue.paths import blob_store_root
-from polylogue.pipeline.services.process_pool import process_pool_executor
+from polylogue.pipeline.services.process_pool import process_pool_executor, resolve_validation_dispatch
 from polylogue.pipeline.services.validation_runtime import _validate_record_sync, _ValidationOutcome
 from polylogue.pipeline.stage_models import ValidatedRawRecord, ValidateResult
 from polylogue.storage.runtime import RawSessionRecord
@@ -176,7 +176,10 @@ async def evaluate_raw_artifacts(
     # ProcessPoolExecutor bypasses the GIL: JSON decode (native C extension
     # accelerator) + Python wrapper code run truly parallel across processes.
     # Measured: Threads(24)=160 MB/s, Process(8)=605 MB/s (3.7x speedup).
-    worker_count = min(len(raw_artifacts), os.cpu_count() or 4, 8)
+    # See resolve_validation_dispatch's docstring for why this ignores
+    # parallel_threads_effective() -- the process-pool preference here is
+    # itself the measurement, not a GIL-avoidance workaround.
+    worker_count = resolve_validation_dispatch(record_count=len(raw_artifacts)).worker_count
     blob_root_str = str(blob_store_root())
     t_batch = _time.perf_counter()
 

--- a/polylogue/sources/census_parse_stage.py
+++ b/polylogue/sources/census_parse_stage.py
@@ -48,10 +48,14 @@ deploy (phase (b), polylogue-m6tp).
 from __future__ import annotations
 
 import os
+import sqlite3
 import threading
 from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import closing
+from pathlib import Path
 
+from polylogue.archive.revision_authority import RawRevisionKind
 from polylogue.config import Config
 from polylogue.logging import get_logger
 from polylogue.pipeline.parsed_tree_size import (
@@ -95,6 +99,32 @@ _MAX_MAX_INFLIGHT_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB
 # this bound can fix -- the bound's job is only to stop the CONVEYOR LOOP
 # from waiting on it forever, which it does.
 _DEFAULT_WARM_TIMEOUT_SECONDS = 300.0
+
+
+def _resolve_readonly_native_ids(archive_root: Path, raw_ids: Sequence[str]) -> dict[str, str | None]:
+    """Read-only ``native_id`` lookup for pre-parse dispatch (no writer needed).
+
+    polylogue-6lyh1: mirrors ``ArchiveStore.raw_native_id`` (same column, same
+    "blank means unknown" contract) but over a plain ``mode=ro`` connection,
+    the same relationship ``raw_materialization_readonly_descriptors`` (in
+    ``storage/repair.py``) has to ``ArchiveStore.raw_revision_descriptor`` --
+    kept as a small dedicated query here rather than widening that shared
+    helper's return shape, since its other callers do not need this column.
+    """
+    raw_ids = list(raw_ids)
+    if not raw_ids:
+        return {}
+    placeholders = ",".join("?" for _ in raw_ids)
+    result: dict[str, str | None] = {}
+    with closing(sqlite3.connect(f"file:{archive_root / 'source.db'}?mode=ro", uri=True)) as conn:
+        rows = conn.execute(
+            f"SELECT raw_id, native_id FROM raw_sessions WHERE raw_id IN ({placeholders})",
+            raw_ids,
+        ).fetchall()
+    for row in rows:
+        value = row[1]
+        result[str(row[0])] = value if isinstance(value, str) and value.strip() else None
+    return result
 
 
 def daemon_parse_stage_worker_count() -> int:
@@ -344,13 +374,23 @@ class CensusParseStage:
         descriptors = raw_materialization_readonly_descriptors(archive_root, raw_ids)
         blob_root_str = str(archive_root / "blob")
         source_db_path_str = str(archive_root / "source.db")
+        # polylogue-6lyh1: resolve the same APPEND fallback-identity hint the
+        # sequential path recovers, so this warmer's parsed output matches
+        # the writer-held pass exactly -- see census_parse_worker's docstring.
+        append_raw_ids = [
+            raw_id
+            for raw_id in raw_ids
+            if (descriptors.get(raw_id) is not None and descriptors[raw_id][3] is RawRevisionKind.APPEND)
+        ]
+        native_ids = _resolve_readonly_native_ids(archive_root, append_raw_ids)
 
         futures = {}
         for raw_id in raw_ids:
             descriptor = descriptors.get(raw_id)
             if descriptor is None:
                 continue
-            provider, blob_hash, source_path, _kind, _size = descriptor
+            provider, blob_hash, source_path, kind, _size = descriptor
+            native_id = native_ids.get(raw_id) if kind is RawRevisionKind.APPEND else None
             future = self._executor.submit(
                 revision_backfill.census_parse_worker,
                 raw_id,
@@ -360,6 +400,8 @@ class CensusParseStage:
                 is_stream_record_provider(source_path, str(provider)),
                 blob_root_str,
                 source_db_path_str,
+                kind.value,
+                native_id,
             )
             futures[future] = raw_id
 

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -38,7 +38,11 @@ from polylogue.core.enums import Origin, Provider
 from polylogue.core.sources import provider_from_origin
 from polylogue.pipeline.ids import session_revision_projection
 from polylogue.pipeline.parsed_tree_size import effective_physical_memory_bytes, estimate_parsed_tree_bytes
-from polylogue.pipeline.services.process_pool import parallel_threads_effective
+from polylogue.pipeline.services.process_pool import (
+    PoolKind,
+    parallel_threads_effective,
+    resolve_revision_backfill_census_dispatch,
+)
 from polylogue.sources.decoders import _iter_json_stream
 from polylogue.sources.dispatch import (
     is_stream_record_provider,
@@ -158,12 +162,20 @@ class _PrefetchedParse:
     revision_kind: RawRevisionKind
 
 
-#: Content-cache dedup key: ``(provider, blob_hash, dedup_path)``, identical
-#: in shape to the per-batch grouping key ``_parse_retained_raws`` already
-#: uses (``dedup_path`` is ``""`` for :data:`_PATH_INDEPENDENT_PARSE_PROVIDERS`,
-#: else the raw's own ``source_path``) -- see :func:`_parse_retained_raws`'s
-#: docstring for why that key shape is safe to reuse across rows.
-ContentCacheKey = tuple[Provider, str, str]
+#: Content-cache dedup key: ``(provider, blob_hash, dedup_path, native_id)``,
+#: identical in shape to the per-batch grouping key ``_parse_retained_raws``
+#: already uses (``dedup_path`` is ``""`` for
+#: :data:`_PATH_INDEPENDENT_PARSE_PROVIDERS`, else the raw's own
+#: ``source_path``) -- see :func:`_parse_retained_raws`'s docstring for why
+#: that key shape is safe to reuse across rows. ``native_id`` (polylogue-
+#: 6lyh1) is the fallback-identity hint an APPEND-kind raw recovers at
+#: replay time (``None`` for every FULL raw and every APPEND raw with no
+#: recorded hint); without it in the key, two byte-identical APPEND payloads
+#: recorded under different recovered native ids -- content-hash dedup alone
+#: cannot see that divergence, since path-independent providers deliberately
+#: ignore ``source_path`` too -- would incorrectly fan the SAME parsed
+#: session identity out to both raw_ids.
+ContentCacheKey = tuple[Provider, str, str, str | None]
 
 #: Default budget for :class:`RawParsePrefetchCache`'s cross-page content
 #: cache (polylogue-oab7). Deliberately a small, fixed, conservative default
@@ -1428,6 +1440,8 @@ def census_parse_worker(
     is_stream: bool,
     blob_root_str: str,
     source_db_path_str: str,
+    kind_token: str,
+    native_id: str | None,
 ) -> tuple[str, list[ParsedSession] | None, str | None]:
     """Parse one retained raw's already-published blob bytes.
 
@@ -1440,24 +1454,45 @@ def census_parse_worker(
     can apply the exact same per-raw quarantine handling as the sequential
     path.
 
-    Dispatched onto a ``ProcessPoolExecutor`` (GIL-build fallback, see
-    ``_parse_unique_retained_raws``), a ``ThreadPoolExecutor`` (real
-    free-threading, see ``_parse_unique_retained_raws_via_threads``), and the
-    daemon's own off-writer-hold pre-parse ``ThreadPoolExecutor``
+    ``kind_token``/``native_id`` (polylogue-6lyh1) mirror
+    ``parse_retained_raw_sessions``'s own fallback-identity recovery exactly:
+    an APPEND-kind raw's own record stream may carry no self-describing
+    identity of its own (e.g. a Codex append delta has no ``session_meta``
+    record), so the identity hint recorded at write time
+    (``sources/live/batch.py``'s ``_append_payload_for_provider`` /
+    ``write_raw_payload``'s ``native_id``) must be used as the parser's
+    fallback_id instead of the bare filename stem -- otherwise a parallel
+    dispatch path silently falls back to ``Path(source_path).stem`` and
+    diverges from the sequential path whenever the source path's stem isn't
+    the provider session id (polylogue-u19l fixed this for the sequential
+    path only; every dispatcher of this worker must apply the identical
+    fallback for parallel and sequential replay to stay byte-identical).
+    Every caller resolves both values on its own calling thread (never
+    inside a worker) for the same thread-affine-connection reason
+    ``_parse_unique_retained_raws_via_threads`` avoids touching a shared
+    ``ArchiveStore`` at all.
+
+    Dispatched onto a ``ThreadPoolExecutor`` (real free-threading, see
+    ``_parse_unique_retained_raws_via_threads``) and the daemon's own
+    off-writer-hold pre-parse ``ThreadPoolExecutor``
     (``polylogue.daemon.parse_prefetch.DaemonParseStage``, polylogue-m6tp
-    phase (a)) -- the function is identical every time; only the executor
-    and the recreated ``ArchiveBlobPublisher``'s process/thread affinity
-    differ. Public (not module-private) precisely so the daemon's warmer can
-    import and dispatch it without duplicating this parse logic.
+    phase (a)), plus the pipelined replay prefetcher's reparse fallback
+    (``_ReplaySpillPrefetcher._decode``) -- the function is identical every
+    time; only the executor and the recreated ``ArchiveBlobPublisher``'s
+    process/thread affinity differ. Public (not module-private) precisely so
+    the daemon's warmer can import and dispatch it without duplicating this
+    parse logic.
     """
     from polylogue.storage.blob_publication import ArchiveBlobPublisher
 
     provider = Provider(provider_token)
+    kind = RawRevisionKind(kind_token)
+    fallback_id_override = native_id if kind is RawRevisionKind.APPEND else None
     publisher = ArchiveBlobPublisher(Path(source_db_path_str), Path(blob_root_str))
     try:
         if is_stream:
             with publisher.open(blob_hash) as payload:
-                sessions = _parse_stream(provider, payload, source_path)
+                sessions = _parse_stream(provider, payload, source_path, fallback_id_override=fallback_id_override)
         else:
             payload_path = None
             if provider is Provider.HERMES:
@@ -1469,6 +1504,7 @@ def census_parse_worker(
                 source_path,
                 payload_path=payload_path,
                 archive_root=Path(blob_root_str).parent,
+                fallback_id_override=fallback_id_override,
             )
         return raw_id, sessions, None
     except Exception as exc:
@@ -1551,7 +1587,15 @@ def _parse_retained_raws(
     (every caller that does not opt in) skips this lookup/store entirely and
     is byte-identical to today's behavior.
     """
-    descriptors = {raw_id: archive.raw_revision_descriptor(raw_id) for raw_id in raw_ids}
+    descriptors: dict[str, tuple[Provider, str, str, RawRevisionKind, int, str | None]] = {}
+    for raw_id in raw_ids:
+        provider, blob_hash, source_path, kind, size = archive.raw_revision_descriptor(raw_id)
+        # polylogue-6lyh1: resolve the same APPEND fallback-identity hint the
+        # sequential path (``parse_retained_raw_sessions``) recovers, on this
+        # calling thread, so every parallel dispatch path below can apply the
+        # identical fallback -- see ``census_parse_worker``'s docstring.
+        native_id = archive.raw_native_id(raw_id) if kind is RawRevisionKind.APPEND else None
+        descriptors[raw_id] = (provider, blob_hash, source_path, kind, size, native_id)
     results: dict[str, tuple[list[ParsedSession], int, RawRevisionKind] | Exception] = {}
     remaining_raw_ids = raw_ids
     if prefetch_cache is not None and raw_ids:
@@ -1562,13 +1606,13 @@ def _parse_retained_raws(
                 remaining_raw_ids.append(raw_id)
             else:
                 results[raw_id] = cached
-    grouped: dict[tuple[Provider, str, str], list[str]] = {}
+    grouped: dict[ContentCacheKey, list[str]] = {}
     for raw_id in remaining_raw_ids:
-        provider, blob_hash, source_path, _kind, _size = descriptors[raw_id]
+        provider, blob_hash, source_path, _kind, _size, native_id = descriptors[raw_id]
         dedup_path = "" if provider in _PATH_INDEPENDENT_PARSE_PROVIDERS else source_path
-        grouped.setdefault((provider, blob_hash, dedup_path), []).append(raw_id)
+        grouped.setdefault((provider, blob_hash, dedup_path, native_id), []).append(raw_id)
 
-    content_hits: dict[tuple[Provider, str, str], tuple[list[ParsedSession], int, RawRevisionKind]] = {}
+    content_hits: dict[ContentCacheKey, tuple[list[ParsedSession], int, RawRevisionKind]] = {}
     representatives: list[str] = []
     for key, members in grouped.items():
         content_hit = prefetch_cache.get_content(key) if prefetch_cache is not None else None
@@ -1601,7 +1645,7 @@ def _parse_retained_raws(
                 results[raw_id] = outcome
             else:
                 sessions, _rep_size, _rep_kind = outcome
-                _provider, _blob_hash, _source_path, kind, size = descriptors[raw_id]
+                _provider, _blob_hash, _source_path, kind, size, _native_id = descriptors[raw_id]
                 results[raw_id] = (sessions, size, kind)
     return results
 
@@ -1610,7 +1654,7 @@ def _parse_unique_retained_raws_via_threads(
     archive: ArchiveStore,
     raw_ids: list[str],
     *,
-    descriptors: dict[str, tuple[Provider, str, str, RawRevisionKind, int]],
+    descriptors: dict[str, tuple[Provider, str, str, RawRevisionKind, int, str | None]],
     ingest_workers: int,
 ) -> dict[str, tuple[list[ParsedSession], int, RawRevisionKind] | Exception]:
     """Thread-parallel parse over every raw, regardless of size.
@@ -1653,7 +1697,7 @@ def _parse_unique_retained_raws_via_threads(
     with ThreadPoolExecutor(max_workers=min(ingest_workers, len(raw_ids))) as pool:
         future_to_raw_id = {}
         for raw_id in raw_ids:
-            provider, blob_hash, source_path, _kind, _payload_size = descriptors[raw_id]
+            provider, blob_hash, source_path, kind, _payload_size, native_id = descriptors[raw_id]
             future = pool.submit(
                 census_parse_worker,
                 raw_id,
@@ -1663,6 +1707,8 @@ def _parse_unique_retained_raws_via_threads(
                 is_stream_record_provider(source_path, str(provider)),
                 blob_root_str,
                 source_db_path_str,
+                kind.value,
+                native_id,
             )
             future_to_raw_id[future] = raw_id
         for future in as_completed(future_to_raw_id):
@@ -1675,7 +1721,7 @@ def _parse_unique_retained_raws_via_threads(
             if error is not None:
                 results[raw_id] = RuntimeError(error)
                 continue
-            _provider, _blob_hash, _source_path, kind, payload_size = descriptors[raw_id]
+            _provider, _blob_hash, _source_path, kind, payload_size, _native_id = descriptors[raw_id]
             results[raw_id] = (sessions or [], payload_size, kind)
     return results
 
@@ -1684,7 +1730,7 @@ def _parse_unique_retained_raws(
     archive: ArchiveStore,
     raw_ids: list[str],
     *,
-    descriptors: dict[str, tuple[Provider, str, str, RawRevisionKind, int]],
+    descriptors: dict[str, tuple[Provider, str, str, RawRevisionKind, int, str | None]],
     ingest_workers: int,
 ) -> dict[str, tuple[list[ParsedSession], int, RawRevisionKind] | Exception]:
     """Parse already-deduplicated raws, optionally in parallel.
@@ -1719,7 +1765,10 @@ def _parse_unique_retained_raws(
     what made a full index rebuild a ~9-hour job on a 24-thread machine.
     """
     results: dict[str, tuple[list[ParsedSession], int, RawRevisionKind] | Exception] = {}
-    if ingest_workers <= 1 or len(raw_ids) <= 1 or not parallel_threads_effective():
+    plan = resolve_revision_backfill_census_dispatch(
+        ingest_workers=ingest_workers, record_count=len(raw_ids), free_threaded=parallel_threads_effective()
+    )
+    if plan.pool_kind is PoolKind.SEQUENTIAL:
         if ingest_workers > 1 and len(raw_ids) > 1:
             _LOGGER.warning(
                 "parsing %d raws sequentially: this interpreter has the GIL enabled, and "
@@ -2040,15 +2089,15 @@ class _ReplaySpillPrefetcher:
         source_conn: sqlite3.Connection,
         keys: tuple[str, ...],
         extra_members: dict[str, frozenset[str]],
-    ) -> tuple[list[tuple[int, str]], dict[str, tuple[Provider, str, str, int]]]:
+    ) -> tuple[list[tuple[int, str]], dict[str, tuple[Provider, str, str, RawRevisionKind, int, str | None]]]:
         """Resolve (seq, raw_id) decode order plus per-raw parse descriptors.
 
         Durable membership comes from source.db on this thread's own
         read-only connection (both mappings are committed before replay
         begins; retirement-phase additions living in an open batch window
         are covered by ``extra_members`` instead). Descriptors mirror
-        ``raw_revision_descriptor``'s SELECT exactly, minus the writer-side
-        connection affinity.
+        ``raw_revision_descriptor``'s SELECT exactly (plus ``native_id``,
+        polylogue-6lyh1), minus the writer-side connection affinity.
         """
         wanted = set(keys)
         members: dict[str, list[str]] = {key: [] for key in keys}
@@ -2078,25 +2127,39 @@ class _ReplaySpillPrefetcher:
             # equals the next key's, which is exactly what enter_key needs.
         with self._lock:
             self._key_start_seq = key_start_seq
-        descriptors: dict[str, tuple[Provider, str, str, int]] = {}
+        descriptors: dict[str, tuple[Provider, str, str, RawRevisionKind, int, str | None]] = {}
         planned = [raw_id for _seq, raw_id in plan]
         for start in range(0, len(planned), 500):
             chunk = planned[start : start + 500]
             placeholders = ",".join("?" for _ in chunk)
             for row in source_conn.execute(
-                "SELECT raw_id, origin, capture_mode, lower(hex(blob_hash)), source_path, blob_size "
+                "SELECT raw_id, origin, capture_mode, lower(hex(blob_hash)), source_path, revision_kind, "
+                "blob_size, native_id "
                 f"FROM raw_sessions WHERE raw_id IN ({placeholders})",
                 chunk,
             ):
                 provider = provider_from_origin(Origin.from_string(str(row[1])), family_hint=row[2])
-                descriptors[str(row[0])] = (provider, str(row[3]), str(row[4]), int(row[5]))
+                kind = RawRevisionKind(str(row[5]))
+                # polylogue-6lyh1: mirror ``census_parse_worker``'s fallback-id
+                # contract exactly -- only an APPEND raw's recovered native_id
+                # is ever used as a fallback identity; see that function's
+                # docstring for why this must match the sequential path.
+                raw_native_id_value = row[7]
+                native_id = (
+                    str(raw_native_id_value)
+                    if kind is RawRevisionKind.APPEND
+                    and isinstance(raw_native_id_value, str)
+                    and raw_native_id_value.strip()
+                    else None
+                )
+                descriptors[str(row[0])] = (provider, str(row[3]), str(row[4]), kind, int(row[6]), native_id)
         return plan, descriptors
 
     def _decode(
         self,
         spill_conn: sqlite3.Connection,
         raw_id: str,
-        descriptors: dict[str, tuple[Provider, str, str, int]],
+        descriptors: dict[str, tuple[Provider, str, str, RawRevisionKind, int, str | None]],
     ) -> tuple[list[ParsedSession], int, bool] | None:
         started = time.perf_counter()
         rows = spill_conn.execute(
@@ -2110,7 +2173,7 @@ class _ReplaySpillPrefetcher:
         descriptor = descriptors.get(raw_id)
         if descriptor is None:
             return None
-        provider, blob_hash, source_path, payload_bytes = descriptor
+        provider, blob_hash, source_path, kind, payload_bytes, native_id = descriptor
         if payload_bytes > self._budget // 4:
             # Oversized decode: leave it to the writer's inline path so one
             # in-flight tree can never balloon far past the buffer budget.
@@ -2123,6 +2186,8 @@ class _ReplaySpillPrefetcher:
             is_stream_record_provider(source_path, str(provider)),
             str(self._blob_root),
             str(self._source_db_path),
+            kind.value,
+            native_id,
         )
         if error is not None or sessions_or_none is None:
             # Do not buffer failures: the writer's inline decode raises the

--- a/tests/benchmarks/test_parse_stage_thread_scaling.py
+++ b/tests/benchmarks/test_parse_stage_thread_scaling.py
@@ -51,7 +51,9 @@ _AVG_PAYLOAD_BYTES = 80_000
 
 def _time_parse(archive_root: Path, raw_ids: list[str], *, ingest_workers: int) -> float:
     with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
-        descriptors = {raw_id: archive.raw_revision_descriptor(raw_id) for raw_id in raw_ids}
+        descriptors = {
+            raw_id: (*archive.raw_revision_descriptor(raw_id), archive.raw_native_id(raw_id)) for raw_id in raw_ids
+        }
         started = time.perf_counter()
         results = _parse_unique_retained_raws(archive, raw_ids, descriptors=descriptors, ingest_workers=ingest_workers)
         elapsed = time.perf_counter() - started

--- a/tests/unit/daemon/test_parse_prefetch.py
+++ b/tests/unit/daemon/test_parse_prefetch.py
@@ -93,6 +93,60 @@ def test_warm_parses_pending_candidates_off_writer_hold(tmp_path: Path) -> None:
         assert payload_bytes > 0
 
 
+def test_warm_recovers_append_native_id_not_source_path_stem(tmp_path: Path) -> None:
+    """polylogue-6lyh1: the daemon's off-writer-hold warmer must apply the
+    same APPEND fallback-identity recovery as the sequential path
+    (``parse_retained_raw_sessions``'s ``archive.raw_native_id`` lookup),
+    not silently fall back to ``Path(source_path).stem``.
+
+    The raw is written APPEND-kind, with a payload carrying no
+    ``session_meta`` record (so the parser genuinely has nothing else to
+    fall back on) and a ``source_path`` stem deliberately different from the
+    recorded native_id -- so a regression to stem-based fallback is
+    observable, not silently masked by the two happening to agree.
+    """
+    from polylogue.archive.revision_authority import RawRevisionAuthority, RawRevisionEnvelope, RawRevisionKind
+    from polylogue.core.enums import Provider
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+    payload = (
+        b'{"type":"response_item","payload":{"type":"message","id":"m0","role":"user",'
+        b'"content":[{"type":"input_text","text":"hello"}]}}\n'
+    )
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=payload,
+            source_path="stem-does-not-match.jsonl",
+            acquired_at_ms=1,
+            raw_id="raw-append",
+            native_id="session-real-native-id",
+            revision=RawRevisionEnvelope(
+                logical_source_key="codex:session-real-native-id",
+                kind=RawRevisionKind.APPEND,
+                source_revision="raw-append-revision",
+                acquisition_generation=0,
+                predecessor_source_revision="raw-append-predecessor",
+                append_start_offset=0,
+                append_end_offset=len(payload),
+                authority=RawRevisionAuthority.QUARANTINED,
+            ),
+        )
+
+    stage = DaemonParseStage(max_workers=2, max_inflight_bytes=10_000_000)
+    try:
+        warmed = stage.warm(_config(tmp_path), limit=10, max_payload_bytes=10_000_000)
+    finally:
+        stage.shutdown()
+
+    assert warmed == 1
+    sessions, _payload_bytes, _kind = stage.cache.pop("raw-append")  # type: ignore[misc]
+    assert len(sessions) == 1
+    assert sessions[0].provider_session_id == "session-real-native-id"
+
+
 def test_warm_dispatches_to_worker_threads_not_the_caller_thread(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -389,6 +443,8 @@ def test_warm_never_retains_a_tree_exceeding_the_whole_cache_budget(
         is_stream: bool,
         blob_root_str: str,
         source_db_path_str: str,
+        kind_token: str,
+        native_id: str | None,
     ) -> object:
         return raw_id, [_session_with_text("session-whale", 50_000)], None
 
@@ -444,6 +500,8 @@ def test_cache_evicts_to_stay_within_tree_bytes_budget_under_pressure(
         is_stream: bool,
         blob_root_str: str,
         source_db_path_str: str,
+        kind_token: str,
+        native_id_arg: str | None,
     ) -> object:
         native_id = source_path_to_native_id[source_path]
         return raw_id, [_session_with_text(native_id, 5_000)], None

--- a/tests/unit/pipeline/test_ingest_batch.py
+++ b/tests/unit/pipeline/test_ingest_batch.py
@@ -2811,7 +2811,7 @@ def test_process_ingest_batch_sync_replaces_stale_sessions_for_same_raw_id(
 
 
 def test_select_ingest_worker_count_uses_cpu_count(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("polylogue.pipeline.services.ingest_batch._core.os.cpu_count", lambda: 16)
+    monkeypatch.setattr("polylogue.pipeline.services.process_pool.os.cpu_count", lambda: 16)
     raw_artifacts = [SimpleNamespace(blob_size=16 * 1024 * 1024) for _ in range(6)]
     worker_count = _select_ingest_worker_count(raw_artifacts, None)
     # min(max(6,1), 16, 8) = 6 — uses all available artifacts
@@ -2821,7 +2821,7 @@ def test_select_ingest_worker_count_uses_cpu_count(monkeypatch: pytest.MonkeyPat
 def test_select_ingest_worker_count_avoids_process_pool_for_tiny_batches(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr("polylogue.pipeline.services.ingest_batch._core.os.cpu_count", lambda: 16)
+    monkeypatch.setattr("polylogue.pipeline.services.process_pool.os.cpu_count", lambda: 16)
     raw_artifacts = [SimpleNamespace(blob_size=512 * 1024) for _ in range(10)]
     worker_count = _select_ingest_worker_count(raw_artifacts, None)
     assert worker_count == 1
@@ -2830,14 +2830,14 @@ def test_select_ingest_worker_count_avoids_process_pool_for_tiny_batches(
 def test_select_ingest_worker_count_caps_small_batches(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr("polylogue.pipeline.services.ingest_batch._core.os.cpu_count", lambda: 16)
+    monkeypatch.setattr("polylogue.pipeline.services.process_pool.os.cpu_count", lambda: 16)
     raw_artifacts = [SimpleNamespace(blob_size=4 * 1024 * 1024) for _ in range(10)]
     worker_count = _select_ingest_worker_count(raw_artifacts, None)
     assert worker_count == 4
 
 
 def test_select_ingest_worker_count_respects_limit(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("polylogue.pipeline.services.ingest_batch._core.os.cpu_count", lambda: 16)
+    monkeypatch.setattr("polylogue.pipeline.services.process_pool.os.cpu_count", lambda: 16)
     raw_artifacts = [SimpleNamespace(blob_size=16 * 1024 * 1024) for _ in range(60)]
     worker_count = _select_ingest_worker_count(raw_artifacts, ingest_workers=4)
     # min(max(60,1), 16, 4) = 4 — respects explicit limit

--- a/tests/unit/pipeline/test_process_pool.py
+++ b/tests/unit/pipeline/test_process_pool.py
@@ -7,9 +7,14 @@ from concurrent.futures import as_completed
 import pytest
 
 from polylogue.pipeline.services.process_pool import (
+    PoolKind,
     parallel_threads_effective,
     process_pool_context,
     process_pool_executor,
+    resolve_archive_ingest_dispatch,
+    resolve_ingest_batch_dispatch,
+    resolve_revision_backfill_census_dispatch,
+    resolve_validation_dispatch,
 )
 
 
@@ -106,3 +111,110 @@ def test_parallel_threads_effective_treats_missing_probe_as_gil_enabled(monkeypa
     build to speak of -- the safe default is "GIL enabled", not an error."""
     monkeypatch.delattr(sys, "_is_gil_enabled", raising=False)
     assert parallel_threads_effective() is False
+
+
+# ---------------------------------------------------------------------------
+# polylogue-xecca: unified parse-dispatch decision matrix
+# ---------------------------------------------------------------------------
+#
+# Each of the four sites' formulas moved here verbatim from
+# archive_ingest.py / validation_flow.py / ingest_batch/_core.py /
+# revision_backfill.py -- these matrices pin the exact numbers those sites
+# relied on before the extraction so a future edit to the shared function
+# cannot silently drift any one site's effective behavior without this file
+# failing first.
+
+
+def test_resolve_archive_ingest_dispatch_defaults_to_resolve_parse_worker_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("polylogue.pipeline.services.process_pool.os.cpu_count", lambda: 9)
+    monkeypatch.setattr(sys, "_is_gil_enabled", lambda: True, raising=False)
+    plan = resolve_archive_ingest_dispatch()
+    assert plan.pool_kind is PoolKind.PROCESS
+    # GIL build: min(8, cpus-1) = min(8, 8) = 8.
+    assert plan.worker_count == 8
+
+
+def test_resolve_archive_ingest_dispatch_honors_explicit_override() -> None:
+    """``parse_workers`` (the demo seeder's force-sequential knob) wins over
+    the ambient CPU-based default, clamped to at least 1."""
+    plan = resolve_archive_ingest_dispatch(parse_workers=1)
+    assert plan.pool_kind is PoolKind.PROCESS
+    assert plan.worker_count == 1
+
+    plan_negative = resolve_archive_ingest_dispatch(parse_workers=-5)
+    assert plan_negative.worker_count == 1
+
+
+@pytest.mark.parametrize(
+    ("record_count", "cpu_count", "expected_workers"),
+    [
+        (8, 24, 8),  # capped at 8 regardless of a wider CPU count
+        (3, 24, 3),  # fewer records than the cap: use the record count
+        (12, 4, 4),  # fewer CPUs than records or the cap: use CPU count
+    ],
+)
+def test_resolve_validation_dispatch_matrix(
+    monkeypatch: pytest.MonkeyPatch, record_count: int, cpu_count: int, expected_workers: int
+) -> None:
+    """validation_flow.py's own measured process-pool preference: always a
+    process pool, ``min(record_count, cpus, 8)``, independent of
+    ``parallel_threads_effective`` -- confirmed by never patching the GIL
+    probe in this test at all."""
+    monkeypatch.setattr("polylogue.pipeline.services.process_pool.os.cpu_count", lambda: cpu_count)
+    plan = resolve_validation_dispatch(record_count=record_count)
+    assert plan.pool_kind is PoolKind.PROCESS
+    assert plan.worker_count == expected_workers
+
+
+@pytest.mark.parametrize(
+    ("total_blob_bytes", "record_count", "worker_limit", "cpu_count", "expected_kind", "expected_workers"),
+    [
+        (4 * 1024 * 1024, 10, 16, 16, PoolKind.SEQUENTIAL, 1),  # <= 8 MiB: sequential
+        (16 * 1024 * 1024, 10, 16, 16, PoolKind.PROCESS, 4),  # <= 64 MiB: capped at 4
+        (16 * 1024 * 1024, 2, 16, 16, PoolKind.PROCESS, 2),  # <= 64 MiB: record count under the 4-cap
+        (100 * 1024 * 1024, 60, 16, 16, PoolKind.PROCESS, 16),  # > 64 MiB: no 4-cap, limited by worker_limit
+        (100 * 1024 * 1024, 60, 4, 16, PoolKind.PROCESS, 4),  # > 64 MiB: explicit narrower limit wins
+        (100 * 1024 * 1024, 2, 16, 16, PoolKind.PROCESS, 2),  # > 64 MiB: record count under every ceiling
+    ],
+)
+def test_resolve_ingest_batch_dispatch_matrix(
+    monkeypatch: pytest.MonkeyPatch,
+    total_blob_bytes: int,
+    record_count: int,
+    worker_limit: int,
+    cpu_count: int,
+    expected_kind: PoolKind,
+    expected_workers: int,
+) -> None:
+    monkeypatch.setattr("polylogue.pipeline.services.process_pool.os.cpu_count", lambda: cpu_count)
+    plan = resolve_ingest_batch_dispatch(
+        total_blob_bytes=total_blob_bytes, record_count=record_count, worker_limit=worker_limit
+    )
+    assert plan.pool_kind is expected_kind
+    assert plan.worker_count == expected_workers
+
+
+@pytest.mark.parametrize(
+    ("ingest_workers", "record_count", "free_threaded", "expected_kind", "expected_workers"),
+    [
+        (1, 10, True, PoolKind.SEQUENTIAL, 1),  # ingest_workers<=1: sequential regardless of build
+        (4, 1, True, PoolKind.SEQUENTIAL, 1),  # record_count<=1: sequential regardless of build
+        (4, 10, False, PoolKind.SEQUENTIAL, 1),  # GIL build: sequential regardless of workers/records
+        (4, 10, True, PoolKind.THREAD, 4),  # free-threaded + eligible: threads, worker_count = min(workers, records)
+        (10, 4, True, PoolKind.THREAD, 4),  # worker_count capped by record_count, not ingest_workers
+    ],
+)
+def test_resolve_revision_backfill_census_dispatch_matrix(
+    ingest_workers: int, record_count: int, free_threaded: bool, expected_kind: PoolKind, expected_workers: int
+) -> None:
+    """``free_threaded`` is an explicit input here (the caller's own
+    ``parallel_threads_effective()`` read), not resolved internally --
+    exercised directly with both booleans rather than monkeypatching the
+    GIL probe, proving the decision is a pure function of its three inputs."""
+    plan = resolve_revision_backfill_census_dispatch(
+        ingest_workers=ingest_workers, record_count=record_count, free_threaded=free_threaded
+    )
+    assert plan.pool_kind is expected_kind
+    assert plan.worker_count == expected_workers

--- a/tests/unit/sources/test_prefetch_cache_thread_safety.py
+++ b/tests/unit/sources/test_prefetch_cache_thread_safety.py
@@ -119,7 +119,7 @@ def test_raw_prefetch_content_cache_concurrent_put_get_stays_within_budget() -> 
     mutate, without the GIL to make that atomic)."""
     budget = 1000
     cache = RawParsePrefetchCache(max_inflight_bytes=1_000_000, max_content_cache_bytes=budget)
-    keys = [(Provider.CODEX, f"hash-{i}", "") for i in range(50)]
+    keys = [(Provider.CODEX, f"hash-{i}", "", None) for i in range(50)]
 
     def _worker(_i: int) -> None:
         for key in keys:

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -14,7 +14,7 @@ from polylogue.archive.ingest_flags import (
     DOM_FALLBACK_INGEST_FLAG,
     NATIVE_BROWSER_CAPTURE_INGEST_FLAG,
 )
-from polylogue.archive.revision_authority import RawRevisionKind
+from polylogue.archive.revision_authority import RawRevisionAuthority, RawRevisionEnvelope, RawRevisionKind
 from polylogue.core.enums import Provider
 from polylogue.pipeline.parsed_tree_size import estimate_parsed_tree_bytes
 from polylogue.sources import revision_backfill
@@ -1615,9 +1615,9 @@ def test_raw_parse_prefetch_cache_content_get_put_lru_and_budget() -> None:
     never admit a single entry bigger than the whole budget (a whale must
     not evict everything and then still fail to fit)."""
     cache = RawParsePrefetchCache(max_inflight_bytes=1_000_000, max_content_cache_bytes=100)
-    key_a = (Provider.CODEX, "hash-A", "")
-    key_b = (Provider.CODEX, "hash-B", "")
-    key_c = (Provider.CODEX, "hash-C", "")
+    key_a = (Provider.CODEX, "hash-A", "", None)
+    key_b = (Provider.CODEX, "hash-B", "", None)
+    key_c = (Provider.CODEX, "hash-C", "", None)
 
     assert cache.content_len() == 0
     assert cache.get_content(key_a) is None
@@ -1887,6 +1887,110 @@ def test_thread_parse_matches_sequential_archive_state(tmp_path: Path, monkeypat
     assert _sessions(sequential_root) == _sessions(thread_root)
 
 
+def _append_delta_without_self_describing_identity(text: str) -> bytes:
+    """A Codex append-delta payload with no ``session_meta`` record of its
+    own -- the polylogue-u19l shape: the parser has no self-describing
+    identity to read and must fall back to whatever fallback_id it is
+    given."""
+    return (
+        b'{"type":"response_item","payload":{"type":"message","id":"m0","role":"user",'
+        b'"content":[{"type":"input_text","text":"' + text.encode() + b'"}]}}\n'
+    )
+
+
+def _write_append_raw_with_recovered_identity(
+    archive: ArchiveStore, *, raw_id: str, native_id: str, source_path: str, payload: bytes, acquired_at_ms: int
+) -> None:
+    """Write an APPEND-kind raw whose own bytes carry no identity, recording
+    ``native_id`` as the write-time recovery hint (``write_raw_payload``'s
+    ``native_id`` -- see ``sources/live/batch.py``'s
+    ``_append_payload_for_provider``) -- deliberately at a ``source_path``
+    whose stem does NOT equal ``native_id``, so a dispatch path that falls
+    back to ``Path(source_path).stem`` instead of the recorded native_id
+    diverges observably from one that recovers it correctly."""
+    assert Path(source_path).stem != native_id
+    archive.write_raw_payload(
+        provider=Provider.CODEX,
+        payload=payload,
+        source_path=source_path,
+        acquired_at_ms=acquired_at_ms,
+        raw_id=raw_id,
+        native_id=native_id,
+        revision=RawRevisionEnvelope(
+            logical_source_key=f"codex:{native_id}",
+            kind=RawRevisionKind.APPEND,
+            source_revision=f"{raw_id}-revision",
+            acquisition_generation=0,
+            predecessor_source_revision=f"{raw_id}-predecessor",
+            append_start_offset=0,
+            append_end_offset=len(payload),
+            authority=RawRevisionAuthority.QUARANTINED,
+        ),
+    )
+
+
+def test_thread_parse_recovers_append_native_id_matching_sequential(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """polylogue-6lyh1 red-first: census_parse_worker lacked kind/native_id,
+    so the thread-parallel census path fell back to
+    ``Path(source_path).stem`` for an APPEND raw with no self-describing
+    identity of its own, instead of the write-time-recorded native_id the
+    sequential path (``parse_retained_raw_sessions``) recovers via
+    ``archive.raw_native_id`` -- see that function's polylogue-u19l comment.
+
+    Two APPEND raws are constructed with a payload carrying NO
+    ``session_meta`` record (so the parser has nothing else to fall back on)
+    AND a ``source_path`` stem that deliberately differs from the recorded
+    native_id, forcing observable divergence: before the fix, the thread
+    path's ``provider_session_id`` would be the source_path's stem
+    (``"delta-file-one"``/``"delta-file-two"``); after the fix, both paths
+    agree on the recorded native_id (``"session-alpha"``/``"session-beta"``).
+    Two raws are used (not one) because ``_parse_unique_retained_raws`` only
+    takes the thread-pool branch when ``record_count > 1``.
+    """
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+    with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+        _write_append_raw_with_recovered_identity(
+            archive,
+            raw_id="raw-alpha",
+            native_id="session-alpha",
+            source_path="delta-file-one.jsonl",
+            payload=_append_delta_without_self_describing_identity("hello alpha"),
+            acquired_at_ms=1,
+        )
+        _write_append_raw_with_recovered_identity(
+            archive,
+            raw_id="raw-beta",
+            native_id="session-beta",
+            source_path="delta-file-two.jsonl",
+            payload=_append_delta_without_self_describing_identity("hello beta"),
+            acquired_at_ms=2,
+        )
+
+    raw_ids = ["raw-alpha", "raw-beta"]
+
+    with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+        sequential_results = revision_backfill._parse_retained_raws(archive, raw_ids, ingest_workers=1)
+
+    monkeypatch.setattr(revision_backfill, "parallel_threads_effective", lambda: True)
+    with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+        thread_results = revision_backfill._parse_retained_raws(archive, raw_ids, ingest_workers=4)
+
+    expected_native_id = {"raw-alpha": "session-alpha", "raw-beta": "session-beta"}
+    for raw_id in raw_ids:
+        seq_sessions, _seq_size, _seq_kind = sequential_results[raw_id]  # type: ignore[misc]
+        thread_sessions, _thread_size, _thread_kind = thread_results[raw_id]  # type: ignore[misc]
+        assert len(seq_sessions) == 1
+        assert len(thread_sessions) == 1
+        assert seq_sessions[0].provider_session_id == expected_native_id[raw_id]
+        # The actual regression proof: the thread path must match the
+        # sequential path's recovered identity, not silently fall back to
+        # the source_path stem instead.
+        assert thread_sessions[0].provider_session_id == seq_sessions[0].provider_session_id
+
+
 def test_thread_parse_never_touches_shared_archive_connection(monkeypatch: pytest.MonkeyPatch) -> None:
     """Regression guard for the sqlite ``check_same_thread`` hazard this
     thread path was designed around: ``ArchiveStore._source_conn`` is a
@@ -1907,9 +2011,9 @@ def test_thread_parse_never_touches_shared_archive_connection(monkeypatch: pytes
         archive_root = Path("/fake-root")
         source_db_path = Path("/fake-root/source.db")
 
-    descriptors = {
-        "raw-a": (Provider.CODEX, "hash-a", "a.jsonl", RawRevisionKind.FULL, 111),
-        "raw-b": (Provider.CODEX, "hash-b", "b.jsonl", RawRevisionKind.FULL, 222),
+    descriptors: dict[str, tuple[Provider, str, str, RawRevisionKind, int, str | None]] = {
+        "raw-a": (Provider.CODEX, "hash-a", "a.jsonl", RawRevisionKind.FULL, 111, None),
+        "raw-b": (Provider.CODEX, "hash-b", "b.jsonl", RawRevisionKind.FULL, 222, None),
     }
 
     def fake_worker(
@@ -1920,6 +2024,8 @@ def test_thread_parse_never_touches_shared_archive_connection(monkeypatch: pytes
         is_stream: bool,
         blob_root_str: str,
         source_db_path_str: str,
+        kind_token: str,
+        native_id: str | None,
     ) -> tuple[str, list[ParsedSession] | None, str | None]:
         return raw_id, [], None
 
@@ -1947,10 +2053,10 @@ def test_thread_parse_propagates_per_raw_exception_without_poisoning_batch(
     ``as_completed`` loop uncaught, this whole test (and every other raw's
     result) would never be reached -- the two surviving successful results
     are asserted explicitly, not merely "no exception raised"."""
-    descriptors = {
-        "ok-1": (Provider.CODEX, "hash-A", "a.jsonl", RawRevisionKind.FULL, 10),
-        "bad-1": (Provider.CODEX, "hash-B", "b.jsonl", RawRevisionKind.FULL, 20),
-        "ok-2": (Provider.CODEX, "hash-C", "c.jsonl", RawRevisionKind.FULL, 30),
+    descriptors: dict[str, tuple[Provider, str, str, RawRevisionKind, int, str | None]] = {
+        "ok-1": (Provider.CODEX, "hash-A", "a.jsonl", RawRevisionKind.FULL, 10, None),
+        "bad-1": (Provider.CODEX, "hash-B", "b.jsonl", RawRevisionKind.FULL, 20, None),
+        "ok-2": (Provider.CODEX, "hash-C", "c.jsonl", RawRevisionKind.FULL, 30, None),
     }
 
     class _FakeArchive:
@@ -1965,6 +2071,8 @@ def test_thread_parse_propagates_per_raw_exception_without_poisoning_batch(
         is_stream: bool,
         blob_root_str: str,
         source_db_path_str: str,
+        kind_token: str,
+        native_id: str | None,
     ) -> tuple[str, list[ParsedSession] | None, str | None]:
         if raw_id == "bad-1":
             raise RuntimeError(f"boom {raw_id}")
@@ -1997,8 +2105,8 @@ def test_thread_parse_results_keyed_by_raw_id_not_completion_order(monkeypatch: 
     descriptor-derived payload_size must still come back attached to it
     regardless."""
     raw_ids = [f"raw-{i}" for i in range(6)]
-    descriptors = {
-        raw_id: (Provider.CODEX, f"hash-{i}", f"path-{i}.jsonl", RawRevisionKind.FULL, 100 + i)
+    descriptors: dict[str, tuple[Provider, str, str, RawRevisionKind, int, str | None]] = {
+        raw_id: (Provider.CODEX, f"hash-{i}", f"path-{i}.jsonl", RawRevisionKind.FULL, 100 + i, None)
         for i, raw_id in enumerate(raw_ids)
     }
     # raw-0 (submitted first) sleeps longest; raw-5 (submitted last) returns
@@ -2017,6 +2125,8 @@ def test_thread_parse_results_keyed_by_raw_id_not_completion_order(monkeypatch: 
         is_stream: bool,
         blob_root_str: str,
         source_db_path_str: str,
+        kind_token: str,
+        native_id: str | None,
     ) -> tuple[str, list[ParsedSession] | None, str | None]:
         time.sleep(delay_by_raw_id[raw_id])
         return raw_id, [], None
@@ -2044,9 +2154,9 @@ def test_parse_unique_retained_raws_routes_to_threads_when_probe_true(
     ``parallel_threads_effective()`` is true, it must call
     ``_parse_unique_retained_raws_via_threads`` (no size partition / floor)
     rather than falling through to the process-pool branch below it."""
-    descriptors = {
-        "raw-a": (Provider.CODEX, "hash-a", "a.jsonl", RawRevisionKind.FULL, 10),
-        "raw-b": (Provider.CODEX, "hash-b", "b.jsonl", RawRevisionKind.FULL, 20),
+    descriptors: dict[str, tuple[Provider, str, str, RawRevisionKind, int, str | None]] = {
+        "raw-a": (Provider.CODEX, "hash-a", "a.jsonl", RawRevisionKind.FULL, 10, None),
+        "raw-b": (Provider.CODEX, "hash-b", "b.jsonl", RawRevisionKind.FULL, 20, None),
     }
 
     sentinel: dict[str, tuple[list[ParsedSession], int, RawRevisionKind] | Exception] = {
@@ -2059,7 +2169,7 @@ def test_parse_unique_retained_raws_routes_to_threads_when_probe_true(
         archive: object,
         raw_ids: list[str],
         *,
-        descriptors: dict[str, tuple[Provider, str, str, RawRevisionKind, int]],
+        descriptors: dict[str, tuple[Provider, str, str, RawRevisionKind, int, str | None]],
         ingest_workers: int,
     ) -> dict[str, tuple[list[ParsedSession], int, RawRevisionKind] | Exception]:
         calls.append((tuple(raw_ids), ingest_workers))


### PR DESCRIPTION
## Summary

Fixes a latent correctness bug where the thread-parallel census parse path, the daemon's off-writer-hold prefetch warmer, and the pipelined replay prefetcher's reparse fallback could silently diverge from the sequential path's session identity for APPEND-kind raws. Also unifies four scattered worker-count/pool-kind formulas into one decision function per call site.

## Problem

`census_parse_worker` (`polylogue/sources/revision_backfill.py`) is the pure blob->ParsedSession decode function dispatched by three parallel paths: the thread-pool census family, the daemon's `CensusParseStage` prefetch warmer, and `_ReplaySpillPrefetcher._decode`. It had no way to recover an APPEND raw's write-time-recorded `native_id`, unlike the sequential path (`parse_retained_raw_sessions`), which recovers it via `archive.raw_native_id` (polylogue-u19l). A Codex append delta carries no self-describing `session_meta` of its own, so every parallel dispatch path silently fell back to `Path(source_path).stem` instead of the recorded identity -- falsifying the documented byte-identical parallel/sequential equivalence for one revision kind, silently, under the production free-threaded config (polylogue-6lyh1).

Separately, four CPU-bound parse-dispatch call sites (`archive_ingest.py`, `validation_flow.py`, `ingest_batch/_core.py`, `revision_backfill.py`'s census family) each carried worker-count arithmetic inline, with the census family's thread-vs-sequential choice also decided inline. This scattering made the parallel/sequential equivalence contract hard to test and hard to reason about as one decision (polylogue-xecca).

## Solution

- `census_parse_worker` now takes `kind_token`/`native_id` and recomputes the same `fallback_id_override` the sequential path applies, only when `kind` is APPEND. Every dispatcher (`_parse_unique_retained_raws_via_threads`, `_ReplaySpillPrefetcher._decode`, `CensusParseStage.warm_raw_ids`) resolves both values on its own calling thread before dispatch, never inside a worker -- preserving the existing no-shared-connection contract (`_NoMethodsArchive`'s test proves `_parse_unique_retained_raws_via_threads` never calls a method on the shared archive).
- The content-cache dedup key (`ContentCacheKey`) widened from `(provider, blob_hash, dedup_path)` to include `native_id`: without it, two byte-identical APPEND payloads recovering different native ids could fan the same parsed identity out to both raw_ids for path-independent providers.
- `census_parse_stage.py`'s daemon warmer resolves `native_id` via a small dedicated read-only query (`_resolve_readonly_native_ids`) rather than widening `storage/repair.py`'s shared `raw_materialization_readonly_descriptors` (out of this PR's ownership scope; its other callers don't need this column).
- Extracted `resolve_archive_ingest_dispatch` / `resolve_validation_dispatch` / `resolve_ingest_batch_dispatch` / `resolve_revision_backfill_census_dispatch` into `pipeline/services/process_pool.py`, one pure function per site (workload shape + a `free_threaded` input + a `PoolKind`/`worker_count` result). Each site's own measured behavior is unchanged -- e.g. `validation_flow`'s process-pool-always preference under the GIL (3.7x measured) is preserved verbatim, not folded into the census family's free-threading gate. `free_threaded` is an explicit input (the caller's own `parallel_threads_effective()` read), not resolved internally, so existing tests can still monkeypatch it at the call site rather than a different module's binding.
- Removed `archive_ingest.py`'s now-redundant `_parse_worker_count()` wrapper around `resolve_parse_worker_count()`.

### Per-site before/after resolution (all effective behavior preserved)

| Site | Before | After |
| --- | --- | --- |
| `archive_ingest.py` (re-ingest file-walk) | `resolve_parse_worker_count()` inline | `resolve_archive_ingest_dispatch().worker_count` |
| `validation_flow.py` (raw-record validation) | `min(len(raw_artifacts), cpus, 8)` inline, always process pool | `resolve_validation_dispatch(record_count=...).worker_count` |
| `ingest_batch/_core.py` (size-tiered ingest) | `_select_ingest_worker_count` inline size-tiered formula | delegates to `resolve_ingest_batch_dispatch` |
| `revision_backfill.py` (census family) | inline `ingest_workers<=1 or len<=1 or not parallel_threads_effective()` | `resolve_revision_backfill_census_dispatch(...).pool_kind` |

## Verification

- `devtools test tests/unit/sources/test_revision_backfill.py tests/unit/daemon/test_parse_prefetch.py tests/unit/pipeline/test_ingest_batch.py tests/unit/pipeline/test_validation_parallelism_contracts.py tests/unit/sources/test_prefetch_cache_thread_safety.py tests/unit/pipeline/test_process_pool.py tests/unit/pipeline/test_archive_ingest_commit_batching.py tests/unit/pipeline/test_archive_ingest_shared_raw.py` -> 191 passed, 1 failed. The 1 failure (`test_backfill_content_cache_across_pages_reduces_parses_and_matches_uncached_archive`, `ActiveByteRevisionChainError`) is confirmed pre-existing and unrelated: it fails identically with this branch's changes stashed out.
- Two new red-first regression tests confirmed failing against the pre-fix code before the fix landed (`test_thread_parse_recovers_append_native_id_matching_sequential` asserted `'delta-file-one' == 'session-alpha'`; `test_warm_recovers_append_native_id_not_source_path_stem` asserted `'stem-does-not-match' == 'session-real-native-id'`), and passing after.
- A new decision-function matrix (`tests/unit/pipeline/test_process_pool.py`) pins each site's exact pre-extraction numbers.
- `/realm/project/polylogue/.venv/bin/python -m mypy polylogue tests devtools` -> `Success: no issues found in 2523 source files`.
- `devtools verify --quick` -> exit 0 (also ran again automatically via the pre-push hook).
- Live archive currently has 0 divergent candidates for this bug (every stem happens to equal its native id) -- the fixture in the new tests constructs the divergent shape deliberately, per the tracking bead's note.

Ref polylogue-6lyh1, polylogue-xecca