### PR TITLE
feat(archive): expose position/is_active_path/is_active_leaf on message read surface

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -88,7 +88,10 @@ wrappers, task notifications, provider-generated context bundles, and tool-resul
 protocol envelopes through `role=user`. Use `material_origin` for authoredness
 accounting and prose projection.
 | `parent_id` | `str?` | Parent message, for branching |
-| `branch_index` | `int` | Branch position among sibling variants |
+| `branch_index` | `int` | Sibling creation order (aka `variant_index`) -- NOT display state |
+| `position` | `int` | Ordinal position of this message within its session |
+| `is_active_path` | `bool?` | Provider-reported "this sibling is the currently-accepted one" signal, authoritative for mainline selection; `None` means unknown, never "not active" |
+| `is_active_leaf` | `bool` | Whether this message is the tip of the currently-active branch |
 | `has_tool_use` / `has_thinking` / `has_paste_evidence` | `bool` | Precomputed content/evidence flags projected from storage |
 | `input_tokens` / `output_tokens` | `int` | Token counts, when reported |
 | `cache_read_tokens` / `cache_write_tokens` | `int` | Cache token counts, when reported |

--- a/docs/schemas/cli-output/session-message-row.schema.json
+++ b/docs/schemas/cli-output/session-message-row.schema.json
@@ -215,6 +215,23 @@
       "title": "Input Tokens",
       "type": "integer"
     },
+    "is_active_leaf": {
+      "default": false,
+      "title": "Is Active Leaf",
+      "type": "boolean"
+    },
+    "is_active_path": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Is Active Path"
+    },
     "material_origin": {
       "default": "unknown",
       "title": "Material Origin",
@@ -265,6 +282,11 @@
       ],
       "default": null,
       "title": "Paste Boundary State"
+    },
+    "position": {
+      "default": 0,
+      "title": "Position",
+      "type": "integer"
     },
     "raw_id": {
       "anyOf": [

--- a/docs/schemas/cli-output/session-messages-response.schema.json
+++ b/docs/schemas/cli-output/session-messages-response.schema.json
@@ -141,6 +141,23 @@
           "title": "Input Tokens",
           "type": "integer"
         },
+        "is_active_leaf": {
+          "default": false,
+          "title": "Is Active Leaf",
+          "type": "boolean"
+        },
+        "is_active_path": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Is Active Path"
+        },
         "material_origin": {
           "default": "unknown",
           "title": "Material Origin",
@@ -191,6 +208,11 @@
           ],
           "default": null,
           "title": "Paste Boundary State"
+        },
+        "position": {
+          "default": 0,
+          "title": "Position",
+          "type": "integer"
         },
         "raw_id": {
           "anyOf": [

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -1966,6 +1966,8 @@ def _archive_message_to_domain(message: ArchiveMessageRow, *, origin: Origin) ->
         # concrete bool (schema default), never a guess.
         branch_index=message.variant_index,
         is_active_path=message.is_active_path,
+        position=message.position,
+        is_active_leaf=message.is_active_leaf,
         parent_id=message.parent_message_id,
         attachments=[_archive_attachment_to_domain(att) for att in message.attachments],
     )

--- a/polylogue/archive/message/models.py
+++ b/polylogue/archive/message/models.py
@@ -38,6 +38,16 @@ class Message(MessageRuntimeMixin, BaseModel):
     # provider with no branch concept -- and must NOT be treated as "not
     # active": collapsing unknown to hidden would silently empty transcripts.
     is_active_path: bool | None = None
+    # polylogue-ksgg: ordinal position of this message within its session
+    # (storage: messages.position), independent of branch_index/variant_index
+    # (creation order among siblings at the same position). Needed to
+    # reconstruct display order without re-querying storage directly.
+    position: int = 0
+    # polylogue-ksgg: whether this message sits on the leaf edge of the
+    # currently-active branch (storage: messages.is_active_leaf). Unlike
+    # is_active_path (which can be true for interior messages on the live
+    # path), this marks the tip messages a reader can resume from.
+    is_active_leaf: bool = False
     # Stats projected from the storage layer so reader surfaces can
     # render fold/paste indicators without re-deriving them. See #1201
     # (paste rendering) and the session-level flags in

--- a/polylogue/archive/query/archive_execution.py
+++ b/polylogue/archive/query/archive_execution.py
@@ -260,6 +260,8 @@ def _message_to_domain(message: ArchiveMessageRow, *, origin: Origin) -> Message
         # concrete bool (schema default), never a guess.
         branch_index=message.variant_index,
         is_active_path=message.is_active_path,
+        position=message.position,
+        is_active_leaf=message.is_active_leaf,
         parent_id=message.parent_message_id,
         stop_reason=message.stop_reason,
     )

--- a/polylogue/storage/hydrators.py
+++ b/polylogue/storage/hydrators.py
@@ -132,6 +132,8 @@ def message_from_record(
         parent_id=record.parent_message_id,
         branch_index=record.branch_index,
         is_active_path=record.is_active_path,
+        position=record.position,
+        is_active_leaf=record.is_active_leaf,
         has_tool_use=bool(record.has_tool_use),
         has_thinking=bool(record.has_thinking),
         has_paste=bool(record.has_paste),

--- a/polylogue/storage/runtime/archive/records.py
+++ b/polylogue/storage/runtime/archive/records.py
@@ -181,6 +181,12 @@ class MessageRecord(BaseModel):
     # not selected the column (unknown), never a fabricated "not active" --
     # callers must not collapse unknown into hidden.
     is_active_path: bool | None = None
+    # polylogue-ksgg: ordinal position within the session (messages.position)
+    # and whether this row is the tip of the currently-active branch
+    # (messages.is_active_leaf). Distinct from branch_index (sibling creation
+    # order) and is_active_path (interior-path membership).
+    position: int = 0
+    is_active_leaf: bool = False
     blocks: list[BlockRecord] = Field(default_factory=list)
     source_name: str = ""
     word_count: int = 0

--- a/polylogue/storage/sqlite/queries/mappers_archive.py
+++ b/polylogue/storage/sqlite/queries/mappers_archive.py
@@ -96,6 +96,8 @@ def _row_to_message(row: sqlite3.Row) -> MessageRecord:
         # None (column not selected by this query) means unknown, not "not
         # active" -- see MessageRecord.is_active_path.
         is_active_path=_row_optional_bool(row, "is_active_path"),
+        position=_row_int(row, "position", 0) or 0,
+        is_active_leaf=bool(_row_int(row, "is_active_leaf", 0)),
         source_name=_row_text(row, "source_name") or "",
         word_count=_row_int(row, "word_count", 0) or 0,
         has_tool_use=_row_int(row, "has_tool_use", 0) or 0,

--- a/polylogue/storage/sqlite/queries/message_query_reads.py
+++ b/polylogue/storage/sqlite/queries/message_query_reads.py
@@ -42,6 +42,8 @@ _MESSAGE_RECORD_SELECT = """
     m.parent_message_id,
     m.variant_index AS branch_index,
     m.is_active_path,
+    m.position,
+    m.is_active_leaf,
     s.origin AS source_name,
     m.word_count,
     m.has_tool_use,

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -679,6 +679,19 @@ class SessionMessagePayload(SurfacePayloadModel):
     parent_id: str | None = None
     # #1487 envelope: branch/lineage state.
     branch_index: int = 0
+    # polylogue-ksgg: ordinal position within the session (storage:
+    # messages.position), independent of branch_index (sibling creation
+    # order). Needed to reconstruct display order without direct SQL.
+    position: int = 0
+    # polylogue-ksgg: provider-reported "this sibling is on the live path"
+    # signal (storage: messages.is_active_path). ``None`` means unknown --
+    # the read path did not select the column or the provider has no branch
+    # concept -- never collapse unknown to "not active".
+    is_active_path: bool | None = None
+    # polylogue-ksgg: whether this message is the tip of the currently-active
+    # branch (storage: messages.is_active_leaf) -- the message a reader would
+    # resume from, distinct from interior is_active_path membership.
+    is_active_leaf: bool = False
     # #1487 envelope: per-message content flags. Surface what the storage
     # layer already projects (#1201/#1583) so the reader does not have
     # to re-derive them from the rendered text.
@@ -754,6 +767,9 @@ class SessionMessagePayload(SurfacePayloadModel):
             content_blocks=message.blocks,
             parent_id=message.parent_id,
             branch_index=int(getattr(message, "branch_index", 0) or 0),
+            position=int(getattr(message, "position", 0) or 0),
+            is_active_path=getattr(message, "is_active_path", None),
+            is_active_leaf=bool(getattr(message, "is_active_leaf", False)),
             has_paste_evidence=bool(getattr(message, "has_paste", False)),
             paste_boundary_state=getattr(message, "paste_boundary_state", None),
             has_tool_use=bool(getattr(message, "has_tool_use", False)),
@@ -823,6 +839,9 @@ class SessionMessagePayload(SurfacePayloadModel):
             content_blocks=content_blocks,
             parent_id=getattr(message, "parent_message_id", None),
             branch_index=int(getattr(message, "variant_index", 0) or 0),
+            position=int(getattr(message, "position", 0) or 0),
+            is_active_path=getattr(message, "is_active_path", None),
+            is_active_leaf=bool(getattr(message, "is_active_leaf", False)),
             has_paste_evidence=bool(getattr(message, "has_paste", False)),
             paste_boundary_state=getattr(message, "paste_boundary_state", None),
             has_tool_use=bool(getattr(message, "has_tool_use", False)),

--- a/tests/unit/surfaces/test_message_render_envelope.py
+++ b/tests/unit/surfaces/test_message_render_envelope.py
@@ -50,6 +50,9 @@ _ENVELOPE_FIELDS: tuple[str, ...] = (
     "content_blocks",
     "parent_id",
     "branch_index",
+    "position",
+    "is_active_path",
+    "is_active_leaf",
     "has_paste_evidence",
     "paste_boundary_state",
     "has_tool_use",
@@ -116,6 +119,9 @@ def test_envelope_minimal_construction_uses_default_envelope_fields() -> None:
     assert payload.timestamp is None
     assert payload.parent_id is None
     assert payload.branch_index == 0
+    assert payload.position == 0
+    assert payload.is_active_path is None
+    assert payload.is_active_leaf is False
     assert payload.has_paste_evidence is False
     assert payload.has_tool_use is False
     assert payload.has_thinking is False
@@ -140,6 +146,46 @@ def test_from_message_propagates_branch_lineage_state() -> None:
     payload = SessionMessagePayload.from_message(msg, session_id="c1")
     assert payload.branch_index == 3
     assert payload.parent_id == "m-parent"
+
+
+def test_from_message_propagates_position_and_active_path_state() -> None:
+    """polylogue-ksgg: position/is_active_path/is_active_leaf must survive
+    the read surface so branch/thread structure can be reconstructed
+    without direct SQL."""
+    msg = _build_message(position=7, is_active_path=True, is_active_leaf=True)
+    payload = SessionMessagePayload.from_message(msg, session_id="c1")
+    assert payload.position == 7
+    assert payload.is_active_path is True
+    assert payload.is_active_leaf is True
+
+
+def test_from_message_preserves_unknown_active_path() -> None:
+    """``is_active_path=None`` (unknown) must not collapse to False."""
+    msg = _build_message(is_active_path=None)
+    payload = SessionMessagePayload.from_message(msg, session_id="c1")
+    assert payload.is_active_path is None
+
+
+def test_from_archive_row_propagates_position_and_active_path_state() -> None:
+    # Note: MessageRecord's sibling-order field is named ``branch_index``
+    # while ``from_archive_row`` reads the real ArchiveMessageRow's
+    # ``variant_index`` attribute -- a pre-existing naming mismatch that
+    # means MessageRecord-as-stand-in only exercises the fields whose
+    # attribute names agree (position/is_active_path/is_active_leaf).
+    row = MessageRecord(
+        message_id=MessageId("m1"),
+        session_id=SessionId("c1"),
+        provider_message_id="native-m1",
+        role=Role.USER,
+        content_hash=ContentHash("0" * 64),
+        is_active_path=True,
+        position=5,
+        is_active_leaf=True,
+    )
+    payload = SessionMessagePayload.from_archive_row(row, session_id="c1")
+    assert payload.position == 5
+    assert payload.is_active_path is True
+    assert payload.is_active_leaf is True
 
 
 def test_from_message_propagates_content_flags() -> None:
@@ -294,6 +340,8 @@ def test_minimal_payload_serializes_compactly_with_exclude_none() -> None:
     # Required: typed envelope fields are observable (the test would
     # fail-fast if a new None-default field crept in).
     assert blob["branch_index"] == 0
+    assert blob["position"] == 0
+    assert blob["is_active_leaf"] is False
     assert blob["has_paste_evidence"] is False
     assert blob["input_tokens"] == 0
     assert blob["attachment_refs"] == []
@@ -301,6 +349,7 @@ def test_minimal_payload_serializes_compactly_with_exclude_none() -> None:
     # None defaults are correctly omitted.
     assert "target_ref" not in blob
     assert "parent_id" not in blob
+    assert "is_active_path" not in blob
     assert "raw_id" not in blob
     assert "source_path" not in blob
     assert "model_name" not in blob


### PR DESCRIPTION
## Summary

Adds `position`, `is_active_path`, and `is_active_leaf` to the shared message read surface (`SessionMessagePayload`, the CLI/MCP `MessageRenderEnvelope`), so a JSON consumer can reconstruct display ordering and which branch was actually live without falling back to direct SQL.

## Problem

polylogue-ksgg (conversation-fidelity audit) measured that the message payload returned by the read surface carries `branch_index`/`parent_id` (renamed from `variant_index`/`parent_message_id`) but omits `position`, `is_active_path`, and `is_active_leaf` entirely -- even for the origins where the underlying storage columns ARE populated (claude-code-session 89%, chatgpt-export 90%, claude-ai-export 68% parent-linked). The suggested split in the bead calls this piece "(D)" -- cheap and self-contained: add the missing columns to the messages payload. It's addressed here.

The two harder pieces of the bead, (A)/(B) per-origin parent-link population (codex-session/hermes-session/aistudio-drive/gemini-cli-session/grok-export all measured at 0% parented -- separate parser work in `sources/parsers/{codex,hermes_spans,drive}.py`) and (C) the 25-session active-path writer bug (every variant marked active, so the live branch can't be recovered), are out of scope for this PR and remain open on polylogue-ksgg.

## Solution

`ArchiveMessageRow`/the write-side storage layer already tracked `position`/`is_active_path`/`is_active_leaf`, but three things dropped them on the read path:

- The domain `Message` model (`polylogue/archive/message/models.py`) and the storage `MessageRecord` (`polylogue/storage/runtime/archive/records.py`) had no `position`/`is_active_leaf` fields (only `is_active_path`, added earlier for polylogue-9qq7).
- The message read query (`_MESSAGE_RECORD_SELECT` in `polylogue/storage/sqlite/queries/message_query_reads.py`) didn't select `m.position`/`m.is_active_leaf`.
- `SessionMessagePayload.from_message`/`from_archive_row` (`polylogue/surfaces/payloads.py`) never mapped any of the three onto the envelope.

Added the two missing fields end to end and threaded `is_active_path` through the read surface for the first time, touching every `ArchiveMessageRow` -> domain `Message` conversion site (`polylogue/api/archive.py`, `polylogue/archive/query/archive_execution.py`) and the storage hydrator (`polylogue/storage/hydrators.py`) so all read paths stay consistent. Regenerated the two affected generated schemas (`docs/schemas/cli-output/session-message-row.schema.json`, `session-messages-response.schema.json`) via `devtools render all`, and extended `docs/data-model.md`.

`tests/unit/surfaces/test_message_render_envelope.py` pins the envelope's exact field set exhaustively -- extended it with the three new fields plus propagation tests for `from_message`/`from_archive_row`, including a case asserting `is_active_path=None` (unknown) does not collapse to `False`.

**Not changed:** `branch_index`/`parent_id` already carry `variant_index`/`parent_message_id`'s semantics under an established rename (documented in-line since polylogue-9qq7); this PR does not add duplicate aliases for those two.

## Verification

- `devtools test tests/unit/surfaces/test_message_render_envelope.py` -- 16 passed
- `devtools test tests/unit/core/test_models.py tests/unit/storage/test_query_mappers.py tests/unit/storage/test_stop_reason_queryable.py` -- 120 passed
- `devtools render all` -- regenerated `session-message-row.schema.json` + `session-messages-response.schema.json`, no other drift
- `devtools verify --quick` -- status `success` (ruff format, ruff check, mypy, render-all-check, topology/layering/closure-matrix, all lab policies)

Ref polylogue-ksgg