### PR TITLE
feat(sources): acquire ChatGPT .dat attachment bytes into blob store

### DIFF
--- a/polylogue/pipeline/ids.py
+++ b/polylogue/pipeline/ids.py
@@ -317,6 +317,12 @@ def _attachment_hash_payload(attachment: ParsedAttachment) -> dict[str, JSONValu
     }
     if attachment.inline_bytes is not None:
         payload["inline_content_hash"] = hash_bytes(attachment.inline_bytes)
+    elif attachment.precomputed_blob is not None:
+        # polylogue-8ac0: bytes already streamed into the blob store during
+        # sidecar discovery carry a known hash without needing to re-read
+        # them here (mirrors the ``inline_bytes`` branch above, whose content
+        # hash marks re-ingest content-changed once bytes newly arrive).
+        payload["inline_content_hash"] = attachment.precomputed_blob[0]
     return payload
 
 

--- a/polylogue/pipeline/services/archive_ingest.py
+++ b/polylogue/pipeline/services/archive_ingest.py
@@ -285,6 +285,7 @@ async def parse_sources_archive(
                         include_mtime=True,
                         known_mtimes=None,
                         discover_sidecars=True,
+                        blob_store=parse_blob_publisher,
                     )
                     if walk is None:
                         continue

--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -411,7 +411,11 @@ def _incoming_write_regresses_attachment_coverage(
     on the pre-fetch revision). This only ever blocks a regression: an
     incoming write that ties or improves attachment coverage is unaffected.
     """
-    incoming_acquired = sum(1 for attachment in session_to_write.attachments if attachment.inline_bytes is not None)
+    incoming_acquired = sum(
+        1
+        for attachment in session_to_write.attachments
+        if attachment.inline_bytes is not None or attachment.precomputed_blob is not None
+    )
     existing_acquired_row = conn.execute(
         """
         SELECT COUNT(*) FROM attachment_refs r
@@ -704,6 +708,19 @@ def _write_session(
         )
         counts.update(sidecar_blob_counts)
         blob_publisher.flush()
+    for attachment in session_to_write.attachments:
+        # bd polylogue-8ac0: bytes for this attachment were already streamed
+        # into the blob store during sidecar discovery (e.g. ChatGPT ``.dat``
+        # asset acquisition) -- record the already-known hash/size directly
+        # rather than re-hashing. Independent of ``blob_publisher`` (no new
+        # write happens here) and skipped when ``inline_bytes`` already
+        # claimed this attachment above.
+        if attachment.inline_bytes is not None or attachment.precomputed_blob is None:
+            continue
+        if preacquired_attachment_blobs is None:
+            preacquired_attachment_blobs = {}
+        hash_hex, size = attachment.precomputed_blob
+        preacquired_attachment_blobs[id(attachment)] = (bytes.fromhex(hash_hex), size, "acquired")
 
     write_parsed_session_to_archive(
         conn,

--- a/polylogue/sources/assembly.py
+++ b/polylogue/sources/assembly.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Protocol, TypeAlias
 from typing_extensions import TypedDict
 
 from polylogue.core.enums import Provider
+from polylogue.storage.blob_store import BlobStore
 
 from .parsers.base import ParsedSession
 
@@ -43,6 +44,12 @@ class _ChatGPTSidecarData(TypedDict, total=False):
     # resolver built once per source scan from conversation_asset_file_names.json
     # + library_files.json. See sources/assembly_chatgpt.py.
     chatgpt_asset_index: ChatGPTAssetIndex
+    # bd polylogue-8ac0: dat asset id -> (blob_hash_hex, size_bytes) for every
+    # ``.dat`` member/sibling file whose bytes were streamed into the blob
+    # store during sidecar discovery. Attachment resolution joins against this
+    # so previously-acquired dat bytes are marked "acquired" without
+    # re-hashing (see ``ingest_batch/_core.py``'s ``preacquired_attachment_blobs``).
+    chatgpt_dat_blobs: dict[str, tuple[str, int]]
 
 
 class SidecarData(_ClaudeCodeSidecarData, _CodexSidecarData, _ChatGPTSidecarData, total=False):
@@ -60,10 +67,21 @@ class TitleResolution:
 class ProviderAssemblySpec(Protocol):
     """Provider-specific sidecar discovery and session enrichment."""
 
-    def discover_sidecars(self, source_paths: list[Path]) -> SidecarData:
+    def discover_sidecars(
+        self,
+        source_paths: list[Path],
+        *,
+        blob_store: BlobStore | None = None,
+    ) -> SidecarData:
         """Discover provider-specific sidecars from source paths.
 
         Returns opaque provider data keyed by parent directory or similar.
+
+        ``blob_store`` is an optional content-addressed blob store/publisher
+        a spec may use to stream sidecar-referenced bytes (not just metadata)
+        into the archive during discovery -- see ``ChatGPTAssemblySpec``'s
+        ``.dat`` asset acquisition (bd polylogue-8ac0). Specs that only need
+        sidecar metadata ignore it.
         """
         ...
 

--- a/polylogue/sources/assembly_chatgpt.py
+++ b/polylogue/sources/assembly_chatgpt.py
@@ -24,19 +24,22 @@ from __future__ import annotations
 
 import json
 import zipfile
+from collections.abc import Mapping
 from pathlib import Path
 
 from polylogue.core.enums import Provider
 from polylogue.logging import get_logger
+from polylogue.storage.blob_store import BlobStore
 
 from .assembly import SidecarData
 from .parsers.base import ParsedAttachment, ParsedSession, ParsedSessionEvent
-from .parsers.chatgpt_sidecars import ChatGPTAssetIndex
+from .parsers.chatgpt_sidecars import ChatGPTAssetIndex, _normalize_file_id
 
 logger = get_logger(__name__)
 
 _LIBRARY_FILES_NAME = "library_files.json"
 _ASSET_NAMES_NAME = "conversation_asset_file_names.json"
+_DAT_SUFFIX = ".dat"
 
 
 def _read_json_file(path: Path) -> object | None:
@@ -64,11 +67,126 @@ def _read_json_zip_member(zip_path: Path, member_name: str) -> object | None:
         return None
 
 
+def _dat_asset_id(basename: str) -> str:
+    bare = basename[: -len(_DAT_SUFFIX)] if basename.lower().endswith(_DAT_SUFFIX) else basename
+    return _normalize_file_id(bare)
+
+
+def _acquire_dat_blobs_from_zip(zip_path: Path, store: BlobStore) -> dict[str, tuple[str, int]]:
+    """Stream every ``.dat`` ZIP member into *store*, keyed by asset id.
+
+    Mirrors ``decoder_zip.py``'s ``capture_raw`` streaming pattern (bounded
+    decompression via ``open_bounded_zip_entry``, no full-file memory load)
+    but scans the whole archive up front rather than the main
+    ``ZipEntryValidator`` per-entry loop, which only ever admits
+    ``.json``/``.jsonl`` entries (``session_only=True``) and would otherwise
+    never see a ``.dat`` member at all.
+    """
+    from polylogue.storage.blob_publication import flush_blob_publications
+
+    from .decoder_zip import (
+        MAX_COMPRESSION_RATIO,
+        MAX_UNCOMPRESSED_SIZE,
+        ZipBombError,
+        open_bounded_zip_entry,
+    )
+
+    acquired: dict[str, tuple[str, int]] = {}
+    try:
+        with zipfile.ZipFile(zip_path) as zf:
+            for info in zf.infolist():
+                if info.is_dir():
+                    continue
+                name = info.filename
+                if not name.lower().endswith(_DAT_SUFFIX):
+                    continue
+                dat_id = _dat_asset_id(Path(name).name)
+                if dat_id in acquired:
+                    continue
+                if info.compress_size > 0 and info.file_size / info.compress_size > MAX_COMPRESSION_RATIO:
+                    logger.warning("chatgpt_dat_suspicious_compression_ratio", path=str(zip_path), member=name)
+                    continue
+                if info.file_size > MAX_UNCOMPRESSED_SIZE:
+                    logger.warning(
+                        "chatgpt_dat_oversized",
+                        path=str(zip_path),
+                        member=name,
+                        size=info.file_size,
+                    )
+                    continue
+                try:
+                    with open_bounded_zip_entry(zf, name) as handle:
+                        blob_hash, size = store.write_from_fileobj(handle)
+                except ZipBombError:
+                    logger.warning("chatgpt_dat_zip_bomb", path=str(zip_path), member=name)
+                    continue
+                except (KeyError, zipfile.BadZipFile, OSError) as exc:
+                    logger.debug(
+                        "chatgpt_dat_read_failed",
+                        path=str(zip_path),
+                        member=name,
+                        error=str(exc),
+                    )
+                    continue
+                acquired[dat_id] = (blob_hash, size)
+    except (OSError, zipfile.BadZipFile) as exc:
+        logger.warning("chatgpt_dat_zip_open_failed", path=str(zip_path), error=str(exc))
+        return acquired
+    if acquired:
+        flush_blob_publications(store)
+    return acquired
+
+
+def _acquire_dat_blobs_from_directory(directory: Path, store: BlobStore) -> dict[str, tuple[str, int]]:
+    """Stream sibling ``*.dat`` files from an extracted export directory.
+
+    ``ChatGPTAssemblySpec.discover_sidecars`` already walks this directory
+    (looking for ``library_files.json``/``conversation_asset_file_names.json``);
+    the ``.dat`` files themselves sit right next to ``conversations-*.json``
+    as ordinary files, streamed via ``BlobStore.write_from_path`` (no
+    full-file memory load).
+    """
+    from polylogue.storage.blob_publication import flush_blob_publications
+
+    from .decoder_zip import MAX_UNCOMPRESSED_SIZE
+
+    acquired: dict[str, tuple[str, int]] = {}
+    try:
+        candidates = sorted(directory.glob(f"*{_DAT_SUFFIX}"))
+    except OSError:
+        return acquired
+    for dat_path in candidates:
+        dat_id = _dat_asset_id(dat_path.name)
+        try:
+            size_on_disk = dat_path.stat().st_size
+        except OSError:
+            continue
+        if size_on_disk > MAX_UNCOMPRESSED_SIZE:
+            logger.warning("chatgpt_dat_oversized", path=str(dat_path), size=size_on_disk)
+            continue
+        try:
+            blob_hash, size = store.write_from_path(dat_path)
+        except OSError as exc:
+            logger.warning("chatgpt_dat_read_failed", path=str(dat_path), error=str(exc))
+            continue
+        acquired[dat_id] = (blob_hash, size)
+    if acquired:
+        flush_blob_publications(store)
+    return acquired
+
+
 class ChatGPTAssemblySpec:
     """ChatGPT provider assembly — ``.dat``/sandbox-file sidecar resolution."""
 
-    def discover_sidecars(self, source_paths: list[Path]) -> SidecarData:
-        """Discover ``library_files.json``/``conversation_asset_file_names.json``.
+    def discover_sidecars(
+        self,
+        source_paths: list[Path],
+        *,
+        blob_store: BlobStore | None = None,
+    ) -> SidecarData:
+        """Discover ``library_files.json``/``conversation_asset_file_names.json``
+        and, when ``blob_store`` is given, stream every ``.dat`` asset's bytes
+        into the content-addressed blob store (bd polylogue-8ac0).
 
         Resolves via each source path's containing directory rather than
         requiring the sidecar filenames to appear verbatim in
@@ -79,9 +197,19 @@ class ChatGPTAssemblySpec:
         parent directory and globbing for the two known sidecar filenames
         there covers both call shapes with the same code, mirroring how
         ``CodexAssemblySpec`` climbs to a stable anchor directory.
+
+        ``.dat`` bytes are acquired the same way: a ZIP source streams every
+        ``.dat`` member through ``BlobStore.write_from_fileobj`` (bounded
+        decompression, no full-file memory load — mirrors
+        ``decoder_zip.py``'s ``capture_raw`` branch); an extracted-directory
+        source streams sibling ``*.dat`` files through
+        ``BlobStore.write_from_path``. ``blob_store`` is ``None`` for callers
+        that only need sidecar metadata (e.g. non-session artifact admission),
+        so this stays a no-op there.
         """
         library_files_payload: object | None = None
         asset_names_payload: object | None = None
+        dat_blobs: dict[str, tuple[str, int]] = {}
         seen_dirs: set[Path] = set()
         for path in source_paths:
             if path.suffix.lower() == ".zip":
@@ -89,6 +217,8 @@ class ChatGPTAssemblySpec:
                     library_files_payload = _read_json_zip_member(path, _LIBRARY_FILES_NAME)
                 if asset_names_payload is None:
                     asset_names_payload = _read_json_zip_member(path, _ASSET_NAMES_NAME)
+                if blob_store is not None:
+                    dat_blobs.update(_acquire_dat_blobs_from_zip(path, blob_store))
                 continue
             directory = path.parent
             if directory in seen_dirs:
@@ -102,11 +232,16 @@ class ChatGPTAssemblySpec:
                 candidate = directory / _ASSET_NAMES_NAME
                 if candidate.is_file():
                     asset_names_payload = _read_json_file(candidate)
+            if blob_store is not None:
+                dat_blobs.update(_acquire_dat_blobs_from_directory(directory, blob_store))
         index = ChatGPTAssetIndex.build(
             library_files_payload=library_files_payload,
             asset_file_names_payload=asset_names_payload,
         )
-        return {"chatgpt_asset_index": index}
+        result: SidecarData = {"chatgpt_asset_index": index}
+        if dat_blobs:
+            result["chatgpt_dat_blobs"] = dat_blobs
+        return result
 
     def enrich_session(
         self,
@@ -116,14 +251,19 @@ class ChatGPTAssemblySpec:
         if conv.source_name is not Provider.CHATGPT or not conv.attachments:
             return conv
         index = sidecar_data.get("chatgpt_asset_index")
-        if index is None or index.is_empty:
+        dat_blobs = sidecar_data.get("chatgpt_dat_blobs") or {}
+        if (index is None or index.is_empty) and not dat_blobs:
             return conv
+        if index is None:
+            index = ChatGPTAssetIndex.empty()
 
         new_attachments: list[ParsedAttachment] = []
         new_events: list[ParsedSessionEvent] = []
         changed = False
         for attachment in conv.attachments:
-            resolved, event = _resolve_attachment(attachment, index, thread_id=conv.provider_session_id)
+            resolved, event = _resolve_attachment(
+                attachment, index, thread_id=conv.provider_session_id, dat_blobs=dat_blobs
+            )
             new_attachments.append(resolved)
             if resolved is not attachment:
                 changed = True
@@ -144,41 +284,60 @@ def _resolve_attachment(
     index: ChatGPTAssetIndex,
     *,
     thread_id: str,
+    dat_blobs: Mapping[str, tuple[str, int]],
 ) -> tuple[ParsedAttachment, ParsedSessionEvent | None]:
     if attachment.attachment_kind == "sandbox_file":
+        # bd polylogue-dt5s: sandbox links carry no bytes of their own -- the
+        # export/capture never ships the Code-Interpreter container's file,
+        # so there is nothing in ``dat_blobs`` to join against here.
         return _resolve_sandbox_attachment(attachment, index, thread_id=thread_id)
-    return _resolve_dat_attachment(attachment, index)
+    return _resolve_dat_attachment(attachment, index, dat_blobs)
 
 
 def _resolve_dat_attachment(
     attachment: ParsedAttachment,
     index: ChatGPTAssetIndex,
+    dat_blobs: Mapping[str, tuple[str, int]],
 ) -> tuple[ParsedAttachment, ParsedSessionEvent | None]:
     resolved = index.resolve_dat(attachment.provider_attachment_id)
-    if resolved is None:
+    blob = dat_blobs.get(_normalize_file_id(attachment.provider_attachment_id))
+    if resolved is None and blob is None:
         return attachment, None
     update: dict[str, object] = {}
-    if attachment.name is None and resolved.name is not None:
-        update["name"] = resolved.name
-    if attachment.mime_type is None and resolved.mime_type is not None:
-        update["mime_type"] = resolved.mime_type
-    if attachment.size_bytes is None and resolved.size_bytes is not None:
-        update["size_bytes"] = resolved.size_bytes
-    if attachment.provider_file_id is None:
-        update["provider_file_id"] = resolved.file_id
+    if resolved is not None:
+        if attachment.name is None and resolved.name is not None:
+            update["name"] = resolved.name
+        if attachment.mime_type is None and resolved.mime_type is not None:
+            update["mime_type"] = resolved.mime_type
+        if attachment.size_bytes is None and resolved.size_bytes is not None:
+            update["size_bytes"] = resolved.size_bytes
+        if attachment.provider_file_id is None:
+            update["provider_file_id"] = resolved.file_id
+    if blob is not None and attachment.inline_bytes is None and attachment.precomputed_blob is None:
+        # bd polylogue-8ac0: bytes already streamed into the blob store during
+        # sidecar discovery (`_acquire_dat_blobs_from_zip`/`_from_directory`).
+        # Recording the (hash, size) pair here -- rather than re-reading the
+        # source bytes -- lets `ingest_batch/_core.py` mark the attachment
+        # acquired without re-hashing already-written bytes.
+        update["precomputed_blob"] = blob
+        if attachment.size_bytes is None:
+            update["size_bytes"] = blob[1]
     new_attachment = attachment.model_copy(update=update) if update else attachment
-    event = ParsedSessionEvent(
-        event_type="chatgpt_asset_resolution",
-        source_message_provider_id=attachment.message_provider_id,
-        payload={
-            "attachment_id": attachment.provider_attachment_id,
-            "resolved_name": resolved.name,
-            "resolved_mime_type": resolved.mime_type,
-            "resolved_size_bytes": resolved.size_bytes,
-            "provider_sha256": resolved.sha256_digest,
-            "resolution_source": resolved.source,
-        },
-    )
+    event: ParsedSessionEvent | None = None
+    if resolved is not None:
+        event = ParsedSessionEvent(
+            event_type="chatgpt_asset_resolution",
+            source_message_provider_id=attachment.message_provider_id,
+            payload={
+                "attachment_id": attachment.provider_attachment_id,
+                "resolved_name": resolved.name,
+                "resolved_mime_type": resolved.mime_type,
+                "resolved_size_bytes": resolved.size_bytes,
+                "provider_sha256": resolved.sha256_digest,
+                "resolution_source": resolved.source,
+                "blob_acquired": blob is not None,
+            },
+        )
     return new_attachment, event
 
 

--- a/polylogue/sources/assembly_claude_code.py
+++ b/polylogue/sources/assembly_claude_code.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from polylogue.core.enums import PasteBoundary
 from polylogue.logging import get_logger
+from polylogue.storage.blob_store import BlobStore
 
 from .assembly import (
     ClaudeCodeHistoryPasteIndex,
@@ -38,13 +39,19 @@ _HISTORY_TIMESTAMP_TOLERANCE_MS = 6_000
 class ClaudeCodeAssemblySpec:
     """Claude Code provider assembly — sessions-index.json + history.jsonl."""
 
-    def discover_sidecars(self, source_paths: list[Path]) -> SidecarData:
+    def discover_sidecars(
+        self,
+        source_paths: list[Path],
+        *,
+        blob_store: BlobStore | None = None,
+    ) -> SidecarData:
         """Discover Claude Code sidecars.
 
         Returns both the session index (used for title/branch enrichment) and
         the per-session history paste index (used for ``has_paste`` evidence,
         #1583).
         """
+        del blob_store
         indices: dict[Path, dict[str, SessionIndexEntry]] = {}
         history_indices: dict[Path, ClaudeCodeHistoryPasteIndex] = {}
         for path in source_paths:

--- a/polylogue/sources/assembly_codex.py
+++ b/polylogue/sources/assembly_codex.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from polylogue.core.enums import MaterialOrigin, TitleSource
 from polylogue.core.json import json_document
 from polylogue.logging import get_logger
+from polylogue.storage.blob_store import BlobStore
 
 from .assembly import CodexHistoryTitles, CodexThreadNames, SidecarData
 from .parsers.base import ParsedSession
@@ -223,11 +224,17 @@ def _is_prompt_echo(candidate: str, conv: ParsedSession) -> bool:
 class CodexAssemblySpec:
     """Codex provider assembly — thread-name and authored-history sidecars."""
 
-    def discover_sidecars(self, source_paths: list[Path]) -> SidecarData:
+    def discover_sidecars(
+        self,
+        source_paths: list[Path],
+        *,
+        blob_store: BlobStore | None = None,
+    ) -> SidecarData:
         """Discover Codex thread names and authored-history titles.
 
         Returns ``{"thread_names": {...}, "history_titles": {...}}``.
         """
+        del blob_store
         thread_names: dict[str, str] = {}
         history_titles: dict[str, str] = {}
         state_titles: dict[str, str] = {}

--- a/polylogue/sources/assembly_gemini.py
+++ b/polylogue/sources/assembly_gemini.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from polylogue.archive.message.roles import Role
 from polylogue.core.enums import TitleSource
+from polylogue.storage.blob_store import BlobStore
 
 from .assembly import SidecarData
 from .parsers.base import ParsedAttachment, ParsedMessage, ParsedSession
@@ -23,9 +24,14 @@ _UUIDISH = re.compile(
 class GeminiAssemblySpec:
     """Gemini assembly using message and attachment evidence for display labels."""
 
-    def discover_sidecars(self, source_paths: list[Path]) -> SidecarData:
+    def discover_sidecars(
+        self,
+        source_paths: list[Path],
+        *,
+        blob_store: BlobStore | None = None,
+    ) -> SidecarData:
         """Gemini display-label enrichment does not require sidecar files."""
-        del source_paths
+        del source_paths, blob_store
         return {}
 
     def enrich_session(

--- a/polylogue/sources/decoder_zip.py
+++ b/polylogue/sources/decoder_zip.py
@@ -14,6 +14,7 @@ from polylogue.logging import get_logger
 from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.cursor_state import CursorStatePayload
 
+from .assembly import SidecarData
 from .cursor import _record_cursor_failure
 from .parsers.base import ParsedSession, RawSessionData
 
@@ -230,8 +231,19 @@ def process_zip(
     cursor_state: CursorStatePayload | None,
     blob_root: Path | None = None,
     blob_store: BlobStore | None = None,
+    sidecar_data: SidecarData | None = None,
 ) -> Iterable[tuple[RawSessionData | None, ParsedSession]]:
-    """Process a ZIP file, yielding sessions from its entries."""
+    """Process a ZIP file, yielding sessions from its entries.
+
+    ``sidecar_data`` (bd polylogue-8ac0) threads the source-scan-level
+    provider assembly sidecars (e.g. ChatGPT's ``chatgpt_asset_index``/
+    ``chatgpt_dat_blobs``, discovered once per source by
+    ``_setup_source_walk`` before any entry is parsed) into every entry's
+    ``_ParseContext`` so ``_SessionEmitter.emit``'s ``enrich_session`` hook
+    actually fires for ZIP-bundle sources. Without it, every entry got an
+    empty sidecar mapping and provider-assembly enrichment silently never ran
+    for ZIP-shaped sources -- the common shape for a GDPR/Takeout export.
+    """
     del should_group
 
     from polylogue.paths import blob_store_root
@@ -240,6 +252,8 @@ def process_zip(
     from .cursor import _ParseContext
     from .dispatch import GROUP_PROVIDERS
     from .emitter import _SessionEmitter
+
+    resolved_sidecar_data: SidecarData = sidecar_data if sidecar_data is not None else {}
 
     store = blob_store or BlobStore(blob_root or blob_store_root())
 
@@ -262,7 +276,7 @@ def process_zip(
                 fallback_id=zip_path.stem,
                 file_mtime=file_mtime,
                 capture_raw=capture_raw,
-                sidecar_data={},
+                sidecar_data=resolved_sidecar_data,
             )
             emitter = _SessionEmitter(ctx)
             precomputed_raw: RawSessionData | None = None

--- a/polylogue/sources/parsers/base_models.py
+++ b/polylogue/sources/parsers/base_models.py
@@ -258,6 +258,14 @@ class ParsedAttachment(BaseModel):
     # addressed blob store and records the true SHA-256 + 'acquired' status instead
     # of fabricating a hash. Excluded from serialization/repr; not a stored field.
     inline_bytes: bytes | None = Field(default=None, exclude=True, repr=False)
+    # Transport-only (polylogue-8ac0): a (blob_hash_hex, size_bytes) pair for
+    # bytes ALREADY streamed into the content-addressed blob store during
+    # sidecar discovery (e.g. ChatGPT ``.dat`` asset acquisition -- see
+    # ``sources/assembly_chatgpt.py``). Distinct from `inline_bytes`: those
+    # bytes still need hashing/writing at ingest time; this records a write
+    # that already happened, so ingestion must record it without re-hashing.
+    # Excluded from serialization/repr; not a stored field.
+    precomputed_blob: tuple[str, int] | None = Field(default=None, exclude=True, repr=False)
 
     @field_validator("path")
     @classmethod

--- a/polylogue/sources/source_parsing.py
+++ b/polylogue/sources/source_parsing.py
@@ -230,6 +230,7 @@ def parse_one_source_path(
             cursor_state=cursor_state,
             blob_root=blob_root,
             blob_store=blob_store,
+            sidecar_data=sidecar_data,
         )
         return
 
@@ -379,6 +380,7 @@ def iter_source_sessions_with_raw(
         include_mtime=capture_raw,
         known_mtimes=known_mtimes,
         discover_sidecars=True,
+        blob_store=blob_store,
     )
     if walk is None:
         return

--- a/polylogue/sources/source_walk.py
+++ b/polylogue/sources/source_walk.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from polylogue.config import Source
 from polylogue.core.enums import Provider
+from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.cursor_state import CursorStatePayload
 
 from . import cursor as _cursor
@@ -83,6 +84,7 @@ def _setup_source_walk(
     known_mtimes: dict[str, str] | None,
     known_cursors: dict[str, dict[str, object]] | None = None,
     discover_sidecars: bool,
+    blob_store: BlobStore | None = None,
 ) -> _SourceWalkSetup | None:
     paths = _resolve_source_paths(source)
     _cursor._initialize_cursor_state(cursor_state, paths)
@@ -99,7 +101,7 @@ def _setup_source_walk(
         provider = Provider.from_string(source.name)
         spec = get_assembly_spec(provider)
         if spec is not None:
-            sidecar_data = spec.discover_sidecars(paths)
+            sidecar_data = spec.discover_sidecars(paths, blob_store=blob_store)
     return _SourceWalkSetup(
         paths=paths,
         paths_to_process=paths_to_process,

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -6667,6 +6667,8 @@ def _acquire_attachment_blob(
     del conn
     if attachment.inline_bytes is not None:
         raise ValueError("inline attachment bytes require preacquired_attachment_blobs from an archive-owned publisher")
+    if attachment.precomputed_blob is not None:
+        raise ValueError("a precomputed attachment blob requires preacquired_attachment_blobs to record it")
     return (None, attachment.size_bytes or 0, "unfetched")
 
 

--- a/tests/unit/pipeline/test_ingest_batch.py
+++ b/tests/unit/pipeline/test_ingest_batch.py
@@ -445,12 +445,14 @@ def _attachment_tuple(
     *,
     mime_type: str = "image/png",
     inline_bytes: bytes | None = None,
+    precomputed_blob: tuple[str, int] | None = None,
 ) -> ParsedAttachment:
     return ParsedAttachment(
         provider_attachment_id=attachment_id,
         mime_type=mime_type,
         size_bytes=len(inline_bytes) if inline_bytes is not None else 1024,
         inline_bytes=inline_bytes,
+        precomputed_blob=precomputed_blob,
     )
 
 
@@ -1060,6 +1062,55 @@ def test_write_session_freshness_tie_allows_attachment_improvement(tmp_path: Pat
             ("aistudio-drive:improve",),
         ).fetchone()
         assert row["raw_id"] == "raw-fetched"
+
+
+def test_write_session_precomputed_blob_attachment_recorded_as_acquired(tmp_path: Path) -> None:
+    """bd polylogue-8ac0: bytes already streamed into the blob store during
+    sidecar discovery (ChatGPT ``.dat`` asset acquisition) are recorded
+    ``acquired`` via ``ParsedAttachment.precomputed_blob`` -- no
+    ``blob_publisher`` write happens here, since the bytes were already
+    published earlier.
+    """
+    store = BlobStore(tmp_path / "blob")
+    payload = b"chatgpt dat asset bytes"
+    blob_hash, size = store.write_from_bytes(payload)
+
+    with open_connection(tmp_path / "index.db") as conn:
+        session = _session_data(
+            "chatgpt-export:conv-1",
+            content_hash="hash-precomputed",
+            message_tuples=[
+                _message_tuple(
+                    "msg-1",
+                    "chatgpt-export:conv-1",
+                    role="user",
+                    text="here is a photo",
+                    content_hash="msg-hash-precomputed",
+                    sort_key=1777636800.0,
+                )
+            ],
+            attachment_tuples=[_attachment_tuple("file-xyz", precomputed_blob=(blob_hash, size))],
+            attachment_ref_tuples=[_attachment_ref_tuple("file-xyz", "chatgpt-export:conv-1", "msg-1")],
+            raw_id="raw-chatgpt",
+            provider=Provider.CHATGPT,
+        )
+        changed, counts = _write_session(conn, session)
+        conn.commit()
+
+        assert changed is True
+        assert counts["attachments"] == 1
+        row = conn.execute(
+            """
+            SELECT a.acquisition_status, a.blob_hash, a.byte_count
+            FROM attachment_refs r JOIN attachments a ON a.attachment_id = r.attachment_id
+            WHERE r.session_id = ?
+            """,
+            ("chatgpt-export:conv-1",),
+        ).fetchone()
+        assert row["acquisition_status"] == "acquired"
+        assert bytes(row["blob_hash"]) == bytes.fromhex(blob_hash)
+        assert row["byte_count"] == size
+        assert store.read_all(blob_hash) == payload
 
 
 def _sidecar_matched_event(tool_use_id: str) -> ParsedSessionEvent:

--- a/tests/unit/pipeline/test_pipeline_ids.py
+++ b/tests/unit/pipeline/test_pipeline_ids.py
@@ -356,6 +356,31 @@ def test_attachment_identity_hash_rejects_full_payload_spread() -> None:
         attachment_identity_hash(**full_payload)
 
 
+def test_attachment_hash_payload_precomputed_blob_mirrors_inline_bytes() -> None:
+    """bd polylogue-8ac0: a precomputed blob changes content hash like inline bytes.
+
+    Bytes streamed into the blob store during sidecar discovery (ChatGPT
+    ``.dat`` asset acquisition) are recorded via ``precomputed_blob`` rather
+    than ``inline_bytes`` -- but must still perturb the attachment's content
+    hash payload the same way, or re-ingesting an export whose ``.dat`` bytes
+    only just became available would look content-unchanged and get skipped.
+    """
+    unresolved = ParsedAttachment(provider_attachment_id="a1", message_provider_id="m1", name="f.png")
+    with_precomputed = ParsedAttachment(
+        provider_attachment_id="a1",
+        message_provider_id="m1",
+        name="f.png",
+        precomputed_blob=("ab" * 32, 5),
+    )
+
+    unresolved_payload = _attachment_hash_payload(unresolved)
+    precomputed_payload = _attachment_hash_payload(with_precomputed)
+
+    assert "inline_content_hash" not in unresolved_payload
+    assert precomputed_payload["inline_content_hash"] == "ab" * 32
+    assert hash_payload(precomputed_payload) != hash_payload(unresolved_payload)
+
+
 def test_event_base_identity_hash_rejects_measurement_fields() -> None:
     """Provider-reported measurement (polylogue-nuec) cannot reach event identity."""
     with pytest.raises(TypeError):

--- a/tests/unit/sources/test_assembly_chatgpt.py
+++ b/tests/unit/sources/test_assembly_chatgpt.py
@@ -17,6 +17,8 @@ from polylogue.core.enums import Provider
 from polylogue.sources.assembly_chatgpt import ChatGPTAssemblySpec
 from polylogue.sources.parsers.base import ParsedAttachment, ParsedMessage, ParsedSession
 from polylogue.sources.parsers.chatgpt_sidecars import ChatGPTAssetIndex
+from polylogue.storage.blob_store import BlobStore
+from tests.infra.source_builders import ChatGPTExportBuilder
 
 
 def _session(
@@ -225,3 +227,182 @@ class TestEnrichSession:
         assert len(events) == 1
         assert events[0].payload["resolution_tier"] == 6
         assert "resolved_file_id" not in events[0].payload
+
+
+class TestAcquireDatBlobsFromZip:
+    """bd polylogue-8ac0 — streaming ``.dat`` asset bytes into the blob store."""
+
+    def test_dat_member_streamed_into_blob_store(self, tmp_path: Path) -> None:
+        zip_path = tmp_path / "export.zip"
+        dat_bytes = b"the real attachment bytes"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("conversation_asset_file_names.json", json.dumps({"file-xyz.dat": "photo.png"}))
+            zf.writestr("file-xyz.dat", dat_bytes)
+
+        store = BlobStore(tmp_path / "blobs")
+        sidecar_data = ChatGPTAssemblySpec().discover_sidecars([zip_path], blob_store=store)
+
+        dat_blobs = sidecar_data.get("chatgpt_dat_blobs")
+        assert dat_blobs is not None
+        assert "file-xyz" in dat_blobs
+        blob_hash, size = dat_blobs["file-xyz"]
+        assert size == len(dat_bytes)
+        assert store.exists(blob_hash)
+        assert store.read_all(blob_hash) == dat_bytes
+
+    def test_no_blob_store_leaves_dat_blobs_absent(self, tmp_path: Path) -> None:
+        zip_path = tmp_path / "export.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("file-xyz.dat", b"bytes")
+
+        sidecar_data = ChatGPTAssemblySpec().discover_sidecars([zip_path])
+        assert "chatgpt_dat_blobs" not in sidecar_data
+
+    def test_non_dat_members_are_not_streamed(self, tmp_path: Path) -> None:
+        zip_path = tmp_path / "export.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("conversations.json", "[]")
+
+        store = BlobStore(tmp_path / "blobs")
+        sidecar_data = ChatGPTAssemblySpec().discover_sidecars([zip_path], blob_store=store)
+        assert "chatgpt_dat_blobs" not in sidecar_data
+
+
+class TestAcquireDatBlobsFromDirectory:
+    def test_dat_sibling_streamed_into_blob_store(self, tmp_path: Path) -> None:
+        (tmp_path / "conversations-000.json").write_text("[]", encoding="utf-8")
+        dat_bytes = b"library file bytes"
+        (tmp_path / "file_abc.dat").write_bytes(dat_bytes)
+
+        store = BlobStore(tmp_path / "blobs")
+        sidecar_data = ChatGPTAssemblySpec().discover_sidecars([tmp_path / "conversations-000.json"], blob_store=store)
+
+        dat_blobs = sidecar_data.get("chatgpt_dat_blobs")
+        assert dat_blobs is not None
+        blob_hash, size = dat_blobs["file_abc"]
+        assert size == len(dat_bytes)
+        assert store.read_all(blob_hash) == dat_bytes
+
+
+class TestEnrichSessionAcquiresBlobs:
+    def test_dat_attachment_gets_precomputed_blob(self) -> None:
+        attachment = ParsedAttachment(provider_attachment_id="file-xyz", message_provider_id="m1")
+        conv = _session([attachment])
+        spec = ChatGPTAssemblySpec()
+
+        result = spec.enrich_session(
+            conv,
+            {
+                "chatgpt_asset_index": ChatGPTAssetIndex.empty(),
+                "chatgpt_dat_blobs": {"file-xyz": ("ab" * 32, 5)},
+            },
+        )
+
+        resolved = result.attachments[0]
+        assert resolved.precomputed_blob == ("ab" * 32, 5)
+        assert resolved.size_bytes == 5
+        events = [e for e in result.session_events if e.event_type == "chatgpt_asset_resolution"]
+        assert events == []  # no library_files/asset_names hit, only the blob join
+
+    def test_does_not_overwrite_inline_bytes(self) -> None:
+        attachment = ParsedAttachment(
+            provider_attachment_id="file-xyz",
+            message_provider_id="m1",
+            inline_bytes=b"already carrying real bytes",
+        )
+        conv = _session([attachment])
+        spec = ChatGPTAssemblySpec()
+
+        result = spec.enrich_session(
+            conv,
+            {
+                "chatgpt_asset_index": ChatGPTAssetIndex.empty(),
+                "chatgpt_dat_blobs": {"file-xyz": ("cd" * 32, 5)},
+            },
+        )
+
+        resolved = result.attachments[0]
+        assert resolved.precomputed_blob is None
+        assert resolved.inline_bytes == b"already carrying real bytes"
+
+    def test_sandbox_attachment_never_joins_dat_blobs(self) -> None:
+        attachment = ParsedAttachment(
+            provider_attachment_id="sandbox:m-unrelated:/mnt/data/mystery.bin",
+            message_provider_id="m-unrelated",
+            name="mystery.bin",
+            attachment_kind="sandbox_file",
+            source_url="sandbox:/mnt/data/mystery.bin",
+        )
+        conv = _session([attachment], provider_session_id="conv-unrelated")
+        spec = ChatGPTAssemblySpec()
+
+        result = spec.enrich_session(
+            conv,
+            {
+                "chatgpt_asset_index": ChatGPTAssetIndex.empty(),
+                "chatgpt_dat_blobs": {"mystery.bin": ("ef" * 32, 5)},
+            },
+        )
+
+        assert result.attachments[0].precomputed_blob is None
+
+
+class TestZipBundleEndToEndBlobAcquisition:
+    """Regression coverage for the ZIP-bundle sidecar-enrichment wiring gap.
+
+    ``process_zip`` used to hardcode ``sidecar_data={}`` for every entry's
+    ``_ParseContext``, so ``enrich_session`` never actually ran for
+    ZIP-shaped ChatGPT sources (the common shape for a GDPR/Takeout export) --
+    only unit tests exercising ``discover_sidecars``/``enrich_session`` in
+    isolation existed, none of them through the real ``parse_one_source_path``
+    entry point. This drives a synthetic ZIP export all the way through.
+    """
+
+    def test_dat_bytes_acquired_through_real_zip_ingest_path(self, tmp_path: Path) -> None:
+        from polylogue.sources.source_parsing import parse_one_source_path
+
+        conversation = (
+            ChatGPTExportBuilder("conv-1")
+            .title("t")
+            .add_node(
+                "user",
+                "hello",
+                metadata={
+                    "attachments": [
+                        {"id": "file-xyz", "name": "photo.png", "mime_type": "image/png", "size": 5},
+                    ]
+                },
+            )
+            .build()
+        )
+
+        zip_path = tmp_path / "export.zip"
+        dat_bytes = b"the real bytes"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("conversations.json", json.dumps([conversation]))
+            zf.writestr("conversation_asset_file_names.json", json.dumps({"file-xyz.dat": "photo.png"}))
+            zf.writestr("file-xyz.dat", dat_bytes)
+
+        blob_root = tmp_path / "blobs"
+        store = BlobStore(blob_root)
+        sidecar_data = ChatGPTAssemblySpec().discover_sidecars([zip_path], blob_store=store)
+        assert "file-xyz" in sidecar_data.get("chatgpt_dat_blobs", {})
+
+        results = list(
+            parse_one_source_path(
+                str(zip_path),
+                file_mtime=None,
+                source_name="chatgpt",
+                sidecar_data=sidecar_data,
+                capture_raw=False,
+                blob_root=blob_root,
+                blob_store=store,
+            )
+        )
+        assert len(results) == 1
+        _, session = results[0]
+        assert len(session.attachments) == 1
+        resolved = session.attachments[0]
+        blob_hash, size = sidecar_data["chatgpt_dat_blobs"]["file-xyz"]
+        assert resolved.precomputed_blob == (blob_hash, size)
+        assert resolved.name == "photo.png"

--- a/tests/unit/storage/test_attachment_acquisition.py
+++ b/tests/unit/storage/test_attachment_acquisition.py
@@ -88,6 +88,52 @@ def test_inline_attachment_bytes_are_stored_with_true_hash(tmp_path: Path, monke
     assert store.read_all(hashlib.sha256(payload).hexdigest()) == payload
 
 
+def test_precomputed_blob_attachment_is_stored_as_acquired(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """bd polylogue-8ac0: bytes already streamed into the blob store (e.g.
+    ChatGPT ``.dat`` asset acquisition during sidecar discovery) are recorded
+    as ``acquired`` via ``precomputed_blob`` without re-hashing/re-writing.
+    """
+    store = BlobStore(tmp_path / "blob")
+    monkeypatch.setattr("polylogue.storage.blob_store.get_blob_store", lambda: store)
+
+    payload = b"dat asset bytes acquired during sidecar discovery"
+    blob_hash, size = store.write_from_bytes(payload)
+
+    conn = _connect(tmp_path / "index.db")
+    attachment = ParsedAttachment(
+        provider_attachment_id="file-xyz",
+        message_provider_id="m0",
+        name="photo.png",
+        mime_type="image/png",
+        precomputed_blob=(blob_hash, size),
+    )
+    session = _session_with_attachment(attachment)
+    preacquired: dict[int, tuple[bytes | None, int, str]] = {
+        id(attachment): (bytes.fromhex(blob_hash), size, "acquired")
+    }
+    write_parsed_session_to_archive(conn, session, preacquired_attachment_blobs=preacquired)
+
+    row = conn.execute("SELECT blob_hash, byte_count, acquisition_status FROM attachments").fetchone()
+    assert row["acquisition_status"] == "acquired"
+    assert row["byte_count"] == len(payload)
+    assert bytes(row["blob_hash"]) == bytes.fromhex(blob_hash)
+    assert store.read_all(blob_hash) == payload
+
+
+def test_low_level_writer_rejects_precomputed_blob_without_preacquisition(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "index.db")
+    session = _session_with_attachment(
+        ParsedAttachment(
+            provider_attachment_id="att-unreserved",
+            message_provider_id="m0",
+            precomputed_blob=("ab" * 32, 5),
+        )
+    )
+
+    with pytest.raises(ValueError, match="preacquired_attachment_blobs"):
+        write_parsed_session_to_archive(conn, session)
+
+
 def test_attachment_without_bytes_is_marked_unfetched_not_faked(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Streams ChatGPT export `.dat` attachment bytes into the content-addressed blob store during sidecar discovery, and fixes a pre-existing wiring gap where ZIP-shaped ChatGPT sources never actually received provider-assembly enrichment at all.

## Problem

Ref polylogue-8ac0 (follow-up to polylogue-0hwv): polylogue-0hwv resolved every `.dat` asset id to its real name/mime/size/sha256 via `library_files.json`/`conversation_asset_file_names.json`, but never streamed the `.dat` bytes themselves into the blob store. Attachments stayed `acquisition_status="unfetched"` with real metadata but no bytes.

While wiring the byte-acquisition path, discovered that `decoder_zip.py`'s `process_zip` hardcoded `sidecar_data={}` for every ZIP entry's `_ParseContext`. This means `ChatGPTAssemblySpec.enrich_session` (the entire `.dat`/sandbox-file resolution machinery from polylogue-0hwv) never actually ran for ZIP-shaped ChatGPT sources — the common shape for a GDPR/Takeout export. Only isolated unit tests of `discover_sidecars`/`enrich_session` existed; none exercised the real `parse_one_source_path` entry point end to end, so this gap was invisible to the existing test suite.

## Solution

- `ChatGPTAssemblySpec.discover_sidecars` now accepts an optional `blob_store` and streams every `.dat` ZIP member (bounded decompression via `open_bounded_zip_entry`, mirroring `decoder_zip.py`'s `capture_raw` pattern — no full-file memory load) or sibling `*.dat` file (extracted-directory shape, via `BlobStore.write_from_path`) into the blob store, returning a `dat_id -> (blob_hash, size)` map in a new `chatgpt_dat_blobs` sidecar key.
- `ParsedAttachment` gains `precomputed_blob`: a transport-only `(blob_hash_hex, size)` pair for bytes already written during sidecar discovery — distinct from `inline_bytes`, which still needs hashing/writing at ingest time. `enrich_session`'s dat-attachment join sets it without re-reading source bytes.
- `ingest_batch/_core.py`'s `preacquired_attachment_blobs` loop records `precomputed_blob` attachments as `acquired` directly (no re-hash, no `blob_publisher` write — the bytes are already durably written and reservation-protected from the discovery-time flush). `_attachment_hash_payload` folds the known hash into the content-hash payload the same way `inline_bytes` does, so re-ingesting an export whose `.dat` bytes only just became available is not mistaken for content-unchanged and silently skipped.
- Threaded `blob_store` through `_setup_source_walk`'s 4 call sites and `sidecar_data` through `process_zip`'s per-entry `_ParseContext` (the wiring-gap fix), so ZIP-shaped ChatGPT sources actually get enriched.
- `ProviderAssemblySpec.discover_sidecars` gained a `blob_store` kwarg (ignored by Claude Code/Codex/Gemini specs, which don't need it).

Not in scope: the raw-replay/reindex path (`revision_governance.py`/`archive.py`'s `preacquired_attachment_blobs` builders) never calls `discover_sidecars`/`enrich_session` at all, so ChatGPT sessions replayed through full reindex don't get `.dat` name/byte enrichment either — this is a pre-existing architecture gap shared with polylogue-0hwv's own scope, not introduced or fixed here.

## Verification

- `devtools test tests/unit/sources/test_assembly_chatgpt.py tests/unit/storage/test_attachment_acquisition.py tests/unit/pipeline/test_ingest_batch.py tests/unit/pipeline/test_pipeline_ids.py tests/unit/sources/test_decoders.py tests/unit/sources/test_assembly.py` → `224 passed in 10.87s`
- `devtools test tests/unit/pipeline/test_archive_ingest_commit_batching.py tests/unit/pipeline/test_archive_ingest_shared_raw.py tests/unit/storage/test_archive_tiers_archive.py` → `54 passed in 40.38s`
- `devtools verify --quick` → `"exit_code": 0` (ruff format/check, mypy --strict, `render all --check`, layering/closure-matrix/lab-policy gates)
- Confirmed via `git stash`: 2 failures in `tests/unit/sources/test_source_laws.py` (`test_iter_source_raw_data_avoids_whole_blob_provider_detection_for_zip_entries`, `test_iter_source_raw_data_splits_multi_session_zip_entries_for_non_grouped_providers`) reproduce identically with this change stashed out — pre-existing, not introduced here.
- New tests cover: streaming `.dat` bytes from both ZIP and extracted-directory shapes, `enrich_session` setting `precomputed_blob` (and never doing so for sandbox-file attachments, which carry no bytes), the low-level writer recording `precomputed_blob` as `acquired` (plus rejecting it without `preacquired_attachment_blobs`, mirroring the existing `inline_bytes` guard), the content-hash payload change, and an end-to-end regression test driving a synthetic ZIP export through the real `parse_one_source_path` entry point to prove the ZIP-enrichment wiring gap is fixed.

Ref polylogue-8ac0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - ChatGPT imports now acquire referenced `.dat` attachments from ZIP files and extracted folders.
  - Attachment metadata and content remain available even when files are streamed rather than embedded inline.
  - ZIP-based imports now enrich sessions with discovered attachment information.

- **Bug Fixes**
  - Prevented unnecessary reprocessing of attachments already stored.
  - Improved attachment hash and size tracking for streamed content.
  - Added safeguards against oversized or highly compressed archive entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->