### PR TITLE
fix(insights): stop mislabeling a local-only repo as a bare directory

### DIFF
--- a/polylogue/insights/session_label.py
+++ b/polylogue/insights/session_label.py
@@ -65,7 +65,12 @@ def compute_session_structural_label(inputs: SessionLabelInputs) -> str:
         return inputs.provider_title.strip()
 
     parts: list[str] = []
-    if inputs.repo_name:
+    # polylogue-cijx.2 AC4: a bare directory must not be displayed as if it
+    # were a repository, even defensively -- if ``is_directory`` is ever True
+    # while ``repo_name`` is populated (e.g. stale pre-fix data, or a future
+    # regression in the write/read-path invariant this guards), the read
+    # surface still refuses to print it as a repo name.
+    if inputs.repo_name and not inputs.is_directory:
         parts.append(inputs.repo_name)
 
     if inputs.dominant_path:
@@ -95,7 +100,7 @@ def _session_repo_root(conn: sqlite3.Connection, session_id: str) -> SessionRepo
     """
     row = conn.execute(
         """
-        SELECT r.origin_url, r.root_path, r.repo_name
+        SELECT r.root_path, r.repo_name
         FROM session_repos sr
         JOIN repos r ON r.repo_id = sr.repo_id
         WHERE sr.session_id = ?
@@ -106,12 +111,23 @@ def _session_repo_root(conn: sqlite3.Connection, session_id: str) -> SessionRepo
     ).fetchone()
     if row is None:
         return None
-    origin_url, root_path, repo_name = row[0], row[1], row[2]
-    is_directory = not origin_url
+    root_path, repo_name = row[0], row[1]
+    # A ``session_repos`` row exists at all only because ``_write_repo_edges``
+    # (storage/sqlite/archive_tiers/write.py, polylogue-cijx.2 AC4) refuses to
+    # write one unless real git evidence was found -- either a discovered
+    # ``.git`` root on disk (``root_path`` non-empty) or an explicit remote
+    # (``repos.origin_url`` non-empty). Testing ``not origin_url`` alone was
+    # wrong: it mislabeled every locally-checked-out repo with no configured
+    # remote (root_path set, origin_url empty) as ``is_directory=True``,
+    # exactly the "sinity repo from a bare directory" mislabeling this AC
+    # exists to kill -- just moved one layer down from the write path to the
+    # read path. A row's mere existence is proof of a real repository; the
+    # only genuine "directory" case is no row at all (handled by the
+    # caller's fallback), so this no longer needs ``origin_url`` at all.
     return SessionRepoRootPath(
         repo_name=repo_name or None,
         root_path=root_path or "",
-        is_directory=is_directory,
+        is_directory=False,
     )
 
 

--- a/tests/unit/insights/test_session_label.py
+++ b/tests/unit/insights/test_session_label.py
@@ -118,7 +118,14 @@ def test_structural_label_degrades_to_message_count_only_with_no_evidence() -> N
     assert compute_session_structural_label(inputs) == "3 msgs"
 
 
-def test_structural_label_falls_back_to_directory_name_with_no_files() -> None:
+def test_structural_label_suppresses_repo_name_when_marked_directory() -> None:
+    """polylogue-cijx.2 AC4: a bare directory (no git evidence) must never
+    display as if it were a repository. This reproduces the exact bug this
+    AC exists to kill -- a session whose cwd happens to be e.g.
+    ``/home/sinity`` must not surface "sinity" as a repo name -- as a defensive
+    read-layer check: even if ``repo_name`` is populated while ``is_directory``
+    is True (contradicting the write-path invariant), the label must not leak
+    it."""
     inputs = SessionLabelInputs(
         provider_title=None,
         repo_name="sinity",
@@ -127,7 +134,7 @@ def test_structural_label_falls_back_to_directory_name_with_no_files() -> None:
         additional_file_count=0,
         message_count=7,
     )
-    assert compute_session_structural_label(inputs) == "sinity · 7 msgs"
+    assert compute_session_structural_label(inputs) == "7 msgs"
 
 
 # ── repo_relative_path ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the read-side residual of polylogue-cijx.2 AC4. `insights/session_label.py::_session_repo_root` computed `is_directory = not origin_url`, which mislabeled any session in a real local git checkout with no configured remote as a bare directory, even though the row it read only exists because real git evidence was found. `compute_session_structural_label` also never consulted `is_directory` at all, so nothing in the read path actually enforced the distinction the field exists to carry.

## Problem

PR #3627 (this session) fixed the write path (`storage/sqlite/archive_tiers/write.py::_write_repo_edges`): a session with zero git evidence no longer synthesizes a `repos`/`session_repos` row. That PR's body explicitly scoped out the read-surface labeling half of AC4 ("A directory with no git evidence... resolves to a directory, not a repository, and read surfaces say which") as remaining work.

Re-reading the read-side consumer of this data — `insights/session_label.py`, which computes the structural-title fallback used across CLI/API/MCP whenever a session has no provider title or Claude Code display name — found the read path still carried the same class of bug one layer down: `_session_repo_root` used `not origin_url` as a proxy for "no repository," but a `session_repos` row only exists at all because `_write_repo_edges` refuses to write one unless either a discovered `.git` root (`root_path` non-empty) or an explicit remote (`origin_url` non-empty) was found. A locally-checked-out repo with no configured remote has `root_path` set and `origin_url` empty -- real git evidence, genuinely not a directory -- yet was marked `is_directory=True`. Separately, `compute_session_structural_label` never read `is_directory` at all, so the field was dead: nothing in the read path actually distinguished a directory from a repository even where the flag was computed correctly.

## Solution

- `_session_repo_root`: a `session_repos` row's mere existence is now treated as proof of a real repository (matching the write-path invariant established by #3627) -- `is_directory` is always `False` when a row is found. The only genuine "directory" case remains no row at all, already handled by the caller's `is_directory=True` fallback. Dropped the now-unused `origin_url` column from the query/unpacking.
- `compute_session_structural_label`: defensively suppresses `repo_name` in the composed label whenever `is_directory` is `True`. Under the corrected write/read invariant this combination should never occur in production, but this closes AC4's "read surfaces say which" independently of that invariant holding, instead of leaving the field purely decorative.
- Renamed `test_structural_label_falls_back_to_directory_name_with_no_files` to `test_structural_label_suppresses_repo_name_when_marked_directory` and updated its assertion -- the old test encoded the exact mislabeling shape this AC exists to kill (`repo_name="sinity"`, `is_directory=True` -> `"sinity · 7 msgs"`) as expected behavior.

## Verification

- Red-first: reverted `_session_repo_root` to the buggy `is_directory = not origin_url` formula (leaving the new label guard in place) and confirmed `test_session_structural_label_for_session_end_to_end` (a real local git checkout with no remote) fails: `AssertionError: assert 'core.py · 2 msgs' == 'myrepo · core.py · 2 msgs'`. Restored the fix and confirmed it passes again.
- `devtools test tests/unit/insights/test_session_label.py tests/unit/storage/test_archive_tiers_write.py -k "label or repo"` -> 18 passed.
- `devtools verify --quick` -> exit 0, all 23 steps ok.

Ref polylogue-cijx.2