### PR TITLE
fix: stop synthesizing redundant content_blocks in claude-ai parser

### DIFF
--- a/polylogue/sources/parsers/claude/common.py
+++ b/polylogue/sources/parsers/claude/common.py
@@ -917,9 +917,18 @@ def normalize_chat_messages(
         role = Role.normalize(str(raw_role)) if isinstance(raw_role, str) and raw_role else Role.UNKNOWN
         text = _extract_message_text(item)
         raw_content = item.get("content")
+        # polylogue-0qfy: do NOT synthesize a content_blocks entry that just
+        # duplicates `text` when `content` itself produced no blocks -- that
+        # made `message.blocks` presence (and therefore the message's
+        # identity hash, `pipeline/ids.py:_message_hash_payload`) depend on
+        # whether a given export vintage's raw record happened to carry a
+        # structured `content` field or only a top-level `text` field, for
+        # the exact same conversation content. The write path
+        # (`storage/sqlite/archive_tiers/write.py:_message_blocks`) already
+        # falls back to a text block for storage whenever `message.blocks`
+        # is empty, so this synthesis was pure redundancy with no storage
+        # benefit and a real comparison-stability cost.
         content_blocks = _claude_content_blocks(raw_content)
-        if not content_blocks and text:
-            content_blocks = [ParsedContentBlock(type=BlockType.TEXT, text=text)]
         role = reclassify_tool_result_envelope(role, content_blocks)
 
         raw_created_at = item.get("created_at") or item.get("create_time") or item.get("timestamp")

--- a/tests/unit/sources/test_claude_web_normalization.py
+++ b/tests/unit/sources/test_claude_web_normalization.py
@@ -471,7 +471,11 @@ def test_claude_dom_fallback_keeps_identity_lineage_and_declares_degraded_fideli
     assert by_id["u2"].is_active_leaf is True
     assert by_id["a-new"].delivery_status == "completed"
     assert by_id["a-new"].end_turn is True
-    assert [str(block.type) for block in by_id["a-new"].blocks] == ["text"]
+    # polylogue-0qfy: a DOM-fallback turn carries only a plain `text` field
+    # (no structured `content`) -- the parser no longer synthesizes a
+    # content_blocks entry duplicating it; `.text` still carries the content.
+    assert by_id["a-new"].blocks == []
+    assert by_id["a-new"].text == "DOM fallback cannot expose native thinking or artifact blocks."
     assert next(row for row in fallback.attachments if row.provider_attachment_id == "att-native").inline_bytes == (
         b'{"captured":true}'
     )

--- a/tests/unit/sources/test_parsers_claude_ai_catalog.py
+++ b/tests/unit/sources/test_parsers_claude_ai_catalog.py
@@ -384,6 +384,47 @@ def test_claude_ai_no_provider_title_falls_back_to_id_with_no_title_source() -> 
     assert session.title_confidence is None
 
 
+def test_claude_ai_plain_text_message_has_no_synthetic_content_block() -> None:
+    """A ``chat_messages`` entry with only a top-level ``text`` field (no
+    structured ``content``) must not grow a synthetic ``content_blocks``
+    entry that just duplicates ``message.text`` (bd polylogue-0qfy).
+
+    Root cause: reparsing real ambiguous-only claude-ai-export cohorts found
+    the SAME message hashing differently across export vintages purely
+    because one vintage's raw record carried a structured ``content`` field
+    and the other carried only a top-level ``text`` field -- the parser
+    synthesized a single ``TEXT`` block from ``message.text`` whenever
+    ``content`` produced no blocks of its own, so ``message.blocks`` presence
+    (and therefore the message's hash payload, ``pipeline/ids.py``
+    ``_message_hash_payload``) depended on incidental export-vintage shape
+    rather than real content. The write path
+    (``storage/sqlite/archive_tiers/write.py:_message_blocks``) already
+    falls back to a text block for storage when ``message.blocks`` is empty,
+    so the parser-level synthesis was pure redundancy with no storage
+    benefit -- removing it makes ``content_blocks`` presence a deterministic
+    function of the raw ``content`` field alone, closing this volatility
+    axis.
+    """
+    payload = {
+        "uuid": "claude-0qfy",
+        "chat_messages": [
+            {
+                "uuid": "m1",
+                "sender": "human",
+                "text": "hello there",
+                "created_at": "2026-01-01T00:00:00Z",
+            },
+        ],
+    }
+
+    session = parse_ai(payload, "fallback")
+
+    assert len(session.messages) == 1
+    message = session.messages[0]
+    assert message.text == "hello there"
+    assert message.blocks == []
+
+
 def test_claude_ai_content_free_chat_message_stubs_emit_zero_messages() -> None:
     """polylogue-p3b2 AC3 full-sweep regression: a claude-ai-export session
     can carry ``chat_messages`` entries that are structurally present but


### PR DESCRIPTION
## Summary
Fixes a claude-ai-export parser bug where a message's `content_blocks` presence -- and therefore its identity hash -- depended on incidental export-vintage shape (whether the raw record carried a structured `content` field or only a top-level `text` field) rather than the message's real content.

## Problem
Reparsing real ambiguous-only claude-ai-export cohorts (bd polylogue-0qfy) while verifying polylogue-oycw's fix found 13/200 (6.5%) cohorts still hitting a genuine `conflict` verdict. Root cause traced for one example: role/text/timestamp are byte-identical between two export vintages of the same message, but the hash payload differs -- one vintage has no `content_blocks` key, the other has `content_blocks: [{"type": "text", "text": "<same text>"}]`.

`normalize_chat_messages` (`polylogue/sources/parsers/claude/common.py`) synthesized a single `TEXT` content_block from `text` whenever `content` itself produced no blocks (`if not content_blocks and text: content_blocks = [ParsedContentBlock(...)]`). This synthetic block just duplicates `message.text` -- the same information, wrapped a second way -- and its presence tracked whichever raw shape a given export happened to use for the same conversation, not anything about the conversation's content. `_message_hash_payload` (`pipeline/ids.py`) only includes `content_blocks` when `message.blocks` is truthy, so this synthetic-block instability leaked directly into the message's identity hash.

## Solution
Deleted the synthesis. The write path (`storage/sqlite/archive_tiers/write.py:_message_blocks`) already falls back to a single text block for storage whenever `message.blocks` is empty, so the parser-level synthesis had no storage benefit -- only a comparison-stability cost. `content_blocks` presence is now a deterministic function of the raw `content` field alone.

Also updates `test_claude_web_normalization.py`'s DOM-fallback assertion: the `a-new` turn in that fixture only ever carried a top-level `text` field (no structured `content`), so it previously asserted a synthetic `["text"]` block; now asserts `blocks == []` with `.text` still carrying the content.

**Stamp-poisoner relevance (operator-flagged, bd polylogue-fsgdd/xselt):** fsgdd's K-class design named this bead as a possible stamp-poisoner for xselt's fingerprint-bootstrap work. This PR **confirms** that classification: the fix changes `message.blocks` (and therefore `_message_hash_payload`/`session_revision_projection` output) for any claude-ai-export message that previously hit this vintage-shape asymmetry -- exactly the kind of identity/hash-semantics change xselt needs resolved before it can safely bootstrap per-session fingerprints.

## Verification
- `devtools test tests/unit/sources/test_parsers_claude_ai_catalog.py tests/unit/sources/test_claude_web_normalization.py` -- 28 passed, including the new `test_claude_ai_plain_text_message_has_no_synthetic_content_block` (red before the fix commit -- asserted `blocks == []`, got one synthetic block -- green after).
- `devtools test tests/unit/sources -k claude` -- 373 passed, 2 failed; both failures are pre-existing/unrelated (reproduced identically with this fix reverted): a zip-entry provider-detection case in `test_source_laws.py`, and an eager-vs-stream session_event ordering flake in `test_claude_code_normalization_laws.py` -- neither touches claude-ai `content_blocks`.
- `devtools verify --quick` -- all steps ok (ran automatically via pre-push hook, exit 0).

Ref polylogue-0qfy