### PR TITLE
test(pipeline): regress the message_type combined-text drift shape

### DIFF
--- a/tests/unit/pipeline/test_message_type_backfill.py
+++ b/tests/unit/pipeline/test_message_type_backfill.py
@@ -114,6 +114,51 @@ def _make_db_with_multi_block_message(db_path: Path) -> str:
     return conv_id
 
 
+def _make_db_with_drifted_mixed_block_message(db_path: Path) -> str:
+    """One row shaped exactly like the bd polylogue-c831 production drift.
+
+    ``classify_text_message_type`` matches most markers with
+    ``str.startswith`` (see ``polylogue/archive/message/artifacts.py``) --
+    anchored at position 0. Before PR #3525, Claude Code ingest classified
+    ``message_type`` from a *combined* string that concatenated every
+    content segment in record order (THINKING, then TOOL_RESULT, then
+    TEXT). A protocol/context marker that starts the message's own TEXT
+    block therefore does NOT start the combined string once non-empty
+    THINKING/TOOL_RESULT segments are prepended ahead of it, so the
+    anchored check misses it and the row is persisted as the default
+    ``message`` type -- exactly the live drift this bead measured (1,901
+    live candidates as of this fix, confirmed by a read-only production
+    scan).
+
+    This row simulates that already-materialized legacy state directly:
+    ``message_type='message'`` with a TEXT block whose content, alone,
+    unambiguously starts with a protocol marker (``<bash-input>``), plus
+    THINKING/TOOL_RESULT blocks carrying no markers of their own (so a
+    reader can see they are not why the row would reclassify). The
+    backfill reconstructs the classification input from the persisted
+    TEXT block only (``text_blocks_prose``'s SQL twin,
+    ``message_prose_sql(block_types=("text",))``), so it must flip this
+    row to ``protocol`` regardless of the other block types attached to
+    the same message.
+    """
+    conv_id = "conv-drifted-mixed-1"
+    builder = SessionBuilder(db_path, conv_id)
+    builder.provider("claude-code").title("Drifted mixed-block backfill test")
+    builder.add_message(
+        message_id="drifted-1",
+        role="assistant",
+        text="<bash-input>ls -la</bash-input>",
+        message_type="message",
+        blocks=[
+            {"type": "thinking", "text": "plain reasoning, no markers here"},
+            {"type": "tool_result", "text": "tool ran fine"},
+            {"type": "text", "text": "<bash-input>ls -la</bash-input>"},
+        ],
+    )
+    builder.save()
+    return conv_id
+
+
 def _make_config(workspace_env: dict[str, Path], db_path: Path) -> Config:
     """Create a minimal Config for tests."""
     return Config(
@@ -351,3 +396,35 @@ class TestMessageTypeBackfill:
 
         assert row is not None
         assert row[1] == "first block\nsecond block"
+
+    def test_backfill_reclassifies_drifted_row_ignoring_other_block_types(
+        self, workspace_env: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """bd polylogue-c831: converge a row drifted by the combined-text
+        vs. TEXT-only classification divergence (PR #3525 root cause).
+
+        Reproduces the live production drift directly: a message persisted
+        with ``message_type='message'`` even though its own TEXT block
+        starts with an unambiguous protocol marker, because ingest (before
+        #3525) classified from a combined THINKING+TOOL_RESULT+TEXT string
+        where the marker was no longer at position 0. The backfill must
+        flip it to ``protocol`` from the persisted TEXT block alone.
+        """
+        db_path = db_setup(workspace_env)
+        _make_db_with_drifted_mixed_block_message(db_path)
+
+        cfg = _make_config(workspace_env, db_path)
+
+        with open_index_db(db_path) as conn:
+            before = conn.execute("SELECT message_type FROM messages WHERE native_id = 'drifted-1'").fetchone()
+        assert before is not None
+        assert before[0] == "message", "fixture must start in the drifted pre-fix state"
+
+        result = repair_message_type_backfill(cfg, dry_run=False)
+        assert result.success, result.detail
+        assert result.repaired_count == 1
+
+        with open_index_db(db_path) as conn:
+            after = conn.execute("SELECT message_type FROM messages WHERE native_id = 'drifted-1'").fetchone()
+        assert after is not None
+        assert after[0] == "protocol", f"drifted row should converge to protocol, got {after[0]}"


### PR DESCRIPTION
## Summary

Regresses bd polylogue-c831's classification-drift bug shape with a fixture, and completes the bead's remaining operational scope by running the actual production backfill against the live archive.

## Problem

polylogue-c831's original evidence: a read-only scan against the live `index.db` found 1,919 rows still persisted as `message_type='message'` that the current classifier would flip to `context`/`protocol` -- a divergence between ingest-time classification and the backfill's own re-derivation.

The root cause was found and fixed in PR #3525 (merged): `classify_text_message_type` matches most markers with an anchored `str.startswith` check, but pre-#3525 Claude Code ingest classified from a *combined* THINKING+TOOL_RESULT+TEXT string. A marker that starts a message's own TEXT block does not start the combined string once non-empty THINKING/TOOL_RESULT segments are concatenated ahead of it, so the anchored check silently misses it at ingest time. That PR stopped new drift from accumulating but explicitly left two things open: a regression test for the backfill side of the divergence, and the operational backfill run over the already-materialized drifted rows.

## Solution

- Added `test_backfill_reclassifies_drifted_row_ignoring_other_block_types` (`tests/unit/pipeline/test_message_type_backfill.py`) with a new fixture (`_make_db_with_drifted_mixed_block_message`) that reproduces the exact drift shape directly: a `message_type='message'` row whose persisted TEXT block alone starts with a protocol marker (`<bash-input>`), alongside marker-free THINKING/TOOL_RESULT blocks, asserting the backfill flips it to `protocol` from the TEXT block content alone -- proving the existing `message_type_backfill` machinery (`storage/message_type_backfill.py`, unchanged by this PR) correctly converges this class of drifted row regardless of other block types on the message.
- Confirmed the live candidate count with the production `count_unclassified_message_type_sync` function (not a reimplementation): 1,901 candidates as of 2026-08-03 (down slightly from the bead's original 1,919, consistent with #3525 having stopped new accumulation and ordinary archive churn since).
- Ran the actual production backfill against the live archive (`/realm/db/polylogue/index.db`) using the existing, unmodified `_backfill_pass`/`count_messages_by_type_sync` functions, opened via the production `open_connection` helper (the same code path `polylogue doctor --repair --target message_type_backfill` exercises). This only touches the `messages.message_type` column on the `index.db` tier, which is the rebuildable-by-design tier in the five-tier durability model -- no durable-tier or DDL change involved.
  - Before: `message=1,230,456, context=19,600, protocol=40,245` (1,901 candidates)
  - Updated: 1,901 rows
  - After: `message=1,228,555, context=19,603, protocol=42,143` (0 candidates)
  - Re-confirmed 0 candidates in a fresh read-only pass after the write.
- No change to `polylogue/` production code in this PR -- the classifier/backfill logic was already correct (delivered by #3525); this PR is the test-coverage + operational-convergence half of the bead's remaining scope.

## Verification

- `devtools test tests/unit/pipeline/test_message_type_backfill.py` -- 8 passed (7 pre-existing + 1 new).
- `devtools verify --quick` -- exit 0, 23/23 steps green, on the rebased branch.
- Live production backfill apply + before/after/re-confirm counts as above (`polylogued` daemon remained healthy throughout; its pre-existing, unrelated schema-version health warning -- `source.db:20!=18, index.db:46!=56`, part of the separate in-flight differential-reindex program -- was unchanged before and after this write).

## Scope notes

Ref polylogue-c831. Not addressed here (out of scope, no evidence of drift found): `classify_material_origin`'s combined-text argument in `code_parser.py` has the same latent divergence shape for OPERATOR_COMMAND/GENERATED_*_PACK markers, per PR #3525's own notes -- a follow-up would need its own drift measurement first.