### PR TITLE
feat(verification): add I6/I10 registry checks, red-twin gate, health scheduling

### DIFF
--- a/polylogue/daemon/health.py
+++ b/polylogue/daemon/health.py
@@ -1289,6 +1289,86 @@ def _check_cursor_lag_anomaly_layer(
         ]
 
 
+def _check_archive_verification_registry_medium() -> list[HealthAlert]:
+    """Schedule the archive-verification registry's LIVENESS/FRESHNESS checks
+    (polylogue-t0m73, binding (c)): those two classes are explicitly the
+    ones that need a recency signal ("something must have happened
+    recently" -- see :class:`~polylogue.maintenance.archive_verification
+    .ArchiveVerificationCheckClass`'s docstring), which is exactly what the
+    periodic daemon health loop provides and a one-shot operator CLI run
+    cannot. The other classes (state-invariant, fidelity, conservation,
+    config, complexity) are point-in-time coherence checks that make sense
+    on any snapshot and are already reachable via the operator CLI /
+    promotion-gate bindings -- this loop deliberately does not duplicate
+    them here.
+
+    A waived check (:data:`~polylogue.maintenance.archive_verification
+    .ARCHIVE_VERIFICATION_WAIVERS`) still surfaces as a health alert (the
+    daemon health loop has no concept of "non-blocking" the way the
+    reindex-acceptance gate does), but at WARNING rather than ERROR
+    severity so an already-tracked, separately-owned debt item doesn't
+    read as a fresh production incident on every health cycle.
+    """
+    now = datetime.now(UTC).isoformat()
+    try:
+        from polylogue.maintenance.archive_verification import (
+            ARCHIVE_VERIFICATION_CHECKS,
+            ArchiveVerificationCheckClass,
+            verify_archive,
+        )
+
+        scheduled_names = [
+            spec.name
+            for spec in ARCHIVE_VERIFICATION_CHECKS
+            if spec.check_class in (ArchiveVerificationCheckClass.LIVENESS, ArchiveVerificationCheckClass.FRESHNESS)
+        ]
+        if not scheduled_names:
+            return []
+        report = verify_archive(archive_root(), checks=scheduled_names)
+        alerts = []
+        any_unwaived_error = False
+        for check in report.checks:
+            if check.status.value == "ok":
+                severity = HealthSeverity.OK
+            elif check.status.value == "warning":
+                severity = HealthSeverity.WARNING
+            elif check.status.value == "skip":
+                severity = HealthSeverity.OK
+            else:
+                waived_bead_id = getattr(check, "waived_bead_id", None)
+                if waived_bead_id is not None:
+                    severity = HealthSeverity.WARNING
+                else:
+                    severity = HealthSeverity.ERROR
+                    any_unwaived_error = True
+            alerts.append(
+                HealthAlert(
+                    check_name=f"archive_verification_{check.name.replace('-', '_')}",
+                    tier=HealthTier.MEDIUM,
+                    severity=severity,
+                    message=check.summary,
+                    checked_at=now,
+                    consecutive_failures=_record_failure(
+                        f"archive_verification_{check.name.replace('-', '_')}", severity == HealthSeverity.OK
+                    ),
+                )
+            )
+        _record_failure("archive_verification_registry", not any_unwaived_error)
+        return alerts
+    except Exception:
+        logger.exception("archive_verification_registry health check raised")
+        return [
+            HealthAlert(
+                check_name="archive_verification_registry",
+                tier=HealthTier.MEDIUM,
+                severity=HealthSeverity.ERROR,
+                message="archive verification registry check failed (see logs)",
+                checked_at=now,
+                consecutive_failures=_record_failure("archive_verification_registry", False),
+            )
+        ]
+
+
 def _run_medium_checks() -> list[HealthAlert]:
     return [
         _check_fts_readiness_medium(),
@@ -1297,6 +1377,7 @@ def _run_medium_checks() -> list[HealthAlert]:
         _check_stale_ingest_attempts_medium(),
         _check_insight_freshness_medium(),
         _check_repeated_stage_failures_medium(),
+        *_check_archive_verification_registry_medium(),
         _check_schema_drift_medium(),
         *_check_convergence_debt_medium(),
         *_check_cursor_lag_medium(),

--- a/polylogue/maintenance/archive_verification.py
+++ b/polylogue/maintenance/archive_verification.py
@@ -420,6 +420,7 @@ def _check_source_index_coverage(archive_root: Path, sample_limit: int) -> Archi
                 WITH heads AS (
                     SELECT
                         r.raw_id,
+                        r.blob_hash,
                         r.parse_error,
                         r.revision_authority,
                         {census_expr} AS census_status,
@@ -479,6 +480,37 @@ def _check_source_index_coverage(archive_root: Path, sample_limit: int) -> Archi
                 )
             ]
 
+            # polylogue-t0m73 (2026-08-03 correction to I1's framing): an
+            # unindexed head whose bytes are byte-identical to an already-
+            # indexed raw (same blob_hash, different raw_id -- e.g. a second
+            # acquisition of content already captured) is not novel missing
+            # content. The operator's live-run challenge measured 4,305 of
+            # 7,200 unindexed heads (77%) in this bucket -- without it, the
+            # check's own evidence overstates the gap as if every unindexed
+            # head were a distinct materialization failure. This never
+            # changes ``blocking`` (an untyped/orphan head is still an error
+            # regardless of whether its bytes happen to be duplicated
+            # elsewhere); it only prevents the report from repeating the
+            # overstatement.
+            byte_dup_of_indexed_n = int(
+                conn.execute(
+                    f"""
+                    {heads_cte}
+                    SELECT SUM(CASE WHEN {quarantined_predicate.replace("rn = 1 AND ", "")}
+                                       OR {untyped_predicate.replace("rn = 1 AND ", "")}
+                                  THEN (
+                                    EXISTS(
+                                        SELECT 1 FROM raw_sessions dup
+                                        JOIN idx_tier.sessions ds ON ds.raw_id = dup.raw_id
+                                        WHERE dup.blob_hash = heads.blob_hash
+                                    )
+                                  ) ELSE 0 END)
+                    FROM heads WHERE rn = 1
+                    """
+                ).fetchone()[0]
+                or 0
+            )
+
             orphan_count = conn.execute(
                 """
                 SELECT COUNT(*) FROM idx_tier.sessions s
@@ -513,6 +545,8 @@ def _check_source_index_coverage(archive_root: Path, sample_limit: int) -> Archi
     else:
         status = OutcomeStatus.OK
 
+    novel_unindexed_n = max(unindexed_head_count - byte_dup_of_indexed_n, 0)
+
     parts = [f"{total_heads:,} logical source head(s), {unindexed_head_count:,} unindexed"]
     if untyped_n:
         parts.append(f"untyped={untyped_n:,}")
@@ -522,6 +556,10 @@ def _check_source_index_coverage(archive_root: Path, sample_limit: int) -> Archi
         parts.append(f"parse_error={parse_error_n:,}")
     if non_session_n or census_failed_n:
         parts.append(f"declared-non-session={non_session_n + census_failed_n:,}")
+    if byte_dup_of_indexed_n:
+        parts.append(
+            f"byte-dup-of-indexed={byte_dup_of_indexed_n:,} (novel={novel_unindexed_n:,} of {unindexed_head_count:,})"
+        )
     if orphan_count:
         parts.append(f"orphans={int(orphan_count):,}")
     summary = "; ".join(parts)
@@ -545,6 +583,8 @@ def _check_source_index_coverage(archive_root: Path, sample_limit: int) -> Archi
             "census_failed_count": census_failed_n,
             "quarantined_count": quarantined_n,
             "quarantined_sample": quarantined_sample,
+            "byte_dup_of_indexed_count": byte_dup_of_indexed_n,
+            "novel_unindexed_count": novel_unindexed_n,
             "orphan_count": int(orphan_count or 0),
             "orphan_sample": orphan_sample,
         },
@@ -1263,6 +1303,250 @@ def _check_counts_summary(archive_root: Path, _sample_limit: int) -> ArchiveVeri
 
 
 # ---------------------------------------------------------------------------
+# Check 8: convergence freshness (I6, polylogue-t0m73)
+# ---------------------------------------------------------------------------
+
+#: Window within which *some* daemon/convergence activity must have been
+#: observed for an open unindexed backlog to read as "being worked" rather
+#: than stalled. 24h matches the daemon's own quiet-window/catch-up cadence
+#: (see ``daemon/convergence_stages.py``) -- shorter than that flags normal
+#: async lag as false-positive stalls; much longer hides a genuinely dead
+#: converger for days.
+CONVERGENCE_FRESHNESS_WINDOW_MS = 24 * 3600 * 1000
+
+
+def _unindexed_backlog_gap(conn: sqlite3.Connection) -> int:
+    """Count of ``raw_sessions`` logical heads with no indexed materialization
+    and no terminal typed refusal (parse_error / declared non-session) --
+    the same universe :func:`_check_source_index_coverage` (I1) tallies as
+    ``untyped_count + quarantined_count``, recomputed here so I6 doesn't
+    need I1's full breakdown/sample evidence, only the scalar gap.
+    """
+    has_census = table_exists(conn, "raw_membership_census")
+    census_expr = "(SELECT c.status FROM raw_membership_census c WHERE c.raw_id = r.raw_id)" if has_census else "NULL"
+    row = conn.execute(
+        f"""
+        WITH heads AS (
+            SELECT
+                r.raw_id,
+                r.parse_error,
+                {census_expr} AS census_status,
+                MAX(EXISTS(SELECT 1 FROM idx_tier.sessions s WHERE s.raw_id = r.raw_id))
+                    OVER (PARTITION BY r.origin, COALESCE(r.native_id, r.source_path)) AS any_indexed,
+                ROW_NUMBER() OVER (
+                    PARTITION BY r.origin, COALESCE(r.native_id, r.source_path)
+                    ORDER BY r.acquired_at_ms DESC, r.raw_id DESC
+                ) AS rn
+            FROM raw_sessions r
+        )
+        SELECT SUM(
+            CASE WHEN rn = 1 AND any_indexed = 0 AND parse_error IS NULL
+                      AND COALESCE(census_status, '') NOT IN ('non_session', 'failed')
+                 THEN 1 ELSE 0 END
+        )
+        FROM heads WHERE rn = 1
+        """
+    ).fetchone()
+    return int(row[0] or 0)
+
+
+def _check_convergence_freshness(archive_root: Path, _sample_limit: int) -> ArchiveVerificationCheck:
+    """An open unindexed backlog is only benign async lag if convergence is
+    actively working it (I6, polylogue-t0m73).
+
+    The prototype's original I6 criterion ("some daemon activity happened
+    ever") was too weak: it passed on an archive with a 7,200-source gap
+    and zero daemon stage events in the preceding 24h, because activity from
+    weeks earlier still counted. The corrected criterion requires BOTH a
+    non-zero gap (reusing I1's universe via :func:`_unindexed_backlog_gap`)
+    AND *no* convergence activity inside :data:`CONVERGENCE_FRESHNESS_WINDOW_MS`
+    across ``daemon_events``, ``daemon_stage_events``, and ``convergence_debt``
+    (the last of these was itself missed by the original predicate --
+    a debt row's own ``updated_at_ms`` is evidence of retry activity even
+    when no daemon_events/stage_events row was emitted in the same window).
+    A gap with recent activity is WARNING (backlog exists, still converging);
+    a gap with no recent activity anywhere is ERROR (stalled, not lag).
+    """
+    source_path = _tier_path(archive_root, ArchiveTier.SOURCE)
+    index_path = _resolve_index_path(archive_root)
+    ops_path = _tier_path(archive_root, ArchiveTier.OPS)
+    if not source_path.exists() or not index_path.exists():
+        return _skip_check("convergence-freshness", "source.db or index.db not present")
+    if not ops_path.exists():
+        return _skip_check("convergence-freshness", "ops.db not present")
+
+    try:
+        conn = _open_ro(source_path)
+    except sqlite3.Error as exc:
+        return _error_check("convergence-freshness", f"could not open source.db: {exc}", exc=exc)
+    try:
+        try:
+            conn.execute("ATTACH DATABASE ? AS idx_tier", (f"file:{index_path}?mode=ro",))
+        except sqlite3.Error as exc:
+            return _error_check("convergence-freshness", f"could not attach index.db: {exc}", exc=exc)
+        try:
+            gap = _unindexed_backlog_gap(conn)
+        except sqlite3.Error as exc:
+            return _error_check("convergence-freshness", f"could not read source/index tiers: {exc}", exc=exc)
+    finally:
+        conn.close()
+
+    if gap == 0:
+        return ArchiveVerificationCheck(
+            name="convergence-freshness",
+            status=OutcomeStatus.OK,
+            summary="no unindexed backlog to converge",
+            evidence={"unindexed_backlog_gap": 0},
+        )
+
+    try:
+        ops_conn = _open_ro(ops_path)
+    except sqlite3.Error as exc:
+        return _error_check("convergence-freshness", f"could not open ops.db: {exc}", exc=exc)
+
+    now_ms = int(datetime.now(UTC).timestamp() * 1000)
+    activity: dict[str, Any] = {}
+    most_recent_ms: int | None = None
+    try:
+        if table_exists(ops_conn, "daemon_events"):
+            row = ops_conn.execute("SELECT MAX(ts_ms) FROM daemon_events").fetchone()
+            if row and row[0] is not None:
+                activity["daemon_events_latest_ms"] = int(row[0])
+                most_recent_ms = max(most_recent_ms or int(row[0]), int(row[0]))
+        if table_exists(ops_conn, "daemon_stage_events"):
+            row = ops_conn.execute("SELECT MAX(observed_at_ms) FROM daemon_stage_events").fetchone()
+            if row and row[0] is not None:
+                activity["daemon_stage_events_latest_ms"] = int(row[0])
+                most_recent_ms = max(most_recent_ms or int(row[0]), int(row[0]))
+        if table_exists(ops_conn, "convergence_debt"):
+            row = ops_conn.execute("SELECT MAX(updated_at_ms), COUNT(*) FROM convergence_debt").fetchone()
+            activity["convergence_debt_count"] = int(row[1] or 0) if row else 0
+            if row and row[0] is not None:
+                activity["convergence_debt_latest_ms"] = int(row[0])
+                most_recent_ms = max(most_recent_ms or int(row[0]), int(row[0]))
+    except sqlite3.Error as exc:
+        return _error_check("convergence-freshness", f"could not read ops.db: {exc}", exc=exc)
+    finally:
+        ops_conn.close()
+
+    age_ms = None if most_recent_ms is None else now_ms - most_recent_ms
+    recent = age_ms is not None and age_ms <= CONVERGENCE_FRESHNESS_WINDOW_MS
+    evidence = {"unindexed_backlog_gap": gap, "window_ms": CONVERGENCE_FRESHNESS_WINDOW_MS, **activity}
+    if age_ms is not None:
+        evidence["most_recent_activity_age_ms"] = age_ms
+
+    if recent:
+        return ArchiveVerificationCheck(
+            name="convergence-freshness",
+            status=OutcomeStatus.WARNING,
+            summary=f"{gap:,} unindexed head(s) with convergence activity in the last "
+            f"{CONVERGENCE_FRESHNESS_WINDOW_MS // 3_600_000}h -- still converging, not stalled",
+            count=gap,
+            evidence=evidence,
+        )
+    return ArchiveVerificationCheck(
+        name="convergence-freshness",
+        status=OutcomeStatus.ERROR,
+        summary=f"{gap:,} unindexed head(s), no daemon/convergence activity in the last "
+        f"{CONVERGENCE_FRESHNESS_WINDOW_MS // 3_600_000}h -- stalled, not just async lag",
+        count=gap,
+        evidence=evidence,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Check 9: user-tier reference liveness (I10, polylogue-t0m73)
+# ---------------------------------------------------------------------------
+
+
+def _check_user_tier_refs(archive_root: Path, sample_limit: int) -> ArchiveVerificationCheck:
+    """``assertions.target_ref`` of kind ``session``/``message`` must resolve
+    to a live row in ``index.db`` (I10, polylogue-t0m73).
+
+    Universe is ``assertions`` itself -- the durable, irreplaceable user-tier
+    ground truth (a mark/annotation/correction a human or agent made) -- not
+    ``index.db``'s own bookkeeping of what it currently holds. An assertion
+    whose target no longer resolves (the session/message it was about was
+    deleted or never survived a rebuild) is a dangling reference: not fatal
+    to read, but the annotation becomes silently unreachable from any
+    normal target-scoped query.
+    """
+    user_path = _tier_path(archive_root, ArchiveTier.USER)
+    index_path = _resolve_index_path(archive_root)
+    if not user_path.exists() or not index_path.exists():
+        return _skip_check("user-tier-refs", "user.db or index.db not present")
+
+    try:
+        conn = _open_ro(user_path)
+    except sqlite3.Error as exc:
+        return _error_check("user-tier-refs", f"could not open user.db: {exc}", exc=exc)
+
+    try:
+        try:
+            conn.execute("ATTACH DATABASE ? AS idx_tier", (f"file:{index_path}?mode=ro",))
+        except sqlite3.Error as exc:
+            return _error_check("user-tier-refs", f"could not attach index.db: {exc}", exc=exc)
+        try:
+            if not table_exists(conn, "assertions"):
+                return _skip_check("user-tier-refs", "assertions table not present")
+
+            dangling_predicate = """
+                (a.target_ref LIKE 'session:%' AND NOT EXISTS (
+                    SELECT 1 FROM idx_tier.sessions s WHERE s.session_id = substr(a.target_ref, 9)
+                ))
+                OR (a.target_ref LIKE 'message:%' AND NOT EXISTS (
+                    SELECT 1 FROM idx_tier.messages m WHERE m.message_id = substr(a.target_ref, 9)
+                ))
+            """
+            total, dangling_sessions, dangling_messages = conn.execute(
+                """
+                SELECT
+                    SUM(CASE WHEN a.target_ref LIKE 'session:%' OR a.target_ref LIKE 'message:%' THEN 1 ELSE 0 END),
+                    SUM(CASE WHEN a.target_ref LIKE 'session:%' AND NOT EXISTS (
+                        SELECT 1 FROM idx_tier.sessions s WHERE s.session_id = substr(a.target_ref, 9)
+                    ) THEN 1 ELSE 0 END),
+                    SUM(CASE WHEN a.target_ref LIKE 'message:%' AND NOT EXISTS (
+                        SELECT 1 FROM idx_tier.messages m WHERE m.message_id = substr(a.target_ref, 9)
+                    ) THEN 1 ELSE 0 END)
+                FROM assertions a
+                """
+            ).fetchone()
+            sample = [
+                str(row[0])
+                for row in conn.execute(
+                    f"SELECT assertion_id FROM assertions a WHERE {dangling_predicate} LIMIT ?",
+                    (sample_limit,),
+                )
+            ]
+        except sqlite3.Error as exc:
+            return _error_check("user-tier-refs", f"could not read user/index tiers: {exc}", exc=exc)
+    finally:
+        conn.close()
+
+    total_n = int(total or 0)
+    dangling_n = int(dangling_sessions or 0) + int(dangling_messages or 0)
+    status = OutcomeStatus.ERROR if dangling_n else OutcomeStatus.OK
+    summary = (
+        f"{total_n:,} session/message-scoped assertion(s), {dangling_n:,} dangling"
+        if dangling_n
+        else f"{total_n:,} session/message-scoped assertion(s), all resolve"
+    )
+    return ArchiveVerificationCheck(
+        name="user-tier-refs",
+        status=status,
+        summary=summary,
+        count=dangling_n,
+        details=[f"dangling:{assertion_id}" for assertion_id in sample],
+        evidence={
+            "total_scoped_assertion_count": total_n,
+            "dangling_session_ref_count": int(dangling_sessions or 0),
+            "dangling_message_ref_count": int(dangling_messages or 0),
+            "dangling_sample": sample,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
 # Registry + entrypoint
 # ---------------------------------------------------------------------------
 
@@ -1341,6 +1625,19 @@ ARCHIVE_VERIFICATION_CHECKS: tuple[ArchiveVerificationCheckSpec, ...] = (
         "Archive-wide session/message/block counts and origin breakdown (numbers-freeze starter).",
         _check_counts_summary,
         ArchiveVerificationCheckClass.COMPLEXITY,
+    ),
+    ArchiveVerificationCheckSpec(
+        "convergence-freshness",
+        "An open unindexed backlog (I1's universe) with no daemon/convergence activity in the last 24h is "
+        "stalled, not async lag (polylogue-t0m73 I6).",
+        _check_convergence_freshness,
+        ArchiveVerificationCheckClass.FRESHNESS,
+    ),
+    ArchiveVerificationCheckSpec(
+        "user-tier-refs",
+        "assertions.target_ref of kind session/message resolves to a live index.db row (polylogue-t0m73 I10).",
+        _check_user_tier_refs,
+        ArchiveVerificationCheckClass.LIVENESS,
     ),
 )
 

--- a/tests/unit/daemon/test_health_check_paths.py
+++ b/tests/unit/daemon/test_health_check_paths.py
@@ -662,6 +662,87 @@ def test_repeated_stage_failures_prefers_populated_archive_ops(
 
 
 # ---------------------------------------------------------------------------
+# MEDIUM: archive_verification_registry (polylogue-t0m73 binding (c))
+# ---------------------------------------------------------------------------
+
+
+def test_archive_verification_registry_ok_on_coherent_archive(
+    workspace_env: dict[str, Path],
+) -> None:
+    from polylogue.daemon.health import _check_archive_verification_registry_medium
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+    initialize_active_archive_root(archive_root())
+
+    alerts = _check_archive_verification_registry_medium()
+
+    assert alerts  # at least the LIVENESS/FRESHNESS checks ran
+    assert all(alert.severity != HealthSeverity.ERROR for alert in alerts)
+    assert all(alert.check_name.startswith("archive_verification_") for alert in alerts)
+
+
+def test_archive_verification_registry_error_on_orphaned_blob_ref(
+    workspace_env: dict[str, Path],
+) -> None:
+    """A LIVENESS-class registry check (blob-refs-liveness) going red must
+    surface as an ERROR health alert -- proves binding (c) actually
+    schedules the LIVENESS/FRESHNESS classes, not merely that the function
+    runs without raising. Uses blob-refs-liveness rather than
+    embeddings-refs-liveness because the latter carries a real, currently
+    open waiver (polylogue-feu0) that would downgrade its severity to
+    WARNING and defeat this test's point."""
+    from polylogue.daemon.health import _check_archive_verification_registry_medium
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+    initialize_active_archive_root(archive_root())
+    with sqlite3.connect(archive_root() / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO blob_refs(blob_hash, ref_id, ref_type, size_bytes, acquired_at_ms)
+            VALUES (?, 'raw-does-not-exist', 'raw_payload', 10, 100)
+            """,
+            (b"z" * 32,),
+        )
+        conn.commit()
+
+    alerts = _check_archive_verification_registry_medium()
+
+    by_name = {alert.check_name: alert for alert in alerts}
+    assert "archive_verification_blob_refs_liveness" in by_name
+    assert by_name["archive_verification_blob_refs_liveness"].severity == HealthSeverity.ERROR
+
+
+def test_archive_verification_registry_only_schedules_liveness_and_freshness_classes(
+    workspace_env: dict[str, Path],
+) -> None:
+    """State-invariant/fidelity/conservation/config/complexity checks are
+    already reachable via the operator CLI and promotion gate -- this
+    scheduling loop must not duplicate them (module docstring's stated
+    scope)."""
+    from polylogue.daemon.health import _check_archive_verification_registry_medium
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+    initialize_active_archive_root(archive_root())
+
+    alerts = _check_archive_verification_registry_medium()
+
+    scheduled = {alert.check_name.removeprefix("archive_verification_") for alert in alerts}
+    # Hardcoded, not re-derived from the registry's class tags: this pins the
+    # exact LIVENESS/FRESHNESS membership as of this change so a future
+    # check silently added under one of these two classes (or an existing
+    # one silently reclassified) is a visible diff here, not just an
+    # incidental pass-through of whatever the production filter currently
+    # computes.
+    assert scheduled == {
+        "blob_refs_liveness",
+        "embeddings_refs_liveness",
+        "planner_stats",
+        "convergence_freshness",
+        "user_tier_refs",
+    }
+
+
+# ---------------------------------------------------------------------------
 # EXPENSIVE: db_integrity (OK + degraded + RECOVERY)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -710,6 +711,181 @@ def test_message_count_projection_passes_on_coherent_archive(tmp_path: Path) -> 
     assert check.evidence["drifted_session_count"] == 0
 
 
+def test_missing_enum_value_trips_enum_superset_check(tmp_path: Path) -> None:
+    """RED TWIN (I2): a live CHECK list frozen at an older, narrower Origin
+    vocabulary is exactly the drift class this check exists to catch -- an
+    additive enum change that didn't rebuild every table's DDL. A fresh
+    fixture can't reproduce a real table falling behind (its DDL is always
+    generated from the current enum), so this creates a synthetic table
+    whose CHECK list the check's own regex recognizes (``origin ... IN
+    (...)``), pinned to a single, deliberately-stale origin value."""
+    _seed_coherent_archive(tmp_path)
+    conn = _connect(tmp_path / "source.db")
+    try:
+        conn.execute("CREATE TABLE frozen_origin_probe (origin TEXT NOT NULL CHECK(origin IN ('codex-session')))")
+        conn.commit()
+    finally:
+        conn.close()
+
+    report = verify_archive(tmp_path, checks=("enum-superset-check",))
+
+    check = _check(report, "enum-superset-check")
+    assert check.status is OutcomeStatus.ERROR
+    assert "source.db:frozen_origin_probe.origin" in check.evidence["missing_by_column"]
+
+
+def test_byte_dup_of_indexed_head_is_reported_as_evidence_not_hidden(tmp_path: Path) -> None:
+    """I1 correction (2026-08-03 operator challenge): an unindexed head whose
+    bytes duplicate an already-indexed raw is real evidence the gap isn't
+    all-novel. This must show up as report evidence (byte_dup_of_indexed_count,
+    novel_unindexed_count) without silently suppressing the underlying
+    quarantined/untyped classification the head still gets."""
+    _seed_coherent_archive(tmp_path)
+    conn = _connect(tmp_path / "source.db")
+    try:
+        conn.execute(
+            """
+            INSERT INTO raw_sessions(raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms)
+            VALUES ('raw-dup', 'codex-session', 'session-dup', '/y', ?, 10, 200)
+            """,
+            (b"a" * 32,),  # same blob_hash as raw-1, which IS indexed; defaults to quarantined
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    report = verify_archive(tmp_path, checks=("source-index-coverage",))
+
+    check = _check(report, "source-index-coverage")
+    assert check.status is OutcomeStatus.WARNING  # quarantined (default authority), not untyped -- doesn't block
+    assert check.evidence["quarantined_count"] == 1
+    assert check.evidence["byte_dup_of_indexed_count"] == 1
+    assert check.evidence["novel_unindexed_count"] == 0
+
+
+def test_stalled_backlog_trips_convergence_freshness(tmp_path: Path) -> None:
+    """RED TWIN (I6): an unindexed backlog (a second, uncovered logical
+    source) with no daemon/convergence activity recorded in ops.db is
+    exactly the "stalled, not async lag" condition this check exists to
+    catch -- the corrected criterion (gap>0 AND no recent activity) that
+    replaced the prototype's too-weak "some activity ever happened"."""
+    _seed_coherent_archive(tmp_path)
+    conn = _connect(tmp_path / "source.db")
+    try:
+        conn.execute(
+            """
+            INSERT INTO raw_sessions(raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms)
+            VALUES ('raw-gap', 'codex-session', 'session-gap', '/z', ?, 10, 300)
+            """,
+            (b"b" * 32,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    # ops.db exists (bootstrapped by _seed_coherent_archive) but carries no
+    # daemon_events/daemon_stage_events/convergence_debt rows -- no activity.
+
+    report = verify_archive(tmp_path, checks=("convergence-freshness",))
+
+    check = _check(report, "convergence-freshness")
+    assert check.status is OutcomeStatus.ERROR
+    assert check.evidence["unindexed_backlog_gap"] == 1
+
+
+@pytest.mark.frozen_clock_modules("polylogue.maintenance.archive_verification")
+def test_recent_activity_downgrades_convergence_freshness_to_warning(tmp_path: Path, frozen_clock: Any) -> None:
+    """A gap with recent daemon activity is WARNING (still converging), not
+    ERROR (stalled) -- the criterion's second half, proven independently of
+    the red twin above."""
+    _seed_coherent_archive(tmp_path)
+    conn = _connect(tmp_path / "source.db")
+    try:
+        conn.execute(
+            """
+            INSERT INTO raw_sessions(raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms)
+            VALUES ('raw-gap', 'codex-session', 'session-gap', '/z', ?, 10, 300)
+            """,
+            (b"b" * 32,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    ops_conn = _connect(tmp_path / "ops.db")
+    try:
+        now_ms = int(frozen_clock.now().timestamp() * 1000)
+        ops_conn.execute(
+            "INSERT INTO daemon_events(ts_ms, kind, operation_id, payload_json) VALUES (?, 'ingest', 'op-1', '{}')",
+            (now_ms,),
+        )
+        ops_conn.commit()
+    finally:
+        ops_conn.close()
+
+    report = verify_archive(tmp_path, checks=("convergence-freshness",))
+
+    check = _check(report, "convergence-freshness")
+    assert check.status is OutcomeStatus.WARNING
+    assert check.evidence["unindexed_backlog_gap"] == 1
+
+
+def test_convergence_freshness_passes_with_no_gap(tmp_path: Path) -> None:
+    _seed_coherent_archive(tmp_path)
+
+    report = verify_archive(tmp_path, checks=("convergence-freshness",))
+
+    check = _check(report, "convergence-freshness")
+    assert check.status is OutcomeStatus.OK
+    assert check.evidence["unindexed_backlog_gap"] == 0
+
+
+def test_dangling_assertion_target_trips_user_tier_refs(tmp_path: Path) -> None:
+    """RED TWIN (I10): a user-tier assertion whose target session/message no
+    longer resolves in index.db is a dangling reference -- silently
+    unreachable from any normal target-scoped query, exactly the liveness
+    gap this check exists to catch."""
+    _seed_coherent_archive(tmp_path)
+    conn = _connect(tmp_path / "user.db")
+    try:
+        conn.execute(
+            """
+            INSERT INTO assertions(assertion_id, target_ref, kind, body_text, created_at_ms, updated_at_ms)
+            VALUES ('a-dangling', 'session:codex-session:no-such-session', 'note', 'orphaned note', 100, 100)
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    report = verify_archive(tmp_path, checks=("user-tier-refs",))
+
+    check = _check(report, "user-tier-refs")
+    assert check.status is OutcomeStatus.ERROR
+    assert check.evidence["dangling_session_ref_count"] == 1
+    assert "a-dangling" in check.evidence["dangling_sample"]
+
+
+def test_user_tier_refs_passes_on_coherent_archive(tmp_path: Path) -> None:
+    _seed_coherent_archive(tmp_path)
+    conn = _connect(tmp_path / "user.db")
+    try:
+        conn.execute(
+            """
+            INSERT INTO assertions(assertion_id, target_ref, kind, body_text, created_at_ms, updated_at_ms)
+            VALUES ('a-live', 'session:codex-session:session', 'note', 'a live note', 100, 100)
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    report = verify_archive(tmp_path, checks=("user-tier-refs",))
+
+    check = _check(report, "user-tier-refs")
+    assert check.status is OutcomeStatus.OK
+    assert check.evidence["total_scoped_assertion_count"] == 1
+    assert check.evidence["dangling_session_ref_count"] == 0
+
+
 @pytest.mark.parametrize("check_name", ARCHIVE_VERIFICATION_CHECK_NAMES)
 def test_every_registry_check_does_not_error_on_the_real_pipeline_corpus(
     check_name: str, seeded_archive: SeededArchiveArtifact
@@ -873,3 +1049,65 @@ def test_reindex_acceptance_subset_is_satisfiable_from_index_only_root(tmp_path:
     assert not report.blocking, [check.summary for check in report.checks if check.status is OutcomeStatus.ERROR]
     for check in report.checks:
         assert check.status is not OutcomeStatus.ERROR, f"{check.name}: {check.summary}"
+
+
+# ---------------------------------------------------------------------------
+# RED-TWIN contract rule (polylogue-t0m73): structural enforcement
+# ---------------------------------------------------------------------------
+
+#: Maps every registry check name to the name of the test function in *this*
+#: module that proves a fixture mutation flips it to a non-OK status. This
+#: is the RED-TWIN contract rule's structural carrier: a check without an
+#: entry here (or whose named function doesn't exist) fails
+#: ``test_every_non_complexity_check_has_a_red_twin_test`` below, rather
+#: than silently shipping a check nobody has proven can ever go red.
+#: ``COMPLEXITY``-class checks (report-only, never pass/fail by design --
+#: see :class:`ArchiveVerificationCheckClass`) are exempt.
+RED_TWIN_TESTS: dict[str, str] = {
+    "tier-schema": "test_missing_tier_trips_tier_schema_check",
+    "pointer-coherence": "test_stale_pointer_trips_pointer_coherence_check",
+    "source-index-coverage": "test_raw_with_no_typed_refusal_and_no_session_is_untyped_gap",
+    "fts-parity": "test_deleted_fts_row_trips_message_fts_parity",
+    "lineage-sanity": "test_dangling_resolved_dst_trips_lineage_sanity",
+    "enum-superset-check": "test_missing_enum_value_trips_enum_superset_check",
+    "blob-refs-liveness": "test_blob_ref_with_no_referent_trips_blob_refs_liveness",
+    "embeddings-refs-liveness": "test_orphaned_embedding_ref_trips_embeddings_refs_liveness",
+    "session-lineage-acyclic": "test_parent_session_id_cycle_trips_session_lineage_acyclic",
+    "message-count-projection": "test_drifted_message_count_trips_message_count_projection",
+    "planner-stats": "test_missing_sqlite_stat1_is_warning_not_error",
+    "convergence-freshness": "test_stalled_backlog_trips_convergence_freshness",
+    "user-tier-refs": "test_dangling_assertion_target_trips_user_tier_refs",
+}
+
+
+def test_every_non_complexity_check_has_a_red_twin_test() -> None:
+    """Structural enforcement of the RED-TWIN contract rule (polylogue-t0m73):
+    every registry check whose class is not COMPLEXITY (a pass/fail
+    invariant, not a report-only summary -- see
+    :class:`ArchiveVerificationCheckClass`'s docstring) must have a
+    registered red-twin test in :data:`RED_TWIN_TESTS`, and that test
+    function must actually exist in this module. A new check added to
+    :data:`ARCHIVE_VERIFICATION_CHECKS` without a red-twin entry fails this
+    test immediately -- the meta-test the AC calls for, not a manual review
+    convention that can be forgotten."""
+    module_globals = globals()
+    missing_entry = []
+    missing_function = []
+    for spec in ARCHIVE_VERIFICATION_CHECKS:
+        if spec.check_class is ArchiveVerificationCheckClass.COMPLEXITY:
+            continue
+        test_name = RED_TWIN_TESTS.get(spec.name)
+        if test_name is None:
+            missing_entry.append(spec.name)
+            continue
+        if test_name not in module_globals or not callable(module_globals[test_name]):
+            missing_function.append((spec.name, test_name))
+    assert not missing_entry, f"registry check(s) with no RED_TWIN_TESTS entry: {missing_entry}"
+    assert not missing_function, f"RED_TWIN_TESTS entries pointing at a missing test function: {missing_function}"
+
+
+def test_red_twin_tests_only_reference_real_registry_checks() -> None:
+    """Inverse of the above: a stale ``RED_TWIN_TESTS`` entry for a check
+    name that no longer exists in the registry (e.g. after a rename) is
+    itself a drift signal worth catching, not silently ignored."""
+    assert set(RED_TWIN_TESTS) <= set(ARCHIVE_VERIFICATION_CHECK_NAMES)


### PR DESCRIPTION
## Summary

Migrates the two remaining prototype invariants (I6 convergence-freshness, I10 user-tier-refs) into the existing `ARCHIVE_VERIFICATION_CHECKS` registry, fixes I1's evidence to distinguish byte-duplicate-of-indexed heads from genuinely novel gaps, structurally enforces the RED-TWIN contract rule with a meta-test, and wires the registry's LIVENESS/FRESHNESS classes into the daemon's periodic MEDIUM health tier.

## Problem

polylogue-t0m73's live bead (not the older prototype-era summary) rescoped this work after a substrate investigation: the registry already existed twice over (`ARCHIVE_VERIFICATION_CHECKS` in `maintenance/archive_verification.py`, and the daemon health tiers), so the task was never to build a new bespoke lab probe -- it was to finish migrating the 10 invariants into that one registry and wire its four consuming bindings. Three prior merged PRs (#3156, #3612, #3635) had already built 8 of the 10 invariants, class tagging, waivers, and the promotion-gate/CLI bindings. What remained on inspection:

- I6 and I10 were entirely absent from the registry.
- I1 (`source-index-coverage`)'s evidence didn't separate byte-identical duplicates of already-indexed content from novel gaps -- the operator's 2026-08-03 challenge measured 4,305 of 7,200 unindexed heads (77%) on the live archive as duplicates, which the check's own report was silently overstating as all-missing.
- `enum-superset-check` (I2) had a passing test but no red twin proving it can ever go red.
- No structural enforcement existed for "every check ships a red twin" -- it was a convention, not a gate.
- The daemon health loop never scheduled the registry's LIVENESS/FRESHNESS classes, despite those two classes being explicitly documented as "the daemon health-tier home" in the class taxonomy's own docstring.

## Solution

- `polylogue/maintenance/archive_verification.py`:
  - `_check_convergence_freshness` (I6, FRESHNESS class): an open unindexed backlog (reusing I1's universe via a new `_unindexed_backlog_gap` helper) is only benign async lag if `daemon_events`/`daemon_stage_events`/`convergence_debt` show activity inside a 24h window (`CONVERGENCE_FRESHNESS_WINDOW_MS`). The prototype's original criterion ("some daemon activity ever happened") was too weak -- it passed on a 7,200-source gap with zero events in the preceding 24h because activity from weeks earlier still counted, and it missed `convergence_debt`'s own `updated_at_ms` as a signal.
  - `_check_user_tier_refs` (I10, LIVENESS class): `assertions.target_ref` of kind `session`/`message` must resolve to a live row in `index.db`. Universe is `assertions` itself (durable, ground-truth), not `index.db`'s bookkeeping.
  - `_check_source_index_coverage` (I1) gains `byte_dup_of_indexed_count`/`novel_unindexed_count` evidence fields (never changes `blocking` -- an untyped/orphan head still errors regardless of byte duplication elsewhere).
- `tests/unit/maintenance/test_archive_verification.py`: red-twin + passing tests for both new checks, a new red twin for `enum-superset-check` (creates a synthetic table the check's own regex recognizes, pinned to a stale origin list), and `RED_TWIN_TESTS` -- a `check name -> test function name` registry checked by `test_every_non_complexity_check_has_a_red_twin_test`, which fails immediately if a non-`COMPLEXITY` registry check has no proven red twin. `COMPLEXITY`-class checks (report-only by the class's own docstring) are exempt.
- `polylogue/daemon/health.py`: `_check_archive_verification_registry_medium` filters `ARCHIVE_VERIFICATION_CHECKS` to the `LIVENESS`/`FRESHNESS` classes (currently: `blob-refs-liveness`, `embeddings-refs-liveness`, `planner-stats`, `convergence-freshness`, `user-tier-refs`) and runs them from the periodic MEDIUM tier, converting a waived error to a WARNING alert (never silently hidden, just non-critical) rather than an ERROR.
- No new `devtools lab` command: per the bead's own 2026-08-03 rescope note ("do NOT build a new lab probe -- the substrate exists twice already"), the existing CLI (`polylogue ops maintenance verify-archive`) already satisfies the operator-CLI-against-any-root binding, and building a second registry would have duplicated rather than completed the target shape.

## Acceptance criteria (polylogue-t0m73)

1. Class-tagged registry with GROUND-TRUTH-UNIVERSE + RED-TWIN rules enforced structurally -- **satisfied**: class tags and the ground-truth-universe rule already shipped in #3612/#3635; this PR adds the RED-TWIN meta-test.
2. All 10 prototype invariants migrated, I1 with byte-dup bucket, I6 with the corrected criterion -- **satisfied**.
3. Four bindings live -- **satisfied**: pytest (this PR + prior), promotion gate (`REINDEX_ACCEPTANCE_CHECKS`, prior PR, unchanged here since I6/I10 need tiers a reindex candidate generation doesn't have), daemon health scheduling (this PR), operator CLI (prior PR).
4. Waiver mechanism with bead-id + expiry-on-close -- **satisfied** (prior PR, unchanged).
5. Registry green on post-reindex archive wired into 818fy acceptance -- **satisfied** (prior PR's `rebuild_index.py` wiring, unchanged; not re-verified against a live reindex in this PR since that's 818fy's own runbook step).

## Verification

- `devtools test tests/unit/maintenance/test_archive_verification.py tests/unit/daemon/test_health_check_paths.py` -> `96 passed`
- `mypy --strict polylogue/maintenance/archive_verification.py polylogue/daemon/health.py` -> `Success: no issues found in 2 source files`
- `devtools verify --quick` -> `"exit_code": 0` (format, lint, mypy, render-all, layering, degrade-loudly, schema/lab policies)

Ref polylogue-t0m73

Co-Authored-By: Claude <noreply@anthropic.com>