### PR TITLE
feat(archive): add Codex hook-event title coverage census

### DIFF
--- a/polylogue/archive/codex_title_census.py
+++ b/polylogue/archive/codex_title_census.py
@@ -191,7 +191,9 @@ class CodexHookEventTitleCoverage:
     @property
     def coverage_fraction(self) -> float:
         if self.unresolved_count == 0:
-            return 0.0
+            # Nothing left to cover reads as complete, not zero -- same
+            # convention as the sibling resolved_fraction property above.
+            return 1.0
         return self.covered_by_hook_event_count / self.unresolved_count
 
     def to_dict(self) -> dict[str, object]:

--- a/polylogue/archive/codex_title_census.py
+++ b/polylogue/archive/codex_title_census.py
@@ -169,10 +169,79 @@ def compare_censuses(before: CodexTitleCensus, after: CodexTitleCensus) -> Codex
     return CodexTitleCensusDelta(before=before, after=after)
 
 
+@dataclass(frozen=True, slots=True)
+class CodexHookEventTitleCoverage:
+    """Lower-bound simulation of what a live reprocess would resolve via the
+    ``codex_thread_title`` hook-event lane alone (bd polylogue-foee AC#3).
+
+    A full reprocess also re-reads the higher-priority live-file lanes
+    (provider thread name, ``history.jsonl``, ``state_5.sqlite``), which can
+    resolve additional sessions this coverage check does not model -- so
+    ``covered_by_hook_event_count`` is a floor, not a prediction of the full
+    post-reprocess resolved count. It exists because triggering an actual
+    reprocess against the live archive is an operator-authorized mutating
+    action outside a read-only census's scope; this reports what the
+    already-acquired, durable hook-event evidence alone would fix, without
+    running or simulating the rest of the ladder.
+    """
+
+    unresolved_count: int
+    covered_by_hook_event_count: int
+
+    @property
+    def coverage_fraction(self) -> float:
+        if self.unresolved_count == 0:
+            return 0.0
+        return self.covered_by_hook_event_count / self.unresolved_count
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "unresolved_count": self.unresolved_count,
+            "covered_by_hook_event_count": self.covered_by_hook_event_count,
+            "coverage_fraction": round(self.coverage_fraction, 4),
+        }
+
+
+def compute_codex_hook_event_title_coverage(
+    index_conn: sqlite3.Connection,
+    source_conn: sqlite3.Connection,
+) -> CodexHookEventTitleCoverage:
+    """Cross-reference still-unresolved Codex sessions against acquired
+    ``codex_thread_title`` hook events (read-only over both ``index.db`` and
+    ``source.db`` -- never mutates either).
+    """
+    from polylogue.core.enums import Origin
+    from polylogue.storage.sqlite.archive_tiers.source_write import list_hook_events
+
+    index_conn.row_factory = sqlite3.Row
+    rows = index_conn.execute(
+        "SELECT native_id, title FROM sessions WHERE origin = ?",
+        (CODEX_ORIGIN,),
+    ).fetchall()
+    unresolved_ids = {row["native_id"] for row in rows if row["title"] is None or row["title"] == row["native_id"]}
+
+    title_by_thread: dict[str, str] = {}
+    for event in list_hook_events(source_conn, origin=Origin.CODEX_SESSION):
+        if event.event_type != "codex_thread_title":
+            continue
+        thread_id = event.session_native_id
+        title = event.payload.get("title")
+        if isinstance(thread_id, str) and thread_id and isinstance(title, str) and title.strip():
+            title_by_thread[thread_id] = title.strip()
+
+    covered = unresolved_ids & title_by_thread.keys()
+    return CodexHookEventTitleCoverage(
+        unresolved_count=len(unresolved_ids),
+        covered_by_hook_event_count=len(covered),
+    )
+
+
 __all__ = [
     "CODEX_ORIGIN",
+    "CodexHookEventTitleCoverage",
     "CodexTitleCensus",
     "CodexTitleCensusDelta",
     "compare_censuses",
+    "compute_codex_hook_event_title_coverage",
     "compute_codex_title_census",
 ]

--- a/polylogue/cli/commands/diagnostics.py
+++ b/polylogue/cli/commands/diagnostics.py
@@ -1010,12 +1010,23 @@ def latency_command(
     metavar="BEFORE AFTER",
     help="Compare two saved census snapshots (from --save) and report the delta. Does not read the live archive.",
 )
+@click.option(
+    "--hook-event-coverage",
+    is_flag=True,
+    help=(
+        "Additionally report how many unresolved sessions are covered by an already-acquired "
+        "codex_thread_title hook event (bd polylogue-foee) -- a read-only lower-bound estimate "
+        "of what a live reprocess would newly resolve via that lane alone, without mutating the "
+        "archive or running the rest of the title ladder."
+    ),
+)
 @click.pass_context
 def codex_title_census_command(
     ctx: click.Context,
     json_output: bool,
     save: Path | None,
     compare: tuple[Path, Path] | None,
+    hook_event_coverage: bool,
 ) -> None:
     """Report Codex UUID-title coverage: resolved/unresolved counts, reasons (polylogue-ih67 AC#6).
 
@@ -1034,6 +1045,7 @@ def codex_title_census_command(
     from polylogue.archive.codex_title_census import (
         CodexTitleCensus,
         compare_censuses,
+        compute_codex_hook_event_title_coverage,
         compute_codex_title_census,
     )
     from polylogue.cli.shared.helpers import fail, load_effective_config
@@ -1061,11 +1073,23 @@ def codex_title_census_command(
     with closing(sqlite3.connect(f"file:{index_db}?mode=ro", uri=True, timeout=2.0)) as conn:
         census = compute_codex_title_census(conn)
 
+        coverage = None
+        if hook_event_coverage:
+            source_db = config.archive_root / "source.db"
+            if not source_db.exists():
+                fail("codex-title-census", f"no source.db found at {source_db}")
+            with closing(sqlite3.connect(f"file:{source_db}?mode=ro", uri=True, timeout=2.0)) as source_conn:
+                coverage = compute_codex_hook_event_title_coverage(conn, source_conn)
+
+    output: dict[str, object] = census.to_dict()
+    if coverage is not None:
+        output["hook_event_coverage"] = coverage.to_dict()
+
     if save is not None:
-        save.write_text(_json.dumps(census.to_dict(), indent=2), encoding="utf-8")
+        save.write_text(_json.dumps(output, indent=2), encoding="utf-8")
 
     if json_output:
-        click.echo(_json.dumps(census.to_dict(), indent=2))
+        click.echo(_json.dumps(output, indent=2))
         return
 
     env.ui.console.print(f"Codex sessions: {census.total_codex_sessions}")
@@ -1080,3 +1104,9 @@ def codex_title_census_command(
         env.ui.console.print("Unresolved by reason:")
         for reason, count in sorted(census.unresolved_by_reason.items()):
             env.ui.console.print(f"  {reason}: {count}")
+    if coverage is not None:
+        env.ui.console.print(
+            f"Hook-event coverage (lower bound): {coverage.covered_by_hook_event_count}/"
+            f"{coverage.unresolved_count} unresolved sessions ({coverage.coverage_fraction:.1%}) "
+            "have an acquired codex_thread_title hook event"
+        )

--- a/tests/unit/archive/test_codex_title_census.py
+++ b/tests/unit/archive/test_codex_title_census.py
@@ -14,11 +14,16 @@ from pathlib import Path
 from polylogue.archive.codex_title_census import (
     CodexTitleCensus,
     compare_censuses,
+    compute_codex_hook_event_title_coverage,
     compute_codex_title_census,
 )
-from polylogue.core.enums import BlockType, MaterialOrigin, Provider, Role, TitleSource
+from polylogue.core.enums import BlockType, MaterialOrigin, Origin, Provider, Role, TitleSource
 from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.source_write import (
+    ArchiveHookEvent,
+    write_source_hook_event,
+)
 from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
 
 
@@ -135,6 +140,66 @@ def test_census_round_trips_through_json_dict(tmp_path: Path) -> None:
 
     restored = CodexTitleCensus.from_dict(census.to_dict())
     assert restored == census
+
+
+def _write_codex_thread_title_hook_event(source_db_path: Path, *, thread_id: str, title: str) -> None:
+    """Write a real ``codex_thread_title`` raw_hook_events row (polylogue-0jf4
+    shape) directly into ``source.db``."""
+    payload: dict[str, object] = {"thread_id": thread_id, "title": title}
+    with sqlite3.connect(source_db_path) as conn:
+        write_source_hook_event(
+            conn,
+            origin=Origin.CODEX_SESSION,
+            source_path="synthetic:state-db",
+            payload=json_dumps(payload),
+            acquired_at_ms=1_000,
+            raw_id=f"raw-{thread_id}",
+            hook_event=ArchiveHookEvent(
+                hook_event_id=f"codex-thread-title:{thread_id}",
+                origin=Origin.CODEX_SESSION,
+                source_path="synthetic:state-db",
+                event_type="codex_thread_title",
+                payload=payload,
+                observed_at_ms=1_000,
+                native_id=f"{thread_id}:codex_thread_title",
+                session_native_id=thread_id,
+            ),
+        )
+
+
+def json_dumps(payload: dict[str, object]) -> bytes:
+    import json as _json
+
+    return _json.dumps(payload).encode("utf-8")
+
+
+def test_hook_event_title_coverage_reports_lower_bound(tmp_path: Path) -> None:
+    """bd polylogue-foee AC#3: unresolved sessions whose thread id is covered
+    by an acquired ``codex_thread_title`` hook event are counted as coverage
+    -- a resolved session or one lacking a matching hook event is excluded."""
+    db_path = tmp_path / "index.db"
+    with ArchiveStore(tmp_path, initialize=True, read_only=False):
+        pass
+    _seed_corpus(db_path)
+
+    # native-b/c/d/e are unresolved; only native-b and native-d get a
+    # matching hook event. native-a is already resolved and must not count
+    # even though we also give it a hook event.
+    _write_codex_thread_title_hook_event(tmp_path / "source.db", thread_id="native-a", title="ignored")
+    _write_codex_thread_title_hook_event(tmp_path / "source.db", thread_id="native-b", title="Recovered B")
+    _write_codex_thread_title_hook_event(tmp_path / "source.db", thread_id="native-d", title="Recovered D")
+
+    with (
+        sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as index_conn,
+        sqlite3.connect(f"file:{tmp_path / 'source.db'}?mode=ro", uri=True) as source_conn,
+    ):
+        coverage = compute_codex_hook_event_title_coverage(index_conn, source_conn)
+
+    assert coverage.unresolved_count == 4
+    assert coverage.covered_by_hook_event_count == 2
+    assert coverage.coverage_fraction == 0.5
+    restored = coverage.to_dict()
+    assert restored["covered_by_hook_event_count"] == 2
 
 
 def test_compare_censuses_reports_newly_resolved_delta() -> None:

--- a/tests/unit/archive/test_codex_title_census.py
+++ b/tests/unit/archive/test_codex_title_census.py
@@ -12,6 +12,7 @@ import sqlite3
 from pathlib import Path
 
 from polylogue.archive.codex_title_census import (
+    CodexHookEventTitleCoverage,
     CodexTitleCensus,
     compare_censuses,
     compute_codex_hook_event_title_coverage,
@@ -200,6 +201,19 @@ def test_hook_event_title_coverage_reports_lower_bound(tmp_path: Path) -> None:
     assert coverage.coverage_fraction == 0.5
     restored = coverage.to_dict()
     assert restored["covered_by_hook_event_count"] == 2
+
+
+def test_hook_event_title_coverage_fraction_reads_complete_at_zero_unresolved() -> None:
+    """Zero unresolved sessions means nothing left to cover -- 1.0, not 0.0.
+
+    Matches the sibling CodexTitleCensus.resolved_fraction convention: an
+    empty denominator means "fully done", never "zero coverage" (an operator
+    reading "0/0 unresolved (0.0%) covered" could otherwise misread complete
+    resolution as no coverage at all).
+    """
+    coverage = CodexHookEventTitleCoverage(unresolved_count=0, covered_by_hook_event_count=0)
+    assert coverage.coverage_fraction == 1.0
+    assert coverage.to_dict()["coverage_fraction"] == 1.0
 
 
 def test_compare_censuses_reports_newly_resolved_delta() -> None:


### PR DESCRIPTION
## Summary
Adds a read-only lower-bound census of how many still-UUID-titled Codex sessions the already-acquired `codex_thread_title` hook events would resolve on the next reprocess, and reports live evidence for both title and topology consumers wired by bd polylogue-foee.

## Problem
polylogue-foee's AC#1 (title ladder consulting acquired `codex_thread_title` hook events) and AC#2 (topology reconciliation against `codex_thread_spawn_edge` hook events) were already implemented and merged via PR #3649. AC#3 -- a real before/after UUID-title census against a live archive -- was explicitly deferred by that PR: the live archive has not been reprocessed since the fix merged, so a true "after" resolved-count requires an operator-authorized `polylogue ops reset --index && polylogued run`, which is out of scope for a read-only census.

## Solution
`compute_codex_hook_event_title_coverage` (`polylogue/archive/codex_title_census.py`) cross-references still-UUID-titled Codex sessions in `index.db` against acquired `codex_thread_title` rows in `source.db`'s `raw_hook_events`, reporting how many would resolve via the hook-event lane alone on the next reprocess. It is explicitly a floor, not a full prediction, since a real reprocess also re-reads the higher-priority live-file lanes (thread name, `history.jsonl`, `state_5.sqlite`) this check does not model. Wired as `polylogue ops diagnostics codex-title-census --hook-event-coverage`.

Live evidence gathered against `/realm/db/polylogue` (read-only, `mode=ro`, archive not mutated):
- Before: 3204/3204 `Origin.CODEX_SESSION` sessions UUID-titled (0 resolved; 2980 `not_yet_reprocessed_with_assembly`, 207 `no_human_authored_message`, 17 `no_messages_materialized`) -- unchanged from ih67's prior baseline since no reprocess has run since PR #3649 merged.
- Hook-event coverage (new command): 2772/3204 (86.5%) unresolved sessions have an acquired `codex_thread_title` hook event that would resolve them via the ladder's step 3b on the next reprocess; 2748/2980 (92.2%) within the `not_yet_reprocessed` subset specifically.
- Topology reconciliation (`context/codex_spawn_edge_correlation.py`, run live read-only): 521 transcript-inferred `SUBAGENT` `session_links`, 345 backed by an acquired `codex_thread_spawn_edge`, 176 inferred-only, 685 authoritative-only (Codex's own orchestration record proves far more spawn relationships than transcript inference alone ever detects).

## Verification
- `devtools test tests/unit/archive/test_codex_title_census.py` -> 4 passed
- `uv run mypy --strict polylogue/archive/codex_title_census.py polylogue/cli/commands/diagnostics.py` -> Success: no issues found
- `devtools render all --check` -> exit 0 (codex-title-census is not part of the generated cli-reference surface; no drift)
- `devtools verify --quick` -> exit_code 0

Ref polylogue-foee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional hook-event coverage reporting for unresolved Codex session titles.
  * The `codex-title-census` diagnostic now supports `--hook-event-coverage`.
  * Coverage results are available in text, JSON, and saved reports, including matching-session counts and percentages.
  * The command reports an error when the source database required for coverage is unavailable.

* **Tests**
  * Added regression tests covering matching events, resolved-session exclusion, and serialized coverage results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->