### PR TITLE
docs: encode no-poll rule for coordinator background-agent dispatch

### DIFF
--- a/.agent/CONVENTIONS.md
+++ b/.agent/CONVENTIONS.md
@@ -89,6 +89,14 @@ bead's cited facts against master before coding.
   and idle-wait on it across turns (2026-08-01: three lanes each stalled for
   multiple turns "waiting for the background job", burning wall-clock and
   coordinator attention until manually interrupted).
+- **No poll loops on background agents (coordinator).** Completion
+  notifications for background subagents are automatic — never
+  `ScheduleWakeup`/`Monitor` as a "done yet?" poll loop. Full rule + the two
+  legitimate exceptions (genuine `Monitor` until-conditions, genuine
+  wall-clock `ScheduleWakeup` deadlines) live in `CLAUDE.md`'s "Coordinator
+  dispatch: no poll loops" section (polylogue-kzse6) — this is the same rule
+  the `lane`/`triage` agent definitions carry for a dispatched agent that
+  itself spawns background work.
 - **Dispatch hygiene (coordinator).** Immediately after spawning a
   worktree-isolated lane, run
   `devtools workspace verify-worktree <path> --expect-branch <branch>` before

--- a/.claude/agents/lane.md
+++ b/.claude/agents/lane.md
@@ -39,6 +39,15 @@ task-specific instructions accompany the dispatch.
   with the escape-hatch env var — that guard exists because a stale or
   wrong-checkout `polylogue` import silently produces correct-looking but
   wrong results.
+- **No poll loops, including on any further agent you spawn.** If this task
+  has you dispatch a background subagent of your own, do not
+  `ScheduleWakeup`/`Monitor` it as a "done yet?" poll — its completion
+  notification is automatic. `Monitor` is for a genuine until-condition
+  (a concrete, checkable state), `ScheduleWakeup` only for a genuine
+  wall-clock deadline the harness can't observe on its own (a CI grace
+  window, an external SLA). Reaching for either tool to check on a
+  background job's progress is itself the signal to stop and let the
+  notification arrive instead (polylogue-kzse6).
 
 ## Beads: read-only
 

--- a/.claude/agents/triage.md
+++ b/.claude/agents/triage.md
@@ -33,6 +33,14 @@ to produce evidence and a verdict, never a code change.
   than discovering the backgrounding after the fact — this is the same
   mechanical rule the `lane` agent definition carries for its (write-mode)
   verification calls.
+- **No poll loops, including on any further agent you spawn.** If your
+  investigation dispatches a background subagent of your own, do not
+  `ScheduleWakeup`/`Monitor` it as a "done yet?" poll — its completion
+  notification is automatic. `Monitor` is for a genuine until-condition,
+  `ScheduleWakeup` only for a genuine wall-clock deadline the harness can't
+  observe on its own. Reaching for either tool to check on a background
+  job's progress is itself the signal to stop and let the notification
+  arrive instead (polylogue-kzse6).
 
 ## Evidence standard
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -415,6 +415,43 @@ workflow, not optional conveniences — use them at the point named, every time:
 If you build a new tool in this family, add it here in the same sentence —
 a tool without a line in this file is a tool the next session won't use.
 
+### Coordinator dispatch: no poll loops
+
+A coordinator running background subagents (`run_in_background: true`, or a
+teammate/job spawned via `agent-control`) already gets an automatic
+completion notification when the agent finishes (Claude Code >=2.1.211) — the
+harness wakes the coordinator itself; nothing needs to ask "done yet?". A
+2026-08-02 mining pass over six days of fanout sessions counted 101
+`ScheduleWakeup` + 78 `Monitor` calls, almost all of them a coordinator turn
+re-deriving state a notification would have delivered for free, and traced
+part of that session's 16 compactions to this churn (polylogue-kzse6,
+polylogue-ltfj9 report item 2).
+
+The rule the data supports:
+
+- **`Monitor` only with a genuine until-condition** (an until-loop over a
+  concrete, checkable state — e.g. waiting for a lock file to clear, a port
+  to open) — never as a bare "poll and see if it's done yet" against a
+  background agent job.
+- **`ScheduleWakeup` only for a genuine wall-clock deadline** the harness
+  cannot observe on its own (a CI grace window, an external system's SLA) —
+  never as a substitute for the automatic completion notification.
+- If you notice yourself reaching for either tool to check on a background
+  agent's progress, that noticing is itself the signal to stop: let the
+  notification arrive, or use a non-polling progress peek (`/tasks`,
+  tailing the agent's transcript, or an `agent-control` status/read-output
+  call made once out of genuine curiosity, not on a timer) instead of a
+  loop.
+- This doctrine assumes Claude Code >=2.1.211; on an older install
+  completion notifications are best-effort, and a bounded wall-clock
+  `ScheduleWakeup` fallback is legitimate until upgrading.
+
+This is a coordinator-behavior rule, not a code change: `ScheduleWakeup` and
+`Monitor` are harness tools, not something this repo's source controls, so
+there is no lint or detector this repo can ship to enforce it mechanically.
+The `lane`/`triage` agent definitions carry the same rule for the case where
+a dispatched agent itself spawns further background work.
+
 ### Commit / PR discipline
 
 All product code lands via **feature branches + squash-merged PRs** to `master`


### PR DESCRIPTION
## Summary
Encodes the "no ScheduleWakeup/Monitor poll loop on background agents" doctrine as contract text in this repo: a new section in CLAUDE.md, a pointer from `.agent/CONVENTIONS.md`, and matching guidance in `.claude/agents/lane.md`/`triage.md` for the case where a dispatched agent spawns further background work of its own.

## Problem
A 2026-08-02 mining pass over six days of fanout sessions counted 101 `ScheduleWakeup` + 78 `Monitor` calls, almost all of them a coordinator turn asking "done yet?" while background agents already deliver completion notifications automatically (Claude Code >=2.1.211). Most wakeups re-derived state a notification would have carried for free, and part of the measured compaction churn traced back to this pattern (polylogue-kzse6, polylogue-ltfj9 report item 2).

## Solution
This is a documentation-only change; there is no shippable lint or detector here. `ScheduleWakeup` and `Monitor` are harness tools (part of the Claude Code runtime the coordinator session runs under), not something this repo's Python source imports or controls, so a static check in `polylogue/` or `devtools/` has no call site to grep for — the anti-pattern lives entirely in agent *behavior* during a session, not in committed code. I considered and rejected building a transcript-mining lint (grepping session JSONL for these tool calls) as out of scope for this bead: that mining already exists as the ops-report methodology referenced in polylogue-ltfj9's re-measure protocol, and duplicating it here would be exactly the kind of measurement-for-its-own-sake pattern flagged in `feedback_no_completeness_check_theater.md`.

Changes:
- `CLAUDE.md`: new "Coordinator dispatch: no poll loops" section (placed next to the existing Multi-lane/merge-train tooling section) stating the rule and its two legitimate exceptions (genuine `Monitor` until-conditions; genuine wall-clock `ScheduleWakeup` deadlines), plus the >=2.1.211 caveat from the bead's capability research.
- `.agent/CONVENTIONS.md`: a pointer bullet in the Execution Tactics list so the rule is discoverable from the conventions file without duplicating the prose.
- `.claude/agents/lane.md` / `.claude/agents/triage.md`: the same rule scoped to the case where a dispatched lane/triage agent itself spawns background work, since those agent definitions are the standing contract for dispatched workers (polylogue-1b6pg).

## Acceptance criteria (from polylogue-kzse6)
1. "CONVENTIONS.md and the lane/triage agent definitions carry the no-poll rule with the two legitimate exceptions named" — satisfied by this PR.
2. "The next large fanout session's mined wakeup+monitor count drops by an order of magnitude vs the 179 baseline" — not addressed by this PR; it's a behavioral outcome to be measured in a future re-measure pass per polylogue-ltfj9's protocol, not something a doc change alone can verify. Deferred to that re-measure.
3. "Any remaining wakeup carries a stated wall-clock reason in its reason field" — same as above, a behavioral/runtime property to check in the future re-measure pass, not verifiable from this diff.

## Verification
`devtools verify --quick` — exit 0 (`ruff format`/`ruff check`/`mypy`/`render all`/`verify layering`/`verify closure-matrix`/schema+policy checks all `ok`, `total_duration_s: 93.56`).

Ref polylogue-kzse6