### PR TITLE
fix(storage): stop synthesizing a repo for a bare directory

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -5074,15 +5074,30 @@ def _aggregate_message_tokens_into_model_usage(conn: sqlite3.Connection, session
 def _write_repo_edges(conn: sqlite3.Connection, session_id: str, session: ParsedSession) -> None:
     observed_at_ms = _timestamp_ms(session.updated_at) or _timestamp_ms(session.created_at)
     raw_root_paths = tuple(path.strip() for path in session.working_directories if path.strip())
+    origin_url = (session.git_repository_url or "").strip()
     # polylogue-cijx.4 decision 1: resolve each raw cwd to its git root before
     # deduplicating, so multiple cwds inside the same checkout (or a cwd
     # that is an agent-worktree subdirectory) collapse to one row instead of
     # one row per distinct raw path.
-    root_paths = tuple(dict.fromkeys(_normalized_repo_root_path(path) for path in raw_root_paths))
-    if not root_paths and not session.git_repository_url:
+    #
+    # polylogue-cijx.2 AC4: a session with no git evidence resolves to a
+    # directory, not a repository. A raw cwd that resolves to no discoverable
+    # git root is dropped here -- not kept as a "dir:<raw_path>" fallback --
+    # unless an explicit remote (``origin_url``) is known, in which case
+    # identity comes from the remote and the raw cwd is retained purely as a
+    # representative checkout-root value. Without this, every session whose
+    # cwd happens to be, say, ``/home/sinity`` would synthesize a "sinity"
+    # repository from a bare directory with zero git evidence.
+    resolved_root_paths: list[str] = []
+    for raw_path in raw_root_paths:
+        discovered_root = _discovered_repo_root_path(raw_path)
+        if discovered_root is not None:
+            resolved_root_paths.append(discovered_root)
+        elif origin_url:
+            resolved_root_paths.append(raw_path)
+    root_paths = tuple(dict.fromkeys(resolved_root_paths))
+    if not root_paths and not origin_url:
         return
-
-    origin_url = (session.git_repository_url or "").strip()
     for root_path in root_paths or ("",):
         repo_name = _repo_name(origin_url, root_path)
         # polylogue-cijx.4 decision 1: identity is the canonicalized remote
@@ -6546,8 +6561,8 @@ def _repo_name(repository_url: str, root_path: str) -> str | None:
     return candidate or None
 
 
-def _normalized_repo_root_path(root_path: str) -> str:
-    """Resolve ``root_path`` to its git root when one is discoverable.
+def _discovered_repo_root_path(root_path: str) -> str | None:
+    """Resolve ``root_path`` to its git root when one is discoverable on disk.
 
     Without this, two sessions whose cwd differs only by subdirectory (or by
     worktree path under one checkout) would write two distinct checkout
@@ -6562,8 +6577,15 @@ def _normalized_repo_root_path(root_path: str) -> str:
     ``repo_checkouts``/``session_repos.root_path`` (decision 2's
     repo-relative path stripping), and as the sole identity fallback for a
     repository with no remote.
+
+    Returns ``None`` -- not the raw ``root_path`` -- when no git root is
+    discoverable (polylogue-cijx.2 AC4: "a session with no git evidence
+    resolves to a directory, not a repository"). Callers with no other git
+    evidence (no known remote) must not synthesize a repository identity
+    from an unresolved bare cwd -- a session in ``/home/sinity`` is honestly
+    a directory, not the "sinity" repo.
     """
-    return normalize_repo_path(root_path) or root_path
+    return normalize_repo_path(root_path)
 
 
 _SCP_LIKE_REMOTE_RE = re.compile(r"^[\w.-]+@([\w.-]+):(.+)$")
@@ -6616,8 +6638,9 @@ def repo_identity_key(origin_url: str, root_path: str) -> str:
     does identity fall back to the resolved checkout root
     (``dir:<root_path>``, decision 1's "where no remote exists, the
     outermost git root"); ``root_path`` is expected to already be resolved
-    to that outermost root by ``_normalized_repo_root_path`` before this is
-    called.
+    to that outermost root by ``_discovered_repo_root_path`` before this is
+    called -- a ``root_path`` with no discoverable git root and no known
+    remote must not reach this function at all (see ``_write_repo_edges``).
 
     This used to be a SQLite ``GENERATED ALWAYS`` column computed as
     ``origin_url || root_path`` -- so two worktree checkouts of the exact

--- a/tests/unit/storage/test_archive_tiers_write.py
+++ b/tests/unit/storage/test_archive_tiers_write.py
@@ -425,11 +425,18 @@ def test_archive_store_connection_applies_canonical_profile(tmp_path: Path) -> N
 def test_archive_tiers_writer_ingests_session_with_root_cwd_and_no_repo_name(tmp_path: Path) -> None:
     """A session whose only working directory is "/" must still ingest.
 
-    ``_repo_name`` returns None when no name can be derived from the cwd (e.g.
-    "/" or "."), but ``repos.repo_name`` is ``NOT NULL``. Passing the None
-    through crashed the write with an IntegrityError, silently dropping the
-    session and retrying it forever. The writer must persist the empty-string
-    sentinel instead and keep the session.
+    Originally a regression test for a crash: ``_repo_name`` returns None
+    when no name can be derived from the cwd (e.g. "/" or "."), but
+    ``repos.repo_name`` is ``NOT NULL`` -- passing the None through used to
+    crash the write with an IntegrityError, silently dropping the session
+    and retrying it forever.
+
+    Since polylogue-cijx.2 AC4 ("a session with no git evidence resolves to
+    a directory, not a repository"), "/" -- which has no discoverable
+    ``.git`` root and no known remote -- no longer synthesizes a ``repos``
+    row at all, so the original NOT NULL crash can no longer occur by
+    construction; this test keeps the "must not raise, session still
+    ingests" assertion and updates the repos-table expectation to match.
     """
     conn = _connect(tmp_path / "index.db")
     session = ParsedSession(
@@ -452,7 +459,7 @@ def test_archive_tiers_writer_ingests_session_with_root_cwd_and_no_repo_name(tmp
     session_id = write_parsed_session_to_archive(conn, session)
 
     repos = [dict(row) for row in conn.execute("SELECT root_path, repo_name FROM repos").fetchall()]
-    assert {"root_path": "/", "repo_name": ""} in repos
+    assert repos == [], "a bare '/' cwd with no git evidence must not synthesize a repos row"
     envelope = read_archive_session_envelope(conn, session_id)
     assert len(envelope.messages) == 1
 

--- a/tests/unit/storage/test_archive_tiers_write.py
+++ b/tests/unit/storage/test_archive_tiers_write.py
@@ -4719,3 +4719,82 @@ def test_reingest_recomputes_message_flags_and_hash_after_block_restoration(tmp_
         )
     finally:
         conn.close()
+
+
+def test_repo_edges_skip_bare_directory_with_no_git_evidence(tmp_path: Path) -> None:
+    """polylogue-cijx.2 AC4: a directory with no git evidence is a directory, not a repository.
+
+    A session whose only location signal is a cwd that resolves to no
+    discoverable git root, and carries no ``git_repository_url``, must not
+    synthesize a ``repos``/``session_repos`` row -- the historic bug this
+    guards was ``dir:/home/sinity`` being recorded as the "sinity" repo for
+    every session merely cd'd there.
+    """
+    conn = _connect(tmp_path / "index.db")
+    try:
+        bare_dir = tmp_path / "not_a_repo"
+        bare_dir.mkdir()
+        session = ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id="bare-directory-session",
+            working_directories=[str(bare_dir)],
+            messages=[
+                ParsedMessage(
+                    provider_message_id="m1",
+                    role=Role.USER,
+                    text="hello from a bare directory",
+                    material_origin=MaterialOrigin.HUMAN_AUTHORED,
+                )
+            ],
+        )
+        session_id = write_parsed_session_to_archive(conn, session)
+
+        repos_count = conn.execute("SELECT COUNT(*) FROM repos").fetchone()[0]
+        session_repos_count = conn.execute(
+            "SELECT COUNT(*) FROM session_repos WHERE session_id = ?", (session_id,)
+        ).fetchone()[0]
+        assert repos_count == 0, "a bare directory with no git evidence must not synthesize a repos row"
+        assert session_repos_count == 0
+    finally:
+        conn.close()
+
+
+def test_repo_edges_write_repo_for_discovered_git_root(tmp_path: Path) -> None:
+    """A cwd inside an on-disk git checkout (``.git`` discoverable) still
+    resolves to a real repository, keyed on the discovered root -- this is
+    the positive case the AC4 fix above must not break.
+    """
+    conn = _connect(tmp_path / "index.db")
+    try:
+        repo_root = tmp_path / "real_repo"
+        (repo_root / ".git").mkdir(parents=True)
+        subdir = repo_root / "src"
+        subdir.mkdir()
+        session = ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id="real-repo-session",
+            working_directories=[str(subdir)],
+            messages=[
+                ParsedMessage(
+                    provider_message_id="m1",
+                    role=Role.USER,
+                    text="hello from inside a real checkout",
+                    material_origin=MaterialOrigin.HUMAN_AUTHORED,
+                )
+            ],
+        )
+        session_id = write_parsed_session_to_archive(conn, session)
+
+        repo_rows = conn.execute("SELECT repo_id, root_path, repo_name FROM repos").fetchall()
+        assert len(repo_rows) == 1
+        assert repo_rows[0]["root_path"] == str(repo_root)
+        assert repo_rows[0]["repo_name"] == "real_repo"
+        assert repo_rows[0]["repo_id"] == f"dir:{repo_root}"
+
+        session_repo_row = conn.execute(
+            "SELECT repo_id, root_path FROM session_repos WHERE session_id = ?", (session_id,)
+        ).fetchone()
+        assert session_repo_row is not None
+        assert session_repo_row["root_path"] == str(repo_root)
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

`_write_repo_edges` (the ingest-time repo-identity writer in `storage/sqlite/archive_tiers/write.py`) wrote a `repos`/`repo_checkouts`/`session_repos` row for every session cwd, falling back to `repo_id = "dir:<raw_cwd>"` even when the cwd had no discoverable `.git` root on disk and the session carried no `git_repository_url`. This fix stops that fallback: a bare directory with zero git evidence no longer synthesizes a fake repository.

## Problem

polylogue-cijx.2 measured this directly against the live archive: for ~84% of sessions the "repo" column is really cwd, and gave the concrete example "a session in `/home/sinity` is recorded as being in the `sinity` repo." The bead's explicit design principle: "A directory with no git evidence is honestly A DIRECTORY. Do not synthesize a repository for it" (AC4).

Most of cijx.2's scope (AC1/AC2/AC3/AC5 -- normalized-remote repo identity, checkout separation, collision-rate measurement) was already landed by the related polylogue-cijx.4 batch (`repo_identity_key`, `repo_checkouts`, read-time structural labels). Re-reading `_write_repo_edges` against that landed code found AC4 was still violated: the sibling attribution-based writer (`storage/insights/session/repo_observations.py`) already filters through `normalize_repo_path`/`normalize_repo_paths`, which drop unresolved cwds -- but the ingest-time writer in `write.py` never applied that same filter and kept a raw-path `dir:` fallback regardless of whether a git root was ever found.

## Solution

- `_normalized_repo_root_path` renamed to `_discovered_repo_root_path` and changed to return `None` (not the raw path) when `normalize_repo_path` finds no `.git` root on disk.
- `_write_repo_edges` now only keeps a cwd when either a git root was actually discovered for it, or the session carries an explicit `git_repository_url` (identity then comes from the remote, and the raw cwd is retained only as a representative checkout-root value). When neither holds for any working directory, no `repos`/`repo_checkouts`/`session_repos` row is written for the session at all.
- Updated `test_archive_tiers_writer_ingests_session_with_root_cwd_and_no_repo_name` (a pre-existing regression test for a different, still-valid bug -- a crash on `repos.repo_name NOT NULL`) to assert the new correct behavior: a `/` cwd with no git evidence writes zero `repos` rows instead of a `dir:/` row.

Deliberately out of scope for this PR (already covered by the closed polylogue-cijx.4, or separately tracked): AC1-3/AC5 normalized-remote identity and collision-rate measurement, and the `repo_identity_evidence` session_event grading in `sources/emitter.py` (landed on master already). This PR closes the one concrete AC4 gap found by re-reading the current write path against the bead's stated design.

## Verification

- `devtools test tests/unit/storage/test_archive_tiers_write.py -k repo_edges` -> 2 passed. Confirmed red-first via `git stash push -- polylogue/storage/sqlite/archive_tiers/write.py` (keeping the new tests): the bare-directory test fails against the pre-fix code (`assert 1 == 0`, a repos row was written), passes after popping the stash.
- `devtools test tests/unit/storage/test_archive_tiers_write.py tests/unit/storage/test_repo_observations.py tests/unit/archive/test_repo_identity.py tests/unit/api/test_repo_facet_canonicalization.py tests/unit/cli/test_insights.py tests/unit/daemon/test_web_reader.py` -> 325 passed (all repo-identity-adjacent test files).
- `devtools verify --quick` -> exit 0, all 23 steps ok (ruff format/check, mypy, render all --check, layering, closure-matrix, schema/policy lints).

Ref polylogue-cijx.2