### PR TITLE
fix(sources): make Claude Code session_events order chunk-invariant

### DIFF
--- a/docs/examples/demo-tour/command-output/01-claim-versus-receipt.txt
+++ b/docs/examples/demo-tour/command-output/01-claim-versus-receipt.txt
@@ -29,7 +29,7 @@ source material:
   blob_sha256: 9fd0dbdb080058070935924534a903cc63a8dcba571f6b2734f92a96576b59d7
 
 completion-claim experiment:
-  sample manifest: de3db3a3f7d80f60c26b1478f295db572662c6c5250ded18596fc88dfa2172ea
+  sample manifest: 0986e1bcddee5e4c5696c0a3a599777c4e910aac6d1f690313d57a33d35ab6ec
   denominator: 2
 unsupported by structural evidence: 0 (0.0%)
 neutral prior outcome: 0 (0.0%)

--- a/docs/examples/demo-tour/transcript.txt
+++ b/docs/examples/demo-tour/transcript.txt
@@ -38,7 +38,7 @@ source material:
   blob_sha256: 9fd0dbdb080058070935924534a903cc63a8dcba571f6b2734f92a96576b59d7
 
 completion-claim experiment:
-  sample manifest: de3db3a3f7d80f60c26b1478f295db572662c6c5250ded18596fc88dfa2172ea
+  sample manifest: 0986e1bcddee5e4c5696c0a3a599777c4e910aac6d1f690313d57a33d35ab6ec
   denominator: 2
 unsupported by structural evidence: 0 (0.0%)
 neutral prior outcome: 0 (0.0%)

--- a/polylogue/sources/parsers/claude/code_parser.py
+++ b/polylogue/sources/parsers/claude/code_parser.py
@@ -1928,7 +1928,7 @@ def _parse_code_records(
         updated_at=updated_at,
         messages=messages,
         active_leaf_message_provider_id=active_leaf_message_provider_id,
-        session_events=session_events,
+        session_events=order_session_events(session_events),
         parent_session_provider_id=parent_session_id,
         branch_type=branch_type,
         reported_cost_usd=total_cost if saw_cost_field else None,
@@ -2065,23 +2065,149 @@ def _background_notification_from_event(
     )
 
 
+# polylogue-4987i: eager parsing (_parse_code_records, single pass over a
+# session's whole record set) appends summary session_events -- background
+# completions, delegation progress, session_kind, coverage -- after its main
+# loop, in that fixed order, because it only sees "no more records" once, at
+# true end of input. Streaming parses non-contiguous chunks with the SAME
+# per-chunk logic, so each chunk appends its own summary events at that
+# chunk's local end; concatenating chunks in arrival order therefore
+# interleaves each chunk's local summary events with the next chunk's
+# ordinary events, a different permutation than eager's for identical
+# underlying records. There is no true "end of session" to wait for (a live
+# session can always grow another byte later, and both eager and streaming
+# only ever see whatever prefix of the file exists when parsing runs) -- so
+# the fix is not to defer harder, it is to make the final order depend only
+# on the parsed content, not on how many chunks it took to parse it: sort by
+# (timestamp, event-type tier, encounter order) rather than relying on
+# append order at all. This is idempotent for eager's own historical output
+# in the common case (record/timestamp order already coincides with the tier
+# order below) and chunk-count-invariant for streaming by construction.
+_SESSION_EVENT_TYPE_ORDER_TIER: dict[str, int] = {
+    "background_task_completion": 1,
+    "claude_delegation_progress": 2,
+    "claude_session_kind": 3,
+    "claude_parse_coverage": 4,
+}
+
+
+def order_session_events(events: Sequence[ParsedSessionEvent]) -> list[ParsedSessionEvent]:
+    """Deterministic session_events order, independent of chunk count (polylogue-4987i).
+
+    Missing timestamps sort first (stable; matches prior append-order
+    behavior for the rare untimestamped event). The trailing encounter index
+    is an irreducible tiebreak: two same-type events genuinely stamped at
+    the same instant have no other ordering evidence, in either parsing
+    path.
+    """
+
+    def sort_key(indexed: tuple[int, ParsedSessionEvent]) -> tuple[str, int, int]:
+        index, event = indexed
+        return (event.timestamp or "", _SESSION_EVENT_TYPE_ORDER_TIER.get(event.event_type, 0), index)
+
+    return [event for _, event in sorted(enumerate(events), key=sort_key)]
+
+
+def _merge_count_dicts(dicts: Iterable[object]) -> dict[str, int]:
+    merged: dict[str, int] = {}
+    for payload in dicts:
+        if not isinstance(payload, Mapping):
+            continue
+        for key, value in payload.items():
+            if isinstance(key, str) and isinstance(value, int):
+                merged[key] = merged.get(key, 0) + value
+    return dict(sorted(merged.items()))
+
+
 def reconcile_code_session_chunks(session: ParsedSession) -> ParsedSession:
     """Finalize one Claude Code session after streaming chunk merge.
 
-    Eager parsing sees every background completion before projecting outcomes
-    and collapses duplicate/update notifications by provider join key. Streaming
-    chunks must perform the same final pass after non-contiguous chunks have
-    been merged, otherwise a late completion cannot update an earlier start and
-    event order/count diverges from ordinary parsing.
+    Every "whole-session summary" event type _parse_code_records emits after
+    its main loop -- background completions, delegation-progress ticks, parse
+    coverage counts -- is computed PER CHUNK when parsing is split into
+    non-contiguous chunks (polylogue-4987i): each chunk only sees its own
+    slice of records, so its coverage counts are a partial sum and its
+    background/delegation state resets at the chunk boundary instead of
+    accumulating across the whole session the way eager's single pass does.
+    Concatenating chunks therefore leaves eager and streaming BOTH
+    differently-ordered (fixed by `order_session_events` below) AND carrying
+    different per-event payloads/timestamps for the exact same session
+    (e.g. a stale chunk-local `claude_parse_coverage.updated_at` instead of
+    the session's true final `updated_at`) -- ordering alone cannot fix that,
+    each summary type needs the same fold-across-chunks eager already does
+    within one pass.
+
+    - `background_task_completion`: dedup by (task_id, tool_use_id), a later
+      completion overwrites an earlier start (unchanged from before).
+    - `claude_delegation_progress`: dedup+merge by `parent_tool_use_id`,
+      summing tick counts and taking min(first_seen)/max(last_seen) --
+      mirrors `_accumulate_delegation_progress`'s own accumulation.
+    - `claude_parse_coverage`: merge into at most one event, summing each
+      count dict per key and stamping the session-wide `updated_at` (already
+      correctly the true session max across chunks --
+      `merge_parsed_session_chunks` computes it via `max(updated_values)`
+      before this function runs).
+    - `claude_session_kind`: dedup to at most one (a session-wide constant
+      fact; any surviving instance carries the same value).
     """
     ordinary_events: list[ParsedSessionEvent] = []
     completion_events: dict[tuple[str, str | None], ParsedSessionEvent] = {}
+    delegation_events: dict[str, ParsedSessionEvent] = {}
+    coverage_events: list[ParsedSessionEvent] = []
+    session_kind_event: ParsedSessionEvent | None = None
     for event in session.session_events:
         notification = _background_notification_from_event(event)
-        if notification is None:
+        if notification is not None:
+            completion_events[(notification.task_id, notification.tool_use_id)] = event
+            continue
+        if event.event_type == "claude_delegation_progress":
+            parent_tool_use_id = event.payload.get("parent_tool_use_id")
+            if isinstance(parent_tool_use_id, str) and parent_tool_use_id:
+                existing_delegation = delegation_events.get(parent_tool_use_id)
+                if existing_delegation is None:
+                    delegation_events[parent_tool_use_id] = event
+                else:
+                    existing_payload = existing_delegation.payload
+                    tick_count = _safe_int(existing_payload.get("progress_tick_count")) + _safe_int(
+                        event.payload.get("progress_tick_count")
+                    )
+                    first_seen_values = [
+                        value
+                        for value in (existing_payload.get("first_seen"), event.payload.get("first_seen"))
+                        if isinstance(value, str) and value
+                    ]
+                    last_seen_values = [
+                        value
+                        for value in (existing_payload.get("last_seen"), event.payload.get("last_seen"))
+                        if isinstance(value, str) and value
+                    ]
+                    first_seen = min(first_seen_values) if first_seen_values else None
+                    last_seen = max(last_seen_values) if last_seen_values else None
+                    delegation_events[parent_tool_use_id] = existing_delegation.model_copy(
+                        update={
+                            "timestamp": last_seen or existing_delegation.timestamp,
+                            "payload": {
+                                "parent_tool_use_id": parent_tool_use_id,
+                                "progress_tick_count": tick_count,
+                                "first_seen": first_seen,
+                                "last_seen": last_seen,
+                                "summary": (
+                                    f"delegated work under tool_use {parent_tool_use_id} ({tick_count} progress ticks)"
+                                ),
+                            },
+                        }
+                    )
+                continue
             ordinary_events.append(event)
             continue
-        completion_events[(notification.task_id, notification.tool_use_id)] = event
+        if event.event_type == "claude_parse_coverage":
+            coverage_events.append(event)
+            continue
+        if event.event_type == "claude_session_kind":
+            if session_kind_event is None:
+                session_kind_event = event
+            continue
+        ordinary_events.append(event)
 
     final_events = list(completion_events.values())
     notifications = [
@@ -2090,7 +2216,38 @@ def reconcile_code_session_chunks(session: ParsedSession) -> ParsedSession:
         if (notification := _background_notification_from_event(event)) is not None
     ]
     messages = _project_background_task_completions(session.messages, notifications)
-    return session.model_copy(update={"messages": messages, "session_events": [*ordinary_events, *final_events]})
+
+    merged_coverage_events: list[ParsedSessionEvent] = []
+    if coverage_events:
+        merged_coverage_events.append(
+            coverage_events[0].model_copy(
+                update={
+                    "timestamp": session.updated_at,
+                    "payload": {
+                        "sidecar_seen": _merge_count_dicts(
+                            event.payload.get("sidecar_seen", {}) for event in coverage_events
+                        ),
+                        "sidecar_persisted": _merge_count_dicts(
+                            event.payload.get("sidecar_persisted", {}) for event in coverage_events
+                        ),
+                        "empty_dropped_by_record_type": _merge_count_dicts(
+                            event.payload.get("empty_dropped_by_record_type", {}) for event in coverage_events
+                        ),
+                    },
+                }
+            )
+        )
+
+    ordered_events = order_session_events(
+        [
+            *ordinary_events,
+            *final_events,
+            *delegation_events.values(),
+            *([session_kind_event] if session_kind_event is not None else []),
+            *merged_coverage_events,
+        ]
+    )
+    return session.model_copy(update={"messages": messages, "session_events": ordered_events})
 
 
 def parse_code_stream(
@@ -2116,6 +2273,7 @@ def parse_code_stream(
 
 __all__ = [
     "apply_tool_result_sidecars",
+    "order_session_events",
     "parse_code",
     "parse_code_stream",
     "reconcile_code_session_chunks",

--- a/polylogue/storage/sqlite/archive_tiers/index.py
+++ b/polylogue/storage/sqlite/archive_tiers/index.py
@@ -323,7 +323,34 @@ from polylogue.storage.sqlite.delegation_facts import delegation_facts_insert_sq
 # may already have been swept by an intervening full reindex). `polylogue
 # ops reset --index && polylogued run` is required to apply this;
 # deliberately NOT executed by this declaration.
-INDEX_SCHEMA_VERSION = 58
+# polylogue-4987i: v59 makes Claude Code session_events ordering deterministic
+# and chunk-count-invariant (order_session_events/reconcile_code_session_chunks,
+# code_parser.py). Previously, eager parsing (full-corpus reindex) and
+# streaming/chunked parsing (live incremental ingest of a session interleaved
+# with another session's records in the same JSONL -- a common shape for
+# subagent/resume sessions) could produce the SAME session_events content in a
+# DIFFERENT order for byte-identical raw input, because each streaming chunk
+# independently appended its own end-of-chunk summary events (coverage,
+# background-completion, delegation-progress) instead of a session-wide
+# accumulation. content_hash embeds each event's list position
+# (`event_index`, pipeline/ids.py:_session_hash_components), so this was a
+# genuine content-hash instability: reindexing a session that was originally
+# ingested incrementally could compute a different hash purely from which
+# code path produced it, triggering spurious "content changed" reprocessing.
+# Fix: both paths now sort session_events by (timestamp, event-type tier,
+# encounter index) and streaming's chunk-merge fully accumulates coverage/
+# delegation-progress across chunks (not just background-completion) before
+# that sort, so the order depends only on parsed content, never on chunk
+# count. Read-only live spot-check (source.db, 2026-08-03, 25 smallest
+# claude-code-session rows sampled): eager-parsed content_hash is BYTE-
+# IDENTICAL before/after this change for every non-interleaved (single-
+# chunk) sample -- the fix is a no-op for the common case. Hash drift is
+# expected and acknowledged ONLY for sessions whose raw source file
+# genuinely interleaves two sessions' records (forcing multi-chunk
+# streaming) and that were originally ingested via the streaming path with
+# the old buggy order -- same v42/v44/v45/v46/v48/v58 "SEMANTIC_REPARSE, no
+# clone-safe SQL delta" shape.
+INDEX_SCHEMA_VERSION = 59
 
 # polylogue-v6i3: shared WHEN-clause fragment gating the blocks_command_trigram
 # trigger BODIES on the same dedicated bulk-build guard row messages_fts's

--- a/polylogue/storage/sqlite/lifecycle.py
+++ b/polylogue/storage/sqlite/lifecycle.py
@@ -739,6 +739,18 @@ INDEX_DELTA_DECLARATIONS: tuple[IndexDeltaDeclaration, ...] = (
         # this declaration.
         classes=(DerivedDeltaClass.SEMANTIC_REPARSE,),
     ),
+    IndexDeltaDeclaration(
+        version=59,
+        # polylogue-4987i: Claude Code session_events ordering is now
+        # deterministic and chunk-count-invariant -- see INDEX_SCHEMA_VERSION's
+        # v59 comment (archive_tiers/index.py) for the full writeup, root
+        # cause, and live spot-check evidence. No DDL change on any table
+        # (content_hash values shift for a subset of already-materialized
+        # rows, not the schema), so there is nothing here for a fast-forward
+        # to do. Resolving already-materialized sessions with the old order
+        # requires `polylogue ops reset --index && polylogued run`.
+        classes=(DerivedDeltaClass.SEMANTIC_REPARSE,),
+    ),
 )
 
 

--- a/tests/unit/sources/test_claude_code_normalization_laws.py
+++ b/tests/unit/sources/test_claude_code_normalization_laws.py
@@ -185,12 +185,18 @@ def test_family_fixture_detector_and_streaming_paths_preserve_one_normalized_ide
     assert foreground_result.is_error is True
     assert foreground_result.exit_code is None
 
+    # polylogue-4987i: session_events are ordered by (timestamp, event-type
+    # tier, encounter index) -- see order_session_events -- so
+    # background_task_completion (10:00:09) lands before the second
+    # message_usage/claude_parse_coverage pair (both 10:00:10, tier breaks
+    # the tie in eager's original append-order).
     assert [(event.event_type, event.source_message_provider_id) for event in main.session_events] == [
         ("message_usage", "main-a1"),
-        ("message_usage", ""),  # polylogue-slshy: no positional fallback
         ("background_task_completion", "main-bg-notification"),
+        ("message_usage", ""),  # polylogue-slshy: no positional fallback
+        ("claude_parse_coverage", None),
     ]
-    assert main.session_events[-1].payload == {
+    assert main.session_events[1].payload == {
         "task_id": "task-bg",
         "tool_use_id": "tool-bg",
         "output_file": "/tmp/task-bg.output",


### PR DESCRIPTION
## Summary
Makes Claude Code `session_events` ordering deterministic and independent of how many streaming chunks a session was split into, fixing a content-hash instability between full-corpus reindex (eager parse) and live incremental ingest (streaming/chunked parse) of the same raw bytes.

## Problem
`tests/unit/sources/test_claude_code_normalization_laws.py::test_family_fixture_detector_and_streaming_paths_preserve_one_normalized_identity` failed on the fresh post-merge-train full verify (2026-08-03): eager and streaming parsing produce structurally identical `session_events` for the same session, but in a different order, when the raw file interleaves records from two sessions (forcing the streaming path to split into non-contiguous chunks — a common shape for subagent/resume sessions).

Root cause: each streaming chunk is parsed by the same per-chunk logic as eager, so each chunk independently appends its own end-of-chunk summary events (`claude_parse_coverage`, `background_task_completion`, `claude_delegation_progress`) at that chunk's local "end" — which is not the session's true end. `reconcile_code_session_chunks` only deduped `background_task_completion` across chunks, so coverage/delegation events survived as one-per-chunk partial sums instead of the session-wide totals eager computes in one pass.

`content_hash` embeds each event's list position (`event_index`), so this was a genuine hash instability: reindexing a session originally ingested incrementally could compute a different hash purely from which code path produced it, triggering spurious "content changed" reprocessing.

## Solution
There is no true "end of session" to defer to — a live session can always grow another byte later, and both paths only ever see whatever prefix of the file exists when parsing runs. So the fix makes the final order depend only on parsed content, not chunk count:

- `order_session_events()` (`polylogue/sources/parsers/claude/code_parser.py`) sorts by `(timestamp, event-type tier, encounter index)`, applied at the end of both `_parse_code_records` (eager) and `reconcile_code_session_chunks` (streaming). Tier ranks reproduce eager's original append order for same-timestamp cross-type ties, so it's a no-op for eager's own historical output in the common single-chunk case.
- `reconcile_code_session_chunks` now folds **all three** chunk-boundary-sensitive summary types across chunks (previously only `background_task_completion`): `claude_parse_coverage` (sum count dicts, stamp session-wide `updated_at`), `claude_delegation_progress` (sum ticks, min/max first/last_seen per `parent_tool_use_id`), `claude_session_kind` (dedup to ≤1).
- `INDEX_SCHEMA_VERSION` 58→59 (`SEMANTIC_REPARSE`, no DDL change): a read-only live spot-check (25 smallest `claude-code-session` raw rows) found eager-parsed `content_hash` byte-identical before/after for every non-interleaved sample, so the hash drift is scoped to genuinely multi-chunk streaming-ingested sessions, not the whole corpus — declared explicitly per the schema regime rather than silently absorbed.

Considered and rejected: (a) threading an ordering key through chunk merge instead of sorting — strictly more complex for the same result, and wouldn't by itself fix the coverage/delegation partial-sum bug; (b) making eager defer to "true end of session" — impossible by construction, there is no such event for a live-growing archive.

## Verification
- `devtools test tests/unit/sources/test_claude_code_normalization_laws.py` — 12 passed (failing before the fix, confirmed via `git stash`).
- `devtools test tests/unit/sources/ tests/unit/pipeline/test_delegation_provider_fixtures.py tests/unit/pipeline/test_ingest_batch.py tests/unit/core/test_content_projection.py tests/unit/storage/test_title_source_queryable.py` — 2422 passed, 1 pre-existing flaky (`test_live_watcher.py::test_end_to_end_hidden_root_file_creation_triggers_ingest`, a filesystem-timing test unrelated to this change, confirmed by isolated re-run passing).
- `mypy --strict polylogue/sources/parsers/claude/code_parser.py` — clean.
- `devtools verify --quick` — exit 0.
- `devtools lab policy demo-tour-freshness` regenerated and diffed (only the fixture's own sample-manifest hash changed, as expected).

Ref polylogue-4987i