### PR TITLE
feat(storage): add raw-admission chokepoint mechanism + atomic-read contract

### DIFF
--- a/polylogue/pipeline/services/archive_ingest.py
+++ b/polylogue/pipeline/services/archive_ingest.py
@@ -398,12 +398,18 @@ def _admit_non_session_origin_artifacts(
             if classification is None or classification.parse_as_session:
                 continue
             try:
-                archive.write_raw_payload(
+                # polylogue-1fijp arm 4: route through the raw-admission
+                # chokepoint so this configured fact artifact gets its
+                # raw_artifacts classification row immediately, instead of
+                # only a bare raw_sessions row waiting on the next offline
+                # materialize_artifact_observations sweep.
+                archive.admit_raw_artifact_payload(
                     provider=Provider.CLAUDE_CODE,
                     payload=Path(candidate).read_bytes(),
                     source_path=str(candidate),
                     source_index=0,
                     acquired_at_ms=acquired_at_ms,
+                    classification=classification,
                 )
                 admitted += 1
             except Exception:

--- a/polylogue/sources/atomic_read.py
+++ b/polylogue/sources/atomic_read.py
@@ -1,0 +1,127 @@
+"""Atomic-read contract for acquiring bytes from a source file.
+
+polylogue-1fijp / polylogue-2t0vp: a live source file can be mid-rewrite when
+an acquisition pass opens it -- a provider CLI truncating and rewriting a
+session log in place, a sync client replacing a Drive cache file, etc. A
+naive ``path.read_bytes()`` can observe a torn snapshot: some bytes from the
+old generation, some from the new, with no error raised. Live evidence of
+this shape: a Codex rollout file recaptured 15-16x with ``blob_size`` growing
+then suddenly dropping from 427MB to 10KB in one read.
+
+The contract: capture ``(size, mtime_ns)`` before reading, read to EOF, then
+re-stat. If the post-read stat disagrees with the pre-read stat, the read
+raced a concurrent writer and the bytes are unsafe to persist -- retry a
+bounded number of times. If the file is still unstable (or vanishes) after
+every retry, raise :class:`TornReadError` rather than ever returning partial
+or torn bytes. Callers that want a non-raising "best effort" read use
+:func:`try_read_source_bytes_atomic`, which turns the same failure into
+``None``.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class AtomicReadResult:
+    """A payload whose bytes are proven stable across the read window."""
+
+    payload: bytes
+    size: int
+    mtime_ns: int
+
+
+class TornReadError(RuntimeError):
+    """Raised when a source file never stabilized across every retry.
+
+    Distinct from a plain ``OSError``/``FileNotFoundError`` propagating from
+    the final attempt (a genuinely vanished/unreadable source) -- this is
+    raised specifically when reads kept succeeding but disagreed with each
+    other, which is the concurrent-rewrite shape this contract exists to
+    catch. ``attempts`` is always ``>= 1``.
+    """
+
+    def __init__(self, *, path: str, attempts: int, reason: str) -> None:
+        self.path = path
+        self.attempts = attempts
+        self.reason = reason
+        super().__init__(f"torn read at {path!r} after {attempts} attempt(s): {reason}")
+
+
+def _stat_identity(path: Path) -> tuple[int, int]:
+    stat_result = path.stat()
+    return stat_result.st_size, stat_result.st_mtime_ns
+
+
+def read_source_bytes_atomic(
+    path: Path | str,
+    *,
+    max_retries: int = 3,
+    retry_delay_s: float = 0.05,
+) -> AtomicReadResult:
+    """Read ``path`` and prove the bytes were not observed mid-rewrite.
+
+    Raises :class:`TornReadError` if the file's ``(size, mtime_ns)`` identity
+    never stabilizes across ``max_retries + 1`` attempts. Any read attempt
+    that hits a genuine OS error (file vanished, permission denied) on its
+    *final* attempt propagates that error directly rather than being wrapped
+    -- only "kept changing under us" is reported as a torn read.
+
+    ``max_retries`` must be ``>= 0`` (0 means a single attempt, no retry).
+    """
+    if max_retries < 0:
+        raise ValueError("max_retries must be non-negative")
+    resolved_path = Path(path)
+    last_reason = "file identity never observed"
+    for attempt in range(max_retries + 1):
+        is_final_attempt = attempt == max_retries
+        try:
+            before_size, before_mtime_ns = _stat_identity(resolved_path)
+            payload = resolved_path.read_bytes()
+            after_size, after_mtime_ns = _stat_identity(resolved_path)
+        except OSError:
+            if is_final_attempt:
+                raise
+            last_reason = "source became unreadable mid-read"
+            time.sleep(retry_delay_s)
+            continue
+        if before_size == after_size and before_mtime_ns == after_mtime_ns and len(payload) == before_size:
+            return AtomicReadResult(payload=payload, size=after_size, mtime_ns=after_mtime_ns)
+        last_reason = (
+            f"pre-read stat (size={before_size}, mtime_ns={before_mtime_ns}) disagreed with "
+            f"post-read stat (size={after_size}, mtime_ns={after_mtime_ns}, read_len={len(payload)})"
+        )
+        if is_final_attempt:
+            break
+        time.sleep(retry_delay_s)
+    raise TornReadError(path=str(resolved_path), attempts=max_retries + 1, reason=last_reason)
+
+
+def try_read_source_bytes_atomic(
+    path: Path | str,
+    *,
+    max_retries: int = 3,
+    retry_delay_s: float = 0.05,
+) -> AtomicReadResult | None:
+    """Non-raising variant of :func:`read_source_bytes_atomic`.
+
+    Returns ``None`` on a torn read or any OS-level read failure (vanished
+    file, permission error) instead of raising -- for callers in the
+    opportunistic re-acquire arm (polylogue-1fijp arm 5) that must fall
+    through to a typed refusal rather than propagate an exception.
+    """
+    try:
+        return read_source_bytes_atomic(path, max_retries=max_retries, retry_delay_s=retry_delay_s)
+    except (TornReadError, OSError):
+        return None
+
+
+__all__ = [
+    "AtomicReadResult",
+    "TornReadError",
+    "read_source_bytes_atomic",
+    "try_read_source_bytes_atomic",
+]

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -27,6 +27,7 @@ from typing import Any, BinaryIO, Literal, TypedDict, cast
 from polylogue.annotations.batch import AnnotationBatch
 from polylogue.annotations.schema import AnnotationSchema
 from polylogue.archive.actions.followup import ACKNOWLEDGMENT_MARKERS
+from polylogue.archive.artifact_taxonomy import ArtifactClassification
 from polylogue.archive.query.metadata import COUNT_QUERY_FIELD_REGISTRY, NUMERIC_QUERY_FIELD_REGISTRY
 from polylogue.archive.query.path_prefix import escaped_sql_path_prefix_patterns
 from polylogue.archive.query.predicate import (
@@ -153,6 +154,7 @@ from polylogue.storage.sqlite.archive_tiers.bootstrap import (
     initialize_active_archive_root,
     initialize_archive_database,
 )
+from polylogue.storage.sqlite.archive_tiers.raw_admission import RawAdmissionResult
 from polylogue.storage.sqlite.archive_tiers.revision_application import (
     FullSnapshotFoldAuthorization,
 )
@@ -172,6 +174,7 @@ from polylogue.storage.sqlite.archive_tiers.revision_governance import (
     _raw_revision_payload_digest_and_size,
     _raw_revision_source_path_has_divergent_evidence,
     _write_parsed_precedence_result,
+    admit_raw_artifact_payload,
     apply_raw_membership_classification,
     apply_raw_revision_replay,
     bind_raw_revision,
@@ -2108,6 +2111,32 @@ class ArchiveStore:
             raw_id=raw_id,
             blob_publication_receipt_id=blob_publication_receipt_id,
             revision=revision,
+        )
+
+    def admit_raw_artifact_payload(
+        self,
+        *,
+        provider: Provider,
+        payload: bytes,
+        source_path: str,
+        acquired_at_ms: int,
+        classification: ArtifactClassification,
+        source_index: int = 0,
+        blob_publication_receipt_id: str | None = None,
+    ) -> RawAdmissionResult:
+        """Route a non-conversational artifact payload through the raw-admission chokepoint.
+
+        See :func:`polylogue.storage.sqlite.archive_tiers.revision_governance.admit_raw_artifact_payload`.
+        """
+        return admit_raw_artifact_payload(
+            self,
+            provider=provider,
+            payload=payload,
+            source_path=source_path,
+            acquired_at_ms=acquired_at_ms,
+            classification=classification,
+            source_index=source_index,
+            blob_publication_receipt_id=blob_publication_receipt_id,
         )
 
     def write_parsed_for_retained_raw(

--- a/polylogue/storage/sqlite/archive_tiers/raw_admission.py
+++ b/polylogue/storage/sqlite/archive_tiers/raw_admission.py
@@ -1,0 +1,403 @@
+"""Raw-admission chokepoint: the single typed decision point for ``raw_sessions`` writes.
+
+polylogue-1fijp (aggz Invariant 2): :func:`admit_raw_observation` is designed
+to become the sole creator of ``raw_sessions`` rows, mirroring
+``write.py``'s ``write_parsed_session_to_archive`` on the index side. Given
+freshly (and atomically -- see :mod:`polylogue.sources.atomic_read`) read
+bytes, origin evidence, and the prior accepted head for the payload's
+logical source key, it resolves exactly one of five typed, exhaustive arms
+-- there is no nullable "unknown, figure it out later" limbo:
+
+1. ``SKIP_DUPLICATE`` -- the bytes are byte-equal to the accepted head.
+   Nothing new to record; the caller gets the existing raw_id back.
+2. ``APPEND`` -- the bytes extend the accepted head as a strict byte-prefix
+   (the common case for tailed logs). Recorded as ``revision_kind=append``
+   with a real ``predecessor_raw_id``.
+3. ``SUPERSEDE`` -- the incoming bytes are themselves a strict byte-prefix
+   of the accepted head. This is the reverse of (2): the newly acquired
+   read is a proven-dominated, strictly older/shorter state than what is
+   already on record (e.g. a source file briefly reverted, or this read
+   raced a rewrite and caught an earlier generation than a sibling read
+   already captured). It is recorded as a ``FULL`` revision with
+   ``authority=BYTE_PROVEN`` and ``predecessor_raw_id`` pointing at the
+   fuller head it is provably subsumed by -- a *proven* relationship, not
+   a guess, so it does not go through arm 5's ambiguity handling.
+
+   NOTE ON INTERPRETATION: the bead text describing this arm ("head is
+   byte-prefix of prior full -> supersede") admits more than one reading.
+   This module's interpretation -- new-shorter-bytes proven subsumed by an
+   already-accepted fuller head -- is the one implemented and tested here.
+   It has not been independently confirmed against operator intent beyond
+   the bead text itself; flag for confirmation before treating this arm's
+   exact semantics as load-bearing for anything beyond "don't silently
+   regress the head".
+4. ``ARTIFACT`` -- the payload is not conversational content (the omsw
+   artifact taxonomy's ``ArtifactClassification.parse_as_session is
+   False``: tool-results/*.json, subagents/workflows/*/journal.jsonl,
+   file-history-snapshot, etc). A ``raw_sessions`` row is still written
+   (it remains the acquisition-evidence ledger for every observed byte,
+   session or not -- ``raw_artifacts.raw_id`` has a ``NOT NULL REFERENCES
+   raw_sessions`` foreign key, so an artifact row cannot exist without
+   one), but its classification is attached immediately as a
+   ``raw_artifacts`` row using the SAME deterministic
+   ``artifact_observation_id`` scheme the offline
+   ``materialize_artifact_observations`` sweep uses, so a later sweep
+   upserts onto the same row rather than colliding. The one guarantee
+   this arm gives is the one arm 4 names: this bytes-classified-as-
+   non-conversational content structurally never reaches any code path
+   that could create an ``index.db`` ``sessions`` row -- this module has
+   no import of any index-tier writer.
+5. ``REFUSED_AMBIGUOUS`` -- neither equal, a forward extension, nor a
+   backward prefix. Per the operator's 2026-08-03 correction on the bead,
+   re-acquisition here is OPPORTUNISTIC, never doctrinal: if a caller
+   supplies a ``reacquire`` callback, it is invoked at most once and, if it
+   returns bytes that resolve one of arms 1-3, that outcome wins. If the
+   source is absent/unreadable (callback returns ``None``) or the
+   re-attempt is itself still ambiguous, this falls through to a typed
+   refusal row (``revision_kind=unknown``, ``revision_authority=
+   quarantined``) carrying a machine-readable reason -- never a silent
+   drop, and never a decision that depends on the source file continuing
+   to exist.
+
+The bootstrap case -- no prior head at all for this logical source key --
+is not one of the five named arms (all five presuppose a prior head to
+compare against); it is handled as a distinct ``BASELINE`` outcome: the
+first-ever observation is recorded as a ``FULL``/``ASSERTED`` revision.
+
+This module composes the existing low-level writers in
+``source_write.py`` (``write_source_raw_session``,
+``deterministic_blob_hash``) rather than re-implementing raw-row
+persistence -- it decides *which* revision envelope to write, not how to
+write it.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Literal
+
+from polylogue.archive.artifact_taxonomy import ArtifactClassification
+from polylogue.archive.revision_authority import RawRevisionAuthority, RawRevisionEnvelope, RawRevisionKind
+from polylogue.core.enums import ArtifactSupportStatus, Origin, Provider
+from polylogue.storage.artifacts.inspection import artifact_observation_id
+from polylogue.storage.sqlite.archive_tiers.source_write import (
+    ArchiveSourceArtifact,
+    deterministic_blob_hash,
+    write_source_raw_session,
+)
+
+
+class RawAdmissionArm(StrEnum):
+    """The exhaustive, typed outcome of one :func:`admit_raw_observation` call."""
+
+    BASELINE = "baseline"
+    SKIP_DUPLICATE = "skip_duplicate"
+    APPEND = "append"
+    SUPERSEDE = "supersede"
+    ARTIFACT = "artifact"
+    REFUSED_AMBIGUOUS = "refused_ambiguous"
+
+
+_ByteRelation = Literal["duplicate", "append", "supersede", "ambiguous"]
+
+
+@dataclass(frozen=True, slots=True)
+class PriorRawHead:
+    """The currently-accepted head raw for one logical source key.
+
+    Callers resolve this themselves (this module makes no assumption about
+    how "head" is determined for a given provider/acquisition mode) and
+    pass its bytes in so the byte-relation comparison in arms 1-3/5 is a
+    pure, synchronous, in-memory decision -- no additional DB or blob-store
+    read happens inside :func:`admit_raw_observation` itself.
+    """
+
+    raw_id: str
+    source_revision: str
+    payload: bytes
+    baseline_raw_id: str | None = None
+    acquisition_generation: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class RawAdmissionResult:
+    """The outcome of one admission decision."""
+
+    arm: RawAdmissionArm
+    raw_id: str
+    artifact_id: str | None = None
+    refusal_reason: str | None = None
+    reacquire_attempted: bool = False
+    reacquire_changed_outcome: bool = False
+
+
+def _classify_bytes(payload: bytes, prior_head_payload: bytes) -> _ByteRelation:
+    if payload == prior_head_payload:
+        return "duplicate"
+    if len(payload) > len(prior_head_payload) and payload.startswith(prior_head_payload):
+        return "append"
+    if len(payload) < len(prior_head_payload) and prior_head_payload.startswith(payload):
+        return "supersede"
+    return "ambiguous"
+
+
+def _enum_value(value: object) -> str | None:
+    if value is None:
+        return None
+    if hasattr(value, "value"):
+        return str(value.value)
+    return str(value)
+
+
+def admit_raw_observation(
+    conn: sqlite3.Connection,
+    *,
+    origin: Origin | str,
+    capture_mode: Provider | str | None = None,
+    source_path: str,
+    source_index: int = 0,
+    payload: bytes,
+    acquired_at_ms: int,
+    native_id: str | None = None,
+    logical_source_key: str,
+    prior_head: PriorRawHead | None = None,
+    artifact: ArtifactClassification | None = None,
+    blob_publication_receipt_id: str | None = None,
+    reacquire: Callable[[], bytes | None] | None = None,
+    manage_transaction: bool = True,
+) -> RawAdmissionResult:
+    """Decide and apply exactly one typed resolution arm for one raw observation.
+
+    ``logical_source_key`` is required even for the ``BASELINE``/``ARTIFACT``
+    outcomes that do not compare against a prior head -- every write this
+    function makes carries a real revision envelope, never the nullable
+    ``revision=None`` fallback the lower-level writers otherwise default to.
+    """
+    if not logical_source_key:
+        raise ValueError("logical_source_key is required for raw admission")
+
+    if artifact is not None and not artifact.parse_as_session:
+        return _admit_artifact(
+            conn,
+            origin=origin,
+            capture_mode=capture_mode,
+            source_path=source_path,
+            source_index=source_index,
+            payload=payload,
+            acquired_at_ms=acquired_at_ms,
+            native_id=native_id,
+            artifact=artifact,
+            blob_publication_receipt_id=blob_publication_receipt_id,
+            manage_transaction=manage_transaction,
+        )
+
+    if prior_head is None:
+        raw_id = write_source_raw_session(
+            conn,
+            origin=origin,
+            capture_mode=capture_mode,
+            source_path=source_path,
+            source_index=source_index,
+            payload=payload,
+            acquired_at_ms=acquired_at_ms,
+            native_id=native_id,
+            blob_publication_receipt_id=blob_publication_receipt_id,
+            revision=RawRevisionEnvelope(
+                logical_source_key=logical_source_key,
+                kind=RawRevisionKind.FULL,
+                source_revision=deterministic_blob_hash(payload).hex(),
+                acquisition_generation=0,
+                authority=RawRevisionAuthority.ASSERTED,
+            ),
+            manage_transaction=manage_transaction,
+        )
+        return RawAdmissionResult(arm=RawAdmissionArm.BASELINE, raw_id=raw_id)
+
+    relation = _classify_bytes(payload, prior_head.payload)
+    reacquire_attempted = False
+    reacquire_changed_outcome = False
+    resolved_payload = payload
+
+    if relation == "ambiguous" and reacquire is not None:
+        reacquire_attempted = True
+        candidate = reacquire()
+        if candidate is not None:
+            candidate_relation = _classify_bytes(candidate, prior_head.payload)
+            if candidate_relation != "ambiguous":
+                reacquire_changed_outcome = True
+                relation = candidate_relation
+                resolved_payload = candidate
+            else:
+                # Still ambiguous, but the refusal row should reflect the
+                # freshest bytes actually observed, not the stale first read.
+                resolved_payload = candidate
+
+    if relation == "duplicate":
+        return RawAdmissionResult(
+            arm=RawAdmissionArm.SKIP_DUPLICATE,
+            raw_id=prior_head.raw_id,
+            reacquire_attempted=reacquire_attempted,
+            reacquire_changed_outcome=reacquire_changed_outcome,
+        )
+
+    if relation == "append":
+        raw_id = write_source_raw_session(
+            conn,
+            origin=origin,
+            capture_mode=capture_mode,
+            source_path=source_path,
+            source_index=source_index,
+            payload=resolved_payload,
+            acquired_at_ms=acquired_at_ms,
+            native_id=native_id,
+            blob_publication_receipt_id=blob_publication_receipt_id,
+            revision=RawRevisionEnvelope(
+                logical_source_key=logical_source_key,
+                kind=RawRevisionKind.APPEND,
+                source_revision=deterministic_blob_hash(resolved_payload).hex(),
+                predecessor_source_revision=prior_head.source_revision,
+                predecessor_raw_id=prior_head.raw_id,
+                baseline_raw_id=prior_head.baseline_raw_id or prior_head.raw_id,
+                append_start_offset=len(prior_head.payload),
+                append_end_offset=len(resolved_payload),
+                acquisition_generation=prior_head.acquisition_generation + 1,
+                authority=RawRevisionAuthority.ASSERTED,
+            ),
+            manage_transaction=manage_transaction,
+        )
+        return RawAdmissionResult(
+            arm=RawAdmissionArm.APPEND,
+            raw_id=raw_id,
+            reacquire_attempted=reacquire_attempted,
+            reacquire_changed_outcome=reacquire_changed_outcome,
+        )
+
+    if relation == "supersede":
+        raw_id = write_source_raw_session(
+            conn,
+            origin=origin,
+            capture_mode=capture_mode,
+            source_path=source_path,
+            source_index=source_index,
+            payload=resolved_payload,
+            acquired_at_ms=acquired_at_ms,
+            native_id=native_id,
+            blob_publication_receipt_id=blob_publication_receipt_id,
+            revision=RawRevisionEnvelope(
+                logical_source_key=logical_source_key,
+                kind=RawRevisionKind.FULL,
+                source_revision=deterministic_blob_hash(resolved_payload).hex(),
+                predecessor_raw_id=prior_head.raw_id,
+                baseline_raw_id=prior_head.baseline_raw_id or prior_head.raw_id,
+                acquisition_generation=prior_head.acquisition_generation,
+                authority=RawRevisionAuthority.BYTE_PROVEN,
+            ),
+            manage_transaction=manage_transaction,
+        )
+        return RawAdmissionResult(
+            arm=RawAdmissionArm.SUPERSEDE,
+            raw_id=raw_id,
+            reacquire_attempted=reacquire_attempted,
+            reacquire_changed_outcome=reacquire_changed_outcome,
+        )
+
+    # Still ambiguous after the (opportunistic, at-most-one) reacquire
+    # attempt -- or no reacquire callback was supplied at all. Never persist
+    # a nullable "figure it out later" row: this is a typed refusal with a
+    # machine-readable reason, not a bare quarantine.
+    refusal_reason = (
+        "reacquire_still_ambiguous"
+        if reacquire_attempted and reacquire_changed_outcome is False and resolved_payload != payload
+        else "reacquire_unavailable_or_absent"
+        if reacquire_attempted
+        else "no_byte_relation_to_prior_head"
+    )
+    raw_id = write_source_raw_session(
+        conn,
+        origin=origin,
+        capture_mode=capture_mode,
+        source_path=source_path,
+        source_index=source_index,
+        payload=resolved_payload,
+        acquired_at_ms=acquired_at_ms,
+        native_id=native_id,
+        blob_publication_receipt_id=blob_publication_receipt_id,
+        revision=RawRevisionEnvelope(
+            logical_source_key=logical_source_key,
+            kind=RawRevisionKind.UNKNOWN,
+            source_revision=deterministic_blob_hash(resolved_payload).hex(),
+            acquisition_generation=prior_head.acquisition_generation + 1,
+            authority=RawRevisionAuthority.QUARANTINED,
+        ),
+        manage_transaction=manage_transaction,
+    )
+    return RawAdmissionResult(
+        arm=RawAdmissionArm.REFUSED_AMBIGUOUS,
+        raw_id=raw_id,
+        refusal_reason=refusal_reason,
+        reacquire_attempted=reacquire_attempted,
+        reacquire_changed_outcome=reacquire_changed_outcome,
+    )
+
+
+def _admit_artifact(
+    conn: sqlite3.Connection,
+    *,
+    origin: Origin | str,
+    capture_mode: Provider | str | None,
+    source_path: str,
+    source_index: int,
+    payload: bytes,
+    acquired_at_ms: int,
+    native_id: str | None,
+    artifact: ArtifactClassification,
+    blob_publication_receipt_id: str | None,
+    manage_transaction: bool,
+) -> RawAdmissionResult:
+    origin_value = _enum_value(origin)
+    artifact_id = artifact_observation_id(
+        source_name=origin_value,
+        source_path=source_path,
+        source_index=source_index,
+    )
+    raw_id = write_source_raw_session(
+        conn,
+        origin=origin,
+        capture_mode=capture_mode,
+        source_path=source_path,
+        source_index=source_index,
+        payload=payload,
+        acquired_at_ms=acquired_at_ms,
+        native_id=native_id,
+        blob_publication_receipt_id=blob_publication_receipt_id,
+        # Artifacts are acquisition-evidence, not part of any revision
+        # chain: no logical_source_key/predecessor tracking applies to a
+        # non-conversational sidecar payload.
+        revision=None,
+        artifact=ArchiveSourceArtifact(
+            artifact_id=artifact_id,
+            origin=origin,
+            source_path=source_path,
+            artifact_kind=artifact.cohort,
+            classification_reason=artifact.reason,
+            support_status=ArtifactSupportStatus.UNKNOWN,
+            parse_as_session=False,
+            schema_eligible=artifact.schema_eligible,
+            first_observed_at_ms=acquired_at_ms,
+            last_observed_at_ms=acquired_at_ms,
+            source_index=source_index,
+        ),
+        manage_transaction=manage_transaction,
+    )
+    return RawAdmissionResult(arm=RawAdmissionArm.ARTIFACT, raw_id=raw_id, artifact_id=artifact_id)
+
+
+__all__ = [
+    "PriorRawHead",
+    "RawAdmissionArm",
+    "RawAdmissionResult",
+    "admit_raw_observation",
+]

--- a/polylogue/storage/sqlite/archive_tiers/revision_governance.py
+++ b/polylogue/storage/sqlite/archive_tiers/revision_governance.py
@@ -110,6 +110,7 @@ from typing import TYPE_CHECKING, Any, BinaryIO, Protocol, cast
 if TYPE_CHECKING:
     from polylogue.sources.parsers.base import ParsedSession
 
+from polylogue.archive.artifact_taxonomy import ArtifactClassification
 from polylogue.archive.ingest_flags import DOM_FALLBACK_INGEST_FLAG, NATIVE_BROWSER_CAPTURE_FLAGS
 from polylogue.archive.revision_authority import (
     RETIRED_FULL_REVISION_GOVERNANCE_DETAILS,
@@ -145,6 +146,7 @@ from polylogue.storage.sqlite.archive_tiers.ingest_precedence import (
     should_skip_stale_replace,
     stored_message_count,
 )
+from polylogue.storage.sqlite.archive_tiers.raw_admission import RawAdmissionResult, admit_raw_observation
 from polylogue.storage.sqlite.archive_tiers.revision_application import (
     FullSnapshotFoldAuthorization,
     RevisionApplicationReceipt,
@@ -552,6 +554,52 @@ def write_raw_blob_ref(
         raw_id=raw_id,
         blob_publication_receipt_id=blob_publication_receipt_id,
         revision=revision,
+        manage_transaction=True,
+    )
+
+
+def admit_raw_artifact_payload(
+    store: RawRevisionGovernanceHost,
+    *,
+    provider: Provider,
+    payload: bytes,
+    source_path: str,
+    acquired_at_ms: int,
+    classification: ArtifactClassification,
+    source_index: int = 0,
+    blob_publication_receipt_id: str | None = None,
+) -> RawAdmissionResult:
+    """Commit a non-conversational artifact payload through the raw-admission chokepoint.
+
+    polylogue-1fijp arm 4: routes a payload already classified as
+    ``not classification.parse_as_session`` (the omsw artifact taxonomy --
+    tool-results/*.json, subagents/workflows/*/journal.jsonl,
+    file-history-snapshot, etc) through :func:`admit_raw_observation` so its
+    ``raw_artifacts`` classification is attached at admission time rather
+    than deferred to the next offline ``materialize_artifact_observations``
+    sweep. A ``raw_sessions`` row is still written (the acquisition-evidence
+    ledger; ``raw_artifacts.raw_id`` has a NOT NULL FK to it), but this arm
+    guarantees the payload never reaches any index-tier writer.
+    """
+    if store._blob_publisher is None:
+        raise RuntimeError("raw archive writes require a writable archive publisher")
+    if blob_publication_receipt_id is None:
+        raw_hash, _raw_size = store._blob_publisher.write_from_bytes(payload)
+        blob_publication_receipt_id = store._blob_publisher.receipt_id(raw_hash)
+    store._blob_publisher.flush()
+    origin = origin_from_provider(provider)
+    return admit_raw_observation(
+        store._ensure_source_conn(),
+        origin=origin,
+        capture_mode=provider,
+        source_path=source_path,
+        source_index=source_index,
+        payload=payload,
+        acquired_at_ms=acquired_at_ms,
+        logical_source_key=f"{origin.value}:{source_path}",
+        prior_head=None,
+        artifact=classification,
+        blob_publication_receipt_id=blob_publication_receipt_id,
         manage_transaction=True,
     )
 

--- a/tests/unit/sources/test_atomic_read.py
+++ b/tests/unit/sources/test_atomic_read.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from polylogue.sources.atomic_read import (
+    TornReadError,
+    read_source_bytes_atomic,
+    try_read_source_bytes_atomic,
+)
+
+
+def test_read_source_bytes_atomic_returns_stable_bytes(tmp_path: Path) -> None:
+    path = tmp_path / "session.jsonl"
+    path.write_bytes(b'{"a":1}\n')
+
+    result = read_source_bytes_atomic(path)
+
+    assert result.payload == b'{"a":1}\n'
+    assert result.size == len(b'{"a":1}\n')
+
+
+def test_read_source_bytes_atomic_detects_torn_read_via_stat_mismatch(tmp_path: Path) -> None:
+    """Simulate a mid-rewrite: the file's mtime/size changes between the
+    pre-read stat and the post-read stat on every attempt, so every retry
+    keeps disagreeing and the call must raise rather than return partial
+    bytes -- never a torn blob persisted."""
+    path = tmp_path / "session.jsonl"
+    path.write_bytes(b"generation-0")
+
+    real_stat = Path.stat
+    call_count = {"n": 0}
+
+    def flaky_stat(self: Path, *args: object, **kwargs: object) -> os.stat_result:
+        # Every stat call after the very first sees a rewritten file: this
+        # forces the pre/post identity comparison to disagree on every pass.
+        call_count["n"] += 1
+        if call_count["n"] > 1:
+            self.write_bytes(f"generation-{call_count['n']}".encode())
+        return real_stat(self, *args, **kwargs)
+
+    with patch.object(Path, "stat", flaky_stat):
+        with pytest.raises(TornReadError) as excinfo:
+            read_source_bytes_atomic(path, max_retries=2, retry_delay_s=0.0)
+
+    assert excinfo.value.attempts == 3
+    assert excinfo.value.path == str(path)
+
+
+def test_read_source_bytes_atomic_retries_then_stabilizes(tmp_path: Path) -> None:
+    """A file that is mid-rewrite on the first attempt but settles by the
+    second retry must return the STABLE final bytes, not the torn ones."""
+    path = tmp_path / "session.jsonl"
+    path.write_bytes(b"stable-final-content")
+
+    real_read_bytes = Path.read_bytes
+    call_count = {"n": 0}
+
+    def flaky_read(self: Path) -> bytes:
+        call_count["n"] += 1
+        payload = real_read_bytes(self)
+        if call_count["n"] == 1:
+            # Mutate the file immediately after the read but before the
+            # post-read stat, so attempt 1's identity check fails.
+            self.write_bytes(self.read_bytes() + b"-appended-mid-read")
+        return payload
+
+    with patch.object(Path, "read_bytes", flaky_read):
+        result = read_source_bytes_atomic(path, max_retries=3, retry_delay_s=0.0)
+
+    assert result.payload == b"stable-final-content-appended-mid-read"
+
+
+def test_read_source_bytes_atomic_propagates_final_os_error(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist.jsonl"
+    with pytest.raises(FileNotFoundError):
+        read_source_bytes_atomic(missing, max_retries=0, retry_delay_s=0.0)
+
+
+def test_read_source_bytes_atomic_rejects_negative_retries(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        read_source_bytes_atomic(tmp_path / "x", max_retries=-1)
+
+
+def test_try_read_source_bytes_atomic_returns_none_on_torn_read(tmp_path: Path) -> None:
+    path = tmp_path / "session.jsonl"
+    path.write_bytes(b"generation-0")
+
+    real_stat = Path.stat
+    call_count = {"n": 0}
+
+    def flaky_stat(self: Path, *args: object, **kwargs: object) -> os.stat_result:
+        call_count["n"] += 1
+        if call_count["n"] > 1:
+            self.write_bytes(f"generation-{call_count['n']}".encode())
+        return real_stat(self, *args, **kwargs)
+
+    with patch.object(Path, "stat", flaky_stat):
+        result = try_read_source_bytes_atomic(path, max_retries=1, retry_delay_s=0.0)
+
+    assert result is None
+
+
+def test_try_read_source_bytes_atomic_returns_none_when_missing(tmp_path: Path) -> None:
+    assert try_read_source_bytes_atomic(tmp_path / "gone.jsonl", max_retries=0) is None

--- a/tests/unit/sources/test_atomic_read.py
+++ b/tests/unit/sources/test_atomic_read.py
@@ -34,13 +34,13 @@ def test_read_source_bytes_atomic_detects_torn_read_via_stat_mismatch(tmp_path: 
     real_stat = Path.stat
     call_count = {"n": 0}
 
-    def flaky_stat(self: Path, *args: object, **kwargs: object) -> os.stat_result:
+    def flaky_stat(self: Path, *, follow_symlinks: bool = True) -> os.stat_result:
         # Every stat call after the very first sees a rewritten file: this
         # forces the pre/post identity comparison to disagree on every pass.
         call_count["n"] += 1
         if call_count["n"] > 1:
             self.write_bytes(f"generation-{call_count['n']}".encode())
-        return real_stat(self, *args, **kwargs)
+        return real_stat(self, follow_symlinks=follow_symlinks)
 
     with patch.object(Path, "stat", flaky_stat):
         with pytest.raises(TornReadError) as excinfo:
@@ -92,11 +92,11 @@ def test_try_read_source_bytes_atomic_returns_none_on_torn_read(tmp_path: Path) 
     real_stat = Path.stat
     call_count = {"n": 0}
 
-    def flaky_stat(self: Path, *args: object, **kwargs: object) -> os.stat_result:
+    def flaky_stat(self: Path, *, follow_symlinks: bool = True) -> os.stat_result:
         call_count["n"] += 1
         if call_count["n"] > 1:
             self.write_bytes(f"generation-{call_count['n']}".encode())
-        return real_stat(self, *args, **kwargs)
+        return real_stat(self, follow_symlinks=follow_symlinks)
 
     with patch.object(Path, "stat", flaky_stat):
         result = try_read_source_bytes_atomic(path, max_retries=1, retry_delay_s=0.0)

--- a/tests/unit/storage/test_raw_admission.py
+++ b/tests/unit/storage/test_raw_admission.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from polylogue.archive.artifact_taxonomy import ArtifactClassification, ArtifactKind
+from polylogue.archive.revision_authority import RawRevisionAuthority
+from polylogue.core.enums import Origin, Provider
+from polylogue.storage.artifacts.inspection import artifact_observation_id
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+from polylogue.storage.sqlite.archive_tiers.raw_admission import (
+    PriorRawHead,
+    RawAdmissionArm,
+    admit_raw_observation,
+)
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    initialize_archive_tier(conn, ArchiveTier.SOURCE)
+    return conn
+
+
+def _row(conn: sqlite3.Connection, raw_id: str) -> sqlite3.Row:
+    row = conn.execute(
+        """
+        SELECT revision_kind, revision_authority, predecessor_raw_id, baseline_raw_id,
+               append_start_offset, append_end_offset, blob_size, logical_source_key
+        FROM raw_sessions WHERE raw_id = ?
+        """,
+        (raw_id,),
+    ).fetchone()
+    assert row is not None
+    return cast(sqlite3.Row, row)
+
+
+def test_admit_raw_observation_baseline_when_no_prior_head(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "source.db")
+
+    result = admit_raw_observation(
+        conn,
+        origin=Origin.CODEX_SESSION,
+        source_path="/tmp/rollout.jsonl",
+        payload=b"line-1\n",
+        acquired_at_ms=1_767_000_000_000,
+        logical_source_key="codex:/tmp/rollout.jsonl",
+        prior_head=None,
+    )
+
+    assert result.arm is RawAdmissionArm.BASELINE
+    row = _row(conn, result.raw_id)
+    assert row["revision_kind"] == "full"
+    assert row["revision_authority"] == RawRevisionAuthority.ASSERTED.value
+    assert row["logical_source_key"] == "codex:/tmp/rollout.jsonl"
+
+
+def test_admit_raw_observation_arm1_skip_duplicate(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "source.db")
+    head_payload = b"line-1\n"
+    baseline = admit_raw_observation(
+        conn,
+        origin=Origin.CODEX_SESSION,
+        source_path="/tmp/rollout.jsonl",
+        payload=head_payload,
+        acquired_at_ms=1_767_000_000_000,
+        logical_source_key="codex:/tmp/rollout.jsonl",
+        prior_head=None,
+    )
+    prior_head = PriorRawHead(
+        raw_id=baseline.raw_id,
+        source_revision="rev-0",
+        payload=head_payload,
+    )
+
+    result = admit_raw_observation(
+        conn,
+        origin=Origin.CODEX_SESSION,
+        source_path="/tmp/rollout.jsonl",
+        payload=head_payload,
+        acquired_at_ms=1_767_000_001_000,
+        logical_source_key="codex:/tmp/rollout.jsonl",
+        prior_head=prior_head,
+    )
+
+    assert result.arm is RawAdmissionArm.SKIP_DUPLICATE
+    assert result.raw_id == baseline.raw_id
+    # No second raw_sessions row was written.
+    count = conn.execute("SELECT COUNT(*) FROM raw_sessions").fetchone()[0]
+    assert count == 1
+
+
+def test_admit_raw_observation_arm2_append_extends_head(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "source.db")
+    head_payload = b"line-1\n"
+    baseline = admit_raw_observation(
+        conn,
+        origin=Origin.CODEX_SESSION,
+        source_path="/tmp/rollout.jsonl",
+        payload=head_payload,
+        acquired_at_ms=1_767_000_000_000,
+        logical_source_key="codex:/tmp/rollout.jsonl",
+        prior_head=None,
+    )
+    prior_head = PriorRawHead(
+        raw_id=baseline.raw_id,
+        source_revision="rev-0",
+        payload=head_payload,
+        acquisition_generation=0,
+    )
+    extended_payload = head_payload + b"line-2\n"
+
+    result = admit_raw_observation(
+        conn,
+        origin=Origin.CODEX_SESSION,
+        source_path="/tmp/rollout.jsonl",
+        payload=extended_payload,
+        acquired_at_ms=1_767_000_002_000,
+        logical_source_key="codex:/tmp/rollout.jsonl",
+        prior_head=prior_head,
+    )
+
+    assert result.arm is RawAdmissionArm.APPEND
+    assert result.raw_id != baseline.raw_id
+    row = _row(conn, result.raw_id)
+    assert row["revision_kind"] == "append"
+    assert row["revision_authority"] == RawRevisionAuthority.ASSERTED.value
+    assert row["predecessor_raw_id"] == baseline.raw_id
+    assert row["baseline_raw_id"] == baseline.raw_id
+    assert row["append_start_offset"] == len(head_payload)
+    assert row["append_end_offset"] == len(extended_payload)
+    assert row["blob_size"] == len(extended_payload)
+
+
+def test_admit_raw_observation_arm3_supersede_when_new_bytes_are_prefix_of_head(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "source.db")
+    fuller_payload = b"line-1\nline-2\n"
+    baseline = admit_raw_observation(
+        conn,
+        origin=Origin.CODEX_SESSION,
+        source_path="/tmp/rollout.jsonl",
+        payload=fuller_payload,
+        acquired_at_ms=1_767_000_000_000,
+        logical_source_key="codex:/tmp/rollout.jsonl",
+        prior_head=None,
+    )
+    prior_head = PriorRawHead(
+        raw_id=baseline.raw_id,
+        source_revision="rev-0",
+        payload=fuller_payload,
+    )
+    shorter_payload = b"line-1\n"
+
+    result = admit_raw_observation(
+        conn,
+        origin=Origin.CODEX_SESSION,
+        source_path="/tmp/rollout.jsonl",
+        payload=shorter_payload,
+        acquired_at_ms=1_767_000_003_000,
+        logical_source_key="codex:/tmp/rollout.jsonl",
+        prior_head=prior_head,
+    )
+
+    assert result.arm is RawAdmissionArm.SUPERSEDE
+    row = _row(conn, result.raw_id)
+    assert row["revision_kind"] == "full"
+    assert row["revision_authority"] == RawRevisionAuthority.BYTE_PROVEN.value
+    assert row["predecessor_raw_id"] == baseline.raw_id
+    assert row["blob_size"] == len(shorter_payload)
+
+
+def test_admit_raw_observation_arm5_refuses_ambiguous_bytes_with_no_reacquire(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "source.db")
+    head_payload = b"line-1\nline-2\n"
+    baseline = admit_raw_observation(
+        conn,
+        origin=Origin.CODEX_SESSION,
+        source_path="/tmp/rollout.jsonl",
+        payload=head_payload,
+        acquired_at_ms=1_767_000_000_000,
+        logical_source_key="codex:/tmp/rollout.jsonl",
+        prior_head=None,
+    )
+    prior_head = PriorRawHead(
+        raw_id=baseline.raw_id,
+        source_revision="rev-0",
+        payload=head_payload,
+    )
+    unrelated_payload = b"totally-different-content\n"
+
+    result = admit_raw_observation(
+        conn,
+        origin=Origin.CODEX_SESSION,
+        source_path="/tmp/rollout.jsonl",
+        payload=unrelated_payload,
+        acquired_at_ms=1_767_000_004_000,
+        logical_source_key="codex:/tmp/rollout.jsonl",
+        prior_head=prior_head,
+        reacquire=None,
+    )
+
+    assert result.arm is RawAdmissionArm.REFUSED_AMBIGUOUS
+    assert result.refusal_reason == "no_byte_relation_to_prior_head"
+    assert result.reacquire_attempted is False
+    row = _row(conn, result.raw_id)
+    assert row["revision_kind"] == "unknown"
+    assert row["revision_authority"] == RawRevisionAuthority.QUARANTINED.value
+
+
+def test_admit_raw_observation_arm5_opportunistic_reacquire_resolves_to_append(tmp_path: Path) -> None:
+    """Ambiguous first read, but a reacquire callback returns bytes that
+    DO extend the head as a prefix -- the opportunistic re-read must win
+    over the stale ambiguous first read (operator correction: re-acquire
+    is opportunistic, only when the source is still present/readable)."""
+    conn = _connect(tmp_path / "source.db")
+    head_payload = b"line-1\n"
+    baseline = admit_raw_observation(
+        conn,
+        origin=Origin.CODEX_SESSION,
+        source_path="/tmp/rollout.jsonl",
+        payload=head_payload,
+        acquired_at_ms=1_767_000_000_000,
+        logical_source_key="codex:/tmp/rollout.jsonl",
+        prior_head=None,
+    )
+    prior_head = PriorRawHead(
+        raw_id=baseline.raw_id,
+        source_revision="rev-0",
+        payload=head_payload,
+    )
+    stable_extended_payload = head_payload + b"line-2\n"
+
+    result = admit_raw_observation(
+        conn,
+        origin=Origin.CODEX_SESSION,
+        source_path="/tmp/rollout.jsonl",
+        payload=b"torn-mid-rewrite-garbage",
+        acquired_at_ms=1_767_000_005_000,
+        logical_source_key="codex:/tmp/rollout.jsonl",
+        prior_head=prior_head,
+        reacquire=lambda: stable_extended_payload,
+    )
+
+    assert result.arm is RawAdmissionArm.APPEND
+    assert result.reacquire_attempted is True
+    assert result.reacquire_changed_outcome is True
+    row = _row(conn, result.raw_id)
+    assert row["blob_size"] == len(stable_extended_payload)
+
+
+def test_admit_raw_observation_arm5_reacquire_returns_none_when_source_vanished(tmp_path: Path) -> None:
+    """Per the operator correction: absence of the source must fall through
+    to a typed refusal, never raise or block on source persistence."""
+    conn = _connect(tmp_path / "source.db")
+    head_payload = b"line-1\n"
+    baseline = admit_raw_observation(
+        conn,
+        origin=Origin.CODEX_SESSION,
+        source_path="/tmp/rollout.jsonl",
+        payload=head_payload,
+        acquired_at_ms=1_767_000_000_000,
+        logical_source_key="codex:/tmp/rollout.jsonl",
+        prior_head=None,
+    )
+    prior_head = PriorRawHead(raw_id=baseline.raw_id, source_revision="rev-0", payload=head_payload)
+
+    result = admit_raw_observation(
+        conn,
+        origin=Origin.CODEX_SESSION,
+        source_path="/tmp/rollout.jsonl",
+        payload=b"unrelated-bytes",
+        acquired_at_ms=1_767_000_006_000,
+        logical_source_key="codex:/tmp/rollout.jsonl",
+        prior_head=prior_head,
+        reacquire=lambda: None,  # source vanished / unreadable
+    )
+
+    assert result.arm is RawAdmissionArm.REFUSED_AMBIGUOUS
+    assert result.reacquire_attempted is True
+    assert result.reacquire_changed_outcome is False
+    assert result.refusal_reason == "reacquire_unavailable_or_absent"
+
+
+def test_admit_raw_observation_arm4_artifact_never_touches_index_db(tmp_path: Path) -> None:
+    """Structural proof for AC(c): the artifact arm writes raw_sessions +
+    raw_artifacts (both source.db tables) and this module has no import of
+    any index-tier writer -- so a tool-results/*.json-classified payload
+    cannot reach a code path that creates an index.db `sessions` row."""
+    import polylogue.storage.sqlite.archive_tiers.raw_admission as raw_admission_module
+
+    assert raw_admission_module.__file__ is not None
+    source_lines = Path(raw_admission_module.__file__).read_text()
+    assert "archive_tiers.write" not in source_lines
+    assert "archive_tiers.index" not in source_lines
+
+    conn = _connect(tmp_path / "source.db")
+    classification = ArtifactClassification(
+        provider=Provider.CLAUDE_CODE,
+        kind=ArtifactKind.TOOL_RESULT_SIDECAR,
+        parse_as_session=False,
+        schema_eligible=False,
+        default_priority=0,
+        reason="tool-results sidecar, not a conversation",
+    )
+
+    result = admit_raw_observation(
+        conn,
+        origin=Origin.CLAUDE_CODE_SESSION,
+        source_path="/tmp/tool-results/abc.json",
+        payload=b'{"tool":"bash","output":"ok"}',
+        acquired_at_ms=1_767_000_000_000,
+        logical_source_key="claude-code:/tmp/tool-results/abc.json",
+        prior_head=None,
+        artifact=classification,
+    )
+
+    assert result.arm is RawAdmissionArm.ARTIFACT
+    assert result.artifact_id is not None
+    expected_artifact_id = artifact_observation_id(
+        source_name=Origin.CLAUDE_CODE_SESSION.value,
+        source_path="/tmp/tool-results/abc.json",
+        source_index=0,
+    )
+    assert result.artifact_id == expected_artifact_id
+
+    raw_row = conn.execute("SELECT raw_id FROM raw_sessions WHERE raw_id = ?", (result.raw_id,)).fetchone()
+    assert raw_row is not None
+    artifact_row = conn.execute(
+        "SELECT parse_as_session, artifact_kind, raw_id FROM raw_artifacts WHERE artifact_id = ?",
+        (result.artifact_id,),
+    ).fetchone()
+    assert artifact_row is not None
+    assert artifact_row["parse_as_session"] == 0
+    assert artifact_row["raw_id"] == result.raw_id
+
+    # There is no `sessions` table in source.db at all -- structural proof
+    # this tier cannot materialize a conversation.
+    tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()}
+    assert "sessions" not in tables
+
+
+def test_admit_raw_observation_requires_logical_source_key(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "source.db")
+    with pytest.raises(ValueError):
+        admit_raw_observation(
+            conn,
+            origin=Origin.CODEX_SESSION,
+            source_path="/tmp/rollout.jsonl",
+            payload=b"x",
+            acquired_at_ms=1_767_000_000_000,
+            logical_source_key="",
+            prior_head=None,
+        )


### PR DESCRIPTION
## Summary

Adds the mechanism for polylogue-1fijp's raw-admission chokepoint: `admit_raw_observation()`, a single typed decision function implementing the bead's five exhaustive resolution arms over a (prior-head-bytes, new-bytes) comparison, plus the atomic-read contract that feeds it stable, torn-read-proof bytes. Routes one real production call site (configured Claude Code fact-artifact admission) through it as proof and regression coverage.

## Problem

`raw_sessions` rows are currently written from several independent call sites (one-shot batch import, live daemon watcher, Drive lineage bind), each deciding `revision_kind`/`revision_authority` on its own. polylogue-sp72's merged fix (#3656, this session) is the live proof this scatter causes real gaps: `iter_drive_raw_data`'s Drive re-acquisition path writes `revision_kind=unknown` + empty `logical_source_key` + `quarantined` directly on ambiguous bytes, with no shared typed-arm resolution to route through, and that PR's own scope notes explicitly defer the general fix to this bead. Separately, `polylogue-2t0vp` found live evidence of a torn-read failure mode: a Codex rollout file recaptured 15-16x with `blob_size` growing then suddenly dropping from 427MB to 10KB in one read -- no acquisition path in the codebase currently proves it isn't reading a source file mid-rewrite.

## Solution

- `polylogue/sources/atomic_read.py`: `read_source_bytes_atomic()` / `try_read_source_bytes_atomic()`. Captures `(size, mtime_ns)` before reading, reads to EOF, re-stats; retries a bounded number of times on disagreement; raises `TornReadError` (or returns `None` for the non-raising variant) rather than ever persisting a torn read. Standalone utility, not yet wired into any acquisition call site.
- `polylogue/storage/sqlite/archive_tiers/raw_admission.py`: `admit_raw_observation()`. Given atomically-read bytes, origin evidence, and an optional `PriorRawHead` (caller-resolved), resolves exactly one of:
  1. `SKIP_DUPLICATE` -- byte-equal to the accepted head.
  2. `APPEND` -- bytes extend the head as a strict byte-prefix; `revision_kind=append` with a real `predecessor_raw_id`.
  3. `SUPERSEDE` -- the incoming bytes are themselves a strict prefix of the accepted head (a proven-dominated, older/shorter read); recorded `FULL`/`BYTE_PROVEN` with `predecessor_raw_id` pointing at the fuller head. **Interpretation note**: the bead's arm-3 text ("head is byte-prefix of prior full -> supersede") admits more than one reading; this is the one implemented and tested here, flagged in the module docstring as not independently confirmed against operator intent beyond the bead text.
  4. `ARTIFACT` -- payload classified `not parse_as_session` by the omsw artifact taxonomy. Still writes a `raw_sessions` row (the acquisition-evidence ledger; `raw_artifacts.raw_id` has a `NOT NULL REFERENCES raw_sessions` FK) but attaches an immediate `raw_artifacts` classification row via the same deterministic `artifact_observation_id()` scheme the offline `materialize_artifact_observations` sweep uses (upsert-safe, no collision). This arm structurally cannot reach an index-tier `sessions` row -- the module has zero imports of any index-tier writer (asserted in a test).
  5. `REFUSED_AMBIGUOUS` -- neither equal, forward-extension, nor backward-prefix. Per the operator's 2026-08-03 correction on the bead: re-acquisition is opportunistic, never doctrinal. A supplied `reacquire` callback is invoked at most once; if it resolves to arms 1-3 that wins, otherwise (source absent/unreadable, or still ambiguous) this falls through to a typed refusal row (`revision_kind=unknown`, `revision_authority=quarantined`) with a machine-readable `refusal_reason` -- never a decision that depends on source persistence, never a silent drop.
  6. `BASELINE` (not one of the 5 named arms -- they all presuppose a prior head): the bootstrap case, first-ever observation for a logical source key, recorded `FULL`/`ASSERTED`.

  Composes the existing `write_source_raw_session()`/`RawRevisionEnvelope` primitives rather than reimplementing raw-row persistence.
- `polylogue/storage/sqlite/archive_tiers/revision_governance.py` + `archive.py`: `admit_raw_artifact_payload()` (module function + `ArchiveStore` wrapper), mirroring the existing `write_raw_payload()` shape (blob publish + `_ensure_source_conn()`), delegating to `admit_raw_observation()`'s ARTIFACT arm.
- `polylogue/pipeline/services/archive_ingest.py`: `_admit_non_session_origin_artifacts()` now calls `archive.admit_raw_artifact_payload(...)` instead of the bare `archive.write_raw_payload(...)` it previously discarded its own already-computed `ArtifactClassification` into -- this one real call site now gets an immediate `raw_artifacts` row instead of waiting on the next offline materialize sweep.

## Scope / call-site status (acceptance-criteria honesty)

The bead is explicitly a multi-session mechanism-plus-migration effort; this PR lands the mechanism and one real call-site migration, not full consolidation. Per the bead's own fallback guidance ("completely acceptable to land a smaller, real, well-tested slice... do NOT attempt a big-bang rewrite of every acquisition path in one shot"):

- **Routed**: `archive_ingest.py`'s `_admit_non_session_origin_artifacts` (configured Claude Code fact-artifact admission, arm 4).
- **Reviewed, NOT routed**:
  - `sources/live/batch.py` -- the bead calls this "mostly compliant"; confirmed it already calls into `revision_governance`'s `classify_raw_revision_cohort_for_live_watch`/`bind_raw_revision` machinery for real lineage tracking. Rewiring its write path onto `admit_raw_observation` would touch the daemon's live-watcher hot path and its `RawRevisionGovernanceHost` Protocol contract -- deferred as a separate, carefully-tested follow-up rather than risked here.
  - `sources/drive/__init__.py` (`iter_drive_raw_data`) / `pipeline/services/ingest_batch/_core.py` (`_bind_drive_revision_lineage`) -- this is the bead's own cited proof case. PR #3656 (merged this session) already closed the byte-prefix-provable subset of this gap and its own scope notes explicitly documented the remaining gap needs a **JSON-structural-diff-aware classifier**, not a byte-prefix one: `_inject_live_drive_attachment_bytes` re-serializes the whole JSON document rather than byte-appending, so `second_bytes.startswith(first_bytes)` is false for the realistic case even when the same underlying session grew. `admit_raw_observation`'s byte-prefix comparison (arms 2/3) cannot resolve that shape either -- routing Drive through it today would not close the residual gap and risks destabilizing the just-merged, well-tested #3656 fix. Building a JSON-structural classifier is materially larger scope, left as explicit follow-up.
  - Browser-capture receiver spool and maintenance backfill call sites -- surveyed via `grep -rln write_source_raw_session` (11 non-test call sites across `codex_title_census.py`, `context/*_correlation.py`, `daemon/antigravity_conversation_acquisition.py`, `hooks.py`, `storage/repair.py`, `storage/raw_reconciler.py`, `storage/hook_payload_ref_reconciliation.py`); not individually routed in this pass -- each is a distinct acquisition shape (hook events, sidecar reconciliation, offline repair) that deserves its own read-and-decide pass rather than a blind mechanical swap.

## AC status

- (a) grep proves no raw_sessions INSERT outside the chokepoint module: **partially satisfied** -- true for the one routed call site; NOT true globally (11+ other call sites still write directly, listed above).
- (b) drive re-acquire with changed bytes produces typed lineage, not quarantined-unknown, through the real `iter_drive_raw_data` path: **not attempted this session** -- would require the JSON-structural-diff classifier noted above; `admit_raw_observation`'s own APPEND/SUPERSEDE arms are tested against synthetic byte-prefix fixtures instead (`tests/unit/storage/test_raw_admission.py`).
- (c) tool-results file ingest creates zero session rows, proven structurally: **satisfied** -- `test_admit_raw_observation_arm4_artifact_never_touches_index_db` asserts both the behavioral outcome (raw_artifacts row, `parse_as_session=0`, no `sessions` table in `source.db` at all) and the structural guarantee (no `archive_tiers.write`/`archive_tiers.index` import in `raw_admission.py`).
- (d) simulated mid-rewrite produces retry-then-refusal, never a stored torn blob: **satisfied** -- `tests/unit/sources/test_atomic_read.py` builds a real fixture that mutates the file's stat identity between pre/post-read checks, proving `TornReadError` on persistent instability and correct stabilized-bytes recovery when a retry succeeds.
- (e) zero NEW quarantined rows under 72h of normal daemon operation: **not this session's job** (explicitly out of scope per the dispatch -- needs live daemon time this session cannot provide).

## Verification

- `devtools test tests/unit/storage/test_raw_admission.py tests/unit/sources/test_atomic_read.py tests/integration/test_claude_workflow_admission.py tests/unit/pipeline/test_archive_ingest_shared_raw.py` -> 21 passed
- `devtools test -k "drive or artifact_taxonomy or tool_result_history"` -> 299 passed, 1 failed (`test_catalog_resolution_drives_end_to_end_cleanup`) -- pre-existing/unrelated, confirmed by PR #3656's own verification notes reproducing the identical failure via `git stash` before that change; not touched by this PR
- `devtools test -k "archive_ingest or revision_governance or admit_raw or raw_admission"` -> 26 passed
- `mypy` (strict) on every touched/added file -> `Success: no issues found in 7 source files`
- `devtools verify --quick` -> `exit_code: 0`

Ref polylogue-1fijp