### PR TITLE
fix(sources): acquire Antigravity's real .pb conversations in the live daemon

### DIFF
--- a/docs/plans/layering-surface-baseline.json
+++ b/docs/plans/layering-surface-baseline.json
@@ -646,6 +646,41 @@
   },
   {
     "target": "polylogue/daemon",
+    "file": "polylogue/daemon/antigravity_conversation_acquisition.py",
+    "import": "polylogue.pipeline.services.archive_ingest"
+  },
+  {
+    "target": "polylogue/daemon",
+    "file": "polylogue/daemon/antigravity_conversation_acquisition.py",
+    "import": "polylogue.sources.live.sqlite_locking"
+  },
+  {
+    "target": "polylogue/daemon",
+    "file": "polylogue/daemon/antigravity_conversation_acquisition.py",
+    "import": "polylogue.sources.source_parsing"
+  },
+  {
+    "target": "polylogue/daemon",
+    "file": "polylogue/daemon/antigravity_conversation_acquisition.py",
+    "import": "polylogue.storage.blob_publication"
+  },
+  {
+    "target": "polylogue/daemon",
+    "file": "polylogue/daemon/antigravity_conversation_acquisition.py",
+    "import": "polylogue.storage.sqlite.archive_tiers.archive"
+  },
+  {
+    "target": "polylogue/daemon",
+    "file": "polylogue/daemon/antigravity_conversation_acquisition.py",
+    "import": "polylogue.storage.sqlite.archive_tiers.source_write"
+  },
+  {
+    "target": "polylogue/daemon",
+    "file": "polylogue/daemon/antigravity_conversation_acquisition.py",
+    "import": "polylogue.storage.sqlite.connection_profile"
+  },
+  {
+    "target": "polylogue/daemon",
     "file": "polylogue/daemon/backup.py",
     "import": "polylogue.storage.backup_attestation"
   },

--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -1536,6 +1536,10 @@ files:
     loc: 19
     target: polylogue/daemon/__init__.py
     owner: stable
+  - path: polylogue/daemon/antigravity_conversation_acquisition.py
+    loc: 183
+    target: polylogue/daemon/antigravity_conversation_acquisition.py
+    owner: stable
   - path: polylogue/daemon/api_auth.py
     loc: 172
     target: polylogue/daemon/api_auth.py
@@ -1565,7 +1569,7 @@ files:
     target: polylogue/daemon/catchup_status.py
     owner: stable
   - path: polylogue/daemon/cli.py
-    loc: 3114
+    loc: 3118
     target: polylogue/daemon/cli.py
     owner: stable
   - path: polylogue/daemon/compare.py
@@ -2536,7 +2540,7 @@ files:
     target: polylogue/pipeline/services/acquisition_streams.py
     owner: stable
   - path: polylogue/pipeline/services/archive_ingest.py
-    loc: 456
+    loc: 468
     target: polylogue/pipeline/services/archive_ingest.py
     owner: stable
   - path: polylogue/pipeline/services/indexing.py
@@ -3449,7 +3453,7 @@ files:
     target: polylogue/sources/origin_specs.py
     owner: stable
   - path: polylogue/sources/parsers/antigravity.py
-    loc: 518
+    loc: 529
     target: polylogue/sources/parsers/antigravity.py
     owner: stable
   - path: polylogue/sources/parsers/base.py
@@ -3642,7 +3646,7 @@ files:
     target: polylogue/sources/source_acquisition_components.py
     owner: stable
   - path: polylogue/sources/source_parsing.py
-    loc: 432
+    loc: 440
     target: polylogue/sources/source_parsing.py
     owner: stable
   - path: polylogue/sources/source_walk.py

--- a/polylogue/daemon/antigravity_conversation_acquisition.py
+++ b/polylogue/daemon/antigravity_conversation_acquisition.py
@@ -1,0 +1,183 @@
+"""Periodic daemon acquisition of Antigravity's real ``.pb`` conversations.
+
+The live daemon's file-watcher model (``sources/live/watcher.py``) only
+observes ``*.metadata.json`` sidecar changes for the ``antigravity`` source
+(``WatchSource(name="antigravity", ..., suffixes=(".metadata.json",))``) --
+the real ``conversations/*.pb`` trajectory files are structurally invisible
+to it (no suffix match), and even if they were watched, the watcher's
+per-file streaming-JSON model has no hook to drive the local Antigravity
+language-server subprocess the ``.pb`` -> markdown conversion requires.
+
+The batch importer (``pipeline/services/archive_ingest.py``) already has
+real acquisition code for this
+(``sources/parsers/antigravity.py::iter_language_server_exports``, wired via
+PR #3441 / polylogue-eo81), but the live daemon never calls it: only a
+one-shot ``polylogue import`` run does. Result (polylogue-3m3de, verified
+live 2026-08-03): the archive kept admitting metadata-only fragment sessions
+forever (116 -> 232 rows and still growing after #3441 merged) while the 44
+real conversations (314MB of ``.pb`` trajectories) sat permanently
+un-acquired by the running daemon.
+
+This module closes that gap with a bounded, quiet-cadence reconciliation
+loop -- the same shape as ``embedding_backlog.py``'s periodic drains -- that
+finds cascades not yet represented in ``raw_sessions`` and acquires only
+those, instead of re-running the language-server conversion for the whole
+corpus on every tick.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+from polylogue.config import Source
+from polylogue.core.enums import Origin
+from polylogue.logging import get_logger
+from polylogue.sources.live.sqlite_locking import is_transient_sqlite_lock
+
+logger = get_logger(__name__)
+
+#: Reconciliation cadence. Antigravity conversation growth happens at human
+#: pace (a chat session ends, a ``.pb`` file is written), not a hot ingest
+#: source, so a long interval keeps the periodic subprocess-driven export
+#: cheap in aggregate.
+ANTIGRAVITY_ACQUISITION_INTERVAL_SECONDS = 1800
+
+#: Bound the number of cascades converted per tick so one reconciliation
+#: pass never issues an unbounded number of language-server RPCs (each
+#: starts/queries a local HTTP loopback subprocess) in a single call.
+ANTIGRAVITY_ACQUISITION_MAX_PER_TICK = 25
+
+
+async def periodic_antigravity_conversation_acquisition_check(
+    *,
+    catch_up_complete: asyncio.Event | None = None,
+) -> None:
+    """Periodically acquire not-yet-acquired Antigravity ``.pb`` conversations."""
+    from polylogue.daemon.cli import _await_catch_up_gate
+    from polylogue.paths import archive_root
+
+    root = archive_root()
+    await _await_catch_up_gate(catch_up_complete, loop_name="antigravity conversation acquisition")
+    while True:
+        await asyncio.sleep(ANTIGRAVITY_ACQUISITION_INTERVAL_SECONDS)
+        try:
+            from polylogue.daemon.write_coordinator import daemon_write_coordinator
+
+            acquired = await daemon_write_coordinator().run_sync(
+                "maintenance.antigravity_conversation_acquisition",
+                acquire_antigravity_conversations_once,
+                root,
+            )
+            if acquired:
+                logger.info(
+                    "antigravity: acquired %d real conversation(s) from conversations/*.pb",
+                    acquired,
+                )
+        except sqlite3.OperationalError as exc:
+            if is_transient_sqlite_lock(exc):
+                logger.info(
+                    "antigravity: archive busy; retrying conversation acquisition on next tick: %s",
+                    exc,
+                )
+                continue
+            logger.warning("antigravity: conversation acquisition check failed", exc_info=True)
+        except Exception:
+            logger.warning("antigravity: conversation acquisition check failed", exc_info=True)
+
+
+def _acquired_pb_cascade_ids(source_db: Path) -> frozenset[str]:
+    """Return cascade ids already present in ``raw_sessions`` for antigravity ``.pb`` sources."""
+    if not source_db.exists():
+        return frozenset()
+    from polylogue.storage.sqlite.connection_profile import open_readonly_connection
+
+    conn = open_readonly_connection(source_db)
+    try:
+        rows = conn.execute(
+            "SELECT source_path FROM raw_sessions WHERE origin = ? AND source_path LIKE ?",
+            (Origin.ANTIGRAVITY_SESSION.value, "%.pb"),
+        ).fetchall()
+    finally:
+        conn.close()
+    return frozenset(Path(row[0]).stem for row in rows)
+
+
+def acquire_antigravity_conversations_once(archive_root: Path) -> int:
+    """Acquire one bounded batch of not-yet-acquired ``.pb`` conversations.
+
+    Returns the number of conversations newly written to ``raw_sessions``/
+    ``index.db``. A ``0`` return is the common steady-state case (nothing
+    new since the last tick, or Antigravity/its language server not present
+    on this host), not a failure.
+    """
+    from polylogue.paths import antigravity_path
+    from polylogue.pipeline.services.archive_ingest import (
+        _archive_raw_payload,
+        _archive_raw_source_index,
+        _archive_raw_source_path,
+    )
+    from polylogue.sources.source_parsing import iter_antigravity_language_server_sessions
+    from polylogue.storage.blob_publication import ArchiveBlobPublisher
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+    from polylogue.storage.sqlite.archive_tiers.source_write import ContentExcisedError
+
+    root = antigravity_path()
+    conversations_dir = root / "conversations"
+    if not conversations_dir.is_dir():
+        return 0
+    all_ids = frozenset(path.stem for path in conversations_dir.glob("*.pb"))
+    if not all_ids:
+        return 0
+
+    acquired_ids = _acquired_pb_cascade_ids(archive_root / "source.db")
+    missing_ids = sorted(all_ids - acquired_ids)
+    if not missing_ids:
+        return 0
+    batch_ids = frozenset(missing_ids[:ANTIGRAVITY_ACQUISITION_MAX_PER_TICK])
+
+    source = Source(name="antigravity", path=root)
+    blob_root = archive_root / "blob"
+    blob_publisher = ArchiveBlobPublisher(archive_root / "source.db", blob_root)
+    acquired_at_ms = int(datetime.now(UTC).timestamp() * 1000)
+
+    admitted = 0
+    with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+        for raw_data, session in iter_antigravity_language_server_sessions(
+            source,
+            capture_raw=True,
+            blob_root=blob_root,
+            blob_store=blob_publisher,
+            only_cascade_ids=batch_ids,
+        ):
+            payload = _archive_raw_payload(raw_data, session, blob_root=blob_root)
+            source_path = _archive_raw_source_path(raw_data, source)
+            source_index = _archive_raw_source_index(raw_data)
+            try:
+                archive.write_raw_and_parsed_result(
+                    session,
+                    payload=payload,
+                    source_path=source_path,
+                    acquired_at_ms=acquired_at_ms,
+                    source_index=source_index,
+                    blob_publication_receipt_id=(
+                        raw_data.blob_publication_receipt_id if raw_data is not None else None
+                    ),
+                )
+                admitted += 1
+            except ContentExcisedError as exc:
+                # The archive can forget on purpose (polylogue-27m): skip
+                # only this one cascade and continue the batch.
+                logger.info("antigravity: skipping durably excised conversation: %s", exc)
+                continue
+    return admitted
+
+
+__all__ = [
+    "ANTIGRAVITY_ACQUISITION_INTERVAL_SECONDS",
+    "ANTIGRAVITY_ACQUISITION_MAX_PER_TICK",
+    "acquire_antigravity_conversations_once",
+    "periodic_antigravity_conversation_acquisition_check",
+]

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -2346,6 +2346,9 @@ async def run_daemon_services(
         # both write-heavy; running them concurrently makes SQLite maintenance
         # time out behind the daemon's own writer.
         if not watcher_blocked:
+            from polylogue.daemon.antigravity_conversation_acquisition import (
+                periodic_antigravity_conversation_acquisition_check,
+            )
             from polylogue.daemon.blob_gc_periodic import periodic_blob_gc_check
             from polylogue.daemon.convergence import DaemonConverger
             from polylogue.daemon.convergence_stages import make_default_convergence_stages
@@ -2396,6 +2399,7 @@ async def run_daemon_services(
                 periodic_fts_orphan_audit(catch_up_complete=catch_up_complete_gate),
                 periodic_blob_gc_check(catch_up_complete=catch_up_complete_gate),
                 periodic_secret_scan_sweep(catch_up_complete=catch_up_complete_gate),
+                periodic_antigravity_conversation_acquisition_check(catch_up_complete=catch_up_complete_gate),
             ]
             if enable_source_catchup:
                 periodic_loops.append(_periodic_drive_source_catchup(catch_up_complete=catch_up_complete_gate))

--- a/polylogue/pipeline/services/archive_ingest.py
+++ b/polylogue/pipeline/services/archive_ingest.py
@@ -259,8 +259,20 @@ async def parse_sources_archive(
         else:
             # Antigravity language-server export stays sequential (it drives a
             # local loopback subprocess); only the file-walk parallelizes.
+            # `capture_raw=True` is required here (polylogue-3m3de): without
+            # it every exported session's `raw_data` is `None`, so
+            # `_archive_raw_payload`/`_archive_raw_source_path` fall back to
+            # a JSON dump of the parsed session and the shared source root
+            # path -- collapsing every conversation's raw provenance onto one
+            # non-unique source_path instead of its actual `.pb` file and
+            # real bytes.
             for source in sources:
-                for raw_data, session in iter_antigravity_language_server_sessions(source):
+                for raw_data, session in iter_antigravity_language_server_sessions(
+                    source,
+                    capture_raw=True,
+                    blob_root=blob_root,
+                    blob_store=parse_blob_publisher,
+                ):
                     await write_pair(source, raw_data, session)
 
             failed = 0

--- a/polylogue/sources/parsers/antigravity.py
+++ b/polylogue/sources/parsers/antigravity.py
@@ -310,8 +310,9 @@ def iter_language_server_exports(
     root: Path,
     *,
     client: AntigravityLanguageServerClient | None = None,
+    only_cascade_ids: frozenset[str] | None = None,
 ) -> Iterable[ParsedSession]:
-    """Export every real conversation trajectory under ``conversations/``.
+    """Export real conversation trajectories under ``conversations/``.
 
     Ground truth for *which* cascades exist is the ``conversations/*.pb``
     file listing, not ``SearchConversations`` -- the search/list RPCs only
@@ -322,6 +323,14 @@ def iter_language_server_exports(
     whether the language server's live index currently tracks it
     (polylogue-eo81). Search results are still consulted to enrich title /
     workspace / snippet metadata for the cascades that *are* indexed.
+
+    ``only_cascade_ids``, when given, restricts export to that subset of
+    cascade ids (matched against each ``.pb`` file's stem). Used by the
+    daemon's periodic reconciliation loop (``polylogue-3m3de``) to convert
+    only cascades not yet acquired into ``raw_sessions``, instead of paying
+    the language-server subprocess + markdown-conversion cost for the whole
+    corpus on every tick. ``None`` (the default) exports every cascade,
+    preserving the original behavior for the one-shot batch importer.
     """
     owned_client = client is None
     runtime_client = client or AntigravityLanguageServerClient(root)
@@ -329,6 +338,8 @@ def iter_language_server_exports(
         runtime_client.start()
     try:
         pb_paths = _conversation_pb_paths(root)
+        if only_cascade_ids is not None:
+            pb_paths = [pb_path for pb_path in pb_paths if pb_path.stem in only_cascade_ids]
         if not pb_paths:
             return
         try:

--- a/polylogue/sources/source_parsing.py
+++ b/polylogue/sources/source_parsing.py
@@ -38,6 +38,7 @@ def iter_antigravity_language_server_sessions(
     capture_raw: bool = False,
     blob_root: Path | None = None,
     blob_store: BlobStore | None = None,
+    only_cascade_ids: frozenset[str] | None = None,
 ) -> Iterable[tuple[RawSessionData | None, ParsedSession]]:
     """Yield Antigravity language-server export sessions for a source.
 
@@ -54,6 +55,11 @@ def iter_antigravity_language_server_sessions(
     ``hermes_state``'s sqlite snapshot pattern above), so ``source.db`` holds
     real acquired bytes with a stable content hash for idempotent re-ingest,
     not just an ephemeral export that re-runs unconditionally every pass.
+
+    ``only_cascade_ids``, when given, restricts export to that subset of
+    cascade ids (see ``antigravity.iter_language_server_exports``) instead of
+    the whole ``conversations/`` corpus -- used by the daemon's periodic
+    reconciliation loop to convert only not-yet-acquired cascades.
 
     Falls back to walking ``brain/**/*.md.metadata.json`` directly
     (``_iter_antigravity_brain_metadata_fallback``) only when there is
@@ -76,7 +82,7 @@ def iter_antigravity_language_server_sessions(
 
     if conversations_dir.is_dir():
         try:
-            for session in antigravity.iter_language_server_exports(source.path):
+            for session in antigravity.iter_language_server_exports(source.path, only_cascade_ids=only_cascade_ids):
                 exported_any = True
                 raw_data = _antigravity_raw_snapshot(
                     source.path,

--- a/tests/unit/daemon/test_antigravity_conversation_acquisition.py
+++ b/tests/unit/daemon/test_antigravity_conversation_acquisition.py
@@ -1,0 +1,151 @@
+"""Periodic Antigravity ``.pb`` conversation acquisition (polylogue-3m3de).
+
+Exercises ``acquire_antigravity_conversations_once`` -- the bounded sync body
+the periodic daemon loop (``periodic_antigravity_conversation_acquisition_check``)
+schedules on a quiet cadence -- against a real archive fixture with a fake
+language-server client, proving:
+
+1. Real ``conversations/*.pb`` cascades get acquired into ``raw_sessions``
+   with their own ``.pb`` source_path (not the metadata-sidecar fragments
+   the live watcher was stuck admitting forever).
+2. Re-running is a no-op once every cascade is acquired (content-hash /
+   already-acquired dedup, not a re-conversion on every tick).
+3. The per-tick batch is bounded so one reconciliation pass never converts
+   an unbounded number of cascades.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from polylogue.daemon.antigravity_conversation_acquisition import (
+    ANTIGRAVITY_ACQUISITION_MAX_PER_TICK,
+    acquire_antigravity_conversations_once,
+)
+from polylogue.sources.parsers.antigravity import AntigravitySessionSummary
+
+
+class _FakeLanguageServerClient:
+    """Drop-in fake of AntigravityLanguageServerClient for driver tests."""
+
+    def __init__(self, markdown_by_cascade: dict[str, str]) -> None:
+        self._markdown = markdown_by_cascade
+        self.started = False
+        self.closed = False
+        self.exported_cascade_ids: list[str] = []
+
+    def start(self) -> None:
+        self.started = True
+
+    def close(self) -> None:
+        self.closed = True
+
+    def search_sessions(self, *, limit: int = 10000, query: str = "") -> list[AntigravitySessionSummary]:
+        return []
+
+    def export_markdown(self, cascade_id: str) -> str:
+        self.exported_cascade_ids.append(cascade_id)
+        return self._markdown[cascade_id]
+
+
+def _touch_conversation_pb(antigravity_root: Path, *cascade_ids: str) -> None:
+    conversations = antigravity_root / "conversations"
+    conversations.mkdir(parents=True, exist_ok=True)
+    for cascade_id in cascade_ids:
+        (conversations / f"{cascade_id}.pb").write_bytes(b"fake-protobuf-bytes-" + cascade_id.encode())
+
+
+def _raw_source_paths(source_db: Path) -> list[str]:
+    import sqlite3
+
+    conn = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
+    try:
+        rows = conn.execute("SELECT source_path FROM raw_sessions WHERE origin = 'antigravity-session'").fetchall()
+    finally:
+        conn.close()
+    return [row[0] for row in rows]
+
+
+@pytest.fixture
+def _fake_client(monkeypatch: pytest.MonkeyPatch) -> _FakeLanguageServerClient:
+    fake = _FakeLanguageServerClient(
+        {f"cascade-{i}": f"### User Input\n\nhello {i}\n" for i in range(ANTIGRAVITY_ACQUISITION_MAX_PER_TICK + 5)}
+    )
+    monkeypatch.setattr(
+        "polylogue.sources.parsers.antigravity.AntigravityLanguageServerClient",
+        lambda root: fake,
+    )
+    return fake
+
+
+def test_no_conversations_dir_is_a_bounded_noop(
+    tmp_path: Path, workspace_env: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    antigravity_root = tmp_path / "antigravity-empty"
+    monkeypatch.setattr("polylogue.paths.antigravity_path", lambda: antigravity_root)
+
+    acquired = acquire_antigravity_conversations_once(workspace_env["archive_root"])
+
+    assert acquired == 0
+
+
+def test_acquires_real_pb_conversations_not_yet_in_raw_sessions(
+    tmp_path: Path,
+    workspace_env: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    _fake_client: _FakeLanguageServerClient,
+) -> None:
+    antigravity_root = tmp_path / "antigravity"
+    _touch_conversation_pb(antigravity_root, "cascade-0", "cascade-1")
+    monkeypatch.setattr("polylogue.paths.antigravity_path", lambda: antigravity_root)
+
+    archive_root = workspace_env["archive_root"]
+    acquired = acquire_antigravity_conversations_once(archive_root)
+
+    assert acquired == 2
+    source_paths = _raw_source_paths(archive_root / "source.db")
+    assert sorted(source_paths) == sorted(str(antigravity_root / "conversations" / f"cascade-{i}.pb") for i in range(2))
+
+
+def test_rerun_after_full_acquisition_is_a_noop(
+    tmp_path: Path,
+    workspace_env: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    _fake_client: _FakeLanguageServerClient,
+) -> None:
+    antigravity_root = tmp_path / "antigravity"
+    _touch_conversation_pb(antigravity_root, "cascade-0", "cascade-1")
+    monkeypatch.setattr("polylogue.paths.antigravity_path", lambda: antigravity_root)
+
+    archive_root = workspace_env["archive_root"]
+    first = acquire_antigravity_conversations_once(archive_root)
+    assert first == 2
+
+    _fake_client.exported_cascade_ids.clear()
+    second = acquire_antigravity_conversations_once(archive_root)
+
+    assert second == 0
+    # No language-server RPC at all for the already-acquired cascades.
+    assert _fake_client.exported_cascade_ids == []
+
+
+def test_batch_is_bounded_per_tick(
+    tmp_path: Path,
+    workspace_env: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    _fake_client: _FakeLanguageServerClient,
+) -> None:
+    antigravity_root = tmp_path / "antigravity"
+    cascade_ids = [f"cascade-{i}" for i in range(ANTIGRAVITY_ACQUISITION_MAX_PER_TICK + 5)]
+    _touch_conversation_pb(antigravity_root, *cascade_ids)
+    monkeypatch.setattr("polylogue.paths.antigravity_path", lambda: antigravity_root)
+
+    archive_root = workspace_env["archive_root"]
+    acquired = acquire_antigravity_conversations_once(archive_root)
+
+    assert acquired == ANTIGRAVITY_ACQUISITION_MAX_PER_TICK
+    # A second tick picks up the remainder.
+    remaining = acquire_antigravity_conversations_once(archive_root)
+    assert remaining == 5

--- a/tests/unit/sources/test_antigravity_language_server.py
+++ b/tests/unit/sources/test_antigravity_language_server.py
@@ -332,6 +332,55 @@ def test_iter_language_server_exports_yields_parsed_sessions(
     assert fake.closed is False
 
 
+def test_iter_language_server_exports_only_cascade_ids_filters_corpus(
+    tmp_path: Path,
+) -> None:
+    """polylogue-3m3de: the daemon's periodic reconciler restricts export to
+    not-yet-acquired cascades so it never re-converts the whole corpus."""
+    _touch_conversation_pb(tmp_path, "cascade-1", "cascade-2", "cascade-3")
+    summaries = [
+        AntigravitySessionSummary(cascade_id="cascade-1", title="One"),
+        AntigravitySessionSummary(cascade_id="cascade-2", title="Two"),
+        AntigravitySessionSummary(cascade_id="cascade-3", title="Three"),
+    ]
+    markdown = {
+        "cascade-1": "### User Input\n\na\n",
+        "cascade-2": "### User Input\n\nb\n",
+        "cascade-3": "### User Input\n\nc\n",
+    }
+    fake = _FakeClientForExports(summaries, markdown)
+
+    sessions = list(
+        iter_language_server_exports(
+            tmp_path,
+            client=fake,  # type: ignore[arg-type]
+            only_cascade_ids=frozenset({"cascade-2"}),
+        )
+    )
+
+    assert [c.provider_session_id for c in sessions] == ["cascade-2"]
+
+
+def test_iter_language_server_exports_only_cascade_ids_empty_set_is_noop(
+    tmp_path: Path,
+) -> None:
+    _touch_conversation_pb(tmp_path, "cascade-1")
+    fake = _FakeClientForExports(
+        [AntigravitySessionSummary(cascade_id="cascade-1")],
+        {"cascade-1": "### User Input\n\na\n"},
+    )
+
+    sessions = list(
+        iter_language_server_exports(
+            tmp_path,
+            client=fake,  # type: ignore[arg-type]
+            only_cascade_ids=frozenset(),
+        )
+    )
+
+    assert sessions == []
+
+
 def test_iter_language_server_exports_manages_owned_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _touch_conversation_pb(tmp_path, "cascade-1")
     summaries = [


### PR DESCRIPTION
## Summary

The live daemon never acquired Antigravity's real conversation trajectories (`conversations/*.pb`) despite PR #3441 fixing the batch-importer's directory-gate bug. This closes the daemon-side acquisition gap with a new periodic reconciliation loop, plus two related bugs found while tracing the root cause.

## Problem

Verified live 2026-08-03 (polylogue-3m3de): `raw_sessions` origin='antigravity-session' held 232 rows (grown from 116 before PR #3441 merged three days earlier), every one a `brain/*.md.metadata.json` sidecar fragment, and zero rows for `conversations/*.pb` -- the 44 real conversations (314MB) sitting permanently un-acquired by the running daemon.

Root cause traced to `sources/live/watcher.py`: the live daemon's only acquisition model for local sources is the `WatchSource` file-watcher, and for antigravity it only matches `*.metadata.json` (`WatchSource(name="antigravity", root=antigravity_path(), suffixes=(".metadata.json",))`). `.pb` files are structurally invisible to it, and even if watched, the watcher's per-file streaming-JSON model has no hook to drive the local Antigravity language-server subprocess the `.pb` -> markdown conversion requires. #3441's fix only reached the batch importer (`pipeline/services/archive_ingest.py`), which the running daemon never calls -- only a one-shot `polylogue import` does. So the watcher kept admitting metadata-only fragments forever while the real conversations sat permanently un-acquired.

Reproduced directly: running `antigravity.iter_language_server_exports` against the real `~/.gemini/antigravity` archive (44 real `.pb` files, 314MB) works correctly and yields real conversation content -- the acquisition *code* is sound, it is simply never invoked by the live daemon.

Two more bugs surfaced while tracing this:
1. `pipeline/services/archive_ingest.py`'s multi-worker parse branch called `iter_antigravity_language_server_sessions(source)` without `capture_raw=True` (unlike the sequential branch), so every exported session's `raw_data` was `None` and raw provenance collapsed onto one non-unique source_path instead of each conversation's actual `.pb` file/bytes.
2. No way to export a bounded subset of cascades -- `iter_language_server_exports` always converted the whole corpus, which would make a periodic reconciliation loop re-run the language-server subprocess for already-acquired conversations on every tick.

## Solution

- `sources/parsers/antigravity.py`: added `only_cascade_ids` filter to `iter_language_server_exports`, threaded through `source_parsing.iter_antigravity_language_server_sessions`. `None` (default) preserves existing behavior.
- `pipeline/services/archive_ingest.py`: fixed the parallel-path `capture_raw` omission.
- New `polylogue/daemon/antigravity_conversation_acquisition.py`: `periodic_antigravity_conversation_acquisition_check`, following the existing periodic-daemon-check shape (`embedding_backlog.py`, `blob_gc_periodic.py`). Runs on a 30-minute cadence via `daemon_write_coordinator`, diffs `conversations/*.pb` cascade ids against `raw_sessions` to find not-yet-acquired ones, and converts only those (bounded to 25/tick) via the new `only_cascade_ids` filter. Wired into `daemon/cli.py`'s `periodic_loops`.
- `docs/plans/layering-surface-baseline.json`: added 7 entries for the new daemon module's direct substrate imports, matching the existing pattern for sibling periodic-check modules (`embedding_backlog.py`, `blob_gc_periodic.py`, `secret_scan_sweep.py` are baselined the same way -- there is no existing product-layer seam for "acquire raw provider bytes" and every sibling periodic check takes the same direct-substrate path).
- `docs/plans/topology-target.yaml` regenerated for the new module.

**Not in scope / deferred:** actually re-triggering full acquisition against the live production archive (this PR ships the mechanism; the daemon will pick up the 44 real conversations on its next reconciliation tick after deploy). Did not add a `.pb` suffix to the `WatchSource` itself -- the per-file streaming-JSON watcher model cannot drive a subprocess conversion, so a dedicated periodic loop is the correct shape, not a watcher suffix change.

## Verification

- `devtools test tests/unit/sources/test_antigravity_language_server.py` -- 21 passed (includes 2 new tests for `only_cascade_ids`)
- `devtools test tests/unit/pipeline/test_archive_ingest_shared_raw.py tests/unit/pipeline/test_archive_ingest_commit_batching.py tests/unit/sources/parsers/test_antigravity.py` -- 21 passed
- `devtools test tests/unit/daemon/test_antigravity_conversation_acquisition.py` -- 4 passed (new file: acquisition, idempotent re-run, bounded batching)
- `devtools verify --quick` -- `exit_code: 0` (format/lint/mypy/render-all/layering all ok)

Ref polylogue-3m3de