### PR TITLE
fix: pin active-leaf flag to position, not id, across duplicate ids

### DIFF
--- a/polylogue/sources/dispatch.py
+++ b/polylogue/sources/dispatch.py
@@ -32,7 +32,12 @@ from .parsers import (
     hermes_verification,
     local_agent,
 )
-from .parsers.base import ParsedMessage, ParsedSession, extract_messages_from_list
+from .parsers.base import (
+    ParsedMessage,
+    ParsedSession,
+    extract_messages_from_list,
+    mark_last_occurrence_as_active_leaf,
+)
 from .parsers.claude.code_parser import apply_tool_result_sidecars
 
 if TYPE_CHECKING:
@@ -751,16 +756,13 @@ def merge_parsed_session_chunks(sessions: Iterable[ParsedSession]) -> list[Parse
 
         messages = [*existing.messages, *session.messages]
         active_leaf_message_provider_id = messages[-1].provider_message_id if messages else None
-        if active_leaf_message_provider_id is not None:
-            messages = [
-                message.model_copy(
-                    update={
-                        "position": position,
-                        "is_active_leaf": message.provider_message_id == active_leaf_message_provider_id,
-                    }
-                )
-                for position, message in enumerate(messages)
-            ]
+        messages = [message.model_copy(update={"position": position}) for position, message in enumerate(messages)]
+        # bd polylogue-2hwl: flag the active leaf by POSITION (the true last
+        # message), never by comparing provider_message_id -- retries and
+        # regenerated variants can legitimately reuse the same native id at
+        # more than one position across merged chunks, and an id-equality
+        # comparison flags every one of them, not just the real leaf.
+        messages = mark_last_occurrence_as_active_leaf(messages)
 
         reported_cost_usd: float | None
         if existing.reported_cost_usd is None and session.reported_cost_usd is None:

--- a/polylogue/sources/parsers/antigravity.py
+++ b/polylogue/sources/parsers/antigravity.py
@@ -20,7 +20,7 @@ from polylogue.archive.message.roles import Role
 from polylogue.core.enums import BlockType, Provider
 from polylogue.core.json import JSONDocument, dumps_bytes, loads
 
-from .base import ParsedContentBlock, ParsedMessage, ParsedSession
+from .base import ParsedContentBlock, ParsedMessage, ParsedSession, mark_last_occurrence_as_active_leaf
 
 _METADATA_SUFFIX = ".metadata.json"
 _SEARCH_ENDPOINT = "/exa.language_server_pb.LanguageServerService/SearchConversations"
@@ -455,13 +455,11 @@ def _messages_from_markdown(markdown: str, cascade_id: str) -> list[ParsedMessag
 
 
 def _mark_active_leaf(messages: list[ParsedMessage]) -> list[ParsedMessage]:
-    if not messages:
-        return messages
-    active_leaf_message_provider_id = messages[-1].provider_message_id
-    return [
-        message.model_copy(update={"is_active_leaf": message.provider_message_id == active_leaf_message_provider_id})
-        for message in messages
-    ]
+    # bd polylogue-2hwl: delegate to the shared position-based helper --
+    # flagging by provider_message_id equality (the previous approach here)
+    # flags every message sharing the final message's id, not just the true
+    # leaf, whenever a retried/regenerated section reuses that id.
+    return mark_last_occurrence_as_active_leaf(messages)
 
 
 def _strip_markdown_preamble(markdown: str) -> str:

--- a/polylogue/sources/parsers/base.py
+++ b/polylogue/sources/parsers/base.py
@@ -21,6 +21,7 @@ from .base_support import (
     content_blocks_from_segments,
     extract_messages_from_list,
     fill_linear_parent_chain,
+    mark_last_occurrence_as_active_leaf,
     text_blocks_prose,
 )
 
@@ -40,5 +41,6 @@ __all__ = [
     "extract_messages_from_list",
     "attachment_from_meta",
     "fill_linear_parent_chain",
+    "mark_last_occurrence_as_active_leaf",
     "text_blocks_prose",
 ]

--- a/polylogue/sources/parsers/base_support.py
+++ b/polylogue/sources/parsers/base_support.py
@@ -402,3 +402,26 @@ def extract_messages_from_list(items: Sequence[object]) -> list[ParsedMessage]:
                 )
             )
     return messages
+
+
+def mark_last_occurrence_as_active_leaf(messages: list[ParsedMessage]) -> list[ParsedMessage]:
+    """Flag exactly one message as ``is_active_leaf``: the LAST message in
+    the list, by position -- never by comparing ``provider_message_id``.
+
+    ``provider_message_id`` is not guaranteed unique across a flat message
+    list assembled by concatenating streaming chunks or markdown sections --
+    retries/variants/regenerations can legitimately reuse the same native id
+    at more than one position (bd polylogue-2hwl). Comparing every message's
+    id against ``messages[-1].provider_message_id`` (the naive approach)
+    flags EVERY matching position, not just the true leaf, which then lets
+    more than one ``is_active_leaf=True`` message reach MCP payloads and
+    archive_query message output -- an invariant violation (at most one
+    active leaf per session). Matching by exact list position instead of by
+    id equality alone keeps the flag unique regardless of duplicate ids.
+    """
+    if not messages:
+        return messages
+    leaf_index = len(messages) - 1
+    return [
+        message.model_copy(update={"is_active_leaf": index == leaf_index}) for index, message in enumerate(messages)
+    ]

--- a/tests/unit/sources/parsers/test_antigravity.py
+++ b/tests/unit/sources/parsers/test_antigravity.py
@@ -8,10 +8,12 @@ from polylogue.core.json import JSONDocument
 from polylogue.sources.parsers.antigravity import (
     BRAIN_METADATA_FRAGMENT_FLAG,
     AntigravitySessionSummary,
+    _mark_active_leaf,
     looks_like_brain_metadata,
     parse_brain_metadata,
     parse_markdown_export,
 )
+from polylogue.sources.parsers.base import ParsedMessage
 
 
 def test_parse_markdown_export_splits_known_sections() -> None:
@@ -54,6 +56,26 @@ The focused checks passed.
     assert [message.is_active_path for message in session.messages] == [True, True]
     assert [message.is_active_leaf for message in session.messages] == [False, True]
     assert session.active_leaf_message_provider_id == "cascade-1:1:planner_response"
+
+
+def test_mark_active_leaf_flags_exactly_one_message_with_duplicate_ids() -> None:
+    """bd polylogue-2hwl: a duplicate ``provider_message_id`` (a retried or
+    regenerated section reusing the same id) must not produce more than one
+    ``is_active_leaf=True`` message -- the pre-fix comparison
+    (``message.provider_message_id == active_leaf_message_provider_id``)
+    flagged every position sharing that id, not just the true final one.
+    """
+    messages = [
+        ParsedMessage(provider_message_id="dup", role=Role.USER, text="first", position=0, is_active_path=True),
+        ParsedMessage(provider_message_id="other", role=Role.ASSISTANT, text="middle", position=1, is_active_path=True),
+        ParsedMessage(provider_message_id="dup", role=Role.ASSISTANT, text="final", position=2, is_active_path=True),
+    ]
+
+    marked = _mark_active_leaf(messages)
+
+    leaves = [message for message in marked if message.is_active_leaf]
+    assert len(leaves) == 1
+    assert leaves[0].text == "final"
 
 
 def test_parse_markdown_export_falls_back_to_single_export_message() -> None:

--- a/tests/unit/sources/test_source_laws.py
+++ b/tests/unit/sources/test_source_laws.py
@@ -1697,6 +1697,91 @@ def test_merge_parsed_session_chunks_keeps_stronger_earlier_title_over_weaker_la
     assert merged[0].title_confidence == 1.0
 
 
+def test_merge_parsed_session_chunks_fills_missing_first_chunk_title_from_later_chunk() -> None:
+    """bd polylogue-2hwl AC1, literal scenario: chunk 1 has no title at all
+    (``title=None``) -- the pre-fix rule froze this permanently since
+    ``None != provider_session_id`` never held true, so a real title
+    arriving in a later chunk was silently dropped. The title-rank merge
+    (bd polylogue-t5lg) must fill it from the later chunk's resolved
+    evidence."""
+    early_chunk = ParsedSession(
+        source_name=Provider.CLAUDE_CODE,
+        provider_session_id="session-1",
+        title=None,
+        messages=[],
+    )
+    later_chunk = ParsedSession(
+        source_name=Provider.CLAUDE_CODE,
+        provider_session_id="session-1",
+        title="Recover what was lost",
+        title_source=TitleSource.ORIGIN,
+        title_ref="claude-ai-title:session-1",
+        title_confidence=1.0,
+        messages=[],
+    )
+
+    merged = merge_parsed_session_chunks([early_chunk, later_chunk])
+
+    assert merged[0].title == "Recover what was lost"
+    assert merged[0].title_source is TitleSource.ORIGIN
+
+
+def test_merge_parsed_session_chunks_marks_exactly_one_active_leaf_with_duplicate_ids() -> None:
+    """bd polylogue-2hwl AC2: a merged session where the SAME
+    ``provider_message_id`` occurs at two different positions (a
+    retry/regenerated variant spanning a chunk boundary) must mark exactly
+    ONE message as ``is_active_leaf`` -- the true final message by position,
+    not every message sharing that id. The pre-fix comparison
+    (``message.provider_message_id == active_leaf_message_provider_id``)
+    flagged every matching position, violating the "at most one active leaf
+    per session" invariant that feeds MCP payloads and archive_query message
+    output.
+    """
+    early_chunk = ParsedSession(
+        source_name=Provider.CLAUDE_CODE,
+        provider_session_id="session-1",
+        title="session-1",
+        messages=[
+            ParsedMessage(
+                provider_message_id="dup",
+                role=Role.ASSISTANT,
+                text="first attempt",
+                position=0,
+                is_active_path=True,
+                is_active_leaf=True,
+            ),
+        ],
+    )
+    later_chunk = ParsedSession(
+        source_name=Provider.CLAUDE_CODE,
+        provider_session_id="session-1",
+        title="session-1",
+        messages=[
+            ParsedMessage(
+                provider_message_id="u-2",
+                role=Role.USER,
+                text="follow up",
+                position=0,
+                is_active_path=True,
+            ),
+            ParsedMessage(
+                provider_message_id="dup",
+                role=Role.ASSISTANT,
+                text="final retry",
+                position=1,
+                is_active_path=True,
+            ),
+        ],
+    )
+
+    merged = merge_parsed_session_chunks([early_chunk, later_chunk])
+
+    leaves = [message for message in merged[0].messages if message.is_active_leaf]
+    assert len(leaves) == 1
+    assert leaves[0].text == "final retry"
+    assert leaves[0] is merged[0].messages[-1]
+
+
 def test_session_emitter_reuses_jsonl_sniff_payloads_for_individual_detection(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
Fixes `merge_parsed_session_chunks` (Claude Code streaming-chunk merge) and `antigravity.py`'s `_mark_active_leaf`, both of which could mark more than one message `is_active_leaf=True` in a single session when a `provider_message_id` repeats at more than one position.

## Problem
Audit finding (bd polylogue-2hwl, 2026-07-17): both `merge_parsed_session_chunks` (`sources/dispatch.py`) and `antigravity.py:_mark_active_leaf` recomputed `is_active_leaf` by comparing every message's `provider_message_id` against the final message's id (`message.provider_message_id == active_leaf_message_provider_id`). `provider_message_id` is not guaranteed unique across a flat message list assembled from merged streaming chunks -- a retried or regenerated variant can legitimately reuse the same native id at a different position -- so a duplicate id let every matching position end up `is_active_leaf=True`, violating the "at most one active leaf per session" invariant that feeds MCP payloads (`mcp/payloads.py:429`) and archive_query message output. A 2026-08-03 registry-check pass quantified this live: 103 sessions currently carry more than one `is_active_leaf=1` message.

The bead's other acceptance criterion (a merge where chunk 1 has no title, dropping a later real title) was **already fixed** by the title-rank merge landed under bd polylogue-t5lg -- confirmed here with a new literal-scenario regression test (`title=None` in chunk 1) rather than re-fixed, since the existing rank comparison already handles it correctly.

## Solution
Added a shared `polylogue.sources.parsers.base.mark_last_occurrence_as_active_leaf` helper (`base_support.py`) that flags the active leaf by list **position**, never by id equality, and wired it into both `dispatch.py:merge_parsed_session_chunks` and `antigravity.py:_mark_active_leaf` -- the same buggy comparison pattern existed independently in both places, per the bead's explicit note.

## Verification
- New tests (red before the fix / green after):
  - `test_merge_parsed_session_chunks_marks_exactly_one_active_leaf_with_duplicate_ids` (`tests/unit/sources/test_source_laws.py`)
  - `test_mark_active_leaf_flags_exactly_one_message_with_duplicate_ids` (`tests/unit/sources/parsers/test_antigravity.py`)
  - `test_merge_parsed_session_chunks_fills_missing_first_chunk_title_from_later_chunk` -- confirms AC1's literal scenario already passes via the existing t5lg title-rank fix (not newly fixed here).
- `devtools test tests/unit/sources/test_source_laws.py tests/unit/sources/parsers/test_antigravity.py` -- 139 passed, 2 failed; both failures are pre-existing/unrelated zip-entry provider-detection cases in `test_source_laws.py` (reproduced identically before this change; neither touches `merge_parsed_session_chunks` or active-leaf logic).
- `mypy polylogue/sources/dispatch.py polylogue/sources/parsers/antigravity.py polylogue/sources/parsers/base_support.py polylogue/sources/parsers/base.py` -- Success: no issues found in 4 source files.
- `devtools verify --quick` -- all steps ok (ran automatically via pre-push hook, exit 0).

Ref polylogue-2hwl