### PR TITLE
refactor: split classify_raw_revision_cohort's identity-split flag

### DIFF
--- a/docs/plans/layering.yaml
+++ b/docs/plans/layering.yaml
@@ -36,7 +36,8 @@ writer_modules:
           durability: durable
           interruption: atomic
       entrypoints:
-        [apply_raw_membership_classification, apply_raw_revision_replay, classify_raw_revision_cohort,
+        [apply_raw_membership_classification, apply_raw_revision_replay,
+        classify_raw_revision_cohort_for_live_watch, classify_raw_revision_cohort_for_rebuild_repair,
         release_provisional_full_revisions, replace_raw_membership_census,
         write_parsed_for_retained_raw, write_parsed_for_retained_raw_result, write_raw_and_parsed,
         write_raw_and_parsed_result, write_raw_blob_and_parsed, write_raw_blob_and_parsed_result]

--- a/polylogue/archive/revision_authority.py
+++ b/polylogue/archive/revision_authority.py
@@ -41,7 +41,7 @@ BYTE_AUTHORITY_CENSUS_DETAIL = "append fragments are governed by byte revision a
 #: non-prefix-chain cohort is retired from byte-revision governance to
 #: membership governance (``ArchiveStore.replace_raw_membership_census``,
 #: ``retire_full_revision_governance=True``). Shared between the writer and
-#: ``ArchiveStore.classify_raw_revision_cohort``'s polylogue-52l2 guard,
+#: ``revision_governance._classify_raw_revision_cohort``'s polylogue-52l2 guard,
 #: which uses it to detect that a logical identity already has retired,
 #: previously-ambiguous sibling evidence before ever accepting a
 #: later-discovered raw as an unconditional singleton byte-proven baseline.

--- a/polylogue/sources/live/append_ingest.py
+++ b/polylogue/sources/live/append_ingest.py
@@ -233,7 +233,7 @@ def _ingest_append_plans_archive(
                     # whose accepted metadata has not yet been established.
                     replay_plan = archive.raw_revision_replay_plan(logical_source_key)
                     if raw_id not in replay_plan.accepted_raw_ids:
-                        replay_plan = archive.classify_raw_revision_cohort(logical_source_key)
+                        replay_plan = archive.classify_raw_revision_cohort_for_live_watch(logical_source_key)
                     if raw_id not in replay_plan.accepted_raw_ids:
                         # A non-empty plan can still represent an older
                         # accepted chain while a newly observed full snapshot

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -2291,7 +2291,7 @@ class LiveBatchProcessor:
                                     authority=RawRevisionAuthority.QUARANTINED,
                                 ),
                             )
-                            plan = archive.classify_raw_revision_cohort(logical_source_key)
+                            plan = archive.classify_raw_revision_cohort_for_live_watch(logical_source_key)
                             if plan.accepted_raw_ids:
                                 parsed_by_raw_id = self._parse_raw_revision_chain(archive, plan)
                                 session_id, applied_raw_ids = archive.apply_raw_revision_replay(

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -618,8 +618,9 @@ def _census_historical_revision_evidence(
     learned identity without independently parsing bytes that byte comparison
     already proved are a strict prefix of the newest capture. This is a
     census-time parse-cost optimization only: it never grants authority --
-    ``classify_raw_revision_cohort`` (called later, during replay) still
-    independently re-derives byte-provenness from raw bytes for every raw.
+    ``classify_raw_revision_cohort_for_rebuild_repair`` (called later, during
+    replay) still independently re-derives byte-provenness from raw bytes for
+    every raw.
     """
     state = _RevisionCensusState(0, 0, 0, set(), {}, {})
     batch_size = commit_batch_size if commit_batch_size is not None and commit_batch_size > 0 else None
@@ -1170,19 +1171,21 @@ def backfill_historical_revision_evidence(
                 # polylogue-eqnv: the offline backfill/rebuild path is the one
                 # where a stale pre-fix parser identity can split one physical
                 # document's re-acquisitions across two logical_source_keys (see
-                # ArchiveStore.classify_raw_revision_cohort's docstring) -- opt
-                # into the source_path cross-key guard here. The live watcher
-                # (sources/live/batch.py) does NOT opt in: a watched path can be
-                # legitimately, atomically replaced with a different session's
-                # content, which must not be quarantined as "divergent evidence".
+                # ArchiveStore.classify_raw_revision_cohort_for_rebuild_repair's
+                # docstring) -- use that entry point here, which always applies
+                # the source_path cross-key guard. The live watcher
+                # (sources/live/batch.py) uses
+                # classify_raw_revision_cohort_for_live_watch instead: a
+                # watched path can be legitimately, atomically replaced with a
+                # different session's content, which must not be quarantined
+                # as "divergent evidence".
                 classify_started = time.perf_counter()
-                plan = archive.classify_raw_revision_cohort(
+                plan = archive.classify_raw_revision_cohort_for_rebuild_repair(
                     logical_key,
-                    check_source_path_identity_split=True,
                     # Batched replay defers the classification's source.db
                     # authority updates into the same batch window as the replay
                     # writes (idempotent, re-derived on resume -- see
-                    # classify_raw_revision_cohort's docstring).
+                    # classify_raw_revision_cohort_for_rebuild_repair's docstring).
                     manage_transaction=not replay_batched,
                 )
                 stage_timings["replay.classify_cohort"] = stage_timings.get("replay.classify_cohort", 0.0) + (

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -175,7 +175,8 @@ from polylogue.storage.sqlite.archive_tiers.revision_governance import (
     apply_raw_revision_replay,
     bind_raw_revision,
     blob_path_for_hash,
-    classify_raw_revision_cohort,
+    classify_raw_revision_cohort_for_live_watch,
+    classify_raw_revision_cohort_for_rebuild_repair,
     classify_untyped_full_revision_groups,
     convertible_full_revision_raw_ids,
     defer_raw_revision_adoption,
@@ -2187,17 +2188,27 @@ class ArchiveStore:
     def _raw_revision_source_path_has_divergent_evidence(self, logical_source_key: str) -> bool:
         return _raw_revision_source_path_has_divergent_evidence(self, logical_source_key)
 
-    def classify_raw_revision_cohort(
+    def classify_raw_revision_cohort_for_rebuild_repair(
         self,
         logical_source_key: str,
         *,
-        check_source_path_identity_split: bool = False,
         manage_transaction: bool = True,
     ) -> RevisionReplayPlan:
-        return classify_raw_revision_cohort(
+        return classify_raw_revision_cohort_for_rebuild_repair(
             self,
             logical_source_key,
-            check_source_path_identity_split=check_source_path_identity_split,
+            manage_transaction=manage_transaction,
+        )
+
+    def classify_raw_revision_cohort_for_live_watch(
+        self,
+        logical_source_key: str,
+        *,
+        manage_transaction: bool = True,
+    ) -> RevisionReplayPlan:
+        return classify_raw_revision_cohort_for_live_watch(
+            self,
+            logical_source_key,
             manage_transaction=manage_transaction,
         )
 

--- a/polylogue/storage/sqlite/archive_tiers/revision_governance.py
+++ b/polylogue/storage/sqlite/archive_tiers/revision_governance.py
@@ -71,18 +71,27 @@ into internals" this module is supposed to make impossible to do by
 accident. The Protocol makes the dependency surface an explicit, readable
 contract instead of "whatever `self` happens to have".
 
-``ArchiveStore`` keeps one-line delegating methods
-(``def classify_raw_revision_cohort(self, ...): return
-classify_raw_revision_cohort(self, ...)``) so every existing external caller
+``ArchiveStore`` keeps one-line delegating methods for the two named
+classification entry points (``def
+classify_raw_revision_cohort_for_rebuild_repair(self, ...): return
+classify_raw_revision_cohort_for_rebuild_repair(self, ...)``, and the
+``_for_live_watch`` twin) so every existing external caller
 (``polylogue/sources/live/batch.py``, ``polylogue/sources/live/append_ingest.py``,
-``polylogue/sources/revision_backfill.py``, ``polylogue/storage/repair.py``,
-``polylogue/pipeline/services/archive_ingest.py``, ``polylogue/api/archive.py``,
-and every test that holds an ``ArchiveStore``/``archive`` instance) keeps
-calling ``archive.classify_raw_revision_cohort(...)`` unchanged. That is not
-a compatibility shim: there is exactly one implementation, it lives here, and
-``ArchiveStore``'s method bodies are the call site — the same shape as any
-other function-then-delegate extraction, not a parallel/duplicated
-implementation kept alive for a deprecated audience.
+``polylogue/sources/revision_backfill.py``, and every test that holds an
+``ArchiveStore``/``archive`` instance) keeps calling
+``archive.classify_raw_revision_cohort_for_*(...)`` unchanged. That is not a
+compatibility shim: there is exactly one shared implementation
+(``_classify_raw_revision_cohort``), it lives here, and ``ArchiveStore``'s
+method bodies are the call site — the same shape as any other
+function-then-delegate extraction, not a parallel/duplicated implementation
+kept alive for a deprecated audience. (polylogue-vp2ky retired the single
+``classify_raw_revision_cohort(..., check_source_path_identity_split: bool)``
+entry point in favor of these two names: the boolean answered two distinct
+questions -- "is this the rebuild/backfill repair path, where a stale-parser
+identity split must be caught" vs. "is this the live-watch path, where an
+atomic same-path content replacement must NOT be mistaken for a split" -- and
+every caller had to independently get the right literal right. Naming the
+question makes it impossible to pass the wrong answer.)
 """
 
 from __future__ import annotations
@@ -785,30 +794,25 @@ def _raw_revision_source_path_has_divergent_evidence(store: RawRevisionGovernanc
     return row is not None
 
 
-def classify_raw_revision_cohort(
+def classify_raw_revision_cohort_for_rebuild_repair(
     store: RawRevisionGovernanceHost,
     logical_source_key: str,
     *,
-    check_source_path_identity_split: bool = False,
     manage_transaction: bool = True,
 ) -> RevisionReplayPlan:
-    """Promote only a unique byte-prefix full chain and contiguous appends.
+    """Classify a cohort for the offline rebuild/backfill repair path.
 
-    ``check_source_path_identity_split`` (polylogue-eqnv, default
-    ``False`` -- opt in explicitly, see
-    ``_raw_revision_source_path_has_divergent_evidence``) additionally
-    refuses a singleton accept when another 'full' raw shares this raw's
-    ``source_path`` under a DIFFERENT key. That heuristic is sound for a
-    genuine re-acquisition of the same physical document (the offline
-    backfill/rebuild path's use case, where a stale pre-fix parser
-    identity can split one document across two keys) but is NOT sound in
-    general: a watched source path can legitimately be atomically
-    replaced with an entirely different session's content (same path,
-    genuinely different identity, exercised by
-    ``test_full_ingest_does_not_advance_cursor_across_same_size_replacement``
-    et al.) -- the live incremental watcher (``sources/live/batch.py``)
-    must not quarantine that as "divergent evidence", so it leaves this
-    off.
+    This is the caller that must catch a stale-parser identity split
+    (polylogue-eqnv): a re-acquisition of the same physical document can end
+    up under two different ``logical_source_key`` values when an older,
+    now-superseded parser assigned identity inconsistently across passes.
+    Always applies the ``source_path`` cross-key divergent-evidence guard
+    (see ``_raw_revision_source_path_has_divergent_evidence``) so such a
+    split is refused a naive singleton byte-chain accept and instead folds
+    into membership governance, where the real content-based classifier
+    weighs every known sibling together. Never call this from the live
+    watcher -- see ``classify_raw_revision_cohort_for_live_watch`` for why
+    the same guard is unsound there.
 
     ``manage_transaction=False`` (polylogue batched-rebuild path) leaves the
     classification's ``raw_sessions`` authority updates uncommitted in the
@@ -819,6 +823,64 @@ def classify_raw_revision_cohort(
     authority evidence -- the resume re-classifies the same cohorts from
     scratch. The follow-up ``raw_revision_replay_plan`` read runs on the
     SAME source connection and sees the uncommitted updates.
+    """
+    return _classify_raw_revision_cohort(
+        store,
+        logical_source_key,
+        check_source_path_identity_split=True,
+        manage_transaction=manage_transaction,
+    )
+
+
+def classify_raw_revision_cohort_for_live_watch(
+    store: RawRevisionGovernanceHost,
+    logical_source_key: str,
+    *,
+    manage_transaction: bool = True,
+) -> RevisionReplayPlan:
+    """Classify a cohort for the live incremental-watch path.
+
+    This is the caller that must NOT apply the source-path cross-key
+    divergent-evidence guard used by
+    ``classify_raw_revision_cohort_for_rebuild_repair``: a watched source
+    path can legitimately be atomically replaced with an entirely different
+    session's content (same path, genuinely different identity, exercised
+    by
+    ``test_full_ingest_does_not_advance_cursor_across_same_size_replacement``
+    et al.). Applying the rebuild-repair guard here would wrongly quarantine
+    that legitimate replacement as "divergent evidence".
+
+    See ``classify_raw_revision_cohort_for_rebuild_repair`` for the
+    ``manage_transaction`` contract.
+    """
+    return _classify_raw_revision_cohort(
+        store,
+        logical_source_key,
+        check_source_path_identity_split=False,
+        manage_transaction=manage_transaction,
+    )
+
+
+def _classify_raw_revision_cohort(
+    store: RawRevisionGovernanceHost,
+    logical_source_key: str,
+    *,
+    check_source_path_identity_split: bool,
+    manage_transaction: bool = True,
+) -> RevisionReplayPlan:
+    """Promote only a unique byte-prefix full chain and contiguous appends.
+
+    Shared implementation behind ``classify_raw_revision_cohort_for_rebuild_repair``
+    and ``classify_raw_revision_cohort_for_live_watch`` -- callers should use
+    one of those two named entry points, never this function directly, so
+    that ``check_source_path_identity_split`` is always set correctly for
+    the calling context by construction rather than by the caller getting a
+    bare boolean right.
+
+    When ``check_source_path_identity_split`` is set, additionally refuses a
+    singleton accept when another 'full' raw shares this raw's
+    ``source_path`` under a DIFFERENT key (see
+    ``_raw_revision_source_path_has_divergent_evidence``).
     """
     if store._blob_publisher is None:
         raise RuntimeError("raw revision classification requires a writable blob publisher")

--- a/tests/infra/append_cohort_memory_counter.py
+++ b/tests/infra/append_cohort_memory_counter.py
@@ -1,7 +1,8 @@
 """Phase-level evidence collection for watcher append/cohort investigations.
 
 The live incident was in ``_ingest_append_plans_archive`` while
-``classify_raw_revision_cohort`` reread historical full snapshots.  This
+``classify_raw_revision_cohort_for_live_watch`` reread historical full
+snapshots.  This
 helper distinguishes the durable metadata replay-plan hot path from that
 conservative classifier fallback.  It deliberately does not serialize parsed
 object graphs: the observer records kernel-visible process/cgroup/I/O state and
@@ -222,7 +223,7 @@ def append_cohort_memory_counter() -> Iterator[AppendCohortMemoryCounter]:
 
     counter = AppendCohortMemoryCounter()
     real_append_ingest = append_ingest._ingest_append_plans_archive
-    real_classify = ArchiveStore.classify_raw_revision_cohort
+    real_classify = ArchiveStore.classify_raw_revision_cohort_for_live_watch
     real_replay_plan = ArchiveStore.raw_revision_replay_plan
     real_read_all = ArchiveBlobPublisher.read_all
     in_cohort_classification = False
@@ -266,7 +267,7 @@ def append_cohort_memory_counter() -> Iterator[AppendCohortMemoryCounter]:
 
     with (
         patch.object(append_ingest, "_ingest_append_plans_archive", counted_append_ingest),
-        patch.object(ArchiveStore, "classify_raw_revision_cohort", counted_classify),
+        patch.object(ArchiveStore, "classify_raw_revision_cohort_for_live_watch", counted_classify),
         patch.object(ArchiveStore, "raw_revision_replay_plan", counted_replay_plan),
         patch.object(ArchiveBlobPublisher, "read_all", counted_read_all),
     ):

--- a/tests/integration/test_append_cohort_memory.py
+++ b/tests/integration/test_append_cohort_memory.py
@@ -212,7 +212,9 @@ def test_watcher_append_does_not_reclassify_an_established_cohort(tmp_path: Path
     """Anti-vacuity: restoring unconditional classification breaks this route."""
     plan = _seed_cohort_and_append_plan(tmp_path)
 
-    with patch.object(ArchiveStore, "classify_raw_revision_cohort", side_effect=AssertionError("cohort route removed")):
+    with patch.object(
+        ArchiveStore, "classify_raw_revision_cohort_for_live_watch", side_effect=AssertionError("cohort route removed")
+    ):
         result = ingest_append_plans(cast(Any, _owner(tmp_path)), [plan])
 
     assert result.succeeded == [plan]

--- a/tests/unit/sources/test_live_append_cursor_resynthesis.py
+++ b/tests/unit/sources/test_live_append_cursor_resynthesis.py
@@ -205,7 +205,7 @@ def test_append_plan_declines_resynthesis_for_an_append_kind_head(tmp_path: Path
         )
         # Promote the append into the accepted chain the same way the real
         # append-ingest path does, via the durable classifier.
-        archive.classify_raw_revision_cohort(f"codex:{session_id}")
+        archive.classify_raw_revision_cohort_for_live_watch(f"codex:{session_id}")
     second_append = _codex_message("second-append")
     source.write_bytes(baseline + first_append_delta + second_append)
     _seed_native_session(tmp_path, session_id=session_id)

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -3889,7 +3889,7 @@ def test_live_third_raw_reunifies_with_backfill_retired_siblings(tmp_path: Path)
 
         # Exactly the polylogue-52l2 guard-tripping sequence: no unique
         # byte-prefix chain across a and b.
-        plan = store.classify_raw_revision_cohort("chatgpt:shared")
+        plan = store.classify_raw_revision_cohort_for_live_watch("chatgpt:shared")
         assert plan.accepted_raw_ids == ()
 
         # Mirror backfill_historical_revision_evidence's own retirement step
@@ -4041,7 +4041,7 @@ def test_membership_sweep_defers_sibling_retirement_instead_of_quarantining_curr
                 "codex:shared", RawRevisionKind.FULL, "rev-b", 0, authority=RawRevisionAuthority.QUARANTINED
             ),
         )
-        archive.classify_raw_revision_cohort("codex:shared")
+        archive.classify_raw_revision_cohort_for_live_watch("codex:shared")
         archive.commit()
         raw_c = archive.write_raw_payload(
             provider=Provider.CODEX,

--- a/tests/unit/storage/test_raw_authority_verdict_projection.py
+++ b/tests/unit/storage/test_raw_authority_verdict_projection.py
@@ -157,7 +157,7 @@ def test_verdicts_match_direct_classification_of_the_same_bytes(tmp_path: Path) 
         _bind_full(archive, raw_id="oldest", payload=b"one\n", logical_source_key="codex:s1")
         _bind_full(archive, raw_id="newest", payload=b"one\ntwo\n", logical_source_key="codex:s1")
 
-        plan = archive.classify_raw_revision_cohort("codex:s1")
+        plan = archive.classify_raw_revision_cohort_for_live_watch("codex:s1")
         verdicts = project_raw_authority_verdicts(archive, "codex:s1")
 
         row = (

--- a/tests/unit/storage/test_revision_replay.py
+++ b/tests/unit/storage/test_revision_replay.py
@@ -442,7 +442,7 @@ def test_cohort_classification_promotes_late_baseline_and_deferred_append(tmp_pa
             ),
         )
 
-        plan = archive.classify_raw_revision_cohort("codex:session")
+        plan = archive.classify_raw_revision_cohort_for_live_watch("codex:session")
 
     assert {item.raw_id: item.decision for item in plan.applications} == {
         baseline_raw_id: ApplicationDecision.SELECTED_BASELINE,
@@ -497,7 +497,7 @@ def test_duplicate_decision_mid_chain_gets_representative_generation_not_zero(tm
             archive, raw_id="raw-011-mid-dup", payload=b"a" * 10 + b"b" * 10, acquired_at_ms=4
         )
 
-        archive.classify_raw_revision_cohort("codex:session")
+        archive.classify_raw_revision_cohort_for_live_watch("codex:session")
 
         assert _acquisition_generation(archive, base) == 0
         assert _acquisition_generation(archive, mid) == 1
@@ -539,7 +539,7 @@ def test_duplicate_generation_copy_does_not_drop_the_chain_continuing_representa
         )
         assert mid < mid_duplicate  # guards the ordering assumption the collision case depends on
 
-        archive.classify_raw_revision_cohort("codex:session")
+        archive.classify_raw_revision_cohort_for_live_watch("codex:session")
 
         assert _acquisition_generation(archive, base) == 0
         assert _acquisition_generation(archive, mid) == 1
@@ -576,7 +576,7 @@ def test_duplicate_of_accepted_baseline_does_not_trip_membership_census_guard(tm
         baseline = _write_full_raw(archive, raw_id="raw-a-baseline", payload=b"hello world", acquired_at_ms=1)
         duplicate = _write_full_raw(archive, raw_id="raw-b-duplicate", payload=b"hello world", acquired_at_ms=2)
 
-        plan = archive.classify_raw_revision_cohort("codex:session")
+        plan = archive.classify_raw_revision_cohort_for_live_watch("codex:session")
 
         # The cohort has a unique byte-proven baseline -- the duplicate no
         # longer manufactures a false "multiple newest baselines" ambiguity.
@@ -674,7 +674,7 @@ def test_real_append_chain_folds_segmentation_distinct_full_snapshot(tmp_path: P
                 authority=RawRevisionAuthority.BYTE_PROVEN,
             ),
         )
-        append_plan = archive.classify_raw_revision_cohort("codex:session")
+        append_plan = archive.classify_raw_revision_cohort_for_live_watch("codex:session")
         archive.apply_raw_revision_replay(
             append_plan,
             {
@@ -697,7 +697,7 @@ def test_real_append_chain_folds_segmentation_distinct_full_snapshot(tmp_path: P
                 "codex:session", RawRevisionKind.FULL, "full-folded", 3, authority=RawRevisionAuthority.BYTE_PROVEN
             ),
         )
-        folded_plan = archive.classify_raw_revision_cohort("codex:session")
+        folded_plan = archive.classify_raw_revision_cohort_for_live_watch("codex:session")
         folded_session = parsed(("full-0", "zero"), ("full-1", "one"), ("full-2", "two"))
         before_hash = archive._conn.execute(
             "SELECT accepted_content_hash FROM raw_revision_heads WHERE logical_source_key = ?", ("codex:session",)
@@ -777,7 +777,7 @@ def test_isolated_later_raw_does_not_override_known_ambiguous_cohort(tmp_path: P
             ),
         )
 
-        first_plan = archive.classify_raw_revision_cohort("chatgpt:s1")
+        first_plan = archive.classify_raw_revision_cohort_for_live_watch("chatgpt:s1")
         assert first_plan.accepted_raw_ids == ()
 
         # Both siblings genuinely disagree (no byte-prefix relation) --
@@ -807,7 +807,7 @@ def test_isolated_later_raw_does_not_override_known_ambiguous_cohort(tmp_path: P
                 "chatgpt:s1", RawRevisionKind.FULL, raw_c, 0, authority=RawRevisionAuthority.QUARANTINED
             ),
         )
-        second_plan = archive.classify_raw_revision_cohort("chatgpt:s1")
+        second_plan = archive.classify_raw_revision_cohort_for_live_watch("chatgpt:s1")
 
     # The isolated raw must not be promoted alone: this identity has known,
     # unresolved ambiguous siblings that a real classifier must weigh it
@@ -1001,7 +1001,7 @@ def test_isolated_later_raw_does_not_override_cohort_retired_under_legacy_detail
             ),
         )
 
-        first_plan = archive.classify_raw_revision_cohort("chatgpt:s1")
+        first_plan = archive.classify_raw_revision_cohort_for_live_watch("chatgpt:s1")
         assert first_plan.accepted_raw_ids == ()
 
         # Retire both siblings under the LEGACY pre-#3234 literal, not the
@@ -1030,7 +1030,7 @@ def test_isolated_later_raw_does_not_override_cohort_retired_under_legacy_detail
                 "chatgpt:s1", RawRevisionKind.FULL, raw_c, 0, authority=RawRevisionAuthority.QUARANTINED
             ),
         )
-        second_plan = archive.classify_raw_revision_cohort("chatgpt:s1")
+        second_plan = archive.classify_raw_revision_cohort_for_live_watch("chatgpt:s1")
 
     # Same assertion as the shared-constant test: the isolated raw must not
     # be promoted alone against siblings retired under the legacy literal.
@@ -1093,8 +1093,8 @@ def test_same_source_path_full_siblings_under_different_keys_are_not_independent
             ),
         )
 
-        enriched_plan = archive.classify_raw_revision_cohort("gemini:doc", check_source_path_identity_split=True)
-        bare_plan = archive.classify_raw_revision_cohort("gemini:doc-0", check_source_path_identity_split=True)
+        enriched_plan = archive.classify_raw_revision_cohort_for_rebuild_repair("gemini:doc")
+        bare_plan = archive.classify_raw_revision_cohort_for_rebuild_repair("gemini:doc-0")
 
     # Neither key's lone member may be promoted alone: a same-source_path
     # sibling under a different key means this identity is genuinely
@@ -1734,7 +1734,7 @@ def test_skip_already_applied_indexes_only_new_tail_of_append_chain(
                 "codex:session", RawRevisionKind.FULL, "full-0", 0, authority=RawRevisionAuthority.BYTE_PROVEN
             ),
         )
-        plan0 = archive.classify_raw_revision_cohort("codex:session")
+        plan0 = archive.classify_raw_revision_cohort_for_live_watch("codex:session")
         archive.apply_raw_revision_replay(
             plan0, {baseline: parsed(("m0", "zero"))}, acquired_at_ms=0, skip_already_applied=True
         )
@@ -1763,7 +1763,7 @@ def test_skip_already_applied_indexes_only_new_tail_of_append_chain(
                 authority=RawRevisionAuthority.BYTE_PROVEN,
             ),
         )
-        plan1 = archive.classify_raw_revision_cohort("codex:session")
+        plan1 = archive.classify_raw_revision_cohort_for_live_watch("codex:session")
         assert plan1.accepted_raw_ids == (baseline, append_one)
         # The real live-watcher hot path always reparses+passes the FULL
         # accepted chain (see append_ingest.py), not just the new tail.
@@ -1803,7 +1803,7 @@ def test_skip_already_applied_indexes_only_new_tail_of_append_chain(
                 authority=RawRevisionAuthority.BYTE_PROVEN,
             ),
         )
-        plan2 = archive.classify_raw_revision_cohort("codex:session")
+        plan2 = archive.classify_raw_revision_cohort_for_live_watch("codex:session")
         assert plan2.accepted_raw_ids == (baseline, append_one, append_two)
         archive.apply_raw_revision_replay(
             plan2,
@@ -1888,7 +1888,7 @@ def test_skip_already_applied_default_false_still_reindexes_whole_chain(
                 "codex:session", RawRevisionKind.FULL, "full-0", 0, authority=RawRevisionAuthority.BYTE_PROVEN
             ),
         )
-        plan0 = archive.classify_raw_revision_cohort("codex:session")
+        plan0 = archive.classify_raw_revision_cohort_for_live_watch("codex:session")
         archive.apply_raw_revision_replay(plan0, {baseline: parsed(("m0", "zero"))}, acquired_at_ms=0)
         indexed_raw_ids.clear()
 
@@ -1914,7 +1914,7 @@ def test_skip_already_applied_default_false_still_reindexes_whole_chain(
                 authority=RawRevisionAuthority.BYTE_PROVEN,
             ),
         )
-        plan1 = archive.classify_raw_revision_cohort("codex:session")
+        plan1 = archive.classify_raw_revision_cohort_for_live_watch("codex:session")
         archive.apply_raw_revision_replay(
             plan1,
             {baseline: parsed(("m0", "zero")), append_one: parsed(("m1", "one"))},


### PR DESCRIPTION
## Summary

`classify_raw_revision_cohort`'s `check_source_path_identity_split: bool` parameter answered two semantically distinct questions that happened to share one flag: whether to apply the source-path cross-key divergent-evidence guard. Its own docstring stated the heuristic is sound for one caller and unsound for the other, so every caller had to independently get the right literal right. This PR replaces the single flag with two named entry points.

## Problem

`polylogue/storage/sqlite/archive_tiers/revision_governance.py:classify_raw_revision_cohort` gates a source-path identity-split guard behind `check_source_path_identity_split`. The rebuild/backfill path (`sources/revision_backfill.py`) always needs the guard on (a stale pre-fix parser identity can split one physical document's re-acquisitions across two logical_source_keys). The live-watch path (`sources/live/batch.py`, `sources/live/append_ingest.py`) must always leave it off (a watched source path can be legitimately, atomically replaced with a different session's content, which must not be quarantined as "divergent evidence"). A boolean shared between two callers who need opposite fixed answers is a naming/logic bug waiting to bite the next caller that gets the literal wrong.

## Solution

- Renamed the implementation to a private `_classify_raw_revision_cohort` (unchanged body/logic).
- Added `classify_raw_revision_cohort_for_rebuild_repair` (always applies the guard) and `classify_raw_revision_cohort_for_live_watch` (never does), each a thin wrapper with no boolean parameter.
- Updated `ArchiveStore`'s two delegating methods, the three production call sites, every test call site (including the `ArchiveStore`/`ArchiveBlobPublisher` monkeypatch targets in `tests/infra/append_cohort_memory_counter.py` and `tests/integration/test_append_cohort_memory.py`, which patch the method by name), and `docs/plans/layering.yaml`'s writer-module entrypoint inventory.
- Pure refactor: no behavior change at any call site, each caller now gets the fixed-correct answer by construction instead of by remembering the right boolean literal.

## Verification

- `devtools test tests/unit/storage/test_revision_replay.py tests/unit/sources/test_live_append_cursor_resynthesis.py tests/unit/storage/test_raw_authority_verdict_projection.py` -> `44 passed`
- `devtools test tests/integration/test_append_cohort_memory.py` -> 1 passed, 3 pre-existing failures confirmed unrelated (reproduced identically against unmodified `origin/master` before this change; these tests do not reference `classify_raw_revision_cohort` in their failure path)
- `devtools test tests/unit/sources/test_live_batch_support.py` -> 3 pre-existing failures (`test_full_ingest_skips_durably_excised_content_without_aborting_batch`, `test_full_ingest_writes_archive_with_route_observability`, `test_append_multi_session_payload_is_rejected_before_index_write`) confirmed to reproduce identically on unmodified `origin/master`; not caused by this change
- `devtools verify --quick` -> exit 0 (all steps ok, including `verify layering` after updating `docs/plans/layering.yaml`'s entrypoint list)

Ref polylogue-vp2ky

Co-Authored-By: Claude <noreply@anthropic.com>