### PR TITLE
fix: anchor chatgpt generation_lifecycle to content, not mapping order

### DIFF
--- a/polylogue/sources/parsers/chatgpt.py
+++ b/polylogue/sources/parsers/chatgpt.py
@@ -102,12 +102,27 @@ def _extract_generation_timings(mapping: Mapping[str, object]) -> list[_Generati
     is preferred over those partial copies; otherwise the best complete node
     on the same assistant branch owns the timing. Provider-finished duration
     is authoritative, with a valid start/end delta as the derived fallback.
+
+    The final tiebreak among nodes that agree on every other criterion is
+    the candidate message id itself, never raw ``mapping`` iteration order
+    (bd polylogue-uqwd). Two nodes on one branch can fully tie on source
+    rank, reasoning-recap flag, start/end presence, and ``end_turn`` --
+    ChatGPT re-exports of the SAME conversation are not guaranteed to
+    serialize ``mapping`` keys in the same order every time, so an
+    order-derived tiebreak silently anchored the resulting
+    ``generation_lifecycle`` event to a different message id per export,
+    even though every node's own content was byte-identical. That anchor
+    drift then made ``event_base_identity_hash``
+    (``pipeline/ids.py``) read the same event as two disjoint identities
+    across revisions -- the same "array position is not identity" hazard
+    ``session_revision_projection`` already guards against for messages,
+    attachments, and events.
     """
 
-    candidates: dict[str, list[tuple[tuple[int, int, int, int, int], _GenerationTiming]]] = {}
+    candidates: dict[str, list[tuple[tuple[int, int, int, int, str], _GenerationTiming]]] = {}
     related_message_ids: dict[str, set[str]] = {}
     legacy_duration_by_message_id: dict[str, dict[str, int]] = {}
-    for position, (node_id, raw_node) in enumerate(mapping.items()):
+    for node_id, raw_node in mapping.items():
         if not isinstance(raw_node, Mapping):
             continue
         raw_message = raw_node.get("message")
@@ -184,7 +199,7 @@ def _extract_generation_timings(mapping: Mapping[str, object]) -> list[_Generati
             int(content_type == "reasoning_recap"),
             int(start_sec is not None and end_sec is not None),
             int(raw_message.get("end_turn") is True),
-            position,
+            message_id,
         )
         candidates.setdefault(branch_key, []).append((score, timing))
 

--- a/tests/unit/sources/test_parsers_chatgpt.py
+++ b/tests/unit/sources/test_parsers_chatgpt.py
@@ -1436,6 +1436,49 @@ def test_chatgpt_generation_timing_fallback_rejects_malformed_values(
     assert len(lifecycle_events) == (1 if expected_duration_ms is not None else 0)
 
 
+def test_chatgpt_generation_timing_anchor_is_stable_across_mapping_order() -> None:
+    """generation_lifecycle anchors to the same message id regardless of raw
+    mapping key order (bd polylogue-uqwd).
+
+    Two candidate nodes on the same generation branch that fully tie on every
+    real scoring signal (source rank, reasoning-recap flag, start/end
+    presence, end_turn) previously fell through to ``position`` -- the raw
+    ``mapping`` dict's iteration order -- as the deciding tiebreak. ChatGPT
+    re-exports of the SAME conversation are not guaranteed to serialize
+    ``mapping`` keys in the same order every time, so which of the two tied
+    nodes won (and therefore which message id the lifecycle event anchored
+    to) silently flipped between export vintages even though every message's
+    content, including both candidates' own metadata, was byte-identical.
+    That anchor drift is exactly what makes ``event_base_identity_hash``
+    (``pipeline/ids.py``) treat the SAME generation event as two disjoint
+    identities across revisions, producing a spurious revision conflict.
+
+    Both mapping orders below carry the identical node set; only the dict
+    insertion order differs, standing in for two export requests of the same
+    conversation. The winning anchor must be identical in both cases.
+    """
+    user = _branch_node("u1", "user", "do the work", parent=None, children=["node_a"])
+    node_a = _branch_node("node_a", "assistant", "first draft", parent="u1", children=["node_b"])
+    node_b = _branch_node("node_b", "assistant", "final draft", parent="node_a", children=[])
+    for node in (node_a, node_b):
+        node["message"]["metadata"] = {"finished_duration_sec": 5}
+
+    def _anchor(order: list[dict[str, Any]]) -> str | None:
+        payload = {
+            "id": "tie-break-order",
+            "mapping": {n["id"]: n for n in order},
+            "current_node": "node_b",
+        }
+        session = chatgpt_parse(payload, "fallback-id")
+        lifecycle = [event for event in session.session_events if event.event_type == "generation_lifecycle"]
+        assert len(lifecycle) == 1
+        return lifecycle[0].source_message_provider_id
+
+    anchor_forward = _anchor([user, node_a, node_b])
+    anchor_reversed = _anchor([user, node_b, node_a])
+    assert anchor_forward == anchor_reversed
+
+
 # ---------------------------------------------------------------------------
 # #1744 — non-`parts` content is preserved (code interpreter, execution output)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes a ChatGPT parser bug where `generation_lifecycle` session events anchor to a different message id across export vintages of the identical conversation, because the tiebreak for choosing the authoritative timing node among fully-tied candidates was the raw `mapping` dict's iteration order rather than content.

## Problem
Reparsing real ambiguous-only chatgpt-export cohorts (bd polylogue-uqwd) while verifying polylogue-oycw's fix found 10/136 (7.4%) cohorts still hitting a genuine `conflict` verdict. Root cause traced to one example: all 46 messages identical across 3 export revisions (message + attachment axes equal), but the conflict came entirely from the event axis -- one `generation_lifecycle` event per revision, same payload shape, but anchored to a *different* `source_message_provider_id` each time.

`_extract_generation_timings` (polylogue/sources/parsers/chatgpt.py) selects one authoritative timing node per generation branch via a score tuple. Two candidate nodes on the same branch can fully tie on every real signal (source rank, reasoning-recap flag, start/end presence, `end_turn`), and the final tiebreak was `position` -- the raw `mapping` dict's iteration order. ChatGPT re-exports of the same conversation are not guaranteed to serialize `mapping` keys in the same order every time, so the winning anchor silently flipped between export vintages even though every node's own content was identical. Downstream, `event_base_identity_hash` (`pipeline/ids.py`) keys on `(event_type, anchoring message)`, so a moved anchor reads as two disjoint event identities across revisions instead of one.

## Solution
Replaced the `position` tiebreak with the candidate message id itself -- deterministic and content-derived, matching the "array position is not identity" principle `session_revision_projection` already documents for messages/attachments/events in the same file. Dropped the now-unused `enumerate`/position bookkeeping in `_extract_generation_timings`.

**Stamp-poisoner relevance (operator-flagged, bd polylogue-fsgdd/xselt):** fsgdd's K-class design named this bead as a possible stamp-poisoner for xselt's fingerprint-bootstrap work. This PR **confirms** that classification: the fix changes `event_base_identity_hash`/`session_revision_projection` output for any chatgpt-export session that previously hit this tie (same anchor-drift symptom xselt would need corrected before stamping). It does not change the general architecture of `event_base_identity_hash`, only which raw node the parser feeds into it.

## Verification
- `devtools test tests/unit/sources/test_parsers_chatgpt.py` -- 123 passed, including the new `test_chatgpt_generation_timing_anchor_is_stable_across_mapping_order` (constructs the same node set in two mapping insertion orders and asserts the winning anchor is identical; red before the fix commit -- `node_a` vs `node_b` -- green after).
- `devtools verify --quick` -- all steps ok (ran automatically via pre-push hook, exit 0).

Ref polylogue-uqwd