### PR TITLE
refactor(daemon): delegate session similarity to provider

### DIFF
--- a/polylogue/api/embeddings.py
+++ b/polylogue/api/embeddings.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from polylogue.config import Config
+    from polylogue.core.protocols import VectorProvider
     from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
 
 
@@ -17,6 +18,9 @@ class PolylogueEmbeddingsMixin:
 
         @property
         def backend(self) -> SQLiteBackend: ...
+
+        @property
+        def repository(self) -> Any: ...
 
     def embedding_status(self, *, detail: bool = False) -> dict[str, object]:
         """Return canonical embedding readiness status for API clients.
@@ -32,6 +36,26 @@ class PolylogueEmbeddingsMixin:
                 include_retrieval_bands=detail,
                 include_detail=detail,
             )
+        )
+
+    async def search_similar_sessions(
+        self,
+        session_id: str,
+        *,
+        limit: int = 10,
+        vector_provider: VectorProvider | None = None,
+        voyage_api_key: str | None = None,
+    ) -> dict[str, object]:
+        """Return vector-ranked session hits for a stored session."""
+        return cast(
+            dict[str, object],
+            await self.repository.search_similar_sessions(
+                session_id,
+                limit=limit,
+                vector_provider=vector_provider,
+                provider_db_path=self.config.archive_root / "embeddings.db",
+                voyage_api_key=voyage_api_key,
+            ),
         )
 
     def embedding_preflight(

--- a/polylogue/daemon/similarity.py
+++ b/polylogue/daemon/similarity.py
@@ -35,39 +35,19 @@ its vectors stored. This is the property that lets the reader expose
 
 from __future__ import annotations
 
-import contextlib
 import sqlite3
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Final
+from typing import Final, cast
 
 from polylogue.config import load_polylogue_config
+from polylogue.core.errors import DatabaseError
 from polylogue.paths import archive_root
 from polylogue.storage.archive_identity import resolve_active_index_path
-from polylogue.storage.sqlite.sqlite_vec_extension import try_load_sqlite_vec
 
 # Hard server-side cap on requested result count. A pathological client
 # asking for ``limit=10**6`` still receives at most this many rows.
 SIMILAR_RESULTS_MAX: Final[int] = 50
 SIMILAR_RESULTS_DEFAULT: Final[int] = 10
-
-# Per-source-message neighbor fanout used to grow the candidate pool
-# before deduplicating to sessions. Picked so the worst case
-# (``limit=SIMILAR_RESULTS_MAX``) still completes in a single small
-# ``MATCH`` per source message.
-_PER_MESSAGE_K: Final[int] = 20
-
-
-@dataclass(frozen=True)
-class SimilarHit:
-    """One ranked similar-session row."""
-
-    session_id: str
-    score: float
-    confidence: str
-    title: str | None
-    origin: str | None
-    matched_message_count: int
 
 
 def _confidence_for_score(score: float) -> str:
@@ -112,14 +92,6 @@ def _empty_envelope(status: str, *, reason: str | None) -> dict[str, object]:
     }
 
 
-def _fetch_session_exists(conn: sqlite3.Connection, session_id: str) -> bool:
-    row = conn.execute(
-        "SELECT 1 FROM sessions WHERE session_id = ?",
-        (session_id,),
-    ).fetchone()
-    return row is not None
-
-
 def _fetch_archive_session_exists(conn: sqlite3.Connection, session_id: str) -> bool:
     row = conn.execute(
         "SELECT 1 FROM sessions WHERE session_id = ?",
@@ -133,208 +105,6 @@ def _vec_table_exists(conn: sqlite3.Connection) -> bool:
     return row is not None
 
 
-def _source_message_embeddings(
-    conn: sqlite3.Connection,
-    session_id: str,
-) -> list[tuple[str, bytes]]:
-    """Return ``(message_id, embedding_blob)`` rows for the source session.
-
-    ``message_embeddings`` is content-addressed (keyed by
-    ``embedding_input_hash``, polylogue-q88p), not by ``message_id``/
-    ``session_id`` directly -- resolve through ``message_embedding_refs``.
-    ``DISTINCT`` on the hash avoids issuing duplicate ``MATCH`` queries when
-    the session has multiple messages sharing identical text. The blob is
-    returned exactly as stored so it can be passed back into a ``vec0``
-    ``MATCH`` clause without any re-encoding round trip.
-    """
-
-    rows = conn.execute(
-        """
-        SELECT MIN(r.message_id), me.embedding
-        FROM message_embedding_refs AS r
-        JOIN message_embeddings AS me
-          ON lower(hex(r.embedding_input_hash)) = me.embedding_input_hash
-        WHERE r.session_id = ?
-        GROUP BY me.embedding_input_hash
-        """,
-        (session_id,),
-    ).fetchall()
-    return [(str(row[0]), bytes(row[1])) for row in rows]
-
-
-def _source_archive_message_embeddings(
-    conn: sqlite3.Connection,
-    session_id: str,
-) -> list[tuple[str, bytes]]:
-    rows = conn.execute(
-        """
-        SELECT MIN(r.message_id), me.embedding
-        FROM message_embedding_refs AS r
-        JOIN message_embeddings AS me
-          ON lower(hex(r.embedding_input_hash)) = me.embedding_input_hash
-        WHERE r.session_id = ?
-        GROUP BY me.embedding_input_hash
-        """,
-        (session_id,),
-    ).fetchall()
-    return [(str(row[0]), bytes(row[1])) for row in rows]
-
-
-def _knn_for_embedding(
-    conn: sqlite3.Connection,
-    embedding_blob: bytes,
-    *,
-    k: int,
-) -> list[tuple[str, str, float]]:
-    """Run a single ``MATCH`` and return ``(message_id, session_id, distance)``.
-
-    A hash hit is resolved back to every message currently referencing it
-    (content-addressed dedup, polylogue-q88p) -- one MATCH row can expand
-    into several result rows. The vec0 column ``distance`` here is L2
-    distance over the indexed embeddings. Cosine similarity is recovered
-    downstream once a row's embedding has been pulled into the
-    score-aggregation step.
-    """
-
-    rows = conn.execute(
-        """
-        SELECT r.message_id, r.session_id, hits.distance
-        FROM (
-            SELECT embedding_input_hash, distance
-            FROM message_embeddings
-            WHERE embedding MATCH ?
-              AND k = ?
-        ) AS hits
-        JOIN message_embedding_refs AS r
-          ON lower(hex(r.embedding_input_hash)) = hits.embedding_input_hash
-        ORDER BY hits.distance
-        """,
-        (embedding_blob, k),
-    ).fetchall()
-    return [(str(row[0]), str(row[1]), float(row[2])) for row in rows]
-
-
-def _archive_knn_for_embedding(
-    conn: sqlite3.Connection,
-    embedding_blob: bytes,
-    *,
-    k: int,
-) -> list[tuple[str, str, float]]:
-    rows = conn.execute(
-        """
-        SELECT r.message_id, r.session_id, hits.distance
-        FROM (
-            SELECT embedding_input_hash, distance
-            FROM message_embeddings
-            WHERE embedding MATCH ?
-              AND k = ?
-        ) AS hits
-        JOIN message_embedding_refs AS r
-          ON lower(hex(r.embedding_input_hash)) = hits.embedding_input_hash
-        ORDER BY hits.distance
-        """,
-        (embedding_blob, k),
-    ).fetchall()
-    return [(str(row[0]), str(row[1]), float(row[2])) for row in rows]
-
-
-def _l2_to_cosine_similarity(distance: float) -> float:
-    """Convert vec0 L2 distance over unit-norm vectors to cosine similarity.
-
-    Voyage embeddings are L2-normalized, so for unit vectors
-    ``||a - b||^2 = 2 - 2 cos(theta)`` and therefore
-    ``cos(theta) = 1 - distance^2 / 2``. The result is clamped to
-    ``[0, 1]`` so noise from non-unit-norm rows can never produce a
-    confidence higher than the upper band.
-    """
-
-    sim = 1.0 - (distance * distance) / 2.0
-    if sim < 0.0:
-        return 0.0
-    if sim > 1.0:
-        return 1.0
-    return sim
-
-
-def _aggregate_hits(
-    per_message_results: list[list[tuple[str, str, float]]],
-    *,
-    self_session_id: str,
-) -> dict[str, dict[str, float | int]]:
-    """Collapse per-message KNN lists into per-session aggregates.
-
-    Each candidate session keeps its best (closest) distance seen
-    across all source messages. The matched-message count records how
-    many source messages picked it as a neighbor — a coarse but useful
-    "this isn't a one-off accidental hit" signal exposed to the reader.
-    """
-
-    aggregates: dict[str, dict[str, float | int]] = {}
-    for hits in per_message_results:
-        seen_in_this_source: set[str] = set()
-        for _msg_id, conv_id, distance in hits:
-            if conv_id == self_session_id:
-                continue
-            entry = aggregates.setdefault(
-                conv_id,
-                {"best_distance": float("inf"), "matched_messages": 0},
-            )
-            if distance < entry["best_distance"]:
-                entry["best_distance"] = distance
-            if conv_id not in seen_in_this_source:
-                seen_in_this_source.add(conv_id)
-                entry["matched_messages"] = int(entry["matched_messages"]) + 1
-    return aggregates
-
-
-def _hydrate_session_metadata(
-    conn: sqlite3.Connection,
-    session_ids: list[str],
-) -> dict[str, tuple[str | None, str | None]]:
-    if not session_ids:
-        return {}
-    placeholders = ",".join("?" * len(session_ids))
-    rows = conn.execute(
-        f"""
-        SELECT session_id, title, source_name
-        FROM sessions
-        WHERE session_id IN ({placeholders})
-        """,
-        tuple(session_ids),
-    ).fetchall()
-    return {
-        str(row[0]): (
-            (str(row[1]) if row[1] is not None else None),
-            (str(row[2]) if row[2] is not None else None),
-        )
-        for row in rows
-    }
-
-
-def _hydrate_archive_session_metadata(
-    conn: sqlite3.Connection,
-    session_ids: list[str],
-) -> dict[str, tuple[str | None, str | None]]:
-    if not session_ids:
-        return {}
-    placeholders = ",".join("?" * len(session_ids))
-    rows = conn.execute(
-        f"""
-        SELECT session_id, title, origin
-        FROM sessions
-        WHERE session_id IN ({placeholders})
-        """,
-        tuple(session_ids),
-    ).fetchall()
-    return {
-        str(row[0]): (
-            (str(row[1]) if row[1] is not None else None),
-            (str(row[2]) if row[2] is not None else None),
-        )
-        for row in rows
-    }
-
-
 def _clamp_limit(requested: int | None) -> int:
     if requested is None:
         return SIMILAR_RESULTS_DEFAULT
@@ -345,13 +115,6 @@ def _clamp_limit(requested: int | None) -> int:
     return requested
 
 
-def _archive_index_path_for(dbf: Path) -> str | None:
-    # dbf always names "index.db" (resolve_active_index_path raises
-    # otherwise), so the old sibling_index_db(path, require_exists=True) call
-    # was provably an identity-plus-existence-check on path itself.
-    return str(dbf) if dbf.exists() else None
-
-
 def _build_archive_similar_payload(
     index_db: str,
     session_id: str,
@@ -360,7 +123,6 @@ def _build_archive_similar_payload(
     disabled_reason: str | None,
     archive_root_path: Path,
 ) -> dict[str, object] | None:
-    conn: sqlite3.Connection | None = None
     index_conn = sqlite3.connect(index_db)
     try:
         index_conn.row_factory = sqlite3.Row
@@ -379,58 +141,46 @@ def _build_archive_similar_payload(
             envelope["session_id"] = session_id
             envelope["limit"] = bounded_limit
             return envelope
-        conn = sqlite3.connect(str(embeddings_db))
-        conn.row_factory = sqlite3.Row
-        if not _vec_table_exists(conn):
-            envelope = _empty_envelope("unavailable", reason="vec0_table_missing")
+        with sqlite3.connect(str(embeddings_db)) as conn:
+            if not _vec_table_exists(conn):
+                envelope = _empty_envelope("unavailable", reason="vec0_table_missing")
+                envelope["session_id"] = session_id
+                envelope["limit"] = bounded_limit
+                return envelope
+
+        from polylogue import Polylogue
+        from polylogue.api.sync.bridge import run_coroutine_sync
+
+        async def query() -> dict[str, object]:
+            async with Polylogue(archive_root=archive_root_path, db_path=Path(index_db)) as polylogue:
+                return await polylogue.search_similar_sessions(
+                    session_id,
+                    limit=bounded_limit,
+                    voyage_api_key=load_polylogue_config().voyage_api_key,
+                )
+
+        try:
+            query_result = run_coroutine_sync(query())
+        except (DatabaseError, ValueError) as exc:
+            status = "unavailable" if "extension" in str(exc).lower() else "not_embedded"
+            envelope = _empty_envelope(status, reason="sqlite_vec_not_loaded" if status == "unavailable" else None)
             envelope["session_id"] = session_id
             envelope["limit"] = bounded_limit
             return envelope
 
-        loaded, _ext_error = try_load_sqlite_vec(conn)
-        if not loaded:
-            envelope = _empty_envelope("unavailable", reason="sqlite_vec_not_loaded")
-            envelope["session_id"] = session_id
-            envelope["limit"] = bounded_limit
-            return envelope
-
-        source_rows = _source_archive_message_embeddings(conn, session_id)
-        if not source_rows:
-            envelope = _empty_envelope("not_embedded", reason=None)
-            envelope["session_id"] = session_id
-            envelope["limit"] = bounded_limit
-            return envelope
-
-        per_message_results: list[list[tuple[str, str, float]]] = []
-        for _msg_id, embedding in source_rows[:_PER_MESSAGE_K]:
-            per_message_results.append(_archive_knn_for_embedding(conn, embedding, k=_PER_MESSAGE_K))
-
-        aggregates = _aggregate_hits(
-            per_message_results,
-            self_session_id=session_id,
-        )
-        ranked = sorted(
-            aggregates.items(),
-            key=lambda item: (item[1]["best_distance"], item[0]),
-        )[:bounded_limit]
-        metadata = _hydrate_archive_session_metadata(
-            index_conn,
-            [session_id for session_id, _ in ranked],
-        )
+        results = cast(list[dict[str, object]], query_result["results"])
         hits: list[dict[str, object]] = []
-        for session_id, agg in ranked:
-            distance = float(agg["best_distance"])
-            score = _l2_to_cosine_similarity(distance)
-            title, origin = metadata.get(session_id, (None, None))
+        for hit in results:
+            score = float(cast(float, hit["score"]))
             hits.append(
                 {
-                    "session_id": session_id,
+                    "session_id": str(hit["session_id"]),
                     "score": round(score, 4),
-                    "distance": round(distance, 4),
+                    "distance": round(float(cast(float, hit["distance"])), 4),
                     "confidence": _confidence_for_score(score),
-                    "title": title,
-                    "origin": origin,
-                    "matched_message_count": int(agg["matched_messages"]),
+                    "title": hit["title"],
+                    "origin": hit["origin"],
+                    "matched_message_count": int(cast(int, hit["matched_message_count"])),
                 }
             )
 
@@ -438,14 +188,11 @@ def _build_archive_similar_payload(
             "status": "ready",
             "reason": None,
             "session_id": session_id,
-            "source_embedded_messages": len(source_rows),
+            "source_embedded_messages": int(cast(int, query_result["source_embedded_messages"])),
             "limit": bounded_limit,
             "results": hits,
         }
     finally:
-        if conn is not None:
-            with contextlib.suppress(sqlite3.Error):
-                conn.close()
         index_conn.close()
 
 
@@ -479,109 +226,25 @@ def build_similar_payload(
         voyage_api_key=cfg.voyage_api_key,
     )
 
-    dbf = resolve_active_index_path(archive_root())
-    index_db = _archive_index_path_for(dbf)
-    if index_db is not None:
-        return _build_archive_similar_payload(
-            index_db,
-            session_id,
-            bounded_limit=bounded_limit,
-            disabled_reason=disabled_reason,
-            archive_root_path=archive_root(),
-        )
+    archive_root_path = archive_root()
+    dbf = resolve_active_index_path(archive_root_path)
     if not dbf.exists():
         # Treat a missing database the same as a missing session —
         # the route layer turns this into 404. The reader will never see
         # this branch in practice once the archive has been bootstrapped.
         return None
 
-    conn = sqlite3.connect(str(dbf))
-    try:
-        conn.row_factory = sqlite3.Row
-        if not _fetch_session_exists(conn, session_id):
-            return None
-
-        if disabled_reason is not None:
-            envelope = _empty_envelope("disabled", reason=disabled_reason)
-            envelope["session_id"] = session_id
-            envelope["limit"] = bounded_limit
-            return envelope
-
-        if not _vec_table_exists(conn):
-            envelope = _empty_envelope("unavailable", reason="vec0_table_missing")
-            envelope["session_id"] = session_id
-            envelope["limit"] = bounded_limit
-            return envelope
-
-        loaded, _ext_error = try_load_sqlite_vec(conn)
-        if not loaded:
-            envelope = _empty_envelope("unavailable", reason="sqlite_vec_not_loaded")
-            envelope["session_id"] = session_id
-            envelope["limit"] = bounded_limit
-            return envelope
-
-        source_rows = _source_message_embeddings(conn, session_id)
-        if not source_rows:
-            envelope = _empty_envelope("not_embedded", reason=None)
-            envelope["session_id"] = session_id
-            envelope["limit"] = bounded_limit
-            return envelope
-
-        # Cap source fanout to avoid issuing a thousand MATCH queries
-        # for a giant session. Twenty representative messages is
-        # enough to populate the candidate pool with good recall for
-        # the reader's top-N display.
-        per_message_results: list[list[tuple[str, str, float]]] = []
-        for _msg_id, embedding in source_rows[:_PER_MESSAGE_K]:
-            per_message_results.append(_knn_for_embedding(conn, embedding, k=_PER_MESSAGE_K))
-
-        aggregates = _aggregate_hits(
-            per_message_results,
-            self_session_id=session_id,
-        )
-
-        ranked = sorted(
-            aggregates.items(),
-            key=lambda item: (item[1]["best_distance"], item[0]),
-        )[:bounded_limit]
-
-        metadata = _hydrate_session_metadata(
-            conn,
-            [conv_id for conv_id, _ in ranked],
-        )
-
-        hits: list[dict[str, object]] = []
-        for conv_id, agg in ranked:
-            distance = float(agg["best_distance"])
-            score = _l2_to_cosine_similarity(distance)
-            title, origin = metadata.get(conv_id, (None, None))
-            hits.append(
-                {
-                    "session_id": conv_id,
-                    "score": round(score, 4),
-                    "distance": round(distance, 4),
-                    "confidence": _confidence_for_score(score),
-                    "title": title,
-                    "origin": origin,
-                    "matched_message_count": int(agg["matched_messages"]),
-                }
-            )
-
-        return {
-            "status": "ready",
-            "reason": None,
-            "session_id": session_id,
-            "source_embedded_messages": len(source_rows),
-            "limit": bounded_limit,
-            "results": hits,
-        }
-    finally:
-        conn.close()
+    return _build_archive_similar_payload(
+        str(dbf),
+        session_id,
+        bounded_limit=bounded_limit,
+        disabled_reason=disabled_reason,
+        archive_root_path=archive_root_path,
+    )
 
 
 __all__ = [
     "SIMILAR_RESULTS_DEFAULT",
     "SIMILAR_RESULTS_MAX",
-    "SimilarHit",
     "build_similar_payload",
 ]

--- a/polylogue/storage/repository/vectors/repository_vectors.py
+++ b/polylogue/storage/repository/vectors/repository_vectors.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import builtins
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol, cast
 
 from polylogue.core.protocols import VectorProvider
 from polylogue.logging import get_logger
@@ -21,6 +22,9 @@ if TYPE_CHECKING:
 
 def resolve_optional_vector_provider(
     vector_provider: VectorProvider | None,
+    *,
+    db_path: Path | None = None,
+    voyage_api_key: str | None = None,
 ) -> VectorProvider | None:
     """Resolve the explicitly supplied provider or create the default one."""
     if vector_provider is not None:
@@ -28,10 +32,14 @@ def resolve_optional_vector_provider(
 
     from polylogue.storage.search_providers import create_vector_provider
 
-    return create_vector_provider()
+    return create_vector_provider(voyage_api_key=voyage_api_key, db_path=db_path)
 
 
 logger = get_logger(__name__)
+
+
+class _SessionEmbeddingCounter(Protocol):
+    def count_session_embeddings(self, session_id: str) -> int: ...
 
 
 class RepositoryVectorMixin:
@@ -73,6 +81,79 @@ class RepositoryVectorMixin:
         )[:limit]
 
         return await self.get_many(ranked_ids)
+
+    async def search_similar_sessions(
+        self,
+        session_id: str,
+        limit: int = 10,
+        vector_provider: VectorProvider | None = None,
+        provider_db_path: Path | None = None,
+        voyage_api_key: str | None = None,
+    ) -> dict[str, object]:
+        """Rank sessions from ``query_by_session`` message hits.
+
+        The vector provider owns KNN ordering. This repository operation only
+        resolves each returned message to its session, keeps the closest hit
+        per session, and hydrates the metadata needed by read surfaces.
+        """
+        vector_provider = resolve_optional_vector_provider(
+            vector_provider,
+            db_path=provider_db_path,
+            voyage_api_key=voyage_api_key,
+        )
+        if vector_provider is None:
+            raise ValueError("No vector provider configured")
+
+        source_embedded_messages = await asyncio.to_thread(
+            cast(_SessionEmbeddingCounter, vector_provider).count_session_embeddings,
+            session_id,
+        )
+        results = await asyncio.to_thread(
+            vector_provider.query_by_session,
+            session_id,
+            limit=limit,
+        )
+        if not results:
+            return {
+                "source_embedded_messages": source_embedded_messages,
+                "results": [],
+            }
+
+        message_ids = [message_id for message_id, _ in results]
+        message_to_session = await self._get_message_session_mapping(message_ids)
+        aggregates: dict[str, tuple[float, set[str]]] = {}
+        for message_id, distance in results:
+            candidate_id = message_to_session.get(message_id)
+            if candidate_id is None or candidate_id == session_id:
+                continue
+            best_distance, matched_messages = aggregates.setdefault(candidate_id, (float("inf"), set()))
+            matched_messages.add(message_id)
+            aggregates[candidate_id] = (min(best_distance, distance), matched_messages)
+
+        ranked = sorted(aggregates.items(), key=lambda item: (item[1][0], item[0]))[:limit]
+        sessions = await self.get_many([candidate_id for candidate_id, _ in ranked])
+        sessions_by_id = {str(session.id): session for session in sessions}
+
+        hits: list[dict[str, object]] = []
+        for candidate_id, (distance, matched_messages) in ranked:
+            candidate = sessions_by_id.get(candidate_id)
+            if candidate is None:
+                continue
+            score = max(0.0, min(1.0, 1.0 - (distance * distance) / 2.0))
+            hits.append(
+                {
+                    "session_id": candidate_id,
+                    "score": score,
+                    "distance": distance,
+                    "matched_message_count": len(matched_messages),
+                    "title": candidate.title,
+                    "origin": str(candidate.origin),
+                }
+            )
+        return {
+            "source_embedded_messages": source_embedded_messages,
+            "results": hits,
+        }
 
     async def _get_message_session_mapping(self, message_ids: builtins.list[str]) -> dict[str, str]:
         if not message_ids:

--- a/polylogue/storage/search_providers/sqlite_vec_queries.py
+++ b/polylogue/storage/search_providers/sqlite_vec_queries.py
@@ -13,8 +13,7 @@ from polylogue.storage.search_providers.sqlite_vec_support import SqliteVecError
 
 # Per-seed-message neighbor fanout used to grow the candidate pool before
 # deduplicating to messages. Bounds the number of MATCH queries issued for a
-# large seed session to a fixed, representative sample (mirrors
-# ``polylogue.daemon.similarity._PER_MESSAGE_K``).
+# large seed session to a fixed, representative sample.
 _SESSION_SEED_FANOUT = 20
 
 
@@ -223,6 +222,26 @@ class SqliteVecQueryMixin:
 
             ranked = sorted(best_distance.items(), key=lambda item: (item[1], item[0]))
             return ranked[:limit]
+        finally:
+            conn.close()
+
+    def count_session_embeddings(self, session_id: str) -> int:
+        """Return the number of distinct stored vectors for ``session_id``."""
+        self._ensure_vec_available()
+        conn = self._get_connection()
+        try:
+            try:
+                row = conn.execute(
+                    """
+                    SELECT COUNT(DISTINCT embedding_input_hash) AS count
+                    FROM message_embedding_refs
+                    WHERE session_id = ?
+                    """,
+                    (session_id,),
+                ).fetchone()
+            except sqlite3.OperationalError as exc:
+                raise SqliteVecError(f"session {session_id!r} has no stored embeddings: {exc}") from exc
+            return int(row["count"]) if row is not None else 0
         finally:
             conn.close()
 

--- a/tests/unit/daemon/test_similarity_endpoint.py
+++ b/tests/unit/daemon/test_similarity_endpoint.py
@@ -12,12 +12,14 @@ Tests use the in-process handler pattern from
 socket listener, just the route dispatch against a freshly seeded
 SQLite archive. ``sqlite-vec``'s ``MATCH`` engine is not exercised in
 unit tests (the extension may not be available in the verify
-environment); the contract tests instead pin the route, the absent
-states, and the helper-level scoring/aggregation logic.
+environment); the ready-state parity test uses the real provider when
+sqlite-vec is available, while the other tests pin the route and absent
+states.
 """
 
 from __future__ import annotations
 
+import hashlib
 import sqlite3
 import threading
 from concurrent.futures import ThreadPoolExecutor
@@ -30,18 +32,22 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from polylogue.core.enums import Origin
 from polylogue.daemon.similarity import (
     SIMILAR_RESULTS_DEFAULT,
     SIMILAR_RESULTS_MAX,
-    _aggregate_hits,
     _clamp_limit,
     _confidence_for_score,
     _disabled_reason,
-    _l2_to_cosine_similarity,
     build_similar_payload,
 )
 from polylogue.paths import archive_root
 from polylogue.storage.archive_identity import resolve_active_index_path
+from polylogue.storage.search_providers.sqlite_vec import SqliteVecProvider
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+from polylogue.storage.sqlite.archive_tiers.embedding_write import upsert_message_embedding
+from polylogue.storage.sqlite.archive_tiers.embeddings import EMBEDDING_DIMENSION
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 
 if TYPE_CHECKING:
     from polylogue.daemon.http import DaemonAPIHandler, DaemonAPIHTTPServer
@@ -125,6 +131,61 @@ def _seed_archive_session(
     return archive_session_id
 
 
+def _unit_vector(*, axis0: float, axis1: float) -> list[float]:
+    vector = [0.0] * EMBEDDING_DIMENSION
+    vector[0] = axis0
+    vector[1] = axis1
+    return vector
+
+
+def _seed_ready_similarity_archive() -> tuple[str, Path]:
+    """Seed canonical index and embedding tiers for the route parity test."""
+    root = archive_root()
+    index_db = root / "index.db"
+    with sqlite3.connect(index_db) as conn:
+        initialize_archive_tier(conn, ArchiveTier.INDEX)
+        for native_id, title in (("seed", "Seed"), ("near", "Near"), ("far", "Far")):
+            conn.execute(
+                "INSERT OR REPLACE INTO sessions (native_id, origin, title, content_hash) VALUES (?, ?, ?, ?)",
+                (native_id, "codex-session", title, b"x" * 32),
+            )
+        for native_id in ("seed", "near", "far"):
+            session_id = f"codex-session:{native_id}"
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO messages (
+                    session_id, native_id, position, role, content_hash
+                ) VALUES (?, ?, 0, 'user', ?)
+                """,
+                (session_id, "m1", b"x" * 32),
+            )
+
+    embeddings_db = root / "embeddings.db"
+    try:
+        with sqlite3.connect(embeddings_db) as conn:
+            initialize_archive_tier(conn, ArchiveTier.EMBEDDINGS)
+            for session_id, message_id, vector in (
+                ("codex-session:seed", "codex-session:seed:m1", _unit_vector(axis0=1.0, axis1=0.0)),
+                ("codex-session:near", "codex-session:near:m1", _unit_vector(axis0=0.99, axis1=0.141)),
+                ("codex-session:far", "codex-session:far:m1", _unit_vector(axis0=0.0, axis1=1.0)),
+            ):
+                upsert_message_embedding(
+                    conn,
+                    message_id=message_id,
+                    session_id=session_id,
+                    origin=Origin.CODEX_SESSION,
+                    embedding=vector,
+                    model="voyage-4",
+                    embedded_at_ms=1_767_225_700_000,
+                    embedding_input_hash=hashlib.sha256(message_id.encode()).digest(),
+                )
+    except RuntimeError as exc:
+        if "sqlite-vec" in str(exc) or "vec0" in str(exc):
+            pytest.skip("sqlite-vec extension is unavailable")
+        raise
+    return "codex-session:seed", embeddings_db
+
+
 def _init_archive() -> None:
     """Create an empty index.db with the ``sessions`` table only.
 
@@ -198,39 +259,6 @@ def test_clamp_limit_bounds_and_defaults() -> None:
     assert _clamp_limit(-5) == SIMILAR_RESULTS_DEFAULT
     assert _clamp_limit(5) == 5
     assert _clamp_limit(10**6) == SIMILAR_RESULTS_MAX
-
-
-def test_l2_to_cosine_similarity_clamps_to_unit_interval() -> None:
-    # Identical unit vectors → distance 0 → cosine 1.
-    assert _l2_to_cosine_similarity(0.0) == 1.0
-    # Orthogonal unit vectors → distance sqrt(2) → cosine 0.
-    assert abs(_l2_to_cosine_similarity(2.0**0.5) - 0.0) < 1e-9
-    # Antipodal unit vectors → distance 2 → cosine -1, clamped to 0.
-    assert _l2_to_cosine_similarity(2.0) == 0.0
-    # Pathological large distances clamp to 0 — never produce a
-    # negative cosine that would slip past the heuristic chip band.
-    assert _l2_to_cosine_similarity(100.0) == 0.0
-    assert _l2_to_cosine_similarity(1000.0) == 0.0
-
-
-def test_aggregate_hits_skips_self_and_takes_best_distance() -> None:
-    per_message = [
-        [("m1", "self", 0.0), ("m2", "other-a", 0.5), ("m3", "other-b", 1.2)],
-        [("m4", "self", 0.1), ("m5", "other-a", 0.3), ("m6", "other-b", 1.0)],
-    ]
-    agg = _aggregate_hits(per_message, self_session_id="self")
-    assert set(agg.keys()) == {"other-a", "other-b"}
-    # other-a was matched by two source messages, best distance 0.3.
-    assert agg["other-a"]["best_distance"] == pytest.approx(0.3)
-    assert agg["other-a"]["matched_messages"] == 2
-    # other-b matched once per source, best distance 1.0.
-    assert agg["other-b"]["best_distance"] == pytest.approx(1.0)
-    assert agg["other-b"]["matched_messages"] == 2
-
-
-def test_aggregate_hits_handles_empty_input() -> None:
-    assert _aggregate_hits([], self_session_id="self") == {}
-    assert _aggregate_hits([[]], self_session_id="self") == {}
 
 
 # ---------------------------------------------------------------------------
@@ -415,3 +443,24 @@ class TestSimilarEndpoint:
         _, payload = send_json.call_args.args
         assert payload["status"] == "not_embedded"
         assert payload["reason"] is None
+
+    def test_ready_route_preserves_provider_query_by_session_order(
+        self, workspace_env: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The live route projects the provider's session-seeded KNN order."""
+        _enable_embeddings(monkeypatch)
+        seed_session_id, embeddings_db = _seed_ready_similarity_archive()
+        provider = SqliteVecProvider(voyage_key="test-key", db_path=embeddings_db, model="voyage-4")
+        expected_message_hits = provider.query_by_session(seed_session_id, limit=3)
+        expected_session_order = list(
+            dict.fromkeys(message_id.rsplit(":", 1)[0] for message_id, _distance in expected_message_hits)
+        )
+
+        handler = _make_handler("GET", f"/api/sessions/{seed_session_id}/similar?limit=3")
+        _, send_json = _capture_responses(handler)
+        handler.do_GET()
+
+        _, payload = send_json.call_args.args
+        assert payload["status"] == "ready"
+        actual_session_order = [row["session_id"] for row in payload["results"]]
+        assert actual_session_order == expected_session_order


### PR DESCRIPTION
## Summary
Delegate the daemon session-similarity route to the storage vector-provider path and keep the daemon responsible for status and JSON projection only.

## Problem
The daemon duplicated sqlite-vec session-seeded KNN, per-session aggregation, and L2-to-cosine scoring even though `SqliteVecProvider.query_by_session` already owns the message ranking path. The duplicate path could drift from CLI and archive query behavior. Ref polylogue-t46.4.

## Solution
The repository resolves provider message hits into ranked session payload data, including scores, metadata, match counts, and source embedding counts. The Polylogue facade exposes that operation. `build_similar_payload` now calls the facade and projects the existing disabled, unavailable, not-embedded, and ready envelopes. The daemon KNN, aggregation, source-vector, and distance-conversion copies were removed. The stale provider comment about mirroring the daemon fanout was removed.

## Verification
- `python -m devtools test tests/unit/daemon/test_similarity_endpoint.py tests/unit/storage/test_vec_session_seed.py` -> 18 passed.
- `python -m devtools verify --quick` -> all 21 steps passed, including ruff, mypy, render all, layering, and policy checks.
- The route parity test seeds canonical index and embedding tiers, calls the real `SqliteVecProvider.query_by_session`, and asserts the live `/api/sessions/{id}/similar` ordering matches its projected session order.

## Acceptance criteria
- Satisfied: daemon `_knn_for_embedding`, `_aggregate_hits`, and `_l2_to_cosine_similarity` are deleted.
- Satisfied: the production similarity route ordering is tested against `SqliteVecProvider.query_by_session`.
- Satisfied: the stale sqlite-vec mirror comment is removed.
- Satisfied: quick verification is green.