### PR TITLE
fix: give Drive re-acquisition real revision lineage

### DIFF
--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, cast
 
 from polylogue.archive.ingest_flags import DOM_FALLBACK_INGEST_FLAG, NATIVE_BROWSER_CAPTURE_FLAGS
+from polylogue.archive.revision_authority import RawRevisionAuthority, RawRevisionEnvelope, RawRevisionKind
 from polylogue.archive.write_gateway import ArchiveWriteGateway, WriteOperation
 from polylogue.core.enums import BlockType, Provider
 from polylogue.core.memory import release_process_memory
@@ -65,6 +66,12 @@ from polylogue.storage.sqlite.archive_tiers.ingest_precedence import (
     should_skip_stale_replace,
     stored_message_count,
 )
+from polylogue.storage.sqlite.archive_tiers.revision_governance import (
+    bind_raw_revision,
+    classify_raw_revision_cohort,
+    raw_membership_raw_ids,
+)
+from polylogue.storage.sqlite.archive_tiers.source_write import ArchiveSourceBlobRef
 from polylogue.storage.sqlite.archive_tiers.write import (
     _timestamp_ms,
     replace_parser_ingest_flag_tags,
@@ -513,6 +520,150 @@ def _preacquire_sidecar_blobs(
     return session_to_write.model_copy(update={"session_events": updated_events}), counts
 
 
+class _DriveRevisionGovernanceAdapter:
+    """Minimal ``RawRevisionGovernanceHost`` for Drive lineage bookkeeping.
+
+    ``bind_raw_revision``/``classify_raw_revision_cohort`` and their
+    transitive call graph (``raw_membership_raw_ids``,
+    ``_raw_revision_candidates``, ``_promote_contiguous_append_evidence``,
+    ``raw_membership_retired_full_revision_siblings``,
+    ``_raw_revision_source_path_has_divergent_evidence``) touch only
+    ``store._ensure_source_conn()`` and, inside
+    ``classify_raw_revision_cohort`` itself, ``store._blob_publisher``
+    (verified by reading every line of that call graph, polylogue-sp72).
+    Nothing in it touches ``_conn`` (index.db), ``_pending_raw_parse_states``,
+    ``_preacquire_attachment_blobs``, ``_write_counts``, or
+    ``_skipped_counts`` -- those Protocol members exist only because
+    ``ArchiveStore`` (the Protocol's only other implementer) happens to
+    carry them. This adapter implements them as typed stubs that raise if
+    ever actually invoked, rather than reaching into ``ArchiveStore``'s
+    ~9,000-line read surface just to satisfy an unused Protocol member.
+    ``_conn`` is declared a plain settable attribute (not a read-only
+    property) because the Protocol types it that way -- it is set to the
+    same ``source_conn`` handle as a harmless placeholder that is never
+    actually read by anything this adapter is used for.
+    """
+
+    def __init__(self, source_conn: sqlite3.Connection, blob_publisher: ArchiveBlobPublisher | None) -> None:
+        self._source_conn = source_conn
+        self._blob_publisher = blob_publisher
+        # Never read by bind_raw_revision/classify_raw_revision_cohort; see
+        # class docstring for why this is a harmless placeholder value.
+        self._conn = source_conn
+        self._pending_raw_parse_states: list[tuple[str, RawSessionStateUpdate]] = []
+
+    def _ensure_source_conn(self) -> sqlite3.Connection:
+        return self._source_conn
+
+    def commit(self) -> None:
+        raise NotImplementedError("ingest_batch owns the index.db commit; this adapter never manages it")
+
+    def _preacquire_attachment_blobs(
+        self,
+        session: ParsedSession,
+        *,
+        source_path: str,
+        acquired_at_ms: int,
+    ) -> tuple[dict[int, tuple[bytes | None, int, str]], tuple[ArchiveSourceBlobRef, ...]]:
+        raise NotImplementedError(
+            "_DriveRevisionGovernanceAdapter is used only for bind_raw_revision/"
+            "classify_raw_revision_cohort, which never call this"
+        )
+
+    @staticmethod
+    def _write_counts(session: ParsedSession) -> dict[str, int]:
+        raise NotImplementedError(
+            "_DriveRevisionGovernanceAdapter is used only for bind_raw_revision/"
+            "classify_raw_revision_cohort, which never call this"
+        )
+
+    @staticmethod
+    def _skipped_counts(session: ParsedSession, *, session_events: int = 0) -> dict[str, int]:
+        raise NotImplementedError(
+            "_DriveRevisionGovernanceAdapter is used only for bind_raw_revision/"
+            "classify_raw_revision_cohort, which never call this"
+        )
+
+
+def _bind_drive_revision_lineage(
+    session_to_write: ParsedSession,
+    *,
+    raw_id: str | None,
+    source_conn: sqlite3.Connection | None,
+    blob_publisher: ArchiveBlobPublisher | None,
+) -> None:
+    """Best-effort revision-lineage bookkeeping for Drive re-acquisitions.
+
+    polylogue-sp72: ``iter_drive_raw_data`` backfills live-fetched
+    attachment bytes into cached Drive JSON on every ingest pass, minting a
+    brand-new ``raw_id`` for the SAME logical session whenever the bytes
+    change. This module's generic write path (``_write_session``, used by
+    every non-tailed-watcher provider) only ever compares content-hash and
+    freshness timestamps -- it never computes ``logical_source_key`` or
+    calls the revision-governance cohort classifier the way the governed
+    "live" batch path does for tailed origins (``sources/live/batch.py``,
+    ``sources/live/append_ingest.py``). Confirmed live: every one of 157
+    duplicate ``aistudio-drive`` raw pairs carries ``revision_kind='unknown'``,
+    ``logical_source_key=NULL``, ``revision_authority='quarantined'`` -- no
+    predecessor/baseline linkage at all.
+
+    This mirrors ``live/batch.py``'s post-parse ``logical_source_key``
+    computation and its ``bind_raw_revision``/``classify_raw_revision_cohort``
+    call for a single-session raw with no pre-existing membership census,
+    including its guard against double-governing an identity already owned
+    by membership-census governance (``raw_membership_raw_ids``). Unlike
+    ``live/batch.py``, this call is called unconditionally for every Drive
+    raw that reaches ``_write_session`` -- including ones ``_write_session``
+    ultimately skips as stale/duplicate -- so lineage metadata (and any
+    future arbitration/rebuild consumer reading it, e.g. polylogue-x1gd) is
+    recorded for every acquisition, not only the one that happened to win
+    ``_write_session``'s own freshness/content-hash comparison. It never
+    replays/applies the classifier's winning revision plan itself: that
+    comparison, plus the #3453 attachment-coverage tie-break, still solely
+    decides what actually lands in ``sessions`` from this call site. This
+    function is non-fatal best-effort bookkeeping -- any failure (including
+    ``classify_raw_revision_cohort`` requiring a writable blob publisher) is
+    logged and swallowed, never allowed to break the session write itself.
+
+    Every real config and test fixture configures Drive acquisition as
+    ``Source(name="gemini", folder=...)``, and ``iter_drive_raw_data`` sets
+    ``provider_hint = Provider.from_string(source.name)`` -- so a parsed
+    Drive session's ``source_name`` is ``Provider.GEMINI``, not
+    ``Provider.DRIVE`` (both map to the same ``Origin.AISTUDIO_DRIVE``, see
+    ``core/sources.py``). Gate on the value actually observed on the wire.
+    """
+    if source_conn is None or blob_publisher is None:
+        return
+    if not raw_id:
+        return
+    if session_to_write.source_name is not Provider.GEMINI:
+        return
+    logical_source_key = f"{session_to_write.source_name.value}:{session_to_write.provider_session_id}"
+    adapter = _DriveRevisionGovernanceAdapter(source_conn, blob_publisher)
+    try:
+        if raw_membership_raw_ids(adapter, logical_source_key):
+            return
+        bind_raw_revision(
+            adapter,
+            raw_id,
+            RawRevisionEnvelope(
+                logical_source_key=logical_source_key,
+                kind=RawRevisionKind.FULL,
+                source_revision=raw_id,
+                acquisition_generation=0,
+                authority=RawRevisionAuthority.QUARANTINED,
+            ),
+        )
+        classify_raw_revision_cohort(adapter, logical_source_key)
+    except Exception:
+        logger.warning(
+            "drive_revision_lineage_bind_failed",
+            raw_id=raw_id,
+            logical_source_key=logical_source_key,
+            exc_info=True,
+        )
+
+
 def _write_session(
     conn: sqlite3.Connection,
     payload: SessionWritePayload,
@@ -554,6 +705,13 @@ def _write_session(
     session_to_write = payload.parsed_session
     merge_append = False
     browser_precedence: BrowserCapturePrecedence = "default"
+
+    _bind_drive_revision_lineage(
+        session_to_write,
+        raw_id=payload.raw_id,
+        source_conn=source_conn,
+        blob_publisher=blob_publisher,
+    )
 
     if revision_authority_refuses_write(
         conn,

--- a/tests/unit/pipeline/test_ingest_batch.py
+++ b/tests/unit/pipeline/test_ingest_batch.py
@@ -67,6 +67,7 @@ from polylogue.storage.raw.models import RawSessionStateUpdate
 from polylogue.storage.runtime import RawSessionRecord
 from polylogue.storage.search.cache import get_cache_stats
 from polylogue.storage.search.runtime import search_messages
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
 from polylogue.storage.sqlite.archive_tiers.write import _attachment_id
 from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
@@ -1062,6 +1063,120 @@ def test_write_session_freshness_tie_allows_attachment_improvement(tmp_path: Pat
             ("aistudio-drive:improve",),
         ).fetchone()
         assert row["raw_id"] == "raw-fetched"
+
+
+def test_write_session_binds_drive_revision_lineage(tmp_path: Path) -> None:
+    """polylogue-sp72: a Drive re-acquisition must get real revision lineage.
+
+    ``iter_drive_raw_data`` backfills live-fetched attachment bytes into
+    cached Drive JSON on every ingest pass; whenever the bytes change, it
+    mints a brand-new ``raw_id`` for the SAME logical session. Before this
+    fix, ``_write_session`` (this module's generic, non-drive-aware write
+    path) never computed ``logical_source_key`` or called the revision
+    governance cohort classifier for that second raw -- confirmed live: all
+    157 duplicate ``aistudio-drive`` raw pairs carried
+    ``revision_kind='unknown'``, ``logical_source_key=NULL``,
+    ``revision_authority='quarantined'``, with no predecessor/baseline
+    linkage at all (see PR #3453's docstring on
+    ``_incoming_write_regresses_attachment_coverage``, the narrow tie-break
+    that papered over exactly this gap without fixing it).
+
+    This asserts the SECOND raw's ``raw_sessions`` row now carries a real
+    ``logical_source_key``, a ``predecessor_raw_id`` pointing at the first
+    raw, and a non-``quarantined`` ``revision_authority`` -- i.e. that the
+    real byte-prefix arbitration classifier actually ran, not just that
+    some metadata got stamped. This must fail against the pre-fix
+    ``_write_session`` (verified by temporarily reverting the production
+    change and re-running: both raws come back with
+    ``logical_source_key IS NULL``).
+    """
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+    source_db_path = archive_root / "source.db"
+    blob_publisher = ArchiveBlobPublisher(source_db_path, archive_root / "blob")
+
+    provider_session_id = "drive-lineage-tie"
+    session_id = f"aistudio-drive:{provider_session_id}"
+    # The second raw's bytes are a strict superset (prefix growth) of the
+    # first's, mirroring a real Drive attachment backfill appending newly
+    # fetched bytes into the cached JSON -- this is what lets the byte-prefix
+    # classifier prove a real predecessor/baseline relation instead of
+    # quarantining both raws as an unrelated/ambiguous pair.
+    first_payload = b'{"drive":"payload","messages":[{"id":"m-1","text":"hi"}]}'
+    second_payload = first_payload + b"  // backfilled attachment bytes appended"
+
+    with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+        first_raw_id = archive.write_raw_payload(
+            provider=Provider.GEMINI,
+            payload=first_payload,
+            source_path="drive://file-1",
+            acquired_at_ms=1_767_000_000_000,
+        )
+        second_raw_id = archive.write_raw_payload(
+            provider=Provider.GEMINI,
+            payload=second_payload,
+            source_path="drive://file-1",
+            acquired_at_ms=1_767_000_000_500,
+        )
+    assert first_raw_id != second_raw_id
+
+    message = _message_tuple(
+        "m-1",
+        session_id,
+        role="user",
+        text="hi",
+        content_hash="msg-hash-drive-lineage",
+        sort_key=1777636800.0,
+    )
+
+    with (
+        open_connection(archive_root / "index.db") as conn,
+        sqlite3.connect(str(source_db_path)) as source_conn,
+    ):
+        first_session = _session_data(
+            session_id,
+            content_hash="hash-drive-lineage-first",
+            raw_id=first_raw_id,
+            message_tuples=[message],
+            provider=Provider.GEMINI,
+            created_at="2026-07-18T17:46:10Z",
+            updated_at="2026-07-18T17:46:10Z",
+        )
+        changed_first, _ = _write_session(conn, first_session, blob_publisher=blob_publisher, source_conn=source_conn)
+        conn.commit()
+        assert changed_first is True
+
+        second_session = _session_data(
+            session_id,
+            content_hash="hash-drive-lineage-second",
+            raw_id=second_raw_id,
+            message_tuples=[message],
+            attachment_tuples=[_attachment_tuple("att-1", inline_bytes=b"fetched drive attachment bytes")],
+            attachment_ref_tuples=[_attachment_ref_tuple("att-1", session_id, "m-1")],
+            provider=Provider.GEMINI,
+            created_at="2026-07-18T17:46:15Z",
+            updated_at="2026-07-18T17:46:15Z",
+        )
+        changed_second, _ = _write_session(conn, second_session, blob_publisher=blob_publisher, source_conn=source_conn)
+        conn.commit()
+        assert changed_second is True
+
+    with sqlite3.connect(str(source_db_path)) as verify_conn:
+        verify_conn.row_factory = sqlite3.Row
+        first_row = verify_conn.execute(
+            "SELECT logical_source_key, revision_authority FROM raw_sessions WHERE raw_id = ?",
+            (first_raw_id,),
+        ).fetchone()
+        second_row = verify_conn.execute(
+            "SELECT logical_source_key, predecessor_raw_id, revision_authority FROM raw_sessions WHERE raw_id = ?",
+            (second_raw_id,),
+        ).fetchone()
+
+    expected_logical_source_key = f"{Provider.GEMINI.value}:{provider_session_id}"
+    assert first_row["logical_source_key"] == expected_logical_source_key
+    assert second_row["logical_source_key"] == expected_logical_source_key
+    assert second_row["predecessor_raw_id"] == first_raw_id
+    assert second_row["revision_authority"] != "quarantined"
 
 
 def test_write_session_precomputed_blob_attachment_recorded_as_acquired(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Drive re-acquisition now gets real revision lineage (`logical_source_key` / `predecessor_raw_id` / a non-quarantined `revision_authority`) via the same byte-prefix revision-governance classifier the "live" tailed-watcher batch path already uses, instead of being invisible to it entirely.

## Problem

`iter_drive_raw_data` (`polylogue/sources/drive/__init__.py`) backfills live-fetched attachment bytes into cached Drive JSON on every ingest pass. When the bytes change, it mints a brand-new `raw_id` for the SAME logical session. That raw is written through `_write_session` (`polylogue/pipeline/services/ingest_batch/_core.py`), the generic ingest_batch write path used by every non-tailed-watcher provider, which only ever compares content-hash and freshness timestamps -- it never computes `logical_source_key` or calls the revision-governance cohort classifier the way the governed "live" batch path does for tailed origins (`sources/live/batch.py`, `sources/live/append_ingest.py`). Confirmed live: every one of 157 duplicate `aistudio-drive` raw pairs carried `revision_kind='unknown'`, `logical_source_key=NULL`, `revision_authority='quarantined'` -- no predecessor/baseline linkage at all. PR #3453 added a narrow tie-break in `_write_session` (`_incoming_write_regresses_attachment_coverage`) that stops a richer revision from being clobbered by a poorer one on a freshness tie, but its own docstring names this missing-lineage gap directly as the real, unaddressed cause.

## Solution

- Added `_bind_drive_revision_lineage` and a minimal `_DriveRevisionGovernanceAdapter` to `polylogue/pipeline/services/ingest_batch/_core.py`. The adapter satisfies `RawRevisionGovernanceHost` (`storage/sqlite/archive_tiers/revision_governance.py`) structurally -- every function in the `bind_raw_revision`/`classify_raw_revision_cohort` call graph only touches `_ensure_source_conn()` and (inside `classify_raw_revision_cohort`) `_blob_publisher`, so the adapter implements the rest of the Protocol (`_conn`, `commit`, `_preacquire_attachment_blobs`, `_write_counts`, `_skipped_counts`) as typed stubs/placeholders never actually exercised by this call path.
- `_bind_drive_revision_lineage` is called unconditionally at the top of `_write_session`, before any of its skip-path early returns -- mirroring `live/batch.py`'s own precedent of binding lineage before the write decision is made, so a raw `_write_session` ultimately skips as stale/duplicate still gets its lineage recorded (useful for future arbitration/rebuild consumers, e.g. polylogue-x1gd). It guards against double-governing an identity already owned by membership-census governance via `raw_membership_raw_ids`, same as `live/batch.py`.
- **Gate deviates from the bead's literal wording**: the bead/task brief named `Provider.DRIVE`, but every real config and test fixture configures Drive acquisition as `Source(name="gemini", folder=...)`, and `iter_drive_raw_data`'s `provider_hint = Provider.from_string(source.name)` means a parsed Drive session's `source_name` is actually `Provider.GEMINI` on the wire (both `Provider.GEMINI` and `Provider.DRIVE` map to the same `Origin.AISTUDIO_DRIVE`, see `core/sources.py`). Gated on the value actually observed, not the enum member whose name reads "Drive".
- Non-fatal, best-effort: any failure (including `classify_raw_revision_cohort` requiring a writable blob publisher) is logged (`drive_revision_lineage_bind_failed`) and swallowed, never breaking the session write.
- Does not replay/apply the classifier's winning revision plan -- `_write_session`'s own freshness/content-hash comparison, plus the #3453 attachment-coverage tie-break (left in place, unchanged), still solely decides what actually lands in `sessions` from this call site.

## Verification

- `devtools test tests/unit/pipeline/test_ingest_batch.py` -- 66 passed, including new `test_write_session_binds_drive_revision_lineage`. Confirmed red-first: temporarily reverted the production call and re-ran the new test -- it failed with `assert None == 'gemini:drive-lineage-tie'` (both raws' `logical_source_key` came back NULL). Re-applied the fix and reran green.
- `.venv/bin/mypy polylogue/pipeline/services/ingest_batch/_core.py` -- `Success: no issues found in 1 source file`.
- `devtools verify --quick` -- `exit_code: 0` (ruff format/check, mypy, render all --check, layering, closure-matrix, schema roundtrip, manifests, ci-workflows, doc-commands, docs-coverage, test-infra-currency, pytest-timeout-overrides, degrade-loudly, hash-boundary-census, schema-versioning, classifier-fingerprints, demo-tour-freshness, raw-payload-hash-purity, position-derived-identity, raw-authority-frontier-executability, schema-promotion-audit all `ok`).

## Scope notes / deferred

- `sources/drive/__init__.py` untouched -- the fix resolves entirely post-parse in the write path, matching `live/batch.py`'s own precedent; no acquire-side change was needed.
- No other provider is wired into this governance path in this PR -- out of scope per the bead.
- The #3453 `_incoming_write_regresses_attachment_coverage` tie-break is left in place unchanged, as a safety net for any `_write_session` call site without a `source_conn`/`blob_publisher` (e.g. tests, or a future caller).
- Cleanup of the 157 already-contaminated `raw_sessions` rows is explicitly out of scope -- retroactive durable-tier cleanup needs its own explicit-consent process per this repo's schema regime.

Ref polylogue-sp72