### PR TITLE
refactor(storage): drive archive hydration from column specs

### DIFF
--- a/polylogue/storage/hydrators.py
+++ b/polylogue/storage/hydrators.py
@@ -12,12 +12,10 @@ Keeping this logic here preserves the dependency direction:
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
 
 from polylogue.archive.attachment.models import Attachment
 from polylogue.archive.message.messages import MessageCollection
 from polylogue.archive.message.models import Message
-from polylogue.archive.message.roles import Role
 from polylogue.archive.session.domain_models import Session, SessionSummary
 from polylogue.archive.session.events import SessionEvent
 from polylogue.core.enums import Origin
@@ -30,6 +28,7 @@ from polylogue.storage.runtime import (
     SessionEventRecord,
     SessionRecord,
 )
+from polylogue.storage.sqlite.archive_tiers.archive_tiers_specs import MESSAGES_SPEC
 
 
 def _parse_json_blob(raw: object) -> object | None:
@@ -80,14 +79,6 @@ def message_from_record(
     origin: Origin | str | None = None,
 ) -> Message:
     """Hydrate a Message domain model from a MessageRecord and attachment records."""
-    # Reconstruct timestamp from sort_key (numeric epoch seconds)
-    ts = None
-    if record.sort_key is not None:
-        try:
-            ts = datetime.fromtimestamp(record.sort_key, tz=timezone.utc)
-        except (ValueError, OSError):
-            ts = None
-
     # Domain messages expose semantic content blocks, not storage row identity.
     # #1240: media_type is stored inside the block-metadata JSON (image/document
     # blocks). Lift it back to the top-level for callers that still expect it.
@@ -120,30 +111,10 @@ def message_from_record(
         normalized_origin = origin if isinstance(origin, Origin) else Origin.from_string(origin)
 
     return Message(
-        id=record.message_id,
-        role=Role.normalize((record.role or "").strip() or "unknown"),
-        text=record.text,
-        timestamp=ts,
+        **MESSAGES_SPEC.domain_kwargs(record),
         origin=normalized_origin,
         attachments=[attachment_from_record(a) for a in attachments],
         blocks=blocks,
-        message_type=record.message_type,
-        material_origin=record.material_origin,
-        parent_id=record.parent_message_id,
-        branch_index=record.branch_index,
-        is_active_path=record.is_active_path,
-        position=record.position,
-        is_active_leaf=record.is_active_leaf,
-        has_tool_use=bool(record.has_tool_use),
-        has_thinking=bool(record.has_thinking),
-        has_paste=bool(record.has_paste),
-        paste_boundary_state=record.paste_boundary_state,
-        input_tokens=record.input_tokens,
-        output_tokens=record.output_tokens,
-        cache_read_tokens=record.cache_read_tokens,
-        cache_write_tokens=record.cache_write_tokens,
-        model_name=record.model_name,
-        stop_reason=record.stop_reason,
     )
 
 

--- a/polylogue/storage/sqlite/archive_tiers/archive_tiers_specs.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive_tiers_specs.py
@@ -14,10 +14,55 @@ placeholder string, tuple order) into a single spec that drives INSERT/SELECT.
 
 from __future__ import annotations
 
-from polylogue.storage.sqlite.archive_tiers.column_spec import ColumnSpec, TableColumnSpec
+from collections.abc import Callable
+from dataclasses import replace
+from datetime import datetime, timezone
+from operator import itemgetter
 
-# Note: extractors are None here; they will be set in write.py where the
-# actual extraction logic lives. This file defines the STRUCTURE only.
+from polylogue.archive.message.roles import Role
+from polylogue.archive.message.types import MessageType
+from polylogue.core.enums import (
+    BlockType,
+    MaterialOrigin,
+    PasteBoundary,
+    StopReason,
+    ToolResultUnknownReason,
+)
+from polylogue.storage.sqlite.archive_tiers.column_spec import ColumnSpec, TableColumnSpec
+from polylogue.storage.sqlite.archive_tiers.common import CONTENT_HASH_CHECK, check, json_object_check, nullable_check
+
+
+def _value(name: str) -> Callable[[dict[str, object]], object]:
+    return itemgetter(name)
+
+
+def _none_to_zero(value: object) -> int:
+    if isinstance(value, (int, float, str)):
+        return int(value)
+    return 0
+
+
+def _epoch_seconds_to_datetime(value: object) -> datetime | None:
+    if value is None:
+        return None
+    try:
+        if isinstance(value, (int, float, str)):
+            return datetime.fromtimestamp(float(value), tz=timezone.utc)
+        return None
+    except (TypeError, ValueError, OSError):
+        return None
+
+
+def _bool_value(value: object) -> bool:
+    return bool(value)
+
+
+def _optional_bool_value(value: object) -> bool | None:
+    return None if value is None else bool(value)
+
+
+def _ddl(name: str, sql: str) -> ColumnSpec:
+    return ColumnSpec(name=name, is_generated="GENERATED ALWAYS" in sql, ddl_sql=f"{name} {sql}")
 
 
 def _make_messages_spec() -> TableColumnSpec:
@@ -35,38 +80,157 @@ def _make_messages_spec() -> TableColumnSpec:
 
     Special handling: parent_message_id is always NULL on INSERT (no tuple value).
     """
-    all_columns = (
-        ColumnSpec("message_id", "TEXT", is_generated=True),
-        ColumnSpec("session_id", "TEXT"),
-        ColumnSpec("native_id", "TEXT"),
-        ColumnSpec("parent_message_id", "TEXT", extract_placeholder="NULL"),
-        ColumnSpec("position", "INTEGER"),
-        ColumnSpec("role", "TEXT"),
-        ColumnSpec("message_type", "TEXT"),
-        ColumnSpec("material_origin", "TEXT"),
-        ColumnSpec("model_name", "TEXT"),
-        ColumnSpec("model_effort", "TEXT"),
-        ColumnSpec("sender_name", "TEXT"),
-        ColumnSpec("recipient", "TEXT"),
-        ColumnSpec("delivery_status", "TEXT"),
-        ColumnSpec("end_turn", "INTEGER"),
-        ColumnSpec("user_context_text", "TEXT"),
-        ColumnSpec("has_tool_use", "INTEGER"),
-        ColumnSpec("has_thinking", "INTEGER"),
-        ColumnSpec("has_paste", "INTEGER"),
-        ColumnSpec("paste_boundary", "TEXT"),
-        ColumnSpec("variant_index", "INTEGER"),
-        ColumnSpec("is_active_path", "INTEGER"),
-        ColumnSpec("is_active_leaf", "INTEGER"),
-        ColumnSpec("word_count", "INTEGER"),
-        ColumnSpec("input_tokens", "INTEGER"),
-        ColumnSpec("output_tokens", "INTEGER"),
-        ColumnSpec("cache_read_tokens", "INTEGER"),
-        ColumnSpec("cache_write_tokens", "INTEGER"),
-        ColumnSpec("duration_ms", "INTEGER"),
-        ColumnSpec("content_hash", "BLOB"),
-        ColumnSpec("occurred_at_ms", "INTEGER"),
-        ColumnSpec("stop_reason", "TEXT"),
+    all_columns: tuple[ColumnSpec, ...] = (
+        _ddl(
+            "message_id",
+            "TEXT GENERATED ALWAYS AS (session_id || ':' || COALESCE(native_id, position || '.' || variant_index)) STORED UNIQUE",
+        ),
+        _ddl("session_id", "TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE"),
+        _ddl("native_id", "TEXT"),
+        ColumnSpec(
+            "parent_message_id",
+            "TEXT",
+            extract_placeholder="NULL",
+            ddl_sql="parent_message_id TEXT REFERENCES messages(message_id) ON DELETE SET NULL",
+        ),
+        _ddl("position", "INTEGER NOT NULL CHECK(position >= 0)"),
+        ColumnSpec("role", "TEXT", ddl_sql=f"role TEXT NOT NULL CHECK ({check('role', Role)})"),
+        ColumnSpec(
+            "message_type",
+            "TEXT",
+            ddl_sql=f"message_type TEXT NOT NULL DEFAULT 'message' CHECK ({check('message_type', MessageType)})",
+        ),
+        ColumnSpec(
+            "material_origin",
+            "TEXT",
+            ddl_sql=f"material_origin TEXT NOT NULL DEFAULT 'unknown' CHECK ({check('material_origin', MaterialOrigin)})",
+        ),
+        _ddl("model_name", "TEXT"),
+        _ddl("model_effort", "TEXT"),
+        _ddl("sender_name", "TEXT"),
+        _ddl("recipient", "TEXT"),
+        _ddl("delivery_status", "TEXT"),
+        _ddl("end_turn", "INTEGER CHECK(end_turn IN (0, 1) OR end_turn IS NULL)"),
+        _ddl("user_context_text", "TEXT"),
+        _ddl("has_tool_use", "INTEGER NOT NULL DEFAULT 0 CHECK(has_tool_use IN (0, 1))"),
+        _ddl("has_thinking", "INTEGER NOT NULL DEFAULT 0 CHECK(has_thinking IN (0, 1))"),
+        _ddl("has_paste", "INTEGER NOT NULL DEFAULT 0 CHECK(has_paste IN (0, 1))"),
+        ColumnSpec(
+            "paste_boundary",
+            "TEXT",
+            ddl_sql=f"paste_boundary TEXT CHECK ({nullable_check('paste_boundary', PasteBoundary)})",
+        ),
+        _ddl("variant_index", "INTEGER NOT NULL DEFAULT 0 CHECK(variant_index >= 0)"),
+        _ddl("is_active_path", "INTEGER NOT NULL DEFAULT 1 CHECK(is_active_path IN (0, 1))"),
+        _ddl("is_active_leaf", "INTEGER NOT NULL DEFAULT 0 CHECK(is_active_leaf IN (0, 1))"),
+        _ddl("word_count", "INTEGER NOT NULL DEFAULT 0 CHECK(word_count >= 0)"),
+        _ddl("input_tokens", "INTEGER NOT NULL DEFAULT 0 CHECK(input_tokens >= 0)"),
+        _ddl("output_tokens", "INTEGER NOT NULL DEFAULT 0 CHECK(output_tokens >= 0)"),
+        _ddl("cache_read_tokens", "INTEGER NOT NULL DEFAULT 0 CHECK(cache_read_tokens >= 0)"),
+        _ddl("cache_write_tokens", "INTEGER NOT NULL DEFAULT 0 CHECK(cache_write_tokens >= 0)"),
+        _ddl("duration_ms", "INTEGER CHECK(duration_ms IS NULL OR duration_ms >= 0)"),
+        _ddl("content_hash", f"BLOB NOT NULL {CONTENT_HASH_CHECK}"),
+        _ddl("occurred_at_ms", "INTEGER"),
+        ColumnSpec(
+            "stop_reason", "TEXT", ddl_sql=f"stop_reason TEXT CHECK ({nullable_check('stop_reason', StopReason)})"
+        ),
+    )
+
+    record_columns = (
+        ColumnSpec(
+            "text",
+            record_name="text",
+            domain_name="text",
+            select_expression="COALESCE((SELECT group_concat(b.text, char(10)) FROM blocks b WHERE b.message_id = {alias}.message_id AND b.text IS NOT NULL), '')",
+        ),
+        ColumnSpec("source_name", record_name="source_name", select_expression="s.origin"),
+        ColumnSpec("version", record_name="version", select_expression="1"),
+    )
+
+    def record(
+        name: str,
+        *,
+        record_name: str | None = None,
+        domain_name: str | None = None,
+        select_expression: str | None = None,
+        record_transform: Callable[[object], object] | None = None,
+        domain_transform: Callable[[object], object] | None = None,
+    ) -> ColumnSpec:
+        return ColumnSpec(
+            name,
+            record_name=record_name or name,
+            domain_name=domain_name,
+            select_expression=select_expression,
+            record_transform=record_transform,
+            domain_transform=domain_transform,
+        )
+
+    mappings = {
+        "message_id": record("message_id", domain_name="id"),
+        "session_id": record("session_id"),
+        "native_id": record("native_id", record_name="provider_message_id"),
+        "parent_message_id": record("parent_message_id", domain_name="parent_id"),
+        "position": record("position", domain_name="position", record_transform=_none_to_zero),
+        "role": record("role", domain_name="role"),
+        "message_type": record("message_type", domain_name="message_type"),
+        "material_origin": record("material_origin", domain_name="material_origin"),
+        "model_name": record("model_name", domain_name="model_name"),
+        "has_tool_use": record(
+            "has_tool_use", domain_name="has_tool_use", record_transform=_none_to_zero, domain_transform=_bool_value
+        ),
+        "has_thinking": record(
+            "has_thinking", domain_name="has_thinking", record_transform=_none_to_zero, domain_transform=_bool_value
+        ),
+        "has_paste": record(
+            "has_paste", domain_name="has_paste", record_transform=_none_to_zero, domain_transform=_bool_value
+        ),
+        "paste_boundary": record(
+            "paste_boundary", record_name="paste_boundary_state", domain_name="paste_boundary_state"
+        ),
+        "variant_index": record(
+            "variant_index", record_name="branch_index", domain_name="branch_index", record_transform=_none_to_zero
+        ),
+        "is_active_path": record(
+            "is_active_path",
+            domain_name="is_active_path",
+            record_transform=_optional_bool_value,
+            domain_transform=lambda value: value,
+        ),
+        "is_active_leaf": record(
+            "is_active_leaf", domain_name="is_active_leaf", record_transform=_bool_value, domain_transform=_bool_value
+        ),
+        "word_count": record("word_count", record_transform=_none_to_zero),
+        "input_tokens": record("input_tokens", domain_name="input_tokens", record_transform=_none_to_zero),
+        "output_tokens": record("output_tokens", domain_name="output_tokens", record_transform=_none_to_zero),
+        "cache_read_tokens": record(
+            "cache_read_tokens", domain_name="cache_read_tokens", record_transform=_none_to_zero
+        ),
+        "cache_write_tokens": record(
+            "cache_write_tokens", domain_name="cache_write_tokens", record_transform=_none_to_zero
+        ),
+        "duration_ms": record("duration_ms", domain_name="duration_ms", domain_transform=_none_to_zero),
+        "content_hash": record("content_hash", select_expression="lower(hex({alias}.content_hash))"),
+        "occurred_at_ms": record(
+            "occurred_at_ms",
+            record_name="sort_key",
+            select_expression="{alias}.occurred_at_ms / 1000.0",
+            domain_transform=_epoch_seconds_to_datetime,
+        ),
+        "stop_reason": record("stop_reason", domain_name="stop_reason"),
+    }
+    all_columns = tuple(
+        replace(
+            col,
+            extract=_value(col.name) if col.extract_placeholder == "?" else None,
+            record_name=mappings[col.name].record_name,
+            select_expression=mappings[col.name].select_expression,
+            record_transform=mappings[col.name].record_transform,
+            domain_name=mappings[col.name].domain_name,
+            domain_transform=mappings[col.name].domain_transform,
+        )
+        if col.name in mappings
+        else replace(col, extract=_value(col.name) if col.extract_placeholder == "?" else None)
+        for col in all_columns
     )
 
     writable_columns = tuple(col for col in all_columns if not col.is_generated)
@@ -75,6 +239,7 @@ def _make_messages_spec() -> TableColumnSpec:
         table_name="messages",
         all_columns=all_columns,
         writable_columns=writable_columns,
+        record_only_columns=record_columns,
     )
 
 
@@ -90,28 +255,71 @@ def _make_blocks_spec() -> TableColumnSpec:
     GENERATED (not writable):
       block_id, tool_command, tool_path, search_text, tool_detail_text
     """
-    all_columns = (
-        ColumnSpec("block_id", "TEXT", is_generated=True),
-        ColumnSpec("message_id", "TEXT"),
-        ColumnSpec("session_id", "TEXT"),
-        ColumnSpec("position", "INTEGER"),
-        ColumnSpec("block_type", "TEXT"),
-        ColumnSpec("text", "TEXT"),
-        ColumnSpec("tool_name", "TEXT"),
-        ColumnSpec("tool_id", "TEXT"),
-        ColumnSpec("tool_input", "TEXT"),
-        ColumnSpec("semantic_type", "TEXT"),
-        ColumnSpec("media_type", "TEXT"),
-        ColumnSpec("language", "TEXT"),
-        ColumnSpec("tool_result_is_error", "INTEGER"),
-        ColumnSpec("tool_result_exit_code", "INTEGER"),
-        ColumnSpec("tool_result_outcome_unknown_reason", "TEXT"),
-        ColumnSpec("signature", "TEXT"),
-        ColumnSpec("content_hash", "BLOB"),
-        ColumnSpec("tool_command", "TEXT", is_generated=True),
-        ColumnSpec("tool_path", "TEXT", is_generated=True),
-        ColumnSpec("search_text", "TEXT", is_generated=True),
-        ColumnSpec("tool_detail_text", "TEXT", is_generated=True),
+    all_columns: tuple[ColumnSpec, ...] = (
+        _ddl("block_id", "TEXT GENERATED ALWAYS AS (message_id || ':' || position) STORED UNIQUE"),
+        _ddl("message_id", "TEXT NOT NULL REFERENCES messages(message_id) ON DELETE CASCADE"),
+        _ddl("session_id", "TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE"),
+        _ddl("position", "INTEGER NOT NULL CHECK(position >= 0)"),
+        ColumnSpec("block_type", "TEXT", ddl_sql=f"block_type TEXT NOT NULL CHECK ({check('block_type', BlockType)})"),
+        _ddl("text", "TEXT"),
+        _ddl("tool_name", "TEXT"),
+        _ddl("tool_id", "TEXT"),
+        ColumnSpec(
+            "tool_input", "TEXT", ddl_sql=f"tool_input TEXT CHECK ({json_object_check('tool_input', nullable=True)})"
+        ),
+        _ddl("semantic_type", "TEXT"),
+        _ddl("media_type", "TEXT"),
+        _ddl("language", "TEXT"),
+        _ddl("tool_result_is_error", "INTEGER CHECK (tool_result_is_error IN (0, 1))"),
+        _ddl("tool_result_exit_code", "INTEGER"),
+        ColumnSpec(
+            "tool_result_outcome_unknown_reason",
+            "TEXT",
+            ddl_sql=f"tool_result_outcome_unknown_reason TEXT CHECK ({nullable_check('tool_result_outcome_unknown_reason', ToolResultUnknownReason)})",
+        ),
+        _ddl("signature", "TEXT"),
+        _ddl("content_hash", "BLOB CHECK(content_hash IS NULL OR length(content_hash) = 32)"),
+        _ddl("tool_command", "TEXT GENERATED ALWAYS AS (json_extract(tool_input, '$.command')) VIRTUAL"),
+        _ddl(
+            "tool_path",
+            "TEXT GENERATED ALWAYS AS (COALESCE(json_extract(tool_input, '$.file_path'), json_extract(tool_input, '$.path'))) VIRTUAL",
+        ),
+        _ddl(
+            "search_text",
+            "TEXT GENERATED ALWAYS AS (trim(COALESCE(text, '') || ' ' || COALESCE(tool_name, '') || ' ' || COALESCE(json_extract(tool_input, '$.command'), '') || ' ' || COALESCE(json_extract(tool_input, '$.file_path'), '') || ' ' || COALESCE(json_extract(tool_input, '$.path'), ''))) VIRTUAL",
+        ),
+        _ddl(
+            "tool_detail_text",
+            "TEXT GENERATED ALWAYS AS (lower(COALESCE(tool_command, '') || ' ' || COALESCE(tool_path, ''))) VIRTUAL",
+        ),
+    )
+
+    record_columns = (ColumnSpec("metadata", record_name="metadata", select_expression="NULL"),)
+    mappings = {
+        "block_id": ("block_id", None),
+        "message_id": ("message_id", None),
+        "session_id": ("session_id", None),
+        "position": ("block_index", None),
+        "block_type": ("type", None),
+        "text": ("text", None),
+        "tool_name": ("tool_name", None),
+        "tool_id": ("tool_id", None),
+        "tool_input": ("tool_input", None),
+        "semantic_type": ("semantic_type", None),
+        "tool_result_is_error": ("tool_result_is_error", None),
+        "tool_result_exit_code": ("tool_result_exit_code", None),
+        "tool_result_outcome_unknown_reason": ("tool_result_outcome_unknown_reason", None),
+        "signature": ("signature", None),
+    }
+    all_columns = tuple(
+        replace(
+            col,
+            extract=_value(col.name) if col.extract_placeholder == "?" else None,
+            record_name=mappings[col.name][0],
+        )
+        if col.name in mappings
+        else replace(col, extract=_value(col.name) if col.extract_placeholder == "?" else None)
+        for col in all_columns
     )
 
     writable_columns = tuple(col for col in all_columns if not col.is_generated)
@@ -120,6 +328,7 @@ def _make_blocks_spec() -> TableColumnSpec:
         table_name="blocks",
         all_columns=all_columns,
         writable_columns=writable_columns,
+        record_only_columns=record_columns,
     )
 
 

--- a/polylogue/storage/sqlite/archive_tiers/column_spec.py
+++ b/polylogue/storage/sqlite/archive_tiers/column_spec.py
@@ -38,6 +38,33 @@ class ColumnSpec:
     is_generated: bool = False
     extract: Callable[[Any], Any] | None = None
     extract_placeholder: str = "?"
+    ddl_sql: str | None = None
+    record_name: str | None = None
+    select_expression: str | None = None
+    record_transform: Callable[[Any], Any] | None = None
+    domain_name: str | None = None
+    domain_transform: Callable[[Any], Any] | None = None
+
+    @property
+    def ddl_definition(self) -> str:
+        """Return the canonical SQL definition for this storage column."""
+        if self.ddl_sql is not None:
+            return self.ddl_sql
+        generated = " GENERATED ALWAYS AS (...) STORED" if self.is_generated else ""
+        return f"{self.name} {self.sql_type}{generated}"
+
+    def select_sql(self, table_alias: str) -> str:
+        """Return this column's row-projection expression.
+
+        ``select_expression`` may use ``{alias}`` to refer to the table alias.
+        The output is always labelled with ``record_name`` so mappers consume
+        the same names regardless of whether a query selected a raw column or
+        a derived expression.
+        """
+        if self.record_name is None:
+            raise ValueError(f"Column {self.name} has no record projection")
+        expression = self.select_expression or f"{table_alias}.{self.name}"
+        return f"{expression.format(alias=table_alias)} AS {self.record_name}"
 
 
 @dataclass(frozen=True, slots=True)
@@ -52,6 +79,17 @@ class TableColumnSpec:
     table_name: str
     all_columns: tuple[ColumnSpec, ...]
     writable_columns: tuple[ColumnSpec, ...]
+    record_only_columns: tuple[ColumnSpec, ...] = ()
+
+    @property
+    def record_columns(self) -> tuple[ColumnSpec, ...]:
+        """Columns and derived fields used to construct the runtime record."""
+        return tuple(col for col in (*self.all_columns, *self.record_only_columns) if col.record_name is not None)
+
+    @property
+    def ddl_column_definitions(self) -> str:
+        """Render the table's column definitions from the storage declaration."""
+        return ",\n    ".join(col.ddl_definition for col in self.all_columns)
 
     @property
     def insert_column_names(self) -> str:
@@ -67,6 +105,10 @@ class TableColumnSpec:
     def select_column_names(self) -> str:
         """Generate SELECT column list (all columns including GENERATED)."""
         return ", ".join(col.name for col in self.all_columns)
+
+    def record_select_column_names(self, table_alias: str) -> str:
+        """Generate the SELECT projection consumed by the record mapper."""
+        return ",\n    ".join(col.select_sql(table_alias) for col in self.record_columns)
 
     def extract_tuple(self, source_obj: Any) -> tuple[Any, ...]:
         """Extract a tuple of values from a source object in writable column order.
@@ -88,6 +130,40 @@ class TableColumnSpec:
     def row_to_dict(self, row: sqlite3.Row) -> dict[str, Any]:
         """Convert a sqlite3.Row to a typed dict using column specs."""
         return {col.name: row[col.name] for col in self.all_columns}
+
+    def row_to_record_kwargs(self, row: sqlite3.Row) -> dict[str, Any]:
+        """Extract only selected record fields, preserving omitted-column defaults."""
+        names = set(row.keys())
+        result: dict[str, Any] = {}
+        for col in self.record_columns:
+            assert col.record_name is not None
+            if col.record_name not in names:
+                continue
+            value = row[col.record_name]
+            if col.record_transform is not None:
+                value = col.record_transform(value)
+            result[col.record_name] = value
+        return result
+
+    def domain_kwargs(self, record: Any) -> dict[str, Any]:
+        """Project a runtime record into domain-model constructor kwargs."""
+        result: dict[str, Any] = {}
+        for col in self.record_columns:
+            if col.domain_name is None or col.record_name is None:
+                continue
+            value = getattr(record, col.record_name)
+            if col.domain_transform is not None:
+                value = col.domain_transform(value)
+            result[col.domain_name] = value
+        return result
+
+    def domain_value(self, record: Any, domain_name: str) -> Any:
+        """Return one domain field using the declaration's record mapping."""
+        for col in self.record_columns:
+            if col.domain_name == domain_name and col.record_name is not None:
+                value = getattr(record, col.record_name)
+                return col.domain_transform(value) if col.domain_transform is not None else value
+        raise KeyError(f"{self.table_name} has no domain field {domain_name!r}")
 
     def row_to_typed_dict(
         self, row: sqlite3.Row, type_mapper: dict[str, Callable[[Any], Any]] | None = None

--- a/polylogue/storage/sqlite/archive_tiers/index.py
+++ b/polylogue/storage/sqlite/archive_tiers/index.py
@@ -6,19 +6,13 @@ from typing import get_args
 
 from polylogue.archive.revision_replay import ApplicationDecision
 from polylogue.core.enums import (
-    BlockType,
     BranchType,
     LinkType,
-    MaterialOrigin,
-    MessageType,
     Origin,
     PasteBoundary,
-    Role,
     SessionKind,
     SessionRefKind,
-    StopReason,
     TitleSource,
-    ToolResultUnknownReason,
     TopologyEdgeStatus,
     WebConstructType,
 )
@@ -28,6 +22,7 @@ from polylogue.storage.fts.sql import (
     FTS_TRIGGER_DDL,
 )
 from polylogue.storage.sqlite.action_pairs import action_pairs_refresh_sql
+from polylogue.storage.sqlite.archive_tiers.archive_tiers_specs import BLOCKS_SPEC, MESSAGES_SPEC
 from polylogue.storage.sqlite.archive_tiers.common import (
     CONTENT_HASH_CHECK,
     check,
@@ -533,45 +528,7 @@ ON sessions(raw_id)
 WHERE raw_id IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS messages (
-    message_id          TEXT GENERATED ALWAYS AS (
-                            session_id || ':' || COALESCE(native_id, position || '.' || variant_index)
-                        ) STORED UNIQUE,
-    session_id          TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE,
-    native_id           TEXT,
-    parent_message_id   TEXT REFERENCES messages(message_id) ON DELETE SET NULL,
-    position            INTEGER NOT NULL CHECK(position >= 0),
-    role                TEXT NOT NULL CHECK ({check("role", Role)}),
-    message_type        TEXT NOT NULL DEFAULT 'message' CHECK ({check("message_type", MessageType)}),
-    material_origin     TEXT NOT NULL DEFAULT 'unknown' CHECK ({check("material_origin", MaterialOrigin)}),
-    model_name          TEXT,
-    model_effort        TEXT,
-    sender_name         TEXT,
-    recipient           TEXT,
-    delivery_status     TEXT,
-    end_turn            INTEGER CHECK(end_turn IN (0, 1) OR end_turn IS NULL),
-    user_context_text   TEXT,
-    has_tool_use        INTEGER NOT NULL DEFAULT 0 CHECK(has_tool_use IN (0, 1)),
-    has_thinking        INTEGER NOT NULL DEFAULT 0 CHECK(has_thinking IN (0, 1)),
-    has_paste           INTEGER NOT NULL DEFAULT 0 CHECK(has_paste IN (0, 1)),
-    paste_boundary      TEXT CHECK ({nullable_check("paste_boundary", PasteBoundary)}),
-    variant_index       INTEGER NOT NULL DEFAULT 0 CHECK(variant_index >= 0),
-    is_active_path      INTEGER NOT NULL DEFAULT 1 CHECK(is_active_path IN (0, 1)),
-    is_active_leaf      INTEGER NOT NULL DEFAULT 0 CHECK(is_active_leaf IN (0, 1)),
-    word_count          INTEGER NOT NULL DEFAULT 0 CHECK(word_count >= 0),
-    input_tokens        INTEGER NOT NULL DEFAULT 0 CHECK(input_tokens >= 0),
-    output_tokens       INTEGER NOT NULL DEFAULT 0 CHECK(output_tokens >= 0),
-    cache_read_tokens   INTEGER NOT NULL DEFAULT 0 CHECK(cache_read_tokens >= 0),
-    cache_write_tokens  INTEGER NOT NULL DEFAULT 0 CHECK(cache_write_tokens >= 0),
-    duration_ms         INTEGER CHECK(duration_ms IS NULL OR duration_ms >= 0),
-    content_hash        BLOB NOT NULL {CONTENT_HASH_CHECK},
-    occurred_at_ms      INTEGER,
-    -- polylogue-2qx.4 / polylogue-cuxz.8 (v46): the provider's own terminal-
-    -- state signal for this assistant turn (608,608 occurrences on the
-    -- Claude wire). Feeds terminal_state/result_status readers directly
-    -- instead of the 85-99%-unknown derived guesses those columns hold
-    -- today. NULL means the provider did not report one (or this is not an
-    -- assistant turn), never a guess.
-    stop_reason         TEXT CHECK ({nullable_check("stop_reason", StopReason)}),
+    {MESSAGES_SPEC.ddl_column_definitions},
     PRIMARY KEY(session_id, position, variant_index)
 ) STRICT;
 
@@ -630,69 +587,7 @@ ON messages(session_id, is_active_leaf)
 WHERE is_active_leaf = 1;
 
 CREATE TABLE IF NOT EXISTS blocks (
-    block_id        TEXT GENERATED ALWAYS AS (message_id || ':' || position) STORED UNIQUE,
-    message_id      TEXT NOT NULL REFERENCES messages(message_id) ON DELETE CASCADE,
-    session_id      TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE,
-    position        INTEGER NOT NULL CHECK(position >= 0),
-    block_type      TEXT NOT NULL CHECK ({check("block_type", BlockType)}),
-    text            TEXT,
-    tool_name       TEXT,
-    tool_id         TEXT,
-    tool_input      TEXT CHECK ({json_object_check("tool_input", nullable=True)}),
-    semantic_type   TEXT,
-    media_type      TEXT,
-    language        TEXT,
-    tool_result_is_error  INTEGER CHECK (tool_result_is_error IN (0, 1)),
-    tool_result_exit_code INTEGER,
-    -- polylogue-2qx.4 / polylogue-cuxz.8 (v46): why tool_result_is_error is
-    -- NULL for this block, when it is a tool_result. Collapsing "provider
-    -- emitted nothing", "parser deliberately distrusts the reported value",
-    -- and "this origin's parser does not read the field" into one flat NULL
-    -- was the defect (72% of blocks.tool_result_is_error is NULL
-    -- archive-wide) -- all three are knowable at parse time. NULL here means
-    -- the outcome IS known (tool_result_is_error is set), never "unknown of
-    -- an unknown reason".
-    tool_result_outcome_unknown_reason TEXT
-        CHECK ({nullable_check("tool_result_outcome_unknown_reason", ToolResultUnknownReason)}),
-    -- polylogue-vf9x (v49): provider-issued cryptographic attestation for a
-    -- THINKING block (Claude's extended-thinking `signature`; Gemini's
-    -- `thoughtSignatures` are the same construct). Populated whenever the
-    -- wire carries one -- notably including the empty-body thinking blocks
-    -- Claude Code has shipped since ~2026-06, where this is the only
-    -- surviving evidence besides the block's existence. Deliberately
-    -- excluded from content_hash below and from the lineage prefix
-    -- signature (write.py): providers re-sign on every replay, so including
-    -- it would break fork-prefix/citation-anchor matching for otherwise-
-    -- identical replayed content.
-    signature       TEXT,
-    -- svfj: the citation anchor atom. Hashes canonical block EVIDENCE only
-    -- (type, text, tool_name, canonical tool_input, semantic/media/language,
-    -- is_error, exit_code) -- deliberately EXCLUDING session_id/message_id/
-    -- position/tool_id so the hash survives fork-position shift, re-ingest,
-    -- and provider tool-id regeneration. Nullable (not every low-level test
-    -- fixture / raw SQL writer populates it) -- the real write path always
-    -- sets it; the resolver treats a NULL row as its own state, never a crash.
-    content_hash    BLOB CHECK(content_hash IS NULL OR length(content_hash) = 32),
-    tool_command    TEXT GENERATED ALWAYS AS (json_extract(tool_input, '$.command')) VIRTUAL,
-    tool_path       TEXT GENERATED ALWAYS AS (
-                        COALESCE(json_extract(tool_input, '$.file_path'), json_extract(tool_input, '$.path'))
-                    ) VIRTUAL,
-    search_text     TEXT GENERATED ALWAYS AS (
-                        trim(COALESCE(text, '') || ' ' ||
-                             COALESCE(tool_name, '') || ' ' ||
-                             COALESCE(json_extract(tool_input, '$.command'), '') || ' ' ||
-                             COALESCE(json_extract(tool_input, '$.file_path'), '') || ' ' ||
-                             COALESCE(json_extract(tool_input, '$.path'), ''))
-                    ) VIRTUAL,
-    -- ohbx: lowercased command+path text for substring lookups (e.g. "did
-    -- this bash/exec_command block invoke `polylogue`?") that need LIKE
-    -- '%x%' semantics, not FTS token matching. Backs blocks_command_trigram
-    -- below -- a plain LIKE scan here recomputes tool_command/tool_path's
-    -- json_extract for every generic-tool row in the archive (measured
-    -- ~70s over 915K rows on a 26GB archive).
-    tool_detail_text TEXT GENERATED ALWAYS AS (
-                        lower(COALESCE(tool_command, '') || ' ' || COALESCE(tool_path, ''))
-                    ) VIRTUAL,
+    {BLOCKS_SPEC.ddl_column_definitions},
     PRIMARY KEY(message_id, position)
 ) STRICT;
 

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -1781,42 +1781,40 @@ def _build_message_rows(
     for fallback_position, message in enumerate(messages):
         position = position_offset + (message.position if message.position is not None else fallback_position)
         variant_index = message.variant_index if message.variant_index is not None else 0
-        # Build tuple in the order defined by spec.writable_columns, skipping
-        # columns with non-standard placeholders (like parent_message_id=NULL)
-        rows.append(
-            (
-                session_id,
-                _stored_message_native_id(message, duplicate_native_ids),
-                # parent_message_id: skipped (always NULL in VALUES)
-                position,
-                _enum_value(message.role),
-                _enum_value(message.message_type),
-                _enum_value(message.material_origin),
-                _sqlite_text(message.model_name),
-                _sqlite_text(message.model_effort),
-                _sqlite_text(message.sender_name),
-                _sqlite_text(message.recipient),
-                _sqlite_text(message.delivery_status),
-                None if message.end_turn is None else int(message.end_turn),
-                _sqlite_text(message.user_context_text),
-                _has_block(message, BlockType.TOOL_USE),
-                _has_block(message, BlockType.THINKING),
-                _has_paste(message),
-                _paste_boundary(message),
-                variant_index,
-                1 if message.is_active_path is not False else 0,
-                1 if message.is_active_leaf else 0,
-                _word_count(message.text),
-                message.input_tokens,
-                message.output_tokens,
-                message.cache_read_tokens,
-                message.cache_write_tokens,
-                message.duration_ms,
-                _message_content_hash(session_id, message, position=position, variant_index=variant_index),
-                message.occurred_at_ms if message.occurred_at_ms is not None else _timestamp_ms(message.timestamp),
-                _enum_value(message.stop_reason),
-            )
-        )
+        values: dict[str, object] = {
+            "session_id": session_id,
+            "native_id": _stored_message_native_id(message, duplicate_native_ids),
+            "position": position,
+            "role": _enum_value(message.role),
+            "message_type": _enum_value(message.message_type),
+            "material_origin": _enum_value(message.material_origin),
+            "model_name": _sqlite_text(message.model_name),
+            "model_effort": _sqlite_text(message.model_effort),
+            "sender_name": _sqlite_text(message.sender_name),
+            "recipient": _sqlite_text(message.recipient),
+            "delivery_status": _sqlite_text(message.delivery_status),
+            "end_turn": None if message.end_turn is None else int(message.end_turn),
+            "user_context_text": _sqlite_text(message.user_context_text),
+            "has_tool_use": _has_block(message, BlockType.TOOL_USE),
+            "has_thinking": _has_block(message, BlockType.THINKING),
+            "has_paste": _has_paste(message),
+            "paste_boundary": _paste_boundary(message),
+            "variant_index": variant_index,
+            "is_active_path": 1 if message.is_active_path is not False else 0,
+            "is_active_leaf": 1 if message.is_active_leaf else 0,
+            "word_count": _word_count(message.text),
+            "input_tokens": message.input_tokens,
+            "output_tokens": message.output_tokens,
+            "cache_read_tokens": message.cache_read_tokens,
+            "cache_write_tokens": message.cache_write_tokens,
+            "duration_ms": message.duration_ms,
+            "content_hash": _message_content_hash(session_id, message, position=position, variant_index=variant_index),
+            "occurred_at_ms": message.occurred_at_ms
+            if message.occurred_at_ms is not None
+            else _timestamp_ms(message.timestamp),
+            "stop_reason": _enum_value(message.stop_reason),
+        }
+        rows.append(archive_tiers_specs.MESSAGES_SPEC.extract_tuple(values))
     return rows
 
 
@@ -1986,38 +1984,36 @@ def _build_block_rows(
             exit_code = getattr(block, "exit_code", None)
             outcome_unknown_reason = _enum_value(block.outcome_unknown_reason)
             signature = getattr(block, "signature", None)
-            # Tuple built in order defined by spec.writable_columns
-            rows.append(
-                (
-                    message_id,
-                    session_id,
-                    position,
-                    block_type.value,
-                    _sqlite_text(block.text),
-                    _sqlite_text(block.tool_name),
-                    _sqlite_text(block.tool_id),
-                    tool_input_json,
-                    _sqlite_text(semantic_type),
-                    _sqlite_text(block.media_type),
-                    _sqlite_text(language),
-                    _sqlite_bool(is_error),
-                    exit_code,
-                    outcome_unknown_reason,
-                    _sqlite_text(signature),
-                    _block_content_hash(
-                        block_type=block_type.value,
-                        text=block.text,
-                        tool_name=block.tool_name,
-                        tool_input_json=tool_input_json,
-                        semantic_type=semantic_type,
-                        media_type=block.media_type,
-                        language=language,
-                        is_error=is_error,
-                        exit_code=exit_code,
-                        outcome_unknown_reason=outcome_unknown_reason,
-                    ),
-                )
-            )
+            values: dict[str, object] = {
+                "message_id": message_id,
+                "session_id": session_id,
+                "position": position,
+                "block_type": block_type.value,
+                "text": _sqlite_text(block.text),
+                "tool_name": _sqlite_text(block.tool_name),
+                "tool_id": _sqlite_text(block.tool_id),
+                "tool_input": tool_input_json,
+                "semantic_type": _sqlite_text(semantic_type),
+                "media_type": _sqlite_text(block.media_type),
+                "language": _sqlite_text(language),
+                "tool_result_is_error": _sqlite_bool(is_error),
+                "tool_result_exit_code": exit_code,
+                "tool_result_outcome_unknown_reason": outcome_unknown_reason,
+                "signature": _sqlite_text(signature),
+                "content_hash": _block_content_hash(
+                    block_type=block_type.value,
+                    text=block.text,
+                    tool_name=block.tool_name,
+                    tool_input_json=tool_input_json,
+                    semantic_type=semantic_type,
+                    media_type=block.media_type,
+                    language=language,
+                    is_error=is_error,
+                    exit_code=exit_code,
+                    outcome_unknown_reason=outcome_unknown_reason,
+                ),
+            }
+            rows.append(archive_tiers_specs.BLOCKS_SPEC.extract_tuple(values))
     return rows
 
 

--- a/polylogue/storage/sqlite/queries/mappers_archive.py
+++ b/polylogue/storage/sqlite/queries/mappers_archive.py
@@ -5,17 +5,12 @@ from __future__ import annotations
 import sqlite3
 from datetime import datetime, timezone
 
-from polylogue.archive.message.roles import Role
-from polylogue.archive.message.types import MessageType
 from polylogue.archive.revision_authority import RawRevisionAuthority, RawRevisionEnvelope, RawRevisionKind
 from polylogue.archive.session.branch_type import BranchType
 from polylogue.core.enums import (
     ArtifactSupportStatus,
-    BlockType,
-    MaterialOrigin,
     Origin,
     Provider,
-    SemanticBlockType,
     SessionKind,
     ValidationMode,
     ValidationStatus,
@@ -33,6 +28,7 @@ from polylogue.storage.runtime import (
     SessionRefRecord,
     WebContentConstructRecord,
 )
+from polylogue.storage.sqlite.archive_tiers.archive_tiers_specs import BLOCKS_SPEC, MESSAGES_SPEC
 from polylogue.storage.sqlite.queries.mappers_support import (
     _json_object,
     _json_object_list,
@@ -79,61 +75,21 @@ def _row_to_session(row: sqlite3.Row) -> SessionRecord:
 
 
 def _row_to_message(row: sqlite3.Row) -> MessageRecord:
-    role = _row_text(row, "role")
-    normalized_role = Role.normalize(role) if role is not None and role.strip() else None
-    parent_message_id = _row_text(row, "parent_message_id")
-    return MessageRecord(
-        message_id=row["message_id"],
-        session_id=row["session_id"],
-        provider_message_id=_row_text(row, "provider_message_id"),
-        role=normalized_role,
-        text=_row_text(row, "text"),
-        sort_key=_row_float(row, "sort_key"),
-        content_hash=row["content_hash"],
-        version=row["version"],
-        parent_message_id=MessageId(parent_message_id) if parent_message_id is not None else None,
-        branch_index=_row_int(row, "branch_index", 0) or 0,
-        # None (column not selected by this query) means unknown, not "not
-        # active" -- see MessageRecord.is_active_path.
-        is_active_path=_row_optional_bool(row, "is_active_path"),
-        position=_row_int(row, "position", 0) or 0,
-        is_active_leaf=bool(_row_int(row, "is_active_leaf", 0)),
-        source_name=_row_text(row, "source_name") or "",
-        word_count=_row_int(row, "word_count", 0) or 0,
-        has_tool_use=_row_int(row, "has_tool_use", 0) or 0,
-        has_thinking=_row_int(row, "has_thinking", 0) or 0,
-        has_paste=_row_int(row, "has_paste", 0) or 0,
-        paste_boundary_state=_row_text(row, "paste_boundary_state"),
-        input_tokens=_row_int(row, "input_tokens", 0) or 0,
-        output_tokens=_row_int(row, "output_tokens", 0) or 0,
-        cache_read_tokens=_row_int(row, "cache_read_tokens", 0) or 0,
-        cache_write_tokens=_row_int(row, "cache_write_tokens", 0) or 0,
-        model_name=_row_text(row, "model_name"),
-        message_type=MessageType.normalize(_row_text(row, "message_type") or "message"),
-        material_origin=MaterialOrigin.normalize(_row_text(row, "material_origin")),
-        stop_reason=_row_text(row, "stop_reason"),
-    )
+    values = MESSAGES_SPEC.row_to_record_kwargs(row)
+    if "parent_message_id" in values and values["parent_message_id"] is not None:
+        values["parent_message_id"] = MessageId(str(values["parent_message_id"]))
+    values.setdefault("message_id", row["message_id"])
+    values.setdefault("session_id", row["session_id"])
+    values.setdefault("content_hash", row["content_hash"])
+    return MessageRecord(**values)
 
 
 def _row_to_content_block(row: sqlite3.Row) -> BlockRecord:
-    semantic_type = _row_text(row, "semantic_type")
-    return BlockRecord(
-        block_id=row["block_id"],
-        message_id=MessageId(row["message_id"]),
-        session_id=SessionId(row["session_id"]),
-        block_index=row["block_index"],
-        type=BlockType.from_string(row["type"]),
-        text=_row_text(row, "text"),
-        tool_name=_row_text(row, "tool_name"),
-        tool_id=_row_text(row, "tool_id"),
-        tool_input=_row_text(row, "tool_input"),
-        metadata=_row_text(row, "metadata"),
-        semantic_type=SemanticBlockType.from_string(semantic_type) if semantic_type is not None else None,
-        tool_result_is_error=_row_int(row, "tool_result_is_error"),
-        tool_result_exit_code=_row_int(row, "tool_result_exit_code"),
-        tool_result_outcome_unknown_reason=_row_text(row, "tool_result_outcome_unknown_reason"),
-        signature=_row_text(row, "signature"),
-    )
+    values = BLOCKS_SPEC.row_to_record_kwargs(row)
+    values.setdefault("block_id", row["block_id"])
+    values["message_id"] = MessageId(str(values["message_id"]))
+    values["session_id"] = SessionId(str(values["session_id"]))
+    return BlockRecord(**values)
 
 
 def _row_to_file_edit(row: sqlite3.Row) -> FileEditRecord:

--- a/polylogue/storage/sqlite/queries/message_query_reads.py
+++ b/polylogue/storage/sqlite/queries/message_query_reads.py
@@ -18,6 +18,7 @@ from polylogue.storage.runtime import (
     MessageRecord,
 )
 from polylogue.storage.runtime.store_constants import LINEAGE_ITERATIVE_DEPTH_LIMIT
+from polylogue.storage.sqlite.archive_tiers.archive_tiers_specs import MESSAGES_SPEC
 from polylogue.storage.sqlite.queries.mappers import _row_to_message
 
 logger = get_logger(__name__)
@@ -25,40 +26,7 @@ logger = get_logger(__name__)
 MessageTypeName = Literal["message", "summary", "tool_use", "tool_result", "thinking", "context", "protocol"]
 MaterialOriginFilter = MaterialOrigin | str | tuple[MaterialOrigin | str, ...] | list[MaterialOrigin | str]
 
-_MESSAGE_RECORD_SELECT = """
-    m.message_id,
-    m.session_id,
-    m.native_id AS provider_message_id,
-    m.role,
-    COALESCE((
-        SELECT group_concat(b.text, char(10))
-        FROM blocks b
-        WHERE b.message_id = m.message_id
-          AND b.text IS NOT NULL
-    ), '') AS text,
-    m.occurred_at_ms / 1000.0 AS sort_key,
-    lower(hex(m.content_hash)) AS content_hash,
-    1 AS version,
-    m.parent_message_id,
-    m.variant_index AS branch_index,
-    m.is_active_path,
-    m.position,
-    m.is_active_leaf,
-    s.origin AS source_name,
-    m.word_count,
-    m.has_tool_use,
-    m.has_thinking,
-    m.has_paste,
-    m.paste_boundary AS paste_boundary_state,
-    m.message_type,
-    m.material_origin,
-    m.model_name,
-    m.input_tokens,
-    m.output_tokens,
-    m.cache_read_tokens,
-    m.cache_write_tokens,
-    m.stop_reason
-"""
+_MESSAGE_RECORD_SELECT = MESSAGES_SPEC.record_select_column_names("m")
 
 
 async def _resolve_session_id(conn: aiosqlite.Connection, session_id: str) -> str:

--- a/tests/unit/storage/test_spec_driven_hydration.py
+++ b/tests/unit/storage/test_spec_driven_hydration.py
@@ -1,0 +1,77 @@
+"""Contracts for the archive declaration-driven row and domain path."""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+import polylogue.storage.hydrators as hydrators
+from polylogue.core.enums import BlockType, Provider, Role
+from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
+from polylogue.storage.hydrators import message_from_record
+from polylogue.storage.sqlite.archive_tiers.archive_tiers_specs import BLOCKS_SPEC, MESSAGES_SPEC
+from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
+from polylogue.storage.sqlite.queries import message_query_reads
+from polylogue.storage.sqlite.queries.mappers_archive import _row_to_message
+from tests.infra.live_ingest import ingest_session
+
+
+def test_archive_specs_have_unique_storage_and_record_projections() -> None:
+    for spec in (MESSAGES_SPEC, BLOCKS_SPEC):
+        storage_names = [column.name for column in spec.all_columns]
+        record_names = [column.record_name for column in spec.record_columns]
+        assert len(storage_names) == len(set(storage_names)), spec.table_name
+        assert len(record_names) == len(set(record_names)), spec.table_name
+        assert all(column.extract is not None for column in spec.writable_columns if column.extract_placeholder == "?")
+        assert sum(column.name == "stop_reason" for column in spec.all_columns) <= 1
+
+
+def test_message_read_and_mapper_use_the_archive_spec_projection() -> None:
+    query_source = inspect.getsource(message_query_reads)
+    mapper_source = inspect.getsource(_row_to_message)
+    hydrator_source = inspect.getsource(hydrators.message_from_record)
+    assert 'MESSAGES_SPEC.record_select_column_names("m")' in query_source
+    assert "m.native_id AS provider_message_id" not in query_source
+    assert "stop_reason=_row_text" not in mapper_source
+    assert "MESSAGES_SPEC.row_to_record_kwargs(row)" in mapper_source
+    assert "MESSAGES_SPEC.domain_kwargs(record)" in hydrator_source
+
+
+@pytest.mark.asyncio
+async def test_real_archive_write_read_hydrates_spec_fields(tmp_path: Path) -> None:
+    backend = SQLiteBackend(db_path=tmp_path / "index.db")
+    parsed_session = ParsedSession(
+        source_name=Provider.CLAUDE_CODE,
+        provider_session_id="spec-hydration",
+        title="Spec hydration",
+        messages=[
+            ParsedMessage(
+                provider_message_id="native-message",
+                role=Role.ASSISTANT,
+                text="finished",
+                position=0,
+                stop_reason="end_turn",
+                is_active_path=True,
+                is_active_leaf=True,
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text="finished")],
+            )
+        ],
+    )
+    try:
+        session_id = await ingest_session(parsed_session, backend)
+        async with backend.connection() as conn:
+            records = await message_query_reads.get_messages(conn, session_id)
+            blocks = await backend.get_blocks([records[0].message_id])
+        record = records[0].model_copy(update={"blocks": blocks[str(records[0].message_id)]})
+        hydrated = message_from_record(record, [], origin=records[0].source_name)
+    finally:
+        await backend.close()
+
+    assert str(records[0].message_id) == "claude-code-session:spec-hydration:native-message"
+    assert str(blocks[str(records[0].message_id)][0].block_id) == f"{records[0].message_id}:0"
+    assert hydrated.stop_reason == "end_turn"
+    assert hydrated.is_active_path is True
+    assert hydrated.is_active_leaf is True
+    assert hydrated.text == "finished"


### PR DESCRIPTION
Summary

The archive message and block storage slice now uses one declaration for DDL-facing columns, write extraction, runtime record projections, message SELECTs, row mappers, and domain hydration. Existing runtime and public domain models remain the compatibility boundary.

Problem

Message-family fields were repeated across archive DDL, write tuple order, SELECT plumbing, row mappers, and hydrators. This allowed a field such as stop_reason or active-branch state to be persisted while being omitted or defaulted on a read path. Ref polylogue-a7xr.24.

Solution

Extended ColumnSpec and TableColumnSpec with canonical DDL, record projection, null-preserving transforms, and domain-field metadata. MESSAGES_SPEC and BLOCKS_SPEC now generate the messages and blocks DDL, writer tuples, message SELECT projection, archive row mappers, and Message constructor kwargs. Added exact-path static contracts for duplicate declaration drift and a real ParsedSession writer-to-reader-to-hydrator round trip. Generated identities, enum checks, lineage fields, and existing public models are preserved.

Verification

- devtools test tests/unit/storage/test_spec_driven_hydration.py tests/unit/storage/test_query_mappers.py tests/unit/storage/test_message_query_reads.py: 19 passed.
- devtools verify --quick: passed format, lint, mypy, render all, layering, schema roundtrip, manifests, policy audits, and schema promotion audit.
- Anti-vacuity: the test invokes the production ParsedSession writer, async archive message/block readers, spec-driven mappers, and message_from_record hydrator. Removing the spec-generated SELECT, mapper projection, or domain kwargs path makes the round-trip assertions fail.

Non-goals

Surface payload projection, session/event-family migration, embedding storage, and the embedding-run stop_reason naming collision remain outside this storage lane.
