### PR TITLE
fix(sources): cursor lifecycle durability gaps (excluded revival, stalled append, failure-count runaway)

### DIFF
--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -1034,6 +1034,26 @@ class LiveBatchProcessor:
         return _throttled_phase_heartbeat(emit)
 
     def _record_failed_cursor(self, path: Path) -> int:
+        # polylogue-awy5: an already-excluded cursor is a poison pill the
+        # daemon has already given up on (5-failure cap,
+        # ``_MAX_CURSOR_FAILURES_BEFORE_EXCLUDE``). Re-running the same
+        # crash-looping batch against it and calling ``mark_failed`` again
+        # every pass has no effect on the cursor's *state* (the lifecycle
+        # table only permits EXCLUDED -> EXCLUDED here) but keeps
+        # incrementing ``failure_count`` forever with no upper bound --
+        # measured live at 689/864/975/1001/2018 on the five ZIPs that hit
+        # this path, i.e. thousands of full acquire+parse+crash cycles
+        # burned re-discovering a fact the cursor already recorded. Consult
+        # ``excluded`` before touching the cursor at all so a poisoned
+        # source stops being re-queued into wasted work.
+        try:
+            preexisting = self._cursor.get_record(path)
+        except sqlite3.OperationalError as exc:
+            if not is_transient_sqlite_lock(exc):
+                raise
+            preexisting = None
+        if preexisting is not None and preexisting.excluded:
+            return 0
         try:
             stat = path.stat()
         except FileNotFoundError:

--- a/polylogue/sources/live/cursor.py
+++ b/polylogue/sources/live/cursor.py
@@ -1312,23 +1312,37 @@ class CursorStore:
         st_dev: int,
         st_ino: int,
         mtime_ns: int,
+        current_parser_fingerprint: str | None = None,
     ) -> None:
-        """Clear a path quarantine only after the observed file was replaced.
+        """Clear a path quarantine after the observed file OR the parser was replaced.
 
         Exclusion belongs to the exact failed file observation, not forever to
-        its pathname.  Keep the prior cursor observation intact so the caller
-        still routes the replacement through full acquisition.
+        its pathname -- but it also should not survive a parser fix that would
+        have parsed the file correctly the first time (polylogue-ix5r): a file
+        whose bytes never change stays permanently dark under identity-only
+        revival, even after the bug that poisoned it is fixed. ``revive`` fires
+        when EITHER the file identity changed OR ``current_parser_fingerprint``
+        differs from the fingerprint recorded at exclusion time; omitting it
+        (``None``, the default) preserves the original identity-only behavior
+        for callers that have not adopted the fingerprint check.
+
+        Keeps the prior cursor observation intact so the caller still routes
+        the replacement through full acquisition.
         """
 
         def mutate(current: CursorRecord | None) -> CursorRecord | None:
             if current is None or not current.excluded:
                 return None
-            if (
+            identity_unchanged = (
                 current.byte_size,
                 current.st_dev,
                 current.st_ino,
                 current.mtime_ns,
-            ) == (byte_size, st_dev, st_ino, mtime_ns):
+            ) == (byte_size, st_dev, st_ino, mtime_ns)
+            parser_changed = (
+                current_parser_fingerprint is not None and current.parser_fingerprint != current_parser_fingerprint
+            )
+            if identity_unchanged and not parser_changed:
                 return None
             return replace(
                 current,

--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -74,6 +74,18 @@ _CATCH_UP_HOT_FILE_AGE_S = 60.0 * 60.0
 # mid-transaction), never mid-record.
 _LIVE_INGEST_MAX_PASS_SECONDS = 20.0
 _INCOMPLETE_APPEND_PROBE_BYTES = 64 * 1024 * 1024
+# polylogue-2qrx: minimum age a deferred incomplete-tail observation must
+# reach (``cursor.updated_at`` unchanged, i.e. the stat-match fast path kept
+# firing) before escalating to an unbounded full-tail probe. An ordinary
+# in-progress writer routinely leaves a genuinely-incomplete trailing record
+# (no closing newline yet) between two polls milliseconds apart -- that must
+# NOT be treated as "the writer is done" just because the stat happened to
+# match on a second, immediate check. Only a source that has been sitting at
+# the exact same byte state for a long time is plausibly finished rather than
+# merely paused; matches the periodic catch-up safety net's own duty cycle
+# (``_PERIODIC_CATCH_UP_MAX_INTERVAL_S``) so the escalation cannot fire
+# before that safety net would have re-observed the file anyway.
+_STUCK_DEFERRED_APPEND_AGE_S = 60.0 * 60.0
 # Filesystem notifications are the real-time delivery path.  This sweep is a
 # recovery mechanism for notifications missed while the daemon was unavailable
 # or a watch backend was briefly unhealthy.  Keeping it at the watch cadence
@@ -823,12 +835,21 @@ class LiveWatcher:
             cursor = self._cursor.get_record(path)
             return cursor is not None and size > cursor.byte_offset
         if cursor.excluded:
-            if (
+            identity_unchanged = (
                 cursor.byte_size,
                 cursor.st_dev,
                 cursor.st_ino,
                 cursor.mtime_ns,
-            ) == (size, stat.st_dev, stat.st_ino, stat.st_mtime_ns):
+            ) == (size, stat.st_dev, stat.st_ino, stat.st_mtime_ns)
+            # polylogue-ix5r: exclusion revival was previously bound only to
+            # file identity, so a parser fix could never revive a cursor
+            # excluded before that fix shipped -- the file itself never
+            # changes, so ``identity_unchanged`` stays True forever and the
+            # cursor stays dark until someone manually re-ingests it. A
+            # parser fingerprint change is exactly the other legitimate
+            # reason a previously-poisoned observation deserves a fresh
+            # attempt: the code that failed to parse it no longer exists.
+            if identity_unchanged and cursor.parser_fingerprint == _PARSER_FINGERPRINT:
                 return False
             self._cursor.revive_replaced_exclusion(
                 path,
@@ -836,6 +857,7 @@ class LiveWatcher:
                 st_dev=stat.st_dev,
                 st_ino=stat.st_ino,
                 mtime_ns=stat.st_mtime_ns,
+                current_parser_fingerprint=_PARSER_FINGERPRINT,
             )
             return True
         if cursor.failure_count == 0 and cursor.content_fingerprint is None and cursor.next_retry_at is not None:
@@ -866,6 +888,44 @@ class LiveWatcher:
             # not rewritten, so any changed observation with modern tail
             # authority must return to the full route.
             if _cursor_stat_matches(cursor, stat):
+                if cursor.byte_offset >= cursor.byte_size:
+                    return False
+                # polylogue-2qrx: ``byte_size`` matches the current file size
+                # but ``byte_offset`` lags behind it. This is exactly the
+                # state ``record_deferred_append_cursor`` leaves after a
+                # bounded incomplete-tail probe (``_defer_incomplete_jsonl_
+                # append``): it advances ``byte_size`` to the observed file
+                # size but deliberately leaves ``byte_offset`` where it was,
+                # pending a complete trailing record. Once the file then
+                # stops changing (the writer finished), the stat-match check
+                # above returned ``False`` unconditionally here forever --
+                # measured live as 211 files / 414MB of stalled append
+                # backlog, up to 329h stale on one 94.8MB lag, with zero
+                # durable signal.
+                #
+                # An ordinary in-progress writer also leaves this exact state
+                # between two close-together polls (a trailing record simply
+                # not terminated *yet*), so escalate only once the deferred
+                # observation is old enough to be implausible as "still
+                # being written" -- ``cursor.updated_at`` is the timestamp of
+                # that original bounded-probe deferral (nothing else touches
+                # this row while the stat keeps matching).
+                if not _cursor_age_exceeds(cursor, _STUCK_DEFERRED_APPEND_AGE_S):
+                    return False
+                # A real complete record past the original bounded window
+                # reopens the normal append path; if truly nothing is there,
+                # record a durable failure instead of parking silently again.
+                if not self._defer_incomplete_jsonl_append(path, stat=stat, cursor=cursor, probe_bytes=None):
+                    return True
+                logger.warning(
+                    "live.watcher: %s has no complete trailing record across its entire "
+                    "outstanding tail (%d bytes past offset %d) and stopped changing; "
+                    "marking failed for durable visibility instead of parking silently",
+                    path,
+                    cursor.byte_size - cursor.byte_offset,
+                    cursor.byte_offset,
+                )
+                self._cursor.mark_failed(path, failed_stat=stat)
                 return False
             prefix_hash = cursor_prefix_hash(cursor.tail_hash)
             if prefix_hash is None:
@@ -931,8 +991,26 @@ class LiveWatcher:
         *,
         stat: os.stat_result,
         cursor: CursorRecord,
+        probe_bytes: int | None = _INCOMPLETE_APPEND_PROBE_BYTES,
     ) -> bool:
-        """Record a grown-but-incomplete JSONL tail without scheduling ingest."""
+        """Record a grown-but-incomplete JSONL tail without scheduling ingest.
+
+        ``probe_bytes=None`` (polylogue-2qrx escalation) reads the *entire*
+        outstanding tail instead of the bounded default. The bounded probe
+        exists so a routine watch/periodic tick never rereads a large
+        unfinished record on every pass; but that same bound means a
+        complete trailing record sitting just past the probe window (e.g. a
+        multi-hundred-MB rollout whose byte range past ``cursor.byte_offset``
+        happens to open with one oversized blob) is never found, and once
+        the source file stops changing (the writing session ends), the
+        stat-matches fast path below skips this cursor forever with zero
+        durable signal -- see the 211-file, 414MB stalled-cursor backlog
+        this bead measured. ``probe_bytes=None`` is only used for that one
+        already-deferred-with-unchanged-stat case, so the full-tail read
+        happens at most once per genuine state (immediately superseded by
+        either a real append or a durable failure record, never repeated
+        against the same stat).
+        """
         if path.suffix.lower() not in {".jsonl", ".ndjson"}:
             return False
         if cursor.content_fingerprint is None:
@@ -945,7 +1023,7 @@ class LiveWatcher:
         if stat.st_size <= start_offset:
             return False
         remaining_bytes = stat.st_size - start_offset
-        bytes_to_probe = min(remaining_bytes, _INCOMPLETE_APPEND_PROBE_BYTES)
+        bytes_to_probe = remaining_bytes if probe_bytes is None else min(remaining_bytes, probe_bytes)
         try:
             with path.open("rb") as handle:
                 handle.seek(start_offset)
@@ -1495,6 +1573,22 @@ def _cursor_db_path(polylogue: Polylogue) -> Path:
 
 def _is_database_locked(exc: sqlite3.OperationalError) -> bool:
     return "database is locked" in str(exc).lower()
+
+
+def _cursor_age_exceeds(cursor: CursorRecord, min_age_s: float) -> bool:
+    """Return True when ``cursor.updated_at`` is older than ``min_age_s``.
+
+    A malformed/missing timestamp is treated as old (fail toward escalating
+    rather than toward parking silently forever, matching this check's own
+    purpose).
+    """
+    try:
+        updated_at = datetime.fromisoformat(cursor.updated_at)
+    except ValueError:
+        return True
+    if updated_at.tzinfo is None:
+        updated_at = updated_at.replace(tzinfo=UTC)
+    return (datetime.now(UTC) - updated_at).total_seconds() >= min_age_s
 
 
 def _retry_due(next_retry_at: str | None) -> bool:

--- a/tests/unit/sources/test_cursor_lifecycle.py
+++ b/tests/unit/sources/test_cursor_lifecycle.py
@@ -221,8 +221,8 @@ def test_soundness_sweep_exclude_then_revive_with_parser_fingerprint_change(tmp_
     assert classify_cursor_lifecycle_state(after) is _S.EXCLUDED
 
     # Same identity, DIFFERENT parser fingerprint: revives.
+    assert after is not None
     before = after
-    assert before is not None
     store.revive_replaced_exclusion(
         path,
         byte_size=before.byte_size,

--- a/tests/unit/sources/test_cursor_lifecycle.py
+++ b/tests/unit/sources/test_cursor_lifecycle.py
@@ -191,6 +191,51 @@ def test_soundness_sweep_exclude_then_revive_with_proved_identity_change(tmp_pat
     assert classify_cursor_lifecycle_state(after) is _S.ACTIVE
 
 
+def test_soundness_sweep_exclude_then_revive_with_parser_fingerprint_change(tmp_path: Path) -> None:
+    """polylogue-ix5r: a parser fingerprint change revives an excluded cursor
+    even when the file's bytes never changed -- the previous identity-only
+    revival left a cursor permanently dark once its bytes stopped changing,
+    even after the parser bug that poisoned it was fixed."""
+    store = CursorStore(tmp_path / "live.sqlite")
+    path = tmp_path / "session.jsonl"
+    path.write_text("{}\n")
+    store.set(path, path.stat().st_size, st_dev=1, st_ino=1, mtime_ns=1, parser_fingerprint="parser-v1")
+
+    store.mark_excluded(path)
+    excluded = store.get_record(path)
+    assert excluded is not None
+    assert excluded.excluded
+
+    # Same identity, same parser fingerprint: still a documented no-op.
+    before = excluded
+    store.revive_replaced_exclusion(
+        path,
+        byte_size=before.byte_size,
+        st_dev=1,
+        st_ino=1,
+        mtime_ns=1,
+        current_parser_fingerprint="parser-v1",
+    )
+    after = store.get_record(path)
+    _assert_declared(before, "revive_replaced_exclusion", after)
+    assert classify_cursor_lifecycle_state(after) is _S.EXCLUDED
+
+    # Same identity, DIFFERENT parser fingerprint: revives.
+    before = after
+    assert before is not None
+    store.revive_replaced_exclusion(
+        path,
+        byte_size=before.byte_size,
+        st_dev=1,
+        st_ino=1,
+        mtime_ns=1,
+        current_parser_fingerprint="parser-v2",
+    )
+    after = store.get_record(path)
+    _assert_declared(before, "revive_replaced_exclusion", after)
+    assert classify_cursor_lifecycle_state(after) is _S.ACTIVE
+
+
 # ---------------------------------------------------------------------------
 # 3. Real production guard against the discovered hazard: defer must never
 #    observe/emit EXCLUDED.

--- a/tests/unit/sources/test_live_cursor_locking.py
+++ b/tests/unit/sources/test_live_cursor_locking.py
@@ -108,6 +108,39 @@ def test_failed_cursor_bookkeeping_does_not_raise_on_transient_sqlite_lock(tmp_p
     assert processor._record_failed_cursor(source) == source.stat().st_size
 
 
+def test_record_failed_cursor_does_not_reincrement_already_excluded_cursor(tmp_path: Path) -> None:
+    """polylogue-awy5: the batch path used to call ``mark_failed`` on every
+    crash-looping pass with no ``excluded`` pre-check, so a poisoned source
+    kept its ``failure_count`` climbing forever after quarantine (measured
+    live at 689/864/975/1001/2018 on five permanently-excluded ZIPs) instead
+    of staying parked at the exclusion threshold."""
+    from polylogue.sources.live.cursor import _MAX_CURSOR_FAILURES_BEFORE_EXCLUDE
+
+    source = tmp_path / "session.jsonl"
+    source.write_text('{"a":1}\n')
+    store = CursorStore(tmp_path / "live.sqlite")
+    for _ in range(_MAX_CURSOR_FAILURES_BEFORE_EXCLUDE):
+        store.mark_failed(source)
+    excluded_record = store.get_record(source)
+    assert excluded_record is not None
+    assert excluded_record.excluded
+    failure_count_at_exclusion = excluded_record.failure_count
+
+    processor = LiveBatchProcessor(
+        cast(Any, object()),
+        [],
+        cursor=store,
+        parser_fingerprint="fp:test",
+    )
+    for _ in range(3):
+        processor._record_failed_cursor(source)
+
+    record = store.get_record(source)
+    assert record is not None
+    assert record.excluded
+    assert record.failure_count == failure_count_at_exclusion
+
+
 def test_failed_persistence_preserves_last_committed_cursor_offset(tmp_path: Path) -> None:
     source = tmp_path / "session.jsonl"
     committed = b'{"role":"user","content":"committed"}\n'

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -1193,6 +1193,160 @@ def test_large_incomplete_jsonl_append_defers_until_the_file_changes(tmp_path: P
     assert watcher._needs_work(f) is False
 
 
+def _backdate_cursor(tmp_path: Path, path: Path, *, now: datetime, seconds_ago: float) -> None:
+    """Directly rewrite ``ingest_cursor.updated_at_ms`` into the past.
+
+    Simulates a deferred append cursor that has sat at the same observed
+    stat for a long time, without sleeping real wall-clock seconds in the
+    test. ``now`` must come from ``frozen_clock.now()`` (or an equivalent
+    already-guarded source), never a direct host-clock read.
+    """
+    past_ms = int((now.timestamp() - seconds_ago) * 1000)
+    with sqlite3.connect(tmp_path / "ops.db") as conn:
+        conn.execute("UPDATE ingest_cursor SET updated_at_ms = ? WHERE source_path = ?", (past_ms, str(path)))
+        conn.commit()
+
+
+def test_incomplete_probe_does_not_escalate_for_a_recent_in_progress_writer(tmp_path: Path) -> None:
+    """An ordinary in-progress writer routinely leaves a genuinely incomplete
+    trailing record between two polls milliseconds apart. That must NOT be
+    treated as "the writer is done" just because the stat happened to match
+    on an immediate second check -- only genuine staleness (see the age-gated
+    escalation test below) justifies the more aggressive full-tail probe."""
+    root = tmp_path / "src"
+    root.mkdir()
+    f = root / "session.jsonl"
+    original = b'{"a":1}\n'
+    f.write_bytes(original)
+    watcher, _parse_sources = _make_watcher(tmp_path, root)
+    stat = f.stat()
+    watcher._cursor.set(
+        f,
+        len(original),
+        byte_offset=len(original),
+        last_complete_newline=len(original),
+        parser_fingerprint=live_watcher._PARSER_FINGERPRINT,
+        content_fingerprint="base",
+        tail_hash=encode_cursor_hash_authority(
+            sha256(original).hexdigest(),
+            sha256(original).hexdigest(),
+            ctime_ns=stat.st_ctime_ns,
+        ),
+        st_dev=stat.st_dev,
+        st_ino=stat.st_ino,
+        mtime_ns=stat.st_mtime_ns,
+    )
+    tail = (b"x" * (live_watcher._INCOMPLETE_APPEND_PROBE_BYTES + 1)) + b'{"b":2}\n'
+    f.write_bytes(original + tail)
+
+    assert watcher._needs_work(f) is False
+    # Second scan, immediately after -- no time has passed, so this must
+    # still be treated as "maybe still writing", not escalated.
+    assert watcher._needs_work(f) is False
+    record = watcher._cursor.get_record(f)
+    assert record is not None
+    assert record.failure_count == 0
+
+
+@pytest.mark.frozen_clock_modules("polylogue.sources.live.watcher", "polylogue.sources.live.cursor")
+def test_incomplete_probe_escalates_to_full_scan_once_stat_stops_changing(
+    tmp_path: Path, frozen_clock: FrozenClock
+) -> None:
+    """polylogue-2qrx: the bounded 64MB no-newline probe can miss a genuine
+    complete trailing record sitting just past its window. Once the writer
+    stops (stat never changes again) for long enough to rule out "still
+    writing", the OLD behavior parked the cursor forever with zero durable
+    signal -- measured live as 211 files / 414MB of stalled append backlog,
+    up to 329h stale on one 94.8MB lag. The escalated full-tail probe on a
+    stale stat-unchanged observation must find that record and unblock
+    catch-up instead."""
+    root = tmp_path / "src"
+    root.mkdir()
+    f = root / "session.jsonl"
+    original = b'{"a":1}\n'
+    f.write_bytes(original)
+    watcher, _parse_sources = _make_watcher(tmp_path, root)
+    stat = f.stat()
+    watcher._cursor.set(
+        f,
+        len(original),
+        byte_offset=len(original),
+        last_complete_newline=len(original),
+        parser_fingerprint=live_watcher._PARSER_FINGERPRINT,
+        content_fingerprint="base",
+        tail_hash=encode_cursor_hash_authority(
+            sha256(original).hexdigest(),
+            sha256(original).hexdigest(),
+            ctime_ns=stat.st_ctime_ns,
+        ),
+        st_dev=stat.st_dev,
+        st_ino=stat.st_ino,
+        mtime_ns=stat.st_mtime_ns,
+    )
+    # A trailing tail whose first PROBE_BYTES contain no newline, but a
+    # complete record follows just past the bounded probe window.
+    tail = (b"x" * (live_watcher._INCOMPLETE_APPEND_PROBE_BYTES + 1)) + b'{"b":2}\n'
+    f.write_bytes(original + tail)
+
+    # First scan: the bounded probe finds no \n in its window and defers.
+    assert watcher._needs_work(f) is False
+    _backdate_cursor(tmp_path, f, now=frozen_clock.now(), seconds_ago=live_watcher._STUCK_DEFERRED_APPEND_AGE_S + 1)
+
+    # Second scan against the SAME unchanged stat, now stale enough that the
+    # writer is implausibly still active: the escalated full-tail probe must
+    # find the trailing record and report work is needed, instead of
+    # trusting the stat-match fast path to skip it forever.
+    assert watcher._needs_work(f) is True
+    record = watcher._cursor.get_record(f)
+    assert record is not None
+    assert record.failure_count == 0
+
+
+@pytest.mark.frozen_clock_modules("polylogue.sources.live.watcher", "polylogue.sources.live.cursor")
+def test_incomplete_probe_marks_failed_when_no_newline_exists_anywhere(
+    tmp_path: Path, frozen_clock: FrozenClock
+) -> None:
+    """polylogue-2qrx: when even the escalated full-tail probe finds no
+    complete trailing record (a genuinely truncated/unterminated tail that
+    will never resolve on its own), the cursor must get a durable failure
+    record instead of parking silently forever."""
+    root = tmp_path / "src"
+    root.mkdir()
+    f = root / "session.jsonl"
+    original = b'{"a":1}\n'
+    f.write_bytes(original)
+    watcher, _parse_sources = _make_watcher(tmp_path, root)
+    stat = f.stat()
+    watcher._cursor.set(
+        f,
+        len(original),
+        byte_offset=len(original),
+        last_complete_newline=len(original),
+        parser_fingerprint=live_watcher._PARSER_FINGERPRINT,
+        content_fingerprint="base",
+        tail_hash=encode_cursor_hash_authority(
+            sha256(original).hexdigest(),
+            sha256(original).hexdigest(),
+            ctime_ns=stat.st_ctime_ns,
+        ),
+        st_dev=stat.st_dev,
+        st_ino=stat.st_ino,
+        mtime_ns=stat.st_mtime_ns,
+    )
+    f.write_bytes(original + (b"x" * (live_watcher._INCOMPLETE_APPEND_PROBE_BYTES + 1)))
+
+    assert watcher._needs_work(f) is False
+    _backdate_cursor(tmp_path, f, now=frozen_clock.now(), seconds_ago=live_watcher._STUCK_DEFERRED_APPEND_AGE_S + 1)
+    # Second scan, same unchanged stat but now stale: the escalated
+    # full-tail probe also finds nothing (there really is no trailing
+    # newline anywhere) -- this must become a durable, visible failure, not
+    # another silent defer.
+    assert watcher._needs_work(f) is False
+    record = watcher._cursor.get_record(f)
+    assert record is not None
+    assert record.failure_count == 1
+
+
 def test_last_complete_newline_from_tail_reads_only_final_chunk(tmp_path: Path) -> None:
     path = tmp_path / "large.jsonl"
     complete_prefix = b'{"a":"' + (b"x" * 200_000) + b'"}\n'


### PR DESCRIPTION
## Summary
Three related fixes to the live-ingest cursor lifecycle subsystem (`polylogue/sources/live/{cursor,watcher,batch}.py`), all found by the 2026-07-31 acquisition-completeness audit: excluded cursors never revive after a parser fix, deferred append cursors can park silently forever once their source file stops changing, and the batch failure path re-increments an already-excluded cursor's failure count without bound.

## Problem
- **polylogue-ix5r**: exclusion revival (`CursorStore.revive_replaced_exclusion`) only lifted quarantine when the file's on-disk identity (size/dev/ino/mtime) proved it had been replaced. A parser bug fix never changes the poisoned file's bytes, so any of the archive's 1,446 excluded cursors stayed dark forever, even once the exact bug that poisoned them was fixed. (A related but distinct fix already shipped in PR #3618 for the daemon-status labeling surface -- that PR did not touch the revival mechanism itself, confirmed by reading both diffs.)
- **polylogue-2qrx**: 211 live cursors sat 414MB behind their source files, 206 cold for days-to-weeks (top offender: 94.8MB lag on a 118MB codex rollout, 329h stale). Root cause: `_defer_incomplete_jsonl_append` probes only the first 64MB past the cursor for a trailing newline, and on a miss writes a deferred cursor whose `byte_size` advances to the current file size while `byte_offset` stays behind. The "hot skip" branch in `_needs_work_from_state_uncorroborated` then trusted an exact stat match unconditionally, without checking whether `byte_offset` had actually caught up -- once the source file stopped changing, that branch returned "no work needed" forever with zero durable signal.
- **polylogue-awy5**: `_record_failed_cursor` (the batch/full-ingest failure path) called `CursorStore.mark_failed` unconditionally on every failing pass with no `excluded` pre-check. An already-excluded cursor is a poison pill the daemon already gave up on, but `failure_count` kept climbing with no upper bound -- measured live at 689/864/975/1001/2018 on five permanently-excluded inbox ZIPs, i.e. thousands of wasted full acquire+parse+crash cycles.

## Solution
- `revive_replaced_exclusion` gained an optional `current_parser_fingerprint`; exclusion lifts when either file identity changed OR the fingerprint differs from the one recorded at exclusion time. `LiveWatcher`'s excluded-cursor branch passes the live parser fingerprint through.
- The hot-skip branch now checks `byte_offset >= byte_size` before trusting a stat match. When it doesn't and the deferred observation is stale (age-gated at 1h via a new `_cursor_age_exceeds` helper, matching the periodic catch-up safety net's own duty cycle -- an ordinary in-progress writer routinely leaves a genuinely-incomplete trailing record between two close-together polls, and that must not be mistaken for "writer is done"), it escalates to one unbounded full-tail probe (`_defer_incomplete_jsonl_append(..., probe_bytes=None)`). A real complete record past the bounded window reopens the normal append path; if truly nothing is there, the cursor gets a durable `mark_failed` instead of parking silently again.
- `_record_failed_cursor` now checks `cursor.excluded` (transient-lock-safe) before touching the cursor at all, and no-ops for an already-excluded cursor.

**Scope notes**: 2qrx's fix root-causes and closes the code path that produces indefinite silent staleness; it does not itself drain the already-stalled production backlog (an operational action outside this environment's reach) and does not add new aggregate freshness/alerting surfacing -- `daemon/cursor_lag_status.py` (#1232/#1349) already provides a "stuck" cursor classification with age and top offenders by byte lag, which covers that part of the bead's AC2. awy5's other three ACs (durable failed-attempt records carrying the real exception; a durable row for pre-acquire failures; an aggregate by-disposition accounting surface) are broader schema/observability work not addressed here; this PR is scoped to the one concrete, independently-verifiable mechanism bug the audit evidence named (AC3).

## Verification
- `devtools test tests/unit/sources/test_cursor_lifecycle.py tests/unit/sources/test_live_cursor_locking.py tests/unit/sources/test_live_watcher.py` -- 115-118 passed depending on run (one pre-existing flaky end-to-end test under parallel contention, confirmed passing standalone); 2 failures (`test_live_full_ingest_worker_cap_can_be_overridden`, `test_live_full_ingest_caps_workers_below_batch_policy`) confirmed pre-existing/unrelated by re-running against the pre-fix tree via `git stash` (same `ModuleNotFoundError` on `polylogue.pipeline.services.ingest_batch._core.os`, unrelated to cursor/watcher logic).
- `devtools verify --quick` -- exit 0 (format, lint, mypy --strict, render-all-check, layering, closure-matrix, schema/lab policy checks).
- New red-first regression tests: `test_soundness_sweep_exclude_then_revive_with_parser_fingerprint_change`, `test_incomplete_probe_does_not_escalate_for_a_recent_in_progress_writer`, `test_incomplete_probe_escalates_to_full_scan_once_stat_stops_changing`, `test_incomplete_probe_marks_failed_when_no_newline_exists_anywhere`, `test_record_failed_cursor_does_not_reincrement_already_excluded_cursor`.

Ref polylogue-ix5r, polylogue-2qrx, polylogue-awy5