### PR TITLE
fix(sources): acquire-only mode survives a genuinely stale index tier

### DIFF
--- a/polylogue/sources/live/append_ingest.py
+++ b/polylogue/sources/live/append_ingest.py
@@ -18,6 +18,7 @@ from polylogue.archive.revision_authority import (
 from polylogue.core.degraded import degraded_reason
 from polylogue.core.enums import Provider
 from polylogue.logging import get_logger
+from polylogue.sources.live.archive_open import _open_archive_for_live_write
 from polylogue.sources.live.batch_support import _AppendPlan, _AppendResult
 from polylogue.sources.live.cursor import CursorStore
 from polylogue.sources.live.sqlite_locking import is_transient_sqlite_lock
@@ -82,7 +83,6 @@ def _ingest_append_plans_archive(
         _is_declared_non_session_artifact,
         parse_retained_raw_sessions,
     )
-    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
     _add_timing(timings, "append.imports", t0)
 
@@ -94,7 +94,7 @@ def _ingest_append_plans_archive(
     acquired_at_ms = int(datetime.now(UTC).timestamp() * 1000)
     try:
         t0 = time.perf_counter()
-        with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+        with _open_archive_for_live_write(archive_root) as archive:
             _add_timing(timings, "append.archive_open", t0)
             for plan in plans:
                 provider: Provider | None = None

--- a/polylogue/sources/live/archive_open.py
+++ b/polylogue/sources/live/archive_open.py
@@ -1,0 +1,35 @@
+"""Degraded-aware archive open for live ingest writers (polylogue-gbs02).
+
+The acquire-only degraded mode (``DegradedReason.derived_only``) skips all
+parse/materialize work — but the ordinary ``ArchiveStore.open_existing``
+writer open still validates EVERY tier and hard-refuses when the index tier
+sits at a semantic-reparse distance (exactly the pre-rebuild state the mode
+exists for; the live archive's index.db 46 vs code 57 reproduces the refusal
+deterministically). Both live write paths therefore route their open through
+this helper: in acquire-only mode it opens the source-tier-only writer,
+which validates the durable tiers it will write and never opens a derived
+tier at all.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from polylogue.core.degraded import degraded_reason
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+
+def _open_archive_for_live_write(archive_root: Path) -> ArchiveStore:
+    """Open the archive for a live ingest write pass.
+
+    In acquire-only degraded mode (a degraded reason flagged
+    ``derived_only``), returns the source-tier acquisition writer: durable
+    tiers validated, derived tiers never opened, only raw admission usable —
+    the per-record acquire-then-skip-parse branches in the callers guarantee
+    nothing beyond raw admission is reached. Otherwise returns the ordinary
+    full writer, preserving its all-tier validation exactly.
+    """
+    reason = degraded_reason()
+    if reason is not None and reason.derived_only:
+        return ArchiveStore.open_source_tier_acquisition(archive_root)
+    return ArchiveStore.open_existing(archive_root, read_only=False)

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -65,6 +65,7 @@ from polylogue.sources.dispatch import (
     require_positive_conversational_evidence,
 )
 from polylogue.sources.live.append_ingest import ingest_append_plans, reset_transient_raw_parse_state
+from polylogue.sources.live.archive_open import _open_archive_for_live_write
 from polylogue.sources.live.batch_observability import (
     record_attempt_progress,
 )
@@ -2066,12 +2067,11 @@ class LiveBatchProcessor:
         max_pass_seconds: float | None = None,
         pass_started: float | None = None,
     ) -> _ArchiveFullWriteResult:
-        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
         archive_root = Path(getattr(self._polylogue, "archive_root", self._cursor._db_path.parent))
         result = _ArchiveFullWriteResult()
         pass_clock_started = pass_started if pass_started is not None else time.monotonic()
-        with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+        with _open_archive_for_live_write(archive_root) as archive:
             for record_index, record in enumerate(records):
                 # polylogue-11cg9: a single logical session write cannot be
                 # split mid-transaction (it must remain atomic), so the

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -1600,6 +1600,27 @@ def _session_filter_is_active(session_filters: Mapping[str, object] | None) -> b
     return False
 
 
+class _SourceTierOnlyIndexConnection:
+    """Loud placeholder for the index connection in source-tier acquisition mode.
+
+    Acquire-only ingestion (polylogue-gbs02) deliberately never opens
+    ``index.db`` — a derived tier awaiting rebuild may be at an older schema
+    version, and the safest way to guarantee no index write can occur is to
+    hold no index handle at all. Any code path that reaches for the index
+    connection in this mode is a bug; it must fail immediately and loudly
+    instead of writing through a stale-schema handle.
+    """
+
+    def __getattr__(self, name: str) -> Any:
+        if name == "close":
+            return lambda: None
+        raise RuntimeError(
+            "index tier is unavailable in source-tier acquisition mode "
+            f"(attempted connection attribute {name!r}); only raw source-tier "
+            "admission is permitted while derived tiers await rebuild"
+        )
+
+
 class ArchiveStore:
     """Minimal archive-root façade for archive source/index/user tiers."""
 
@@ -1611,7 +1632,11 @@ class ArchiveStore:
         read_only: bool = False,
         read_timeout: float = 5.0,
         owned_inactive_generation: tuple[str, str] | None = None,
+        source_tier_acquisition: bool = False,
     ) -> None:
+        if source_tier_acquisition and read_only:
+            raise ValueError("source_tier_acquisition mode is a writer mode; read_only must be False")
+        self._source_tier_acquisition = source_tier_acquisition
         self._active_writer_lease = None
         if not read_only:
             from polylogue.paths import archive_root as configured_archive_root
@@ -1646,7 +1671,7 @@ class ArchiveStore:
         try:
             self._initialize_store(
                 archive_root,
-                initialize=initialize,
+                initialize=initialize and not source_tier_acquisition,
                 read_only=read_only,
                 read_timeout=read_timeout,
                 # polylogue-623q: only ever True for a write connection against
@@ -1682,6 +1707,38 @@ class ArchiveStore:
         self.user_db_path = archive_root / "user.db"
         self.ops_db_path = archive_root / "ops.db"
         self._read_only = read_only
+        # Attribute type declarations shared by every open mode (the
+        # source-tier acquisition branch below returns early, so inference
+        # from a single assignment site would otherwise mistype these).
+        self._source_conn: sqlite3.Connection | None = None
+        self._blob_publisher: ArchiveBlobPublisher | None = None
+        self._pending_index_blob_receipts: list[tuple[str, bytes]] = []
+        self._pending_raw_parse_states: list[tuple[str, RawSessionStateUpdate]] = []
+        if getattr(self, "_source_tier_acquisition", False):
+            # polylogue-gbs02: acquire-only mode validates the DURABLE tiers it
+            # will write and never touches derived tiers. A stale or missing
+            # durable tier is a hard refusal (writing through it would corrupt
+            # irreplaceable evidence); a stale index/embeddings tier is exactly
+            # the situation this mode exists for and is not checked here.
+            for tier in (ArchiveTier.SOURCE, ArchiveTier.USER):
+                spec = archive_tier_spec(tier)
+                path = archive_root / spec.filename
+                if not path.exists():
+                    raise RuntimeError(f"source-tier acquisition refused: durable tier {spec.filename} is missing")
+                with closing(sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=read_timeout)) as vconn:
+                    current = int(vconn.execute("PRAGMA user_version").fetchone()[0])
+                if current != spec.version:
+                    raise RuntimeError(
+                        f"source-tier acquisition refused: durable tier {spec.filename} "
+                        f"user_version {current} != expected {spec.version}"
+                    )
+            from polylogue.storage.blob_publication import ArchiveBlobPublisher
+
+            self._conn = cast(sqlite3.Connection, _SourceTierOnlyIndexConnection())
+            self._user_tier_attached = False
+            self._tags_relation = "session_tags"
+            self._blob_publisher = ArchiveBlobPublisher(self.source_db_path, self.archive_root / "blob")
+            return
         if initialize:
             initialize_active_archive_root(archive_root)
         if read_only:
@@ -1714,14 +1771,10 @@ class ArchiveStore:
             ensure_runtime_indexes_sync(self._conn)
         self._user_tier_attached = False
         self._tags_relation = "session_tags"
-        self._source_conn: sqlite3.Connection | None = None
-        self._blob_publisher = None
         if not read_only:
             from polylogue.storage.blob_publication import ArchiveBlobPublisher
 
             self._blob_publisher = ArchiveBlobPublisher(self.source_db_path, self.archive_root / "blob")
-        self._pending_index_blob_receipts: list[tuple[str, bytes]] = []
-        self._pending_raw_parse_states: list[tuple[str, RawSessionStateUpdate]] = []
         self._attach_user_tier_if_present()
 
     @classmethod
@@ -1734,6 +1787,19 @@ class ArchiveStore:
         """
         initialize = not read_only
         return cls(archive_root, initialize=initialize, read_only=read_only, read_timeout=read_timeout)
+
+    @classmethod
+    def open_source_tier_acquisition(cls, archive_root: Path) -> ArchiveStore:
+        """Open a writer restricted to raw source-tier admission (polylogue-gbs02).
+
+        Used by acquire-only degraded mode: durable tiers (source/user) must be
+        current; derived tiers (index/embeddings) are never opened, so their
+        schema state is irrelevant and cannot be corrupted. Only raw admission
+        surfaces (``write_raw_payload``/``write_raw_blob_ref``/
+        ``write_hook_event``) are usable; anything touching the index
+        connection raises immediately.
+        """
+        return cls(archive_root, initialize=False, read_only=False, source_tier_acquisition=True)
 
     @classmethod
     def open_owned_inactive_generation(cls, archive_root: Path, *, generation_id: str, owner_id: str) -> ArchiveStore:

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -258,6 +258,75 @@ def test_full_ingest_acquires_but_does_not_parse_when_derived_tier_degraded(
     assert parse_error is None
 
 
+def test_full_ingest_acquires_when_index_is_genuinely_semantic_distance_stale(
+    tmp_path: Path,
+) -> None:
+    """polylogue-gbs02: acquire-only mode must survive a REAL stale index tier.
+
+    The sibling test above proves the skip logic but leaves index.db at the
+    current version, so it never exercises the open: the ordinary
+    ``ArchiveStore.open_existing(read_only=False)`` writer hard-refuses an
+    index tier at a semantic-reparse distance (the live archive's actual
+    pre-rebuild state, index.db 46 vs current code). This test ages the
+    index to that distance first — with the source-tier-only open routed via
+    ``_open_archive_for_live_write`` the acquire succeeds and the stale
+    index file stays byte-identical; without it, the open raises before any
+    raw write and this test fails.
+    """
+    import hashlib
+    import sqlite3 as _sqlite3
+
+    from polylogue.core.degraded import DegradedReason, clear_degraded, set_degraded
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+    root = tmp_path / "sessions"
+    root.mkdir()
+    path = root / "degraded-stale-index.jsonl"
+    path.write_bytes(
+        b'{"type":"session_meta","payload":{"id":"degraded-stale-index"}}\n'
+        b'{"type":"response_item","payload":{"type":"message","id":"message-0","role":"user",'
+        b'"content":[{"type":"input_text","text":"zero"}]}}\n'
+    )
+    # Bootstrap a real archive file set, then age the index tier to the
+    # semantic-reparse distance (46 is the live pre-818fy generation).
+    with ArchiveStore.open_existing(tmp_path, read_only=False):
+        pass
+    index_db = tmp_path / "index.db"
+    conn = _sqlite3.connect(index_db)
+    try:
+        conn.execute("PRAGMA user_version = 46")
+        conn.commit()
+    finally:
+        conn.close()
+    index_digest_before = hashlib.sha256(index_db.read_bytes()).hexdigest()
+
+    processor = LiveBatchProcessor(
+        cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=index_db))),
+        (WatchSource(name="codex", root=root),),
+        cursor=CursorStore(tmp_path / "cursors.db", ops_db_path=tmp_path / "ops.db"),
+        parser_fingerprint="test-parser",
+    )
+    set_degraded(
+        DegradedReason(
+            code="schema_version_mismatch",
+            message="index.db:46!=current",
+            derived_only=True,
+        )
+    )
+    try:
+        result = processor._ingest_full_paths_sync([path], source_name="codex")
+    finally:
+        clear_degraded()
+
+    assert result.succeeded == [path], f"failed={result.failed}"
+    parsed_at_ms, parse_error = _raw_parse_state(tmp_path)
+    assert parsed_at_ms is None
+    assert parse_error is None
+    assert hashlib.sha256(index_db.read_bytes()).hexdigest() == index_digest_before, (
+        "the stale index tier must never be opened for write during acquire-only ingest"
+    )
+
+
 def test_full_ingest_empty_jsonl_is_not_misclassified_as_truncated(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/storage/test_source_tier_acquisition_open.py
+++ b/tests/unit/storage/test_source_tier_acquisition_open.py
@@ -1,0 +1,97 @@
+"""Source-tier acquisition open mode (polylogue-gbs02).
+
+Acquire-only degraded mode must be able to admit raw evidence while the
+derived index tier is at an older schema version, without ever opening —
+let alone writing — index.db. These tests exercise the production
+``ArchiveStore`` open modes against a real archive whose index tier is then
+aged, plus the durable-tier refusal that keeps the mode from masking real
+corruption risk.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.core.enums import Provider
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import archive_tier_spec
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+
+def _set_user_version(db: Path, version: int) -> None:
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute(f"PRAGMA user_version = {int(version)}")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _file_digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+@pytest.fixture
+def stale_index_root(workspace_env: dict[str, Path]) -> Path:
+    root = workspace_env["archive_root"]
+    # A one-version-old index can hit a declared in-place fast-forward delta;
+    # this mode exists for the SEMANTIC_REPARSE distance (rebuild required),
+    # so age the index far enough that no fast-forward chain covers it —
+    # v46 is the live pre-818fy generation, a known rebuild-only distance.
+    _set_user_version(root / "index.db", 46)
+    return root
+
+
+def test_ordinary_writer_open_refuses_stale_index(stale_index_root: Path) -> None:
+    with pytest.raises(RuntimeError, match="schema version"):
+        ArchiveStore.open_existing(stale_index_root, read_only=False)
+
+
+def test_source_tier_acquisition_opens_and_admits_raw(stale_index_root: Path) -> None:
+    index_db = stale_index_root / "index.db"
+    index_digest_before = _file_digest(index_db)
+
+    with ArchiveStore.open_source_tier_acquisition(stale_index_root) as archive:
+        raw_id = archive.write_raw_payload(
+            provider=Provider.CLAUDE_CODE,
+            payload=b'{"type":"summary","summary":"acquired in degraded mode"}\n',
+            source_path=str(stale_index_root / "inbox" / "session.jsonl"),
+            acquired_at_ms=1_754_200_000_000,
+        )
+    assert raw_id
+
+    source_conn = sqlite3.connect(f"file:{stale_index_root / 'source.db'}?mode=ro", uri=True)
+    try:
+        row = source_conn.execute(
+            "SELECT parsed_at_ms FROM raw_sessions WHERE raw_id = ?",
+            (raw_id,),
+        ).fetchone()
+    finally:
+        source_conn.close()
+    assert row is not None, "raw admission must land a raw_sessions row"
+    assert row[0] is None, "acquire-only admission must leave the raw unparsed (convergence backlog)"
+
+    # The stale derived tier must be byte-identical: no handle was ever opened.
+    assert _file_digest(index_db) == index_digest_before
+
+
+def test_source_tier_acquisition_index_access_raises(stale_index_root: Path) -> None:
+    store = ArchiveStore.open_source_tier_acquisition(stale_index_root)
+    try:
+        with pytest.raises(RuntimeError, match="index tier is unavailable"):
+            store.begin_read_snapshot()
+        with pytest.raises(RuntimeError, match="index tier is unavailable"):
+            store._conn.execute("SELECT 1")
+    finally:
+        store.close()
+
+
+def test_source_tier_acquisition_refuses_stale_durable_tier(workspace_env: dict[str, Path]) -> None:
+    root = workspace_env["archive_root"]
+    _set_user_version(root / "source.db", archive_tier_spec(ArchiveTier.SOURCE).version + 1)
+    with pytest.raises(RuntimeError, match="durable tier source.db"):
+        ArchiveStore.open_source_tier_acquisition(root)


### PR DESCRIPTION
## Summary

Complement to cb60c02a3 (acquire-only degraded mode, polylogue-gbs02): both live write paths still opened the archive via `ArchiveStore.open_existing(read_only=False)`, whose preflight hard-refuses an index tier at semantic-reparse distance — the live archive's actual pre-rebuild state (index.db 46 vs current code). This PR adds a source-tier-only writer open and routes both paths through it when the degraded reason is `derived_only`, so acquisition genuinely proceeds against the real stale archive instead of dying at the open.

## Problem

cb60c02a3's skip logic is correct but untriggered in production: its regression test leaves index.db at the current version, so `open_existing` succeeds in tests while the live daemon (index at 46) would raise `RuntimeError: ... schema version 46 is not the current index tier version ...` before any raw write. Reproduced deterministically this session with a bootstrapped-then-aged temp archive.

## Solution

- `ArchiveStore.open_source_tier_acquisition()`: validates the durable tiers it will write (refuses stale/missing source.db or user.db, fail-closed), never opens index.db at all — a placeholder connection object raises loudly on any attribute access, so no code path can write through a stale-schema handle. Only raw-admission surfaces are usable.
- `sources/live/archive_open.py` (new module, render all run): `_open_archive_for_live_write()` — source-tier-only open when `degraded_reason().derived_only`, ordinary all-tier-validating open otherwise. Wired into `_ingest_full_records_archive` (batch.py) and `_ingest_append_plans_archive` (append_ingest.py).

## Verification

- New `test_full_ingest_acquires_when_index_is_genuinely_semantic_distance_stale`: bootstraps a real archive file set, ages index.db to 46, runs the production full-ingest path under a derived-only degraded reason — raw acquired with `parsed_at_ms IS NULL` and index.db byte-identical (sha256 before/after). **Red/green verified**: neutering the open routing makes it fail on the open refusal; restoring it passes.
- `tests/unit/storage/test_source_tier_acquisition_open.py` (4 passed): ordinary writer-open still refuses a semantic-distance index; source-tier open admits raw with index untouched; index access raises; stale durable tier refuses.
- `devtools test ... -k 'degraded or stale'` → 2 passed; mypy clean on the four touched files; ruff clean. Pre-commit secret-scan candidate is a pre-existing pattern-shape hit in the test file's fixtures, not a credential.
- Not run: full testmon-affected suite (two concurrent lane verifies saturating host RAM); will be recorded via merge-gate at the merge boundary. Live daemon restart against the real archive is the post-merge deploy step.

Ref polylogue-gbs02

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXhWsSQZMNShPBwo15PePT