### PR TITLE
fix(sources): excluded-cursor honesty + stalled append-cursor freshness signal

### DIFF
--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -2982,8 +2982,37 @@ def format_daemon_status_lines(payload: JSONDocument) -> list[str]:
             lines.append(f"Failing files: {len(failing_files)} shown, {omitted} omitted")
         else:
             lines.append(f"Failing files: {len(failing_files)}")
-        for path in failing_files:
-            lines.append(f"  {path}")
+        # polylogue-ix5r: the per-file listing used to print bare paths with
+        # no age, so an operator scanning "50 shown, 1397 omitted" had no way
+        # to tell a file excluded seconds ago from one excluded weeks ago, or
+        # to see at a glance which rows are permanently parked (excluded)
+        # versus merely retrying. ``live_cursor["failing_files"]`` (the
+        # richer nested ``LiveCursorSummary.failing_files``, distinct from
+        # the flattened path-only ``payload["failing_files"]`` used above
+        # only for the count) carries per-row ``excluded``/``excluded_age_s``
+        # -- use it here so each line is honestly labeled.
+        rich_failing_files = live_cursor.get("failing_files") if isinstance(live_cursor, dict) else None
+        rich_by_path: dict[str, dict[str, Any]] = {}
+        if isinstance(rich_failing_files, list):
+            for item in rich_failing_files:
+                if isinstance(item, dict):
+                    source_path = item.get("source_path")
+                    if isinstance(source_path, str):
+                        rich_by_path[source_path] = cast(dict[str, Any], item)
+        for path_value in failing_files:
+            path = str(path_value)
+            file_detail = rich_by_path.get(path)
+            if file_detail is None:
+                lines.append(f"  {path}")
+                continue
+            if file_detail.get("excluded"):
+                age = file_detail.get("excluded_age_s")
+                age_text = f", excluded {_fmt_age_s(float(age))} ago" if isinstance(age, int | float) else ", excluded"
+                lines.append(f"  {path} (permanent until file replaced{age_text})")
+            elif file_detail.get("retry_due"):
+                lines.append(f"  {path} (retry due)")
+            else:
+                lines.append(f"  {path} (in backoff)")
     attempts = payload.get("live_ingest_attempts")
     if isinstance(attempts, dict):
         recent = attempts.get("recent", [])

--- a/polylogue/maintenance/archive_verification.py
+++ b/polylogue/maintenance/archive_verification.py
@@ -1348,6 +1348,103 @@ def _check_excluded_cursor_vocabulary_honesty(archive_root: Path, sample_limit: 
 
 
 # ---------------------------------------------------------------------------
+# Check: stalled append-cursor freshness (polylogue-2qrx)
+# ---------------------------------------------------------------------------
+
+#: How long a non-excluded cursor may sit with ``byte_offset < stat_size``
+#: (content on disk, fully acquirable, but not yet caught up) before it is
+#: flagged stale rather than merely "still catching up". Mirrors the
+#: escalation age ``sources/live/watcher.py``'s
+#: ``_STUCK_DEFERRED_APPEND_AGE_S`` already uses for the deferred-tail
+#: sub-case of this same shape (polylogue-2qrx's root-caused stall
+#: mechanism, PR #3650) -- reusing the same value here rather than picking a
+#: second, undocumented threshold.
+_STALLED_APPEND_CURSOR_STALE_AGE_S = 60.0 * 60.0
+
+
+def _check_stalled_append_cursor_freshness(archive_root: Path, sample_limit: int) -> ArchiveVerificationCheck:
+    """Flag non-excluded cursors stuck behind their file's current size.
+
+    A cursor with ``byte_offset < stat_size`` has content sitting on disk
+    that is fully recoverable -- but only via ordinary acquisition catch-up;
+    an index rebuild replays ``source.db`` and recovers none of it, since it
+    was never acquired in the first place (polylogue-2qrx). A cursor briefly
+    behind its file's size is normal (a writer mid-append); one behind for
+    longer than :data:`_STALLED_APPEND_CURSOR_STALE_AGE_S` with the file
+    otherwise cold is exactly the "329h stale, 94.8MB behind" shape the
+    2026-07-31 audit found with zero durable signal -- this check is that
+    signal.
+    """
+    ops_path = _tier_path(archive_root, ArchiveTier.OPS)
+    if not ops_path.exists():
+        return _skip_check("stalled-append-cursor-freshness", "ops.db not present")
+
+    try:
+        conn = _open_ro(ops_path)
+    except sqlite3.Error as exc:
+        return _error_check("stalled-append-cursor-freshness", f"could not open ops.db: {exc}", exc=exc)
+
+    try:
+        if not table_exists(conn, "ingest_cursor"):
+            return _skip_check("stalled-append-cursor-freshness", "ingest_cursor table not present")
+        now_ms = int(datetime.now(UTC).timestamp() * 1000)
+        stale_before_ms = now_ms - int(_STALLED_APPEND_CURSOR_STALE_AGE_S * 1000)
+        rows = conn.execute(
+            """
+            SELECT source_path, stat_size, byte_offset, updated_at_ms
+            FROM ingest_cursor
+            WHERE excluded = 0
+              AND byte_offset IS NOT NULL AND stat_size IS NOT NULL
+              AND byte_offset < stat_size
+              AND updated_at_ms <= ?
+            ORDER BY (stat_size - byte_offset) DESC
+            """,
+            (stale_before_ms,),
+        ).fetchall()
+    except sqlite3.Error as exc:
+        return _error_check("stalled-append-cursor-freshness", f"could not read ops.db: {exc}", exc=exc)
+    finally:
+        conn.close()
+
+    stalled_count = len(rows)
+    total_lag_bytes = sum(int(row[1]) - int(row[2]) for row in rows)
+    oldest_age_s = max((now_ms - int(row[3]) for row in rows), default=0) / 1000.0
+    samples = [
+        {
+            "source_path": str(row[0]),
+            "lag_bytes": int(row[1]) - int(row[2]),
+            "stale_age_s": (now_ms - int(row[3])) / 1000.0,
+        }
+        for row in rows[:sample_limit]
+    ]
+    evidence: dict[str, Any] = {
+        "stalled_count": stalled_count,
+        "total_lag_bytes": total_lag_bytes,
+        "oldest_stale_age_s": oldest_age_s if stalled_count else None,
+        "stale_age_threshold_s": _STALLED_APPEND_CURSOR_STALE_AGE_S,
+        "samples": samples,
+    }
+    if stalled_count:
+        return ArchiveVerificationCheck(
+            name="stalled-append-cursor-freshness",
+            status=OutcomeStatus.WARNING,
+            summary=(
+                f"{stalled_count:,} cursor(s) stalled behind their file's current size "
+                f"({total_lag_bytes:,} bytes lag, oldest {oldest_age_s / 3600.0:.1f}h)"
+            ),
+            count=stalled_count,
+            details=[str(sample["source_path"]) for sample in samples],
+            evidence=evidence,
+        )
+    return ArchiveVerificationCheck(
+        name="stalled-append-cursor-freshness",
+        status=OutcomeStatus.OK,
+        summary="no non-excluded cursor is stalled behind its file's current size",
+        evidence=evidence,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Check 7: counts summary
 # ---------------------------------------------------------------------------
 
@@ -1732,6 +1829,13 @@ ARCHIVE_VERIFICATION_CHECKS: tuple[ArchiveVerificationCheckSpec, ...] = (
         "excluded-cursor-vocabulary-honesty",
         "No excluded ingest_cursor row carries a live next_retry_at (would misreport as retry-due, polylogue-ix5r).",
         _check_excluded_cursor_vocabulary_honesty,
+        ArchiveVerificationCheckClass.LIVENESS,
+    ),
+    ArchiveVerificationCheckSpec(
+        "stalled-append-cursor-freshness",
+        "No non-excluded ingest_cursor row sits behind its file's current size for longer than "
+        "the stall-escalation threshold (polylogue-2qrx).",
+        _check_stalled_append_cursor_freshness,
         ArchiveVerificationCheckClass.LIVENESS,
     ),
 )

--- a/polylogue/maintenance/archive_verification.py
+++ b/polylogue/maintenance/archive_verification.py
@@ -1259,6 +1259,95 @@ def _check_planner_stats(archive_root: Path, _sample_limit: int) -> ArchiveVerif
 
 
 # ---------------------------------------------------------------------------
+# Check: excluded-cursor vocabulary honesty (polylogue-ix5r)
+# ---------------------------------------------------------------------------
+
+
+def _check_excluded_cursor_vocabulary_honesty(archive_root: Path, sample_limit: int) -> ArchiveVerificationCheck:
+    """An excluded (quarantined) cursor row must never carry a live ``next_retry_at``.
+
+    Exclusion is permanent-until-file-replaced (or, since polylogue-ix5r, until
+    the responsible parser's fingerprint changes) -- it never retries on a
+    schedule. A row that is both ``excluded=1`` and carries a non-NULL
+    ``next_retry_at`` is exactly the mislabeling shape the 2026-07-31 audit
+    found in ``polylogued status`` output (excluded rows folded into a
+    "retry due" count that would never actually come due for them): any
+    consumer that queries "failing rows with a due retry timer" without
+    remembering to filter ``excluded = 0`` would misreport this row as
+    retryable. The production actuators (``mark_failed``'s exclusion branch)
+    already null ``next_retry_at`` when they set ``excluded=1``; this check
+    is the standing regression guard that invariant holds archive-wide, plus
+    it surfaces the excluded population's size and oldest age so an operator
+    can see at a glance how large and how stale the permanently-parked set
+    is (previously only visible via ``polylogue ops status`` truncated to a
+    50-row sample).
+    """
+    ops_path = _tier_path(archive_root, ArchiveTier.OPS)
+    if not ops_path.exists():
+        return _skip_check("excluded-cursor-vocabulary-honesty", "ops.db not present")
+
+    try:
+        conn = _open_ro(ops_path)
+    except sqlite3.Error as exc:
+        return _error_check("excluded-cursor-vocabulary-honesty", f"could not open ops.db: {exc}", exc=exc)
+
+    try:
+        if not table_exists(conn, "ingest_cursor"):
+            return _skip_check("excluded-cursor-vocabulary-honesty", "ingest_cursor table not present")
+        excluded_count = int(conn.execute("SELECT COUNT(*) FROM ingest_cursor WHERE excluded = 1").fetchone()[0])
+        oldest_row = conn.execute("SELECT MIN(updated_at_ms) FROM ingest_cursor WHERE excluded = 1").fetchone()
+        mislabeled_rows = conn.execute(
+            """
+            SELECT source_path FROM ingest_cursor
+            WHERE excluded = 1 AND next_retry_at IS NOT NULL
+            ORDER BY source_path
+            LIMIT ?
+            """,
+            (sample_limit,),
+        ).fetchall()
+        mislabeled_count = int(
+            conn.execute(
+                "SELECT COUNT(*) FROM ingest_cursor WHERE excluded = 1 AND next_retry_at IS NOT NULL"
+            ).fetchone()[0]
+        )
+    except sqlite3.Error as exc:
+        return _error_check("excluded-cursor-vocabulary-honesty", f"could not read ops.db: {exc}", exc=exc)
+    finally:
+        conn.close()
+
+    oldest_age_s = None
+    if oldest_row is not None and oldest_row[0] is not None:
+        oldest_age_s = max(0.0, datetime.now(UTC).timestamp() - int(oldest_row[0]) / 1000.0)
+
+    evidence: dict[str, Any] = {
+        "excluded_count": excluded_count,
+        "excluded_oldest_age_s": oldest_age_s,
+        "mislabeled_count": mislabeled_count,
+    }
+    if mislabeled_count:
+        return ArchiveVerificationCheck(
+            name="excluded-cursor-vocabulary-honesty",
+            status=OutcomeStatus.ERROR,
+            summary=(
+                f"{mislabeled_count:,} excluded cursor row(s) still carry a next_retry_at "
+                "(would misreport as retry-due)"
+            ),
+            count=mislabeled_count,
+            details=[str(row[0]) for row in mislabeled_rows],
+            evidence=evidence,
+        )
+    return ArchiveVerificationCheck(
+        name="excluded-cursor-vocabulary-honesty",
+        status=OutcomeStatus.OK,
+        summary=(
+            f"{excluded_count:,} excluded cursor(s), none mislabeled as retry-due"
+            + (f", oldest excluded {oldest_age_s / 3600.0:.1f}h ago" if oldest_age_s is not None else "")
+        ),
+        evidence=evidence,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Check 7: counts summary
 # ---------------------------------------------------------------------------
 
@@ -1637,6 +1726,12 @@ ARCHIVE_VERIFICATION_CHECKS: tuple[ArchiveVerificationCheckSpec, ...] = (
         "user-tier-refs",
         "assertions.target_ref of kind session/message resolves to a live index.db row (polylogue-t0m73 I10).",
         _check_user_tier_refs,
+        ArchiveVerificationCheckClass.LIVENESS,
+    ),
+    ArchiveVerificationCheckSpec(
+        "excluded-cursor-vocabulary-honesty",
+        "No excluded ingest_cursor row carries a live next_retry_at (would misreport as retry-due, polylogue-ix5r).",
+        _check_excluded_cursor_vocabulary_honesty,
         ArchiveVerificationCheckClass.LIVENESS,
     ),
 )

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -652,7 +652,44 @@ def test_daemon_status_payload_and_plain_output_include_failed_files(tmp_path: P
     lines = format_daemon_status_lines(payload)
     assert "Live cursor: 1 tracked, 1 failed, 0 excluded, 0 retry due, 1 in backoff" in lines
     assert "Failing files: 1" in lines
-    assert f"  {failed}" in lines
+    # polylogue-ix5r: a non-excluded, not-yet-due failing file is labeled "in
+    # backoff" rather than printed as a bare path with no status.
+    assert f"  {failed} (in backoff)" in lines
+
+
+def test_daemon_status_failing_files_listing_labels_excluded_rows_with_age(tmp_path: Path) -> None:
+    """polylogue-ix5r AC2: the per-file 'Failing files' listing must not print
+    an excluded (permanently-quarantined) row as a bare path indistinguishable
+    from an ordinary retrying failure -- it must say the row is excluded and
+    how long ago, so "50 shown, N omitted" is not read as "N more due soon".
+    """
+    db = tmp_path / "index.db"
+    excluded = tmp_path / "poison.jsonl"
+    excluded.write_text('{"bad":true}\n')
+    cursor = CursorStore(db)
+    for _ in range(5):
+        cursor.mark_failed(excluded)
+    record = cursor.get_record(excluded)
+    assert record is not None and record.excluded
+
+    with (
+        patch("polylogue.daemon.status.archive_root", return_value=db.parent),
+        patch("polylogue.daemon.status._active_status_db_path", return_value=db),
+        patch("polylogue.daemon.status._check_daemon_liveness", return_value=False),
+        patch("polylogue.daemon.status._blob_size_info", return_value=0),
+        patch("polylogue.daemon.status._fts_readiness_info", return_value={}),
+        patch("polylogue.daemon.status._insight_freshness_info", return_value={}),
+    ):
+        payload = daemon_status_payload(sources=())
+
+    lines = format_daemon_status_lines(payload)
+    matching = [line for line in lines if str(excluded) in line]
+    assert len(matching) == 1
+    assert "permanent until file replaced" in matching[0]
+    assert "excluded" in matching[0]
+    # Not mislabeled as a due-soon retry.
+    assert "retry due" not in matching[0]
+    assert "in backoff" not in matching[0]
 
 
 def test_daemon_status_payload_links_unified_archive_debt(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -930,6 +930,68 @@ def test_excluded_cursor_vocabulary_honesty_passes_on_coherent_archive(tmp_path:
     assert check.evidence["mislabeled_count"] == 0
 
 
+def test_stalled_append_cursor_trips_freshness_check(tmp_path: Path) -> None:
+    _seed_coherent_archive(tmp_path)
+    now_ms = 10_000_000_000  # far enough past epoch that "now - threshold" stays positive
+    stale_updated_at_ms = now_ms - int(3 * 60 * 60 * 1000)  # 3h old, past the 1h threshold
+    conn = _connect(tmp_path / "ops.db")
+    try:
+        conn.execute(
+            """
+            INSERT INTO ingest_cursor(source_path, excluded, stat_size, byte_offset, updated_at_ms)
+            VALUES ('/rollout-stalled.jsonl', 0, 100000000, 5000000, ?)
+            """,
+            (stale_updated_at_ms,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    report = verify_archive(tmp_path, checks=("stalled-append-cursor-freshness",))
+
+    check = _check(report, "stalled-append-cursor-freshness")
+    assert check.status is OutcomeStatus.WARNING
+    assert check.evidence["stalled_count"] == 1
+    assert check.evidence["total_lag_bytes"] == 95_000_000
+    assert "/rollout-stalled.jsonl" in check.details
+
+
+def test_recently_stalled_append_cursor_does_not_trip_freshness_check(tmp_path: Path) -> None:
+    """A cursor briefly behind its file's size (writer mid-append) is not a
+    finding -- only one stalled longer than the escalation threshold is."""
+    _seed_coherent_archive(tmp_path)
+    conn = _connect(tmp_path / "ops.db")
+    try:
+        conn.execute(
+            """
+            INSERT INTO ingest_cursor(source_path, excluded, stat_size, byte_offset, updated_at_ms)
+            VALUES (
+                '/rollout-active.jsonl', 0, 100000000, 5000000,
+                CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)
+            )
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    report = verify_archive(tmp_path, checks=("stalled-append-cursor-freshness",))
+
+    check = _check(report, "stalled-append-cursor-freshness")
+    assert check.status is OutcomeStatus.OK
+    assert check.evidence["stalled_count"] == 0
+
+
+def test_stalled_append_cursor_freshness_passes_on_coherent_archive(tmp_path: Path) -> None:
+    _seed_coherent_archive(tmp_path)
+
+    report = verify_archive(tmp_path, checks=("stalled-append-cursor-freshness",))
+
+    check = _check(report, "stalled-append-cursor-freshness")
+    assert check.status is OutcomeStatus.OK
+    assert check.evidence["stalled_count"] == 0
+
+
 @pytest.mark.parametrize("check_name", ARCHIVE_VERIFICATION_CHECK_NAMES)
 def test_every_registry_check_does_not_error_on_the_real_pipeline_corpus(
     check_name: str, seeded_archive: SeededArchiveArtifact

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -1183,6 +1183,8 @@ RED_TWIN_TESTS: dict[str, str] = {
     "planner-stats": "test_missing_sqlite_stat1_is_warning_not_error",
     "convergence-freshness": "test_stalled_backlog_trips_convergence_freshness",
     "user-tier-refs": "test_dangling_assertion_target_trips_user_tier_refs",
+    "excluded-cursor-vocabulary-honesty": "test_excluded_cursor_with_live_next_retry_at_trips_vocabulary_honesty",
+    "stalled-append-cursor-freshness": "test_stalled_append_cursor_trips_freshness_check",
 }
 
 

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -886,6 +886,50 @@ def test_user_tier_refs_passes_on_coherent_archive(tmp_path: Path) -> None:
     assert check.evidence["dangling_session_ref_count"] == 0
 
 
+def test_excluded_cursor_with_live_next_retry_at_trips_vocabulary_honesty(tmp_path: Path) -> None:
+    _seed_coherent_archive(tmp_path)
+    conn = _connect(tmp_path / "ops.db")
+    try:
+        conn.execute(
+            """
+            INSERT INTO ingest_cursor(source_path, excluded, failure_count, next_retry_at, updated_at_ms)
+            VALUES ('/poison.jsonl', 1, 5, '2026-08-04T00:00:00+00:00', 100)
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    report = verify_archive(tmp_path, checks=("excluded-cursor-vocabulary-honesty",))
+
+    check = _check(report, "excluded-cursor-vocabulary-honesty")
+    assert check.status is OutcomeStatus.ERROR
+    assert check.evidence["mislabeled_count"] == 1
+    assert "/poison.jsonl" in check.details
+
+
+def test_excluded_cursor_vocabulary_honesty_passes_on_coherent_archive(tmp_path: Path) -> None:
+    _seed_coherent_archive(tmp_path)
+    conn = _connect(tmp_path / "ops.db")
+    try:
+        conn.execute(
+            """
+            INSERT INTO ingest_cursor(source_path, excluded, failure_count, next_retry_at, updated_at_ms)
+            VALUES ('/poison.jsonl', 1, 5, NULL, 100)
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    report = verify_archive(tmp_path, checks=("excluded-cursor-vocabulary-honesty",))
+
+    check = _check(report, "excluded-cursor-vocabulary-honesty")
+    assert check.status is OutcomeStatus.OK
+    assert check.evidence["excluded_count"] == 1
+    assert check.evidence["mislabeled_count"] == 0
+
+
 @pytest.mark.parametrize("check_name", ARCHIVE_VERIFICATION_CHECK_NAMES)
 def test_every_registry_check_does_not_error_on_the_real_pipeline_corpus(
     check_name: str, seeded_archive: SeededArchiveArtifact

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -1027,6 +1027,57 @@ def test_replaced_excluded_file_is_revived_without_retrying_unchanged_poison(tmp
     assert revived.next_retry_at is None
 
 
+def test_excluded_file_revives_on_parser_fingerprint_change_without_identity_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """polylogue-ix5r: a parser fix must revive an excluded cursor even when
+    the poisoned file's own bytes never change. Exclusion revival was
+    previously bound only to file identity (size/dev/inode/mtime), so a file
+    that fails to parse stays permanently dark even after the parser bug that
+    poisoned it is fixed -- the file on disk never changes, only the code
+    that reads it. A ``_PARSER_FINGERPRINT`` bump (this module's existing,
+    deliberately-versioned marker for a parser-semantics change, the same
+    pattern ``RAW_AUTHORITY_PARSER_FINGERPRINT`` uses) must be enough to
+    trigger a fresh attempt through the real ``LiveWatcher._needs_work`` path,
+    not merely through ``CursorStore.revive_replaced_exclusion`` directly.
+    """
+    root = tmp_path / "src"
+    root.mkdir()
+    path = root / "capture.json"
+    path.write_text('{"broken":true}', encoding="utf-8")
+    watcher, _parse_sources = _make_watcher(tmp_path, root)
+    stat = path.stat()
+    watcher._cursor.set(
+        path,
+        stat.st_size,
+        parser_fingerprint=live_watcher._PARSER_FINGERPRINT,
+        content_fingerprint="broken",
+        st_dev=stat.st_dev,
+        st_ino=stat.st_ino,
+        mtime_ns=stat.st_mtime_ns,
+        failure_count=5,
+        excluded=True,
+    )
+
+    # Identity-only revival check: unchanged bytes, unchanged parser -> stays
+    # excluded and dark.
+    assert watcher._needs_work(path) is False
+    still_excluded = watcher._cursor.get_record(path)
+    assert still_excluded is not None
+    assert still_excluded.excluded is True
+
+    # Simulate a parser fix shipping (the responsible parser's fingerprint
+    # changes) with the file itself completely untouched.
+    monkeypatch.setattr(live_watcher, "_PARSER_FINGERPRINT", "live-batched-v3-test")
+
+    assert watcher._needs_work(path) is True
+    revived = watcher._cursor.get_record(path)
+    assert revived is not None
+    assert revived.excluded is False
+    assert revived.failure_count == 0
+    assert revived.next_retry_at is None
+
+
 def test_full_cursor_uses_batch_raw_fingerprint_without_db_lookup(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
Cursor-layer follow-through on the 2026-07-31 acquisition/ingest-cursor audit, covering polylogue-ix5r (excluded cursors mislabeled as retryable) and polylogue-2qrx (stalled append-cursor freshness). Both live in the same subsystem (ops.db ingest_cursor, sources/live/cursor.py + polylogue/maintenance/archive_verification.py) so they land on one branch as two separate commits.

## Problem
The 2026-07-31 audit found 1,446 ops.db ingest_cursor rows permanently excluded (5-consecutive-failure cap) with no way to distinguish "will retry" from "permanently parked" in `polylogued status`, and 211 non-excluded cursors stuck behind their file's current size (206 cold for days-to-weeks, one 94.8MB/329h-stale), both invisible to any durable, archive-wide signal.

Separately, PR #3650 (merged same day) already root-caused and fixed both beads' core mechanisms: fingerprint-aware exclusion revival (`CursorStore.revive_replaced_exclusion`'s `current_parser_fingerprint` parameter) and the stalled-append stall mechanism (age-gated escalation past the deferred-tail stat-match false skip). But neither fix had an end-to-end regression test at the point a future change is most likely to break it, and neither bead's remaining honesty/freshness-signal acceptance criteria were addressed.

## Solution

**polylogue-ix5r** (commit 0d5b43a59):
- `polylogue/daemon/status.py`: the "Failing files" text listing now reads the richer `LiveCursorSummary.failing_files` (previously used only for its count) and labels each row `excluded (age)` / `retry due` / `in backoff` instead of a bare path.
- `polylogue/maintenance/archive_verification.py`: new LIVENESS-class registry check `excluded-cursor-vocabulary-honesty` — flags any excluded `ingest_cursor` row still carrying a live `next_retry_at` (the exact mislabeling shape the audit found), plus surfaces excluded population size/oldest age.
- `tests/unit/sources/test_live_watcher.py`: new end-to-end test proving an excluded cursor with unchanged file identity revives through the real `LiveWatcher._needs_work` path (not just `CursorStore` directly) when `_PARSER_FINGERPRINT` changes.

**polylogue-2qrx** (commit ac67482f0):
- `polylogue/maintenance/archive_verification.py`: new LIVENESS-class registry check `stalled-append-cursor-freshness` — flags a non-excluded cursor stuck behind its file's current size for longer than the same escalation age (1h) `sources/live/watcher.py`'s deferred-tail case already uses, so the class of stall PR #3650 root-caused/fixed has a durable, archive-wide signal instead of only a fixture-level unit test.

**Explicitly deferred (both beads' design notes call these operational, not code):**
- Bumping the live `_PARSER_FINGERPRINT` literal to actually revive the already-landed slshy/gzgyl/0qfy-fixed population — this forces every tracked live file to reprocess on next scan, not only the excluded ones, so it's an operator deploy decision.
- Draining the already-stalled 206-file production backlog (2qrx AC2) and per-file dispositions for any that refuse (feeds the awy5 disposition ledger) — both require the live archive.
- Full daemon-health-tier (Plane 2) scheduling of the two new LIVENESS checks is polylogue-t0m73's own remaining productization scope; they are available today via `polylogue ops maintenance verify-archive`.
- Coordination with aex0/a7xr.23 (2qrx AC4): both changes here are read-only/observability additions to the existing cursor mechanism, not bespoke catch-up machinery, so they impose no migration cost if that architecture decision changes the catch-up mechanism later.

## Verification
- `devtools test tests/unit/daemon/test_daemon_status.py tests/unit/maintenance/test_archive_verification.py tests/unit/sources/test_live_watcher.py -k "not test_end_to_end_hidden_root_file_creation_triggers_ingest"` → 215 passed (the excluded selector is a pre-existing flaky/unrelated failure, confirmed identical on a clean `master` checkout before any of this branch's changes).
- `/realm/project/polylogue/.venv/bin/python -m mypy --strict polylogue/daemon/status.py polylogue/maintenance/archive_verification.py tests/unit/daemon/test_daemon_status.py tests/unit/sources/test_live_watcher.py tests/unit/maintenance/test_archive_verification.py` → Success: no issues found in 5 source files.
- `devtools verify --quick` → all 21 steps `ok`, exit 0.

Ref polylogue-ix5r
Ref polylogue-2qrx