### PR TITLE
feat(storage): persist a raw_authority_verdicts cache table

### DIFF
--- a/docs/plans/hash-boundary-registry.yaml
+++ b/docs/plans/hash-boundary-registry.yaml
@@ -974,6 +974,12 @@ entries:
   occurrence: 0
   classification: content-hash
   note: 'compares document_sha256 != requested_revision -- offset-continuation validity check.'
+- path: polylogue/storage/raw_authority_verdict_cache.py
+  function: '<module>._cohort_fingerprint'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'raw_authority_verdicts cache invalidation key -- SHA-256 over a cohort''s (raw_id, revision_kind, blob_hash) rows; a content or membership change to the cohort changes this fingerprint so a prior cache row reads as stale (polylogue-tw4ar).'
 - path: polylogue/storage/raw_reconciler.py
   function: '<module>._digest'
   call: hashlib.sha256

--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -3996,6 +3996,10 @@ files:
     loc: 2305
     target: TBD
     owner: storage-domain
+  - path: polylogue/storage/raw_authority_verdict_cache.py
+    loc: 172
+    target: TBD
+    owner: storage-domain
   - path: polylogue/storage/raw_authority_verdict_projection.py
     loc: 105
     target: TBD
@@ -4318,7 +4322,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/session_annotations_write.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/source.py
-    loc: 623
+    loc: 657
     target: polylogue/storage/sqlite/archive_tiers/source.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/source_write.py

--- a/polylogue/storage/raw_authority_verdict_cache.py
+++ b/polylogue/storage/raw_authority_verdict_cache.py
@@ -1,0 +1,172 @@
+"""Persisted read-through cache for :class:`RawAuthorityVerdict` (polylogue-tw4ar).
+
+Follow-up from polylogue-w6hql (PR #3593): :func:`polylogue.storage.
+raw_authority_verdict_projection.project_raw_authority_verdicts` recomputes a
+cohort's verdicts on demand by re-running
+``classify_historical_full_revision_streams`` against live blob storage every
+call -- correct, but not cheap at scale. This module adds a persisted cache
+table (``raw_authority_verdicts``, migration 022) in front of that projection.
+
+The cache is **not a new source of truth**. Every row is invalidated by
+*content*, not by elapsed time: :func:`_cohort_fingerprint` hashes the
+cohort's own ``(raw_id, revision_kind, blob_hash)`` rows, so any membership or
+content change to a ``logical_source_key`` cohort (a new revision acquired, a
+row's ``revision_kind`` resolved from ``unknown`` to ``full``) changes the
+fingerprint and the previously-cached rows read back as stale on the very
+next lookup, rather than being trusted for some duration. This makes the
+cache impossible to observe returning a verdict that disagrees with what
+``project_raw_authority_verdicts`` would compute right now for the same
+cohort shape.
+
+This module only fills the cache lazily on read
+(:func:`get_or_compute_raw_authority_verdicts`). Wiring a ``DaemonConverger``
+stage to keep it warm proactively ahead of reads is deliberately deferred --
+see polylogue-tw4ar's own notes for why that needs its own careful staging
+rather than landing bundled with the cache table itself.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from polylogue.core.enums import RawAuthorityVerdict
+from polylogue.storage.raw_authority_verdict_projection import (
+    RawAuthorityVerdictProjectionHost,
+    project_raw_authority_verdicts,
+)
+
+
+def _current_cohort_rows(
+    store: RawAuthorityVerdictProjectionHost, logical_source_key: str
+) -> list[tuple[str, str, str]]:
+    """Return every ``(raw_id, revision_kind, blob_hash_hex)`` row for a cohort."""
+    conn = store._ensure_source_conn()
+    rows = conn.execute(
+        """
+        SELECT raw_id, revision_kind, lower(hex(blob_hash))
+        FROM raw_sessions
+        WHERE logical_source_key = ?
+        """,
+        (logical_source_key,),
+    ).fetchall()
+    return [(str(row[0]), str(row[1]), str(row[2])) for row in rows]
+
+
+def _cohort_fingerprint(rows: list[tuple[str, str, str]]) -> bytes:
+    """SHA-256 over the sorted ``(raw_id, revision_kind, blob_hash)`` rows defining a cohort.
+
+    Sorting first makes the fingerprint independent of SQL row order. Each
+    field is length-delimited by a trailing NUL/SOH-style separator byte
+    (rather than plain concatenation) so no ambiguous split exists between
+    e.g. ``raw_id="ab"`` + ``revision_kind="c"`` and ``raw_id="a"`` +
+    ``revision_kind="bc"``.
+    """
+    hasher = hashlib.sha256()
+    for raw_id, revision_kind, blob_hash in sorted(rows):
+        hasher.update(raw_id.encode("utf-8"))
+        hasher.update(b"\x00")
+        hasher.update(revision_kind.encode("utf-8"))
+        hasher.update(b"\x00")
+        hasher.update(blob_hash.encode("utf-8"))
+        hasher.update(b"\x01")
+    return hasher.digest()
+
+
+def read_cached_raw_authority_verdicts(
+    store: RawAuthorityVerdictProjectionHost, logical_source_key: str
+) -> dict[str, RawAuthorityVerdict] | None:
+    """Return cached verdicts for a cohort if the cache is fresh, else ``None``.
+
+    ``None`` covers both "never cached" and "cached but stale" -- callers
+    that get ``None`` back should recompute via
+    :func:`~polylogue.storage.raw_authority_verdict_projection.project_raw_authority_verdicts`
+    (or just call :func:`get_or_compute_raw_authority_verdicts`, which does
+    exactly that and persists the result).
+    """
+    current_rows = _current_cohort_rows(store, logical_source_key)
+    if not current_rows:
+        return None
+    fingerprint = _cohort_fingerprint(current_rows)
+
+    conn = store._ensure_source_conn()
+    cached_rows = conn.execute(
+        "SELECT raw_id, verdict, cohort_fingerprint FROM raw_authority_verdicts WHERE logical_source_key = ?",
+        (logical_source_key,),
+    ).fetchall()
+    if not cached_rows or len(cached_rows) != len(current_rows):
+        return None
+
+    verdicts: dict[str, RawAuthorityVerdict] = {}
+    for raw_id, verdict, cached_fingerprint in cached_rows:
+        if bytes(cached_fingerprint) != fingerprint:
+            return None
+        verdicts[str(raw_id)] = RawAuthorityVerdict(str(verdict))
+    return verdicts
+
+
+def write_raw_authority_verdict_cache(
+    store: RawAuthorityVerdictProjectionHost,
+    logical_source_key: str,
+    verdicts: dict[str, RawAuthorityVerdict],
+    *,
+    now_ms: int,
+) -> None:
+    """Persist ``verdicts`` -- the *complete* result for one cohort -- to the cache.
+
+    Callers must pass the full verdict dict
+    :func:`~polylogue.storage.raw_authority_verdict_projection.project_raw_authority_verdicts`
+    returned for this ``logical_source_key``, never a partial subset: a
+    partial write would leave a stale row behind that silently fails the next
+    read's ``len(cached_rows) != len(current_rows)`` check for the wrong
+    reason (row-count mismatch masking a real content change). Replaces the
+    cohort's entire prior cache row set atomically in one transaction.
+    """
+    fingerprint = _cohort_fingerprint(_current_cohort_rows(store, logical_source_key))
+    member_count = len(verdicts)
+
+    conn = store._ensure_source_conn()
+    with conn:
+        conn.execute(
+            "DELETE FROM raw_authority_verdicts WHERE logical_source_key = ?",
+            (logical_source_key,),
+        )
+        conn.executemany(
+            """
+            INSERT INTO raw_authority_verdicts
+                (raw_id, logical_source_key, verdict, cohort_member_count, cohort_fingerprint, computed_at_ms)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (raw_id, logical_source_key, str(verdict), member_count, fingerprint, now_ms)
+                for raw_id, verdict in verdicts.items()
+            ],
+        )
+
+
+def get_or_compute_raw_authority_verdicts(
+    store: RawAuthorityVerdictProjectionHost,
+    logical_source_key: str,
+    *,
+    now_ms: int,
+) -> dict[str, RawAuthorityVerdict]:
+    """Read-through cache: return a fresh cached result, else recompute and persist.
+
+    This is the entry point real consumers (blob-GC invariant checks,
+    operator surfaces) should call instead of
+    ``project_raw_authority_verdicts`` directly, so a warm cache is used when
+    available and a cold/stale one is filled as a side effect of the read.
+    """
+    cached = read_cached_raw_authority_verdicts(store, logical_source_key)
+    if cached is not None:
+        return cached
+    verdicts = project_raw_authority_verdicts(store, logical_source_key)
+    if verdicts:
+        write_raw_authority_verdict_cache(store, logical_source_key, verdicts, now_ms=now_ms)
+    return verdicts
+
+
+__all__ = [
+    "get_or_compute_raw_authority_verdicts",
+    "read_cached_raw_authority_verdicts",
+    "write_raw_authority_verdict_cache",
+]

--- a/polylogue/storage/sqlite/archive_tiers/source.py
+++ b/polylogue/storage/sqlite/archive_tiers/source.py
@@ -10,11 +10,18 @@ from typing import get_args
 
 from polylogue.archive.revision_authority import RawRevisionAuthority
 from polylogue.archive.session_revision_membership import MembershipDecision
-from polylogue.core.enums import ArtifactSupportStatus, Origin, Provider, ValidationMode, ValidationStatus
+from polylogue.core.enums import (
+    ArtifactSupportStatus,
+    Origin,
+    Provider,
+    RawAuthorityVerdict,
+    ValidationMode,
+    ValidationStatus,
+)
 from polylogue.storage.sqlite.archive_tiers.common import check, literal_check, nullable_check
 from polylogue.storage.sqlite.archive_tiers.types import ProvenRevisionAuthority
 
-SOURCE_SCHEMA_VERSION = 23
+SOURCE_SCHEMA_VERSION = 24
 
 SOURCE_DDL = f"""
 CREATE TABLE IF NOT EXISTS raw_sessions (
@@ -379,6 +386,33 @@ WHERE resolved_at_ms IS NULL;
 -- a hook-event blob ref keyed as 'raw_payload' with a synthetic ref_id could
 -- never join to any raw_sessions row and was therefore permanently
 -- GC-invisible under a naive membership check.
+-- Persisted cache of the closed RawAuthorityVerdict vocabulary (polylogue-w6hql
+-- Phase 2, polylogue-tw4ar). Not a new source of truth: every row here is a
+-- read-through cache of what polylogue.storage.raw_authority_verdict_projection
+-- .project_raw_authority_verdicts would recompute from raw_sessions + blob
+-- storage, kept here only so repeated reads (e.g. blob-GC invariant checks at
+-- scale) don't re-run the full byte-proof classifier every time. Invalidated
+-- by content, not by elapsed time: cohort_fingerprint is a SHA-256 over the
+-- cohort's own (raw_id, revision_kind, blob_hash) rows, so any membership or
+-- content change to the logical_source_key cohort changes the fingerprint and
+-- the cached rows read as stale on the next lookup (see
+-- polylogue.storage.raw_authority_verdict_cache). No write-side actuator
+-- writes here yet -- polylogue.storage.raw_authority_verdict_cache's
+-- get_or_compute_raw_authority_verdicts() populates it lazily on read;
+-- DaemonConverger convergence-stage wiring to keep it warm proactively is
+-- deferred, see polylogue-tw4ar.
+CREATE TABLE IF NOT EXISTS raw_authority_verdicts (
+    raw_id                TEXT PRIMARY KEY REFERENCES raw_sessions(raw_id) ON DELETE CASCADE,
+    logical_source_key    TEXT NOT NULL,
+    verdict                TEXT NOT NULL CHECK ({check("verdict", RawAuthorityVerdict)}),
+    cohort_member_count   INTEGER NOT NULL CHECK(cohort_member_count >= 1),
+    cohort_fingerprint    BLOB NOT NULL CHECK(length(cohort_fingerprint) = 32),
+    computed_at_ms        INTEGER NOT NULL CHECK(computed_at_ms >= 0)
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_raw_authority_verdicts_logical_source
+ON raw_authority_verdicts(logical_source_key);
+
 CREATE TABLE IF NOT EXISTS blob_refs (
     blob_hash       BLOB NOT NULL CHECK(length(blob_hash) = 32),
     ref_id          TEXT NOT NULL,

--- a/polylogue/storage/sqlite/migrations/source/024_raw_authority_verdicts_cache.sql
+++ b/polylogue/storage/sqlite/migrations/source/024_raw_authority_verdicts_cache.sql
@@ -1,0 +1,31 @@
+-- polylogue-w6hql (Phase 2) / polylogue-tw4ar: persisted cache table for the
+-- closed RawAuthorityVerdict vocabulary. Not a new source of truth -- every
+-- row is a read-through cache of what
+-- polylogue.storage.raw_authority_verdict_projection.project_raw_authority_verdicts
+-- would recompute from raw_sessions + blob storage; it exists only so a
+-- repeated read (e.g. blob-GC invariant checks at scale) doesn't re-run the
+-- full byte-proof classifier every time.
+--
+-- Invalidated by content, not by elapsed time: cohort_fingerprint is a
+-- SHA-256 over the cohort's own (raw_id, revision_kind, blob_hash) rows
+-- (polylogue.storage.raw_authority_verdict_cache._cohort_fingerprint), so any
+-- membership or content change to the logical_source_key cohort changes the
+-- fingerprint and the previously-cached rows read as stale on the next
+-- lookup rather than being trusted past their true validity window.
+--
+-- No write-side actuator populates this table proactively yet --
+-- get_or_compute_raw_authority_verdicts() (raw_authority_verdict_cache.py)
+-- fills it lazily on first read. Wiring a DaemonConverger stage to keep it
+-- warm ahead of reads is deferred to a follow-up within polylogue-tw4ar's own
+-- scope, not attempted in this migration.
+CREATE TABLE IF NOT EXISTS raw_authority_verdicts (
+    raw_id                TEXT PRIMARY KEY REFERENCES raw_sessions(raw_id) ON DELETE CASCADE,
+    logical_source_key    TEXT NOT NULL,
+    verdict                TEXT NOT NULL CHECK(verdict IN ('verified', 'superseded', 'sole-copy', 'diverged', 'unchecked')),
+    cohort_member_count   INTEGER NOT NULL CHECK(cohort_member_count >= 1),
+    cohort_fingerprint    BLOB NOT NULL CHECK(length(cohort_fingerprint) = 32),
+    computed_at_ms        INTEGER NOT NULL CHECK(computed_at_ms >= 0)
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_raw_authority_verdicts_logical_source
+ON raw_authority_verdicts(logical_source_key);

--- a/tests/unit/storage/test_raw_authority_verdict_cache.py
+++ b/tests/unit/storage/test_raw_authority_verdict_cache.py
@@ -1,0 +1,140 @@
+"""Persisted RawAuthorityVerdict cache (polylogue-w6hql Phase 2 / polylogue-tw4ar).
+
+Anti-vacuity: ``test_second_read_does_not_recompute`` proves the cache is
+actually consulted (not merely written and ignored) by monkeypatching the
+underlying projection to raise if called a second time. ``test_new_revision_
+invalidates_the_cache`` proves the fingerprint-based invalidation is real by
+adding a new raw to a cached cohort and checking the stale cache is rejected
+and the recomputed result reflects the new member, not the cached one.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from polylogue.archive.revision_authority import RawRevisionEnvelope, RawRevisionKind
+from polylogue.core.enums import Provider, RawAuthorityVerdict
+from polylogue.storage import raw_authority_verdict_cache as cache_module
+from polylogue.storage.raw_authority_verdict_cache import (
+    get_or_compute_raw_authority_verdicts,
+    read_cached_raw_authority_verdicts,
+    write_raw_authority_verdict_cache,
+)
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+
+def _bind_full(archive: ArchiveStore, *, raw_id: str, payload: bytes, logical_source_key: str) -> str:
+    written_id = archive.write_raw_payload(
+        provider=Provider.CODEX,
+        payload=payload,
+        source_path="session.jsonl",
+        acquired_at_ms=1,
+        raw_id=raw_id,
+    )
+    archive.bind_raw_revision(
+        written_id,
+        RawRevisionEnvelope(logical_source_key, RawRevisionKind.FULL, f"revision-{raw_id}", 0),
+    )
+    return written_id
+
+
+def test_cold_cache_computes_and_persists(tmp_path: Path) -> None:
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        _bind_full(archive, raw_id="oldest", payload=b"one\n", logical_source_key="codex:s1")
+        _bind_full(archive, raw_id="newest", payload=b"one\ntwo\n", logical_source_key="codex:s1")
+
+        assert read_cached_raw_authority_verdicts(archive, "codex:s1") is None
+
+        verdicts = get_or_compute_raw_authority_verdicts(archive, "codex:s1", now_ms=1000)
+
+        cached = read_cached_raw_authority_verdicts(archive, "codex:s1")
+
+    assert verdicts == {
+        "oldest": RawAuthorityVerdict.SUPERSEDED,
+        "newest": RawAuthorityVerdict.VERIFIED,
+    }
+    assert cached == verdicts
+
+
+def test_second_read_does_not_recompute(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        _bind_full(archive, raw_id="only", payload=b"payload", logical_source_key="codex:s1")
+
+        first = get_or_compute_raw_authority_verdicts(archive, "codex:s1", now_ms=1000)
+
+        def _fail(*args: object, **kwargs: object) -> dict[str, RawAuthorityVerdict]:
+            raise AssertionError("project_raw_authority_verdicts must not run against a warm cache")
+
+        monkeypatch.setattr(cache_module, "project_raw_authority_verdicts", _fail)
+
+        second = get_or_compute_raw_authority_verdicts(archive, "codex:s1", now_ms=2000)
+
+    assert first == {"only": RawAuthorityVerdict.SOLE_COPY}
+    assert second == first
+
+
+def test_new_revision_invalidates_the_cache(tmp_path: Path) -> None:
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        _bind_full(archive, raw_id="only", payload=b"payload", logical_source_key="codex:s1")
+        first = get_or_compute_raw_authority_verdicts(archive, "codex:s1", now_ms=1000)
+        assert first == {"only": RawAuthorityVerdict.SOLE_COPY}
+
+        # A second revision joins the cohort -- the previously-cached SOLE_COPY
+        # verdict for "only" is now wrong (it has a successor).
+        _bind_full(archive, raw_id="newer", payload=b"payload\nmore\n", logical_source_key="codex:s1")
+
+        assert read_cached_raw_authority_verdicts(archive, "codex:s1") is None
+
+        second = get_or_compute_raw_authority_verdicts(archive, "codex:s1", now_ms=2000)
+
+    assert second == {
+        "only": RawAuthorityVerdict.SUPERSEDED,
+        "newer": RawAuthorityVerdict.VERIFIED,
+    }
+
+
+def test_write_requires_full_cohort_and_replaces_prior_rows(tmp_path: Path) -> None:
+    """A rewrite must clear the cohort's whole prior row set, not accumulate."""
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        _bind_full(archive, raw_id="oldest", payload=b"one\n", logical_source_key="codex:s1")
+        _bind_full(archive, raw_id="newest", payload=b"one\ntwo\n", logical_source_key="codex:s1")
+
+        write_raw_authority_verdict_cache(
+            archive,
+            "codex:s1",
+            {"oldest": RawAuthorityVerdict.SUPERSEDED, "newest": RawAuthorityVerdict.VERIFIED},
+            now_ms=1000,
+        )
+        write_raw_authority_verdict_cache(
+            archive,
+            "codex:s1",
+            {"oldest": RawAuthorityVerdict.SUPERSEDED, "newest": RawAuthorityVerdict.VERIFIED},
+            now_ms=2000,
+        )
+
+        rows = (
+            archive._ensure_source_conn()
+            .execute("SELECT raw_id, computed_at_ms FROM raw_authority_verdicts WHERE logical_source_key = 'codex:s1'")
+            .fetchall()
+        )
+
+    assert {str(r[0]) for r in rows} == {"oldest", "newest"}
+    assert all(int(r[1]) == 2000 for r in rows)
+
+
+def test_missing_cohort_returns_no_verdicts_and_no_cache_write(tmp_path: Path) -> None:
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        verdicts = get_or_compute_raw_authority_verdicts(archive, "codex:does-not-exist", now_ms=1000)
+
+        rows = archive._ensure_source_conn().execute("SELECT COUNT(*) FROM raw_authority_verdicts").fetchall()
+
+    assert verdicts == {}
+    assert rows[0][0] == 0


### PR DESCRIPTION
## Summary

Adds a persisted `raw_authority_verdicts` cache table (source.db, migration 022) plus a read-through cache module in front of the read-only `RawAuthorityVerdict` projection landed in polylogue-w6hql's Phase 2 (PR #3593).

## Problem

`project_raw_authority_verdicts` (`polylogue/storage/raw_authority_verdict_projection.py`) recomputes a cohort's `RawAuthorityVerdict` on demand by re-running the full byte-proof classifier (`classify_historical_full_revision_streams`) against live blob storage on every call. That is correct, but not cheap at the archive's current scale, and there was no persisted table for a real consumer (blob-GC invariant checks, operator surfaces) to read cheaply instead. This is exactly the gap named in polylogue-w6hql's own notes and filed as its dedicated follow-up, polylogue-tw4ar.

## Solution

- Migration 022 (source schema v21 -> v22) adds `raw_authority_verdicts`, generated via `check("verdict", RawAuthorityVerdict)` — same idiom just landed for the two decision vocabularies (polylogue-z22ml, PR #3619) and `revision_authority` (polylogue-h57ic, PR #3615) — so the CHECK constraint can never drift out of sync with the enum.
- `polylogue/storage/raw_authority_verdict_cache.py` adds the read-through cache:
  - `_cohort_fingerprint` hashes the sorted `(raw_id, revision_kind, blob_hash)` rows for a `logical_source_key` cohort (registered in `docs/plans/hash-boundary-registry.yaml`, classification `identifier`).
  - `read_cached_raw_authority_verdicts` returns cached verdicts only if the cohort's *current* fingerprint matches the cached one — invalidated by content/membership change, not by elapsed time, so a stale cache row can never be observed disagreeing with what `project_raw_authority_verdicts` would compute right now for the same cohort shape.
  - `write_raw_authority_verdict_cache` replaces a cohort's entire prior cache row set atomically (never a partial update).
  - `get_or_compute_raw_authority_verdicts` is the read-through entry point real consumers should call.
- Updated `tests/unit/storage/test_durable_migrations.py`'s hardcoded `SOURCE_SCHEMA_VERSION == 21` / `applied_versions` assertions to 22, matching the precedent set by migrations 019-021.

## Deliberately deferred

Wiring a `DaemonConverger` stage to keep the cache warm proactively ahead of reads (rather than filling it lazily on first read, which is all this PR does) is explicitly still open under polylogue-tw4ar. Bundling that into this same change would mean touching the daemon's sole-writer convergence loop in the same diff as a new schema table — this subsystem's own precedent (polylogue-lb39z's session notes) is to land safe increments rather than force everything into one PR, so the cache table + read-through accessor lands now and the daemon wiring stays a separate, independently reviewable follow-up.

## Verification

- `devtools test tests/unit/storage/test_raw_authority_verdict_cache.py tests/unit/storage/test_raw_authority_verdict_projection.py tests/unit/storage/test_durable_migrations.py polylogue/storage/raw_authority_verdict_cache.py polylogue/storage/sqlite/archive_tiers/source.py` — `55 passed`
- `devtools verify --quick` — `exit_code: 0` (ruff format/check, mypy --strict, render all, topology, layering, hash-boundary-census, schema-versioning, schema promotion audit)

Ref polylogue-tw4ar. Ref polylogue-w6hql.