### PR TITLE
feat(storage): add byte-duplicate supersession classifier + actuator

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -1067,6 +1067,33 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
+        "workspace raw-byte-duplicate-supersession-apply",
+        "workspace",
+        "Promote quarantined, logical-key-less raws proven byte-identical to an already-indexed raw.",
+        "devtools.raw_byte_duplicate_supersession_apply",
+        use_when=(
+            "polylogue-6753s (corrected finding, 2026-08-03): of 7,200 unindexed logical-source "
+            "heads, 4,305 (17.6 of 22.9 GiB) are revision_authority='quarantined' with "
+            "logical_source_key IS NULL -- invisible to every reconciliation path, since all of "
+            "them key off logical_source_key -- and are byte-identical (same blob_hash) to some "
+            "OTHER raw that already has a materialized session in index.db: re-acquisitions/"
+            "re-syncs of already-archived content, not missing content. Default is dry-run; "
+            "--apply requires --backup-manifest pointing at a verified source-tier backup "
+            "(polylogue backup --output-dir <dir> --verify). Writes an immutable per-row receipt "
+            "(raw_byte_duplicate_supersession_receipts) recording which indexed raw_id/session_id "
+            "each duplicate matches; never touches index.db or the indexed twin's own row; never "
+            "runs blob GC or VACUUM -- those are separate, later steps. The genuinely novel "
+            "remainder (no indexed byte-identical twin) is left untouched for polylogue-lkrc/"
+            "polylogue-hjpx's reconciler."
+        ),
+        examples=(
+            "devtools workspace raw-byte-duplicate-supersession-apply",
+            "devtools workspace raw-byte-duplicate-supersession-apply --json",
+            "devtools workspace raw-byte-duplicate-supersession-apply --apply "
+            "--backup-manifest /realm/staging/polylogue-backup/manifest.json",
+        ),
+    ),
+    CommandSpec(
         "workspace binary-artifact-sweep",
         "workspace",
         "Find raw_sessions rows whose bytes are a non-session binary format (SQLite, etc).",

--- a/devtools/raw_byte_duplicate_supersession_apply.py
+++ b/devtools/raw_byte_duplicate_supersession_apply.py
@@ -1,0 +1,114 @@
+"""Actuator: promote quarantined, logical-key-less raws proven byte-identical to an indexed raw.
+
+polylogue-6753s (corrected finding, 2026-08-03): of 7,200 unindexed logical-
+source heads, 4,305 (17.6 of 22.9 GiB) are ``revision_authority='quarantined'``
+with ``logical_source_key IS NULL`` -- invisible to every reconciliation path,
+since all of them key off ``logical_source_key`` -- and are byte-identical
+(same ``blob_hash``) to some OTHER raw that already has a materialized session
+in ``index.db``. These are re-acquisitions/re-syncs of already-archived
+content, not missing content.
+
+Default mode is dry-run (report only, zero mutation). Pass ``--apply`` to
+actually promote rows, which additionally requires ``--backup-manifest``
+pointing at a verified backup manifest for the ``source`` tier (see
+``polylogue backup --output-dir <dir> --verify``). This never runs blob GC or
+``VACUUM`` -- that is a separate, later, operator-invoked step. ``index.db``
+is only ever opened read-only; nothing here writes to it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import TextIO
+
+from polylogue.maintenance.raw_byte_duplicate_supersession_apply import (
+    RawByteDuplicateSupersessionApplyError,
+    apply_raw_byte_duplicate_supersession,
+)
+from polylogue.paths import archive_root as default_archive_root
+
+
+def main(argv: list[str] | None = None, *, stdout: TextIO | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--archive-root",
+        type=Path,
+        default=None,
+        help="Archive root to operate on; defaults to the configured active archive root.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Cap the number of quarantined, logical-key-less rows classified/promoted (unbounded by default).",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually promote rows. Without this flag, nothing is mutated.",
+    )
+    parser.add_argument(
+        "--backup-manifest",
+        type=Path,
+        default=None,
+        help="Verified backup manifest for the source tier. Required with --apply.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit the report as JSON.")
+    args = parser.parse_args(argv)
+
+    root = args.archive_root if args.archive_root is not None else default_archive_root()
+
+    try:
+        report = apply_raw_byte_duplicate_supersession(
+            root,
+            backup_manifest=args.backup_manifest,
+            limit=args.limit,
+            dry_run=not args.apply,
+        )
+    except (RawByteDuplicateSupersessionApplyError, FileNotFoundError) as exc:
+        print(f"refused: {exc}", file=stdout)
+        return 1
+
+    if args.json:
+        payload = {
+            "applied": report.applied,
+            "scanned_count": report.scanned_count,
+            "promoted_count": report.promoted_count,
+            "promoted_bytes": report.promoted_bytes,
+            "novel_count": report.novel_count,
+            "promoted_raw_ids": list(report.promoted_raw_ids),
+            "backup_manifest": str(report.backup_manifest) if report.backup_manifest is not None else None,
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True), file=stdout)
+        return 0
+
+    def _gib(byte_count: int) -> str:
+        return f"{byte_count / (1024**3):.2f} GiB"
+
+    mode = "APPLIED" if report.applied else "dry-run (no mutation performed -- pass --apply to promote)"
+    print(f"mode: {mode}", file=stdout)
+    print(f"quarantined, logical-key-less rows scanned: {report.scanned_count}", file=stdout)
+    print(
+        f"{'promoted' if report.applied else 'promotable'} (byte-identical to an indexed raw): "
+        f"{report.promoted_count:>7}  ({_gib(report.promoted_bytes)})",
+        file=stdout,
+    )
+    print(
+        f"novel (no indexed byte-identical twin, left untouched -- lkrc/hjpx scope): {report.novel_count}",
+        file=stdout,
+    )
+    if report.applied:
+        print(f"backup manifest used: {report.backup_manifest}", file=stdout)
+        print(
+            "Each promoted row has an immutable receipt in "
+            "raw_byte_duplicate_supersession_receipts. No blob GC or VACUUM was run -- "
+            "that is a separate, later step. index.db was never written to.",
+            file=stdout,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -253,6 +253,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools workspace raw-authority-daemon-health-proof` | Prove daemon status/health HTTP responsiveness during a real raw-authority drain. |
 | `devtools workspace raw-authority-restart-proof` | Prove raw-authority crash recovery and conserved fixed-point convergence. |
 | `devtools workspace raw-authority-scale-proof` | Run bounded raw-authority replay to a two-census fixed point. |
+| `devtools workspace raw-byte-duplicate-supersession-apply` | Promote quarantined, logical-key-less raws proven byte-identical to an already-indexed raw. |
 | `devtools workspace raw-live-source-reconciliation` | Classify quarantined raw evidence against its live source file's current bytes. |
 | `devtools workspace raw-live-source-reconciliation-apply` | Promote quarantined raw evidence proven correct by live-source verification. |
 | `devtools workspace raw-membership-writeback-apply` | Propagate already-decided membership verdicts onto raw_sessions.revision_authority. |

--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -546,7 +546,7 @@ files:
     target: polylogue/archive/revision_authority.py
     owner: stable
   - path: polylogue/archive/revision_replay.py
-    loc: 243
+    loc: 252
     target: polylogue/archive/revision_replay.py
     owner: stable
   - path: polylogue/archive/semantic/__init__.py
@@ -704,7 +704,7 @@ files:
     owner: archive-session
     reason: archive-domain semantics
   - path: polylogue/archive/session_revision_membership.py
-    loc: 467
+    loc: 493
     target: polylogue/archive/session_revision_membership.py
     owner: stable
   - path: polylogue/archive/stats.py
@@ -2242,6 +2242,10 @@ files:
   - path: polylogue/maintenance/raw_authority_reset.py
     loc: 109
     target: polylogue/maintenance/raw_authority_reset.py
+    owner: stable
+  - path: polylogue/maintenance/raw_byte_duplicate_supersession_apply.py
+    loc: 230
+    target: polylogue/maintenance/raw_byte_duplicate_supersession_apply.py
     owner: stable
   - path: polylogue/maintenance/raw_live_source_reconciliation_apply.py
     loc: 286
@@ -3989,15 +3993,19 @@ files:
     target: TBD
     owner: storage-domain
   - path: polylogue/storage/raw_authority.py
-    loc: 2295
+    loc: 2305
     target: TBD
     owner: storage-domain
   - path: polylogue/storage/raw_authority_verdict_projection.py
     loc: 105
     target: TBD
     owner: storage-domain
+  - path: polylogue/storage/raw_byte_duplicate_supersession.py
+    loc: 203
+    target: TBD
+    owner: storage-domain
   - path: polylogue/storage/raw_membership_writeback.py
-    loc: 124
+    loc: 133
     target: TBD
     owner: storage-domain
   - path: polylogue/storage/raw_reconciler.py
@@ -4270,7 +4278,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/embeddings.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/index.py
-    loc: 2307
+    loc: 2305
     target: polylogue/storage/sqlite/archive_tiers/index.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/index_convergence.py
@@ -4302,7 +4310,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/revision_application.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/revision_governance.py
-    loc: 2931
+    loc: 2952
     target: polylogue/storage/sqlite/archive_tiers/revision_governance.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/session_annotations_write.py
@@ -4310,7 +4318,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/session_annotations_write.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/source.py
-    loc: 590
+    loc: 623
     target: polylogue/storage/sqlite/archive_tiers/source.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/source_write.py

--- a/polylogue/maintenance/raw_byte_duplicate_supersession_apply.py
+++ b/polylogue/maintenance/raw_byte_duplicate_supersession_apply.py
@@ -1,0 +1,230 @@
+"""Promote quarantined, logical-key-less raws proven byte-identical to an already-indexed raw.
+
+polylogue-6753s: :mod:`polylogue.storage.raw_byte_duplicate_supersession`
+classifies ``raw_sessions`` rows that are ``revision_authority='quarantined'``
+with ``logical_source_key IS NULL`` -- invisible to every existing
+reconciliation path, since all of them key off ``logical_source_key`` -- and
+whose ``blob_hash`` matches some *other* raw that already has a materialized
+session in ``index.db``. This module is the "act" half, following the
+identical safety pattern as every other actuator in this family
+(``raw_live_source_reconciliation_apply``, ``raw_membership_writeback_apply``,
+``raw_append_chain_backfill_apply``):
+
+* Dry-run by default. ``dry_run=False`` requires a verified backup manifest
+  for the ``source`` tier, validated with the same gate durable-tier schema
+  migrations use.
+* Classification is re-run *live*, inside the same write transaction the
+  promotion runs in -- never trusts a previously computed plan.
+* Every promoted row gets an immutable receipt in
+  ``raw_byte_duplicate_supersession_receipts`` in the same transaction as its
+  ``revision_authority`` update.
+* Deliberately never touches ``predecessor_raw_id`` / ``baseline_raw_id`` /
+  ``acquisition_generation`` / ``revision_authority_evidence`` (a closed
+  vocabulary scoped to live-source-verification promotions) -- this is a
+  distinct, independently-verifiable evidence mechanism, and its own receipt
+  row is the durable record of it, exactly like ``raw_membership_writeback``
+  already established for its own distinct mechanism.
+* Never touches, re-parses, or writes to ``index.db``. ``index.db`` is opened
+  strictly read-only, purely to re-confirm which raw_ids are indexed at apply
+  time; it is never mutated, and the duplicate's own indexed twin (its
+  ``raw_sessions`` row, its ``sessions`` row) is never modified.
+* Never performs blob GC or ``VACUUM``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from polylogue.config import Config
+from polylogue.maintenance.offline_guard import offline_maintenance_block_reason
+from polylogue.paths import render_root
+from polylogue.storage.raw_byte_duplicate_supersession import (
+    ByteDuplicateSupersessionPlan,
+    plan_byte_duplicate_supersession,
+)
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.migration_runner import validate_migration_backup_manifest
+
+TOOL_VERSION = "raw-byte-duplicate-supersession-apply-v1"
+
+
+class RawByteDuplicateSupersessionApplyError(RuntimeError):
+    """Raised when applying a byte-duplicate supersession promotion is refused."""
+
+
+@dataclass(frozen=True, slots=True)
+class RawByteDuplicateSupersessionApplyReport:
+    scanned_count: int
+    promoted_count: int
+    promoted_bytes: int
+    novel_count: int
+    promoted_raw_ids: tuple[str, ...]
+    applied: bool
+    backup_manifest: Path | None = None
+
+    @classmethod
+    def from_plan(
+        cls,
+        plan: ByteDuplicateSupersessionPlan,
+        *,
+        applied: bool,
+        promoted_raw_ids: tuple[str, ...] = (),
+        backup_manifest: Path | None = None,
+    ) -> RawByteDuplicateSupersessionApplyReport:
+        by_id = {candidate.raw_id: candidate for candidate in plan.duplicates}
+        promoted_bytes = (
+            sum(by_id[raw_id].blob_size for raw_id in promoted_raw_ids if raw_id in by_id)
+            if applied
+            else plan.duplicate_bytes
+        )
+        return cls(
+            scanned_count=plan.scanned_count,
+            promoted_count=len(promoted_raw_ids) if applied else len(plan.duplicates),
+            promoted_bytes=promoted_bytes,
+            novel_count=plan.novel_count,
+            promoted_raw_ids=promoted_raw_ids,
+            applied=applied,
+            backup_manifest=backup_manifest,
+        )
+
+
+def _offline_config(archive_root: Path) -> Config:
+    return Config(archive_root=archive_root, render_root=render_root(), sources=[])
+
+
+def _checkpoint_live_tier(conn: sqlite3.Connection) -> None:
+    try:
+        row = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+    except sqlite3.Error as exc:
+        raise RawByteDuplicateSupersessionApplyError("could not checkpoint source.db before backup validation") from exc
+    if row is None:
+        raise RawByteDuplicateSupersessionApplyError("could not checkpoint source.db before backup validation")
+
+
+def apply_raw_byte_duplicate_supersession(
+    archive_root: Path,
+    *,
+    backup_manifest: Path | None = None,
+    limit: int | None = None,
+    dry_run: bool = True,
+) -> RawByteDuplicateSupersessionApplyReport:
+    """Classify quarantined, logical-key-less raws live, then promote proven byte-duplicates.
+
+    ``dry_run=True`` (the default) never opens a write transaction on
+    ``source.db`` and never touches ``index.db`` beyond a read-only open. It
+    runs the same classifier a real apply would and reports what it would do.
+
+    ``dry_run=False`` requires ``backup_manifest`` and re-runs classification
+    live, inside the same ``BEGIN IMMEDIATE`` write transaction on
+    ``source.db`` the promotion UPDATE/INSERT pair runs in, so nothing acted
+    on can be stale relative to what gets promoted. ``index.db`` is opened
+    read-only for the classification re-run and is never written to.
+    """
+    source_db = archive_root / "source.db"
+    index_db = archive_root / "index.db"
+    if not source_db.exists():
+        raise FileNotFoundError(f"no source.db at {source_db}")
+    if not index_db.exists():
+        raise FileNotFoundError(f"no index.db at {index_db}")
+
+    if dry_run:
+        source_conn = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
+        index_conn = sqlite3.connect(f"file:{index_db}?mode=ro", uri=True)
+        try:
+            plan = plan_byte_duplicate_supersession(source_conn, index_conn, limit=limit)
+        finally:
+            source_conn.close()
+            index_conn.close()
+        return RawByteDuplicateSupersessionApplyReport.from_plan(plan, applied=False)
+
+    if backup_manifest is None:
+        raise RawByteDuplicateSupersessionApplyError(
+            "applying raw-byte-duplicate-supersession requires a verified backup manifest (--backup-manifest)"
+        )
+    if reason := offline_maintenance_block_reason(_offline_config(archive_root), active=True, dry_run=False):
+        raise RawByteDuplicateSupersessionApplyError(reason)
+
+    index_conn = sqlite3.connect(f"file:{index_db}?mode=ro", uri=True)
+    conn = sqlite3.connect(source_db)
+    promoted: list[str] = []
+    try:
+        _checkpoint_live_tier(conn)
+        validate_migration_backup_manifest(backup_manifest, ArchiveTier.SOURCE, connection=conn)
+
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            validate_migration_backup_manifest(backup_manifest, ArchiveTier.SOURCE, connection=conn)
+
+            plan = plan_byte_duplicate_supersession(conn, index_conn, limit=limit)
+            promoted_at_ms = int(time.time() * 1000)
+
+            for candidate in plan.duplicates:
+                cursor = conn.execute(
+                    """
+                    UPDATE raw_sessions
+                    SET revision_authority = 'byte_proven'
+                    WHERE raw_id = ? AND revision_authority = 'quarantined' AND logical_source_key IS NULL
+                    """,
+                    (candidate.raw_id,),
+                )
+                if cursor.rowcount != 1:
+                    # Defensive: no longer quarantined/logical-key-less under
+                    # this same locked transaction's own read -- should not
+                    # happen given the classification above ran on this same
+                    # connection under this same lock, but skipping instead
+                    # of asserting keeps this pass conservative.
+                    continue
+                conn.execute(
+                    """
+                    INSERT INTO raw_byte_duplicate_supersession_receipts (
+                        raw_id, blob_hash, blob_size, duplicate_of_raw_id, duplicate_of_session_id,
+                        previous_revision_authority, promoted_at_ms, tool_version,
+                        backup_manifest_path, detail
+                    ) VALUES (?, ?, ?, ?, ?, 'quarantined', ?, ?, ?, ?)
+                    """,
+                    (
+                        candidate.raw_id,
+                        candidate.blob_hash,
+                        candidate.blob_size,
+                        candidate.duplicate_of_raw_id,
+                        candidate.duplicate_of_session_id,
+                        promoted_at_ms,
+                        TOOL_VERSION,
+                        str(backup_manifest),
+                        "",
+                    ),
+                )
+                promoted.append(candidate.raw_id)
+
+            quick_check = conn.execute("PRAGMA quick_check").fetchone()
+            if quick_check is None or str(quick_check[0]).lower() != "ok":
+                raise RawByteDuplicateSupersessionApplyError(
+                    f"source.db quick_check failed after promotion: {quick_check!r}"
+                )
+        except Exception:
+            if conn.in_transaction:
+                conn.rollback()
+            raise
+        else:
+            conn.commit()
+    finally:
+        conn.close()
+        index_conn.close()
+
+    return RawByteDuplicateSupersessionApplyReport.from_plan(
+        plan,
+        applied=True,
+        promoted_raw_ids=tuple(promoted),
+        backup_manifest=backup_manifest,
+    )
+
+
+__all__ = [
+    "TOOL_VERSION",
+    "RawByteDuplicateSupersessionApplyError",
+    "RawByteDuplicateSupersessionApplyReport",
+    "apply_raw_byte_duplicate_supersession",
+]

--- a/polylogue/storage/raw_byte_duplicate_supersession.py
+++ b/polylogue/storage/raw_byte_duplicate_supersession.py
@@ -1,0 +1,203 @@
+"""Read-only classification: quarantined, logical-key-less raws byte-identical to an already-indexed raw.
+
+polylogue-6753s (corrected finding, 2026-08-03): of 7,200 unindexed logical-
+source heads in the live archive, 4,305 (17.6 of 22.9 GiB, 77% of the bytes)
+are ``revision_authority='quarantined'`` with ``logical_source_key IS NULL``
+-- never touched by the reconciler, because every reconciliation path
+(``classify_raw_revision_cohort``, the membership pipeline, the append-chain
+backfill) keys off ``logical_source_key`` and a row with none is invisible to
+all of them. That population is not homogeneous: 4,305 of those rows turn out
+to be **byte-identical re-acquisitions** of content the archive already
+indexed under a *different* ``raw_id`` -- a re-synced export, a re-run
+capture, a duplicate upload -- not missing or novel content at all. The
+genuinely novel remainder (~2,895 rows, ~5.3 GiB) is explicitly out of scope
+here; it is polylogue-lkrc/polylogue-hjpx's reconciler work, not this bead's.
+
+This module answers exactly one question per candidate row, read-only: does
+this raw's ``blob_hash`` match some *other* ``raw_sessions`` row whose content
+is already materialized as an indexed ``sessions`` row in ``index.db``? If so,
+this raw is a pure duplicate of already-archived content and its terminal
+disposition is "superseded by an already-indexed byte-identical raw" -- it
+carries nothing the archive doesn't already have.
+
+Terminal-disposition mechanism reused, not invented: this follows the exact
+precedent ``polylogue.storage.raw_membership_writeback`` (polylogue-lb39z item
+2) already established for "pure fact transfer, not new judgment" promotions.
+``revision_authority`` promotes from ``'quarantined'`` to ``'byte_proven'``
+(the only two-value axis this closed vocabulary offers for "provenance no
+longer contested"); ``revision_authority_evidence`` is deliberately left
+``NULL`` rather than widening its closed CHECK vocabulary (widening that
+column requires a full ``raw_sessions`` table rebuild, migration 021's own
+precedent for *why* that is expensive -- unwarranted for a mechanism whose
+real evidence belongs in its own dedicated, independently-verifiable receipt
+table anyway, exactly as item 2's writeback module already decided for its
+own distinct evidence mechanism). The real evidence -- *which* indexed raw_id
+and session this duplicate matches -- is recorded in a dedicated
+``raw_byte_duplicate_supersession_receipts`` row (migration 022), never
+silently.
+
+This is **strictly read-then-classify-then-mark**: it never touches, re-
+parses, or writes to ``index.db``, and it never mutates the indexed twin's
+``raw_sessions`` row (its own ``revision_authority``/``logical_source_key``
+stay exactly as they were). ``index.db`` is opened read-only, purely to
+determine which raw_ids already have a materialized session; nothing here
+ever writes to it.
+
+:mod:`polylogue.maintenance.raw_byte_duplicate_supersession_apply` is the
+"act" half, following the identical dry-run-by-default /
+verified-backup-required-to-apply / immutable-receipt pattern as every other
+actuator in this family (``raw_live_source_reconciliation_apply``,
+``raw_membership_writeback_apply``, ``raw_append_chain_backfill_apply``).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ByteDuplicateSupersessionCandidate:
+    """One quarantined, logical-key-less raw proven byte-identical to an indexed twin."""
+
+    raw_id: str
+    blob_hash: bytes
+    blob_size: int
+    #: The OTHER raw_sessions row (never this row) whose bytes are identical
+    #: and which already has a materialized session in index.db.
+    duplicate_of_raw_id: str
+    #: The indexed session_id materialized from duplicate_of_raw_id -- proof,
+    #: not just an assertion, that the twin really is indexed.
+    duplicate_of_session_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class ByteDuplicateSupersessionPlan:
+    """Read-only projection: how much quarantined, logical-key-less authority is a pure byte duplicate.
+
+    Mirrors the report-first shape every sibling classifier in this family
+    uses (``LiveSourceReconciliationPlan``, ``AppendChainBackfillPlan``) --
+    nothing here marks a row's authority or touches index.db.
+    """
+
+    scanned_count: int
+    duplicates: tuple[ByteDuplicateSupersessionCandidate, ...]
+    #: Scanned rows with no byte-identical indexed twin -- left untouched;
+    #: this is the genuinely-novel remainder lkrc/hjpx's reconciler owns.
+    novel_count: int
+
+    @property
+    def duplicate_bytes(self) -> int:
+        return sum(candidate.blob_size for candidate in self.duplicates)
+
+
+def plan_byte_duplicate_supersession(
+    source_conn: sqlite3.Connection,
+    index_conn: sqlite3.Connection,
+    *,
+    limit: int | None = None,
+) -> ByteDuplicateSupersessionPlan:
+    """Read-only: classify quarantined, logical-key-less raws against already-indexed twins.
+
+    ``source_conn`` and ``index_conn`` are both used strictly for reads --
+    safe to pass connections opened ``file:...?mode=ro``. Never mutates
+    either database.
+    """
+    original_source_row_factory = source_conn.row_factory
+    original_index_row_factory = index_conn.row_factory
+    source_conn.row_factory = sqlite3.Row
+    index_conn.row_factory = sqlite3.Row
+    try:
+        query = """
+            SELECT raw_id, blob_hash, blob_size
+            FROM raw_sessions
+            WHERE revision_authority = 'quarantined'
+              AND logical_source_key IS NULL
+            ORDER BY raw_id
+        """
+        params: tuple[object, ...] = ()
+        if limit is not None:
+            query += " LIMIT ?"
+            params = (limit,)
+        candidate_rows = source_conn.execute(query, params).fetchall()
+        if not candidate_rows:
+            return ByteDuplicateSupersessionPlan(scanned_count=0, duplicates=(), novel_count=0)
+
+        candidate_hashes = sorted({bytes(row["blob_hash"]) for row in candidate_rows})
+
+        # Every raw_sessions row sharing one of the candidate hashes --
+        # including other candidates themselves (a candidate's duplicate
+        # twin need not have a logical_source_key or a non-quarantined
+        # authority; it only needs to already be indexed) -- lets us find
+        # each candidate's "other raws with this same blob_hash" without one
+        # query per candidate. Self-exclusion happens per-candidate below,
+        # not here, since a raw_id can legitimately be the "other" raw for
+        # every other candidate sharing its hash while still being a
+        # candidate in its own right.
+        hash_to_raw_ids: dict[bytes, list[str]] = {}
+        for chunk_start in range(0, len(candidate_hashes), 500):
+            chunk = candidate_hashes[chunk_start : chunk_start + 500]
+            placeholders = ", ".join("?" for _ in chunk)
+            rows = source_conn.execute(
+                f"SELECT raw_id, blob_hash FROM raw_sessions WHERE blob_hash IN ({placeholders})",
+                chunk,
+            ).fetchall()
+            for row in rows:
+                hash_to_raw_ids.setdefault(bytes(row["blob_hash"]), []).append(str(row["raw_id"]))
+
+        # Which of those raw_ids are actually materialized in index.db --
+        # the one live-tier fact this classifier is allowed to read (never
+        # write).
+        all_raw_ids = sorted({raw_id for raw_ids in hash_to_raw_ids.values() for raw_id in raw_ids})
+        indexed_session_by_raw_id: dict[str, str] = {}
+        for chunk_start in range(0, len(all_raw_ids), 500):
+            raw_id_chunk = all_raw_ids[chunk_start : chunk_start + 500]
+            placeholders = ", ".join("?" for _ in raw_id_chunk)
+            rows = index_conn.execute(
+                f"SELECT raw_id, session_id FROM sessions WHERE raw_id IN ({placeholders}) ORDER BY session_id",
+                raw_id_chunk,
+            ).fetchall()
+            for row in rows:
+                raw_id = str(row["raw_id"])
+                # Deterministic: first (lowest) session_id wins if a raw_id
+                # somehow materialized more than one session row.
+                indexed_session_by_raw_id.setdefault(raw_id, str(row["session_id"]))
+
+        duplicates: list[ByteDuplicateSupersessionCandidate] = []
+        novel_count = 0
+        for row in candidate_rows:
+            raw_id = str(row["raw_id"])
+            blob_hash = bytes(row["blob_hash"])
+            other_raw_ids_for_hash = [rid for rid in hash_to_raw_ids.get(blob_hash, []) if rid != raw_id]
+            indexed_matches = sorted(
+                other_raw_id for other_raw_id in other_raw_ids_for_hash if other_raw_id in indexed_session_by_raw_id
+            )
+            if not indexed_matches:
+                novel_count += 1
+                continue
+            duplicate_of_raw_id = indexed_matches[0]
+            duplicates.append(
+                ByteDuplicateSupersessionCandidate(
+                    raw_id=raw_id,
+                    blob_hash=blob_hash,
+                    blob_size=int(row["blob_size"]),
+                    duplicate_of_raw_id=duplicate_of_raw_id,
+                    duplicate_of_session_id=indexed_session_by_raw_id[duplicate_of_raw_id],
+                )
+            )
+
+        return ByteDuplicateSupersessionPlan(
+            scanned_count=len(candidate_rows),
+            duplicates=tuple(duplicates),
+            novel_count=novel_count,
+        )
+    finally:
+        source_conn.row_factory = original_source_row_factory
+        index_conn.row_factory = original_index_row_factory
+
+
+__all__ = [
+    "ByteDuplicateSupersessionCandidate",
+    "ByteDuplicateSupersessionPlan",
+    "plan_byte_duplicate_supersession",
+]

--- a/polylogue/storage/sqlite/archive_tiers/source.py
+++ b/polylogue/storage/sqlite/archive_tiers/source.py
@@ -14,7 +14,7 @@ from polylogue.core.enums import ArtifactSupportStatus, Origin, Provider, Valida
 from polylogue.storage.sqlite.archive_tiers.common import check, literal_check, nullable_check
 from polylogue.storage.sqlite.archive_tiers.types import ProvenRevisionAuthority
 
-SOURCE_SCHEMA_VERSION = 22
+SOURCE_SCHEMA_VERSION = 23
 
 SOURCE_DDL = f"""
 CREATE TABLE IF NOT EXISTS raw_sessions (
@@ -227,6 +227,36 @@ CREATE TABLE IF NOT EXISTS raw_append_chain_backfill_receipts (
 
 CREATE INDEX IF NOT EXISTS idx_raw_append_chain_backfill_receipts_compared_at
 ON raw_append_chain_backfill_receipts(compared_at_ms);
+
+-- v22 (polylogue-6753s): one immutable receipt per raw_sessions row promoted
+-- out of quarantine because it is byte-identical (same blob_hash) to some
+-- OTHER raw_sessions row that already has a materialized session in
+-- index.db -- a pure re-acquisition/re-sync of already-archived content, not
+-- missing content. Deliberately does not widen revision_authority_evidence's
+-- closed CHECK vocabulary (would require a full raw_sessions table rebuild,
+-- see migration 021); this distinct, independently-verifiable evidence
+-- mechanism gets its own receipt table instead, exactly like
+-- raw_membership_writeback_receipts (v19) already does for its own distinct
+-- mechanism. See polylogue.storage.raw_byte_duplicate_supersession +
+-- polylogue.maintenance.raw_byte_duplicate_supersession_apply.
+CREATE TABLE IF NOT EXISTS raw_byte_duplicate_supersession_receipts (
+    raw_id                      TEXT PRIMARY KEY REFERENCES raw_sessions(raw_id) ON DELETE CASCADE,
+    blob_hash                   BLOB NOT NULL CHECK(length(blob_hash) = 32),
+    blob_size                   INTEGER NOT NULL CHECK(blob_size >= 0),
+    duplicate_of_raw_id         TEXT NOT NULL,
+    duplicate_of_session_id     TEXT NOT NULL,
+    previous_revision_authority TEXT NOT NULL CHECK(previous_revision_authority IN ('asserted', 'byte_proven', 'quarantined')),
+    promoted_at_ms              INTEGER NOT NULL CHECK(promoted_at_ms >= 0),
+    tool_version                TEXT NOT NULL,
+    backup_manifest_path        TEXT NOT NULL,
+    detail                      TEXT NOT NULL DEFAULT ''
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_raw_byte_duplicate_supersession_receipts_promoted_at
+ON raw_byte_duplicate_supersession_receipts(promoted_at_ms);
+
+CREATE INDEX IF NOT EXISTS idx_raw_byte_duplicate_supersession_receipts_duplicate_of
+ON raw_byte_duplicate_supersession_receipts(duplicate_of_raw_id);
 
 -- Durable authority reconciliation ledger.  The source tier owns this
 -- evidence because index.db and ops.db are rebuildable/disposable: neither

--- a/polylogue/storage/sqlite/migrations/source/023_raw_byte_duplicate_supersession_receipts.sql
+++ b/polylogue/storage/sqlite/migrations/source/023_raw_byte_duplicate_supersession_receipts.sql
@@ -1,0 +1,39 @@
+-- polylogue-6753s: 4,305 raw_sessions rows (17.6 of 22.9 GiB, measured
+-- 2026-08-03) are revision_authority='quarantined' with logical_source_key
+-- IS NULL -- never touched by the reconciler, because every reconciliation
+-- path keys off logical_source_key -- and are byte-identical
+-- (same blob_hash) to some OTHER raw_sessions row that already has a
+-- materialized session in index.db. These are re-acquisitions/re-syncs of
+-- content the archive already indexed, not missing content. A new,
+-- explicitly operator-invoked actuator (devtools workspace
+-- raw-byte-duplicate-supersession-apply) promotes exactly these rows to
+-- revision_authority='byte_proven'.
+--
+-- Deliberately does NOT widen revision_authority_evidence's closed CHECK
+-- vocabulary (that requires a full raw_sessions table rebuild, migration
+-- 021's own precedent for why that is expensive) and does NOT touch
+-- predecessor_raw_id / baseline_raw_id / acquisition_generation
+-- (revision-graph linkage owned by classify_raw_revision_cohort) or the
+-- duplicate twin's own raw_sessions row at all. Mirrors
+-- raw_membership_writeback_receipts (migration 019): a distinct,
+-- independently-verifiable evidence mechanism gets its own dedicated
+-- receipt table recording what was actually proven, rather than reusing
+-- revision_authority_evidence for a mechanism it was never scoped to.
+CREATE TABLE IF NOT EXISTS raw_byte_duplicate_supersession_receipts (
+    raw_id                      TEXT PRIMARY KEY REFERENCES raw_sessions(raw_id) ON DELETE CASCADE,
+    blob_hash                   BLOB NOT NULL CHECK(length(blob_hash) = 32),
+    blob_size                   INTEGER NOT NULL CHECK(blob_size >= 0),
+    duplicate_of_raw_id         TEXT NOT NULL,
+    duplicate_of_session_id     TEXT NOT NULL,
+    previous_revision_authority TEXT NOT NULL CHECK(previous_revision_authority IN ('asserted', 'byte_proven', 'quarantined')),
+    promoted_at_ms              INTEGER NOT NULL CHECK(promoted_at_ms >= 0),
+    tool_version                TEXT NOT NULL,
+    backup_manifest_path        TEXT NOT NULL,
+    detail                      TEXT NOT NULL DEFAULT ''
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_raw_byte_duplicate_supersession_receipts_promoted_at
+ON raw_byte_duplicate_supersession_receipts(promoted_at_ms);
+
+CREATE INDEX IF NOT EXISTS idx_raw_byte_duplicate_supersession_receipts_duplicate_of
+ON raw_byte_duplicate_supersession_receipts(duplicate_of_raw_id);

--- a/tests/unit/maintenance/test_raw_byte_duplicate_supersession_apply.py
+++ b/tests/unit/maintenance/test_raw_byte_duplicate_supersession_apply.py
@@ -1,0 +1,239 @@
+"""polylogue-6753s: the actuator for byte-duplicate supersession.
+
+Builds a fixture archive with a genuine byte-duplicate pair (one indexed, one
+quarantined-with-no-logical_source_key sharing its blob_hash) plus a genuine
+non-duplicate quarantined-no-lsk raw (must NOT be resolved), and proves:
+
+* dry-run (the default) never mutates anything, and never writes to index.db;
+* --apply promotes only the true duplicate to revision_authority='byte_proven'
+  (revision_authority_evidence left NULL -- this is a distinct, independently
+  verifiable mechanism recorded in its own receipt table, not the
+  live-source-verification vocabulary), and writes an immutable receipt
+  naming the indexed twin's raw_id/session_id;
+* the novel (non-duplicate) row and the already-indexed twin's own row are
+  left untouched;
+* applying without a backup manifest is refused before anything is touched;
+* predecessor_raw_id / baseline_raw_id / acquisition_generation /
+  revision_authority_evidence are never touched.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.core.enums import Provider
+from polylogue.maintenance.raw_byte_duplicate_supersession_apply import (
+    TOOL_VERSION,
+    RawByteDuplicateSupersessionApplyError,
+    apply_raw_byte_duplicate_supersession,
+)
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+_DUPLICATE_PAYLOAD = b'{"messages":["dup"]}\n'
+_NOVEL_PAYLOAD = b'{"messages":["novel"]}\n'
+
+
+def _write_quarantined_no_lsk_raw(archive: ArchiveStore, *, raw_id: str, payload: bytes, source_path: str) -> None:
+    archive.write_raw_payload(
+        provider=Provider.CLAUDE_CODE,
+        payload=payload,
+        source_path=source_path,
+        source_index=-1,
+        acquired_at_ms=1_700_000_000_000,
+        raw_id=raw_id,
+    )
+
+
+def _index_session(conn: sqlite3.Connection, *, raw_id: str, native_id: str) -> None:
+    conn.execute(
+        "INSERT INTO sessions (origin, native_id, content_hash, raw_id, created_at_ms, updated_at_ms) "
+        "VALUES ('claude-code-session', ?, ?, ?, 0, 0)",
+        (native_id, b"\x11" * 32, raw_id),
+    )
+
+
+def _build_fixture_archive(tmp_path: Path) -> Path:
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+
+    with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+        # The already-indexed twin -- never touched by the actuator.
+        _write_quarantined_no_lsk_raw(
+            archive,
+            raw_id="raw-indexed-twin",
+            payload=_DUPLICATE_PAYLOAD,
+            source_path=str(tmp_path / "twin.jsonl"),
+        )
+        # The genuine duplicate -- byte-identical to the indexed twin, no
+        # logical_source_key: the population this bead resolves.
+        _write_quarantined_no_lsk_raw(
+            archive,
+            raw_id="raw-duplicate",
+            payload=_DUPLICATE_PAYLOAD,
+            source_path=str(tmp_path / "dup.jsonl"),
+        )
+        # A genuinely novel row: quarantined, no logical_source_key, but no
+        # indexed byte-identical twin anywhere -- must never be resolved
+        # here (polylogue-lkrc/hjpx's reconciler scope, not this bead's).
+        _write_quarantined_no_lsk_raw(
+            archive,
+            raw_id="raw-novel",
+            payload=_NOVEL_PAYLOAD,
+            source_path=str(tmp_path / "novel.jsonl"),
+        )
+        archive.commit()
+
+        _index_session(archive._conn, raw_id="raw-indexed-twin", native_id="native-indexed-twin")
+        archive.commit()
+
+    return archive_root
+
+
+def _revision_authority_rows(archive_root: Path) -> dict[str, tuple[str, str | None]]:
+    conn = sqlite3.connect(archive_root / "source.db")
+    try:
+        rows = conn.execute(
+            "SELECT raw_id, revision_authority, revision_authority_evidence FROM raw_sessions"
+        ).fetchall()
+    finally:
+        conn.close()
+    return {raw_id: (authority, evidence) for raw_id, authority, evidence in rows}
+
+
+def _linkage_rows(archive_root: Path) -> dict[str, tuple[object, object, object]]:
+    conn = sqlite3.connect(archive_root / "source.db")
+    try:
+        rows = conn.execute(
+            "SELECT raw_id, predecessor_raw_id, baseline_raw_id, acquisition_generation FROM raw_sessions"
+        ).fetchall()
+    finally:
+        conn.close()
+    return {raw_id: (pred, baseline, gen) for raw_id, pred, baseline, gen in rows}
+
+
+def _receipt_rows(archive_root: Path) -> dict[str, tuple[str, str]]:
+    conn = sqlite3.connect(archive_root / "source.db")
+    try:
+        rows = conn.execute(
+            "SELECT raw_id, duplicate_of_raw_id, tool_version FROM raw_byte_duplicate_supersession_receipts"
+        ).fetchall()
+    finally:
+        conn.close()
+    return {raw_id: (duplicate_of_raw_id, tool_version) for raw_id, duplicate_of_raw_id, tool_version in rows}
+
+
+def _index_sessions_rows(archive_root: Path) -> list[tuple[str, str | None]]:
+    conn = sqlite3.connect(archive_root / "index.db")
+    try:
+        rows = conn.execute("SELECT session_id, raw_id FROM sessions ORDER BY session_id").fetchall()
+    finally:
+        conn.close()
+    return [(session_id, raw_id) for session_id, raw_id in rows]
+
+
+def test_dry_run_makes_zero_mutations(tmp_path: Path) -> None:
+    archive_root = _build_fixture_archive(tmp_path)
+    before_source = _revision_authority_rows(archive_root)
+    before_index = _index_sessions_rows(archive_root)
+    assert all(authority == "quarantined" for authority, _evidence in before_source.values())
+
+    report = apply_raw_byte_duplicate_supersession(archive_root, dry_run=True)
+
+    assert report.applied is False
+    # raw-indexed-twin, raw-duplicate, raw-novel are all quarantined with no
+    # logical_source_key -- the whole population is in scope. Only
+    # raw-duplicate has an OTHER raw (raw-indexed-twin) that is indexed;
+    # raw-indexed-twin's only same-hash sibling (raw-duplicate) is not
+    # indexed, so it is correctly classified as novel, not as a duplicate of
+    # itself.
+    assert report.scanned_count == 3
+    assert report.promoted_count == 1
+    assert report.novel_count == 2
+    assert report.promoted_raw_ids == ()
+
+    assert _revision_authority_rows(archive_root) == before_source
+    assert _index_sessions_rows(archive_root) == before_index
+    assert _receipt_rows(archive_root) == {}
+
+
+def test_apply_promotes_only_the_true_duplicate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    archive_root = _build_fixture_archive(tmp_path)
+
+    validated: list[tuple[Path, object]] = []
+
+    def _fake_validate(manifest: Path, tier: object, *, connection: sqlite3.Connection) -> Path:
+        validated.append((manifest, tier))
+        assert connection.execute("SELECT 1").fetchone() == (1,)
+        return manifest.with_name("verification-receipt.json")
+
+    monkeypatch.setattr(
+        "polylogue.maintenance.raw_byte_duplicate_supersession_apply.validate_migration_backup_manifest",
+        _fake_validate,
+    )
+
+    linkage_before = _linkage_rows(archive_root)
+    index_before = _index_sessions_rows(archive_root)
+
+    manifest = tmp_path / "verified-backup" / "manifest.json"
+    report = apply_raw_byte_duplicate_supersession(archive_root, backup_manifest=manifest, dry_run=False)
+
+    assert report.applied is True
+    assert report.promoted_count == 1
+    assert set(report.promoted_raw_ids) == {"raw-duplicate"}
+    assert report.novel_count == 2
+    assert report.backup_manifest == manifest
+    assert validated == [(manifest, ArchiveTier.SOURCE), (manifest, ArchiveTier.SOURCE)]
+
+    rows = _revision_authority_rows(archive_root)
+    assert rows["raw-duplicate"] == ("byte_proven", None)
+    # The indexed twin's own row is never touched.
+    assert rows["raw-indexed-twin"] == ("quarantined", None)
+    # Genuinely novel row is never touched.
+    assert rows["raw-novel"] == ("quarantined", None)
+
+    receipts = _receipt_rows(archive_root)
+    assert receipts == {"raw-duplicate": ("raw-indexed-twin", TOOL_VERSION)}
+
+    # Revision-graph linkage untouched.
+    linkage_after = _linkage_rows(archive_root)
+    assert linkage_after["raw-duplicate"] == linkage_before["raw-duplicate"]
+    assert linkage_after["raw-indexed-twin"] == linkage_before["raw-indexed-twin"]
+
+    # index.db is never written to.
+    assert _index_sessions_rows(archive_root) == index_before
+
+
+def test_apply_refuses_without_backup_manifest(tmp_path: Path) -> None:
+    archive_root = _build_fixture_archive(tmp_path)
+    before = _revision_authority_rows(archive_root)
+
+    with pytest.raises(RawByteDuplicateSupersessionApplyError, match="backup manifest"):
+        apply_raw_byte_duplicate_supersession(archive_root, backup_manifest=None, dry_run=False)
+
+    assert _revision_authority_rows(archive_root) == before
+    assert _receipt_rows(archive_root) == {}
+
+
+def test_apply_refuses_when_backup_manifest_invalid(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    archive_root = _build_fixture_archive(tmp_path)
+    before = _revision_authority_rows(archive_root)
+
+    def _reject(manifest: Path, tier: object, *, connection: sqlite3.Connection) -> Path:
+        raise ValueError("backup manifest does not match live source.db")
+
+    monkeypatch.setattr(
+        "polylogue.maintenance.raw_byte_duplicate_supersession_apply.validate_migration_backup_manifest",
+        _reject,
+    )
+
+    manifest = tmp_path / "stale-backup" / "manifest.json"
+    with pytest.raises(ValueError, match="does not match"):
+        apply_raw_byte_duplicate_supersession(archive_root, backup_manifest=manifest, dry_run=False)
+
+    assert _revision_authority_rows(archive_root) == before
+    assert _receipt_rows(archive_root) == {}

--- a/tests/unit/storage/test_raw_byte_duplicate_supersession.py
+++ b/tests/unit/storage/test_raw_byte_duplicate_supersession.py
@@ -1,0 +1,176 @@
+"""polylogue-6753s: byte-duplicate supersession classifier.
+
+Proves the read-only classifier scopes strictly to the named population
+(quarantined, ``logical_source_key IS NULL``) and only flags a candidate as a
+duplicate when its ``blob_hash`` matches some OTHER raw that already has a
+materialized ``sessions`` row in index.db -- never the candidate's own row,
+never a raw sharing bytes with only unindexed siblings, and never a candidate
+that already has a ``logical_source_key`` (out of this bead's scope; that
+population is reachable by the ordinary reconciler).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from polylogue.archive.revision_authority import RawRevisionAuthority, RawRevisionEnvelope, RawRevisionKind
+from polylogue.core.enums import Provider
+from polylogue.storage.raw_byte_duplicate_supersession import plan_byte_duplicate_supersession
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+
+def _write_quarantined_no_lsk_raw(archive: ArchiveStore, *, raw_id: str, payload: bytes, source_path: str) -> None:
+    """Write a raw the way real acquisition does before any reconciler ever sees it: no revision envelope at all."""
+    archive.write_raw_payload(
+        provider=Provider.CLAUDE_CODE,
+        payload=payload,
+        source_path=source_path,
+        source_index=-1,
+        acquired_at_ms=1_700_000_000_000,
+        raw_id=raw_id,
+    )
+
+
+def _write_raw_with_logical_key(
+    archive: ArchiveStore, *, raw_id: str, payload: bytes, source_path: str, logical_source_key: str
+) -> None:
+    archive.write_raw_payload(
+        provider=Provider.CLAUDE_CODE,
+        payload=payload,
+        source_path=source_path,
+        source_index=-1,
+        acquired_at_ms=1_700_000_000_000,
+        raw_id=raw_id,
+        revision=RawRevisionEnvelope(
+            logical_source_key=logical_source_key,
+            kind=RawRevisionKind.FULL,
+            source_revision=f"{raw_id}-revision",
+            acquisition_generation=0,
+            authority=RawRevisionAuthority.QUARANTINED,
+        ),
+    )
+
+
+def _index_session(conn: sqlite3.Connection, *, raw_id: str, native_id: str) -> None:
+    conn.execute(
+        "INSERT INTO sessions (origin, native_id, content_hash, raw_id, created_at_ms, updated_at_ms) "
+        "VALUES ('claude-code-session', ?, ?, ?, 0, 0)",
+        (native_id, b"\x11" * 32, raw_id),
+    )
+
+
+def test_only_flags_quarantined_no_lsk_raws_byte_identical_to_an_indexed_twin(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+
+    duplicate_payload = b'{"messages":["dup"]}\n'
+    novel_payload = b'{"messages":["novel"]}\n'
+    unindexed_twin_payload = b'{"messages":["unindexed-twin"]}\n'
+
+    with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+        # The target population: quarantined, no logical_source_key, and an
+        # OTHER raw with the same bytes IS indexed below -- must be flagged.
+        _write_quarantined_no_lsk_raw(
+            archive,
+            raw_id="raw-dup",
+            payload=duplicate_payload,
+            source_path=str(tmp_path / "dup.jsonl"),
+        )
+        # The already-indexed twin -- byte-identical, but its OWN row must
+        # never be touched by this classifier (it's the reference, not the
+        # duplicate).
+        _write_quarantined_no_lsk_raw(
+            archive,
+            raw_id="raw-dup-indexed-twin",
+            payload=duplicate_payload,
+            source_path=str(tmp_path / "dup-twin.jsonl"),
+        )
+        # Quarantined, no logical_source_key, but genuinely unique bytes --
+        # no indexed twin exists anywhere. Must be left alone (novel; in
+        # scope for lkrc/hjpx's reconciler, not this bead).
+        _write_quarantined_no_lsk_raw(
+            archive,
+            raw_id="raw-novel",
+            payload=novel_payload,
+            source_path=str(tmp_path / "novel.jsonl"),
+        )
+        # Quarantined, no logical_source_key, and shares bytes with ANOTHER
+        # raw -- but that other raw is never indexed. Must NOT be flagged:
+        # byte-identical to *something*, but not to anything the archive
+        # already accepted.
+        _write_quarantined_no_lsk_raw(
+            archive,
+            raw_id="raw-unindexed-dup",
+            payload=unindexed_twin_payload,
+            source_path=str(tmp_path / "unindexed-dup.jsonl"),
+        )
+        _write_quarantined_no_lsk_raw(
+            archive,
+            raw_id="raw-unindexed-dup-sibling",
+            payload=unindexed_twin_payload,
+            source_path=str(tmp_path / "unindexed-dup-sibling.jsonl"),
+        )
+        # Out of scope: already HAS a logical_source_key, even though its
+        # bytes match the indexed twin exactly -- the ordinary reconciler
+        # already sees this row; this bead's classifier must not touch it.
+        _write_raw_with_logical_key(
+            archive,
+            raw_id="raw-has-lsk",
+            payload=duplicate_payload,
+            source_path=str(tmp_path / "has-lsk.jsonl"),
+            logical_source_key="claude-code:has-lsk",
+        )
+        archive.commit()
+
+        _index_session(archive._conn, raw_id="raw-dup-indexed-twin", native_id="native-dup-indexed-twin")
+        archive.commit()
+
+    source_conn = sqlite3.connect(f"file:{archive_root / 'source.db'}?mode=ro", uri=True)
+    index_conn = sqlite3.connect(f"file:{archive_root / 'index.db'}?mode=ro", uri=True)
+    try:
+        plan = plan_byte_duplicate_supersession(source_conn, index_conn)
+    finally:
+        source_conn.close()
+        index_conn.close()
+
+    # raw-dup, raw-novel, raw-unindexed-dup, raw-unindexed-dup-sibling --
+    # raw-dup-indexed-twin and raw-has-lsk are excluded from the scan itself
+    # (the twin has no logical_source_key either, so it too satisfies the
+    # WHERE clause -- but it must not appear as a "duplicate OF itself").
+    assert plan.scanned_count == 5
+    assert {c.raw_id for c in plan.duplicates} == {"raw-dup"}
+    duplicate = next(c for c in plan.duplicates if c.raw_id == "raw-dup")
+    assert duplicate.duplicate_of_raw_id == "raw-dup-indexed-twin"
+    assert duplicate.duplicate_of_session_id == "claude-code-session:native-dup-indexed-twin"
+    assert duplicate.blob_size == len(duplicate_payload)
+    # novel + both unindexed-dup siblings (neither has an indexed twin) are
+    # left alone.
+    assert plan.novel_count == 4
+    assert plan.duplicate_bytes == len(duplicate_payload)
+
+
+def test_limit_caps_scanned_rows(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+
+    with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+        for i in range(3):
+            _write_quarantined_no_lsk_raw(
+                archive,
+                raw_id=f"raw-{i}",
+                payload=f'{{"n":{i}}}\n'.encode(),
+                source_path=str(tmp_path / f"{i}.jsonl"),
+            )
+        archive.commit()
+
+    source_conn = sqlite3.connect(f"file:{archive_root / 'source.db'}?mode=ro", uri=True)
+    index_conn = sqlite3.connect(f"file:{archive_root / 'index.db'}?mode=ro", uri=True)
+    try:
+        plan = plan_byte_duplicate_supersession(source_conn, index_conn, limit=2)
+    finally:
+        source_conn.close()
+        index_conn.close()
+
+    assert plan.scanned_count == 2


### PR DESCRIPTION
## Summary

Adds a read-only classifier plus a dry-run-by-default actuator that resolves quarantined, logical-key-less raws that are byte-identical to content the archive already indexed under a different raw_id.

## Problem

Of 7,200 unindexed logical-source heads in the live archive, 4,305 (17.6 of 22.9 GiB, 77% of the bytes) sit at `revision_authority='quarantined'` with `logical_source_key IS NULL` -- invisible to every existing reconciliation path (`classify_raw_revision_cohort`, the membership pipeline, the append-chain backfill all key off `logical_source_key`). These rows turn out to be byte-identical re-acquisitions/re-syncs of content the archive already indexed under a different raw_id, not missing content -- they inflate every "archive is X% unconverged" measurement while carrying nothing the archive doesn't already have.

## Solution

`polylogue/storage/raw_byte_duplicate_supersession.py` is a strictly read-only classifier: for each quarantined, logical-key-less raw, it checks whether the raw's `blob_hash` matches some OTHER `raw_sessions` row that already has a materialized session in `index.db`. `index.db` is opened read-only; nothing here writes to it or touches the indexed twin's own row.

`polylogue/maintenance/raw_byte_duplicate_supersession_apply.py` is the "act" half, following the identical dry-run-by-default / verified-backup-required / immutable-receipt pattern already established by `raw_live_source_reconciliation_apply`, `raw_membership_writeback_apply`, and `raw_append_chain_backfill_apply`. It promotes matched rows to `revision_authority='byte_proven'` -- reusing the existing closed vocabulary rather than inventing a new disposition -- and deliberately leaves `revision_authority_evidence` `NULL` (widening its closed CHECK constraint requires a full `raw_sessions` table rebuild, per migration 021's own precedent for why that's expensive) in favor of a dedicated `raw_byte_duplicate_supersession_receipts` table (migration 022, source schema v21->v22) that records which indexed raw_id/session_id each duplicate matches, so the evidence is durable and inspectable, not silent.

Wired as `devtools workspace raw-byte-duplicate-supersession-apply`.

The genuinely novel remainder (~2,895 rows / ~5.3 GiB, no indexed byte-identical twin) is left untouched -- that population is polylogue-lkrc/polylogue-hjpx's reconciler scope, explicitly out of scope here.

## Verification

- `devtools test tests/unit/storage/test_raw_byte_duplicate_supersession.py tests/unit/maintenance/test_raw_byte_duplicate_supersession_apply.py` -- 6 passed. Fixture proves a genuine byte-duplicate pair (one indexed, one quarantined-no-lsk raw with matching blob_hash) resolves, a genuine non-duplicate quarantined-no-lsk raw does not, dry-run makes zero mutations to source.db or index.db, and apply refuses without a verified backup manifest.
- `devtools test tests/unit/storage/test_durable_migrations.py` -- 43 passed (updated hardcoded v21 schema-chain assertions to v22).
- `devtools test -k raw_authority` -- 108 passed, 6 failed; confirmed via `git stash` (reverting this change) that the same 6 failures (`test_raw_authority_scale_proof.py` x5, `test_raw_authority_daemon_health_proof.py` x1) reproduce identically without this change -- pre-existing/unrelated.
- `devtools verify --quick` -- exit 0 (format, lint, mypy --strict, render all --check, layering, schema-versioning and raw-authority-frontier-executability lab policies all pass).

Not run against the live archive as part of this PR -- the dry-run sanity check against `/realm/db/polylogue` (and any subsequent `--apply`) is a separate, explicitly operator-supervised step, tracked in the referenced bead.

Ref polylogue-6753s