### PR TITLE
feat(sources): ingest ChatGPT shared-page decode + Claude AI attachment recovery sidecar

### DIFF
--- a/docs/plans/classifier-fingerprints.json
+++ b/docs/plans/classifier-fingerprints.json
@@ -184,6 +184,14 @@
         "ref": "polylogue-gucv"
       }
     },
+    "polylogue/sources/parsers/chatgpt.py:looks_like_shared_decode": {
+      "fingerprint": "37a68475cdef7916bf2c2552676bb7267f7aa429fc0be78c02690fbfb7ea161e",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "New provider-shape detector for the ChatGPT shared-page stream-decode format (polylogue-4zqh3): flat messages list, no mapping key.",
+        "ref": "polylogue-4zqh3"
+      }
+    },
     "polylogue/sources/parsers/chatgpt_codex_sidecar.py:looks_like": {
       "fingerprint": "273bc13adae90435566dc75ef802a83beae650e03894a2146e44e897394dc8d9",
       "covered_by": {

--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -3261,12 +3261,16 @@ files:
     target: polylogue/sources/__init__.py
     owner: stable
   - path: polylogue/sources/assembly.py
-    loc: 130
+    loc: 142
     target: polylogue/sources/assembly.py
     owner: stable
   - path: polylogue/sources/assembly_chatgpt.py
     loc: 380
     target: polylogue/sources/assembly_chatgpt.py
+    owner: stable
+  - path: polylogue/sources/assembly_claude_ai.py
+    loc: 161
+    target: polylogue/sources/assembly_claude_ai.py
     owner: stable
   - path: polylogue/sources/assembly_claude_code.py
     loc: 210
@@ -3301,7 +3305,7 @@ files:
     target: polylogue/sources/decoders.py
     owner: stable
   - path: polylogue/sources/dispatch.py
-    loc: 1789
+    loc: 1796
     target: polylogue/sources/dispatch.py
     owner: stable
   - path: polylogue/sources/drive/__init__.py
@@ -3474,7 +3478,7 @@ files:
     target: polylogue/sources/parsers/browser_capture.py
     owner: stable
   - path: polylogue/sources/parsers/chatgpt.py
-    loc: 1329
+    loc: 1421
     target: polylogue/sources/parsers/chatgpt.py
     owner: stable
   - path: polylogue/sources/parsers/chatgpt_codex_sidecar.py

--- a/polylogue/sources/assembly.py
+++ b/polylogue/sources/assembly.py
@@ -39,6 +39,13 @@ class _CodexSidecarData(TypedDict, total=False):
     state_titles: CodexHistoryTitles
 
 
+class _ClaudeAISidecarData(TypedDict, total=False):
+    # bd polylogue-4zqh3: attachment native id -> (blob_hash_hex, size_bytes)
+    # for sole-copy attachment bytes recovered out of band and streamed into
+    # the blob store during sidecar discovery. See assembly_claude_ai.py.
+    claude_ai_recovered_blobs: dict[str, tuple[str, int]]
+
+
 class _ChatGPTSidecarData(TypedDict, total=False):
     # bd polylogue-0hwv / polylogue-dt5s: the merged asset-name/sandbox-file
     # resolver built once per source scan from conversation_asset_file_names.json
@@ -52,7 +59,7 @@ class _ChatGPTSidecarData(TypedDict, total=False):
     chatgpt_dat_blobs: dict[str, tuple[str, int]]
 
 
-class SidecarData(_ClaudeCodeSidecarData, _CodexSidecarData, _ChatGPTSidecarData, total=False):
+class SidecarData(_ClaudeCodeSidecarData, _CodexSidecarData, _ChatGPTSidecarData, _ClaudeAISidecarData, total=False):
     pass
 
 
@@ -112,6 +119,10 @@ def get_assembly_spec(provider: Provider) -> ProviderAssemblySpec | None:
         from .assembly_chatgpt import ChatGPTAssemblySpec
 
         return ChatGPTAssemblySpec()
+    if provider is Provider.CLAUDE_AI:
+        from .assembly_claude_ai import ClaudeAIAssemblySpec
+
+        return ClaudeAIAssemblySpec()
     return None
 
 
@@ -123,6 +134,7 @@ __all__ = [
     "ProviderAssemblySpec",
     "SidecarData",
     "_ChatGPTSidecarData",
+    "_ClaudeAISidecarData",
     "_CodexSidecarData",
     "_ClaudeCodeSidecarData",
     "TitleResolution",

--- a/polylogue/sources/assembly_claude_ai.py
+++ b/polylogue/sources/assembly_claude_ai.py
@@ -1,0 +1,163 @@
+"""Claude AI provider assembly — sole-copy attachment recovery sidecar.
+
+bd polylogue-4zqh3: a Claude.ai browser-captured session can carry attachment
+references whose bytes were never fetched at capture time (upload-only
+metadata, no ``extracted_content``) and are permanently gone from claude.ai
+itself once the message/attachment scrolls out of the API's retention
+window. When those bytes are later recovered out of band -- a Borg backup,
+an adjacent knowledge-base file, a manually-preserved copy -- the durable,
+reindex-safe way to bind them back to the archived session is the same
+provider-assembly extension point ``assembly_chatgpt.py`` uses for ``.dat``
+asset bytes: resolve them at *parse time*, from evidence sitting next to the
+source being (re-)ingested, not by patching ``index.db`` directly (a derived
+tier a later full reindex would silently discard).
+
+This spec looks for a small, purpose-built sidecar file named
+``attachment-recovery.json`` next to (or in a same-or-parent directory of)
+each ``source_paths`` entry:
+
+    {"attachments": [{"native_id": "<attachment provider id>",
+                       "path": "<file path, relative to the manifest>"}]}
+
+``native_id`` must equal ``ParsedAttachment.provider_attachment_id`` (the
+bare id Claude.ai assigns the attachment -- see
+``base_support.attachment_from_meta``). For each entry whose file exists,
+``discover_sidecars`` streams it into the blob store (when one is given) and
+records ``(sha256_hex, byte_count)`` keyed by ``native_id``; ``enrich_session``
+joins that back onto matching attachments as ``precomputed_blob``, exactly
+the field ``ingest_batch/_core.py``'s ``preacquired_attachment_blobs`` loop
+already knows how to record as ``acquired`` without re-hashing.
+
+This does not run automatically against already-ingested sessions -- it
+fires when the source carrying the manifest is (re-)walked, e.g. a one-off
+``polylogue import`` pointed at a recovery-packet directory that places
+both the manifest and the recovered files next to the original captured
+document. See polylogue-4zqh3's bead notes for the concrete recovery-packet
+path and the one attachment currently known to have a confirmed native-id
+match (a corpus-wide reindex is the trigger this exists to survive).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from polylogue.core.enums import Provider
+from polylogue.logging import get_logger
+from polylogue.storage.blob_store import BlobStore
+
+from .assembly import SidecarData
+from .parsers.base import ParsedAttachment, ParsedSession
+
+logger = get_logger(__name__)
+
+_MANIFEST_NAME = "attachment-recovery.json"
+
+
+def _read_manifest(path: Path) -> object | None:
+    try:
+        with path.open("rb") as handle:
+            data: object = json.load(handle)
+            return data
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("claude_ai_attachment_recovery_manifest_read_failed", path=str(path), error=str(exc))
+        return None
+
+
+def _acquire_recovered_blobs(
+    manifest_dir: Path, payload: object, store: BlobStore | None
+) -> dict[str, tuple[str, int]]:
+    acquired: dict[str, tuple[str, int]] = {}
+    if not isinstance(payload, dict):
+        return acquired
+    entries = payload.get("attachments")
+    if not isinstance(entries, list):
+        return acquired
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        native_id = entry.get("native_id")
+        rel_path = entry.get("path")
+        if not isinstance(native_id, str) or not native_id or not isinstance(rel_path, str) or not rel_path:
+            continue
+        file_path = (manifest_dir / rel_path).resolve()
+        if not file_path.is_file():
+            logger.warning(
+                "claude_ai_attachment_recovery_file_missing",
+                native_id=native_id,
+                path=str(file_path),
+            )
+            continue
+        if store is None:
+            continue
+        try:
+            blob_hash, size = store.write_from_path(file_path)
+        except OSError as exc:
+            logger.warning(
+                "claude_ai_attachment_recovery_write_failed",
+                native_id=native_id,
+                path=str(file_path),
+                error=str(exc),
+            )
+            continue
+        acquired[native_id] = (blob_hash, size)
+    return acquired
+
+
+class ClaudeAIAssemblySpec:
+    """Claude AI provider assembly — sole-copy attachment recovery sidecar."""
+
+    def discover_sidecars(
+        self,
+        source_paths: list[Path],
+        *,
+        blob_store: BlobStore | None = None,
+    ) -> SidecarData:
+        recovered: dict[str, tuple[str, int]] = {}
+        seen_dirs: set[Path] = set()
+        for path in source_paths:
+            directory = path if path.is_dir() else path.parent
+            if directory in seen_dirs:
+                continue
+            seen_dirs.add(directory)
+            manifest_path = directory / _MANIFEST_NAME
+            if not manifest_path.is_file():
+                continue
+            payload = _read_manifest(manifest_path)
+            if payload is None:
+                continue
+            recovered.update(_acquire_recovered_blobs(directory, payload, blob_store))
+        result: SidecarData = {}
+        if recovered:
+            result["claude_ai_recovered_blobs"] = recovered
+        return result
+
+    def enrich_session(
+        self,
+        conv: ParsedSession,
+        sidecar_data: SidecarData,
+    ) -> ParsedSession:
+        if conv.source_name is not Provider.CLAUDE_AI or not conv.attachments:
+            return conv
+        recovered = sidecar_data.get("claude_ai_recovered_blobs")
+        if not recovered:
+            return conv
+
+        new_attachments: list[ParsedAttachment] = []
+        changed = False
+        for attachment in conv.attachments:
+            blob = recovered.get(attachment.provider_attachment_id)
+            if blob is None or attachment.inline_bytes is not None or attachment.precomputed_blob is not None:
+                new_attachments.append(attachment)
+                continue
+            update: dict[str, object] = {"precomputed_blob": blob}
+            if attachment.size_bytes is None:
+                update["size_bytes"] = blob[1]
+            new_attachments.append(attachment.model_copy(update=update))
+            changed = True
+        if not changed:
+            return conv
+        return conv.model_copy(update={"attachments": new_attachments})
+
+
+__all__ = ["ClaudeAIAssemblySpec"]

--- a/polylogue/sources/dispatch.py
+++ b/polylogue/sources/dispatch.py
@@ -229,6 +229,13 @@ def _detect_provider_from_record_evidence(record: PayloadRecord) -> tuple[Provid
     # ``chatgpt.looks_like``'s document-identity requirements (polylogue-t0ta).
     if chatgpt.looks_like_fragment(record):
         return Provider.CHATGPT, "chatgpt.looks_like_fragment (mapping node shape)"
+    # A ChatGPT shared-page (chatgpt.com/share/<id>) stream decode has no
+    # "mapping" key at all -- a flattened top-level "messages" list instead
+    # (polylogue-4zqh3). Checked here, ahead of the generic "has a messages
+    # list" fallback used elsewhere in dispatch, which would otherwise
+    # silently accept-then-drop it (no payload-asserted "id" field).
+    if chatgpt.looks_like_shared_decode(record):
+        return Provider.CHATGPT, "chatgpt.looks_like_shared_decode (shared-page stream decode)"
     # Claude Design (bd polylogue-tbun) checked before the general claude.ai
     # detector: its shape (messages + project, no chat_messages, camelCase
     # contentBlocks) is a distinct, tighter product signature -- not a

--- a/polylogue/sources/origin_specs.py
+++ b/polylogue/sources/origin_specs.py
@@ -893,6 +893,8 @@ def _claude_ai_spec() -> OriginSpec:
         acquisition_modes=("export-json",),
         parser_paths=("polylogue/sources/parsers/claude/ai_parser.py",),
         fixture_paths=("tests/unit/sources/test_parsers_claude_ai_catalog.py",),
+        # bd polylogue-4zqh3: sole-copy attachment-byte recovery sidecar.
+        assembly_spec_path="polylogue/sources/assembly_claude_ai.py:ClaudeAIAssemblySpec",
         display_description="Claude web exports (lab: Anthropic)",
     )
 

--- a/polylogue/sources/parsers/chatgpt.py
+++ b/polylogue/sources/parsers/chatgpt.py
@@ -1190,6 +1190,90 @@ def looks_like(payload: object) -> bool:
     return _mapping_nodes_are_valid(mapping)
 
 
+def looks_like_shared_decode(payload: object) -> bool:
+    """Detect a ChatGPT shared-page (``chatgpt.com/share/<id>``) stream decode.
+
+    A shared conversation page serves its content through a client React
+    Router data stream, not the authenticated export/API ``mapping`` tree
+    ``looks_like``/``looks_like_fragment`` require. A local decode of that
+    stream (polylogue-4zqh3: the recovery-packet decode of conversation
+    ``6a4ac87b-...``, produced by a router-stream parse rather than a DOM
+    scrape) flattens the conversation tree into a top-level ``messages``
+    list of ``{node_id, parent, children, role, text, ...}`` records with no
+    ``mapping`` key anywhere in the document. Before this detector existed,
+    such a document matched no provider detector at all: dispatch's generic
+    "has a messages list" fallback (``_record_messages``) *would* match it,
+    but that fallback also requires a payload-asserted ``id`` field (there
+    is none here -- only ``conversation_id``/``shared_conversation_id``), so
+    it silently produced zero sessions and the decode never reached the
+    archive.
+    """
+    if not isinstance(payload, dict):
+        return False
+    if "mapping" in payload:
+        return False
+    if not isinstance(payload.get("shared_conversation_id"), str) or not payload["shared_conversation_id"]:
+        return False
+    messages = payload.get("messages")
+    if not isinstance(messages, list) or not messages:
+        return False
+    first = messages[0]
+    if not isinstance(first, dict):
+        return False
+    return isinstance(first.get("node_id"), str) and isinstance(first.get("role"), str)
+
+
+def _shared_decode_mapping(payload: Mapping[str, object]) -> tuple[dict[str, object], str | None]:
+    """Build a ``mapping``-tree-shaped dict from a shared-decode ``messages`` list.
+
+    Reuses ``extract_messages_from_mapping`` (the same node/message-tree
+    walk every other ChatGPT shape goes through) instead of duplicating its
+    branch-index/attachment/content-type logic for this flattened shape:
+    each flat record becomes a native-shaped ``{id, parent, children,
+    message: {id, author, create_time, content, metadata, status}}`` node.
+    Returns the synthesized mapping plus the leaf node id (the one node
+    with no children) to stand in for the native export's ``current_node``,
+    since the decode carries no explicit current-node marker.
+    """
+    messages = payload.get("messages")
+    mapping: dict[str, object] = {}
+    leaf_node_id: str | None = None
+    if not isinstance(messages, list):
+        return mapping, leaf_node_id
+    for raw in messages:
+        if not isinstance(raw, dict):
+            continue
+        node_id = raw.get("node_id")
+        if not isinstance(node_id, str) or not node_id:
+            continue
+        message_id_raw = raw.get("message_id")
+        message_id = message_id_raw if isinstance(message_id_raw, str) and message_id_raw else node_id
+        role = raw.get("role")
+        text = raw.get("text")
+        text = text if isinstance(text, str) else ""
+        metadata = raw.get("metadata")
+        metadata = metadata if isinstance(metadata, dict) else {}
+        children_raw = raw.get("children")
+        children = [child for child in children_raw if isinstance(child, str)] if isinstance(children_raw, list) else []
+        parent = raw.get("parent")
+        parent = parent if isinstance(parent, str) else None
+        message: dict[str, object] | None = None
+        if isinstance(role, str) and role:
+            message = {
+                "id": message_id,
+                "author": {"role": role},
+                "create_time": raw.get("create_time"),
+                "update_time": raw.get("update_time"),
+                "content": {"content_type": "text", "parts": [text] if text else []},
+                "metadata": metadata,
+                "status": raw.get("status"),
+            }
+        mapping[node_id] = {"id": node_id, "parent": parent, "children": children, "message": message}
+        if not children:
+            leaf_node_id = node_id
+    return mapping, leaf_node_id
+
+
 # polylogue-9x22: ``ParsedContentBlock.metadata`` is never persisted -- the
 # ``blocks`` table has no metadata column and the write path only reads a
 # ``language`` key back out of it (``storage/sqlite/archive_tiers/write.py:
@@ -1225,8 +1309,16 @@ def parse(payload: Mapping[str, object], fallback_id: str) -> ParsedSession:
     mapping = payload.get("mapping") or {}
     if not isinstance(mapping, dict):
         mapping = {}
+    derived_current_node: str | None = None
+    if not mapping and looks_like_shared_decode(payload):
+        # polylogue-4zqh3: a shared-page stream decode has no ``mapping``
+        # key at all -- synthesize one from its flat ``messages`` list so
+        # the rest of this function (title/timestamps/ingest_flags below)
+        # and ``extract_messages_from_mapping`` handle it identically to a
+        # native export.
+        mapping, derived_current_node = _shared_decode_mapping(payload)
     current_node = payload.get("current_node")
-    current_node = current_node if isinstance(current_node, str) else None
+    current_node = current_node if isinstance(current_node, str) else derived_current_node
     messages, attachments = extract_messages_from_mapping(mapping, current_node)
     generation_timings = _extract_generation_timings(mapping)
     emitted_message_ids = {message.provider_message_id for message in messages}

--- a/tests/unit/sources/test_assembly.py
+++ b/tests/unit/sources/test_assembly.py
@@ -13,6 +13,7 @@ from polylogue.archive.session.branch_type import BranchType
 from polylogue.core.enums import MaterialOrigin, Provider, TitleSource
 from polylogue.sources.assembly import SidecarData, get_assembly_spec
 from polylogue.sources.assembly_chatgpt import ChatGPTAssemblySpec
+from polylogue.sources.assembly_claude_ai import ClaudeAIAssemblySpec
 from polylogue.sources.assembly_claude_code import ClaudeCodeAssemblySpec
 from polylogue.sources.assembly_codex import (
     CodexAssemblySpec,
@@ -122,7 +123,12 @@ class TestGetAssemblySpec:
         spec = get_assembly_spec(Provider.CHATGPT)
         assert isinstance(spec, ChatGPTAssemblySpec)
 
-    @pytest.mark.parametrize("provider", [Provider.CLAUDE_AI, Provider.UNKNOWN])
+    def test_claude_ai_returns_spec(self) -> None:
+        # bd polylogue-4zqh3: sole-copy attachment recovery sidecar.
+        spec = get_assembly_spec(Provider.CLAUDE_AI)
+        assert isinstance(spec, ClaudeAIAssemblySpec)
+
+    @pytest.mark.parametrize("provider", [Provider.UNKNOWN])
     def test_no_spec_for_other_providers(self, provider: Provider) -> None:
         assert get_assembly_spec(provider) is None
 

--- a/tests/unit/sources/test_assembly_claude_ai.py
+++ b/tests/unit/sources/test_assembly_claude_ai.py
@@ -1,0 +1,126 @@
+"""Tests for ClaudeAIAssemblySpec — bd polylogue-4zqh3 sole-copy attachment recovery.
+
+Exercises the real ``sources/assembly.py`` protocol wiring end to end: an
+``attachment-recovery.json`` sidecar next to a recovery source is discovered,
+its referenced local file is streamed into the blob store, and a matching
+attachment is enriched with ``precomputed_blob`` -- the same field
+``ingest_batch/_core.py``'s ``preacquired_attachment_blobs`` loop records as
+``acquired`` without re-hashing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from polylogue.archive.message.roles import Role
+from polylogue.core.enums import Provider
+from polylogue.sources.assembly import SidecarData, get_assembly_spec
+from polylogue.sources.assembly_claude_ai import ClaudeAIAssemblySpec
+from polylogue.sources.parsers.base import ParsedAttachment, ParsedMessage, ParsedSession
+from polylogue.storage.blob_store import BlobStore
+
+
+def _session(attachments: list[ParsedAttachment], *, source_name: Provider = Provider.CLAUDE_AI) -> ParsedSession:
+    return ParsedSession(
+        source_name=source_name,
+        provider_session_id="conv-1",
+        title="t",
+        messages=[ParsedMessage(provider_message_id="m1", role=Role.ASSISTANT, text="hi")],
+        attachments=attachments,
+    )
+
+
+def test_get_assembly_spec_returns_claude_ai_spec() -> None:
+    assert isinstance(get_assembly_spec(Provider.CLAUDE_AI), ClaudeAIAssemblySpec)
+
+
+def test_discover_sidecars_finds_manifest_next_to_source_and_streams_bytes(tmp_path: Path) -> None:
+    recovered = tmp_path / "recovered.md"
+    recovered.write_bytes(b"recovered attachment payload")
+    (tmp_path / "attachment-recovery.json").write_text(
+        json.dumps({"attachments": [{"native_id": "att-1", "path": "recovered.md"}]}),
+        encoding="utf-8",
+    )
+    (tmp_path / "claude-ai-browser-capture.json").write_text("{}", encoding="utf-8")
+    store = BlobStore(tmp_path / "blobs")
+
+    sidecar_data = ClaudeAIAssemblySpec().discover_sidecars(
+        [tmp_path / "claude-ai-browser-capture.json"], blob_store=store
+    )
+
+    recovered_blobs = sidecar_data["claude_ai_recovered_blobs"]
+    blob_hash, size = recovered_blobs["att-1"]
+    assert blob_hash == hashlib.sha256(b"recovered attachment payload").hexdigest()
+    assert size == len(b"recovered attachment payload")
+    assert store.exists(blob_hash)
+
+
+def test_discover_sidecars_skips_missing_manifest(tmp_path: Path) -> None:
+    (tmp_path / "claude-ai-browser-capture.json").write_text("{}", encoding="utf-8")
+
+    sidecar_data = ClaudeAIAssemblySpec().discover_sidecars([tmp_path / "claude-ai-browser-capture.json"])
+
+    assert sidecar_data == {}
+
+
+def test_discover_sidecars_warns_and_skips_missing_referenced_file(tmp_path: Path) -> None:
+    (tmp_path / "attachment-recovery.json").write_text(
+        json.dumps({"attachments": [{"native_id": "att-1", "path": "does-not-exist.md"}]}),
+        encoding="utf-8",
+    )
+    (tmp_path / "claude-ai-browser-capture.json").write_text("{}", encoding="utf-8")
+
+    sidecar_data = ClaudeAIAssemblySpec().discover_sidecars(
+        [tmp_path / "claude-ai-browser-capture.json"], blob_store=BlobStore(tmp_path / "blobs")
+    )
+
+    assert sidecar_data == {}
+
+
+def test_enrich_session_sets_precomputed_blob_for_matching_attachment() -> None:
+    attachment = ParsedAttachment(provider_attachment_id="att-1", message_provider_id="m1", name="recovered.md")
+    conv = _session([attachment])
+    sidecar_data: SidecarData = {"claude_ai_recovered_blobs": {"att-1": ("deadbeef" * 8, 29)}}
+
+    enriched = ClaudeAIAssemblySpec().enrich_session(conv, sidecar_data)
+
+    assert enriched.attachments[0].precomputed_blob == ("deadbeef" * 8, 29)
+    assert enriched.attachments[0].size_bytes == 29
+
+
+def test_enrich_session_ignores_non_matching_attachment() -> None:
+    attachment = ParsedAttachment(provider_attachment_id="att-other", message_provider_id="m1", name="unrelated.md")
+    conv = _session([attachment])
+    sidecar_data: SidecarData = {"claude_ai_recovered_blobs": {"att-1": ("deadbeef" * 8, 29)}}
+
+    enriched = ClaudeAIAssemblySpec().enrich_session(conv, sidecar_data)
+
+    assert enriched is conv
+
+
+def test_enrich_session_does_not_overwrite_already_acquired_attachment() -> None:
+    attachment = ParsedAttachment(
+        provider_attachment_id="att-1",
+        message_provider_id="m1",
+        name="already-acquired.md",
+        precomputed_blob=("cafebabe" * 8, 10),
+    )
+    conv = _session([attachment])
+    sidecar_data: SidecarData = {"claude_ai_recovered_blobs": {"att-1": ("deadbeef" * 8, 29)}}
+
+    enriched = ClaudeAIAssemblySpec().enrich_session(conv, sidecar_data)
+
+    assert enriched is conv
+    assert enriched.attachments[0].precomputed_blob == ("cafebabe" * 8, 10)
+
+
+def test_enrich_session_ignores_non_claude_ai_sessions() -> None:
+    attachment = ParsedAttachment(provider_attachment_id="att-1", message_provider_id="m1", name="recovered.md")
+    conv = _session([attachment], source_name=Provider.CHATGPT)
+    sidecar_data: SidecarData = {"claude_ai_recovered_blobs": {"att-1": ("deadbeef" * 8, 29)}}
+
+    enriched = ClaudeAIAssemblySpec().enrich_session(conv, sidecar_data)
+
+    assert enriched is conv

--- a/tests/unit/sources/test_dispatch_evidence.py
+++ b/tests/unit/sources/test_dispatch_evidence.py
@@ -36,6 +36,15 @@ _CHATGPT_LIKE_RECORD = {
     "conversation_id": "conv-1",
 }
 _CLAUDE_AI_RECORD = {"chat_messages": [{"sender": "human", "text": "hi"}]}
+_CHATGPT_SHARED_DECODE_RECORD = {
+    "shared_conversation_id": "shared-conv-evidence",
+    "conversation_id": "shared-conv-evidence",
+    "title": "Shared decode evidence",
+    "create_time": 1700000000.0,
+    "messages": [
+        {"node_id": "n1", "parent": None, "children": [], "role": "user", "text": "hi"},
+    ],
+}
 
 
 @pytest.mark.parametrize(
@@ -43,6 +52,7 @@ _CLAUDE_AI_RECORD = {"chat_messages": [{"sender": "human", "text": "hi"}]}
     [
         ([_CLAUDE_CODE_RECORD], Provider.CLAUDE_CODE),
         (_CHATGPT_LIKE_RECORD, Provider.CHATGPT),
+        (_CHATGPT_SHARED_DECODE_RECORD, Provider.CHATGPT),
         (_CLAUDE_AI_RECORD, Provider.CLAUDE_AI),
         ({"unrelated": "shape"}, None),
         ([], None),

--- a/tests/unit/sources/test_dispatch_payloads.py
+++ b/tests/unit/sources/test_dispatch_payloads.py
@@ -447,6 +447,54 @@ def test_parse_one_source_path_treats_jsonl_text_json_wrappers_as_jsonl(tmp_path
     assert [session.provider_session_id for _raw, session in rows] == ["first-session", "second-session"]
 
 
+def test_chatgpt_shared_page_decode_detects_and_parses_end_to_end() -> None:
+    """A ChatGPT shared-page (chatgpt.com/share/<id>) stream decode has no
+    ``mapping`` key -- a flat top-level ``messages`` list instead
+    (polylogue-4zqh3). Before this detector, ``detect_provider`` matched no
+    provider for this shape at all: dispatch's generic "has a messages list"
+    fallback would consider it, but that fallback also requires a payload-
+    asserted ``id`` (absent here), so the whole document silently produced
+    zero sessions. This pins the full detect -> lower -> parse path end to
+    end.
+    """
+    payload: dict[str, object] = {
+        "shared_conversation_id": "shared-conv-e2e",
+        "conversation_id": "shared-conv-e2e",
+        "title": "Shared decode end to end",
+        "create_time": 1700000000.0,
+        "messages": [
+            {
+                "node_id": "user-node",
+                "parent": None,
+                "children": ["assistant-node"],
+                "role": "user",
+                "create_time": 1700000000.0,
+                "metadata": {},
+                "text": "hi from the shared decode",
+            },
+            {
+                "node_id": "assistant-node",
+                "parent": "user-node",
+                "children": [],
+                "role": "assistant",
+                "create_time": 1700000010.0,
+                "metadata": {},
+                "text": "hello back",
+            },
+        ],
+    }
+
+    provider = detect_provider(payload)
+    assert provider is Provider.CHATGPT
+
+    sessions = parse_payload(provider, payload, "shared-decode-fallback")
+
+    assert len(sessions) == 1
+    session = sessions[0]
+    assert session.provider_session_id == "shared-conv-e2e"
+    assert [m.role for m in session.messages] == ["user", "assistant"]
+
+
 def _chatgpt_conversation_record(conversation_id: str) -> dict[str, object]:
     return {
         "id": conversation_id,

--- a/tests/unit/sources/test_parsers_chatgpt.py
+++ b/tests/unit/sources/test_parsers_chatgpt.py
@@ -209,6 +209,101 @@ def test_chatgpt_shared_conversation_index_shell_is_tagged() -> None:
     assert SHARED_CONVERSATION_INDEX_INGEST_FLAG in session.ingest_flags
 
 
+def _shared_decode_payload() -> dict[str, object]:
+    """A minimal shared-page (chatgpt.com/share/<id>) stream-decode document.
+
+    Mirrors the real recovery-packet decode shape (polylogue-4zqh3): a
+    top-level ``messages`` list of flat ``{node_id, parent, children, role,
+    text, ...}`` records, no ``mapping`` key anywhere, and no payload-
+    asserted ``id`` (only ``conversation_id``/``shared_conversation_id``).
+    """
+    return {
+        "source_url": "https://chatgpt.com/share/shared-conv-id",
+        "shared_conversation_id": "shared-conv-id",
+        "conversation_id": "shared-conv-id",
+        "title": "Shared Decode Title",
+        "default_model_slug": "gpt-5-5-pro",
+        "create_time": 1700000000.0,
+        "update_time": 1700000100.0,
+        "mapping_node_count": 3,
+        "message_count": 2,
+        "messages": [
+            {
+                "node_id": "root-node",
+                "message_id": "root-node",
+                "parent": "client-created-root",
+                "children": ["user-node"],
+                "role": "system",
+                "create_time": None,
+                "update_time": None,
+                "status": "finished_successfully",
+                "metadata": {"is_visually_hidden_from_conversation": True},
+                "text": "",
+            },
+            {
+                "node_id": "user-node",
+                "message_id": "user-node",
+                "parent": "root-node",
+                "children": ["assistant-node"],
+                "role": "user",
+                "create_time": 1700000000.0,
+                "update_time": None,
+                "status": "finished_successfully",
+                "metadata": {},
+                "text": "Hello from the shared page decode",
+            },
+            {
+                "node_id": "assistant-node",
+                "message_id": "assistant-node",
+                "parent": "user-node",
+                "children": [],
+                "role": "assistant",
+                "create_time": 1700000050.0,
+                "update_time": None,
+                "status": "finished_successfully",
+                "metadata": {},
+                "text": "Reply from the shared page decode",
+            },
+        ],
+    }
+
+
+def test_chatgpt_looks_like_shared_decode_detects_flat_messages_shape() -> None:
+    from polylogue.sources.parsers.chatgpt import looks_like_fragment, looks_like_shared_decode
+
+    payload = _shared_decode_payload()
+    assert looks_like_shared_decode(payload)
+    # The neighboring mapping-tree detectors must NOT also claim this shape --
+    # it genuinely has no "mapping" key, so both would silently reject it
+    # anyway, but this pins the non-overlap explicitly.
+    assert not chatgpt_looks_like(payload)
+    assert not looks_like_fragment(payload)
+
+
+def test_chatgpt_looks_like_shared_decode_rejects_native_mapping_export() -> None:
+    from polylogue.sources.parsers.chatgpt import looks_like_shared_decode
+
+    assert not looks_like_shared_decode({"mapping": {}, "messages": [{"node_id": "x", "role": "user"}]})
+    assert not looks_like_shared_decode({"shared_conversation_id": "x", "messages": []})
+    assert not looks_like_shared_decode({"shared_conversation_id": "x"})
+    assert not looks_like_shared_decode("not-a-dict")
+
+
+def test_chatgpt_parse_shared_decode_produces_real_messages() -> None:
+    session = chatgpt_parse(_shared_decode_payload(), "fallback")
+
+    assert session.provider_session_id == "shared-conv-id"
+    assert session.title == "Shared Decode Title"
+    assert SHARED_CONVERSATION_INDEX_INGEST_FLAG not in session.ingest_flags
+    # The hidden empty system root is skipped by extract_messages_from_mapping's
+    # usual empty-text filtering; the two real turns come through.
+    roles_and_text = [(m.role, m.blocks[0].text if m.blocks else "") for m in session.messages]
+    assert ("user", "Hello from the shared page decode") in roles_and_text
+    assert ("assistant", "Reply from the shared page decode") in roles_and_text
+    # The leaf node (no children) is derived as the active path tail.
+    assert session.active_leaf_message_provider_id == "assistant-node"
+
+
 def test_chatgpt_temporary_payload_sets_session_kind() -> None:
     session = chatgpt_parse(
         {


### PR DESCRIPTION
## Summary

Two source-tier fixes for the hermes/project-comparison recovery packet (bd polylogue-4zqh3): a parser for the ChatGPT shared-page (chatgpt.com/share/<id>) stream-decode format, and a reusable, reindex-safe sidecar mechanism for recovering sole-copy Claude AI attachment bytes from an out-of-band recovery packet.

## Problem

A recovery packet at `/realm/data/exports/chatlog/raw/recovery/hermes-project-comparison-2026-07/` preserves two capture gaps against the live archive (verified read-only 2026-08-02, re-verified during this work):

1. A 948-message decode of a ChatGPT shared page (`chatgpt-shared-decode-6a4ac87b/`) matched no provider detector at all. `chatgpt.looks_like`/`looks_like_fragment` both require a `mapping` key; this decode flattens the conversation tree into a top-level `messages` list instead. Dispatch's generic "has a messages list" fallback (`_record_messages`) would consider it, but also requires a payload-asserted top-level `id` (this shape only has `conversation_id`/`shared_conversation_id`), so the document silently produced zero sessions.
2. The Claude.ai session `claude-ai-export:2c2eab57-fc6c-4c61-99fa-f61af3b7ac57` is acquired and indexed, but most of its attachment refs are `unfetched` with no bytes, and the recovery packet holds some of those bytes locally.

## Solution

**ChatGPT shared-page decode** (`polylogue/sources/parsers/chatgpt.py`, `polylogue/sources/dispatch.py`):
- `looks_like_shared_decode()` detects the flat-messages shape; `_shared_decode_mapping()` adapts it into the same `{id, parent, children, message: {...}}` node shape `extract_messages_from_mapping()` already walks for every other ChatGPT shape, deriving a `current_node` stand-in from the one node with no children.
- `parse()` uses this synthesized mapping when the payload has no native `mapping` key but matches the shared-decode shape, so every downstream field (title/timestamps/ingest_flags) goes through the existing, unmodified code path.
- `_detect_provider_from_record_evidence` checks the new detector ahead of the generic messages-list fallback.
- Verified end to end against the real 948-node packet file: decodes into 622 real messages (9 user, 316 assistant, 297 tool) under `provider_session_id "6a4ac87b-8478-83ed-8708-dd04b5f4955e"`.

**Claude AI attachment recovery sidecar** (`polylogue/sources/assembly_claude_ai.py`, `assembly.py`, `origin_specs.py`):
- `index.db` (where `acquisition_status`/`blob_hash` live) is a rebuildable tier, and the sibling bead polylogue-f1vg is explicitly gating an imminent corpus-wide reindex. A one-off script that directly UPDATEs those rows would be silently discarded the next time this session reparses or a full reindex runs.
- `ChatGPTAssemblySpec` (bd polylogue-8ac0) already solves this shape of problem for `.dat` assets: stream bytes into the blob store at parse time and record `precomputed_blob` on matching attachments, so `ingest_batch/_core.py` marks them `acquired` without re-hashing on every reparse — durable because it re-derives the same result each time, not because a row was patched once. No equivalent existed for Claude AI.
- `ClaudeAIAssemblySpec.discover_sidecars()` looks for a small `attachment-recovery.json` sidecar next to each source path (`{"attachments": [{"native_id": ..., "path": ...}]}`), streams each referenced file into the blob store, and returns a `native_id -> (sha256_hex, size)` map; `enrich_session()` joins that onto matching `ParsedAttachment.provider_attachment_id` values as `precomputed_blob`.
- Registered via `get_assembly_spec(Provider.CLAUDE_AI)`; `origin_specs.py`'s Claude AI `OriginSpec` now declares `assembly_spec_path` so the assembly-registry parity check stays accurate.

## Deferred / not done in this PR

This PR does **not** acquire the real recovery-packet bytes into the live archive. That needs an `attachment-recovery.json` placed next to the source being (re-)ingested plus a one-off re-import run — an operator action against `/realm/data` and `/realm/db`, not something to execute from an isolated worktree.

Investigation while scoping this also found the bead's own attachment-identity claims only partially hold: of the three payloads it names, only the 309,149-byte ChatGPT temporary transcript (native id `d9339abb-76fe-4e49-a846-422b264e88a5`) has a confirmed size/native-id match against the claude-ai-export session's attachment_refs. The other two (`hermes-agent-main.zip`, `hermes-agent-all.tar.gz`) turn out to belong to a *different*, currently-uningested ChatGPT temporary conversation (`chatgpt-export:temporary:b5e53115cf353f807b9708f5`, 0 rows in the archive today) and appear in the claude.ai capture only as plain text mentioning those filenames — no attachment identity exists to bind bytes to. Full trace recorded in the bead notes.

## Verification

- `devtools test tests/unit/sources/test_parsers_chatgpt.py tests/unit/sources/test_dispatch_evidence.py tests/unit/sources/test_dispatch_payloads.py` → 158 passed across two invocations
- `devtools test tests/unit/sources/test_assembly.py tests/unit/sources/test_origin_specs.py tests/unit/sources/test_assembly_claude_ai.py` → 109 passed
- `devtools test tests/unit/sources/` → 2295 passed, 8 failed; all 8 confirmed pre-existing/unrelated via `git stash` (identical failures reproduce with this PR's changes stashed out: `test_live_batch_support.py` x3, `test_live_watcher.py` x2, `test_source_laws.py` x2, `test_claude_code_normalization_laws.py` x1)
- `ruff format --check` / `mypy` / `devtools render all --check` (grepped for "out of sync", none found) / `devtools verify --quick` → all exit 0
- Manual smoke test against the real recovery-packet decode file: `detect_provider` → chatgpt, `parse_payload` → 1 session, 622 messages, title "Project and Codebase Analysis"

Ref polylogue-4zqh3