### PR TITLE
feat(storage): reconcile SQLite mmap budget with cgroup memory limit

### DIFF
--- a/polylogue/core/metrics.py
+++ b/polylogue/core/metrics.py
@@ -115,6 +115,30 @@ def read_cgroup_memory_swap_current_mb() -> float | None:
     return _bytes_to_mb(_read_cgroup_int("memory.swap.current"))
 
 
+def read_cgroup_memory_max_bytes() -> int | None:
+    """Return this cgroup's ``memory.max`` (hard ceiling) in bytes.
+
+    ``None`` when the cgroup v2 controller is not mounted, the file is
+    missing (no controller delegated, e.g. outside a cgroup or in a
+    container without ``memory`` enabled), or the limit is literally
+    ``max`` (unlimited) -- ``_read_cgroup_int`` already treats ``max`` as
+    ``None``, which is the correct "no ceiling" reading here too.
+    """
+    return _read_cgroup_int("memory.max")
+
+
+def read_cgroup_memory_high_bytes() -> int | None:
+    """Return this cgroup's ``memory.high`` (soft throttle threshold) in bytes.
+
+    ``None`` under the same conditions as :func:`read_cgroup_memory_max_bytes`.
+    Reclaimable/mmap'd file-backed pages are throttled (evict-under-pressure)
+    once usage crosses this threshold, before ``memory.max`` would ever OOM-kill
+    -- see ``polylogue.storage.sqlite.connection_profile.mapped_bytes_budget``
+    for why this threshold matters independently of the hard ceiling.
+    """
+    return _read_cgroup_int("memory.high")
+
+
 def read_cgroup_memory_stat_mb() -> dict[str, float]:
     """Return selected memory.stat counters for the current cgroup in MiB."""
     path = _cgroup_file("memory.stat")
@@ -277,6 +301,8 @@ __all__ = [
     "SlowItemTracker",
     "StageMetrics",
     "read_cgroup_memory_current_mb",
+    "read_cgroup_memory_high_bytes",
+    "read_cgroup_memory_max_bytes",
     "read_cgroup_memory_peak_mb",
     "read_cgroup_memory_stat_mb",
     "read_cgroup_memory_swap_current_mb",

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -2130,6 +2130,19 @@ async def run_daemon_services(
 
     logger.info("daemon started")
 
+    # polylogue-e98k: log the computed SQLite mmap/cache budget against this
+    # process' cgroup memory limits before anything else runs. This is the
+    # observability half of the 2026-07-31 memory-throttling incident (see
+    # connection_profile.py's module comment) -- a mismatch used to be
+    # discoverable only by symptom (slow_write, throttling, a stalled ingest)
+    # hours later; now it is a one-line grep of the startup log.
+    from polylogue.storage.sqlite.connection_profile import (
+        check_mapped_bytes_budget_against_cgroup_limit,
+        log_mapped_bytes_budget_check,
+    )
+
+    log_mapped_bytes_budget_check(logger, check_mapped_bytes_budget_against_cgroup_limit())
+
     # Schema preflight runs FIRST, before any DB-touching startup task. A
     # mismatched runtime/db combination must not even open the DB for FTS or
     # heartbeat queries — that is the IO cost #1003 is meant to avoid.

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -553,6 +553,16 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
     the *location* it resolved, catching e.g. a concurrent devtools campaign
     or a foreign/rotated root before this rebuild can act on stale identity).
     """
+    from polylogue.storage.sqlite.connection_profile import (
+        check_mapped_bytes_budget_against_cgroup_limit,
+        log_mapped_bytes_budget_check,
+    )
+
+    # polylogue-e98k: this is the other path (besides daemon startup) that can
+    # hold a ``BULK_BUILD_WRITE_CONNECTION_PROFILE`` connection (4 GiB mmap) --
+    # log the budget-vs-cgroup-limit comparison before replay starts, not only
+    # discoverable by symptom after a throttled/stalled rebuild.
+    log_mapped_bytes_budget_check(logger, check_mapped_bytes_budget_against_cgroup_limit())
     validate_rebuild_index_request(request)
     root = request.archive_root
     location = ArchiveLocation.resolve(root)

--- a/polylogue/storage/sqlite/connection_profile.py
+++ b/polylogue/storage/sqlite/connection_profile.py
@@ -20,7 +20,10 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from polylogue.logging import BoundLoggerLike
 
 
 @dataclass(frozen=True, slots=True)
@@ -196,6 +199,165 @@ BULK_BUILD_WRITE_CONNECTION_PRAGMA_STATEMENTS = BULK_BUILD_WRITE_CONNECTION_PROF
 
 
 # ---------------------------------------------------------------------------
+# Mapped-bytes budget vs. the cgroup memory limit (polylogue-e98k)
+# ---------------------------------------------------------------------------
+#
+# 2026-07-31 incident: the mmap/cache profile sizes above (this file) and the
+# systemd cgroup limits (sinnix repo, `modules/services/polylogue.nix`) were
+# picked independently, in two different repos, with nothing tying them
+# together. A 4 GiB `BULK_BUILD_MMAP_SIZE_BYTES` window over a 38 GB
+# `index.db` fills completely under any scan-heavy work; one bulk-build
+# connection alone therefore accounted for ~4.5 GiB against a 6 GiB
+# `MemoryHigh` ceiling, leaving no headroom for the daemon's own writer and
+# concurrent readers. `MemoryHigh` was the wrong instrument for reclaimable,
+# file-backed mmap'd pages (it throttles anon growth; mapped pages just
+# evict-and-refault under pressure -- the observed `slow_write` signature),
+# not a leak, so pinning at the ceiling was structurally guaranteed rather
+# than a bug in either repo. A runtime bump to `MemoryHigh=14G` stopped the
+# throttling dead; that finding is now the committed default
+# (`MemoryHigh=14G` / `MemoryMax=18G`) -- see the comment beside that
+# override for the measurement. `mapped_bytes_budget` below is the
+# mechanical anchor so nobody has to re-derive that arithmetic from scratch
+# next time either side's constants move: the sinnix `MemoryMax`/`MemoryHigh`
+# override for `polylogued.service` must stay comfortably above the value
+# this returns, and `check_mapped_bytes_budget_against_cgroup_limit` makes
+# that comparison observable at runtime instead of only discoverable hours
+# into an incident.
+#
+# `mmap_size` is an upper bound SQLite MAY map into, never a guaranteed
+# allocation, so `mapped_bytes_budget()` is a conservative ceiling estimate,
+# not a live-RSS prediction -- it will typically overstate actual usage.
+
+
+def mapped_bytes_budget(*, concurrent_read_connections: int = 4) -> int:
+    """Plausible peak concurrent SQLite mmap+cache footprint for one polylogued process.
+
+    Models the worst case that actually bit us: one bulk-build connection
+    (an offline `polylogue ops maintenance rebuild-index`, or a
+    daemon-triggered bulk rebuild via `daemon/bulk_rebuild.py`) running
+    concurrently with the daemon's own long-lived write connection
+    (`DAEMON_WRITE_CONNECTION_PROFILE`) and a handful of concurrent
+    short-lived read connections (CLI/MCP/API reads against the live
+    archive while a rebuild is in flight). It deliberately excludes the
+    ad hoc `WRITE_CONNECTION_PROFILE` (1 GiB mmap) that one-shot
+    maintenance/CLI writers use -- those do not overlap with a
+    daemon-triggered bulk rebuild in the failure mode this budget guards
+    against, and folding it in would inflate the budget past what was ever
+    observed live without adding real signal.
+
+    `concurrent_read_connections` defaults to 4: a conservative but not
+    extreme estimate of simultaneous interactive reads (CLI/MCP/API) during
+    a bulk rebuild. Callers with better knowledge of their own concurrency
+    (e.g. a fixed MCP worker pool size) may override it.
+    """
+    return (
+        BULK_BUILD_MMAP_SIZE_BYTES
+        + BULK_BUILD_CACHE_SIZE_KIB * 1024
+        + DAEMON_WRITE_MMAP_SIZE_BYTES
+        + DAEMON_WRITE_CACHE_SIZE_KIB * 1024
+        + concurrent_read_connections * (READ_MMAP_SIZE_BYTES + READ_CACHE_SIZE_KIB * 1024)
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class MappedBytesBudgetCheck:
+    """Result of comparing :func:`mapped_bytes_budget` to the detected cgroup limits."""
+
+    budget_bytes: int
+    memory_max_bytes: int | None
+    memory_high_bytes: int | None
+    concurrent_read_connections: int
+
+    @property
+    def budget_mb(self) -> float:
+        return round(self.budget_bytes / (1024 * 1024), 1)
+
+    @property
+    def memory_max_mb(self) -> float | None:
+        return round(self.memory_max_bytes / (1024 * 1024), 1) if self.memory_max_bytes is not None else None
+
+    @property
+    def memory_high_mb(self) -> float | None:
+        return round(self.memory_high_bytes / (1024 * 1024), 1) if self.memory_high_bytes is not None else None
+
+    @property
+    def at_risk_limits(self) -> tuple[str, ...]:
+        """Which cgroup limit file(s), if any, sit at or below the computed budget.
+
+        Either limit landing at or below the budget reproduces the 2026-07-31
+        incident shape: `memory.high` throttles mapped/reclaimable pages before
+        `memory.max` would ever OOM-kill, so `memory.high` is actually the
+        more precise reproduction of what happened -- but a `memory.max` this
+        low is also worth flagging, since it means the hard ceiling itself
+        cannot even hold one worst-case concurrent footprint.
+        """
+        at_risk: list[str] = []
+        if self.memory_max_bytes is not None and self.memory_max_bytes <= self.budget_bytes:
+            at_risk.append("memory.max")
+        if self.memory_high_bytes is not None and self.memory_high_bytes <= self.budget_bytes:
+            at_risk.append("memory.high")
+        return tuple(at_risk)
+
+
+def check_mapped_bytes_budget_against_cgroup_limit(*, concurrent_read_connections: int = 4) -> MappedBytesBudgetCheck:
+    """Compare the computed mmap/cache budget to this process' cgroup v2 memory limits.
+
+    Reads `memory.max`/`memory.high` under `/sys/fs/cgroup/<this process' unified
+    cgroup path>` via `polylogue.core.metrics`. Both are `None` when cgroup v2
+    is not mounted, the controller isn't delegated (e.g. outside a cgroup, or a
+    container without the `memory` controller), or the limit is literally
+    `max` (unlimited) -- callers must treat `None` as "no limit detected", not
+    as an error.
+    """
+    from polylogue.core.metrics import read_cgroup_memory_high_bytes, read_cgroup_memory_max_bytes
+
+    return MappedBytesBudgetCheck(
+        budget_bytes=mapped_bytes_budget(concurrent_read_connections=concurrent_read_connections),
+        memory_max_bytes=read_cgroup_memory_max_bytes(),
+        memory_high_bytes=read_cgroup_memory_high_bytes(),
+        concurrent_read_connections=concurrent_read_connections,
+    )
+
+
+def log_mapped_bytes_budget_check(logger: BoundLoggerLike, check: MappedBytesBudgetCheck | None = None) -> None:
+    """Log the mapped-bytes budget vs. detected cgroup memory limit at startup.
+
+    Call once at daemon startup and once at the start of an offline bulk
+    rebuild -- the two paths that can hold a `BULK_BUILD_WRITE_CONNECTION_PROFILE`
+    connection. Degrades gracefully (a debug-level line, never a raised
+    exception) when no cgroup limit is detected at all, since that is the
+    ordinary case for a dev-machine or non-cgroup-confined run, not an error.
+    """
+    if check is None:
+        check = check_mapped_bytes_budget_against_cgroup_limit()
+    if check.memory_max_bytes is None and check.memory_high_bytes is None:
+        logger.debug(
+            "mmap_budget_no_cgroup_limit_detected",
+            budget_mb=check.budget_mb,
+            concurrent_read_connections=check.concurrent_read_connections,
+        )
+        return
+    at_risk = check.at_risk_limits
+    if at_risk:
+        logger.warning(
+            "mmap_budget_at_or_above_cgroup_limit",
+            budget_mb=check.budget_mb,
+            memory_max_mb=check.memory_max_mb,
+            memory_high_mb=check.memory_high_mb,
+            at_risk_limits=list(at_risk),
+            concurrent_read_connections=check.concurrent_read_connections,
+        )
+    else:
+        logger.info(
+            "mmap_budget_within_cgroup_limit",
+            budget_mb=check.budget_mb,
+            memory_max_mb=check.memory_max_mb,
+            memory_high_mb=check.memory_high_mb,
+            concurrent_read_connections=check.concurrent_read_connections,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Lightweight factory functions — open + apply pragmas, no caching / schema / vec
 # ---------------------------------------------------------------------------
 
@@ -346,6 +508,7 @@ __all__ = [
     "DAEMON_WRITE_CONNECTION_PRAGMA_STATEMENTS",
     "DAEMON_WRITE_CONNECTION_PROFILE",
     "DAEMON_WRITE_MMAP_SIZE_BYTES",
+    "MappedBytesBudgetCheck",
     "READ_CACHE_SIZE_KIB",
     "READ_CONNECTION_PRAGMA_STATEMENTS",
     "READ_CONNECTION_PROFILE",
@@ -357,7 +520,10 @@ __all__ = [
     "WRITE_CONNECTION_PRAGMA_STATEMENTS",
     "WRITE_CONNECTION_PROFILE",
     "WRITE_MMAP_SIZE_BYTES",
+    "check_mapped_bytes_budget_against_cgroup_limit",
     "connection_context",
+    "log_mapped_bytes_budget_check",
+    "mapped_bytes_budget",
     "open_daemon_connection",
     "open_connection",
     "open_readonly_connection",

--- a/tests/unit/core/test_metrics_cgroup_memory_limits.py
+++ b/tests/unit/core/test_metrics_cgroup_memory_limits.py
@@ -1,0 +1,59 @@
+"""polylogue-e98k: cgroup memory.max/memory.high readers used by the mmap budget check.
+
+Production dependency exercised: the real ``read_cgroup_memory_max_bytes``/
+``read_cgroup_memory_high_bytes`` -> ``_read_cgroup_int`` -> ``_cgroup_file``
+chain, not a reimplemented parser. Reverting either reader to always return
+``None`` (or to mis-treat the literal ``"max"`` value as a real 0-byte limit)
+would make these tests fail.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from polylogue.core import metrics as metrics_module
+from polylogue.core.metrics import read_cgroup_memory_high_bytes, read_cgroup_memory_max_bytes
+
+
+def _patch_cgroup_file(monkeypatch: pytest.MonkeyPatch, cgroup_dir: Path) -> None:
+    def _fake_cgroup_file(name: str) -> Path:
+        return cgroup_dir / name
+
+    monkeypatch.setattr(metrics_module, "_cgroup_file", _fake_cgroup_file)
+
+
+def test_read_cgroup_memory_max_bytes_parses_numeric_limit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (tmp_path / "memory.max").write_text("19327352832\n")  # 18 GiB
+    _patch_cgroup_file(monkeypatch, tmp_path)
+    assert read_cgroup_memory_max_bytes() == 19327352832
+
+
+def test_read_cgroup_memory_high_bytes_parses_numeric_limit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (tmp_path / "memory.high").write_text("15032385536\n")  # 14 GiB
+    _patch_cgroup_file(monkeypatch, tmp_path)
+    assert read_cgroup_memory_high_bytes() == 15032385536
+
+
+def test_read_cgroup_memory_max_bytes_treats_literal_max_as_unlimited(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "memory.max").write_text("max\n")
+    _patch_cgroup_file(monkeypatch, tmp_path)
+    assert read_cgroup_memory_max_bytes() is None
+
+
+def test_read_cgroup_memory_max_bytes_missing_file_returns_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No cgroup file at all (no controller / not in a cgroup) degrades to None,
+    never an exception -- the dev-machine / cloud-sandbox ordinary case."""
+    _patch_cgroup_file(monkeypatch, tmp_path)  # directory exists but no memory.max inside
+    assert read_cgroup_memory_max_bytes() is None
+
+
+def test_read_cgroup_memory_max_bytes_no_cgroup_path_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(metrics_module, "_cgroup_file", lambda name: None)
+    assert read_cgroup_memory_max_bytes() is None
+    assert read_cgroup_memory_high_bytes() is None

--- a/tests/unit/storage/test_mapped_bytes_budget.py
+++ b/tests/unit/storage/test_mapped_bytes_budget.py
@@ -1,0 +1,190 @@
+"""polylogue-e98k: reconcile the SQLite mmap/cache budget with the cgroup memory limit.
+
+Production dependencies exercised here: ``mapped_bytes_budget`` (the real
+arithmetic over the real ``BULK_BUILD_*``/``DAEMON_WRITE_*``/``READ_*``
+constants -- not a reimplemented copy), ``check_mapped_bytes_budget_against_cgroup_limit``
+(the real cgroup-reading composition), and ``log_mapped_bytes_budget_check``
+(the real branch selecting debug/info/warning). Reverting the budget formula
+to the single largest constant (``BULK_BUILD_MMAP_SIZE_BYTES`` alone) would
+make ``test_mapped_bytes_budget_reflects_documented_worst_case`` fail, not
+merely report a smaller number; reverting ``at_risk_limits`` to always return
+empty would make ``test_at_risk_when_limit_at_or_below_budget`` fail to warn.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from polylogue.storage.sqlite.connection_profile import (
+    BULK_BUILD_CACHE_SIZE_KIB,
+    BULK_BUILD_MMAP_SIZE_BYTES,
+    DAEMON_WRITE_CACHE_SIZE_KIB,
+    DAEMON_WRITE_MMAP_SIZE_BYTES,
+    READ_CACHE_SIZE_KIB,
+    READ_MMAP_SIZE_BYTES,
+    MappedBytesBudgetCheck,
+    check_mapped_bytes_budget_against_cgroup_limit,
+    log_mapped_bytes_budget_check,
+    mapped_bytes_budget,
+)
+
+
+def test_mapped_bytes_budget_reflects_documented_worst_case() -> None:
+    """Budget = bulk-build + daemon-write + N concurrent read connections.
+
+    Not just the single largest constant (``BULK_BUILD_MMAP_SIZE_BYTES``) --
+    that was exactly the gap the 2026-07-31 incident exposed: one bulk-build
+    connection alone was assumed representative of the worst case, when the
+    daemon's own write connection and concurrent reads add on top of it.
+    """
+    expected = (
+        BULK_BUILD_MMAP_SIZE_BYTES
+        + BULK_BUILD_CACHE_SIZE_KIB * 1024
+        + DAEMON_WRITE_MMAP_SIZE_BYTES
+        + DAEMON_WRITE_CACHE_SIZE_KIB * 1024
+        + 4 * (READ_MMAP_SIZE_BYTES + READ_CACHE_SIZE_KIB * 1024)
+    )
+    assert mapped_bytes_budget() == expected
+    # Strictly greater than the single largest constant alone -- proves this
+    # isn't a no-op reformulation of the old single-constant framing.
+    assert mapped_bytes_budget() > BULK_BUILD_MMAP_SIZE_BYTES
+
+    # concurrent_read_connections is a real parameter, not vestigial.
+    assert mapped_bytes_budget(concurrent_read_connections=0) < mapped_bytes_budget(concurrent_read_connections=4)
+
+
+def test_check_reads_cgroup_limits_via_core_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "polylogue.core.metrics.read_cgroup_memory_max_bytes",
+        lambda: 20 * 1024 * 1024 * 1024,
+    )
+    monkeypatch.setattr(
+        "polylogue.core.metrics.read_cgroup_memory_high_bytes",
+        lambda: 16 * 1024 * 1024 * 1024,
+    )
+    check = check_mapped_bytes_budget_against_cgroup_limit()
+    assert check.memory_max_bytes == 20 * 1024 * 1024 * 1024
+    assert check.memory_high_bytes == 16 * 1024 * 1024 * 1024
+    assert check.budget_bytes == mapped_bytes_budget()
+
+
+def test_at_risk_when_limit_at_or_below_budget() -> None:
+    budget = mapped_bytes_budget()
+    check = MappedBytesBudgetCheck(
+        budget_bytes=budget,
+        memory_max_bytes=budget + 1,
+        memory_high_bytes=budget,  # exactly at the budget: still at-risk
+        concurrent_read_connections=4,
+    )
+    assert check.at_risk_limits == ("memory.high",)
+
+    check_both_ok = MappedBytesBudgetCheck(
+        budget_bytes=budget,
+        memory_max_bytes=budget * 2,
+        memory_high_bytes=budget * 2,
+        concurrent_read_connections=4,
+    )
+    assert check_both_ok.at_risk_limits == ()
+
+    check_both_risky = MappedBytesBudgetCheck(
+        budget_bytes=budget,
+        memory_max_bytes=budget - 1,
+        memory_high_bytes=budget - 1,
+        concurrent_read_connections=4,
+    )
+    assert set(check_both_risky.at_risk_limits) == {"memory.max", "memory.high"}
+
+
+def test_no_cgroup_limit_detected_degrades_to_debug_log() -> None:
+    """No cgroup files present (dev machine, no controller) must never raise --
+    it's the ordinary case, not an error."""
+    check = MappedBytesBudgetCheck(
+        budget_bytes=mapped_bytes_budget(),
+        memory_max_bytes=None,
+        memory_high_bytes=None,
+        concurrent_read_connections=4,
+    )
+
+    class _Recorder:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, str, dict[str, object]]] = []
+
+        def debug(self, message: str, **kw: object) -> None:
+            self.calls.append(("debug", message, kw))
+
+        def info(self, message: str, **kw: object) -> None:
+            self.calls.append(("info", message, kw))
+
+        def warning(self, message: str, **kw: object) -> None:
+            self.calls.append(("warning", message, kw))
+
+    recorder = _Recorder()
+    log_mapped_bytes_budget_check(recorder, check)  # type: ignore[arg-type]
+
+    assert len(recorder.calls) == 1
+    level, message, _kw = recorder.calls[0]
+    assert level == "debug"
+    assert message == "mmap_budget_no_cgroup_limit_detected"
+
+
+def test_warns_when_at_risk() -> None:
+    budget = mapped_bytes_budget()
+    check = MappedBytesBudgetCheck(
+        budget_bytes=budget,
+        memory_max_bytes=budget * 2,
+        memory_high_bytes=budget - 1,
+        concurrent_read_connections=4,
+    )
+
+    class _Recorder:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, str, dict[str, object]]] = []
+
+        def debug(self, message: str, **kw: object) -> None:
+            self.calls.append(("debug", message, kw))
+
+        def info(self, message: str, **kw: object) -> None:
+            self.calls.append(("info", message, kw))
+
+        def warning(self, message: str, **kw: object) -> None:
+            self.calls.append(("warning", message, kw))
+
+    recorder = _Recorder()
+    log_mapped_bytes_budget_check(recorder, check)  # type: ignore[arg-type]
+
+    assert len(recorder.calls) == 1
+    level, message, kw = recorder.calls[0]
+    assert level == "warning"
+    assert message == "mmap_budget_at_or_above_cgroup_limit"
+    assert kw["at_risk_limits"] == ["memory.high"]
+
+
+def test_logs_info_when_within_limits() -> None:
+    budget = mapped_bytes_budget()
+    check = MappedBytesBudgetCheck(
+        budget_bytes=budget,
+        memory_max_bytes=budget * 3,
+        memory_high_bytes=budget * 2,
+        concurrent_read_connections=4,
+    )
+
+    class _Recorder:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, str, dict[str, object]]] = []
+
+        def debug(self, message: str, **kw: object) -> None:
+            self.calls.append(("debug", message, kw))
+
+        def info(self, message: str, **kw: object) -> None:
+            self.calls.append(("info", message, kw))
+
+        def warning(self, message: str, **kw: object) -> None:
+            self.calls.append(("warning", message, kw))
+
+    recorder = _Recorder()
+    log_mapped_bytes_budget_check(recorder, check)  # type: ignore[arg-type]
+
+    assert len(recorder.calls) == 1
+    level, message, _kw = recorder.calls[0]
+    assert level == "info"
+    assert message == "mmap_budget_within_cgroup_limit"


### PR DESCRIPTION
## Summary

Adds a named, computable "peak concurrent mapped-bytes budget" for polylogued's SQLite connection profiles, compares it against the detected cgroup v2 `memory.max`/`memory.high` at daemon startup and at the start of an index rebuild, and logs a WARNING when either cgroup limit sits at or below the computed budget.

## Problem

The 2026-07-31 memory-throttling incident (polylogue-e98k) traced to two independently chosen constants that never met: `BULK_BUILD_MMAP_SIZE_BYTES` (4 GiB, `polylogue/storage/sqlite/connection_profile.py`) and the sinnix `polylogued.service` cgroup `MemoryHigh`/`MemoryMax` limits were picked in two separate repos with nothing tying them together. A 4 GiB mmap window over a 38 GB `index.db` fills completely under scan-heavy work, so one bulk-build connection alone accounted for ~4.5 GiB of a 6 GiB `MemoryHigh` ceiling. `MemoryHigh` was also the wrong instrument for reclaimable, file-backed mmap'd pages (it throttles anon growth; mapped pages evict-and-refault under pressure, which is exactly the observed `slow_write` signature), so the throttling was structurally guaranteed rather than a bug in either repo. A runtime bump to `MemoryHigh=14G` stopped the throttling and that finding is already the committed default in sinnix (`MemoryHigh=14G`/`MemoryMax=18G`). This PR closes the remaining reconciliation and observability gap so a future archive-growth-driven mismatch of this kind is a one-line grep of the startup log instead of an hours-long forensic investigation.

## Solution

- `polylogue/storage/sqlite/connection_profile.py`: added `mapped_bytes_budget()`, a documented worst-case concurrent mmap+cache footprint (one bulk-build connection + the daemon's own long-lived write connection + N concurrent read connections, not just the single largest constant). Added `MappedBytesBudgetCheck` (a frozen dataclass exposing `budget_mb`/`memory_max_mb`/`memory_high_mb`/`at_risk_limits`), `check_mapped_bytes_budget_against_cgroup_limit()` to build one from the live cgroup state, and `log_mapped_bytes_budget_check()` to log it: debug when no cgroup limit is detected at all (the ordinary dev-machine/cloud-sandbox case), warning when either `memory.max` or `memory.high` is at or below the budget, info otherwise.
- `polylogue/core/metrics.py`: added `read_cgroup_memory_max_bytes()`/`read_cgroup_memory_high_bytes()`, reusing the existing cgroup v2 path resolution (`_cgroup_file`/`_read_cgroup_int`) already used by `read_cgroup_memory_current_mb`/`read_cgroup_memory_peak_mb`/`read_cgroup_memory_swap_current_mb`.
- Wired the check into the two production paths that can hold a `BULK_BUILD_WRITE_CONNECTION_PROFILE` connection: daemon startup (`polylogue/daemon/cli.py::run_daemon_services`, immediately after the `"daemon started"` log line, before any DB-touching schema preflight) and the offline/online index rebuild entrypoint (`polylogue/maintenance/rebuild_index.py::rebuild_index_from_source`, before request validation).

**Deferred / no-op findings**, per the bead's own framing:

- Point 2 of the bead ("confirm memory.high is now the correctly-chosen instrument, and no other polylogue code makes the same category error") is a no-op finding, not new code: grepping the codebase's `cgroup`/`MemoryHigh`/`setrlimit` usage shows every other cgroup touchpoint in polylogue (`polylogue/sources/live/*`, `polylogue/daemon/status.py`, `polylogue/pipeline/parsed_tree_size.py`) is read-only observability, never a throttling-instrument choice. That choice lives entirely in the sinnix repo's `modules/services/polylogue.nix`, which is out of scope for this PR (already fixed there) and was left untouched per this task's scope boundary.
- Fully deriving both sides from one literal shared source of truth across the polylogue/sinnix repo boundary is not possible in one PR (two separate repos). `mapped_bytes_budget()` is the polylogue-side anchor a human/agent updating the sinnix `MemoryMax`/`MemoryHigh` override should check against; wiring sinnix to actually consume this value programmatically (rather than a human reading the docstring/log line) is a plausible follow-up for the coordinator to file against the sinnix repo, not something this PR can do without editing a repo outside its scope.

## Verification

- `devtools test tests/unit/storage/test_mapped_bytes_budget.py tests/unit/core/test_metrics_cgroup_memory_limits.py` — `11 passed in 8.90s`
- `devtools test tests/unit/storage/test_bulk_build_connection_profile.py tests/unit/maintenance/test_rebuild_index_ownership.py tests/unit/maintenance/test_rebuild_index_bulk_build.py` — `5 passed` / `2 passed` (confirms the new call sites don't disturb existing rebuild/profile behavior)
- `devtools verify --quick` — `"exit_code": 0` (format + lint + mypy + `render all --check` all green; no new `polylogue/` module was added, so no topology-projection regeneration was required)

Ref polylogue-e98k