### PR TITLE
fix(drive): let proven revision lineage bypass Drive freshness tie-break

### DIFF
--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING, Protocol, cast
 
 from polylogue.archive.ingest_flags import DOM_FALLBACK_INGEST_FLAG, NATIVE_BROWSER_CAPTURE_FLAGS
 from polylogue.archive.revision_authority import RawRevisionAuthority, RawRevisionEnvelope, RawRevisionKind
+from polylogue.archive.revision_replay import RevisionReplayPlan
 from polylogue.archive.write_gateway import ArchiveWriteGateway, WriteOperation
 from polylogue.core.enums import BlockType, Provider
 from polylogue.core.memory import release_process_memory
@@ -591,7 +592,7 @@ def _bind_drive_revision_lineage(
     raw_id: str | None,
     source_conn: sqlite3.Connection | None,
     blob_publisher: ArchiveBlobPublisher | None,
-) -> None:
+) -> RevisionReplayPlan | None:
     """Best-effort revision-lineage bookkeeping for Drive re-acquisitions.
 
     polylogue-sp72: ``iter_drive_raw_data`` backfills live-fetched
@@ -617,13 +618,18 @@ def _bind_drive_revision_lineage(
     ultimately skips as stale/duplicate -- so lineage metadata (and any
     future arbitration/rebuild consumer reading it, e.g. polylogue-x1gd) is
     recorded for every acquisition, not only the one that happened to win
-    ``_write_session``'s own freshness/content-hash comparison. It never
-    replays/applies the classifier's winning revision plan itself: that
-    comparison, plus the #3453 attachment-coverage tie-break, still solely
-    decides what actually lands in ``sessions`` from this call site. This
+    ``_write_session``'s own freshness/content-hash comparison. This
     function is non-fatal best-effort bookkeeping -- any failure (including
     ``classify_raw_revision_cohort`` requiring a writable blob publisher) is
-    logged and swallowed, never allowed to break the session write itself.
+    logged and swallowed (returning ``None``), never allowed to break the
+    session write itself.
+
+    Returns the classifier's :class:`RevisionReplayPlan` on success (``None``
+    on any early-return or swallowed failure) so the caller can tell whether
+    ``raw_id`` is a governance-*proven* member of the accepted chain --
+    see ``_write_session``'s use of this to bypass the #3453
+    freshness-tie-break safety net once real lineage evidence has already
+    settled the question that heuristic exists to guess at.
 
     Every real config and test fixture configures Drive acquisition as
     ``Source(name="gemini", folder=...)``, and ``iter_drive_raw_data`` sets
@@ -633,16 +639,16 @@ def _bind_drive_revision_lineage(
     ``core/sources.py``). Gate on the value actually observed on the wire.
     """
     if source_conn is None or blob_publisher is None:
-        return
+        return None
     if not raw_id:
-        return
+        return None
     if session_to_write.source_name is not Provider.GEMINI:
-        return
+        return None
     logical_source_key = f"{session_to_write.source_name.value}:{session_to_write.provider_session_id}"
     adapter = _DriveRevisionGovernanceAdapter(source_conn, blob_publisher)
     try:
         if raw_membership_raw_ids(adapter, logical_source_key):
-            return
+            return None
         bind_raw_revision(
             adapter,
             raw_id,
@@ -654,7 +660,7 @@ def _bind_drive_revision_lineage(
                 authority=RawRevisionAuthority.QUARANTINED,
             ),
         )
-        classify_raw_revision_cohort_for_live_watch(adapter, logical_source_key)
+        return classify_raw_revision_cohort_for_live_watch(adapter, logical_source_key)
     except Exception:
         logger.warning(
             "drive_revision_lineage_bind_failed",
@@ -662,6 +668,7 @@ def _bind_drive_revision_lineage(
             logical_source_key=logical_source_key,
             exc_info=True,
         )
+        return None
 
 
 def _write_session(
@@ -706,11 +713,22 @@ def _write_session(
     merge_append = False
     browser_precedence: BrowserCapturePrecedence = "default"
 
-    _bind_drive_revision_lineage(
+    drive_revision_plan = _bind_drive_revision_lineage(
         session_to_write,
         raw_id=payload.raw_id,
         source_conn=source_conn,
         blob_publisher=blob_publisher,
+    )
+    # polylogue-sp72 AC2: once real byte-prefix lineage evidence has proven
+    # this raw is the classifier's accepted chain head for its logical
+    # source key, the #3453 freshness-tie heuristic below no longer needs to
+    # guess at a question governance has already answered -- it stays purely
+    # a safety net for the ungoverned case (no source_conn/blob_publisher,
+    # non-Gemini Drive identity, or a classification failure).
+    drive_revision_proven_winner = (
+        drive_revision_plan is not None
+        and payload.raw_id is not None
+        and payload.raw_id in drive_revision_plan.accepted_chain
     )
 
     if revision_authority_refuses_write(
@@ -805,6 +823,7 @@ def _write_session(
             and existing_raw_id
             and payload.raw_id
             and existing_raw_id != payload.raw_id
+            and not drive_revision_proven_winner
             and _incoming_write_regresses_attachment_coverage(conn, payload, session_to_write)
         ):
             counts["skipped_sessions"] = 1

--- a/tests/unit/pipeline/test_ingest_batch.py
+++ b/tests/unit/pipeline/test_ingest_batch.py
@@ -1179,6 +1179,163 @@ def test_write_session_binds_drive_revision_lineage(tmp_path: Path) -> None:
     assert second_row["revision_authority"] != "quarantined"
 
 
+def test_write_session_drive_lineage_proven_winner_bypasses_freshness_tie(tmp_path: Path) -> None:
+    """polylogue-sp72 AC2: a governance-proven Drive revision must not need
+    the #3453 freshness-tie safety net to land.
+
+    Reproduces the exact tie shape the #3453 tie-break exists to guess at
+    (identical message content/timestamps, differing attachment coverage,
+    differing raw_id) -- but this time the second raw's bytes are a proven
+    byte-prefix successor of the first (the same fixture shape as
+    ``test_write_session_binds_drive_revision_lineage``), so
+    ``classify_raw_revision_cohort_for_live_watch`` has already settled which
+    raw wins before the freshness comparison ever runs. The second write here
+    carries FEWER acquired attachments than the first -- exactly the shape
+    ``_incoming_write_regresses_attachment_coverage`` blocks -- yet must still
+    land, because governance (not the heuristic) already proved it is the
+    legitimate next revision in the chain.
+
+    The negative control (``test_write_session_freshness_tie_regression_without_lineage_still_blocks``)
+    proves the tie-break safety net is untouched when no governance evidence
+    is available (no ``source_conn``/``blob_publisher``): it still blocks the
+    exact same regression shape.
+    """
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+    source_db_path = archive_root / "source.db"
+    blob_publisher = ArchiveBlobPublisher(source_db_path, archive_root / "blob")
+
+    provider_session_id = "drive-tie-proven-winner"
+    session_id = f"aistudio-drive:{provider_session_id}"
+    first_payload = b'{"drive":"payload","messages":[{"id":"m-1","text":"hi"}]}'
+    second_payload = first_payload + b"  // backfilled attachment bytes appended"
+
+    with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+        first_raw_id = archive.write_raw_payload(
+            provider=Provider.GEMINI,
+            payload=first_payload,
+            source_path="drive://file-tie",
+            acquired_at_ms=1_767_000_000_000,
+        )
+        second_raw_id = archive.write_raw_payload(
+            provider=Provider.GEMINI,
+            payload=second_payload,
+            source_path="drive://file-tie",
+            acquired_at_ms=1_767_000_000_500,
+        )
+    assert first_raw_id != second_raw_id
+
+    message = _message_tuple(
+        "m-1",
+        session_id,
+        role="user",
+        text="hi",
+        content_hash="msg-hash-drive-tie",
+        sort_key=1777636800.0,
+    )
+    tied_timestamp = "2026-07-18T17:46:10Z"
+
+    with (
+        open_connection(archive_root / "index.db") as conn,
+        sqlite3.connect(str(source_db_path)) as source_conn,
+    ):
+        first_session = _session_data(
+            session_id,
+            content_hash="hash-drive-tie-first",
+            raw_id=first_raw_id,
+            message_tuples=[message],
+            attachment_tuples=[_attachment_tuple("att-1", inline_bytes=b"acquired drive attachment bytes")],
+            attachment_ref_tuples=[_attachment_ref_tuple("att-1", session_id, "m-1")],
+            provider=Provider.GEMINI,
+            created_at=tied_timestamp,
+            updated_at=tied_timestamp,
+        )
+        changed_first, _ = _write_session(conn, first_session, blob_publisher=blob_publisher, source_conn=source_conn)
+        conn.commit()
+        assert changed_first is True
+
+        # Same content-derived timestamp as the first write, but zero
+        # acquired attachments -- a coverage regression the #3453 tie-break
+        # exists to block, UNLESS governance already proved this raw is the
+        # legitimate next revision (which it does here).
+        second_session = _session_data(
+            session_id,
+            content_hash="hash-drive-tie-second",
+            raw_id=second_raw_id,
+            message_tuples=[message],
+            provider=Provider.GEMINI,
+            created_at=tied_timestamp,
+            updated_at=tied_timestamp,
+        )
+        changed_second, _ = _write_session(conn, second_session, blob_publisher=blob_publisher, source_conn=source_conn)
+        conn.commit()
+
+        assert changed_second is True
+        row = conn.execute(
+            "SELECT raw_id FROM sessions WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+        assert row["raw_id"] == second_raw_id
+
+
+def test_write_session_freshness_tie_regression_without_lineage_still_blocks(tmp_path: Path) -> None:
+    """Negative control for the test above: absent lineage governance
+    evidence (no ``source_conn``, so ``_bind_drive_revision_lineage`` bails
+    out before ever classifying), the #3453 tie-break safety net still
+    blocks the identical regression shape -- this fix only ever bypasses the
+    heuristic when governance has independently proven a real
+    predecessor/successor relationship, never unconditionally.
+    ``blob_publisher`` is still supplied (attachments require one to write
+    inline bytes at all) -- ``source_conn`` alone is what gates lineage
+    governance."""
+    with open_connection(tmp_path / "index.db") as conn:
+        blob_publisher = ArchiveBlobPublisher(tmp_path / "source.db", tmp_path / "blob")
+        session_id = "aistudio-drive:tie-no-lineage"
+        tied_timestamp = "2026-07-18T17:46:10Z"
+        message = _message_tuple(
+            "m-1",
+            session_id,
+            role="user",
+            text="hi",
+            content_hash="msg-hash-tie-no-lineage",
+            sort_key=1777636800.0,
+        )
+        first_session = _session_data(
+            session_id,
+            content_hash="hash-tie-no-lineage-first",
+            raw_id="raw-no-lineage-first",
+            message_tuples=[message],
+            attachment_tuples=[_attachment_tuple("att-1", inline_bytes=b"acquired bytes")],
+            attachment_ref_tuples=[_attachment_ref_tuple("att-1", session_id, "m-1")],
+            provider=Provider.GEMINI,
+            created_at=tied_timestamp,
+            updated_at=tied_timestamp,
+        )
+        changed_first, _ = _write_session(conn, first_session, blob_publisher=blob_publisher)
+        conn.commit()
+        assert changed_first is True
+
+        second_session = _session_data(
+            session_id,
+            content_hash="hash-tie-no-lineage-second",
+            raw_id="raw-no-lineage-second",
+            message_tuples=[message],
+            provider=Provider.GEMINI,
+            created_at=tied_timestamp,
+            updated_at=tied_timestamp,
+        )
+        changed_second, counts_second = _write_session(conn, second_session, blob_publisher=blob_publisher)
+        conn.commit()
+
+        assert changed_second is False
+        assert counts_second["skipped_sessions"] == 1
+        row = conn.execute(
+            "SELECT raw_id FROM sessions WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+        assert row["raw_id"] == "raw-no-lineage-first"
+
+
 def test_write_session_precomputed_blob_attachment_recorded_as_acquired(tmp_path: Path) -> None:
     """bd polylogue-8ac0: bytes already streamed into the blob store during
     sidecar discovery (ChatGPT ``.dat`` asset acquisition) are recorded

--- a/tests/unit/sources/test_drive_ops.py
+++ b/tests/unit/sources/test_drive_ops.py
@@ -23,17 +23,25 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import polylogue.pipeline.services.ingest_batch._core as ingest_batch_core
 from polylogue.config import Source
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONValue
+from polylogue.pipeline.ids import session_content_hash
+from polylogue.pipeline.ids import session_id as make_session_id
+from polylogue.pipeline.services.ingest_worker import SessionWritePayload
 from polylogue.sources import DriveFile, download_drive_files
 from polylogue.sources.dispatch import parse_payload
 from polylogue.sources.drive import iter_drive_raw_data
 from polylogue.sources.parsers.base import ParsedSession
+from polylogue.storage.blob_publication import ArchiveBlobPublisher
 from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.cursor_state import CursorStatePayload
-from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root, initialize_archive_tier
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
+from polylogue.storage.sqlite.connection import open_connection
 
 
 @dataclass
@@ -326,3 +334,180 @@ def test_drive_attachment_fetch_failure_stays_honestly_unfetched(tmp_path: Path)
     row = conn.execute("SELECT blob_hash, acquisition_status FROM attachments").fetchone()
     assert row["acquisition_status"] == "unfetched"
     assert row["blob_hash"] is None
+
+
+def _write_via_ingest_batch(
+    *,
+    conn: sqlite3.Connection,
+    source_conn: sqlite3.Connection,
+    blob_publisher: ArchiveBlobPublisher,
+    session: ParsedSession,
+    raw_id: str,
+) -> None:
+    payload = SessionWritePayload(
+        session_id=str(make_session_id(session.source_name, session.provider_session_id)),
+        content_hash=session_content_hash(session),
+        parsed_session=session,
+        message_count=len(session.messages),
+        attachment_count=len(session.attachments),
+        raw_id=raw_id,
+    )
+    changed, _ = ingest_batch_core._write_session(conn, payload, blob_publisher=blob_publisher, source_conn=source_conn)
+    assert changed is True
+    conn.commit()
+
+
+def test_iter_drive_raw_data_two_revision_fixture_gets_real_lineage(tmp_path: Path) -> None:
+    """polylogue-sp72 AC1: thread two REAL ``iter_drive_raw_data`` acquisition
+    passes (the exact live-attachment-backfill shape, not a hand-crafted
+    byte-append fixture) all the way through the actual production write
+    path (``ingest_batch._core._write_session``) and inspect what
+    ``raw_sessions`` lineage they end up with.
+
+    First pass: the Drive-hosted attachment reference fails to fetch, so the
+    cache file is written with the plain downloaded JSON. Second pass: the
+    same file, now with the attachment fetchable -- ``iter_drive_raw_data``
+    backfills the resolved bytes into the cached JSON and re-serializes the
+    whole document (``_inject_live_drive_attachment_bytes``), producing a
+    brand-new raw for the SAME logical session, exactly the polylogue-sp72
+    problem shape.
+
+    Both raws MUST carry a real, non-NULL ``logical_source_key`` (the
+    concrete, durable fix: they are no longer invisible to
+    ``raw_revision_heads``/future arbitration) and ``revision_kind='full'``
+    (never the pre-fix ``'unknown'``). Whether the second raw also gets a
+    proven ``predecessor_raw_id`` depends on whether its bytes are a literal
+    byte-prefix continuation of the first's, per
+    ``classify_historical_full_revision_streams``
+    (``archive/revision_authority.py``) -- and a full JSON re-serialization
+    that injects the resolved attachment bytes into the MIDDLE of the
+    document (not appended at the very end) is generally NOT a byte-prefix
+    superset of the original, so this real fixture is expected to land
+    ``revision_authority='quarantined'`` with no predecessor link, same as
+    before this PR for this exact non-prefix shape -- what changed is that
+    the identity (``logical_source_key``) is now recorded at all, so a
+    future consumer (or a classifier upgraded to recognize JSON-structural
+    supersets, not just byte-literal ones -- polylogue-1fijp's larger
+    raw-admission-chokepoint scope) can still find and arbitrate this
+    cohort. This is intentionally NOT asserted as "predecessor-linked" --
+    doing so would be a false claim about what the current byte-prefix-only
+    classifier can prove for this shape; see the PR description for the
+    scope boundary this test exists to keep honest.
+    """
+    payload = {
+        "chunkedPrompt": {
+            "chunks": [
+                {
+                    "role": "model",
+                    "driveDocument": {"id": "att-1", "name": "doc.txt", "mimeType": "text/plain"},
+                },
+            ]
+        }
+    }
+    client = _DriveSessionClient(
+        files=[DriveFile("file-1", "chat.json", "application/json", "2025-01-01T00:00:00Z", 10)],
+        payload_bytes={"file-1": json.dumps(payload).encode("utf-8")},
+        attachment_failures={"att-1": RuntimeError("not yet fetchable")},
+    )
+    acquire_blob_store = BlobStore(tmp_path / "acquire-blob")
+
+    first_records = list(
+        iter_drive_raw_data(
+            source=Source(name="gemini", folder="Google AI Studio", path=tmp_path),
+            client=client,
+            blob_store=acquire_blob_store,
+        )
+    )
+    assert len(first_records) == 1
+    first_bytes = acquire_blob_store.read_all(first_records[0].blob_hash)  # type: ignore[arg-type]
+
+    fetchable_client = _DriveSessionClient(
+        files=client.files,
+        payload_bytes=client.payload_bytes,
+        attachment_bytes={"att-1": b"the actual drive attachment bytes"},
+    )
+    second_records = list(
+        iter_drive_raw_data(
+            source=Source(name="gemini", folder="Google AI Studio", path=tmp_path),
+            client=fetchable_client,
+            blob_store=acquire_blob_store,
+        )
+    )
+    assert len(second_records) == 1
+    second_bytes = acquire_blob_store.read_all(second_records[0].blob_hash)  # type: ignore[arg-type]
+    assert second_bytes != first_bytes
+    # Confirms the real mechanism's shape: the backfill re-serializes the
+    # WHOLE document (injecting resolved bytes into the middle), it does not
+    # append at the end -- so the second raw is not a literal byte-prefix
+    # continuation of the first.
+    assert not second_bytes.startswith(first_bytes)
+
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+    source_db_path = archive_root / "source.db"
+    blob_publisher = ArchiveBlobPublisher(source_db_path, archive_root / "blob")
+
+    with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+        first_raw_id = archive.write_raw_payload(
+            provider=Provider.GEMINI,
+            payload=first_bytes,
+            source_path=first_records[0].source_path,
+            acquired_at_ms=1_767_000_000_000,
+        )
+        second_raw_id = archive.write_raw_payload(
+            provider=Provider.GEMINI,
+            payload=second_bytes,
+            source_path=second_records[0].source_path,
+            acquired_at_ms=1_767_000_000_500,
+        )
+    assert first_raw_id != second_raw_id
+
+    first_sessions = parse_payload("gemini", json.loads(first_bytes), "fallback-id")
+    second_sessions = parse_payload("gemini", json.loads(second_bytes), "fallback-id")
+    assert len(first_sessions) == 1
+    assert len(second_sessions) == 1
+
+    with (
+        open_connection(archive_root / "index.db") as conn,
+        sqlite3.connect(str(source_db_path)) as source_conn,
+    ):
+        _write_via_ingest_batch(
+            conn=conn,
+            source_conn=source_conn,
+            blob_publisher=blob_publisher,
+            session=first_sessions[0],
+            raw_id=first_raw_id,
+        )
+        _write_via_ingest_batch(
+            conn=conn,
+            source_conn=source_conn,
+            blob_publisher=blob_publisher,
+            session=second_sessions[0],
+            raw_id=second_raw_id,
+        )
+
+    with sqlite3.connect(str(source_db_path)) as verify_conn:
+        verify_conn.row_factory = sqlite3.Row
+        first_row = verify_conn.execute(
+            "SELECT logical_source_key, revision_kind FROM raw_sessions WHERE raw_id = ?",
+            (first_raw_id,),
+        ).fetchone()
+        second_row = verify_conn.execute(
+            "SELECT logical_source_key, revision_kind, predecessor_raw_id FROM raw_sessions WHERE raw_id = ?",
+            (second_raw_id,),
+        ).fetchone()
+
+    provider_session_id = first_sessions[0].provider_session_id
+    expected_logical_source_key = f"{Provider.GEMINI.value}:{provider_session_id}"
+    # The durable fix: both raws now carry the real identity key and a typed
+    # revision_kind, no longer NULL/'unknown' -- regardless of whether the
+    # byte-prefix classifier can additionally prove a predecessor link for
+    # this non-append-shaped fixture.
+    assert first_row["logical_source_key"] == expected_logical_source_key
+    assert second_row["logical_source_key"] == expected_logical_source_key
+    assert first_row["revision_kind"] == "full"
+    assert second_row["revision_kind"] == "full"
+    # Documented, expected residual gap (see docstring): a mid-document JSON
+    # re-serialization is not byte-prefix provable, so no predecessor link is
+    # established for THIS shape yet.
+    assert second_row["predecessor_raw_id"] is None


### PR DESCRIPTION
## Summary

Drive revision-lineage bookkeeping (added in #3639 for polylogue-sp72) computed a `RevisionReplayPlan` but discarded it, so the #3453 freshness-tie safety net still solely decided whether a governed Drive revision landed even when governance had already proven the winner. This closes that gap for the cases governance CAN prove, and adds an honest end-to-end test through the real `iter_drive_raw_data` acquisition path that documents a real residual limitation.

## Problem

`_bind_drive_revision_lineage` (`polylogue/pipeline/services/ingest_batch/_core.py`, added in #3639) calls `classify_raw_revision_cohort_for_live_watch` to bind real lineage (`logical_source_key`/`predecessor_raw_id`/`revision_authority`) for Drive re-acquisitions, but never used the returned `RevisionReplayPlan`. The #3453 tie-break (`_incoming_write_regresses_attachment_coverage`) — which fires when two raws share an identical content-derived timestamp but differ in acquired-attachment coverage — kept deciding the outcome on its own heuristic even in cases where governance had already independently proven which raw is the legitimate accepted-chain successor. No existing test exercised the exact tie shape (identical message timestamps + differing attachment coverage) together with lineage governance, so this gap had no red/green evidence either way (confirmed: adding the test first and reverting the fix produces `assert False is True`).

Separately, while building an honest test through the real `iter_drive_raw_data` acquisition path (not a hand-crafted byte-append fixture), I found that `_inject_live_drive_attachment_bytes`'s live-attachment backfill re-serializes the WHOLE JSON document (injecting resolved bytes into a nested dict), not a byte-append at the document's end. The second raw is therefore NOT a byte-prefix superset of the first (`not second_bytes.startswith(first_bytes)`, verified). `classify_raw_revision_cohort`'s classifier (`archive/revision_authority.py`) is strictly byte-prefix based, so this realistic shape still lands `revision_authority='quarantined'` with no `predecessor_raw_id` — same as before #3639 for this shape. What #3639 genuinely changed: both raws now carry a non-NULL `logical_source_key` and `revision_kind='full'` (never `'unknown'`), so a future consumer — or a classifier upgraded to recognize JSON-structural supersets, not just byte-literal ones — can still find and arbitrate the cohort.

## Solution

- `_bind_drive_revision_lineage` now returns the `RevisionReplayPlan` it computes (`None` on any early-return or swallowed failure) instead of discarding it.
- `_write_session` captures `drive_revision_proven_winner` (true when `payload.raw_id` is in the plan's `accepted_chain`) and skips the #3453 tie-break only when governance has proven this exact raw is the legitimate successor. The heuristic remains the deciding factor for every ungoverned case (no `source_conn`/`blob_publisher`, non-Gemini identity, or a classification failure) — this is a strict narrowing of when the safety net applies, never an unconditional bypass.
- New tests in `tests/unit/pipeline/test_ingest_batch.py`:
  - `test_write_session_drive_lineage_proven_winner_bypasses_freshness_tie` — byte-append fixture (same shape as #3639's own lineage test), identical timestamps, an attachment-coverage regression that the old tie-break would have blocked; asserts the write lands anyway.
  - `test_write_session_freshness_tie_regression_without_lineage_still_blocks` — negative control: the identical regression shape, but no `source_conn` (so no governance evidence); asserts the safety net still blocks it.
- New test in `tests/unit/sources/test_drive_ops.py`:
  - `test_iter_drive_raw_data_two_revision_fixture_gets_real_lineage` — threads two genuine `iter_drive_raw_data` passes (attachment fetch fails, then succeeds) through `ArchiveStore.write_raw_payload` + `parse_payload` + `_write_session`, the real production path. Asserts both raws get `logical_source_key` populated and `revision_kind='full'`, and documents (via an explicit assertion + docstring) that `predecessor_raw_id` is NOT established for this realistic non-append shape.

## Scope notes / deferred

Per the bead's own notes ("absorbed by polylogue-1fijp ... individual fix remains legitimate if 1fijp stalls"):

- Full closure of AC1's literal "predecessor-linked, not quarantined" wording for the realistic mid-document JSON mutation shape needs a JSON-structural-diff-aware classifier, not a byte-prefix one — materially larger scope, correctly deferred to polylogue-1fijp's raw-admission-chokepoint rewrite. This PR's bypass is real and tested for whatever cases DO produce a genuine byte-prefix relationship.
- The 157 already-contaminated `aistudio-drive` raw pairs need a live re-measure after deploy — not attempted here (retroactive durable-tier cleanup needs its own explicit-consent process per this repo's schema regime).

## Verification

- `devtools test -k drive` — 281 passed, 1 failed (`tests/integration/test_blob_lifecycle_e2e.py::TestOrphanedBlobsCatalogRouting::test_catalog_resolution_drives_end_to_end_cleanup`), confirmed pre-existing/unrelated by reproducing identically with `git stash` before this change applied.
- `devtools test tests/unit/pipeline/test_ingest_batch.py` — 68 passed.
- Red-first: temporarily reverted the `not drive_revision_proven_winner` guard and reran `test_write_session_drive_lineage_proven_winner_bypasses_freshness_tie` — failed with `assert False is True`; reapplied and reran green.
- `mypy polylogue/pipeline/services/ingest_batch/_core.py tests/unit/sources/test_drive_ops.py tests/unit/pipeline/test_ingest_batch.py` — `Success: no issues found in 3 source files`.
- `devtools verify --quick` — `exit_code: 0`.

Ref polylogue-sp72

Co-Authored-By: Claude <noreply@anthropic.com>