### PR TITLE
fix(devtools): give synthetic codex raw payloads real message text

### DIFF
--- a/devtools/raw_authority_scale_proof.py
+++ b/devtools/raw_authority_scale_proof.py
@@ -243,13 +243,35 @@ class RawAuthorityScaleScenario:
         )
 
 
+def _payload_header(native_id: str, revision: int, *, first: bool) -> bytes:
+    """Build the leading JSONL record(s) for one raw payload write.
+
+    polylogue-h7y0j: the first write for a logical source (``first=True``,
+    i.e. ``previous is None``) used to emit only a ``session_meta`` record
+    with no message at all, so ``require_positive_conversational_evidence``
+    (``sources/dispatch.py``) refused every such session outright once PR
+    #3497 started requiring at least one message with real authored text.
+    Every generated raw payload -- first write or chained revision -- must
+    carry a message with non-empty text, mirroring the real Codex JSONL
+    shape. This is the single place that constructs the header so
+    ``_row_sizes``' minimum-row-bytes accounting cannot drift out of sync
+    with what actually gets written.
+    """
+    message_line = (
+        f'{{"type":"response_item","payload":{{"type":"message","id":"{native_id}-{revision}","role":"user",'
+        f'"content":[{{"type":"input_text","text":"revision-{revision}"}}]}}}}\n'
+    )
+    if first:
+        return (
+            f'{{"type":"session_meta","payload":{{"id":"{native_id}","timestamp":"2026-07-15T00:00:00Z"}}}}\n'
+            + message_line
+        ).encode()
+    return message_line.encode()
+
+
 def _write_payload(path: Path, *, native_id: str, revision: int, target_size: int, previous: Path | None) -> int:
     """Stream a valid JSONL raw and return its truthful serialized byte size."""
-    header = (
-        f'{{"type":"session_meta","payload":{{"id":"{native_id}","timestamp":"2026-07-15T00:00:00Z"}}}}\n'
-        if previous is None
-        else f'{{"type":"response_item","payload":{{"type":"message","id":"{native_id}-{revision}","role":"user","content":[{{"type":"input_text","text":"revision-{revision}"}}]}}}}\n'
-    ).encode()
+    header = _payload_header(native_id, revision, first=previous is None)
     previous_size = previous.stat().st_size if previous is not None else 0
     serialized_size = max(target_size, previous_size + len(header))
     with path.open("wb") as destination:
@@ -333,16 +355,32 @@ def _row_sizes(
 
     Captured byte buckets are observations, and valid tiny blobs can be below
     one JSONL record.  The synthetic corpus records those buckets verbatim but
-    expands its on-disk rows to the smallest valid evidence document.  It must
-    never pretend that a 64-byte captured bucket was replayed as a 64-byte
-    JSONL blob.
+    expands its on-disk rows to the smallest valid evidence document -- the
+    real ``_payload_header`` bytes for that row's native id/revision (not a
+    guessed constant), so this floor can never undershoot what
+    ``_write_payload`` actually has to write (polylogue-h7y0j: an undershoot
+    here silently inflated the generated corpus past the requested
+    ``total_payload_bytes``).
+
+    Non-independent (chained) rows physically copy the previous row's whole
+    blob before appending their own new header (``_write_payload``'s
+    ``previous`` chaining), so row R's floor must be at least the previous
+    row's floor plus its own new header bytes -- a running cumulative sum,
+    not each row's header length in isolation.
     """
-    minimum_rows = [
-        [256 * (revision + 1) for revision in range(count)]
-        if not _uses_independent_component_members(scenario)
-        else [1] * count
-        for count in component_counts
-    ]
+    independent_members = _uses_independent_component_members(scenario)
+    minimum_rows: list[list[int]] = []
+    for component, count in enumerate(component_counts):
+        session_native_id = f"scale-authority-component-{component:05d}"
+        rows: list[int] = []
+        cumulative = 0
+        for revision in range(count):
+            if independent_members:
+                cumulative = len(_payload_header(f"{session_native_id}-member-{revision:05d}", revision, first=True))
+            else:
+                cumulative += len(_payload_header(session_native_id, revision, first=revision == 0))
+            rows.append(cumulative)
+        minimum_rows.append(rows)
     minimum_component_bytes = [sum(rows) for rows in minimum_rows]
     if component_byte_upper_bounds is None:
         target_component_bytes = list(minimum_component_bytes)


### PR DESCRIPTION
## Summary
Fixes the raw-authority-scale-proof synthetic Codex corpus generator so every generated raw payload carries at least one message with real text, and re-derives its minimum-row-bytes accounting from the real header size instead of a guessed constant.

## Problem
`devtools/raw_authority_scale_proof.py`'s synthetic codex-session generator wrote the first revision of each logical source as a JSONL payload containing only a `session_meta` record with no message at all. PR #3497 made `require_positive_conversational_evidence` (`sources/dispatch.py`) refuse any session whose sole message carries no real text, and by extension refuse a session that has no message at all. Every generated raw session was refused outright ("no messages, no positive conversational evidence"), which broke 5 tests in `tests/unit/devtools/test_raw_authority_scale_proof.py` and made `tests/integration/test_raw_authority_daemon_health_proof.py::test_real_daemon_drains_backlog_while_staying_probeable` hang for the full 120s timeout, since the synthetic backlog it drives a real daemon against could never actually drain (every candidate refused, forever).

Reproduced independently of `polylogue-k2grh`'s `test_raw_authority_ledger.py` fix (stashed that fix out, identical failure), confirming this is a distinct instance of the same PR #3497 fallout class, as `polylogue-h7y0j` describes.

## Solution
- Extracted a shared `_payload_header(native_id, revision, *, first)` helper used by both `_write_payload` (the actual JSONL writer) and `_row_sizes` (the byte-budget planner), so the two can never drift out of sync again. The `first=True` (i.e. `previous is None`) header now always includes a `response_item` message with non-empty text alongside `session_meta`.
- `_row_sizes`'s per-row minimum-byte floor is now the real cumulative header length for that row (each chained/non-independent revision physically copies the previous row's blob before appending its own new header, so its floor must be the previous row's floor plus its own header, not each row's header length in isolation) instead of the old `256 * (revision + 1)` guessed constant. That constant happened to be generous enough for the old (smaller) header, but undershot the new header size for small scenarios, which silently inflated the generated corpus past the requested `total_payload_bytes` (`SUM(blob_size)` from a manual repro measured 8465 vs. a requested 8192 before this fix, exactly right after fixing it).

## Verification
- `devtools test tests/unit/devtools/test_raw_authority_scale_proof.py` — 21 passed (previously 5 failed with `polylogue-9ykn: refusing session ... no messages, no positive conversational evidence`).
- `tests/integration/test_raw_authority_daemon_health_proof.py::test_real_daemon_drains_backlog_while_staying_probeable`: with the fix, the synthetic backlog now actually drains (no more refusal warnings in the daemon log, confirmed by grep) instead of hanging for the full 120s timeout as it does on unfixed `origin/master` (reproduced: unfixed run hit `Failed: Timeout (>120.0s) from pytest-timeout`). The test still fails on this host, but on a different, later assertion (`/api/status was unresponsive for ~20-29s, exceeding the documented 5.00s bound`) — this looks like host-load-driven flakiness rather than a regression from this change: the failure duration varies run to run (20.21s, then 29.29s on a second attempt), the daemon log shows no error for `/api/status` at all (just heavy background-thread activity), and this host is currently under substantial contention from concurrent agent worktrees (`uptime` load average ~28 on 24 cores, ~15 GiB swapped at the time of testing). Recommend re-verifying this specific integration test on a quieter host/CI; not something a fixture-text fix should paper over by loosening the responsiveness bound.
- `ruff check` / `ruff format --check` / `mypy --strict` clean on the touched file.
- `devtools verify --quick` — exit 0.

Ref polylogue-h7y0j