### PR TITLE
fix(sources): fill Codex linear parent links, wire title/topology hook evidence

### DIFF
--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -70,7 +70,7 @@ files:
     owner: stable
     cross_cut: { api: async }
   - path: polylogue/api/archive.py
-    loc: 7406
+    loc: 7468
     target: polylogue/api/archive.py
     owner: stable
     cross_cut: { api: async }
@@ -1329,6 +1329,10 @@ files:
     loc: 29
     target: polylogue/context/__init__.py
     owner: stable
+  - path: polylogue/context/codex_spawn_edge_correlation.py
+    loc: 116
+    target: polylogue/context/codex_spawn_edge_correlation.py
+    owner: stable
   - path: polylogue/context/compiler.py
     loc: 572
     target: polylogue/context/compiler.py
@@ -1441,7 +1445,7 @@ files:
     owner: core-primitive
     reason: core primitive
   - path: polylogue/core/metrics.py
-    loc: 287
+    loc: 313
     target: polylogue/core/metrics.py
     owner: core-primitive
     reason: core primitive
@@ -1573,7 +1577,7 @@ files:
     target: polylogue/daemon/catchup_status.py
     owner: stable
   - path: polylogue/daemon/cli.py
-    loc: 3118
+    loc: 3131
     target: polylogue/daemon/cli.py
     owner: stable
   - path: polylogue/daemon/compare.py
@@ -1698,7 +1702,7 @@ files:
     target: polylogue/daemon/maintenance_registry_http.py
     owner: stable
   - path: polylogue/daemon/metrics.py
-    loc: 2036
+    loc: 2053
     target: polylogue/daemon/metrics.py
     owner: stable
   - path: polylogue/daemon/notification_backends/__init__.py
@@ -1842,7 +1846,7 @@ files:
     target: polylogue/daemon/workspace_routes.py
     owner: stable
   - path: polylogue/daemon/write_coordinator.py
-    loc: 562
+    loc: 605
     target: polylogue/daemon/write_coordinator.py
     owner: stable
   - path: polylogue/declarations/__init__.py
@@ -2151,7 +2155,7 @@ files:
     target: polylogue/insights/session_commit.py
     owner: stable
   - path: polylogue/insights/session_label.py
-    loc: 180
+    loc: 196
     target: polylogue/insights/session_label.py
     owner: stable
   - path: polylogue/insights/tag_rollups.py
@@ -2204,7 +2208,7 @@ files:
     target: polylogue/maintenance/agent_meta_sidecar_purge_apply.py
     owner: stable
   - path: polylogue/maintenance/archive_verification.py
-    loc: 1282
+    loc: 1445
     target: polylogue/maintenance/archive_verification.py
     owner: stable
   - path: polylogue/maintenance/cost_backfill.py
@@ -2264,7 +2268,7 @@ files:
     target: polylogue/maintenance/raw_membership_writeback_apply.py
     owner: stable
   - path: polylogue/maintenance/rebuild_index.py
-    loc: 1204
+    loc: 1225
     target: polylogue/maintenance/rebuild_index.py
     owner: stable
   - path: polylogue/maintenance/registry.py
@@ -2556,7 +2560,7 @@ files:
     target: polylogue/pipeline/services/ingest_batch/__init__.py
     owner: stable
   - path: polylogue/pipeline/services/ingest_batch/_core.py
-    loc: 2051
+    loc: 2220
     target: polylogue/pipeline/services/ingest_batch/_core.py
     owner: stable
   - path: polylogue/pipeline/services/ingest_batch/_memory.py
@@ -3094,7 +3098,7 @@ files:
     target: polylogue/schemas/sampling.py
     owner: stable
   - path: polylogue/schemas/sampling_db.py
-    loc: 530
+    loc: 540
     target: polylogue/schemas/sampling_db.py
     owner: stable
   - path: polylogue/schemas/sampling_sessions.py
@@ -3269,7 +3273,7 @@ files:
     target: polylogue/sources/__init__.py
     owner: stable
   - path: polylogue/sources/assembly.py
-    loc: 142
+    loc: 150
     target: polylogue/sources/assembly.py
     owner: stable
   - path: polylogue/sources/assembly_chatgpt.py
@@ -3277,7 +3281,7 @@ files:
     target: polylogue/sources/assembly_chatgpt.py
     owner: stable
   - path: polylogue/sources/assembly_claude_ai.py
-    loc: 161
+    loc: 163
     target: polylogue/sources/assembly_claude_ai.py
     owner: stable
   - path: polylogue/sources/assembly_claude_code.py
@@ -3285,7 +3289,7 @@ files:
     target: polylogue/sources/assembly_claude_code.py
     owner: stable
   - path: polylogue/sources/assembly_codex.py
-    loc: 382
+    loc: 440
     target: polylogue/sources/assembly_codex.py
     owner: stable
   - path: polylogue/sources/assembly_gemini.py
@@ -3457,7 +3461,7 @@ files:
     target: polylogue/sources/live/watcher.py
     owner: stable
   - path: polylogue/sources/origin_specs.py
-    loc: 1445
+    loc: 1447
     target: polylogue/sources/origin_specs.py
     owner: stable
   - path: polylogue/sources/parsers/antigravity.py
@@ -3465,7 +3469,7 @@ files:
     target: polylogue/sources/parsers/antigravity.py
     owner: stable
   - path: polylogue/sources/parsers/base.py
-    loc: 42
+    loc: 44
     target: polylogue/sources/parsers/base.py
     owner: stable
   - path: polylogue/sources/parsers/base_models.py
@@ -3474,7 +3478,7 @@ files:
     owner: stable
     cross_cut: { lifecycle: model }
   - path: polylogue/sources/parsers/base_support.py
-    loc: 370
+    loc: 404
     target: polylogue/sources/parsers/base_support.py
     owner: stable
   - path: polylogue/sources/parsers/beads.py
@@ -3534,7 +3538,7 @@ files:
     target: polylogue/sources/parsers/claude/todos.py
     owner: stable
   - path: polylogue/sources/parsers/codex.py
-    loc: 2830
+    loc: 2837
     target: polylogue/sources/parsers/codex.py
     owner: stable
   - path: polylogue/sources/parsers/codex_state.py
@@ -3542,7 +3546,7 @@ files:
     target: polylogue/sources/parsers/codex_state.py
     owner: stable
   - path: polylogue/sources/parsers/drive.py
-    loc: 520
+    loc: 527
     target: polylogue/sources/parsers/drive.py
     owner: stable
   - path: polylogue/sources/parsers/drive_support.py
@@ -3562,7 +3566,7 @@ files:
     target: polylogue/sources/parsers/drive_support_text.py
     owner: stable
   - path: polylogue/sources/parsers/grok.py
-    loc: 178
+    loc: 183
     target: polylogue/sources/parsers/grok.py
     owner: stable
   - path: polylogue/sources/parsers/hermes_identity.py
@@ -3578,7 +3582,7 @@ files:
     target: polylogue/sources/parsers/hermes_spans.py
     owner: stable
   - path: polylogue/sources/parsers/hermes_state.py
-    loc: 1013
+    loc: 1019
     target: polylogue/sources/parsers/hermes_state.py
     owner: stable
   - path: polylogue/sources/parsers/hermes_verification.py
@@ -3586,7 +3590,7 @@ files:
     target: polylogue/sources/parsers/hermes_verification.py
     owner: stable
   - path: polylogue/sources/parsers/local_agent.py
-    loc: 677
+    loc: 686
     target: polylogue/sources/parsers/local_agent.py
     owner: stable
   - path: polylogue/sources/provider_completeness.py
@@ -3642,7 +3646,7 @@ files:
     owner: stable
     cross_cut: { lifecycle: model }
   - path: polylogue/sources/revision_backfill.py
-    loc: 2669
+    loc: 2672
     target: polylogue/sources/revision_backfill.py
     owner: stable
   - path: polylogue/sources/source_acquisition.py
@@ -3654,7 +3658,7 @@ files:
     target: polylogue/sources/source_acquisition_components.py
     owner: stable
   - path: polylogue/sources/source_parsing.py
-    loc: 440
+    loc: 438
     target: polylogue/sources/source_parsing.py
     owner: stable
   - path: polylogue/sources/source_walk.py
@@ -4034,7 +4038,7 @@ files:
     owner: storage-root
     reason: storage-root cross-cutting helper
   - path: polylogue/storage/repair.py
-    loc: 7315
+    loc: 7349
     target: polylogue/storage/repair.py
     owner: storage-root
     reason: storage-root cross-cutting helper
@@ -4254,7 +4258,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/__init__.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/archive.py
-    loc: 11593
+    loc: 11606
     target: polylogue/storage/sqlite/archive_tiers/archive.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/archive_init.py
@@ -4326,7 +4330,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/revision_application.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/revision_governance.py
-    loc: 2952
+    loc: 3039
     target: polylogue/storage/sqlite/archive_tiers/revision_governance.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/session_annotations_write.py
@@ -4366,7 +4370,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/user_write.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/write.py
-    loc: 6847
+    loc: 6984
     target: polylogue/storage/sqlite/archive_tiers/write.py
     owner: stable
   - path: polylogue/storage/sqlite/async_sqlite.py
@@ -4386,7 +4390,7 @@ files:
     target: polylogue/storage/sqlite/connection.py
     owner: stable
   - path: polylogue/storage/sqlite/connection_profile.py
-    loc: 364
+    loc: 530
     target: polylogue/storage/sqlite/connection_profile.py
     owner: stable
   - path: polylogue/storage/sqlite/delegation_facts.py

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -101,6 +101,7 @@ if TYPE_CHECKING:
     from polylogue.archive.session.neighbor_candidates import SessionNeighborCandidate
     from polylogue.archive.stats import ArchiveStats as StorageArchiveStats
     from polylogue.config import Config
+    from polylogue.context.codex_spawn_edge_correlation import CodexSpawnEdgeReconciliation
     from polylogue.context.compiler import ContextImage, ContextOmission, ContextSpec
     from polylogue.context.hermes_delivery_correlation import HermesContextDeliveryCorrelation
     from polylogue.core.protocols import ProgressCallback
@@ -1312,6 +1313,49 @@ def _archive_reconcile_hermes_session_lifecycle(
             "hermes_session_lifecycle reconciliation read failed (archive present but unreadable): "
             "hermes_session_native_id=%s source_db=%s index_db=%s",
             hermes_session_native_id,
+            source_db,
+            index_db,
+            exc_info=True,
+        )
+        return None
+
+
+def _archive_reconcile_codex_spawn_edges(config: Config) -> CodexSpawnEdgeReconciliation | None:
+    """Reconcile acquired Codex ``thread_spawn_edge`` evidence against
+    transcript-inferred topology (bd polylogue-foee AC#2).
+
+    Read-only audit seam over ``source.db``'s hook-event spool and
+    ``index.db``'s ``session_links``; see
+    ``context.codex_spawn_edge_correlation`` for the join semantics.
+    Returns ``None``, never raises, when either tier is unavailable --
+    "archive not yet initialized" and "archive present but the read failed"
+    both return ``None`` here, matching
+    ``_archive_reconcile_hermes_session_lifecycle``'s contract, but only the
+    second case logs a warning.
+    """
+
+    from polylogue.context.codex_spawn_edge_correlation import reconcile_codex_spawn_edges
+
+    archive_root = _active_archive_root(config)
+    source_db = archive_root / "source.db"
+    index_db = archive_root / "index.db"
+    if not source_db.exists() or not index_db.exists():
+        return None
+    try:
+        source_conn = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
+        source_conn.row_factory = sqlite3.Row
+        try:
+            index_conn = sqlite3.connect(f"file:{index_db}?mode=ro", uri=True)
+            index_conn.row_factory = sqlite3.Row
+            try:
+                return reconcile_codex_spawn_edges(source_conn, index_conn)
+            finally:
+                index_conn.close()
+        finally:
+            source_conn.close()
+    except sqlite3.Error:
+        logger.warning(
+            "codex_spawn_edge reconciliation read failed (archive present but unreadable): source_db=%s index_db=%s",
             source_db,
             index_db,
             exc_info=True,
@@ -2878,6 +2922,24 @@ class PolylogueArchiveMixin:
             self.config,
             hermes_session_native_id=hermes_session_native_id,
         )
+
+    async def reconcile_codex_spawn_edges(self) -> CodexSpawnEdgeReconciliation | None:
+        """Reconcile acquired Codex spawn-edge evidence against inferred topology (bd polylogue-foee AC#2).
+
+        Read-only audit seam over the durable spool (source.db
+        ``raw_hook_events``, ``codex_thread_spawn_edge`` events acquired by
+        polylogue-0jf4) and the ingested topology (index.db
+        ``session_links``, ``BranchType.SUBAGENT`` edges
+        ``sources/parsers/codex.py`` infers structurally from each child
+        session's own transcript). Reports how many transcript-inferred
+        edges are backed by Codex's own orchestration-level record, and how
+        many edges exist in each source but not the other (Codex's own
+        record can carry edges from a crashed or still-running child the
+        transcript never proves). Returns ``None`` only when the archive
+        itself is not yet initialized.
+        """
+
+        return _archive_reconcile_codex_spawn_edges(self.config)
 
     async def hermes_integration_health(self) -> HermesIntegrationHealth:
         """Return the bounded Hermes-to-Polylogue integration health rollup (fs1.15).

--- a/polylogue/context/codex_spawn_edge_correlation.py
+++ b/polylogue/context/codex_spawn_edge_correlation.py
@@ -1,0 +1,116 @@
+"""Correlate acquired Codex ``thread_spawn_edges`` against inferred topology.
+
+bd polylogue-foee (AC#2). ``sources/parsers/codex.py`` infers a
+``BranchType.SUBAGENT`` ``session_links`` edge structurally, from in-session
+evidence on the CHILD's own transcript (``source.subagent.thread_spawn`` /
+``forked_from_id``). ``polylogue-0jf4`` separately acquires Codex's own
+orchestration-level record of the same relationship --
+``thread_spawn_edges`` from ``state_5.sqlite`` -- as durable
+``codex_thread_spawn_edge`` ``raw_hook_events`` (see
+``sources/live/batch.py::_write_codex_thread_state_evidence``). Until this
+module, nothing ever read the acquired edges back to compare them against
+what the transcript-based inference already produced.
+
+This is a read-only reconciliation, mirroring the pattern
+``context.hermes_lifecycle_reconciliation`` established: a bridge over two
+durable/rebuildable tiers (``source.db`` hook-event spool,
+``index.db`` ingested ``session_links``) that makes the comparison visible
+without mutating either side. Codex's own ``thread_spawn_edges`` record can
+carry edges the transcript never proves (e.g. a child that crashed or is
+still running, per ``sources/parsers/codex_state.py``'s module docstring),
+so this reports both directions: inferred edges now backed by authoritative
+evidence, and authoritative edges the transcript-based inference never
+produced.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+from polylogue.core.enums import LinkType, Origin
+from polylogue.storage.sqlite.archive_tiers.source_write import list_hook_events
+
+
+@dataclass(frozen=True, slots=True)
+class CodexSpawnEdgeReconciliation:
+    """Archive-wide comparison of acquired vs. transcript-inferred Codex spawn edges.
+
+    Edges are identified by ``(parent_thread_id, child_thread_id)`` pairs --
+    the raw Codex thread id space both the hook-event payload and
+    ``sessions.native_id`` share for ``Origin.CODEX_SESSION``.
+    """
+
+    total_authoritative_edges: int
+    total_inferred_subagent_links: int
+    backed_by_authoritative_count: int
+    inferred_only_count: int
+    authoritative_only_count: int
+    inferred_only_edges: tuple[tuple[str, str], ...]
+    authoritative_only_edges: tuple[tuple[str, str], ...]
+
+
+def _authoritative_spawn_edges(source_conn: sqlite3.Connection) -> dict[tuple[str, str], str]:
+    """Return ``{(parent_thread_id, child_thread_id): status}`` from acquired
+    ``codex_thread_spawn_edge`` hook events."""
+    edges: dict[tuple[str, str], str] = {}
+    for event in list_hook_events(source_conn, origin=Origin.CODEX_SESSION):
+        if event.event_type != "codex_thread_spawn_edge":
+            continue
+        payload = event.payload
+        parent = payload.get("parent_thread_id")
+        child = payload.get("child_thread_id")
+        status = payload.get("status")
+        if isinstance(parent, str) and parent and isinstance(child, str) and child:
+            edges[(parent, child)] = status if isinstance(status, str) and status else "unknown"
+    return edges
+
+
+def _inferred_subagent_edges(index_conn: sqlite3.Connection) -> set[tuple[str, str]]:
+    """Return ``{(parent_thread_id, child_thread_id)}`` for every codex-session
+    ``SUBAGENT`` ``session_links`` row -- the edges ``parsers/codex.py``
+    infers structurally from the child's own transcript evidence, never from
+    ``thread_spawn_edges``."""
+    rows = index_conn.execute(
+        """
+        SELECT sl.dst_native_id AS parent_native_id, s.native_id AS child_native_id
+        FROM session_links sl
+        JOIN sessions s ON s.session_id = sl.src_session_id
+        WHERE s.origin = ? AND sl.dst_origin = ? AND sl.link_type = ?
+        """,
+        (Origin.CODEX_SESSION.value, Origin.CODEX_SESSION.value, LinkType.SUBAGENT.value),
+    ).fetchall()
+    # Row-factory agnostic (positional indices): callers may pass a plain
+    # tuple-factory connection, not necessarily one with sqlite3.Row set.
+    return {(str(row[0]), str(row[1])) for row in rows}
+
+
+def reconcile_codex_spawn_edges(
+    source_conn: sqlite3.Connection,
+    index_conn: sqlite3.Connection,
+) -> CodexSpawnEdgeReconciliation:
+    """Reconcile acquired Codex spawn-edge evidence against inferred topology.
+
+    ``source_conn`` reads the durable hook-event spool (``source.db``);
+    ``index_conn`` reads the ingested ``session_links`` topology
+    (``index.db``). Neither side is mutated -- see module docstring for why
+    this stays read-only for now.
+    """
+    authoritative = _authoritative_spawn_edges(source_conn)
+    inferred = _inferred_subagent_edges(index_conn)
+    authoritative_keys = set(authoritative.keys())
+    backed = authoritative_keys & inferred
+    inferred_only = inferred - authoritative_keys
+    authoritative_only = authoritative_keys - inferred
+    return CodexSpawnEdgeReconciliation(
+        total_authoritative_edges=len(authoritative),
+        total_inferred_subagent_links=len(inferred),
+        backed_by_authoritative_count=len(backed),
+        inferred_only_count=len(inferred_only),
+        authoritative_only_count=len(authoritative_only),
+        inferred_only_edges=tuple(sorted(inferred_only)),
+        authoritative_only_edges=tuple(sorted(authoritative_only)),
+    )
+
+
+__all__ = ["CodexSpawnEdgeReconciliation", "reconcile_codex_spawn_edges"]

--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -1586,7 +1586,7 @@ def _resolve_codex_sidecar_snapshots(
         return
 
     from polylogue.core.sources import origin_from_provider
-    from polylogue.sources.assembly_codex import CodexAssemblySpec
+    from polylogue.sources.assembly_codex import CodexAssemblySpec, read_codex_thread_title_hook_events
     from polylogue.storage.sqlite.archive_tiers.source_write import (
         read_earliest_history_sidecar_for_path,
         write_history_sidecar,
@@ -1597,6 +1597,13 @@ def _resolve_codex_sidecar_snapshots(
     resolved: dict[str, dict[str, dict[str, str]]] = {}
     source_db_path = archive_root / "source.db"
     with closing(sqlite3.connect(str(source_db_path), timeout=DB_TIMEOUT)) as conn:
+        # bd polylogue-foee: read acquired codex_thread_title hook events
+        # fresh on every batch (never frozen into the persisted sidecar
+        # snapshot below -- the hook events themselves come from a separate,
+        # later-running acquisition path, polylogue-0jf4, so freezing them
+        # into the once-and-done snapshot could permanently exclude titles
+        # acquired after the first parse of a given source_path).
+        hook_event_titles = read_codex_thread_title_hook_events(conn)
         for record in codex_records:
             source_path = record.source_path
             if source_path in resolved:
@@ -1633,7 +1640,11 @@ def _resolve_codex_sidecar_snapshots(
             except Exception:
                 logger.exception("failed to persist codex sidecar snapshot for %s", source_path)
     for record in codex_records:
-        record.sidecar_snapshot = resolved.get(record.source_path)
+        snapshot = resolved.get(record.source_path)
+        if hook_event_titles:
+            snapshot = dict(snapshot) if snapshot else {}
+            snapshot["hook_event_titles"] = hook_event_titles
+        record.sidecar_snapshot = snapshot
 
 
 def _process_ingest_batch_sync(

--- a/polylogue/sources/assembly.py
+++ b/polylogue/sources/assembly.py
@@ -37,6 +37,14 @@ class _CodexSidecarData(TypedDict, total=False):
     thread_names: CodexThreadNames
     history_titles: CodexHistoryTitles
     state_titles: CodexHistoryTitles
+    # bd polylogue-foee: thread_id -> title read from acquired
+    # codex_thread_title raw_hook_events (polylogue-0jf4's durable,
+    # snapshot-safe capture of state_5.sqlite's threads.title). Populated by
+    # pipeline/services/ingest_batch/_core.py::_resolve_codex_sidecar_snapshots
+    # (which has the source.db connection this needs), never by
+    # CodexAssemblySpec.discover_sidecars itself (file-system only, no DB
+    # access) -- see assembly_codex.py's ladder step 3b.
+    hook_event_titles: CodexHistoryTitles
 
 
 class _ClaudeAISidecarData(TypedDict, total=False):

--- a/polylogue/sources/assembly_codex.py
+++ b/polylogue/sources/assembly_codex.py
@@ -193,7 +193,7 @@ def read_codex_thread_title_hook_events(source_conn: sqlite3.Connection) -> dict
         if event.event_type != "codex_thread_title":
             continue
         thread_id = event.session_native_id
-        title = event.payload.get("title") if isinstance(event.payload, dict) else None
+        title = event.payload.get("title")
         if isinstance(thread_id, str) and thread_id and isinstance(title, str) and title.strip():
             titles[thread_id] = title.strip()
     return titles

--- a/polylogue/sources/assembly_codex.py
+++ b/polylogue/sources/assembly_codex.py
@@ -165,6 +165,40 @@ def _parse_state_db_file(state_path: Path) -> dict[str, str]:
     return titles
 
 
+def read_codex_thread_title_hook_events(source_conn: sqlite3.Connection) -> dict[str, str]:
+    """Return ``{thread_id: title}`` from acquired ``codex_thread_title`` hook events.
+
+    bd polylogue-foee: ``sources/live/batch.py``'s
+    ``_write_codex_thread_state_evidence`` writes one durable
+    ``raw_hook_events`` row per Codex thread (``hook_event_id ==
+    f"codex-thread-title:{thread_id}"``, upserted -- at most one row per
+    thread) whenever ``polylogue-0jf4``'s state-db acquisition observes a
+    ``threads.title``. This is the read side: called from
+    ``pipeline/services/ingest_batch/_core.py::_resolve_codex_sidecar_snapshots``,
+    which owns the only open ``source.db`` connection available at the point
+    Codex sidecar discovery runs. Any failure (missing table, locked file,
+    corrupt payload) degrades to an empty mapping, matching every other
+    sidecar source in this module.
+    """
+    from polylogue.core.enums import Origin
+    from polylogue.storage.sqlite.archive_tiers.source_write import list_hook_events
+
+    titles: dict[str, str] = {}
+    try:
+        events = list_hook_events(source_conn, origin=Origin.CODEX_SESSION)
+    except sqlite3.Error as exc:
+        logger.debug("Failed to read Codex thread-title hook events: %s", exc)
+        return {}
+    for event in events:
+        if event.event_type != "codex_thread_title":
+            continue
+        thread_id = event.session_native_id
+        title = event.payload.get("title") if isinstance(event.payload, dict) else None
+        if isinstance(thread_id, str) and thread_id and isinstance(title, str) and title.strip():
+            titles[thread_id] = title.strip()
+    return titles
+
+
 def _title_preview(text: str) -> str | None:
     """First non-empty line, bounded, or None when nothing usable remains."""
     for line in text.strip().splitlines():
@@ -260,8 +294,9 @@ class CodexAssemblySpec:
         sidecar_data: SidecarData,
     ) -> ParsedSession:
         """Resolve a Codex title: thread name → authored history →
-        state_5.sqlite thread title → first human-authored message → leave
-        the native id.
+        state_5.sqlite thread title (live read) → acquired
+        codex_thread_title hook event (durable snapshot, gap-fill only) →
+        first human-authored message → leave the native id.
 
         A ``role=user`` row alone never becomes a title: Codex runtime
         context and operator protocol rows share that role, so only
@@ -271,6 +306,7 @@ class CodexAssemblySpec:
         thread_names: CodexThreadNames = sidecar_data.get("thread_names", {})
         history_titles: CodexHistoryTitles = sidecar_data.get("history_titles", {})
         state_titles: CodexHistoryTitles = sidecar_data.get("state_titles", {})
+        hook_event_titles: CodexHistoryTitles = sidecar_data.get("hook_event_titles", {})
         cid = conv.provider_session_id
 
         # 1. Provider thread name — authoritative, may replace a stale title.
@@ -341,6 +377,27 @@ class CodexAssemblySpec:
                     }
                 )
 
+        # 3b. codex_thread_title raw_hook_events -- bd polylogue-foee. A
+        # durable, replay-safe capture of the SAME threads.title column step
+        # 3 reads live (polylogue-0jf4's snapshot acquisition, via
+        # sqlite3.Connection.backup() rather than a racy direct open). Only
+        # fills the gap left by a live-read miss (state_5.sqlite rotated,
+        # deleted, or momentarily locked past step 3's own read) -- never
+        # overrides a title step 3 already resolved from the live file.
+        hook_event_text = hook_event_titles.get(cid)
+        if hook_event_text:
+            preview = _title_preview(hook_event_text)
+            if preview:
+                is_echo = _is_prompt_echo(hook_event_text, conv)
+                return conv.model_copy(
+                    update={
+                        "title": preview,
+                        "title_source": TitleSource.HEURISTIC if is_echo else TitleSource.ORIGIN,
+                        "title_ref": f"codex-thread-title-hook-event:{cid}",
+                        "title_confidence": 0.5 if is_echo else 0.7,
+                    }
+                )
+
         # 4. First human-authored message in the parsed session.
         for msg in conv.messages:
             if msg.material_origin is not MaterialOrigin.HUMAN_AUTHORED:
@@ -379,4 +436,5 @@ __all__ = [
     "_parse_codex_history",
     "_parse_codex_session_index",
     "_parse_codex_state_titles",
+    "read_codex_thread_title_hook_events",
 ]

--- a/polylogue/sources/parsers/base.py
+++ b/polylogue/sources/parsers/base.py
@@ -20,6 +20,7 @@ from .base_support import (
     attachment_from_meta,
     content_blocks_from_segments,
     extract_messages_from_list,
+    fill_linear_parent_chain,
     text_blocks_prose,
 )
 
@@ -38,5 +39,6 @@ __all__ = [
     "content_blocks_from_segments",
     "extract_messages_from_list",
     "attachment_from_meta",
+    "fill_linear_parent_chain",
     "text_blocks_prose",
 ]

--- a/polylogue/sources/parsers/base_support.py
+++ b/polylogue/sources/parsers/base_support.py
@@ -41,6 +41,40 @@ def text_blocks_prose(blocks: Sequence[ParsedContentBlock]) -> str | None:
     return "\n".join(parts) if parts else None
 
 
+def fill_linear_parent_chain(messages: Sequence[ParsedMessage]) -> list[ParsedMessage]:
+    """Backfill ``parent_message_provider_id`` for a strictly linear message list.
+
+    bd polylogue-ksgg: five of nine archive origins (Codex, Hermes, Gemini
+    CLI, Grok, and AI Studio Drive's non-branch path) never assert an
+    explicit reply-to edge, because their session shape is a plain ordered
+    turn sequence with no fork/retry concept at the message level -- there is
+    no ``variant_index>0`` row in any of them today (ksgg finding B). Leaving
+    ``parent_message_provider_id`` at ``None`` for every message makes
+    position-order the ONLY way to reconstruct the conversation shape for
+    these origins, unlike Claude Code / ChatGPT where a real parent chain is
+    carried end to end.
+
+    This fills the trivial, unambiguous case -- chaining each message to the
+    previous message on the same active path -- without fabricating branch
+    structure: a message that already carries real parent evidence (e.g.
+    ``parsers/drive.py``'s explicit Gemini branch chunks) is left untouched,
+    and only a message with ``parent_message_provider_id is None`` is
+    chained to the nearest preceding *active-path* message. A session's
+    first message (and any message with no preceding active-path message)
+    keeps ``parent_message_provider_id=None`` -- there is nothing to chain
+    it to.
+    """
+    filled: list[ParsedMessage] = []
+    previous_active_id: str | None = None
+    for message in messages:
+        if message.parent_message_provider_id is None and previous_active_id is not None:
+            message = message.model_copy(update={"parent_message_provider_id": previous_active_id})
+        filled.append(message)
+        if message.is_active_path is not False:
+            previous_active_id = message.provider_message_id
+    return filled
+
+
 def content_blocks_from_segments(content: object) -> list[ParsedContentBlock]:
     """Convert raw API content (str, list, dict) to ParsedContentBlock list."""
     if isinstance(content, str):

--- a/polylogue/sources/parsers/codex.py
+++ b/polylogue/sources/parsers/codex.py
@@ -29,6 +29,7 @@ from .base import (
     ParsedSession,
     ParsedSessionEvent,
     content_blocks_from_segments,
+    fill_linear_parent_chain,
 )
 
 logger = get_logger(__name__)
@@ -2802,6 +2803,12 @@ def _parse_records(records: Iterable[object], fallback_id: str) -> ParsedSession
             )
             for message in messages
         ]
+    # bd polylogue-ksgg: Codex rollout messages carry no parent-message
+    # evidence at all (0% parented, 0 variant_index>0 rows) -- a strictly
+    # linear turn sequence. Chain each message to the previous one so
+    # readers of `parent_message_id` don't need origin-specific fallback to
+    # position order.
+    messages = fill_linear_parent_chain(messages)
 
     return ParsedSession(
         source_name=Provider.CODEX,

--- a/polylogue/sources/parsers/drive.py
+++ b/polylogue/sources/parsers/drive.py
@@ -11,7 +11,7 @@ from polylogue.core.json import JSONDocument, json_document
 from polylogue.logging import get_logger
 from polylogue.sources.providers.gemini import GeminiMessage
 
-from .base import ParsedAttachment, ParsedMessage, ParsedSession, ParsedSessionEvent
+from .base import ParsedAttachment, ParsedMessage, ParsedSession, ParsedSessionEvent, fill_linear_parent_chain
 from .drive_support import (
     _attachment_from_doc as _attachment_from_doc_impl,
 )
@@ -435,6 +435,13 @@ def parse_chunked_prompt(provider: Provider | str, payload: JSONDocument, fallba
             )
             for message in messages
         ]
+    # bd polylogue-ksgg: real Gemini branch evidence (``_branch_parent_provider_id``
+    # / ``branch_child_parents`` above) already sets ``parent_message_provider_id``
+    # for messages that carry it; most AI Studio Drive sessions have none
+    # (0% parented measured) because they're a plain linear chat with no
+    # branch. Only fill the remaining gap -- chain to the previous message on
+    # the active path -- without touching real branch evidence already set.
+    messages = fill_linear_parent_chain(messages)
     return ParsedSession(
         source_name=runtime_provider,
         provider_session_id=str(payload.get("id") or fallback_id),

--- a/polylogue/sources/parsers/grok.py
+++ b/polylogue/sources/parsers/grok.py
@@ -45,7 +45,7 @@ from polylogue.archive.message.roles import Role
 from polylogue.core.enums import BlockType, Provider
 from polylogue.core.timestamps import canonical_timestamp_text
 
-from .base import ParsedContentBlock, ParsedMessage, ParsedSession
+from .base import ParsedContentBlock, ParsedMessage, ParsedSession, fill_linear_parent_chain
 
 _SENDER_ROLE: dict[str, Role] = {
     "human": Role.USER,
@@ -158,6 +158,11 @@ def parse_conversation(payload: Mapping[str, object], fallback_id: str) -> Parse
             )
             for message in messages
         ]
+    # bd polylogue-ksgg: Grok exports carry no native conversation/message id
+    # or parent evidence at all (see module docstring) -- a plain ordered
+    # response list. Chain each message to the previous one so this origin
+    # doesn't need a bespoke position-order fallback either.
+    messages = fill_linear_parent_chain(messages)
     updated_at = messages[-1].timestamp if messages and messages[-1].timestamp else created_at
 
     return ParsedSession(

--- a/polylogue/sources/parsers/hermes_state.py
+++ b/polylogue/sources/parsers/hermes_state.py
@@ -21,7 +21,7 @@ from polylogue.archive.session.branch_type import BranchType
 from polylogue.core.enums import BlockType, MaterialOrigin, Provider
 from polylogue.core.json import JSONDocument, json_document
 
-from .base import ParsedContentBlock, ParsedMessage, ParsedSession, ParsedSessionEvent
+from .base import ParsedContentBlock, ParsedMessage, ParsedSession, ParsedSessionEvent, fill_linear_parent_chain
 from .hermes_identity import profile_key as _profile_key
 from .hermes_identity import qualified_session_id as _qualified_session_id
 from .local_agent import _content_blocks_from_content, _content_text, _tool_use_block
@@ -654,6 +654,12 @@ def _parse_session_row(
         messages.append(parsed)
         state_events.append(_message_state_event(message_row, parsed, message_columns=message_columns))
         state_events.extend(_reasoning_evidence_events(message_row, parsed))
+    # bd polylogue-ksgg: the Hermes state-db conversational transcript is a
+    # linear turn sequence (variant_index is always 0) with no
+    # parent_message_provider_id evidence at all -- chain each message to
+    # the previous one on the active path so readers don't need a
+    # Hermes-specific position-order fallback.
+    messages = fill_linear_parent_chain(messages)
     messages = _mark_active_leaf(messages)
     parent_raw_id = _optional_text(_row_value(row, "parent_session_id"))
     parent_id = _qualified_session_id(parent_raw_id, profile_key) if parent_raw_id else None

--- a/polylogue/sources/parsers/local_agent.py
+++ b/polylogue/sources/parsers/local_agent.py
@@ -9,7 +9,7 @@ from polylogue.archive.message.roles import Role
 from polylogue.core.enums import BlockType, BranchType, Provider
 from polylogue.core.json import JSONDocument, json_document
 
-from .base import ParsedContentBlock, ParsedMessage, ParsedSession, ParsedSessionEvent
+from .base import ParsedContentBlock, ParsedMessage, ParsedSession, ParsedSessionEvent, fill_linear_parent_chain
 
 
 # polylogue-9x22: ``ParsedContentBlock.metadata`` is never persisted -- the
@@ -93,6 +93,10 @@ def parse_gemini_cli(payload: JSONDocument, fallback_id: str) -> ParsedSession:
                 models_used.add(parsed.model_name)
             if usage_event := _gemini_message_usage_event(item, parsed):
                 session_events.append(usage_event)
+    # bd polylogue-ksgg: Gemini CLI sessions carry no parent-message evidence
+    # (0% parented, 0 variant_index>0 rows) -- a linear turn sequence. Chain
+    # each message to the previous one on the active path.
+    messages = fill_linear_parent_chain(messages)
     messages = _mark_active_leaf(messages)
     if metadata_event := _gemini_cli_session_metadata_event(payload, message_count=len(messages)):
         session_events.append(metadata_event)
@@ -146,6 +150,11 @@ def parse_hermes(payload: JSONDocument, fallback_id: str) -> ParsedSession:
             messages.append(parsed)
             if extras_event := _hermes_message_wire_extras_event(item, parsed):
                 session_events.append(extras_event)
+    # bd polylogue-ksgg: this JSON-sidecar Hermes shape has no parent-message
+    # evidence either -- chain each message to the previous one on the
+    # active path, same as the state-db conversational parser
+    # (hermes_state.py::_parse_session_row).
+    messages = fill_linear_parent_chain(messages)
     messages = _mark_active_leaf(messages)
     if metadata_event := _hermes_session_metadata_event(payload, message_count=len(messages)):
         session_events.append(metadata_event)

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -257,6 +257,7 @@ BESPOKE_METHODS: frozenset[str] = frozenset(
         "compile_and_record_context",
         "correlate_hermes_context_deliveries",
         "reconcile_hermes_session_lifecycle",
+        "reconcile_codex_spawn_edges",
         "hermes_integration_health",
         "list_assertion_candidate_reviews",
         "assertion_candidate_queue_health",
@@ -1249,6 +1250,64 @@ async def test_reconcile_hermes_session_lifecycle_resolves_via_the_facade(tmp_pa
         assert empty_report is not None
         assert empty_report.total_events == 0
         assert empty_report.complete
+    finally:
+        await archive.close()
+
+
+async def test_reconcile_codex_spawn_edges_resolves_via_the_facade(tmp_path: Path) -> None:
+    """bd polylogue-foee (AC#2): the facade method reaches the real
+    hook-event spool and ingested ``session_links`` topology."""
+    import json
+
+    from polylogue.storage.sqlite.archive_tiers.source_write import (
+        ArchiveHookEvent,
+        write_source_hook_event,
+    )
+
+    archive = _archive(tmp_path)
+    with sqlite3.connect(tmp_path / "index.db") as index_conn:
+        index_conn.execute(
+            "INSERT INTO sessions (native_id, origin, title, content_hash, message_count) VALUES (?, ?, ?, ?, ?)",
+            ("child-facade-1", "codex-session", "test", _HASH, 1),
+        )
+        index_conn.execute(
+            "INSERT INTO session_links (src_session_id, dst_origin, dst_native_id, link_type, observed_at_ms) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("codex-session:child-facade-1", "codex-session", "parent-facade-1", "subagent", 1_000),
+        )
+        index_conn.commit()
+
+    payload = {"parent_thread_id": "parent-facade-1", "child_thread_id": "child-facade-1", "status": "closed"}
+    encoded = json.dumps(payload).encode("utf-8")
+    with sqlite3.connect(tmp_path / "source.db") as source_conn:
+        write_source_hook_event(
+            source_conn,
+            origin="codex-session",
+            source_path="synthetic:state-db",
+            payload=encoded,
+            acquired_at_ms=1_000,
+            raw_id="raw-facade-spawn-edge",
+            hook_event=ArchiveHookEvent(
+                hook_event_id="codex-thread-spawn-edge:parent-facade-1:child-facade-1",
+                origin="codex-session",
+                source_path="synthetic:state-db",
+                event_type="codex_thread_spawn_edge",
+                payload=payload,
+                observed_at_ms=1_000,
+                native_id="parent-facade-1:child-facade-1:codex_thread_spawn_edge",
+                session_native_id="parent-facade-1",
+            ),
+        )
+
+    try:
+        report = await archive.reconcile_codex_spawn_edges()
+
+        assert report is not None
+        assert report.total_authoritative_edges == 1
+        assert report.total_inferred_subagent_links == 1
+        assert report.backed_by_authoritative_count == 1
+        assert report.inferred_only_count == 0
+        assert report.authoritative_only_count == 0
     finally:
         await archive.close()
 

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -1277,7 +1277,11 @@ async def test_reconcile_codex_spawn_edges_resolves_via_the_facade(tmp_path: Pat
         )
         index_conn.commit()
 
-    payload = {"parent_thread_id": "parent-facade-1", "child_thread_id": "child-facade-1", "status": "closed"}
+    payload: dict[str, object] = {
+        "parent_thread_id": "parent-facade-1",
+        "child_thread_id": "child-facade-1",
+        "status": "closed",
+    }
     encoded = json.dumps(payload).encode("utf-8")
     with sqlite3.connect(tmp_path / "source.db") as source_conn:
         write_source_hook_event(

--- a/tests/unit/context/test_codex_spawn_edge_correlation.py
+++ b/tests/unit/context/test_codex_spawn_edge_correlation.py
@@ -45,7 +45,11 @@ def _init_source_db(archive_root: Path) -> None:
 def _write_spawn_edge(
     archive_root: Path, *, parent_thread_id: str, child_thread_id: str, status: str = "closed"
 ) -> None:
-    payload = {"parent_thread_id": parent_thread_id, "child_thread_id": child_thread_id, "status": status}
+    payload: dict[str, object] = {
+        "parent_thread_id": parent_thread_id,
+        "child_thread_id": child_thread_id,
+        "status": status,
+    }
     encoded = json.dumps(payload).encode("utf-8")
     with sqlite3.connect(archive_root / "source.db") as conn:
         write_source_hook_event(

--- a/tests/unit/context/test_codex_spawn_edge_correlation.py
+++ b/tests/unit/context/test_codex_spawn_edge_correlation.py
@@ -1,0 +1,135 @@
+"""bd polylogue-foee (AC#2): reconcile acquired Codex thread_spawn_edges
+against transcript-inferred session_links topology.
+
+Exercises ``context.codex_spawn_edge_correlation`` directly against real
+``source.db``/``index.db`` connections -- the facade-level integration test
+lives alongside the other reconciliation facade tests in
+``tests/unit/api/test_facade_contracts.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from polylogue.context.codex_spawn_edge_correlation import reconcile_codex_spawn_edges
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+from polylogue.storage.sqlite.archive_tiers.index import INDEX_DDL, INDEX_SCHEMA_VERSION
+from polylogue.storage.sqlite.archive_tiers.source_write import ArchiveHookEvent, write_source_hook_event
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+_HASH = b"x" * 32
+
+
+def _index_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(INDEX_DDL)
+    conn.execute(f"PRAGMA user_version = {INDEX_SCHEMA_VERSION}")
+    return conn
+
+
+def _source_conn(archive_root: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(f"file:{archive_root / 'source.db'}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _init_source_db(archive_root: Path) -> None:
+    archive_root.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        initialize_archive_tier(conn, ArchiveTier.SOURCE)
+        conn.commit()
+
+
+def _write_spawn_edge(
+    archive_root: Path, *, parent_thread_id: str, child_thread_id: str, status: str = "closed"
+) -> None:
+    payload = {"parent_thread_id": parent_thread_id, "child_thread_id": child_thread_id, "status": status}
+    encoded = json.dumps(payload).encode("utf-8")
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        write_source_hook_event(
+            conn,
+            origin="codex-session",
+            source_path="synthetic:state-db",
+            payload=encoded,
+            acquired_at_ms=1_000,
+            raw_id=f"raw-{parent_thread_id}-{child_thread_id}",
+            hook_event=ArchiveHookEvent(
+                hook_event_id=f"codex-thread-spawn-edge:{parent_thread_id}:{child_thread_id}",
+                origin="codex-session",
+                source_path="synthetic:state-db",
+                event_type="codex_thread_spawn_edge",
+                payload=payload,
+                observed_at_ms=1_000,
+                native_id=f"{parent_thread_id}:{child_thread_id}:codex_thread_spawn_edge",
+                session_native_id=parent_thread_id,
+            ),
+        )
+
+
+def _seed_subagent_link(index_conn: sqlite3.Connection, *, parent_thread_id: str, child_thread_id: str) -> None:
+    index_conn.execute(
+        "INSERT INTO sessions (native_id, origin, title, content_hash, message_count) VALUES (?, ?, ?, ?, ?)",
+        (child_thread_id, "codex-session", "test", _HASH, 1),
+    )
+    index_conn.execute(
+        "INSERT INTO session_links (src_session_id, dst_origin, dst_native_id, link_type, observed_at_ms) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (f"codex-session:{child_thread_id}", "codex-session", parent_thread_id, "subagent", 1_000),
+    )
+    index_conn.commit()
+
+
+def test_inferred_edge_backed_by_matching_authoritative_evidence(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    _init_source_db(archive_root)
+    _write_spawn_edge(archive_root, parent_thread_id="parent-1", child_thread_id="child-1")
+
+    index_conn = _index_conn()
+    _seed_subagent_link(index_conn, parent_thread_id="parent-1", child_thread_id="child-1")
+
+    source_conn = _source_conn(archive_root)
+    report = reconcile_codex_spawn_edges(source_conn, index_conn)
+
+    assert report.total_authoritative_edges == 1
+    assert report.total_inferred_subagent_links == 1
+    assert report.backed_by_authoritative_count == 1
+    assert report.inferred_only_count == 0
+    assert report.authoritative_only_count == 0
+
+
+def test_inferred_only_and_authoritative_only_edges_are_both_visible(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    _init_source_db(archive_root)
+    # Authoritative evidence for an edge the transcript never proved (e.g. a
+    # crashed child -- see module docstring).
+    _write_spawn_edge(archive_root, parent_thread_id="parent-a", child_thread_id="child-crashed")
+
+    index_conn = _index_conn()
+    # Transcript-inferred edge with no authoritative counterpart.
+    _seed_subagent_link(index_conn, parent_thread_id="parent-b", child_thread_id="child-inferred-only")
+
+    source_conn = _source_conn(archive_root)
+    report = reconcile_codex_spawn_edges(source_conn, index_conn)
+
+    assert report.total_authoritative_edges == 1
+    assert report.total_inferred_subagent_links == 1
+    assert report.backed_by_authoritative_count == 0
+    assert report.inferred_only_count == 1
+    assert report.authoritative_only_count == 1
+    assert report.inferred_only_edges == (("parent-b", "child-inferred-only"),)
+    assert report.authoritative_only_edges == (("parent-a", "child-crashed"),)
+
+
+def test_no_evidence_either_side_reconciles_as_empty(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    _init_source_db(archive_root)
+    index_conn = _index_conn()
+
+    source_conn = _source_conn(archive_root)
+    report = reconcile_codex_spawn_edges(source_conn, index_conn)
+
+    assert report.total_authoritative_edges == 0
+    assert report.total_inferred_subagent_links == 0
+    assert report.backed_by_authoritative_count == 0

--- a/tests/unit/pipeline/test_ingest_batch_codex_sidecar_snapshot.py
+++ b/tests/unit/pipeline/test_ingest_batch_codex_sidecar_snapshot.py
@@ -193,7 +193,7 @@ def _write_codex_thread_title_hook_event(archive_root: Path, *, thread_id: str, 
         write_source_hook_event,
     )
 
-    payload = {"thread_id": thread_id, "title": title}
+    payload: dict[str, object] = {"thread_id": thread_id, "title": title}
     encoded = _json.dumps(payload).encode("utf-8")
     with sqlite3.connect(str(archive_root / "source.db")) as conn:
         write_source_hook_event(

--- a/tests/unit/pipeline/test_ingest_batch_codex_sidecar_snapshot.py
+++ b/tests/unit/pipeline/test_ingest_batch_codex_sidecar_snapshot.py
@@ -181,6 +181,91 @@ def test_transient_discovery_failure_does_not_freeze_an_empty_snapshot(
     assert persisted["history_titles"][session_id] == "real title"
 
 
+def _write_codex_thread_title_hook_event(archive_root: Path, *, thread_id: str, title: str) -> None:
+    """Write a real ``codex_thread_title`` raw_hook_events row (polylogue-0jf4
+    shape), the same one ``sources/live/batch.py::_write_codex_thread_state_evidence``
+    produces from an acquired ``state_5.sqlite``."""
+    import json as _json
+
+    from polylogue.core.enums import Origin
+    from polylogue.storage.sqlite.archive_tiers.source_write import (
+        ArchiveHookEvent,
+        write_source_hook_event,
+    )
+
+    payload = {"thread_id": thread_id, "title": title}
+    encoded = _json.dumps(payload).encode("utf-8")
+    with sqlite3.connect(str(archive_root / "source.db")) as conn:
+        write_source_hook_event(
+            conn,
+            origin=Origin.CODEX_SESSION,
+            source_path="synthetic:state-db",
+            payload=encoded,
+            acquired_at_ms=1_000,
+            raw_id="raw-codex-thread-title",
+            hook_event=ArchiveHookEvent(
+                hook_event_id=f"codex-thread-title:{thread_id}",
+                origin=Origin.CODEX_SESSION,
+                source_path="synthetic:state-db",
+                event_type="codex_thread_title",
+                payload=payload,
+                observed_at_ms=1_000,
+                native_id=f"{thread_id}:codex_thread_title",
+                session_native_id=thread_id,
+            ),
+        )
+
+
+def test_hook_event_titles_merged_from_acquired_evidence(tmp_path: Path, archive_root: Path) -> None:
+    """bd polylogue-foee: a codex_thread_title hook event acquired via
+    polylogue-0jf4's state-db snapshot (never the JSONL rollout the parser
+    reads) surfaces as ``hook_event_titles`` in the sidecar snapshot handed
+    to ``CodexAssemblySpec.enrich_session``, even though the rollout itself
+    carries no session_index.jsonl/history.jsonl/state_5.sqlite of its own.
+    """
+    session_id = "cccc1111-2222-3333-4444-555566667777"
+    rollout = _codex_runtime_root(tmp_path, session_id)
+    _write_codex_thread_title_hook_event(archive_root, thread_id=session_id, title="Durable curated title")
+
+    record = _record(str(rollout))
+    _resolve_codex_sidecar_snapshots([record], archive_root=archive_root)
+
+    assert record.sidecar_snapshot is not None
+    assert record.sidecar_snapshot["hook_event_titles"][session_id] == "Durable curated title"
+    # Never a live-read title source -- nothing else discovered one.
+    assert not record.sidecar_snapshot.get("state_titles")
+
+    # Never frozen into the persisted history_sidecars snapshot: it is read
+    # fresh from raw_hook_events on every batch (see the _core.py comment),
+    # so a hook event acquired AFTER a source_path's first-ever resolution
+    # still surfaces on the next batch.
+    with sqlite3.connect(str(archive_root / "source.db")) as conn:
+        rows = conn.execute("SELECT payload_json FROM history_sidecars").fetchall()
+    assert len(rows) == 1
+    persisted = json.loads(rows[0][0])
+    assert "hook_event_titles" not in persisted
+
+
+def test_hook_event_titles_surface_on_replay_even_when_acquired_later(tmp_path: Path, archive_root: Path) -> None:
+    """The hook event can be acquired AFTER a source_path's frozen sidecar
+    snapshot already exists; since hook_event_titles is never part of that
+    frozen payload, a later batch still sees it."""
+    session_id = "eeee1111-2222-3333-4444-555566667777"
+    rollout = _codex_runtime_root(tmp_path, session_id)
+
+    record_first = _record(str(rollout))
+    _resolve_codex_sidecar_snapshots([record_first], archive_root=archive_root)
+    assert record_first.sidecar_snapshot is not None
+    assert "hook_event_titles" not in record_first.sidecar_snapshot
+
+    _write_codex_thread_title_hook_event(archive_root, thread_id=session_id, title="Acquired after first parse")
+
+    record_second = _record(str(rollout))
+    _resolve_codex_sidecar_snapshots([record_second], archive_root=archive_root)
+    assert record_second.sidecar_snapshot is not None
+    assert record_second.sidecar_snapshot["hook_event_titles"][session_id] == "Acquired after first parse"
+
+
 def test_non_codex_records_are_left_unresolved(tmp_path: Path, archive_root: Path) -> None:
     record = RawSessionRecord(
         raw_id="raw-claude",

--- a/tests/unit/sources/parsers/test_base_support.py
+++ b/tests/unit/sources/parsers/test_base_support.py
@@ -1,0 +1,53 @@
+"""Unit tests for shared parser helpers (sources/parsers/base_support.py)."""
+
+from __future__ import annotations
+
+from polylogue.archive.message.roles import Role
+from polylogue.sources.parsers.base import ParsedMessage, fill_linear_parent_chain
+
+
+def _msg(pid: str, *, parent: str | None = None, active: bool | None = True) -> ParsedMessage:
+    return ParsedMessage(
+        provider_message_id=pid,
+        role=Role.USER,
+        text=pid,
+        position=int(pid.rsplit("-", 1)[-1]) if "-" in pid else 0,
+        variant_index=0,
+        is_active_path=active,
+        parent_message_provider_id=parent,
+    )
+
+
+def test_fill_linear_parent_chain_chains_previous_message() -> None:
+    messages = [_msg("m-0"), _msg("m-1"), _msg("m-2")]
+    filled = fill_linear_parent_chain(messages)
+    assert [m.parent_message_provider_id for m in filled] == [None, "m-0", "m-1"]
+
+
+def test_fill_linear_parent_chain_preserves_existing_parent_evidence() -> None:
+    # A message that already carries real parent evidence (e.g. drive.py's
+    # branch chunks) must not be overwritten.
+    messages = [_msg("m-0"), _msg("m-1", parent="m-0-real-branch-parent"), _msg("m-2")]
+    filled = fill_linear_parent_chain(messages)
+    assert filled[1].parent_message_provider_id == "m-0-real-branch-parent"
+    # m-2 still chains to the nearest preceding active-path message (m-1),
+    # not to the overridden parent of m-1.
+    assert filled[2].parent_message_provider_id == "m-1"
+
+
+def test_fill_linear_parent_chain_skips_inactive_path_messages() -> None:
+    # An inactive-path message is never used as a chain anchor for the
+    # message that follows it.
+    messages = [_msg("m-0"), _msg("m-1", active=False), _msg("m-2")]
+    filled = fill_linear_parent_chain(messages)
+    assert filled[1].parent_message_provider_id == "m-0"
+    assert filled[2].parent_message_provider_id == "m-0"
+
+
+def test_fill_linear_parent_chain_empty_list() -> None:
+    assert fill_linear_parent_chain([]) == []
+
+
+def test_fill_linear_parent_chain_single_message_stays_unparented() -> None:
+    filled = fill_linear_parent_chain([_msg("m-0")])
+    assert filled[0].parent_message_provider_id is None

--- a/tests/unit/sources/test_assembly.py
+++ b/tests/unit/sources/test_assembly.py
@@ -87,11 +87,13 @@ def _thread_sidecars(
     thread_names: dict[str, str] | None = None,
     history_titles: dict[str, str] | None = None,
     state_titles: dict[str, str] | None = None,
+    hook_event_titles: dict[str, str] | None = None,
 ) -> SidecarData:
     return {
         "thread_names": {} if thread_names is None else thread_names,
         "history_titles": {} if history_titles is None else history_titles,
         "state_titles": {} if state_titles is None else state_titles,
+        "hook_event_titles": {} if hook_event_titles is None else hook_event_titles,
     }
 
 
@@ -1115,6 +1117,77 @@ class TestCodexStateTitles:
         sessions_root = tmp_path / ".codex" / "sessions"
         sessions_root.mkdir(parents=True)
         assert _parse_codex_state_titles(sessions_root) == {}
+
+    # -----------------------------------------------------------------
+    # bd polylogue-foee: acquired codex_thread_title hook events (step 3b)
+    # -----------------------------------------------------------------
+
+    def test_hook_event_title_fills_gap_when_nothing_else_resolves(self) -> None:
+        spec = CodexAssemblySpec()
+        conv = _parsed_session(Provider.CODEX, "thread-1", "thread-1", [])
+        sidecar_data = _thread_sidecars(hook_event_titles={"thread-1": "Durable acquired title"})
+
+        enriched = spec.enrich_session(conv, sidecar_data)
+
+        assert enriched.title == "Durable acquired title"
+        assert enriched.title_source == TitleSource.ORIGIN
+        assert enriched.title_ref == "codex-thread-title-hook-event:thread-1"
+        assert enriched.title_confidence == 0.7
+
+    def test_state_title_beats_hook_event_title(self) -> None:
+        """A live state_5.sqlite read (step 3) is fresher than the durable
+        hook-event snapshot (step 3b) -- it wins when both resolve."""
+        spec = CodexAssemblySpec()
+        conv = _parsed_session(Provider.CODEX, "thread-1", "thread-1", [])
+        sidecar_data = _thread_sidecars(
+            state_titles={"thread-1": "Live-read title"},
+            hook_event_titles={"thread-1": "Stale acquired title"},
+        )
+
+        enriched = spec.enrich_session(conv, sidecar_data)
+
+        assert enriched.title == "Live-read title"
+
+    def test_hook_event_title_beats_first_message_fallback(self) -> None:
+        spec = CodexAssemblySpec()
+        conv = _parsed_session(
+            Provider.CODEX,
+            "thread-1",
+            "thread-1",
+            [_authored_message("m1", "message body that would otherwise win")],
+        )
+        sidecar_data = _thread_sidecars(hook_event_titles={"thread-1": "Durable acquired title"})
+
+        enriched = spec.enrich_session(conv, sidecar_data)
+
+        assert enriched.title == "Durable acquired title"
+        assert enriched.title_source == TitleSource.ORIGIN
+
+    def test_hook_event_title_downgrades_when_it_echoes_the_first_prompt(self) -> None:
+        spec = CodexAssemblySpec()
+        conv = _parsed_session(
+            Provider.CODEX,
+            "thread-1",
+            "thread-1",
+            [_authored_message("m1", "find, using whatever means, either directly ~/.codex or polylogue")],
+        )
+        sidecar_data = _thread_sidecars(
+            hook_event_titles={"thread-1": "find, using whatever means, either directly ~/.codex or polylogue"}
+        )
+
+        enriched = spec.enrich_session(conv, sidecar_data)
+
+        assert enriched.title_source == TitleSource.HEURISTIC
+        assert enriched.title_confidence == 0.5
+
+    def test_hook_event_title_never_replaces_real_title(self) -> None:
+        spec = CodexAssemblySpec()
+        conv = _parsed_session(Provider.CODEX, "thread-1", "A real existing title", [])
+        sidecar_data = _thread_sidecars(hook_event_titles={"thread-1": "Durable acquired title"})
+
+        result = spec.enrich_session(conv, sidecar_data)
+
+        assert result is conv
 
     def test_state_titles_cache_invalidates_on_file_change(self, tmp_path: Path) -> None:
         import os


### PR DESCRIPTION
## Summary
Fills message-level `parent_message_id` for the five Codex/parser-evidence origins that carried none (bd polylogue-ksgg's remaining (A)/(B) scope, since (D) -- the read-surface column exposure -- already shipped in PR #3626), and wires polylogue-0jf4's acquired Codex thread-title/spawn-edge evidence into title resolution and topology reconciliation (bd polylogue-foee).

## Problem
polylogue-ksgg's 2026-07-31 audit measured 5 of 9 archive origins (codex-session, hermes-session, gemini-cli-session, grok-export, and the non-branch path of aistudio-drive) with 0% of messages carrying `parent_message_provider_id`. These are strictly linear turn sequences (no `variant_index>0` row exists in any of them), so the gap wasn't missing real branch evidence -- no parser ever asserted the trivial "previous message" edge, leaving consumers to fall back to position-order for these origins while Claude Code/ChatGPT carry a real parent chain.

Separately, polylogue-foee's prior lane (polylogue-0jf4) built acquisition for Codex's live `state_5.sqlite` (`threads.title` and `thread_spawn_edges`), landing them as typed `raw_hook_events` keyed to the existing codex-session row -- but nothing ever consumed that evidence. Codex sessions kept UUID titles even when a curated title had been durably acquired, and the transcript-inferred subagent-spawn topology (`session_links`) was never compared against Codex's own orchestration-level spawn-edge record.

## Solution
**Parent-link fill (polylogue-ksgg):** `fill_linear_parent_chain` (`polylogue/sources/parsers/base_support.py`) chains each message with no `parent_message_provider_id` to the nearest preceding active-path message, leaving any already-set parent evidence untouched (e.g. `drive.py`'s real Gemini branch chunks). Wired into `parsers/codex.py`, `parsers/hermes_state.py` (the state-db conversational parser), `parsers/local_agent.py` (`parse_gemini_cli` + `parse_hermes`), `parsers/grok.py`, and `parsers/drive.py` (gap-fill only, after existing branch-evidence assignment).

**Title resolution (polylogue-foee AC#1):** `read_codex_thread_title_hook_events` (`sources/assembly_codex.py`) reads acquired `codex_thread_title` hook events. `pipeline/services/ingest_batch/_core.py`'s `_resolve_codex_sidecar_snapshots` (the only place with an open `source.db` connection at Codex sidecar-discovery time) reads it fresh on every batch and merges it into each record's sidecar snapshot as `hook_event_titles` -- deliberately NOT frozen into the persisted `history_sidecars` payload, since the hook events come from a separate, later-running acquisition path. `assembly_codex.py`'s title ladder gets a new step 3b between the live `state_titles` read and the first-human-message fallback: only fills the gap left by a live-read miss, never overrides the fresher live read.

**Topology (polylogue-foee AC#2):** `context/codex_spawn_edge_correlation.py` (mirroring `context/hermes_lifecycle_reconciliation`'s read-only bridge pattern) compares acquired `codex_thread_spawn_edge` hook events against transcript-inferred `session_links` SUBAGENT rows, reporting edges backed by authoritative evidence, inferred-only edges, and authoritative-only edges (e.g. a crashed or still-running child the transcript never proves). Wired onto the `Polylogue` facade as `reconcile_codex_spawn_edges()`.

**AC#3 (before/after UUID-title census against a live archive):** not run against the operator's real production archive from this worktree -- doing so would require an operational `polylogue ops reset --index && polylogued run` (or a live `reprocess` pass), which is outside a worktree-isolated PR's authority to trigger unilaterally. Instead this PR provides reproducible test evidence of the same effect: `test_hook_event_title_fills_gap_when_nothing_else_resolves` and the `_resolve_codex_sidecar_snapshots` tests demonstrate a UUID-titled session resolving to the acquired hook-event title end-to-end through the real production code path. The actual archive-wide census is deferred to the coordinator/operator as a follow-up verification step once this lands.

## Verification
- `devtools test tests/unit/sources/test_parsers_codex.py tests/unit/sources/parsers/test_hermes_state.py tests/unit/sources/test_parsers_local_agent.py tests/unit/sources/parsers/test_grok.py tests/unit/sources/test_parsers_drive.py` -> 177 passed
- `devtools test tests/unit/sources/parsers/test_base_support.py` -> 5 passed
- `devtools test tests/unit/sources/test_assembly.py tests/unit/pipeline/test_ingest_batch_codex_sidecar_snapshot.py` -> 91 passed, 6 passed
- `devtools test tests/unit/context/test_codex_spawn_edge_correlation.py tests/unit/api/test_facade_contracts.py` -> 3 passed, 293 passed
- `devtools verify --quick` -> exit_code 0 (format, lint, mypy --strict, render all --check including topology-projection, layering, closure-matrix, and the rest of the quick gate)

Ref polylogue-ksgg
Ref polylogue-foee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Codex spawn-edge reconciliation, highlighting relationships supported by authoritative events, inferred topology, or both.
  - Codex thread titles can now be recovered from durable hook-event data when live state information is unavailable.
  - Added linear parent links for messages lacking explicit ancestry across supported conversation sources.

- **Bug Fixes**
  - Improved title availability during ingestion and replay without altering persisted sidecar snapshots.

- **Tests**
  - Added coverage for reconciliation, title precedence and fallback behavior, and parent-chain handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->