### PR TITLE
refactor(surfaces): derive envelopes from archive domain models

### DIFF
--- a/devtools/self_verify.py
+++ b/devtools/self_verify.py
@@ -22,11 +22,11 @@ from polylogue.paths import archive_root
 from polylogue.storage.archive_identity import resolve_active_index_path
 from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 from polylogue.surfaces.payloads import (
-    SessionListRowPayload,
-    SessionMessagePayload,
     SessionSearchHitPayload,
     build_search_envelope,
+    message_render_envelope_from_domain,
     model_json_document,
+    session_list_envelope_from_domain,
 )
 
 REPORT_VERSION = 1
@@ -78,7 +78,7 @@ def _stable_mapping(value: Mapping[str, int]) -> dict[str, int]:
 
 def _archive_stats_payload(stats: Any) -> JSONDocument:
     recent = [
-        model_json_document(SessionListRowPayload.from_session(session), exclude_none=True)
+        model_json_document(session_list_envelope_from_domain(session), exclude_none=True)
         for session in getattr(stats, "recent", [])
     ]
     return require_json_document(
@@ -132,7 +132,7 @@ async def _capture_list_cases(poly: Polylogue, *, limit: int) -> list[JSONDocume
         sessions = await poly.list_sessions_for_spec(spec)
         total = await spec.count(poly.config)
         rows = [
-            model_json_document(SessionListRowPayload.from_session(session), exclude_none=True) for session in sessions
+            model_json_document(session_list_envelope_from_domain(session), exclude_none=True) for session in sessions
         ]
         payloads.append(_query_case_payload(name, spec, rows, total))
     return payloads
@@ -188,7 +188,7 @@ async def _capture_message_cases(
                     "offset": 0,
                     "messages": [
                         model_json_document(
-                            SessionMessagePayload.from_message(message, session_id=session_id),
+                            message_render_envelope_from_domain(message, session_id=session_id),
                             exclude_none=True,
                         )
                         for message in messages

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -823,9 +823,9 @@ The schema files live under `docs/schemas/cli-output/`.
 
 | Schema | Model | Surfaces |
 | --- | --- | --- |
-| `session-list-row` | `SessionListRowPayload` | `polylogue read --all --format json`<br>`polylogue read --all --format ndjson`<br>`polylogue read --all --format yaml` |
-| `session-summary` | `SessionSummaryPayload` | `polylogue analyze --format json (rows)`<br>`polylogue --format json <query> (hits[].session)` |
-| `session-message-row` | `SessionMessageRowPayload` | `polylogue read --view messages --format ndjson`<br>`polylogue read --view messages --format json (messages[])` |
+| `session-list-row` | `SessionListEnvelope` | `polylogue read --all --format json`<br>`polylogue read --all --format ndjson`<br>`polylogue read --all --format yaml` |
+| `session-summary` | `SessionSummaryEnvelope` | `polylogue analyze --format json (rows)`<br>`polylogue --format json <query> (hits[].session)` |
+| `session-message-row` | `MessageRowEnvelope` | `polylogue read --view messages --format ndjson`<br>`polylogue read --view messages --format json (messages[])` |
 | `session-messages-response` | `SessionMessagesResponsePayload` | `polylogue read --view messages --format json` |
 | `session-search-hit` | `SessionSearchHitPayload` | `polylogue --format json <query>`<br>`polylogue --format ndjson <query>` |
 | `search-envelope` | `SearchEnvelope` | `polylogue --format json <query>`<br>`GET /api/sessions?query=...` |

--- a/docs/openapi/search.yaml
+++ b/docs/openapi/search.yaml
@@ -1149,7 +1149,7 @@ components:
       description: Search-hit payload with summary identity and match evidence.
       properties:
         session:
-          $ref: '#/components/schemas/SessionSummaryPayload'
+          $ref: '#/components/schemas/SessionSummaryEnvelope'
         match:
           $ref: '#/components/schemas/SessionSearchMatchPayload'
       required:
@@ -1253,9 +1253,9 @@ components:
       - match_surface
       title: SessionSearchMatchPayload
       type: object
-    SessionSummaryPayload:
+    SessionSummaryEnvelope:
       additionalProperties: false
-      description: Compact session summary payload used by MCP/search surfaces.
+      description: Compact session envelope derived from ``SessionSummary``.
       properties:
         id:
           title: Id
@@ -1264,6 +1264,7 @@ components:
           title: Origin
           type: string
         title:
+          default: null
           title: Title
           type: string
         title_source:
@@ -1285,8 +1286,11 @@ components:
           default: null
           title: Title Confidence
         message_count:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          default: null
           title: Message Count
-          type: integer
         target_ref:
           anyOf:
           - $ref: '#/components/schemas/TargetRefPayload'
@@ -1320,9 +1324,7 @@ components:
       required:
       - id
       - origin
-      - title
-      - message_count
-      title: SessionSummaryPayload
+      title: SessionSummaryEnvelope
       type: object
     TargetRefPayload:
       additionalProperties: false
@@ -1513,12 +1515,9 @@ components:
           type: boolean
       title: SessionFlagsPayload
       type: object
-    SessionListRowPayload:
+    SessionListEnvelope:
       additionalProperties: false
-      description: 'Session row payload used by CLI list, JSON, and YAML surfaces.
-
-
-        Carries the canonical row shape for the web reader contract (#848).'
+      description: Session list-row envelope derived from ``Session``.
       properties:
         id:
           title: Id
@@ -1527,6 +1526,7 @@ components:
           title: Origin
           type: string
         title:
+          default: null
           title: Title
           type: string
         title_source:
@@ -1639,8 +1639,7 @@ components:
       required:
       - id
       - origin
-      - title
-      title: SessionListRowPayload
+      title: SessionListEnvelope
       type: object
     SessionListResponse:
       additionalProperties: false
@@ -1651,7 +1650,7 @@ components:
       properties:
         items:
           items:
-            $ref: '#/components/schemas/SessionListRowPayload'
+            $ref: '#/components/schemas/SessionListEnvelope'
           title: Items
           type: array
         total:

--- a/docs/schemas/cli-output/README.md
+++ b/docs/schemas/cli-output/README.md
@@ -15,9 +15,9 @@ devtools render cli-output-schemas --check # CI sync check
 
 | File | Surfaces | Source model |
 | --- | --- | --- |
-| [`session-list-row.schema.json`](./session-list-row.schema.json) | `polylogue read --all --format json`<br>`polylogue read --all --format ndjson`<br>`polylogue read --all --format yaml` | `SessionListRowPayload` |
-| [`session-summary.schema.json`](./session-summary.schema.json) | `polylogue analyze --format json (rows)`<br>`polylogue --format json <query> (hits[].session)` | `SessionSummaryPayload` |
-| [`session-message-row.schema.json`](./session-message-row.schema.json) | `polylogue read --view messages --format ndjson`<br>`polylogue read --view messages --format json (messages[])` | `SessionMessageRowPayload` |
+| [`session-list-row.schema.json`](./session-list-row.schema.json) | `polylogue read --all --format json`<br>`polylogue read --all --format ndjson`<br>`polylogue read --all --format yaml` | `SessionListEnvelope` |
+| [`session-summary.schema.json`](./session-summary.schema.json) | `polylogue analyze --format json (rows)`<br>`polylogue --format json <query> (hits[].session)` | `SessionSummaryEnvelope` |
+| [`session-message-row.schema.json`](./session-message-row.schema.json) | `polylogue read --view messages --format ndjson`<br>`polylogue read --view messages --format json (messages[])` | `MessageRowEnvelope` |
 | [`session-messages-response.schema.json`](./session-messages-response.schema.json) | `polylogue read --view messages --format json` | `SessionMessagesResponsePayload` |
 | [`session-search-hit.schema.json`](./session-search-hit.schema.json) | `polylogue --format json <query>`<br>`polylogue --format ndjson <query>` | `SessionSearchHitPayload` |
 | [`search-envelope.schema.json`](./search-envelope.schema.json) | `polylogue --format json <query>`<br>`GET /api/sessions?query=...` | `SearchEnvelope` |

--- a/docs/schemas/cli-output/search-envelope.schema.json
+++ b/docs/schemas/cli-output/search-envelope.schema.json
@@ -540,7 +540,7 @@
           "$ref": "#/$defs/SessionSearchMatchPayload"
         },
         "session": {
-          "$ref": "#/$defs/SessionSummaryPayload"
+          "$ref": "#/$defs/SessionSummaryEnvelope"
         }
       },
       "required": [
@@ -707,9 +707,9 @@
       "title": "SessionSearchMatchPayload",
       "type": "object"
     },
-    "SessionSummaryPayload": {
+    "SessionSummaryEnvelope": {
       "additionalProperties": false,
-      "description": "Compact session summary payload used by MCP/search surfaces.",
+      "description": "Compact session envelope derived from ``SessionSummary``.",
       "properties": {
         "actions": {
           "additionalProperties": {
@@ -748,8 +748,16 @@
           "type": "string"
         },
         "message_count": {
-          "title": "Message Count",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Message Count"
         },
         "origin": {
           "title": "Origin",
@@ -767,6 +775,7 @@
           "default": null
         },
         "title": {
+          "default": null,
           "title": "Title",
           "type": "string"
         },
@@ -822,11 +831,9 @@
       },
       "required": [
         "id",
-        "origin",
-        "title",
-        "message_count"
+        "origin"
       ],
-      "title": "SessionSummaryPayload",
+      "title": "SessionSummaryEnvelope",
       "type": "object"
     },
     "TargetRefPayload": {

--- a/docs/schemas/cli-output/session-list-row.schema.json
+++ b/docs/schemas/cli-output/session-list-row.schema.json
@@ -162,7 +162,7 @@
   "$id": "https://polylogue.dev/schemas/cli-output/session-list-row.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
-  "description": "One row of `polylogue read --all --format json` output. The read-all path emits an array of these objects; the `ndjson` format emits one per line as results stream.\n\nGenerated from `polylogue.surfaces.payloads.SessionListRowPayload` by `devtools render cli-output-schemas`. Do not edit by hand.",
+  "description": "One row of `polylogue read --all --format json` output. The read-all path emits an array of these objects; the `ndjson` format emits one per line as results stream.\n\nGenerated from `polylogue.surfaces.payloads.SessionListEnvelope` by `devtools render cli-output-schemas`. Do not edit by hand.",
   "properties": {
     "actions": {
       "additionalProperties": {
@@ -317,6 +317,7 @@
       "default": null
     },
     "title": {
+      "default": null,
       "title": "Title",
       "type": "string"
     },
@@ -383,8 +384,7 @@
   },
   "required": [
     "id",
-    "origin",
-    "title"
+    "origin"
   ],
   "title": "Session List Row",
   "type": "object",
@@ -393,5 +393,5 @@
     "polylogue read --all --format ndjson",
     "polylogue read --all --format yaml"
   ],
-  "x-polylogue-source-model": "SessionListRowPayload"
+  "x-polylogue-source-model": "SessionListEnvelope"
 }

--- a/docs/schemas/cli-output/session-message-row.schema.json
+++ b/docs/schemas/cli-output/session-message-row.schema.json
@@ -139,7 +139,7 @@
   "$id": "https://polylogue.dev/schemas/cli-output/session-message-row.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
-  "description": "One message row emitted by `polylogue read --view messages --format ndjson` and embedded inside the finite messages response.\n\nGenerated from `polylogue.surfaces.payloads.SessionMessageRowPayload` by `devtools render cli-output-schemas`. Do not edit by hand.",
+  "description": "One message row emitted by `polylogue read --view messages --format ndjson` and embedded inside the finite messages response.\n\nGenerated from `polylogue.surfaces.payloads.MessageRowEnvelope` by `devtools render cli-output-schemas`. Do not edit by hand.",
   "properties": {
     "actions": {
       "additionalProperties": {
@@ -190,6 +190,11 @@
       },
       "title": "Content Blocks",
       "type": "array"
+    },
+    "duration_ms": {
+      "default": 0,
+      "title": "Duration Ms",
+      "type": "integer"
     },
     "has_paste_evidence": {
       "default": false,
@@ -320,6 +325,18 @@
       "default": null,
       "title": "Source Path"
     },
+    "stop_reason": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Stop Reason"
+    },
     "target_ref": {
       "anyOf": [
         {
@@ -332,6 +349,7 @@
       "default": null
     },
     "text": {
+      "default": "",
       "title": "Text",
       "type": "string"
     },
@@ -352,7 +370,6 @@
   "required": [
     "id",
     "role",
-    "text",
     "session_id"
   ],
   "title": "Session Message Row",
@@ -361,5 +378,5 @@
     "polylogue read --view messages --format ndjson",
     "polylogue read --view messages --format json (messages[])"
   ],
-  "x-polylogue-source-model": "SessionMessageRowPayload"
+  "x-polylogue-source-model": "MessageRowEnvelope"
 }

--- a/docs/schemas/cli-output/session-messages-response.schema.json
+++ b/docs/schemas/cli-output/session-messages-response.schema.json
@@ -1,71 +1,8 @@
 {
   "$defs": {
-    "ReaderActionAvailabilityPayload": {
+    "MessageRowEnvelope": {
       "additionalProperties": false,
-      "description": "Per-target reader action availability with explicit disabled reason.\n\nReader actions surface seven distinct states (see :data:`ReaderActionState`)\nso the UI can render \"disabled because X\" / \"loading\" / \"dangerous\"\nwithout conflating them under a single boolean (#1488). ``enabled`` is the\ncompact actionability bit consumed by current reader clients; ``state`` is\nthe richer reason category.",
-      "properties": {
-        "disabled_reason": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Disabled Reason"
-        },
-        "enabled": {
-          "default": true,
-          "title": "Enabled",
-          "type": "boolean"
-        },
-        "inspect_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Inspect Path"
-        },
-        "repair_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Repair Path"
-        },
-        "state": {
-          "default": "enabled",
-          "enum": [
-            "enabled",
-            "disabled",
-            "partial",
-            "dangerous",
-            "loading",
-            "target",
-            "unavailable"
-          ],
-          "title": "State",
-          "type": "string"
-        }
-      },
-      "title": "ReaderActionAvailabilityPayload",
-      "type": "object"
-    },
-    "SessionMessageRowPayload": {
-      "additionalProperties": false,
-      "description": "One `read --view messages` machine-output row.",
+      "description": "Message envelope used by the paginated message-row surface.",
       "properties": {
         "actions": {
           "additionalProperties": {
@@ -116,6 +53,11 @@
           },
           "title": "Content Blocks",
           "type": "array"
+        },
+        "duration_ms": {
+          "default": 0,
+          "title": "Duration Ms",
+          "type": "integer"
         },
         "has_paste_evidence": {
           "default": false,
@@ -246,6 +188,18 @@
           "default": null,
           "title": "Source Path"
         },
+        "stop_reason": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Stop Reason"
+        },
         "target_ref": {
           "anyOf": [
             {
@@ -258,6 +212,7 @@
           "default": null
         },
         "text": {
+          "default": "",
           "title": "Text",
           "type": "string"
         },
@@ -278,10 +233,72 @@
       "required": [
         "id",
         "role",
-        "text",
         "session_id"
       ],
-      "title": "SessionMessageRowPayload",
+      "title": "MessageRowEnvelope",
+      "type": "object"
+    },
+    "ReaderActionAvailabilityPayload": {
+      "additionalProperties": false,
+      "description": "Per-target reader action availability with explicit disabled reason.\n\nReader actions surface seven distinct states (see :data:`ReaderActionState`)\nso the UI can render \"disabled because X\" / \"loading\" / \"dangerous\"\nwithout conflating them under a single boolean (#1488). ``enabled`` is the\ncompact actionability bit consumed by current reader clients; ``state`` is\nthe richer reason category.",
+      "properties": {
+        "disabled_reason": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Disabled Reason"
+        },
+        "enabled": {
+          "default": true,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "inspect_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Inspect Path"
+        },
+        "repair_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Repair Path"
+        },
+        "state": {
+          "default": "enabled",
+          "enum": [
+            "enabled",
+            "disabled",
+            "partial",
+            "dangerous",
+            "loading",
+            "target",
+            "unavailable"
+          ],
+          "title": "State",
+          "type": "string"
+        }
+      },
+      "title": "ReaderActionAvailabilityPayload",
       "type": "object"
     },
     "TargetRefPayload": {
@@ -385,7 +402,7 @@
     },
     "messages": {
       "items": {
-        "$ref": "#/$defs/SessionMessageRowPayload"
+        "$ref": "#/$defs/MessageRowEnvelope"
       },
       "title": "Messages",
       "type": "array"

--- a/docs/schemas/cli-output/session-neighbor-candidate.schema.json
+++ b/docs/schemas/cli-output/session-neighbor-candidate.schema.json
@@ -100,9 +100,9 @@
       "title": "SessionNeighborReasonPayload",
       "type": "object"
     },
-    "SessionSummaryPayload": {
+    "SessionSummaryEnvelope": {
       "additionalProperties": false,
-      "description": "Compact session summary payload used by MCP/search surfaces.",
+      "description": "Compact session envelope derived from ``SessionSummary``.",
       "properties": {
         "actions": {
           "additionalProperties": {
@@ -141,8 +141,16 @@
           "type": "string"
         },
         "message_count": {
-          "title": "Message Count",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Message Count"
         },
         "origin": {
           "title": "Origin",
@@ -160,6 +168,7 @@
           "default": null
         },
         "title": {
+          "default": null,
           "title": "Title",
           "type": "string"
         },
@@ -215,11 +224,9 @@
       },
       "required": [
         "id",
-        "origin",
-        "title",
-        "message_count"
+        "origin"
       ],
-      "title": "SessionSummaryPayload",
+      "title": "SessionSummaryEnvelope",
       "type": "object"
     },
     "TargetRefPayload": {
@@ -328,7 +335,7 @@
       "type": "number"
     },
     "session": {
-      "$ref": "#/$defs/SessionSummaryPayload"
+      "$ref": "#/$defs/SessionSummaryEnvelope"
     },
     "source_session_id": {
       "anyOf": [

--- a/docs/schemas/cli-output/session-search-hit.schema.json
+++ b/docs/schemas/cli-output/session-search-hit.schema.json
@@ -220,9 +220,9 @@
       "title": "SessionSearchMatchPayload",
       "type": "object"
     },
-    "SessionSummaryPayload": {
+    "SessionSummaryEnvelope": {
       "additionalProperties": false,
-      "description": "Compact session summary payload used by MCP/search surfaces.",
+      "description": "Compact session envelope derived from ``SessionSummary``.",
       "properties": {
         "actions": {
           "additionalProperties": {
@@ -261,8 +261,16 @@
           "type": "string"
         },
         "message_count": {
-          "title": "Message Count",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Message Count"
         },
         "origin": {
           "title": "Origin",
@@ -280,6 +288,7 @@
           "default": null
         },
         "title": {
+          "default": null,
           "title": "Title",
           "type": "string"
         },
@@ -335,11 +344,9 @@
       },
       "required": [
         "id",
-        "origin",
-        "title",
-        "message_count"
+        "origin"
       ],
-      "title": "SessionSummaryPayload",
+      "title": "SessionSummaryEnvelope",
       "type": "object"
     },
     "TargetRefPayload": {
@@ -424,7 +431,7 @@
       "$ref": "#/$defs/SessionSearchMatchPayload"
     },
     "session": {
-      "$ref": "#/$defs/SessionSummaryPayload"
+      "$ref": "#/$defs/SessionSummaryEnvelope"
     }
   },
   "required": [

--- a/docs/schemas/cli-output/session-summary.schema.json
+++ b/docs/schemas/cli-output/session-summary.schema.json
@@ -139,7 +139,7 @@
   "$id": "https://polylogue.dev/schemas/cli-output/session-summary.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
-  "description": "Compact session identity payload used by analyze group-by and embedded inside search hits.\n\nGenerated from `polylogue.surfaces.payloads.SessionSummaryPayload` by `devtools render cli-output-schemas`. Do not edit by hand.",
+  "description": "Compact session identity payload used by analyze group-by and embedded inside search hits.\n\nGenerated from `polylogue.surfaces.payloads.SessionSummaryEnvelope` by `devtools render cli-output-schemas`. Do not edit by hand.",
   "properties": {
     "actions": {
       "additionalProperties": {
@@ -178,8 +178,16 @@
       "type": "string"
     },
     "message_count": {
-      "title": "Message Count",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Message Count"
     },
     "origin": {
       "title": "Origin",
@@ -197,6 +205,7 @@
       "default": null
     },
     "title": {
+      "default": null,
       "title": "Title",
       "type": "string"
     },
@@ -252,9 +261,7 @@
   },
   "required": [
     "id",
-    "origin",
-    "title",
-    "message_count"
+    "origin"
   ],
   "title": "Session Summary",
   "type": "object",
@@ -262,5 +269,5 @@
     "polylogue analyze --format json (rows)",
     "polylogue --format json <query> (hits[].session)"
   ],
-  "x-polylogue-source-model": "SessionSummaryPayload"
+  "x-polylogue-source-model": "SessionSummaryEnvelope"
 }

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -2086,14 +2086,14 @@ def _archive_search_hit_to_payload(
     from polylogue.surfaces.payloads import (
         SessionSearchHitPayload,
         SessionSearchMatchPayload,
-        SessionSummaryPayload,
         TargetRefPayload,
         reader_anchor,
         reader_message_actions,
+        session_summary_envelope_from_summary,
     )
 
     return SessionSearchHitPayload(
-        session=SessionSummaryPayload.from_summary(
+        session=session_summary_envelope_from_summary(
             _archive_summary_to_domain(summary),
             message_count=summary.message_count,
         ),
@@ -3893,7 +3893,11 @@ class PolylogueArchiveMixin:
         object_ref: ObjectRef,
         evidence_ref: EvidenceRef | None,
     ) -> PublicRefResolutionPayload:
-        from polylogue.surfaces.payloads import PublicRefResolutionPayload, SessionSummaryPayload, model_json_document
+        from polylogue.surfaces.payloads import (
+            PublicRefResolutionPayload,
+            model_json_document,
+            session_summary_envelope_from_summary,
+        )
 
         try:
             session_id = archive.resolve_session_id(object_ref.object_id)
@@ -3908,7 +3912,7 @@ class PolylogueArchiveMixin:
                 PublicRefResolutionPayload,
                 _unresolved_ref_payload(ref, "session not found", normalized_ref=normalized_ref, kind="session"),
             )
-        summary_payload = SessionSummaryPayload.from_summary(_archive_summary_to_domain(summaries[0]))
+        summary_payload = session_summary_envelope_from_summary(_archive_summary_to_domain(summaries[0]))
         return PublicRefResolutionPayload(
             ref=ref,
             normalized_ref=normalized_ref,
@@ -3931,7 +3935,11 @@ class PolylogueArchiveMixin:
         object_ref: ObjectRef,
         evidence_ref: EvidenceRef | None,
     ) -> PublicRefResolutionPayload:
-        from polylogue.surfaces.payloads import PublicRefResolutionPayload, SessionMessagePayload, model_json_document
+        from polylogue.surfaces.payloads import (
+            PublicRefResolutionPayload,
+            message_render_envelope_from_domain,
+            model_json_document,
+        )
 
         row = archive._conn.execute(
             """
@@ -3957,7 +3965,7 @@ class PolylogueArchiveMixin:
                 PublicRefResolutionPayload,
                 _unresolved_ref_payload(ref, "message not found", normalized_ref=normalized_ref, kind="message"),
             )
-        payload = SessionMessagePayload.from_message(message, session_id=session_id)
+        payload = message_render_envelope_from_domain(message, session_id=session_id)
         return PublicRefResolutionPayload(
             ref=ref,
             normalized_ref=normalized_ref,

--- a/polylogue/api/contracts/tui_surface.py
+++ b/polylogue/api/contracts/tui_surface.py
@@ -38,7 +38,7 @@ from polylogue.archive.query.spec import SessionQuerySpec
 from polylogue.surfaces.payloads import (
     QueryMissDiagnosticsPayload,
     SessionListResponse,
-    SessionListRowPayload,
+    session_list_envelope_from_domain,
 )
 
 if TYPE_CHECKING:
@@ -77,7 +77,7 @@ class TUIReadSurface:
             if miss is not None:
                 diagnostics = QueryMissDiagnosticsPayload.from_diagnostics(miss)
         return SessionListResponse(
-            items=tuple(SessionListRowPayload.from_session(conv) for conv in sessions),
+            items=tuple(session_list_envelope_from_domain(conv) for conv in sessions),
             total=total,
             limit=spec.limit if spec.limit is not None else len(sessions),
             offset=spec.offset,

--- a/polylogue/cli/messages.py
+++ b/polylogue/cli/messages.py
@@ -19,8 +19,8 @@ from polylogue.rendering.semantic_cards import (
 )
 from polylogue.rendering.semantic_markdown import render_semantic_transcript_markdown
 from polylogue.surfaces.payloads import (
-    SessionMessageRowPayload,
     SessionMessagesResponsePayload,
+    message_row_envelope_from_domain,
     model_json_document,
 )
 
@@ -65,7 +65,7 @@ def run_messages(
                 return cast(
                     "dict[str, object]",
                     model_json_document(
-                        SessionMessageRowPayload.from_message(m, session_id=session_id),
+                        message_row_envelope_from_domain(m, session_id=session_id),
                         exclude_none=True,
                     ),
                 )
@@ -77,9 +77,7 @@ def run_messages(
                 payload = model_json_document(
                     SessionMessagesResponsePayload(
                         session_id=session_id,
-                        messages=tuple(
-                            SessionMessageRowPayload.from_message(m, session_id=session_id) for m in messages
-                        ),
+                        messages=tuple(message_row_envelope_from_domain(m, session_id=session_id) for m in messages),
                         total=total,
                         limit=effective_limit,
                         offset=offset,

--- a/polylogue/cli/query_output.py
+++ b/polylogue/cli/query_output.py
@@ -39,10 +39,10 @@ from polylogue.logging import get_logger
 from polylogue.rendering.formatting import format_session
 from polylogue.surfaces.payloads import (
     SearchCursor,
-    SessionListRowPayload,
     SessionSearchHitPayload,
     build_search_envelope,
     model_json_document,
+    session_list_envelope_from_summary,
 )
 
 logger = get_logger(__name__)
@@ -411,7 +411,7 @@ def open_result(
 
 
 def summary_to_dict(summary: SessionSummary, message_count: int) -> JSONDocument:
-    return SessionListRowPayload.from_summary(
+    return session_list_envelope_from_summary(
         summary,
         message_count=message_count,
     ).selected()

--- a/polylogue/cli/read_views/messages.py
+++ b/polylogue/cli/read_views/messages.py
@@ -21,7 +21,7 @@ from polylogue.cli.read_views.base import (
 from polylogue.cli.root_request import RootModeRequest
 from polylogue.cli.shared.types import AppEnv
 from polylogue.config import Config
-from polylogue.surfaces.payloads import SessionMessageRowPayload, model_json_document
+from polylogue.surfaces.payloads import message_row_envelope_from_domain, model_json_document
 
 
 def build_message_options(values: ReadViewOptionValues) -> ReadViewMessageOptions:
@@ -129,7 +129,7 @@ def _write_messages_file(
                         payload = {
                             "session_id": session_id,
                             **model_json_document(
-                                SessionMessageRowPayload.from_message(message, session_id=session_id),
+                                message_row_envelope_from_domain(message, session_id=session_id),
                                 exclude_none=True,
                             ),
                         }
@@ -153,7 +153,7 @@ def _write_messages_file(
                     fh.write(
                         json.dumps(
                             model_json_document(
-                                SessionMessageRowPayload.from_message(message, session_id=session_id),
+                                message_row_envelope_from_domain(message, session_id=session_id),
                                 exclude_none=True,
                             ),
                             indent=2,

--- a/polylogue/mcp/archive_support.py
+++ b/polylogue/mcp/archive_support.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import replace
 from pathlib import Path
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, TypedDict, cast
 
 from polylogue.archive.query.spec import parse_query_date, resolve_default_root_filter
 from polylogue.core.timestamps import parse_archive_datetime
@@ -286,9 +286,9 @@ def _project_archive_message(
 
 def archive_message_payload(message: ArchiveMessageRow, *, session_id: str) -> MCPMessagePayload:
     """Project one archive message into the generic MCP message shape."""
-    from polylogue.surfaces.payloads import SessionMessagePayload
+    from polylogue.surfaces.payloads import message_render_envelope_from_archive_row
 
-    return SessionMessagePayload.from_archive_row(message, session_id=session_id)
+    return message_render_envelope_from_archive_row(message, session_id=session_id)
 
 
 def archive_session_list_payload(
@@ -701,7 +701,7 @@ def archive_message_page_payload(
     one-message request remain one-message work, even for very large sessions.
     """
     from polylogue.mcp.payloads import MCPMessagesListPayload
-    from polylogue.surfaces.payloads import SessionMessagePayload
+    from polylogue.surfaces.payloads import message_render_envelope_from_archive_row
 
     resolved_session_id = archive.resolve_session_id(session_id)
     if archive.has_prefix_lineage(resolved_session_id):
@@ -738,7 +738,7 @@ def archive_message_page_payload(
     )
     messages = []
     for row in rows:
-        message = SessionMessagePayload.from_archive_row(row, session_id=resolved_session_id)
+        message = message_render_envelope_from_archive_row(row, session_id=resolved_session_id)
         messages.append(
             _bounded_message_payload(
                 message,
@@ -788,7 +788,7 @@ def _bounded_message_payload(
         {key: ("" if key == "text" and isinstance(value, str) else value) for key, value in block.items()}
         for block in payload.content_blocks
     ]
-    return payload.model_copy(update={"text": text, "content_blocks": blocks})
+    return cast(MCPMessagePayload, payload.model_copy(update={"text": text, "content_blocks": blocks}))
 
 
 def _excerpt_text(text: str, max_chars: int, *, match_query: str | None = None) -> str:

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -23,6 +23,7 @@ from polylogue.surfaces.payloads import (
     build_search_envelope,
     model_json_document,
     role_label,
+    session_summary_envelope_from_domain,
 )
 from polylogue.surfaces.payloads import (
     ReaderActionAvailabilityPayload as MCPReaderActionAvailabilityPayload,
@@ -519,7 +520,7 @@ class MCPArchiveSessionPayload(SurfacePayloadModel):
 def session_summary_list_payload(
     sessions: Sequence[Session],
 ) -> MCPSessionSummaryListPayload:
-    return MCPSessionSummaryListPayload(root=[MCPSessionSummaryPayload.from_session(conv) for conv in sessions])
+    return MCPSessionSummaryListPayload(root=[session_summary_envelope_from_domain(conv) for conv in sessions])
 
 
 def session_query_result_payload(
@@ -534,7 +535,7 @@ def session_query_result_payload(
     return MCPPaginatedQueryResultPayload(
         items=tuple(
             MCPMatchedSessionSummaryPayload(
-                **MCPSessionSummaryPayload.from_session(conv).model_dump(mode="python"),
+                **session_summary_envelope_from_domain(conv).model_dump(mode="python"),
             )
             for conv in sessions
         ),
@@ -571,7 +572,7 @@ def session_neighbor_candidate_list_payload(
 def session_tree_payload(
     sessions: Sequence[Session],
 ) -> MCPSessionTreePayload:
-    items = tuple(MCPSessionSummaryPayload.from_session(conv) for conv in sessions)
+    items = tuple(session_summary_envelope_from_domain(conv) for conv in sessions)
     return MCPSessionTreePayload(items=items, total=len(items))
 
 

--- a/polylogue/rendering/formatting.py
+++ b/polylogue/rendering/formatting.py
@@ -21,9 +21,9 @@ from typing import TYPE_CHECKING
 from polylogue.archive.semantic.content_projection import ContentProjectionSpec
 from polylogue.surfaces.payloads import (
     JSONDocument,
-    SessionDetailPayload,
-    SessionListRowPayload,
     model_json_document,
+    session_detail_envelope_from_domain,
+    session_list_envelope_from_domain,
 )
 
 if TYPE_CHECKING:
@@ -93,14 +93,14 @@ def _conv_to_dict(conv: Session, fields: str | None, *, bound_title: bool = True
     lossless (polylogue-x7d PR #3420 follow-up).
     """
     selected = {field.strip() for field in fields.split(",")} if fields else None
-    return SessionListRowPayload.from_session(conv, bound_title=bound_title).selected(selected)
+    return session_list_envelope_from_domain(conv, bound_title=bound_title).selected(selected)
 
 
 def _conv_to_json(conv: Session, fields: str | None) -> str:
     """Convert a single session to full JSON with message content."""
     data = _conv_to_dict(conv, fields, bound_title=False)
     if fields is None or "messages" in {field.strip() for field in fields.split(",")}:
-        detail_payload = SessionDetailPayload.from_session(conv)
+        detail_payload = session_detail_envelope_from_domain(conv)
         data["messages"] = [
             model_json_document(message_payload, exclude_none=True) for message_payload in detail_payload.messages
         ]
@@ -121,7 +121,7 @@ def _conv_to_yaml(conv: Session, fields: str | None) -> str:
 
     data = _conv_to_dict(conv, fields, bound_title=False)
     if fields is None or "messages" in {field.strip() for field in fields.split(",")}:
-        detail_payload = SessionDetailPayload.from_session(conv)
+        detail_payload = session_detail_envelope_from_domain(conv)
         data["messages"] = [
             model_json_document(message_payload, exclude_none=True) for message_payload in detail_payload.messages
         ]

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -11,9 +11,10 @@ from datetime import UTC, datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypeAlias, cast
 
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, create_model, field_validator, model_validator
 from typing_extensions import Self, TypedDict
 
+from polylogue.archive.models import Message, Session, SessionSummary
 from polylogue.archive.query.search_hits import bound_display_title
 from polylogue.archive.semantic.content_projection import ContentProjectionSpec
 from polylogue.core.assertions import AssertionContextTrustClass
@@ -76,7 +77,6 @@ if TYPE_CHECKING:
     from collections.abc import Container
 
     from polylogue.annotations.batch import AnnotationBatch
-    from polylogue.archive.models import Message, Session, SessionSummary
     from polylogue.archive.query.search_hits import SessionSearchHit
     from polylogue.archive.session.neighbor_candidates import NeighborReason, SessionNeighborCandidate
     from polylogue.storage.sqlite.archive_tiers.archive import (
@@ -651,308 +651,6 @@ def reader_message_actions() -> dict[str, ReaderActionAvailabilityPayload]:
     }
 
 
-class SessionMessagePayload(SurfacePayloadModel):
-    """Machine-readable message payload shared across CLI and MCP surfaces.
-
-    #1487: this is the canonical ``MessageRenderEnvelope`` for every
-    reader entry. Both session-detail and paginated-message
-    endpoints emit this exact shape so the UI can render parent/branch
-    state, paste/attachment flags, raw/source refs, usage/cost
-    metadata, and disabled actions without per-endpoint special cases.
-
-    Every field beyond the original id/role/text/target_ref/anchor/
-    actions/timestamp/message_type/blocks/parent_id set is
-    additive with sensible default — so existing callers that only
-    set the original fields continue to work unchanged.
-    """
-
-    id: str
-    role: str
-    text: str
-    target_ref: TargetRefPayload | None = None
-    anchor: str | None = None
-    actions: dict[str, ReaderActionAvailabilityPayload] = Field(default_factory=reader_message_actions)
-    timestamp: datetime | None = None
-    message_type: str = "message"
-    material_origin: str = "unknown"
-    content_blocks: list[dict[str, object]] = Field(default_factory=list)
-    parent_id: str | None = None
-    # #1487 envelope: branch/lineage state.
-    branch_index: int = 0
-    # polylogue-ksgg: ordinal position within the session (storage:
-    # messages.position), independent of branch_index (sibling creation
-    # order). Needed to reconstruct display order without direct SQL.
-    position: int = 0
-    # polylogue-ksgg: provider-reported "this sibling is on the live path"
-    # signal (storage: messages.is_active_path). ``None`` means unknown --
-    # the read path did not select the column or the provider has no branch
-    # concept -- never collapse unknown to "not active".
-    is_active_path: bool | None = None
-    # polylogue-ksgg: whether this message is the tip of the currently-active
-    # branch (storage: messages.is_active_leaf) -- the message a reader would
-    # resume from, distinct from interior is_active_path membership.
-    is_active_leaf: bool = False
-    # #1487 envelope: per-message content flags. Surface what the storage
-    # layer already projects (#1201/#1583) so the reader does not have
-    # to re-derive them from the rendered text.
-    has_paste_evidence: bool = False
-    has_tool_use: bool = False
-    has_thinking: bool = False
-    # #1487 envelope: usage/cost metadata. Carries through from parsers
-    # that populated token counts (claude-code session JSONL records
-    # usage; codex sometimes does). All four default to zero so
-    # rendering paths can compute cost without dispatching on presence.
-    input_tokens: int = 0
-    output_tokens: int = 0
-    cache_read_tokens: int = 0
-    cache_write_tokens: int = 0
-    model_name: str | None = None
-    # #1487 envelope: provider attachment identifiers for the message.
-    # Tuple (immutable + ordered) so the reader can render them in
-    # parser order and the test contract pins exact equality.
-    attachment_refs: tuple[str, ...] = ()
-    # #1487 envelope: raw/source refs so the inspector can deep-link
-    # to provenance without re-querying. ``raw_id`` is the
-    # content-addressed blob id from ``raw_sessions``;
-    # ``source_path`` is the on-disk path the session was
-    # acquired from. Both default to None for messages whose
-    # session has no recorded raw artifact.
-    raw_id: str | None = None
-    source_path: str | None = None
-    # #1655: paste boundary state — exact, projected, whole_message_fallback,
-    # hash_only, or None when the message has no paste evidence. Projected
-    # from the stored ``messages.paste_boundary`` column.
-    paste_boundary_state: str | None = None
-
-    @classmethod
-    def from_message(
-        cls,
-        message: Message,
-        *,
-        session_id: object | None = None,
-        raw_id: str | None = None,
-        source_path: str | None = None,
-    ) -> SessionMessagePayload:
-        raw_message_type = getattr(message, "message_type", None)
-        if raw_message_type is None:
-            message_type = "message"
-        elif hasattr(raw_message_type, "value"):
-            message_type = str(raw_message_type.value)
-        else:
-            message_type = str(raw_message_type)
-        raw_material_origin = getattr(message, "material_origin", None)
-        if raw_material_origin is None:
-            material_origin = "unknown"
-        elif hasattr(raw_material_origin, "value"):
-            material_origin = str(raw_material_origin.value)
-        else:
-            material_origin = str(raw_material_origin)
-        target_ref = (
-            TargetRefPayload.message(session_id=session_id, message_id=message.id) if session_id is not None else None
-        )
-        attachment_refs = tuple(
-            str(getattr(attachment, "id", ""))
-            for attachment in getattr(message, "attachments", ())
-            if getattr(attachment, "id", None)
-        )
-        return cls(
-            id=str(message.id),
-            role=role_label(message.role),
-            text=message.text or "",
-            target_ref=target_ref,
-            anchor=reader_anchor("message", message.id),
-            timestamp=message.timestamp,
-            message_type=message_type,
-            material_origin=material_origin,
-            content_blocks=message.blocks,
-            parent_id=message.parent_id,
-            branch_index=int(getattr(message, "branch_index", 0) or 0),
-            position=int(getattr(message, "position", 0) or 0),
-            is_active_path=getattr(message, "is_active_path", None),
-            is_active_leaf=bool(getattr(message, "is_active_leaf", False)),
-            has_paste_evidence=bool(getattr(message, "has_paste", False)),
-            paste_boundary_state=getattr(message, "paste_boundary_state", None),
-            has_tool_use=bool(getattr(message, "has_tool_use", False)),
-            has_thinking=bool(getattr(message, "has_thinking", False)),
-            input_tokens=int(getattr(message, "input_tokens", 0) or 0),
-            output_tokens=int(getattr(message, "output_tokens", 0) or 0),
-            cache_read_tokens=int(getattr(message, "cache_read_tokens", 0) or 0),
-            cache_write_tokens=int(getattr(message, "cache_write_tokens", 0) or 0),
-            model_name=getattr(message, "model_name", None),
-            attachment_refs=attachment_refs,
-            raw_id=raw_id,
-            source_path=source_path,
-        )
-
-    @classmethod
-    def from_archive_row(cls, message: Any, *, session_id: object) -> SessionMessagePayload:
-        """Project an ``ArchiveMessageRow`` into the canonical reader payload.
-
-        Archive-backed MCP/resource paths read split-tier row DTOs directly
-        instead of hydrating domain ``Message`` objects. Keep their message
-        envelope identical by mapping those row fields here, not in each
-        surface adapter.
-        """
-
-        message_id = str(message.message_id)
-        blocks = tuple(getattr(message, "blocks", ()))
-        text = "\n\n".join(str(block.text) for block in blocks if block.text)
-        if not text:
-            text = str(getattr(message, "text", "") or "")
-        content_blocks: list[dict[str, object]] = []
-        for block in blocks:
-            row: dict[str, object] = {
-                "type": str(getattr(block, "block_type", "")),
-                "text": str(getattr(block, "text", "") or ""),
-                "block_id": str(getattr(block, "block_id", "") or ""),
-            }
-            for source_name, target_name in (
-                ("tool_name", "tool_name"),
-                ("tool_id", "tool_id"),
-                ("semantic_type", "semantic_type"),
-            ):
-                value = getattr(block, source_name, None)
-                if value:
-                    row[target_name] = str(value)
-            content_blocks.append(row)
-        attachment_refs = tuple(
-            str(getattr(attachment, "attachment_id", ""))
-            for attachment in getattr(message, "attachments", ())
-            if getattr(attachment, "attachment_id", None)
-        )
-        return cls(
-            id=message_id,
-            role=role_label(getattr(message, "role", "")),
-            text=text,
-            target_ref=TargetRefPayload.message(session_id=session_id, message_id=message_id),
-            anchor=reader_anchor("message", message_id),
-            timestamp=(
-                _parse_optional_datetime(getattr(message, "occurred_at", None))
-                or (
-                    datetime.fromtimestamp(float(message.occurred_at_ms) / 1000.0, UTC)
-                    if getattr(message, "occurred_at_ms", None) is not None
-                    else None
-                )
-            ),
-            message_type=str(getattr(message, "message_type", "message") or "message"),
-            material_origin=str(getattr(message, "material_origin", "unknown") or "unknown"),
-            content_blocks=content_blocks,
-            parent_id=getattr(message, "parent_message_id", None),
-            branch_index=int(getattr(message, "variant_index", 0) or 0),
-            position=int(getattr(message, "position", 0) or 0),
-            is_active_path=getattr(message, "is_active_path", None),
-            is_active_leaf=bool(getattr(message, "is_active_leaf", False)),
-            has_paste_evidence=bool(getattr(message, "has_paste", False)),
-            paste_boundary_state=getattr(message, "paste_boundary_state", None),
-            has_tool_use=bool(getattr(message, "has_tool_use", False)),
-            has_thinking=bool(getattr(message, "has_thinking", False)),
-            attachment_refs=attachment_refs,
-        )
-
-
-class SessionMessageRowPayload(SessionMessagePayload):
-    """One `read --view messages` machine-output row."""
-
-    session_id: str
-
-    @classmethod
-    def from_message(
-        cls,
-        message: Message,
-        *,
-        session_id: object | None = None,
-        raw_id: str | None = None,
-        source_path: str | None = None,
-    ) -> SessionMessageRowPayload:
-        if session_id is None:
-            msg_id = getattr(message, "id", "<unknown>")
-            raise ValueError(f"SessionMessageRowPayload requires session_id for message {msg_id}")
-        base = SessionMessagePayload.from_message(
-            message,
-            session_id=session_id,
-            raw_id=raw_id,
-            source_path=source_path,
-        )
-        return cls(session_id=str(session_id), **base.model_dump())
-
-
-class SessionSummaryPayload(SurfacePayloadModel):
-    """Compact session summary payload used by MCP/search surfaces."""
-
-    id: str
-    origin: str
-    title: str
-    title_source: str | None = None
-    title_ref: str | None = None
-    title_confidence: float | None = None
-    message_count: int
-    target_ref: TargetRefPayload | None = None
-    anchor: str | None = None
-    actions: dict[str, ReaderActionAvailabilityPayload] = Field(default_factory=reader_session_actions)
-    created_at: datetime | None = None
-    updated_at: datetime | None = None
-
-    @classmethod
-    def from_session(cls, session: Session) -> SessionSummaryPayload:
-        session_id = str(session.id)
-        return cls(
-            id=session_id,
-            origin=session.origin,
-            title=session.display_title,
-            title_source=session.title_source.value if session.title_source else None,
-            title_ref=session.title_ref,
-            title_confidence=session.title_confidence,
-            message_count=len(session.messages),
-            target_ref=TargetRefPayload.session(session_id),
-            anchor=reader_anchor("session", session_id),
-            created_at=session.created_at,
-            updated_at=session.updated_at,
-        )
-
-    @classmethod
-    def from_summary(
-        cls,
-        summary: SessionSummary,
-        *,
-        message_count: int | None = None,
-    ) -> SessionSummaryPayload:
-        session_id = str(summary.id)
-        return cls(
-            id=session_id,
-            origin=summary.origin,
-            title=bound_display_title(summary.display_title, session_id),
-            title_source=summary.title_source.value if summary.title_source else None,
-            title_ref=summary.title_ref,
-            title_confidence=summary.title_confidence,
-            message_count=summary.message_count or 0 if message_count is None else message_count,
-            target_ref=TargetRefPayload.session(session_id),
-            anchor=reader_anchor("session", session_id),
-            created_at=summary.created_at,
-            updated_at=summary.updated_at,
-        )
-
-
-class SessionDetailPayload(SessionSummaryPayload):
-    """Full session detail payload with serialized messages."""
-
-    messages: tuple[SessionMessagePayload, ...]
-
-    @classmethod
-    def from_session(
-        cls,
-        session: Session,
-        *,
-        content_projection: ContentProjectionSpec | None = None,
-    ) -> SessionDetailPayload:
-        if content_projection is not None and content_projection.filters_content():
-            session = session.with_content_projection(content_projection)
-        summary = SessionSummaryPayload.from_session(session)
-        return cls(
-            **summary.model_dump(),
-            messages=tuple(SessionMessagePayload.from_message(msg, session_id=session.id) for msg in session.messages),
-        )
-
-
 class SessionFlagsPayload(SurfacePayloadModel):
     """Boolean flags summarizing session content characteristics."""
 
@@ -961,120 +659,617 @@ class SessionFlagsPayload(SurfacePayloadModel):
     has_paste_evidence: bool = False
 
 
-class SessionListRowPayload(SurfacePayloadModel):
-    """Session row payload used by CLI list, JSON, and YAML surfaces.
+_MESSAGE_MASK: tuple[tuple[str, str], ...] = (
+    ("id", "id"),
+    ("role", "role"),
+    ("text", "text"),
+    ("timestamp", "timestamp"),
+    ("blocks", "content_blocks"),
+    ("message_type", "message_type"),
+    ("material_origin", "material_origin"),
+    ("parent_id", "parent_id"),
+    ("branch_index", "branch_index"),
+    ("position", "position"),
+    ("is_active_path", "is_active_path"),
+    ("is_active_leaf", "is_active_leaf"),
+    ("has_tool_use", "has_tool_use"),
+    ("has_thinking", "has_thinking"),
+    ("has_paste", "has_paste_evidence"),
+    ("paste_boundary_state", "paste_boundary_state"),
+    ("input_tokens", "input_tokens"),
+    ("output_tokens", "output_tokens"),
+    ("cache_read_tokens", "cache_read_tokens"),
+    ("cache_write_tokens", "cache_write_tokens"),
+    ("duration_ms", "duration_ms"),
+    ("model_name", "model_name"),
+    ("stop_reason", "stop_reason"),
+)
 
-    Carries the canonical row shape for the web reader contract (#848).
-    """
+_SESSION_SUMMARY_MASK: tuple[tuple[str, str], ...] = (
+    ("id", "id"),
+    ("origin", "origin"),
+    ("title", "title"),
+    ("title_source", "title_source"),
+    ("title_ref", "title_ref"),
+    ("title_confidence", "title_confidence"),
+    ("message_count", "message_count"),
+    ("created_at", "created_at"),
+    ("updated_at", "updated_at"),
+)
 
-    id: str
-    origin: str
-    title: str
-    title_source: str | None = None
-    title_ref: str | None = None
-    title_confidence: float | None = None
-    target_ref: TargetRefPayload | None = None
-    anchor: str | None = None
-    actions: dict[str, ReaderActionAvailabilityPayload] = Field(default_factory=reader_session_actions)
-    created_at: str | None = None
-    updated_at: str | None = None
-    message_count: int = 0
-    tags: tuple[str, ...] = ()
-    summary: str | None = None
-    words: int | None = None
-    repo: str | None = None
-    cwd_display: str | None = None
-    flags: SessionFlagsPayload | None = None
-    # Recursive-graph projection (#z9gh.3): populated only for lineage-seeded
-    # (``lineage:id:<ref>``) list pages. ``parent_refs``/``child_refs`` are the
-    # session's direct one-hop lineage edges within the current page;
-    # ``continuation`` mirrors the page-level cursor (``None`` once the
-    # lineage family's last page has been served).
-    parent_refs: tuple[str, ...] | None = None
-    child_refs: tuple[str, ...] | None = None
-    continuation: str | None = None
+_SESSION_LIST_MASK: tuple[tuple[str, str], ...] = (
+    ("id", "id"),
+    ("origin", "origin"),
+    ("title", "title"),
+    ("title_source", "title_source"),
+    ("title_ref", "title_ref"),
+    ("title_confidence", "title_confidence"),
+    ("created_at", "created_at"),
+    ("updated_at", "updated_at"),
+)
 
-    @classmethod
-    def from_session(cls, session: Session, *, bound_title: bool = True) -> SessionListRowPayload:
-        """Build a row payload from a full ``Session``.
+_NO_DEFAULT = object()
 
-        ``bound_title`` defaults to ``True`` for genuine list contexts (the
-        common case). It must be passed ``False`` where this payload is
-        spliced into a *full single-session* JSON/YAML detail read
-        (``rendering/formatting.py::_conv_to_json``/``_conv_to_yaml``, via
-        ``_conv_to_dict``) -- that surface promises lossless output, and a
-        row-list title budget would silently truncate the title on every
-        ``find ... then read --format json`` call (polylogue-x7d PR #3420
-        follow-up: caught by review before merge, see PR discussion).
-        """
-        session_id = str(session.id)
-        created_at = session.created_at.isoformat() if session.created_at else None
-        updated_at = session.updated_at.isoformat() if session.updated_at else None
-        msg_count = len(session.messages)
-        title = (
-            bound_display_title(session.display_title, session_id)
-            if bound_title
-            else (session.display_title or session_id)
-        )
-        return cls(
-            id=session_id,
-            origin=session.origin,
-            title=title,
-            title_source=session.title_source.value if session.title_source else None,
-            title_ref=session.title_ref,
-            title_confidence=session.title_confidence,
-            target_ref=TargetRefPayload.session(session_id),
-            anchor=reader_anchor("session", session_id),
-            created_at=created_at,
-            updated_at=updated_at,
-            message_count=msg_count,
-            tags=tuple(session.tags),
-            summary=session.summary,
-            words=sum(message.word_count for message in session.messages),
-            repo=_session_repo(session),
-            cwd_display=_session_cwd(session),
-            flags=_build_flags_from_session(session),
-        )
 
-    @classmethod
-    def from_summary(
-        cls,
-        summary: SessionSummary,
-        *,
-        message_count: int,
-        word_count: int | None = None,
-        flags: SessionFlagsPayload | None = None,
-        repo: str | None = None,
-        cwd_display: str | None = None,
-    ) -> SessionListRowPayload:
-        session_id = str(summary.id)
-        created_at = summary.created_at.isoformat() if summary.created_at else None
-        updated_at = summary.updated_at.isoformat() if summary.updated_at else None
-        return cls(
-            id=session_id,
-            origin=summary.origin,
-            title=bound_display_title(summary.display_title, session_id),
-            title_source=summary.title_source.value if summary.title_source else None,
-            title_ref=summary.title_ref,
-            title_confidence=summary.title_confidence,
-            target_ref=TargetRefPayload.session(session_id),
-            anchor=reader_anchor("session", session_id),
-            created_at=created_at,
-            updated_at=updated_at,
-            message_count=message_count,
-            tags=tuple(summary.tags),
-            summary=summary.summary,
-            words=word_count,
-            repo=repo or _session_repo(summary),
-            cwd_display=cwd_display or _session_cwd(summary),
-            flags=flags,
-        )
+def _projection_field_definitions(
+    domain_model: type[BaseModel],
+    mask: tuple[tuple[str, str], ...],
+    *,
+    annotation_overrides: Mapping[str, object] = {},
+    default_overrides: Mapping[str, object] = {},
+) -> dict[str, tuple[object, object]]:
+    definitions: dict[str, tuple[object, object]] = {}
+    for domain_name, surface_name in mask:
+        field = domain_model.model_fields[domain_name]
+        annotation = annotation_overrides.get(surface_name, field.annotation)
+        default = default_overrides.get(surface_name, _NO_DEFAULT)
+        if default is _NO_DEFAULT:
+            if field.default_factory is not None:
+                field_default: object = Field(
+                    default_factory=field.default_factory,
+                    serialization_alias=surface_name,
+                )
+            elif field.is_required():
+                field_default = Field(..., serialization_alias=surface_name)
+            else:
+                field_default = Field(field.default, serialization_alias=surface_name)
+        else:
+            field_default = Field(default, serialization_alias=surface_name)
+        definitions[surface_name] = (annotation, field_default)
+    return definitions
+
+
+def _create_projection_model(
+    name: str,
+    domain_model: type[BaseModel],
+    mask: tuple[tuple[str, str], ...],
+    *,
+    extra_fields: Mapping[str, tuple[object, object]] = {},
+    annotation_overrides: Mapping[str, object] = {},
+    default_overrides: Mapping[str, object] = {},
+    field_order: Sequence[str] | None = None,
+) -> type[SurfacePayloadModel]:
+    fields: dict[str, tuple[Any, Any]] = _projection_field_definitions(
+        domain_model,
+        mask,
+        annotation_overrides=annotation_overrides,
+        default_overrides=default_overrides,
+    )
+    fields.update(extra_fields)
+    if field_order is not None:
+        fields = {field_name: fields[field_name] for field_name in field_order}
+    return cast(
+        type[SurfacePayloadModel],
+        create_model(name, __base__=SurfacePayloadModel, __module__=__name__, **fields),  # type: ignore[call-overload]
+    )
+
+
+_MESSAGE_EXTRA_FIELDS: dict[str, tuple[object, object]] = {
+    "target_ref": (TargetRefPayload | None, Field(default=None)),
+    "anchor": (str | None, Field(default=None)),
+    "actions": (
+        dict[str, ReaderActionAvailabilityPayload],
+        Field(default_factory=reader_message_actions),
+    ),
+    "attachment_refs": (tuple[str, ...], Field(default=())),
+    "raw_id": (str | None, Field(default=None)),
+    "source_path": (str | None, Field(default=None)),
+}
+
+_MESSAGE_ANNOTATION_OVERRIDES: dict[str, object] = {
+    "role": str,
+    "text": str,
+    "message_type": str,
+    "material_origin": str,
+}
+_MESSAGE_DEFAULT_OVERRIDES: dict[str, object] = {
+    "text": "",
+    "message_type": "message",
+    "material_origin": "unknown",
+}
+
+_MessageRenderEnvelopeBase = _create_projection_model(
+    "SessionMessagePayload",
+    Message,
+    _MESSAGE_MASK,
+    extra_fields=_MESSAGE_EXTRA_FIELDS,
+    annotation_overrides=_MESSAGE_ANNOTATION_OVERRIDES,
+    default_overrides=_MESSAGE_DEFAULT_OVERRIDES,
+    field_order=(
+        "id",
+        "role",
+        "text",
+        "target_ref",
+        "anchor",
+        "actions",
+        "timestamp",
+        "message_type",
+        "material_origin",
+        "content_blocks",
+        "parent_id",
+        "branch_index",
+        "position",
+        "is_active_path",
+        "is_active_leaf",
+        "has_paste_evidence",
+        "has_tool_use",
+        "has_thinking",
+        "input_tokens",
+        "output_tokens",
+        "cache_read_tokens",
+        "cache_write_tokens",
+        "model_name",
+        "attachment_refs",
+        "raw_id",
+        "source_path",
+        "paste_boundary_state",
+        "stop_reason",
+        "duration_ms",
+    ),
+)
+
+
+class MessageRenderEnvelope(_MessageRenderEnvelopeBase):  # type: ignore[valid-type,misc]
+    """Message reader envelope derived from the canonical ``Message`` model."""
+
+
+_MessageRowEnvelopeBase = _create_projection_model(
+    "MessageRowEnvelope",
+    Message,
+    _MESSAGE_MASK,
+    extra_fields={**_MESSAGE_EXTRA_FIELDS, "session_id": (str, Field(...))},
+    annotation_overrides=_MESSAGE_ANNOTATION_OVERRIDES,
+    default_overrides=_MESSAGE_DEFAULT_OVERRIDES,
+    field_order=(
+        "id",
+        "role",
+        "text",
+        "target_ref",
+        "anchor",
+        "actions",
+        "timestamp",
+        "message_type",
+        "material_origin",
+        "content_blocks",
+        "parent_id",
+        "branch_index",
+        "position",
+        "is_active_path",
+        "is_active_leaf",
+        "has_paste_evidence",
+        "has_tool_use",
+        "has_thinking",
+        "input_tokens",
+        "output_tokens",
+        "cache_read_tokens",
+        "cache_write_tokens",
+        "model_name",
+        "attachment_refs",
+        "raw_id",
+        "source_path",
+        "paste_boundary_state",
+        "stop_reason",
+        "duration_ms",
+        "session_id",
+    ),
+)
+
+
+class MessageRowEnvelope(_MessageRowEnvelopeBase):  # type: ignore[valid-type,misc]
+    """Message envelope used by the paginated message-row surface."""
+
+
+_SessionSummaryEnvelopeBase = _create_projection_model(
+    "SessionSummaryPayload",
+    SessionSummary,
+    _SESSION_SUMMARY_MASK,
+    extra_fields={
+        "target_ref": (TargetRefPayload | None, Field(default=None)),
+        "anchor": (str | None, Field(default=None)),
+        "actions": (
+            dict[str, ReaderActionAvailabilityPayload],
+            Field(default_factory=reader_session_actions),
+        ),
+    },
+    annotation_overrides={
+        "origin": str,
+        "title": str,
+        "title_source": str | None,
+    },
+    field_order=(
+        "id",
+        "origin",
+        "title",
+        "title_source",
+        "title_ref",
+        "title_confidence",
+        "message_count",
+        "target_ref",
+        "anchor",
+        "actions",
+        "created_at",
+        "updated_at",
+    ),
+)
+
+
+class SessionSummaryEnvelope(_SessionSummaryEnvelopeBase):  # type: ignore[valid-type,misc]
+    """Compact session envelope derived from ``SessionSummary``."""
+
+
+_SessionDetailEnvelopeBase = _create_projection_model(
+    "SessionDetailPayload",
+    SessionSummary,
+    _SESSION_SUMMARY_MASK,
+    extra_fields={
+        "target_ref": (TargetRefPayload | None, Field(default=None)),
+        "anchor": (str | None, Field(default=None)),
+        "actions": (
+            dict[str, ReaderActionAvailabilityPayload],
+            Field(default_factory=reader_session_actions),
+        ),
+        "messages": (tuple[MessageRenderEnvelope, ...], Field(...)),
+    },
+    annotation_overrides={
+        "origin": str,
+        "title": str,
+        "title_source": str | None,
+    },
+    field_order=(
+        "id",
+        "origin",
+        "title",
+        "title_source",
+        "title_ref",
+        "title_confidence",
+        "message_count",
+        "target_ref",
+        "anchor",
+        "actions",
+        "created_at",
+        "updated_at",
+        "messages",
+    ),
+)
+
+
+class SessionDetailEnvelope(_SessionDetailEnvelopeBase):  # type: ignore[valid-type,misc]
+    """Full session envelope with derived message envelopes."""
+
+
+_SessionListEnvelopeBase = _create_projection_model(
+    "SessionListRowPayload",
+    Session,
+    _SESSION_LIST_MASK,
+    extra_fields={
+        "target_ref": (TargetRefPayload | None, Field(default=None)),
+        "anchor": (str | None, Field(default=None)),
+        "actions": (
+            dict[str, ReaderActionAvailabilityPayload],
+            Field(default_factory=reader_session_actions),
+        ),
+        "message_count": (int, Field(default=0)),
+        "tags": (tuple[str, ...], Field(default=())),
+        "summary": (str | None, Field(default=None)),
+        "words": (int | None, Field(default=None)),
+        "repo": (str | None, Field(default=None)),
+        "cwd_display": (str | None, Field(default=None)),
+        "flags": (SessionFlagsPayload | None, Field(default=None)),
+        "parent_refs": (tuple[str, ...] | None, Field(default=None)),
+        "child_refs": (tuple[str, ...] | None, Field(default=None)),
+        "continuation": (str | None, Field(default=None)),
+    },
+    annotation_overrides={
+        "origin": str,
+        "title": str,
+        "title_source": str | None,
+        "created_at": str | None,
+        "updated_at": str | None,
+    },
+    field_order=(
+        "id",
+        "origin",
+        "title",
+        "title_source",
+        "title_ref",
+        "title_confidence",
+        "target_ref",
+        "anchor",
+        "actions",
+        "created_at",
+        "updated_at",
+        "message_count",
+        "tags",
+        "summary",
+        "words",
+        "repo",
+        "cwd_display",
+        "flags",
+        "parent_refs",
+        "child_refs",
+        "continuation",
+    ),
+)
+
+
+class SessionListEnvelope(_SessionListEnvelopeBase):  # type: ignore[valid-type,misc]
+    """Session list-row envelope derived from ``Session``."""
 
     def selected(self, fields: Container[str] | None = None) -> JSONDocument:
         data = model_json_document(self, exclude_none=True)
         if fields is None:
             return data
         return {key: value for key, value in data.items() if key in fields}
+
+
+def _domain_values(
+    model: object,
+    mask: tuple[tuple[str, str], ...],
+) -> dict[str, object]:
+    model_dump = getattr(model, "model_dump", None)
+    if callable(model_dump):
+        dumped = model_dump(mode="python")
+        return {surface_name: dumped[domain_name] for domain_name, surface_name in mask}
+    return {surface_name: getattr(model, domain_name, None) for domain_name, surface_name in mask}
+
+
+def message_render_envelope_from_domain(
+    message: Message,
+    *,
+    session_id: object | None = None,
+    raw_id: str | None = None,
+    source_path: str | None = None,
+) -> MessageRenderEnvelope:
+    values = _domain_values(message, _MESSAGE_MASK)
+    values.update(
+        role=role_label(message.role),
+        text=message.text or "",
+        message_type=role_label(getattr(message, "message_type", "message") or "message"),
+        material_origin=role_label(getattr(message, "material_origin", "unknown") or "unknown"),
+        parent_id=getattr(message, "parent_id", None),
+        branch_index=int(getattr(message, "branch_index", 0) or 0),
+        position=int(getattr(message, "position", 0) or 0),
+        is_active_path=getattr(message, "is_active_path", None),
+        is_active_leaf=bool(getattr(message, "is_active_leaf", False)),
+        has_tool_use=bool(getattr(message, "has_tool_use", False)),
+        has_thinking=bool(getattr(message, "has_thinking", False)),
+        input_tokens=int(getattr(message, "input_tokens", 0) or 0),
+        output_tokens=int(getattr(message, "output_tokens", 0) or 0),
+        cache_read_tokens=int(getattr(message, "cache_read_tokens", 0) or 0),
+        cache_write_tokens=int(getattr(message, "cache_write_tokens", 0) or 0),
+        duration_ms=int(getattr(message, "duration_ms", 0) or 0),
+        model_name=getattr(message, "model_name", None),
+        stop_reason=getattr(message, "stop_reason", None),
+        target_ref=(
+            TargetRefPayload.message(session_id=session_id, message_id=message.id) if session_id is not None else None
+        ),
+        anchor=reader_anchor("message", message.id),
+        actions=reader_message_actions(),
+        has_paste_evidence=bool(message.has_paste),
+        attachment_refs=tuple(str(attachment.id) for attachment in message.attachments if attachment.id),
+        raw_id=raw_id,
+        source_path=source_path,
+    )
+    return MessageRenderEnvelope(**values)
+
+
+def message_row_envelope_from_domain(
+    message: Message,
+    *,
+    session_id: object,
+    raw_id: str | None = None,
+    source_path: str | None = None,
+) -> MessageRowEnvelope:
+    values = message_render_envelope_from_domain(
+        message,
+        session_id=session_id,
+        raw_id=raw_id,
+        source_path=source_path,
+    ).model_dump()
+    values["session_id"] = str(session_id)
+    return MessageRowEnvelope(**values)
+
+
+def message_render_envelope_from_archive_row(message: Any, *, session_id: object) -> MessageRenderEnvelope:
+    """Project an archive row without making each surface own a mapper."""
+    message_id = str(message.message_id)
+    blocks = tuple(getattr(message, "blocks", ()))
+    text = "\n\n".join(str(block.text) for block in blocks if block.text)
+    if not text:
+        text = str(getattr(message, "text", "") or "")
+    content_blocks: list[dict[str, object]] = []
+    for block in blocks:
+        row: dict[str, object] = {
+            "type": str(getattr(block, "block_type", "")),
+            "text": str(getattr(block, "text", "") or ""),
+            "block_id": str(getattr(block, "block_id", "") or ""),
+        }
+        for source_name in ("tool_name", "tool_id", "semantic_type"):
+            value = getattr(block, source_name, None)
+            if value:
+                row[source_name] = str(value)
+        content_blocks.append(row)
+    values = {
+        "id": message_id,
+        "role": role_label(getattr(message, "role", "")),
+        "text": text,
+        "timestamp": (
+            _parse_optional_datetime(getattr(message, "occurred_at", None))
+            or (
+                datetime.fromtimestamp(float(message.occurred_at_ms) / 1000.0, UTC)
+                if getattr(message, "occurred_at_ms", None) is not None
+                else None
+            )
+        ),
+        "content_blocks": content_blocks,
+        "message_type": role_label(getattr(message, "message_type", "message") or "message"),
+        "material_origin": role_label(getattr(message, "material_origin", "unknown") or "unknown"),
+        "parent_id": getattr(message, "parent_message_id", None),
+        "branch_index": int(getattr(message, "variant_index", 0) or 0),
+        "position": int(getattr(message, "position", 0) or 0),
+        "is_active_path": getattr(message, "is_active_path", None),
+        "is_active_leaf": bool(getattr(message, "is_active_leaf", False)),
+        "has_tool_use": bool(getattr(message, "has_tool_use", False)),
+        "has_thinking": bool(getattr(message, "has_thinking", False)),
+        "has_paste_evidence": bool(getattr(message, "has_paste", False)),
+        "paste_boundary_state": getattr(message, "paste_boundary_state", None),
+        "input_tokens": int(getattr(message, "input_tokens", 0) or 0),
+        "output_tokens": int(getattr(message, "output_tokens", 0) or 0),
+        "cache_read_tokens": int(getattr(message, "cache_read_tokens", 0) or 0),
+        "cache_write_tokens": int(getattr(message, "cache_write_tokens", 0) or 0),
+        "duration_ms": int(getattr(message, "duration_ms", 0) or 0),
+        "model_name": getattr(message, "model_name", None),
+        "stop_reason": getattr(message, "stop_reason", None),
+        "target_ref": TargetRefPayload.message(session_id=session_id, message_id=message_id),
+        "anchor": reader_anchor("message", message_id),
+        "actions": reader_message_actions(),
+        "attachment_refs": tuple(
+            str(getattr(attachment, "attachment_id", ""))
+            for attachment in getattr(message, "attachments", ())
+            if getattr(attachment, "attachment_id", None)
+        ),
+    }
+    return MessageRenderEnvelope(**values)
+
+
+def session_summary_envelope_from_domain(session: Session) -> SessionSummaryEnvelope:
+    session_id = str(session.id)
+    values = _domain_values(session, _SESSION_LIST_MASK)
+    values.update(
+        title=session.display_title,
+        origin=role_label(session.origin),
+        title_source=session.title_source.value if session.title_source else None,
+        message_count=len(session.messages),
+        target_ref=TargetRefPayload.session(session_id),
+        anchor=reader_anchor("session", session_id),
+        actions=reader_session_actions(),
+    )
+    return SessionSummaryEnvelope(**values)
+
+
+def session_summary_envelope_from_summary(
+    summary: SessionSummary,
+    *,
+    message_count: int | None = None,
+) -> SessionSummaryEnvelope:
+    values = _domain_values(summary, _SESSION_SUMMARY_MASK)
+    session_id = str(summary.id)
+    values.update(
+        title=bound_display_title(summary.display_title, session_id),
+        origin=role_label(summary.origin),
+        title_source=summary.title_source.value if summary.title_source else None,
+        message_count=summary.message_count or 0 if message_count is None else message_count,
+        target_ref=TargetRefPayload.session(session_id),
+        anchor=reader_anchor("session", session_id),
+        actions=reader_session_actions(),
+    )
+    return SessionSummaryEnvelope(**values)
+
+
+def session_detail_envelope_from_domain(
+    session: Session,
+    *,
+    content_projection: ContentProjectionSpec | None = None,
+) -> SessionDetailEnvelope:
+    if content_projection is not None and content_projection.filters_content():
+        session = session.with_content_projection(content_projection)
+    summary = session_summary_envelope_from_domain(session)
+    return SessionDetailEnvelope(
+        **summary.model_dump(),
+        messages=tuple(message_render_envelope_from_domain(msg, session_id=session.id) for msg in session.messages),
+    )
+
+
+def session_list_envelope_from_domain(
+    session: Session,
+    *,
+    bound_title: bool = True,
+) -> SessionListEnvelope:
+    session_id = str(session.id)
+    values = _domain_values(session, _SESSION_LIST_MASK)
+    values.update(
+        title=(
+            bound_display_title(session.display_title, session_id)
+            if bound_title
+            else session.display_title or session_id
+        ),
+        origin=role_label(session.origin),
+        title_source=session.title_source.value if session.title_source else None,
+        created_at=session.created_at.isoformat() if session.created_at else None,
+        updated_at=session.updated_at.isoformat() if session.updated_at else None,
+        target_ref=TargetRefPayload.session(session_id),
+        anchor=reader_anchor("session", session_id),
+        actions=reader_session_actions(),
+        message_count=len(session.messages),
+        tags=tuple(session.tags),
+        summary=session.summary,
+        words=sum(message.word_count for message in session.messages),
+        repo=_session_repo(session),
+        cwd_display=_session_cwd(session),
+        flags=_build_flags_from_session(session),
+    )
+    return SessionListEnvelope(**values)
+
+
+def session_list_envelope_from_summary(
+    summary: SessionSummary,
+    *,
+    message_count: int,
+    word_count: int | None = None,
+    flags: SessionFlagsPayload | None = None,
+    repo: str | None = None,
+    cwd_display: str | None = None,
+) -> SessionListEnvelope:
+    session_id = str(summary.id)
+    values = _domain_values(summary, _SESSION_LIST_MASK)
+    values.update(
+        title=bound_display_title(summary.display_title, session_id),
+        origin=role_label(summary.origin),
+        title_source=summary.title_source.value if summary.title_source else None,
+        created_at=summary.created_at.isoformat() if summary.created_at else None,
+        updated_at=summary.updated_at.isoformat() if summary.updated_at else None,
+        target_ref=TargetRefPayload.session(session_id),
+        anchor=reader_anchor("session", session_id),
+        actions=reader_session_actions(),
+        message_count=message_count,
+        tags=tuple(summary.tags),
+        summary=summary.summary,
+        words=word_count,
+        repo=repo or _session_repo(summary),
+        cwd_display=cwd_display or _session_cwd(summary),
+        flags=flags,
+    )
+    return SessionListEnvelope(**values)
+
+
+# Compatibility names retain the existing Python imports and generated wire
+# names while the implementations above are derived projections, not field
+# twins with hand-written constructors.
+SessionMessagePayload = MessageRenderEnvelope
+SessionMessageRowPayload = MessageRowEnvelope
+SessionSummaryPayload = SessionSummaryEnvelope
+SessionDetailPayload = SessionDetailEnvelope
+SessionListRowPayload = SessionListEnvelope
 
 
 class SessionSearchMatchPayload(SurfacePayloadModel):
@@ -1134,7 +1329,7 @@ class SessionSearchHitPayload(SurfacePayloadModel):
             anchor = reader_anchor("session", hit.session_id)
             actions = reader_session_actions()
         return cls(
-            session=SessionSummaryPayload.from_summary(
+            session=session_summary_envelope_from_summary(
                 hit.summary,
                 message_count=message_count if message_count is not None else hit.summary.message_count,
             ),
@@ -1192,7 +1387,7 @@ class SessionNeighborCandidatePayload(SurfacePayloadModel):
         candidate: SessionNeighborCandidate,
     ) -> SessionNeighborCandidatePayload:
         return cls(
-            session=SessionSummaryPayload.from_summary(
+            session=session_summary_envelope_from_summary(
                 candidate.summary,
                 message_count=candidate.summary.message_count,
             ),
@@ -3335,7 +3530,7 @@ def _cursor_strictly_before(cursor: SearchCursor, hit: SessionSearchHitPayload) 
     # Same score (or no score on one side) — use rank, then conv id.
     if hit.match.rank != cursor.r:
         return hit.match.rank > cursor.r
-    return hit.session.id > cursor.c
+    return bool(hit.session.id > cursor.c)
 
 
 def build_search_envelope(
@@ -3921,6 +4116,7 @@ __all__ = [
     "SessionMessageRowPayload",
     "SessionMessagesResponsePayload",
     "SessionMessagePayload",
+    "MessageRenderEnvelope",
     "ContextPreamble",
     "ContextPreambleBlackboardNote",
     "ContextPreambleIssue",
@@ -3935,6 +4131,15 @@ __all__ = [
     "SessionSearchMatchPayload",
     "SessionReadViewEnvelope",
     "SessionSummaryPayload",
+    "SessionSummaryEnvelope",
+    "message_render_envelope_from_archive_row",
+    "message_render_envelope_from_domain",
+    "message_row_envelope_from_domain",
+    "session_detail_envelope_from_domain",
+    "session_list_envelope_from_domain",
+    "session_list_envelope_from_summary",
+    "session_summary_envelope_from_domain",
+    "session_summary_envelope_from_summary",
     "FacetBucketsPayload",
     "FacetTimeRange",
     "FacetFamilyStatusPayload",

--- a/tests/unit/cli/test_query_fmt.py
+++ b/tests/unit/cli/test_query_fmt.py
@@ -344,7 +344,7 @@ class TestSessionFormatting:
         """polylogue-x7d PR #3420 follow-up (caught by review before merge):
 
         ``_conv_to_json``/``_conv_to_yaml`` build their top-level document
-        via ``_conv_to_dict`` -> ``SessionListRowPayload.from_session``, the
+        via ``_conv_to_dict`` -> ``session_list_envelope_from_domain``, the
         same constructor list contexts use. A single-session ``find ...
         then read --format json/yaml`` must stay lossless -- it must NOT
         inherit the 96-char list-row title budget, unlike genuine list

--- a/tests/unit/storage/test_title_ref_confidence_queryable.py
+++ b/tests/unit/storage/test_title_ref_confidence_queryable.py
@@ -113,7 +113,7 @@ def test_session_list_row_payload_carries_title_ref_confidence() -> None:
     from polylogue.archive.session.domain_models import Session
     from polylogue.core.enums import Origin
     from polylogue.core.types import SessionId
-    from polylogue.surfaces.payloads import SessionListRowPayload, SessionSummaryPayload
+    from polylogue.surfaces.payloads import session_list_envelope_from_domain, session_summary_envelope_from_domain
 
     session = Session(
         id=SessionId("codex-session:codex-tr-4"),
@@ -124,10 +124,10 @@ def test_session_list_row_payload_carries_title_ref_confidence() -> None:
         title_confidence=0.5,
         messages=MessageCollection(messages=[]),
     )
-    row = SessionListRowPayload.from_session(session)
+    row = session_list_envelope_from_domain(session)
     assert row.title_ref == "message:codex-session:codex-tr-4:m1"
     assert row.title_confidence == pytest.approx(0.5)
-    summary_payload = SessionSummaryPayload.from_session(session)
+    summary_payload = session_summary_envelope_from_domain(session)
     assert summary_payload.title_ref == "message:codex-session:codex-tr-4:m1"
     assert summary_payload.title_confidence == pytest.approx(0.5)
 

--- a/tests/unit/storage/test_title_source_queryable.py
+++ b/tests/unit/storage/test_title_source_queryable.py
@@ -205,7 +205,7 @@ def test_session_list_row_payload_carries_title_source() -> None:
     from polylogue.archive.session.domain_models import Session
     from polylogue.core.enums import Origin
     from polylogue.core.types import SessionId
-    from polylogue.surfaces.payloads import SessionListRowPayload, SessionSummaryPayload
+    from polylogue.surfaces.payloads import session_list_envelope_from_domain, session_summary_envelope_from_domain
 
     session = Session(
         id=SessionId("codex-session:codex-ts-4"),
@@ -214,7 +214,7 @@ def test_session_list_row_payload_carries_title_source() -> None:
         title_source=TitleSource.HEURISTIC,
         messages=MessageCollection(messages=[]),
     )
-    row = SessionListRowPayload.from_session(session)
+    row = session_list_envelope_from_domain(session)
     assert row.title_source == "heuristic"
-    summary_payload = SessionSummaryPayload.from_session(session)
+    summary_payload = session_summary_envelope_from_domain(session)
     assert summary_payload.title_source == "heuristic"

--- a/tests/unit/surfaces/test_message_render_envelope.py
+++ b/tests/unit/surfaces/test_message_render_envelope.py
@@ -6,7 +6,7 @@ contract enumerates which fields must be present (with their defaults)
 and asserts that a roundtrip through ``Message`` populates every typed
 slot from the canonical Message model.
 
-If a new field is added to ``SessionMessagePayload``, this test
+If a new field is added to the canonical ``Message`` model, this test
 must learn about it (the field list is exhaustively checked). That
 prevents the divergence the issue worried about — detail emitting one
 field set, paginated emitting another.
@@ -28,43 +28,12 @@ from polylogue.core.types import ContentHash, MessageId, SessionId
 from polylogue.storage.hydrators import message_from_record
 from polylogue.storage.runtime.archive.records import BlockRecord, MessageRecord
 from polylogue.surfaces.payloads import (
+    _MESSAGE_MASK,
+    MessageRenderEnvelope,
     ReaderActionAvailabilityPayload,
-    SessionMessagePayload,
     TargetRefPayload,
-)
-
-# The canonical envelope field set. Adding a new field to
-# ``SessionMessagePayload`` requires extending this list — that's
-# the point: the contract should know about every emitted field so
-# downstream surfaces never silently drop one.
-_ENVELOPE_FIELDS: tuple[str, ...] = (
-    "id",
-    "role",
-    "text",
-    "target_ref",
-    "anchor",
-    "actions",
-    "timestamp",
-    "message_type",
-    "material_origin",
-    "content_blocks",
-    "parent_id",
-    "branch_index",
-    "position",
-    "is_active_path",
-    "is_active_leaf",
-    "has_paste_evidence",
-    "paste_boundary_state",
-    "has_tool_use",
-    "has_thinking",
-    "input_tokens",
-    "output_tokens",
-    "cache_read_tokens",
-    "cache_write_tokens",
-    "model_name",
-    "attachment_refs",
-    "raw_id",
-    "source_path",
+    message_render_envelope_from_archive_row,
+    message_render_envelope_from_domain,
 )
 
 
@@ -96,23 +65,54 @@ def _build_message(**overrides: object) -> Message:
 
 
 def test_envelope_field_set_is_exhaustive() -> None:
-    """``SessionMessagePayload`` field set matches the canonical envelope.
+    """The derived envelope contains the mask plus computed affordances.
 
     The contract is exact equality — extra fields would silently widen
     the surface; missing fields would silently drop one. Either case
-    requires updating ``_ENVELOPE_FIELDS`` deliberately.
+    requires updating the domain mask deliberately.
     """
-    assert set(SessionMessagePayload.model_fields) == set(_ENVELOPE_FIELDS), (
-        "SessionMessagePayload field set drifted from the canonical envelope. "
-        "Update tests/unit/surfaces/test_message_render_envelope.py:_ENVELOPE_FIELDS "
-        "to match, and verify the detail and paginated message endpoints both emit "
-        "the new field."
+    expected = {surface_name for _, surface_name in _MESSAGE_MASK} | {
+        "target_ref",
+        "anchor",
+        "actions",
+        "attachment_refs",
+        "raw_id",
+        "source_path",
+    }
+    assert set(MessageRenderEnvelope.model_fields) == expected, (
+        "MessageRenderEnvelope drifted from the domain mask and affordance set. "
+        "Update the mask only when the canonical Message model grows."
     )
+
+
+def test_domain_roundtrip_populates_every_masked_message_field() -> None:
+    message = _build_message(
+        role=Role.ASSISTANT,
+        text="answer",
+        duration_ms=1234,
+        stop_reason="max_tokens",
+        has_paste=True,
+    )
+    payload = message_render_envelope_from_domain(message, session_id="c1")
+    dumped = message.model_dump(mode="python")
+
+    for domain_name, surface_name in _MESSAGE_MASK:
+        expected = dumped[domain_name]
+        if domain_name in {"role", "message_type", "material_origin"}:
+            expected = expected.value
+        elif domain_name == "text":
+            expected = expected or ""
+        elif domain_name == "has_paste":
+            expected = bool(expected)
+        assert getattr(payload, surface_name) == expected, surface_name
+
+    assert payload.duration_ms == 1234
+    assert payload.stop_reason == "max_tokens"
 
 
 def test_envelope_minimal_construction_uses_default_envelope_fields() -> None:
     """The minimum required kwargs are id/role/text; everything else has a default."""
-    payload = SessionMessagePayload(id="m1", role="user", text="hi")
+    payload = MessageRenderEnvelope(id="m1", role="user", text="hi")
 
     assert payload.target_ref is None
     assert payload.anchor is None
@@ -137,38 +137,38 @@ def test_envelope_minimal_construction_uses_default_envelope_fields() -> None:
 
 
 # ---------------------------------------------------------------------------
-# from_message: every typed slot populated from the canonical Message model
+# Domain projection: every typed slot populated from the canonical Message model
 # ---------------------------------------------------------------------------
 
 
-def test_from_message_propagates_branch_lineage_state() -> None:
+def test_message_envelope_propagates_branch_lineage_state() -> None:
     msg = _build_message(branch_index=3, parent_id="m-parent")
-    payload = SessionMessagePayload.from_message(msg, session_id="c1")
+    payload = message_render_envelope_from_domain(msg, session_id="c1")
     assert payload.branch_index == 3
     assert payload.parent_id == "m-parent"
 
 
-def test_from_message_propagates_position_and_active_path_state() -> None:
+def test_message_envelope_propagates_position_and_active_path_state() -> None:
     """polylogue-ksgg: position/is_active_path/is_active_leaf must survive
     the read surface so branch/thread structure can be reconstructed
     without direct SQL."""
     msg = _build_message(position=7, is_active_path=True, is_active_leaf=True)
-    payload = SessionMessagePayload.from_message(msg, session_id="c1")
+    payload = message_render_envelope_from_domain(msg, session_id="c1")
     assert payload.position == 7
     assert payload.is_active_path is True
     assert payload.is_active_leaf is True
 
 
-def test_from_message_preserves_unknown_active_path() -> None:
+def test_message_envelope_preserves_unknown_active_path() -> None:
     """``is_active_path=None`` (unknown) must not collapse to False."""
     msg = _build_message(is_active_path=None)
-    payload = SessionMessagePayload.from_message(msg, session_id="c1")
+    payload = message_render_envelope_from_domain(msg, session_id="c1")
     assert payload.is_active_path is None
 
 
 def test_from_archive_row_propagates_position_and_active_path_state() -> None:
     # Note: MessageRecord's sibling-order field is named ``branch_index``
-    # while ``from_archive_row`` reads the real ArchiveMessageRow's
+    # while the archive-row projection reads the real ArchiveMessageRow's
     # ``variant_index`` attribute -- a pre-existing naming mismatch that
     # means MessageRecord-as-stand-in only exercises the fields whose
     # attribute names agree (position/is_active_path/is_active_leaf).
@@ -182,20 +182,20 @@ def test_from_archive_row_propagates_position_and_active_path_state() -> None:
         position=5,
         is_active_leaf=True,
     )
-    payload = SessionMessagePayload.from_archive_row(row, session_id="c1")
+    payload = message_render_envelope_from_archive_row(row, session_id="c1")
     assert payload.position == 5
     assert payload.is_active_path is True
     assert payload.is_active_leaf is True
 
 
-def test_from_message_propagates_content_flags() -> None:
+def test_message_envelope_propagates_content_flags() -> None:
     msg = _build_message(
         has_paste=True,
         paste_boundary_state="projected",
         has_tool_use=True,
         has_thinking=True,
     )
-    payload = SessionMessagePayload.from_message(msg, session_id="c1")
+    payload = message_render_envelope_from_domain(msg, session_id="c1")
     assert payload.has_paste_evidence is True
     assert payload.paste_boundary_state == "projected"
     assert payload.has_tool_use is True
@@ -224,7 +224,7 @@ def test_from_archive_row_propagates_paste_boundary_state() -> None:
         paste_boundary_state="projected",
     )
 
-    payload = SessionMessagePayload.from_archive_row(row, session_id="c1")
+    payload = message_render_envelope_from_archive_row(row, session_id="c1")
 
     assert payload.has_paste_evidence is True
     assert payload.paste_boundary_state == "projected"
@@ -253,13 +253,13 @@ def test_hydrated_message_envelope_preserves_paste_boundary_state() -> None:
     )
 
     message = message_from_record(record, [])
-    payload = SessionMessagePayload.from_message(message, session_id="c1")
+    payload = message_render_envelope_from_domain(message, session_id="c1")
 
     assert payload.has_paste_evidence is True
     assert payload.paste_boundary_state == "whole_message_fallback"
 
 
-def test_from_message_propagates_usage_and_model() -> None:
+def test_message_envelope_propagates_usage_and_model() -> None:
     msg = _build_message(
         input_tokens=10,
         output_tokens=20,
@@ -267,7 +267,7 @@ def test_from_message_propagates_usage_and_model() -> None:
         cache_write_tokens=2,
         model_name="claude-sonnet-4-6",
     )
-    payload = SessionMessagePayload.from_message(msg, session_id="c1")
+    payload = message_render_envelope_from_domain(msg, session_id="c1")
     assert payload.input_tokens == 10
     assert payload.output_tokens == 20
     assert payload.cache_read_tokens == 5
@@ -275,11 +275,11 @@ def test_from_message_propagates_usage_and_model() -> None:
     assert payload.model_name == "claude-sonnet-4-6"
 
 
-def test_from_message_carries_explicit_raw_and_source_refs() -> None:
+def test_message_envelope_carries_explicit_raw_and_source_refs() -> None:
     """``raw_id``/``source_path`` are caller-supplied because they live on
     the session, not the message."""
     msg = _build_message()
-    payload = SessionMessagePayload.from_message(
+    payload = message_render_envelope_from_domain(
         msg,
         session_id="c1",
         raw_id="raw-sha256-abc",
@@ -289,17 +289,17 @@ def test_from_message_carries_explicit_raw_and_source_refs() -> None:
     assert payload.source_path == "/home/user/.claude/projects/p/c1.jsonl"
 
 
-def test_from_message_carries_target_ref_when_session_id_supplied() -> None:
+def test_message_envelope_carries_target_ref_when_session_id_supplied() -> None:
     msg = _build_message()
-    payload = SessionMessagePayload.from_message(msg, session_id="c1")
+    payload = message_render_envelope_from_domain(msg, session_id="c1")
     assert payload.target_ref == TargetRefPayload.message(session_id="c1", message_id="m1")
     assert payload.anchor == "message-m1"
 
 
-def test_from_message_omits_target_ref_when_no_session_id() -> None:
+def test_message_envelope_omits_target_ref_when_no_session_id() -> None:
     """Without ``session_id`` the message can't be deep-linked."""
     msg = _build_message()
-    payload = SessionMessagePayload.from_message(msg)
+    payload = message_render_envelope_from_domain(msg)
     assert payload.target_ref is None
     # Anchor stays present because it only needs the message id.
     assert payload.anchor == "message-m1"
@@ -311,7 +311,7 @@ def test_from_message_omits_target_ref_when_no_session_id() -> None:
 
 
 def test_minimal_message_payload_constructs() -> None:
-    payload = SessionMessagePayload(
+    payload = MessageRenderEnvelope(
         id="m-c1",
         role="user",
         text="Hello reader",
@@ -334,7 +334,7 @@ def test_minimal_payload_serializes_compactly_with_exclude_none() -> None:
     crowding the JSON. Defaults that are False/0/() must still appear so
     the contract is observable; only the optional ``None`` defaults are
     omitted under ``exclude_none``."""
-    payload = SessionMessagePayload(id="m1", role="user", text="hi")
+    payload = MessageRenderEnvelope(id="m1", role="user", text="hi")
     blob = json.loads(payload.to_json(exclude_none=True))
 
     # Required: typed envelope fields are observable (the test would
@@ -363,7 +363,7 @@ def test_minimal_payload_serializes_compactly_with_exclude_none() -> None:
 def test_envelope_rejects_unknown_fields() -> None:
     """``extra="forbid"`` on SurfacePayloadModel keeps the contract closed."""
     with pytest.raises(ValidationError):
-        SessionMessagePayload(  # type: ignore[call-arg]
+        MessageRenderEnvelope(
             id="m1",
             role="user",
             text="hi",

--- a/tests/unit/surfaces/test_session_envelope_derivation.py
+++ b/tests/unit/surfaces/test_session_envelope_derivation.py
@@ -1,0 +1,85 @@
+"""Round-trip laws for domain-derived session surface envelopes."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from polylogue.archive.message.messages import MessageCollection
+from polylogue.archive.message.models import Message
+from polylogue.archive.message.roles import Role
+from polylogue.archive.session.domain_models import Session
+from polylogue.core.enums import Origin, TitleSource
+from polylogue.core.types import SessionId
+from polylogue.surfaces.payloads import (
+    _SESSION_LIST_MASK,
+    _SESSION_SUMMARY_MASK,
+    SessionDetailEnvelope,
+    SessionListEnvelope,
+    SessionSummaryEnvelope,
+    session_detail_envelope_from_domain,
+    session_list_envelope_from_domain,
+    session_summary_envelope_from_domain,
+)
+
+
+def _build_session() -> Session:
+    message = Message(
+        id="m1",
+        role=Role.USER,
+        text="hello",
+        timestamp=datetime(2026, 5, 27, 10, 0, tzinfo=UTC),
+        duration_ms=17,
+        stop_reason="end_turn",
+    )
+    return Session(
+        id=SessionId("codex-session:c1"),
+        origin=Origin.CODEX_SESSION,
+        title="A canonical session",
+        title_source=TitleSource.HEURISTIC,
+        messages=MessageCollection(messages=[message]),
+    )
+
+
+def test_session_envelopes_are_pydantic_models_with_compatible_wire_fields() -> None:
+    session = _build_session()
+    summary = session_summary_envelope_from_domain(session)
+    detail = session_detail_envelope_from_domain(session)
+    row = session_list_envelope_from_domain(session)
+
+    assert isinstance(summary, SessionSummaryEnvelope)
+    assert isinstance(detail, SessionDetailEnvelope)
+    assert isinstance(row, SessionListEnvelope)
+    assert summary.model_dump(mode="json")["origin"] == "codex-session"
+    assert detail.messages[0].duration_ms == 17
+    assert detail.messages[0].stop_reason == "end_turn"
+    assert row.selected({"id", "title"}) == {"id": "codex-session:c1", "title": "A canonical session"}
+
+
+def test_session_masks_cover_the_domain_fields_used_by_each_surface() -> None:
+    session = _build_session()
+    dumped = session.model_dump(mode="python")
+    summary = session_summary_envelope_from_domain(session)
+    row = session_list_envelope_from_domain(session)
+
+    for domain_name, surface_name in _SESSION_SUMMARY_MASK:
+        if domain_name == "message_count":
+            assert summary.message_count == len(session.messages)
+        else:
+            expected = dumped[domain_name]
+            if domain_name == "origin":
+                expected = expected.value
+            elif domain_name == "title_source":
+                expected = expected.value if expected else None
+            assert getattr(summary, surface_name) == expected
+
+    for domain_name, surface_name in _SESSION_LIST_MASK:
+        if domain_name == "title":
+            continue
+        expected = dumped[domain_name]
+        if domain_name == "origin":
+            expected = expected.value
+        elif domain_name in {"created_at", "updated_at"}:
+            expected = expected.isoformat() if expected else None
+        elif domain_name == "title_source":
+            expected = expected.value if expected else None
+        assert getattr(row, surface_name) == expected

--- a/webui/src/api/generated.ts
+++ b/webui/src/api/generated.ts
@@ -597,17 +597,7 @@ export type SessionFlagsPayload = {
   readonly has_tool_use?: boolean;
 };
 
-export type SessionListResponse = {
-  readonly diagnostics?: QueryMissDiagnosticsPayload | null;
-  readonly items: ReadonlyArray<SessionListRowPayload>;
-  readonly limit: number;
-  readonly offset: number;
-  readonly query_description?: ReadonlyArray<string>;
-  readonly route_state?: RouteReadinessPayload | null;
-  readonly total: number;
-};
-
-export type SessionListRowPayload = {
+export type SessionListEnvelope = {
   readonly actions?: {
   readonly [key: string]: ReaderActionAvailabilityPayload;
 };
@@ -625,12 +615,22 @@ export type SessionListRowPayload = {
   readonly summary?: string | null;
   readonly tags?: ReadonlyArray<string>;
   readonly target_ref?: TargetRefPayload | null;
-  readonly title: string;
+  readonly title?: string;
   readonly title_confidence?: number | null;
   readonly title_ref?: string | null;
   readonly title_source?: string | null;
   readonly updated_at?: string | null;
   readonly words?: number | null;
+};
+
+export type SessionListResponse = {
+  readonly diagnostics?: QueryMissDiagnosticsPayload | null;
+  readonly items: ReadonlyArray<SessionListEnvelope>;
+  readonly limit: number;
+  readonly offset: number;
+  readonly query_description?: ReadonlyArray<string>;
+  readonly route_state?: RouteReadinessPayload | null;
+  readonly total: number;
 };
 
 export type SessionReadViewEnvelope = {
@@ -652,7 +652,7 @@ export type SessionReadViewEnvelope = {
 
 export type SessionSearchHitPayload = {
   readonly match: SessionSearchMatchPayload;
-  readonly session: SessionSummaryPayload;
+  readonly session: SessionSummaryEnvelope;
 };
 
 export type SessionSearchMatchPayload = {
@@ -677,17 +677,17 @@ export type SessionSearchMatchPayload = {
   readonly target_ref?: TargetRefPayload | null;
 };
 
-export type SessionSummaryPayload = {
+export type SessionSummaryEnvelope = {
   readonly actions?: {
   readonly [key: string]: ReaderActionAvailabilityPayload;
 };
   readonly anchor?: string | null;
   readonly created_at?: string | null;
   readonly id: string;
-  readonly message_count: number;
+  readonly message_count?: number | null;
   readonly origin: string;
   readonly target_ref?: TargetRefPayload | null;
-  readonly title: string;
+  readonly title?: string;
   readonly title_confidence?: number | null;
   readonly title_ref?: string | null;
   readonly title_source?: string | null;


### PR DESCRIPTION
## Summary
Phase 1 derives the message and session surface envelopes from the canonical archive domain models. Existing public JSON keys and field order are preserved, with the required message stop_reason and duration_ms fields now reaching the reader surfaces.

## Problem
The phase 1 payloads duplicated fields already declared by Message, Session, and SessionSummary. Hand-written constructors spread mapping logic across payload classes and left production routes dependent on payload-specific constructors. The message surface also omitted domain fields that are needed for complete reader evidence.

## Solution
Added masked projection models and canonical factories in polylogue/surfaces/payloads.py. The factories preserve role and enum string conversion, has_paste_evidence and content_blocks wire names, computed affordances, attachment references, and caller-supplied provenance. Migrated CLI, MCP, API, rendering, self-verify, storage, and direct tests to those factories. Existing Python payload names remain compatibility aliases to the derived models. Regenerated the affected CLI docs, schemas, OpenAPI document, and web client types.

Phase 2 insight payload cleanup and the unrelated row-informativeness work tracked by x7d are intentionally outside this change.

## Verification
Focused real-route checks after rebase:

```text
python -m devtools test tests/unit/surfaces/test_message_render_envelope.py tests/unit/surfaces/test_session_envelope_derivation.py tests/unit/cli/test_messages.py tests/unit/devtools/test_self_verify.py tests/unit/archive/query/test_discovery.py tests/unit/storage/test_title_source_queryable.py tests/unit/storage/test_title_ref_confidence_queryable.py tests/unit/mcp/test_archive_support_miss_predicates.py tests/unit/mcp/test_bounded_query_transport.py
182 passed in 3.25s
```

The exact static sweep found no phase 1 payload twins, removed from_* constructors, or removed phase 1 constructor call sites. `python -m devtools verify --quick` passed all 21 steps after rebase, including mypy, render all, layering, schema roundtrip, and policy checks.

The pre-PR `python -m devtools verify` affected-test path could not run because its required testmon seed was unavailable. A seed attempt exercised 18,862 tests and recorded 18,836 passes, 3 skips, and 23 failures. The failures were unrelated timing, fixture, watcher, and existing baseline tests. The seed was therefore correctly rejected as incomplete.

Anti-vacuity: the focused tests exercise the production CLI message route, self-verify snapshot route, MCP archive message route, TUI and search session projections, and storage-backed title projections. Removing the domain-derived masks or any migrated factory call would either drop the asserted canonical fields and affordances or make those production routes fail validation and the focused tests fail.

Ref polylogue-4p1.4
