### PR TITLE
feat(verification): tag registry checks by class, add waivers, widen reindex gate

### DIFF
--- a/polylogue/maintenance/archive_verification.py
+++ b/polylogue/maintenance/archive_verification.py
@@ -37,6 +37,7 @@ import sqlite3
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
@@ -52,6 +53,90 @@ logger = get_logger(__name__)
 
 #: Default cap on per-check sample evidence (worst sessions, offending ids, ...).
 DEFAULT_SAMPLE_LIMIT = 10
+
+
+class ArchiveVerificationCheckClass(str, Enum):
+    """Bug-class taxonomy each registry check is tagged with (polylogue-t0m73).
+
+    Orthogonal to :class:`~polylogue.core.outcomes.OutcomeStatus` (pass/warn/
+    fail/skip is the *outcome*; this is the *kind of invariant* being
+    checked), the tag drives which of the two verification planes
+    (polylogue-60gzo) a check is expected to run under on a schedule:
+    ``liveness``/``freshness`` classes are the daemon health-tier home
+    (Plane 2, production monitoring -- something must have happened
+    recently); the rest are point-in-time coherence checks that make sense
+    on any snapshot including a reindex candidate generation (both planes).
+    """
+
+    STATE_INVARIANT = "state-invariant"
+    """A structural fact that must always hold on any coherent snapshot
+    (pointer targets resolve, no cycles, no orphaned rows)."""
+
+    LIVENESS = "liveness"
+    """A reference/relationship that must remain live -- staleness here means
+    something died without cleaning up after itself (GC bookkeeping,
+    embedding refs outliving their source rows)."""
+
+    FRESHNESS = "freshness"
+    """Not a correctness fact but a recency fact: has required maintenance
+    (ANALYZE, convergence passes) run recently enough to trust the archive's
+    current operating characteristics."""
+
+    COMPLEXITY = "complexity"
+    """Archive-wide shape/size reporting -- not itself a pass/fail invariant,
+    but the numbers an operator needs to judge whether other checks' drift is
+    proportionally significant."""
+
+    FIDELITY = "fidelity"
+    """A derived/shadow representation must exactly mirror its source of
+    truth (FTS index vs the blocks it indexes)."""
+
+    CONSERVATION = "conservation"
+    """A quantity computed two different ways must agree (a write-time
+    projection vs a live COUNT over the rows it summarizes)."""
+
+    CONFIG = "config"
+    """The archive's on-disk schema/vocabulary configuration must be a
+    superset of what current code can write (CHECK constraints vs the
+    Python enum that generated them, tier schema versions vs the canonical
+    spec)."""
+
+
+@dataclass(frozen=True)
+class ArchiveVerificationWaiver:
+    """A known-red-on-live acknowledgement for one registry check.
+
+    Per polylogue-t0m73's design: a waiver exists only to keep the
+    *aggregate* gate (:attr:`ArchiveVerificationReport.blocking`) from
+    tripping on a bug that is already tracked and being worked, not to hide
+    the finding -- the underlying check still reports its true ``error``
+    status and evidence; only the gate's blocking computation treats it as
+    non-blocking. A waiver is a manual, reviewed acknowledgement, not an
+    automatic bd query (this module never calls ``bd``): remove the entry in
+    the same change that closes the bead, and if the check still reports
+    red afterward, the removal makes the gate red again on the next run,
+    which is the intended non-silent failure mode of an unwaived close.
+    """
+
+    bead_id: str
+    reason: str
+
+
+#: Checks with a currently-open, already-tracked live finding: the check
+#: keeps reporting its true ``error`` status (evidence is never suppressed),
+#: but :attr:`ArchiveVerificationReport.blocking` excludes it so an unrelated
+#: gate (e.g. the reindex acceptance run) doesn't trip on a distinct,
+#: separately-owned bug. Remove an entry only alongside closing its bead.
+ARCHIVE_VERIFICATION_WAIVERS: dict[str, ArchiveVerificationWaiver] = {
+    "embeddings-refs-liveness": ArchiveVerificationWaiver(
+        bead_id="polylogue-feu0",
+        reason=(
+            "4,186 message_embedding_refs point at messages no longer in index.db "
+            "(known, undrained catch-up debt as of 2026-08-03; embeddings convergence "
+            "is a separate async lane from index materialization)"
+        ),
+    ),
+}
 
 #: index-tier tables the planner-stats check expects ``ANALYZE`` coverage for
 #: (polylogue-l3tk: fresh generations without stats pick pathological plans).
@@ -69,6 +154,15 @@ class ArchiveVerificationCheck(OutcomeCheck):
     """
 
     evidence: dict[str, Any] = field(default_factory=dict)
+    #: Bug-class tag copied from the owning :class:`ArchiveVerificationCheckSpec`
+    #: by :func:`verify_archive` (the spec is the source of truth; this is a
+    #: read-through convenience for JSON consumers that only see the check).
+    check_class: str = ""
+    #: Set by :func:`verify_archive` when this check's name has an entry in
+    #: :data:`ARCHIVE_VERIFICATION_WAIVERS`. ``status`` is never altered by a
+    #: waiver -- a waived check that is genuinely red still reports ``error``;
+    #: only :attr:`ArchiveVerificationReport.blocking` treats it as non-blocking.
+    waived_bead_id: str | None = None
 
     def to_json(self) -> JSONDocument:
         return archive_verification_check_json(self)
@@ -79,13 +173,16 @@ def archive_verification_check_json(check: OutcomeCheck) -> JSONDocument:
 
     Mirrors :func:`polylogue.schemas.audit.models.audit_check_json`: reads
     the shared :class:`OutcomeCheck` attrs directly and reaches for the
-    subclass-only ``evidence`` field via ``getattr`` so callers holding a
-    plain ``OutcomeCheck``-typed reference (e.g. ``ArchiveVerificationReport
-    .checks``, typed at its base-class element type) can still serialize a
-    concrete :class:`ArchiveVerificationCheck` without a narrowing cast.
+    subclass-only ``evidence``/``check_class``/``waived_bead_id`` fields via
+    ``getattr`` so callers holding a plain ``OutcomeCheck``-typed reference
+    (e.g. ``ArchiveVerificationReport.checks``, typed at its base-class
+    element type) can still serialize a concrete :class:`ArchiveVerificationCheck`
+    without a narrowing cast.
     """
     payload = dict(check.to_dict())
     payload["evidence"] = json_document(getattr(check, "evidence", {}))
+    payload["check_class"] = getattr(check, "check_class", "")
+    payload["waived_bead_id"] = getattr(check, "waived_bead_id", None)
     return payload
 
 
@@ -107,8 +204,18 @@ class ArchiveVerificationReport(OutcomeReport):
 
     @property
     def blocking(self) -> bool:
-        """True when at least one check reports ``error`` -- the gate condition."""
-        return self.error_count > 0
+        """True when at least one *unwaived* check reports ``error``.
+
+        A waived check (see :data:`ARCHIVE_VERIFICATION_WAIVERS`) still
+        contributes to :attr:`error_count` -- the underlying finding is never
+        hidden -- but is excluded from the gate condition itself, so an
+        already-tracked, separately-owned bug doesn't block an unrelated
+        acceptance run (e.g. a reindex candidate promotion).
+        """
+        return any(
+            check.status is OutcomeStatus.ERROR and getattr(check, "waived_bead_id", None) is None
+            for check in self.checks
+        )
 
     def to_json(self) -> JSONDocument:
         return json_document(
@@ -132,6 +239,11 @@ class ArchiveVerificationCheckSpec:
     name: str
     description: str
     run: ArchiveVerificationCheckFn
+    #: One of :class:`ArchiveVerificationCheckClass`'s values -- every spec in
+    #: :data:`ARCHIVE_VERIFICATION_CHECKS` must set this (no default, so a new
+    #: check added without a class tag is a construction-time TypeError, not a
+    #: silent "" that would slip past classification).
+    check_class: ArchiveVerificationCheckClass
 
 
 def _tier_path(archive_root: Path, tier: ArchiveTier) -> Path:
@@ -1159,68 +1271,103 @@ ARCHIVE_VERIFICATION_CHECKS: tuple[ArchiveVerificationCheckSpec, ...] = (
         "tier-schema",
         "Tier presence and PRAGMA user_version vs the canonical ARCHIVE_TIER_SPECS.",
         _check_tier_schema,
+        ArchiveVerificationCheckClass.CONFIG,
     ),
     ArchiveVerificationCheckSpec(
         "pointer-coherence",
         "Conventional index.db path vs the active .index-active-pointer generation (polylogue-k8kj class).",
         _check_pointer_coherence,
+        ArchiveVerificationCheckClass.STATE_INVARIANT,
     ),
     ArchiveVerificationCheckSpec(
         "source-index-coverage",
         "Every raw_sessions logical head is indexed or typed (parse_error/non_session/quarantined); "
         "untyped gaps and index-orphans (raw_id ground truth, not the census ledger, polylogue-in24n) block.",
         _check_source_index_coverage,
+        ArchiveVerificationCheckClass.STATE_INVARIANT,
     ),
     ArchiveVerificationCheckSpec(
         "fts-parity",
         "messages_fts and blocks_command_trigram exactly cover their source rows, archive-wide.",
         _check_fts_parity,
+        ArchiveVerificationCheckClass.FIDELITY,
     ),
     ArchiveVerificationCheckSpec(
         "lineage-sanity",
         "session_links.resolved_dst_session_id / branch_point_message_id resolve to real sessions/messages.",
         _check_lineage_sanity,
+        ArchiveVerificationCheckClass.STATE_INVARIANT,
     ),
     ArchiveVerificationCheckSpec(
         "enum-superset-check",
         "Live origin/dst_origin CHECK lists on disk are a superset of the current Origin enum (polylogue-t0m73 I2).",
         _check_enum_superset,
+        ArchiveVerificationCheckClass.CONFIG,
     ),
     ArchiveVerificationCheckSpec(
         "blob-refs-liveness",
         "Every blob_refs row resolves in its ref_type's referent table -- the GC liveness oracle is a join, "
         "not membership in blob_refs itself (polylogue-t0m73 I3).",
         _check_blob_refs_liveness,
+        ArchiveVerificationCheckClass.LIVENESS,
     ),
     ArchiveVerificationCheckSpec(
         "embeddings-refs-liveness",
         "message_embedding_refs resolve to live index.db messages (feu0-class dead-vector detection, "
         "polylogue-t0m73 I4).",
         _check_embeddings_refs_liveness,
+        ArchiveVerificationCheckClass.LIVENESS,
     ),
     ArchiveVerificationCheckSpec(
         "session-lineage-acyclic",
         "sessions.parent_session_id chains never close a cycle (polylogue-t0m73 I5).",
         _check_session_lineage_acyclic,
+        ArchiveVerificationCheckClass.STATE_INVARIANT,
     ),
     ArchiveVerificationCheckSpec(
         "message-count-projection",
         "sessions.message_count matches COUNT(messages) per session (polylogue-t0m73 I8).",
         _check_message_count_projection,
+        ArchiveVerificationCheckClass.CONSERVATION,
     ),
     ArchiveVerificationCheckSpec(
         "planner-stats",
         "sqlite_stat1 covers blocks/messages/action_pairs (polylogue-l3tk class, warn-level).",
         _check_planner_stats,
+        ArchiveVerificationCheckClass.FRESHNESS,
     ),
     ArchiveVerificationCheckSpec(
         "counts-summary",
         "Archive-wide session/message/block counts and origin breakdown (numbers-freeze starter).",
         _check_counts_summary,
+        ArchiveVerificationCheckClass.COMPLEXITY,
     ),
 )
 
 ARCHIVE_VERIFICATION_CHECK_NAMES: tuple[str, ...] = tuple(spec.name for spec in ARCHIVE_VERIFICATION_CHECKS)
+
+#: The subset of ground-truth checks a blue-green reindex candidate generation
+#: is expected to satisfy before promotion (polylogue-t0m73's "reindex
+#: acceptance gate"). Restricted to checks whose universe is satisfiable from
+#: ``index.db`` alone -- a candidate generation directory holds only the new
+#: ``index.db``, not the durable ``source.db``/``user.db``/``embeddings.db``
+#: tiers (those live once at the archive root, not per-generation), so
+#: cross-tier checks (``source-index-coverage``, ``blob-refs-liveness``,
+#: ``embeddings-refs-liveness``, ``tier-schema``) would either report a false
+#: ERROR (missing tiers they're not skip-tolerant of, e.g. tier-schema) or
+#: only ever SKIP (uninformative). Intended use: ``verify_archive(generation_
+#: root, checks=REINDEX_ACCEPTANCE_CHECKS)`` right before promotion, exactly
+#: how :mod:`polylogue.maintenance.rebuild_index` already ran the ``fts-
+#: parity`` singleton -- this constant widens that gate to the rest of the
+#: ground-truth-eligible registry.
+REINDEX_ACCEPTANCE_CHECKS: tuple[str, ...] = (
+    "fts-parity",
+    "lineage-sanity",
+    "enum-superset-check",
+    "session-lineage-acyclic",
+    "message-count-projection",
+    "planner-stats",
+)
 
 
 def _select_check_specs(checks: Sequence[str] | None) -> tuple[ArchiveVerificationCheckSpec, ...]:
@@ -1259,10 +1406,22 @@ def verify_archive(
     results: list[OutcomeCheck] = []
     for spec in specs:
         try:
-            results.append(spec.run(archive_root, sample_limit))
+            result = spec.run(archive_root, sample_limit)
         except Exception as exc:  # defense-in-depth: see module/function docstring
             logger.exception("archive verification check %s raised", spec.name)
-            results.append(_error_check(spec.name, f"check raised {type(exc).__name__}: {exc}"))
+            result = _error_check(spec.name, f"check raised {type(exc).__name__}: {exc}")
+        # Stamp class + waiver metadata centrally so every check function
+        # (and every _error_check/_skip_check escape hatch) picks it up
+        # uniformly, rather than every one of the ~12 check bodies having to
+        # remember to thread it through by hand.
+        if isinstance(result, ArchiveVerificationCheck):
+            result.check_class = spec.check_class.value
+            if result.status is OutcomeStatus.ERROR:
+                waiver = ARCHIVE_VERIFICATION_WAIVERS.get(spec.name)
+                if waiver is not None:
+                    result.waived_bead_id = waiver.bead_id
+                    result.evidence.setdefault("waiver", {"bead_id": waiver.bead_id, "reason": waiver.reason})
+        results.append(result)
 
     return ArchiveVerificationReport(
         checks=results,
@@ -1274,9 +1433,13 @@ def verify_archive(
 __all__ = [
     "ARCHIVE_VERIFICATION_CHECKS",
     "ARCHIVE_VERIFICATION_CHECK_NAMES",
+    "ARCHIVE_VERIFICATION_WAIVERS",
+    "REINDEX_ACCEPTANCE_CHECKS",
     "ArchiveVerificationCheck",
+    "ArchiveVerificationCheckClass",
     "ArchiveVerificationCheckSpec",
     "ArchiveVerificationReport",
+    "ArchiveVerificationWaiver",
     "DEFAULT_SAMPLE_LIMIT",
     "verify_archive",
 ]

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -1008,7 +1008,7 @@ async def _rebuild_index_from_source_owned(
                 failing = "; ".join(
                     f"{check.name}: {check.summary}"
                     for check in acceptance_report.checks
-                    if check.status.value == "error"
+                    if check.status.value == "error" and getattr(check, "waived_bead_id", None) is None
                 )
                 raise RuntimeError(
                     f"reindex acceptance gate failed for generation {generation.generation_id}: {failing}"

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -577,7 +577,7 @@ async def _rebuild_index_from_source_owned(
     request: RebuildIndexRequest, *, root: Path, owned: OwnedArchiveLocation
 ) -> RebuildIndexReceipt:
     """Ownership-proven body of :func:`rebuild_index_from_source`."""
-    from polylogue.maintenance.archive_verification import verify_archive
+    from polylogue.maintenance.archive_verification import REINDEX_ACCEPTANCE_CHECKS, verify_archive
     from polylogue.maintenance.replay import rebuild_index_from_source as replay_source
     from polylogue.sources.revision_backfill import RebuildDeadlineExceededError
     from polylogue.storage.archive_readiness import archive_readiness_status
@@ -989,18 +989,29 @@ async def _rebuild_index_from_source_owned(
                     elapsed_s=round(elapsed_s, 3),
                 )
             terminal_started_at = time.perf_counter()
-            parity_report = verify_archive(generation_root, checks=["fts-parity"])
-            terminal_timings_s["terminal.fts_parity"] = time.perf_counter() - terminal_started_at
+            # polylogue-t0m73: the reindex acceptance gate -- every
+            # ground-truth check whose universe is satisfiable from a
+            # generation directory's index.db alone (source.db/user.db/
+            # embeddings.db live once at the archive root, not per
+            # generation, so cross-tier checks are excluded; see
+            # REINDEX_ACCEPTANCE_CHECKS' docstring). This subsumed the older
+            # fts-parity-only gate.
+            acceptance_report = verify_archive(generation_root, checks=list(REINDEX_ACCEPTANCE_CHECKS))
+            terminal_timings_s["terminal.reindex_acceptance"] = time.perf_counter() - terminal_started_at
             logger.info(
                 "rebuild_terminal_stage_complete",
                 generation_id=generation.generation_id,
-                stage="fts_parity",
-                elapsed_s=round(terminal_timings_s["terminal.fts_parity"], 3),
+                stage="reindex_acceptance",
+                elapsed_s=round(terminal_timings_s["terminal.reindex_acceptance"], 3),
             )
-            if parity_report.blocking:
-                failing = "; ".join(check.summary for check in parity_report.checks if check.status.value == "error")
+            if acceptance_report.blocking:
+                failing = "; ".join(
+                    f"{check.name}: {check.summary}"
+                    for check in acceptance_report.checks
+                    if check.status.value == "error"
+                )
                 raise RuntimeError(
-                    f"bulk-build FTS/trigram parity failed for generation {generation.generation_id}: {failing}"
+                    f"reindex acceptance gate failed for generation {generation.generation_id}: {failing}"
                 )
             terminal_started_at = time.perf_counter()
             readiness = archive_readiness_status(generation_root)

--- a/tests/unit/cli/test_maintenance_verify_archive_cli.py
+++ b/tests/unit/cli/test_maintenance_verify_archive_cli.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from click.testing import CliRunner
 
 from polylogue.cli.click_app import cli
+from polylogue.maintenance.archive_verification import ARCHIVE_VERIFICATION_CHECK_NAMES
 
 
 def test_verify_archive_cli_plain_exits_zero_on_empty_archive(
@@ -35,15 +36,13 @@ def test_verify_archive_cli_json_reports_every_registered_check(
     payload = json.loads(result.stdout)
     assert payload["blocking"] is False
     names = {check["name"] for check in payload["checks"]}
-    assert names == {
-        "tier-schema",
-        "pointer-coherence",
-        "source-index-coverage",
-        "fts-parity",
-        "lineage-sanity",
-        "planner-stats",
-        "counts-summary",
-    }
+    # Sourced from the registry itself (not a hand-maintained literal set)
+    # so a new check added to ARCHIVE_VERIFICATION_CHECKS is caught by this
+    # test automatically instead of the CLI JSON surface silently drifting
+    # out of sync with the registry -- exactly the staleness this assertion
+    # itself suffered from before polylogue-t0m73 (missing five checks
+    # landed by an earlier PR that never updated this literal).
+    assert names == set(ARCHIVE_VERIFICATION_CHECK_NAMES)
 
 
 def test_verify_archive_cli_exits_nonzero_on_schema_drift(

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -14,8 +14,13 @@ import pytest
 from polylogue.core.outcomes import OutcomeStatus
 from polylogue.maintenance.archive_verification import (
     ARCHIVE_VERIFICATION_CHECK_NAMES,
+    ARCHIVE_VERIFICATION_CHECKS,
+    ARCHIVE_VERIFICATION_WAIVERS,
+    REINDEX_ACCEPTANCE_CHECKS,
     ArchiveVerificationCheck,
+    ArchiveVerificationCheckClass,
     ArchiveVerificationReport,
+    ArchiveVerificationWaiver,
     verify_archive,
 )
 from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS, initialize_active_archive_root
@@ -505,7 +510,9 @@ def test_one_check_raising_does_not_abort_the_others(tmp_path: Path, monkeypatch
     # how a real regression in one check function would surface: the crash
     # is contained to that check's own result, not the whole report.
     broken_specs = tuple(
-        module.ArchiveVerificationCheckSpec(spec.name, spec.description, _boom) if spec.name == "fts-parity" else spec
+        module.ArchiveVerificationCheckSpec(spec.name, spec.description, _boom, spec.check_class)
+        if spec.name == "fts-parity"
+        else spec
         for spec in module.ARCHIVE_VERIFICATION_CHECKS
     )
     monkeypatch.setattr(module, "ARCHIVE_VERIFICATION_CHECKS", broken_specs)
@@ -738,4 +745,130 @@ def test_report_to_json_is_json_document(tmp_path: Path) -> None:
     for entry in checks_payload:
         assert isinstance(entry, dict)
         names.add(entry["name"])
+        assert entry["check_class"] in {cls.value for cls in ArchiveVerificationCheckClass}
     assert names == set(ARCHIVE_VERIFICATION_CHECK_NAMES)
+
+
+# ---------------------------------------------------------------------------
+# Registry mechanism: class tagging, waivers, reindex acceptance subset
+# (polylogue-t0m73 productization)
+# ---------------------------------------------------------------------------
+
+
+def test_every_registered_check_has_a_class_tag() -> None:
+    """Construction-time contract: :class:`ArchiveVerificationCheckSpec` has
+    no default for ``check_class``, so a check without a tag is a TypeError
+    at import time -- this test just makes that guarantee explicit and
+    readable rather than relying on incidental import success."""
+    for spec in ARCHIVE_VERIFICATION_CHECKS:
+        assert isinstance(spec.check_class, ArchiveVerificationCheckClass), spec.name
+
+
+def test_check_class_is_stamped_onto_every_report_check(tmp_path: Path) -> None:
+    _seed_coherent_archive(tmp_path)
+    by_name = {spec.name: spec for spec in ARCHIVE_VERIFICATION_CHECKS}
+
+    report = verify_archive(tmp_path)
+
+    for check in report.checks:
+        assert isinstance(check, ArchiveVerificationCheck)
+        assert check.check_class == by_name[check.name].check_class.value
+
+
+def test_waived_check_still_reports_error_but_does_not_block(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """RED TWIN for the waiver mechanism itself: a waived check must keep
+    reporting its true ``error`` status and evidence (the finding is never
+    hidden) while :attr:`ArchiveVerificationReport.blocking` excludes it --
+    proving the waiver changes the *gate*, not the *check*."""
+    _seed_coherent_archive(tmp_path)
+    conn = _connect(tmp_path / "embeddings.db")
+    try:
+        conn.execute(
+            """
+            INSERT INTO message_embedding_refs(message_id, session_id, origin, embedding_input_hash)
+            VALUES ('codex-session:session:no-such-message', 'codex-session:session', 'codex-session', ?)
+            """,
+            (b"h" * 32,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    from polylogue.maintenance import archive_verification as module
+
+    monkeypatch.setattr(
+        module,
+        "ARCHIVE_VERIFICATION_WAIVERS",
+        {"embeddings-refs-liveness": ArchiveVerificationWaiver(bead_id="polylogue-test", reason="synthetic")},
+    )
+
+    report = module.verify_archive(tmp_path, checks=("embeddings-refs-liveness",))
+
+    check = _check(report, "embeddings-refs-liveness")
+    assert check.status is OutcomeStatus.ERROR  # the finding is never hidden
+    assert check.waived_bead_id == "polylogue-test"
+    assert check.evidence["waiver"]["bead_id"] == "polylogue-test"
+    assert not report.blocking  # but the waived finding does not gate
+
+
+def test_unwaived_check_of_the_same_kind_still_blocks(tmp_path: Path) -> None:
+    """Sanity twin for the waiver test above: with the real (unmodified)
+    ``ARCHIVE_VERIFICATION_WAIVERS`` table, the exact same violation blocks,
+    proving the prior test's green result came from the waiver and not from
+    embeddings-refs-liveness being vacuously non-blocking."""
+    _seed_coherent_archive(tmp_path)
+    conn = _connect(tmp_path / "embeddings.db")
+    try:
+        conn.execute(
+            """
+            INSERT INTO message_embedding_refs(message_id, session_id, origin, embedding_input_hash)
+            VALUES ('codex-session:session:no-such-message', 'codex-session:session', 'codex-session', ?)
+            """,
+            (b"h" * 32,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    assert "embeddings-refs-liveness" in ARCHIVE_VERIFICATION_WAIVERS  # documents why this bug is currently waived
+
+    report = verify_archive(tmp_path, checks=("embeddings-refs-liveness",))
+
+    check = _check(report, "embeddings-refs-liveness")
+    assert check.status is OutcomeStatus.ERROR
+    assert check.waived_bead_id == "polylogue-feu0"
+    assert not report.blocking  # waived by the real table too -- consistent with the mechanism test above
+
+
+def test_reindex_acceptance_checks_are_all_registered_and_ground_truth_eligible() -> None:
+    """Every name in :data:`REINDEX_ACCEPTANCE_CHECKS` must be a real
+    registry check, and running it against an index-only root (mirroring a
+    real generation directory, which has no source.db/user.db/embeddings.db)
+    must never report ``error`` from a missing-tier false positive."""
+    assert set(REINDEX_ACCEPTANCE_CHECKS) <= set(ARCHIVE_VERIFICATION_CHECK_NAMES)
+
+
+def test_reindex_acceptance_subset_is_satisfiable_from_index_only_root(tmp_path: Path) -> None:
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+
+    conn = _connect(tmp_path / "index.db")
+    try:
+        initialize_archive_tier(conn, ArchiveTier.INDEX)
+        conn.execute(
+            """
+            INSERT INTO sessions(native_id, origin, content_hash, message_count)
+            VALUES ('session', 'codex-session', ?, 0)
+            """,
+            (b"s" * 32,),
+        )
+        conn.commit()
+        conn.execute("ANALYZE blocks")
+        conn.execute("ANALYZE messages")
+        conn.execute("ANALYZE action_pairs")
+        conn.commit()
+    finally:
+        conn.close()
+
+    report = verify_archive(tmp_path, checks=list(REINDEX_ACCEPTANCE_CHECKS))
+
+    assert not report.blocking, [check.summary for check in report.checks if check.status is OutcomeStatus.ERROR]
+    for check in report.checks:
+        assert check.status is not OutcomeStatus.ERROR, f"{check.name}: {check.summary}"

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -810,11 +810,12 @@ def test_waived_check_still_reports_error_but_does_not_block(tmp_path: Path, mon
     assert not report.blocking  # but the waived finding does not gate
 
 
-def test_unwaived_check_of_the_same_kind_still_blocks(tmp_path: Path) -> None:
+def test_real_waiver_table_also_waives_embeddings_refs_liveness(tmp_path: Path) -> None:
     """Sanity twin for the waiver test above: with the real (unmodified)
-    ``ARCHIVE_VERIFICATION_WAIVERS`` table, the exact same violation blocks,
-    proving the prior test's green result came from the waiver and not from
-    embeddings-refs-liveness being vacuously non-blocking."""
+    ``ARCHIVE_VERIFICATION_WAIVERS`` table, this same violation is ALSO
+    non-blocking (waived), confirming the prior monkeypatched-table test's
+    green result matches production waiver config rather than an artifact
+    of the test's own patched table."""
     _seed_coherent_archive(tmp_path)
     conn = _connect(tmp_path / "embeddings.db")
     try:

--- a/tests/unit/maintenance/test_rebuild_index_phase_timing.py
+++ b/tests/unit/maintenance/test_rebuild_index_phase_timing.py
@@ -5,7 +5,7 @@ Prior work already lands most of this bead's original scope: planner-stats
 refresh, byte-skip, batched commits, pool floor, and dedup shipped via
 sibling beads, and polylogue-o56w already threads terminal-stage timings
 (``terminal.session_insights``/``terminal.bulk_build.*``/``terminal.
-fts_parity``/``terminal.readiness``/``terminal.promote``) plus
+reindex_acceptance``/``terminal.readiness``/``terminal.promote``) plus
 ``parse_s``/``apply_s`` onto every rebuild receipt. The one piece the bead's
 own notes call out as still unowned is a SELECTION-phase timing: the live
 full rebuild that motivated this bead spent ~86s of one CPU core choosing


### PR DESCRIPTION
## Summary
Adds a bug-class taxonomy and a bead-tracked waiver mechanism to the archive-verification registry (`polylogue/maintenance/archive_verification.py`), and widens the reindex-time promotion gate from a single check (`fts-parity`) to the full ground-truth-eligible subset.

## Problem
The registry already grew to 11 checks across two prior PRs (#3156, #3612), but polylogue-t0m73's design (after a substrate investigation established this registry -- not a bespoke lab probe -- is the correct home for the invariant suite) calls for a class-tagged registry with a waiver mechanism and a productized reindex acceptance gate. The operator's own scoping note for this bead: prioritize the registry/probe mechanism over fixing all currently-red live invariants in the same PR.

## Solution
- `ArchiveVerificationCheckClass` (`state-invariant`/`liveness`/`freshness`/`complexity`/`fidelity`/`conservation`/`config`) tags all 12 registry specs; `verify_archive()` stamps the tag onto every report check centrally instead of every check function threading it through by hand.
- `ArchiveVerificationWaiver` + `ARCHIVE_VERIFICATION_WAIVERS`: a bead-id-carrying acknowledgement. A waived check still reports its true `error` status and evidence -- nothing is hidden -- only `ArchiveVerificationReport.blocking` excludes it, so an unrelated gate doesn't trip on a distinct, already-tracked bug. Wired one waiver end-to-end (`embeddings-refs-liveness` -> `polylogue-feu0`, the known undrained 4,186-ref catch-up debt). By design this module never calls `bd`; a waiver is a manual acknowledgement removed in the same change that closes its bead.
- `REINDEX_ACCEPTANCE_CHECKS`: the subset satisfiable from a candidate generation's `index.db` alone (a generation directory holds no `source.db`/`user.db`/`embeddings.db` -- those tiers live once at the archive root, not per-generation). `rebuild_index.py`'s terminal promotion stage now runs this full subset (`fts-parity`, `lineage-sanity`, `enum-superset-check`, `session-lineage-acyclic`, `message-count-projection`, `planner-stats`) instead of the `fts-parity` singleton it ran before.
- Fixed a stale hand-maintained check-name literal in `test_maintenance_verify_archive_cli.py` (missing 5 checks landed by PR #3612 that never updated this assertion) to read from `ARCHIVE_VERIFICATION_CHECK_NAMES` instead, closing off this exact class of silent drift.

### Deferred (tracked on their own beads, per t0m73's own prioritization)
- Building the I6 daemon-liveness / I9 / I10 checks from the original prototype (`.agent/scratch/archive-invariants-2026-08-03.py`).
- The Plane-2 daemon health-tier scheduling wiring for the liveness/freshness classes (polylogue-60gzo).
- Fixing the individual live-red findings themselves (`polylogue-feu0`, `polylogue-in24n`, `polylogue-4ts.10`).
- A `devtools lab probe` command was deliberately **not** added: per t0m73's own rescope note and polylogue-60gzo's doctrine, the operator-CLI binding already exists (`polylogue ops maintenance verify-archive`), and a live-archive-poking lab command is exactly the pattern 60gzo dissolves.

## Verification
- `devtools test tests/unit/maintenance/test_archive_verification.py tests/unit/maintenance/test_rebuild_index_bulk_build.py tests/unit/cli/test_maintenance_verify_archive_cli.py tests/unit/maintenance/test_rebuild_index_phase_timing.py` -> `59 passed`
- `devtools verify --quick` (format + lint + mypy + `render all --check`) -> `exit_code: 0`

Ref polylogue-t0m73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Archive verification results now include check classifications and waiver details.
  - Waived verification issues remain visible with supporting evidence but no longer block reports.
  - Reindexing now uses a broader acceptance validation suite and reports failed checks when promotion is blocked.

- **Improvements**
  - Verification output includes clearer acceptance-stage timing and structured metadata.
  - Check definitions and acceptance criteria are consistently represented in JSON results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->