### PR TITLE
fix(daemon): surface detached-writer failures and closed-loop hangs

### DIFF
--- a/docs/plans/degrade-loudly-allowlist.yaml
+++ b/docs/plans/degrade-loudly-allowlist.yaml
@@ -289,14 +289,6 @@ entries:
   occurrence: 0
   reason: Captures refresh_error = str(exc) and passes it into _minimal_status_payload(refresh_error=...)
     -- a typed signal.
-- path: polylogue/daemon/write_coordinator.py
-  function: <module>._run_in_daemon_thread.worker
-  exceptions:
-  - BaseException
-  occurrence: 0
-  reason: Propagates the exception itself via loop.call_soon_threadsafe(publish, None, exc) to the awaiting
-    asyncio Future, which re-raises it to the caller -- the exception is not discarded, just marshalled
-    across the thread boundary.
 - path: polylogue/insights/audit.py
   function: <module>.build_insight_rigor_audit_report
   exceptions:

--- a/polylogue/daemon/metrics.py
+++ b/polylogue/daemon/metrics.py
@@ -41,6 +41,8 @@ varies on a known-bounded dimension):
   (polylogue-6rvt).
 - ``polylogue_status_snapshot_age_seconds`` (gauge) — cached status age
 - ``polylogue_status_snapshot_state`` (gauge) — labels: state
+- ``polylogue_detached_writer_failures_total`` (counter) — process-lifetime
+  count of detached background daemon-writer tasks that raised (polylogue-es7b)
 - ``polylogue_live_ingest_attempts_total`` (counter) — labels: status
 - ``polylogue_live_ingest_attempts_in_flight`` (gauge)
 - ``polylogue_live_ingest_storage_route_total`` (counter) — labels: route
@@ -1072,6 +1074,21 @@ def format_metrics(
         help_text="1 for the current daemon status snapshot freshness state.",
         metric_type="gauge",
         samples=[({"state": state}, 1 if state == snapshot_state else 0) for state in ("fresh", "stale", "missing")],
+    )
+
+    from polylogue.daemon.write_coordinator import daemon_write_telemetry_payload
+
+    write_telemetry = daemon_write_telemetry_payload()
+    detached_writer_failures = write_telemetry.get("detached_writer_failures", 0)
+    _emit_metric(
+        lines,
+        name="polylogue_detached_writer_failures_total",
+        help_text=(
+            "Total detached background daemon-writer tasks that raised an exception "
+            "since process start (polylogue-es7b)."
+        ),
+        metric_type="counter",
+        samples=[(None, int(detached_writer_failures) if isinstance(detached_writer_failures, (int, float)) else 0)],
     )
 
     if not db.exists():

--- a/polylogue/daemon/write_coordinator.py
+++ b/polylogue/daemon/write_coordinator.py
@@ -137,6 +137,10 @@ class DaemonWriteSnapshot:
     queued_actors: tuple[str, ...]
     last_event: DaemonWriteEvent | None
     accepting: bool = True
+    # polylogue-es7b: daemon-lifetime count of detached background-writer
+    # tasks that raised -- previously surfaced only via a log line, with no
+    # counter across the daemon's lifetime.
+    detached_writer_failures: int = 0
 
 
 @dataclass(slots=True)
@@ -159,6 +163,7 @@ _LATEST_TELEMETRY: dict[str, object] = {
     "queue_depth": 0,
     "accepting": True,
     "last_event": None,
+    "detached_writer_failures": 0,
 }
 
 
@@ -193,6 +198,7 @@ class DaemonWriteCoordinator:
         self._executions: set[asyncio.Task[object]] = set()
         self._idle = asyncio.Event()
         self._idle.set()
+        self._detached_writer_failures = 0
         self._publish_telemetry()
 
     def snapshot(self) -> DaemonWriteSnapshot:
@@ -201,6 +207,7 @@ class DaemonWriteCoordinator:
             queued_actors=tuple(actor for _sequence, actor in self._queued),
             last_event=self._last_event,
             accepting=self._accepting,
+            detached_writer_failures=self._detached_writer_failures,
         )
 
     async def run(self, actor: str, operation: Callable[[], Awaitable[T]]) -> T:
@@ -355,9 +362,18 @@ class DaemonWriteCoordinator:
             try:
                 exception = done.exception()
             except Exception:
+                # polylogue-es7b: a detached writer's own exception-retrieval
+                # failed (e.g. the task itself never actually completed
+                # cleanly) -- still count it as a lost forensic detail so the
+                # daemon-lifetime counter reflects every such event, not only
+                # the ordinary "task.exception() returned non-None" path.
+                self._detached_writer_failures += 1
+                self._publish_telemetry()
                 logger.warning("detached daemon writer failed", exc_info=True)
             else:
                 if exception is not None:
+                    self._detached_writer_failures += 1
+                    self._publish_telemetry()
                     logger.warning("detached daemon writer failed: %s", exception)
 
         task.add_done_callback(completed)
@@ -385,6 +401,7 @@ class DaemonWriteCoordinator:
             "queue_depth": len(snapshot.queued_actors),
             "accepting": snapshot.accepting,
             "last_event": None,
+            "detached_writer_failures": snapshot.detached_writer_failures,
         }
         if event is not None:
             payload["last_event"] = {
@@ -425,11 +442,37 @@ async def _run_in_daemon_thread(
         try:
             value = context.run(function, *args, **kwargs)
         except BaseException as exc:
-            with contextlib.suppress(RuntimeError):
+            try:
                 loop.call_soon_threadsafe(publish, None, exc)
+            except RuntimeError:
+                # polylogue-es7b: the event loop is already closed, so the
+                # ``result`` future left above is never resolved from here.
+                # This does not itself weaken anything -- a closed loop
+                # genuinely cannot be scheduled on -- but it was previously
+                # silent, indistinguishable from the worker simply never
+                # finishing. Callers that need a hard bound against this
+                # already have one: ``DaemonWriteThreadBridge`` awaits a
+                # ``concurrent.futures.Future`` with its own timeout, which
+                # is independent of whether this loop is still running.
+                # Direct ``coordinator.run_sync`` callers on the coordinator's
+                # own loop are not protected by that bridge; if this warning
+                # ever fires for one of those, it is real evidence a hang
+                # occurred and should be traced to its call site.
+                logger.warning(
+                    "daemon writer thread %s finished with an exception after its event "
+                    "loop already closed; the awaiting result future was left unresolved",
+                    thread_name,
+                    exc_info=exc,
+                )
         else:
-            with contextlib.suppress(RuntimeError):
+            try:
                 loop.call_soon_threadsafe(publish, value, None)
+            except RuntimeError:
+                logger.warning(
+                    "daemon writer thread %s finished after its event loop already closed; "
+                    "the awaiting result future was left unresolved",
+                    thread_name,
+                )
 
     threading.Thread(target=worker, name=thread_name, daemon=True).start()
     return await result

--- a/polylogue/schemas/sampling_db.py
+++ b/polylogue/schemas/sampling_db.py
@@ -273,6 +273,16 @@ def _iter_schema_units_from_db(
     source_name = Provider.from_string(source_name)
     source_db_path = db_path.parent / "source.db"
     if not source_db_path.exists():
+        # polylogue-es7b: a missing sibling tier file yields the same empty
+        # generator as "genuinely zero matching rows for this provider" --
+        # log so callers/operators can tell the two apart instead of silently
+        # reading zero schema units as a clean, exhaustive result.
+        logger.warning(
+            "schema sampling found no source.db tier file at %s; yielding zero schema units for %s "
+            "(this is a missing tier file, not a genuine zero-row result)",
+            source_db_path,
+            source_name,
+        )
         return
     blob_store = get_blob_store()
     query_provider = config.db_source_name or source_name

--- a/tests/unit/core/test_sampling.py
+++ b/tests/unit/core/test_sampling.py
@@ -7,6 +7,7 @@ and load_samples_from_sessions with JSON/JSONL fixtures.
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
@@ -197,6 +198,31 @@ class TestLoadSamplesFromDb:
         db = _archive_index_db(tmp_path)
         result = load_samples_from_db("chatgpt", db_path=db)
         assert result == []
+
+    def test_missing_source_db_tier_logs_warning_distinct_from_zero_rows(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """polylogue-es7b: a missing sibling ``source.db`` tier file previously
+        yielded the exact same empty result as a genuine zero-row scan,
+        silently. ``index.db`` exists here (unlike ``test_nonexistent_db_returns_empty``,
+        whose outer ``db_path.exists()`` check in ``load_samples_from_db``
+        short-circuits before ever reaching ``_iter_schema_units_from_db``),
+        so this reaches the tier-file check inside
+        ``polylogue.schemas.sampling_db._iter_schema_units_from_db`` and must
+        warn instead of returning silently.
+        """
+        db = _archive_index_db(tmp_path)
+        (db.parent / "source.db").unlink()
+        assert db.exists()
+        assert not (db.parent / "source.db").exists()
+
+        with caplog.at_level(logging.WARNING, logger="polylogue.schemas.sampling_db"):
+            result = load_samples_from_db("chatgpt", db_path=db)
+
+        assert result == []
+        assert any("source.db" in record.message and record.levelno == logging.WARNING for record in caplog.records), [
+            record.message for record in caplog.records
+        ]
 
     def test_nonexistent_db_with_default_path(self) -> None:
         # When db_path=None and default doesn't exist, should return []

--- a/tests/unit/daemon/test_write_coordinator.py
+++ b/tests/unit/daemon/test_write_coordinator.py
@@ -438,12 +438,16 @@ def test_stuck_sync_writer_cannot_pin_process_exit() -> None:
         """
     )
 
+    # polylogue-es7b: bumped from 5.0s -- this module's cold-import cost alone
+    # can run several seconds under concurrent xdist workers (each spawning
+    # its own subprocess simultaneously), which made this timeout marginal
+    # once a third subprocess-spawning test landed in this file.
     completed = subprocess.run(
         [sys.executable, "-c", script],
         cwd=Path(__file__).parents[3],
         capture_output=True,
         text=True,
-        timeout=5.0,
+        timeout=20.0,
         check=False,
     )
 
@@ -489,12 +493,16 @@ def test_real_startup_writer_routes_cannot_pin_process_exit(helper_name: str, wr
         """
     )
 
+    # polylogue-es7b: bumped from 5.0s -- this module's cold-import cost alone
+    # can run several seconds under concurrent xdist workers (each spawning
+    # its own subprocess simultaneously), which made this timeout marginal
+    # once a third subprocess-spawning test landed in this file.
     completed = subprocess.run(
         [sys.executable, "-c", script],
         cwd=Path(__file__).parents[3],
         capture_output=True,
         text=True,
-        timeout=5.0,
+        timeout=20.0,
         check=False,
     )
 
@@ -530,6 +538,114 @@ async def test_operational_telemetry_reports_actor_queue_wait_and_hold() -> None
     assert event["actor"] == "watcher"
     assert isinstance(event["wait_seconds"], float)
     assert isinstance(event["hold_seconds"], float)
+
+
+@pytest.mark.asyncio
+async def test_detached_writer_failure_increments_lifetime_counter() -> None:
+    """polylogue-es7b: a failed writer task's exception previously surfaced only via a log line.
+
+    ``completed()`` (the task's done-callback) must also increment a durable
+    daemon-lifetime counter so the failure is observable through the
+    coordinator's telemetry snapshot/payload, not only in logs.
+    """
+    coordinator = DaemonWriteCoordinator()
+    assert coordinator.snapshot().detached_writer_failures == 0
+
+    async def boom() -> None:
+        raise RuntimeError("writer blew up")
+
+    with pytest.raises(RuntimeError, match="writer blew up"):
+        await coordinator.run("actor", boom)
+
+    # The done-callback that increments the counter is scheduled via
+    # call_soon alongside the outer await's own resumption; give the loop one
+    # more tick so ordering between the two doesn't make this test flaky.
+    for _ in range(10):
+        if coordinator.snapshot().detached_writer_failures:
+            break
+        await asyncio.sleep(0)
+
+    assert coordinator.snapshot().detached_writer_failures == 1
+    payload = daemon_write_telemetry_payload()
+    assert payload["detached_writer_failures"] == 1
+
+    # A second failure keeps accumulating -- this is a lifetime counter, not
+    # a one-shot flag.
+    with pytest.raises(RuntimeError, match="writer blew up"):
+        await coordinator.run("actor", boom)
+    for _ in range(10):
+        if coordinator.snapshot().detached_writer_failures == 2:
+            break
+        await asyncio.sleep(0)
+    assert coordinator.snapshot().detached_writer_failures == 2
+
+
+def test_run_in_daemon_thread_logs_instead_of_hanging_when_loop_already_closed() -> None:
+    """polylogue-es7b: a worker thread finishing after its loop closed must not hang silently.
+
+    ``_run_in_daemon_thread`` spawns a plain (uncancellable) ``threading.Thread``.
+    If the coordinator's event loop closes before that thread finishes --
+    the real shape of the hazard is a stuck sync writer that outlives a
+    process shutdown that gave up waiting on it (see
+    ``test_stuck_sync_writer_cannot_pin_process_exit`` above) -- the worker's
+    final ``loop.call_soon_threadsafe`` raises ``RuntimeError`` because the
+    loop is closed. Previously this was silently swallowed, leaving the
+    original awaiting future unresolved with zero forensic trace. The fix
+    logs a warning instead of swallowing it silently; run in a subprocess
+    because it requires actually closing a real event loop out from under a
+    still-running background thread.
+    """
+    script = textwrap.dedent(
+        """
+        import asyncio
+        import logging
+        import sys
+        import threading
+
+        from polylogue.daemon.write_coordinator import DaemonWriteCoordinator
+
+        logging.basicConfig(level=logging.WARNING, stream=sys.stderr)
+
+        finish = threading.Event()
+
+        async def main() -> None:
+            coordinator = DaemonWriteCoordinator()
+            started = threading.Event()
+
+            def writer() -> None:
+                started.set()
+                finish.wait()
+                raise RuntimeError("late failure after loop closed")
+
+            asyncio.create_task(coordinator.run_sync("late", writer))
+            while not started.is_set():
+                await asyncio.sleep(0.001)
+            # Return now: asyncio.run() cancels outstanding tasks and closes
+            # the loop while ``writer`` is still blocked in its background
+            # thread -- the real-world shape of the hazard.
+
+        asyncio.run(main())
+        # The loop asyncio.run() owned is now closed. Release the writer
+        # thread so it raises and tries to publish onto the closed loop.
+        finish.set()
+        threading.Event().wait(0.5)
+        """
+    )
+
+    # A generous timeout: importing ``polylogue.daemon.write_coordinator`` in
+    # a cold subprocess dominates this test's wall time far more than the
+    # writer/loop-close dance itself does.
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).parents[3],
+        capture_output=True,
+        text=True,
+        timeout=20.0,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "event loop already closed" in completed.stderr, completed.stderr
 
 
 def test_thread_bridge_serializes_sync_request_bodies_without_overlap() -> None:


### PR DESCRIPTION
## Summary

Closes three of four silent-degradation findings from a 2026-07-31 audit (polylogue-es7b): a detached daemon-writer task's failure was previously observable only via a log line with no daemon-lifetime counter; a worker thread that finished after its event loop had already closed silently swallowed the resulting RuntimeError, leaving the awaiting future unresolved with zero trace; and schema sampling silently returned zero schema units when a sibling `source.db` tier file was simply missing, indistinguishable from a genuine zero-row result.

## Problem

The fourth finding in the bead ((a), `storage/embeddings/materialization.py`'s embedding-failure origin lookup) was already fixed on `master` before this branch was cut -- it carries a `polylogue-es7b` marker and always calls `record_embedding_failure` with a fallback `origin=str(Origin.UNKNOWN_EXPORT)` sentinel. That file is untouched here.

The remaining three:

- `polylogue/daemon/write_coordinator.py`'s `_track_execution`'s `completed()` done-callback logged a detached writer's exception but never counted it anywhere durable, so an operator had no way to see how many had occurred over the daemon's lifetime.
- `_run_in_daemon_thread`'s `worker()` wrapped `loop.call_soon_threadsafe(...)` in a bare `contextlib.suppress(RuntimeError)`. When the loop is already closed (the real-world shape: a stuck/uncooperative sync writer that a bounded `shutdown()` deliberately leaves held, per the existing `test_stuck_sync_writer_cannot_pin_process_exit` test), this silently discarded the failure with the awaiting `result` future left forever unresolved.
- `polylogue/schemas/sampling_db.py`'s `_iter_schema_units_from_db` returned an empty generator identically whether the sibling `source.db` tier file was missing or genuinely had zero matching rows.

## Solution

- Added `DaemonWriteSnapshot.detached_writer_failures`, incremented in `completed()` and threaded through `_publish_telemetry()` / `daemon_write_telemetry_payload()` (already consumed by `status_snapshot.py`'s live status payload, so this reaches a real, already-wired observability surface) plus a new `polylogue_detached_writer_failures_total` Prometheus counter in `daemon/metrics.py`.
- `worker()`'s two `call_soon_threadsafe` call sites now use explicit `try`/`except RuntimeError` and log a warning naming the thread instead of silently discarding. This does not change the underlying behavior (a closed loop genuinely cannot be scheduled on) -- `DaemonWriteThreadBridge` callers already have a real bound via `concurrent.futures.Future.result(timeout=...)`, independent of loop state; direct `coordinator.run_sync` callers on the coordinator's own loop are not, so the new warning is the actionable signal for those.
- `_iter_schema_units_from_db` now logs a warning naming the missing path and provider before returning, so operators/callers can tell a missing tier file apart from an exhaustive zero-row scan.
- Removed a `docs/plans/degrade-loudly-allowlist.yaml` entry for `_run_in_daemon_thread.worker` that `devtools verify degrade-loudly` flagged as stale: the entry excused a silent broad-except shape that no longer exists now that the handler logs.

## Verification

- `devtools test tests/unit/daemon/test_write_coordinator.py` -- 21 passed (run twice for stability).
- `devtools test tests/unit/core/test_sampling.py` -- 43 passed, 1 pre-existing unrelated failure (`test_schema_observation_records_included_and_decode_failed_raws`, confirmed failing identically via `git stash` i.e. without this diff -- `assert 100 == 1` in code this change does not touch).
- `devtools verify --quick` -- full pass (format + lint + mypy + render-all-check + layering + degrade-loudly + schema/policy lints), including on the pre-push hook's own re-run.

Ref polylogue-es7b