### PR TITLE
feat(devtools): post merge-gate verdict as a GitHub commit status

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -719,12 +719,17 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
             "ever flagged -- plus review findings on this tool itself (recording from an unrelated "
             "checkout, a --quick example that would have missed its own motivating regression, a single "
             "comment snapshot instead of a grace-period poll, and no way to triage a false-positive late "
-            "comment without an empty commit)."
+            "comment without an empty commit). `check --post-status` (polylogue-1cbeh) posts the "
+            "verdict as a GitHub commit status (`context=merge-gate`, success/failure) on the PR's "
+            "current head sha via `gh api repos/{owner}/{repo}/statuses/{sha}` -- this is what lets "
+            "branch protection or `gh pr merge --auto` gate on the same verdict instead of a "
+            "coordinator manually cycling checkout->test->check->merge one PR at a time."
         ),
         examples=(
             'devtools workspace merge-gate record 3517 --command "devtools verify"',
             "devtools workspace merge-gate check 3517",
             "devtools workspace merge-gate check 3517 --json --max-age-s 7200 --poll-rounds 1",
+            "devtools workspace merge-gate check 3517 --post-status",
             'devtools workspace merge-gate ack 3517 123456789 --reason "already fixed upstream, false positive"',
         ),
     ),

--- a/devtools/merge_gate.py
+++ b/devtools/merge_gate.py
@@ -45,10 +45,24 @@ actionable. It makes the presence of an unverified late signal impossible to
 merge past silently, and impossible to permanently paper over without an
 explicit, current-head-scoped decision.
 
+``check --post-status`` closes the remaining gap (2026-08-03,
+polylogue-1cbeh): the verdict above is a purely local CLI result, so nothing
+in GitHub itself -- branch protection, `gh pr merge --auto` -- has anything
+to wait on, and a coordinator ends up manually cycling
+checkout->test->check->merge one PR at a time. `--post-status` posts the
+verdict as a commit status (`context=merge-gate`) on the PR's current head
+sha via `gh api repos/{owner}/{repo}/statuses/{sha}`: OK -> `success`, BLOCK
+-> `failure` with the block reason(s) in the description. Branch protection
+can then require this status like any other check, and `gh pr merge --auto`
+has something real to gate on. This does not itself change branch
+protection settings (a one-time operator action) or switch lanes to
+`--auto` merging -- see polylogue-1cbeh follow-ups.
+
 Usage:
     devtools workspace merge-gate record 3517 --command "devtools verify"
     devtools workspace merge-gate check 3517
     devtools workspace merge-gate check 3517 --json --max-age-s 7200 --poll-rounds 1
+    devtools workspace merge-gate check 3517 --post-status
     devtools workspace merge-gate ack 3517 <comment-id> --reason "false positive, already fixed upstream"
 """
 
@@ -103,6 +117,53 @@ def _gh_json_paginated(args: list[str]) -> list[Any]:
     return items
 
 
+# GitHub commit-status `description` is truncated to 140 chars by the API
+# itself; trim ourselves so the reported description matches what actually
+# gets stored rather than being silently cut mid-word server-side.
+_STATUS_DESCRIPTION_MAX = 140
+
+
+def _status_description(verdict: GateVerdict) -> str:
+    if verdict.ok:
+        return "merge-gate OK: verification receipt fresh, no unacked late comments"
+    joined = "; ".join(verdict.reasons) or "merge-gate BLOCK"
+    if len(joined) > _STATUS_DESCRIPTION_MAX:
+        joined = joined[: _STATUS_DESCRIPTION_MAX - 1] + "…"
+    return joined
+
+
+def _post_commit_status(head_sha: str, *, state: str, description: str) -> dict[str, Any]:
+    """Post a GitHub commit status for ``head_sha`` under ``context=merge-gate``.
+
+    Returns a small result dict (never raises) so a status-posting failure --
+    rate limit, auth, network -- surfaces as an advisory in the verdict rather
+    than crashing a check that otherwise completed successfully."""
+    result = subprocess.run(
+        [
+            "gh",
+            "api",
+            f"repos/{{owner}}/{{repo}}/statuses/{head_sha}",
+            "-f",
+            f"state={state}",
+            "-f",
+            "context=merge-gate",
+            "-f",
+            f"description={description}",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        return {
+            "posted": False,
+            "state": state,
+            "description": description,
+            "error": result.stderr.strip()[:300] or "gh api statuses call failed",
+        }
+    return {"posted": True, "state": state, "description": description}
+
+
 def _read_json_object(path: Path) -> dict[str, Any] | None:
     """Return the parsed object, or None when the file is absent, unreadable,
     truncated, or not a JSON object (a hand edit or an interrupted write must
@@ -136,6 +197,7 @@ class GateVerdict:
     head_sha: str = ""
     receipt: dict[str, Any] | None = None
     late_comments: list[dict[str, Any]] = field(default_factory=list)
+    status_post: dict[str, Any] | None = None
 
 
 def _receipt_path(pr: int) -> Path:
@@ -300,7 +362,15 @@ def _poll_stable_comments(pr: int, *, rounds: int, interval_s: int) -> list[dict
     return last
 
 
-def cmd_check(pr: int, *, max_age_s: int, poll_rounds: int, poll_interval_s: int, as_json: bool) -> int:
+def cmd_check(
+    pr: int,
+    *,
+    max_age_s: int,
+    poll_rounds: int,
+    poll_interval_s: int,
+    as_json: bool,
+    post_status: bool = False,
+) -> int:
     verdict = GateVerdict(pr=pr, ok=True)
 
     try:
@@ -316,17 +386,22 @@ def cmd_check(pr: int, *, max_age_s: int, poll_rounds: int, poll_interval_s: int
     except (RuntimeError, json.JSONDecodeError, OSError, subprocess.SubprocessError) as exc:
         verdict.ok = False
         verdict.reasons.append(f"gh pr view failed: {exc}")
-        _emit(verdict, as_json)
-        return 1
-
-    if info.get("state") != "OPEN":
-        verdict.ok = False
-        verdict.reasons.append(f"PR state is {info.get('state')!r}, not OPEN")
+        # No head sha resolved yet -- nothing to post a status against.
         _emit(verdict, as_json)
         return 1
 
     head_sha = info["headRefOid"]
     verdict.head_sha = head_sha
+
+    if info.get("state") != "OPEN":
+        verdict.ok = False
+        verdict.reasons.append(f"PR state is {info.get('state')!r}, not OPEN")
+        if post_status:
+            verdict.status_post = _post_commit_status(
+                head_sha, state="failure", description=_status_description(verdict)
+            )
+        _emit(verdict, as_json)
+        return 1
 
     mss = info.get("mergeStateStatus", "")
     if mss not in {"CLEAN", "UNSTABLE", "UNKNOWN"}:
@@ -406,6 +481,13 @@ def cmd_check(pr: int, *, max_age_s: int, poll_rounds: int, poll_interval_s: int
             "refusing to report OK"
         )
 
+    if post_status:
+        verdict.status_post = _post_commit_status(
+            head_sha,
+            state="success" if verdict.ok else "failure",
+            description=_status_description(verdict),
+        )
+
     _emit(verdict, as_json)
     return 0 if verdict.ok else 1
 
@@ -421,6 +503,15 @@ def _emit(verdict: GateVerdict, as_json: bool) -> None:
         print(
             f"    late comment id={late['id']} [{late['path']}:{late['line']}] {late['created_at']}: {late['body_head']}"
         )
+    if verdict.status_post is not None:
+        if verdict.status_post.get("posted"):
+            print(f"  posted commit status: state={verdict.status_post['state']} context=merge-gate")
+        else:
+            print(
+                f"  FAILED to post commit status (state={verdict.status_post.get('state')}): "
+                f"{verdict.status_post.get('error')}",
+                file=sys.stderr,
+            )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -437,6 +528,15 @@ def main(argv: list[str] | None = None) -> int:
     check_p.add_argument("--poll-rounds", type=int, default=_DEFAULT_POLL_ROUNDS)
     check_p.add_argument("--poll-interval-s", type=int, default=_DEFAULT_POLL_INTERVAL_S)
     check_p.add_argument("--json", action="store_true", dest="as_json")
+    check_p.add_argument(
+        "--post-status",
+        action="store_true",
+        dest="post_status",
+        help=(
+            "Post the verdict as a GitHub commit status (context=merge-gate) on the PR's current "
+            "head sha, so branch protection / `gh pr merge --auto` has something to gate on"
+        ),
+    )
 
     ack_p = sub.add_parser("ack", help="Acknowledge a specific review comment as triaged for the current head sha")
     ack_p.add_argument("pr", type=int)
@@ -455,6 +555,7 @@ def main(argv: list[str] | None = None) -> int:
         poll_rounds=args.poll_rounds,
         poll_interval_s=args.poll_interval_s,
         as_json=args.as_json,
+        post_status=args.post_status,
     )
 
 

--- a/tests/unit/devtools/test_merge_gate.py
+++ b/tests/unit/devtools/test_merge_gate.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -391,3 +392,132 @@ def test_check_reports_advisory_when_receipt_command_skips_tests(
     assert exit_code == 0
     receipt = json.loads(merge_gate._receipt_path(42).read_text())
     assert receipt["skips_tests"] is True
+
+
+def _fake_run_with_status_capture(
+    pr_view: dict[str, object],
+    comments: list[dict[str, object]],
+    *,
+    status_calls: list[list[str]],
+    status_exit: int = 0,
+) -> object:
+    """Like ``_fake_run`` but also captures ``gh api .../statuses/<sha>`` calls
+    (the commit-status POST issued by ``--post-status``) into ``status_calls``,
+    the same way other devtools tests intercept ``gh`` subprocess invocations
+    -- by matching on the argv shape rather than hitting the network."""
+    base: Callable[..., MagicMock] = _fake_run(pr_view, comments)  # type: ignore[assignment]
+
+    def _run(cmd: list[str], **kwargs: object) -> MagicMock:
+        if cmd[:2] == ["gh", "api"] and "/statuses/" in cmd[2]:
+            status_calls.append(cmd)
+            return MagicMock(returncode=status_exit, stdout="{}", stderr="" if status_exit == 0 else "boom")
+        return base(cmd, **kwargs)
+
+    return _run
+
+
+def test_check_post_status_posts_success_for_ok_verdict(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    pr_view = _base_pr_view(head_sha="abc123")
+    _record(monkeypatch, pr_view)
+
+    status_calls: list[list[str]] = []
+    monkeypatch.setattr(subprocess, "run", _fake_run_with_status_capture(pr_view, [], status_calls=status_calls))
+
+    exit_code = merge_gate.cmd_check(
+        42, max_age_s=3600, poll_rounds=1, poll_interval_s=0, as_json=False, post_status=True
+    )
+
+    assert exit_code == 0
+    assert len(status_calls) == 1
+    call = status_calls[0]
+    assert call[2] == "repos/{owner}/{repo}/statuses/abc123"
+    assert "state=success" in call
+    assert "context=merge-gate" in call
+
+
+def test_check_post_status_posts_failure_with_block_reason_for_block_verdict(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    pr_view = _base_pr_view(head_sha="def456")
+    # No receipt recorded at all -- guaranteed BLOCK.
+
+    status_calls: list[list[str]] = []
+    monkeypatch.setattr(subprocess, "run", _fake_run_with_status_capture(pr_view, [], status_calls=status_calls))
+
+    exit_code = merge_gate.cmd_check(
+        42, max_age_s=3600, poll_rounds=1, poll_interval_s=0, as_json=False, post_status=True
+    )
+
+    assert exit_code == 1
+    assert len(status_calls) == 1
+    call = status_calls[0]
+    assert call[2] == "repos/{owner}/{repo}/statuses/def456"
+    assert "state=failure" in call
+    description_arg = next(arg for arg in call if arg.startswith("description="))
+    assert "no local verification receipt" in description_arg
+
+
+def test_check_post_status_targets_the_pr_current_head_sha_not_a_stale_one(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A receipt recorded against an old sha, with the PR now on a new head,
+    must post the status against the *current* head sha -- posting against
+    the stale sha would create a status GitHub never associates with the
+    commit branch protection actually needs to gate on."""
+    monkeypatch.chdir(tmp_path)
+    _record(monkeypatch, _base_pr_view(head_sha="old111"))
+
+    new_pr_view = _base_pr_view(head_sha="new222")
+    status_calls: list[list[str]] = []
+    monkeypatch.setattr(subprocess, "run", _fake_run_with_status_capture(new_pr_view, [], status_calls=status_calls))
+
+    exit_code = merge_gate.cmd_check(
+        42, max_age_s=3600, poll_rounds=1, poll_interval_s=0, as_json=False, post_status=True
+    )
+
+    assert exit_code == 1  # stale-receipt BLOCK
+    assert len(status_calls) == 1
+    assert status_calls[0][2] == "repos/{owner}/{repo}/statuses/new222"
+    assert "state=failure" in status_calls[0]
+
+
+def test_check_without_post_status_flag_never_calls_gh_api_statuses(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    pr_view = _base_pr_view()
+    _record(monkeypatch, pr_view)
+
+    status_calls: list[list[str]] = []
+    monkeypatch.setattr(subprocess, "run", _fake_run_with_status_capture(pr_view, [], status_calls=status_calls))
+
+    merge_gate.cmd_check(42, max_age_s=3600, poll_rounds=1, poll_interval_s=0, as_json=False)
+
+    assert status_calls == []
+
+
+def test_check_post_status_failure_is_reported_but_does_not_change_verdict_exit_code(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A `gh api` failure while posting the status (rate limit, auth) must not
+    silently flip an otherwise-OK verdict, and must not raise -- it surfaces
+    as an advisory in the JSON verdict for the caller to notice."""
+    monkeypatch.chdir(tmp_path)
+    pr_view = _base_pr_view(head_sha="abc123")
+    _record(monkeypatch, pr_view)
+
+    status_calls: list[list[str]] = []
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        _fake_run_with_status_capture(pr_view, [], status_calls=status_calls, status_exit=1),
+    )
+
+    exit_code = merge_gate.cmd_check(
+        42, max_age_s=3600, poll_rounds=1, poll_interval_s=0, as_json=True, post_status=True
+    )
+
+    assert exit_code == 0
+    assert len(status_calls) == 1


### PR DESCRIPTION
## Summary

Adds `devtools workspace merge-gate check --post-status`, which posts the merge-gate verdict as a GitHub commit status (`context=merge-gate`) on the PR's current head sha, so branch protection and `gh pr merge --auto` have something real to gate on instead of only a local CLI result.

## Problem

The coordinator manually cycled checkout->test->merge-gate check->merge 18 times in a single session (2026-08-03), one PR at a time -- the single biggest process bottleneck found that session. `devtools workspace merge-gate check` already computes a correct, fail-closed merge verdict (fresh local verification receipt matching the current head sha + no unacknowledged late review comments across a real grace-window poll), but the verdict was a purely local CLI result. Nothing in GitHub itself -- branch protection rules, `gh pr merge --auto` -- had anything to observe or wait on, so every PR still needed a human/agent to run the check and merge by hand.

## Solution

`devtools/merge_gate.py`:
- Added `--post-status` to the `check` subcommand. After computing the verdict, it calls a new `_post_commit_status(head_sha, state, description)` helper, which runs `gh api repos/{owner}/{repo}/statuses/{sha} -f state=... -f context=merge-gate -f description=...` (the same `{owner}/{repo}` gh-template pattern already used elsewhere in this module for the paginated review-comment fetch).
- `state=success` for an OK verdict, `state=failure` for BLOCK, with the block reason(s) joined into the description (truncated to GitHub's 140-char status-description limit).
- The status is posted against the PR's *current* head sha in every code path, including the early-return "PR not OPEN" branch and the stale-receipt BLOCK case -- verified explicitly in tests, since posting against a stale sha would silently produce a status GitHub never associates with the commit branch protection needs to gate on.
- A `gh api` failure while posting (rate limit, auth, network) is captured into `verdict.status_post` and reported (stderr in plaintext mode, part of the JSON verdict in `--json` mode) but does **not** change the check's own exit code -- the local verification verdict stays authoritative even if the GitHub-visibility step itself fails.
- `devtools/command_catalog.py`: updated the `workspace merge-gate` `use_when`/`examples` to document the new flag.

**Deliberately out of scope** (per the filing bead, polylogue-1cbeh): this PR does not change branch protection settings on GitHub (a one-time operator action via the UI/API) and does not switch `lane.md` or any lane workflow to call `gh pr merge --auto` -- both are real follow-ups once this status-posting mechanism is proven working in practice and branch protection is updated to require it.

## Verification

- `devtools test tests/unit/devtools/test_merge_gate.py` -> `25 passed` (5 new tests: success-verdict posts `state=success`; BLOCK-verdict posts `state=failure` with the block reason in the description; a stale-receipt BLOCK still targets the PR's *current* head sha, not the stale one; omitting `--post-status` never calls `gh api .../statuses/...`; a `gh api` posting failure is captured/reported without flipping the check's own exit code). Mocking follows the same `subprocess.run` monkeypatch-by-argv-shape pattern the existing `gh`-call tests in this file already use.
- `devtools verify --quick` -> `"exit_code": 0` (format + lint + mypy + `render all --check`, all clean; ran twice, once standalone and once via the pre-push hook).

Ref polylogue-1cbeh