### PR TITLE
feat(operations): route derived rebuilds through executor

### DIFF
--- a/docs/plans/mutation-census.yaml
+++ b/docs/plans/mutation-census.yaml
@@ -272,6 +272,38 @@ rows:
       - polylogue.api.archive.PolylogueArchiveMixin.post_blackboard_note
       - polylogue.mcp.server_cutover._dispatch_write (operation=blackboard_post, via post_blackboard_note)
 
+  # --- Phase 7: executor-routed (derived maintenance rebuilds) ---------------
+  # These facade methods are the shared gateway for the MCP maintenance
+  # operations. The existing MCP confirmation gates remain in place; the
+  # executor now owns target planning, capability binding, and receipts for
+  # the underlying derived-tier effects.
+  - operation: rebuild_index
+    spec_name: mutate-rebuild-index
+    status: executor-routed
+    actuator: polylogue.operations.mutation_actuators.IndexRebuildActuator
+    surfaces: [facade, mcp]
+    adapters:
+      - polylogue.api.ingest.PolylogueIngestMixin.rebuild_index
+      - polylogue.mcp.server_cutover._dispatch_maintenance (operation=rebuild_index, via facade)
+
+  - operation: update_index
+    spec_name: mutate-update-index
+    status: executor-routed
+    actuator: polylogue.operations.mutation_actuators.IndexRebuildActuator
+    surfaces: [facade, mcp]
+    adapters:
+      - polylogue.api.archive.PolylogueArchiveMixin.update_index
+      - polylogue.mcp.server_cutover._dispatch_maintenance (operation=update_index, via facade)
+
+  - operation: rebuild_insights
+    spec_name: mutate-rebuild-insights
+    status: executor-routed
+    actuator: polylogue.operations.mutation_actuators.InsightsRebuildActuator
+    surfaces: [facade, mcp]
+    adapters:
+      - polylogue.api.archive.PolylogueArchiveMixin.rebuild_insights
+      - polylogue.mcp.server_cutover._dispatch_maintenance (operation=rebuild_insights, via facade)
+
   # --- Phase 3+ debt: declared-not-routed -------------------------------------
   # MCP-only mutation family with no OperationSpec entry yet (pre-existing
   # gap, not introduced by this PR). jn40's confirm-boolean sweep was the
@@ -279,7 +311,8 @@ rows:
   # remove_mark (phase 2), save_annotation/delete_annotation (phase 3), the
   # saved-view/recall-pack/workspace family (phase 4), record_correction/
   # delete_correction/clear_corrections (phase 5), and blackboard_post
-  # (phase 6, above) are all executor-routed now; the rest of this family
+  # (phase 6, above) and the derived maintenance trio (phase 7, above) are
+  # all executor-routed now; the rest of this family
   # remains debt for a later phase.
 
   - operation: capture_assertion_candidate
@@ -292,16 +325,14 @@ rows:
     surfaces: [mcp]
     reason: Additive batch import with its own provenance/versioning contract.
 
-  - operation: rebuild_index / update_index / rebuild_insights (maintenance_execute family)
+  - operation: maintenance_execute (resumable maintenance run)
     status: declared-not-routed
     surfaces: [mcp, daemon]
     reason: >
-      jn40 confirm-gated (maintenance_execute/rebuild_index/
-      rebuild_session_insights in the named-ten list); internal
-      idempotent-rebuild maintenance, not a data-loss operation in the same
-      sense as delete/excise/reset. OperationSpec entries
-      index-message-fts/materialize-session-insights already declare
-      declared-not-routed.
+      The resumable target-catalog replay has a separate operation-id,
+      cursor, failure-isolation, and partial-resume contract. This slice
+      routes the facade/MCP rebuild_index, update_index, and rebuild_insights
+      methods only; the maintenance run family remains deferred.
 
   - operation: ops reset --database/--index/--blob/--assets/--cache/--auth
     status: declared-not-routed

--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -24,16 +24,16 @@ Current registry snapshot:
 
 ## Runtime Coverage
 
-- covered runtime paths: `21`
+- covered runtime paths: `19`
 - covered runtime artifacts: `45`
 - covered runtime operations: `25`
 - covered maintenance targets: `2`
 - covered declared operation targets: `46`
-- uncovered runtime paths: `thread-query-loop`, `tool-usage-query-loop`
+- uncovered runtime paths: `message-fts-readiness-loop`, `session-insight-repair-loop`, `thread-query-loop`, `tool-usage-query-loop`
 - uncovered runtime artifacts: `thread_results`, `tool_usage_results`
-- uncovered runtime operations: `mutate-add-mark`, `mutate-add-tag`, `mutate-blackboard-post`, `mutate-bulk-tag-sessions`, `mutate-clear-corrections`, `mutate-delete-annotation`, `mutate-delete-correction`, `mutate-delete-metadata`, `mutate-delete-recall-pack`, `mutate-delete-saved-view`, `mutate-delete-session`, `mutate-delete-workspace`, `mutate-identity-reset`, `mutate-record-correction`, `mutate-remove-mark`, `mutate-remove-tag`, `mutate-resolve-raw-authority-blocker`, `mutate-save-annotation`, `mutate-save-recall-pack`, `mutate-save-saved-view`, `mutate-save-workspace`, `mutate-session-excision`, `mutate-set-metadata`, `query-threads`, `query-tool-usage`
+- uncovered runtime operations: `mutate-add-mark`, `mutate-add-tag`, `mutate-blackboard-post`, `mutate-bulk-tag-sessions`, `mutate-clear-corrections`, `mutate-delete-annotation`, `mutate-delete-correction`, `mutate-delete-metadata`, `mutate-delete-recall-pack`, `mutate-delete-saved-view`, `mutate-delete-session`, `mutate-delete-workspace`, `mutate-identity-reset`, `mutate-rebuild-index`, `mutate-rebuild-insights`, `mutate-record-correction`, `mutate-remove-mark`, `mutate-remove-tag`, `mutate-resolve-raw-authority-blocker`, `mutate-save-annotation`, `mutate-save-recall-pack`, `mutate-save-saved-view`, `mutate-save-workspace`, `mutate-session-excision`, `mutate-set-metadata`, `mutate-update-index`, `query-threads`, `query-tool-usage`
 - uncovered maintenance targets: `empty_sessions`, `message_type_backfill`, `superseded_raw_snapshots`
-- uncovered declared operation targets: `mutate-add-mark`, `mutate-add-tag`, `mutate-blackboard-post`, `mutate-bulk-tag-sessions`, `mutate-clear-corrections`, `mutate-delete-annotation`, `mutate-delete-correction`, `mutate-delete-metadata`, `mutate-delete-recall-pack`, `mutate-delete-saved-view`, `mutate-delete-session`, `mutate-delete-workspace`, `mutate-identity-reset`, `mutate-record-correction`, `mutate-remove-mark`, `mutate-remove-tag`, `mutate-resolve-raw-authority-blocker`, `mutate-save-annotation`, `mutate-save-recall-pack`, `mutate-save-saved-view`, `mutate-save-workspace`, `mutate-session-excision`, `mutate-set-metadata`, `query-threads`, `query-tool-usage`
+- uncovered declared operation targets: `mutate-add-mark`, `mutate-add-tag`, `mutate-blackboard-post`, `mutate-bulk-tag-sessions`, `mutate-clear-corrections`, `mutate-delete-annotation`, `mutate-delete-correction`, `mutate-delete-metadata`, `mutate-delete-recall-pack`, `mutate-delete-saved-view`, `mutate-delete-session`, `mutate-delete-workspace`, `mutate-identity-reset`, `mutate-rebuild-index`, `mutate-rebuild-insights`, `mutate-record-correction`, `mutate-remove-mark`, `mutate-remove-tag`, `mutate-resolve-raw-authority-blocker`, `mutate-save-annotation`, `mutate-save-recall-pack`, `mutate-save-saved-view`, `mutate-save-workspace`, `mutate-session-excision`, `mutate-set-metadata`, `mutate-update-index`, `query-threads`, `query-tool-usage`
 
 Inspect the full authored map with:
 

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -5341,14 +5341,26 @@ class PolylogueArchiveMixin:
         emits a per-table heartbeat (#1607 parity) so a long rebuild shows
         forward motion instead of hanging silently.
         """
-        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from polylogue.operations.mutation_actuators import InsightsRebuildActuator, InsightsRebuildArgs
+        from polylogue.storage.insights.session.runtime import SessionInsightCounts
 
-        with ArchiveStore.open_existing(_active_archive_root(self.config), read_only=False) as archive:
-            return _rebuild_archive_session_insights(
-                archive,
-                session_ids=session_ids,
+        receipt, _plan = self._execute_facade_mutation(
+            InsightsRebuildActuator(),
+            lambda archive: InsightsRebuildArgs(
+                archive=archive,
+                session_ids=None if session_ids is None else tuple(session_ids),
                 progress_callback=progress_callback,
-            )
+            ),
+            capability="archive.rebuild_insights",
+        )
+        domain_receipt = receipt.domain_receipt
+        return SessionInsightCounts(
+            profiles=int(cast("int", domain_receipt.get("profiles", 0))),
+            work_events=int(cast("int", domain_receipt.get("work_events", 0))),
+            phases=int(cast("int", domain_receipt.get("phases", 0))),
+            threads=int(cast("int", domain_receipt.get("threads", 0))),
+            tag_rollups=int(cast("int", domain_receipt.get("tag_rollups", 0))),
+        )
 
     async def resume_brief(
         self,
@@ -5954,12 +5966,14 @@ class PolylogueArchiveMixin:
         with ``index.db`` blocks. ``session_ids`` is accepted for surface
         symmetry but the archive rebuild always reconciles the whole index.
         """
-        del session_ids
-        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from polylogue.operations.mutation_actuators import IndexRebuildActuator, IndexRebuildArgs
 
-        with ArchiveStore.open_existing(_active_archive_root(self.config), read_only=False) as archive:
-            archive.rebuild_index()
-        return True
+        receipt, _plan = self._execute_facade_mutation(
+            IndexRebuildActuator(operation="mutate-update-index"),
+            lambda archive: IndexRebuildArgs(archive=archive, session_ids=tuple(session_ids)),
+            capability="archive.update_index",
+        )
+        return receipt.status in {"applied", "already_satisfied"}
 
     async def neighbor_candidates(
         self,

--- a/polylogue/api/ingest.py
+++ b/polylogue/api/ingest.py
@@ -58,9 +58,24 @@ class PolylogueIngestMixin:
         return await parse_sources_archive(_active_archive_root(self.config), sources)
 
     async def rebuild_index(self) -> bool:
+        """Rebuild the derived block-FTS index through the mutation executor."""
         from polylogue.api.archive import _active_archive_root
+        from polylogue.operations.mutation_actuators import IndexRebuildActuator, IndexRebuildArgs
+        from polylogue.operations.mutation_transaction import OperationExecutor
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
         with ArchiveStore.open_existing(_active_archive_root(self.config), read_only=False) as archive:
-            archive.rebuild_index()
-        return True
+            actuator = IndexRebuildActuator()
+            args = IndexRebuildArgs(archive=archive)
+            executor = OperationExecutor()
+            plan = executor.prepare(actuator, args)
+            authorization = executor.authorize(
+                actuator,
+                plan,
+                actor="facade",
+                role="write",
+                capability="archive.rebuild_index",
+                confirmation_strength="role_only",
+            )
+            receipt = executor.execute(actuator, plan, authorization, args)
+        return receipt.status in {"applied", "already_satisfied"}

--- a/polylogue/operations/mutation_actuators.py
+++ b/polylogue/operations/mutation_actuators.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
+from polylogue.core.protocols import ProgressCallback
 from polylogue.operations.mutation_transaction import (
     ConfirmationStrength,
     DestructiveClass,
@@ -1619,6 +1620,130 @@ class BlackboardPostActuator:
         )
 
 
+# ---------------------------------------------------------------------------
+# Derived maintenance rebuilds (mutate-rebuild-index / mutate-update-index /
+# mutate-rebuild-insights)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class IndexRebuildArgs:
+    """Shared archive handle and caller scope for derived-index rebuilds."""
+
+    archive: ArchiveStore
+    session_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class IndexRebuildActuator:
+    """Actuator for the trigger-maintained block FTS rebuild primitive.
+
+    ``update_index`` historically accepts session ids for surface symmetry,
+    but the storage primitive reconciles the complete derived index. The
+    requested scope is still included in the plan context so the executor
+    binds the caller's exact request before the full-index effect is applied.
+    """
+
+    operation: str = "mutate-rebuild-index"
+    destructive_class: DestructiveClass = "maintenance"
+    required_confirmation: ConfirmationStrength = "role_only"
+
+    def prepare(self, args: IndexRebuildArgs) -> MutationPlan:
+        return build_plan(
+            operation=self.operation,
+            destructive_class="maintenance",
+            target_refs=(make_target_ref("source", "index.db:messages_fts"),),
+            affected_tiers=("index",),
+            reversible=False,
+            context={"session_ids": list(dict.fromkeys(args.session_ids))},
+        )
+
+    def apply(self, plan: MutationPlan, args: IndexRebuildArgs) -> MutationReceipt:
+        rebuilt_rows = args.archive.rebuild_index()
+        return MutationReceipt(
+            operation=self.operation,
+            plan_hash=plan.plan_hash,
+            status="applied",
+            target_refs=plan.target_refs,
+            affected_count=rebuilt_rows,
+            detail=None,
+            receipt_ref=None,
+            applied_at=plan.prepared_at,
+            domain_receipt={"indexed_rows": rebuilt_rows},
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class InsightsRebuildArgs:
+    """Archive handle, exact session scope, and optional progress observer."""
+
+    archive: ArchiveStore
+    session_ids: tuple[str, ...] | None = None
+    progress_callback: ProgressCallback | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class InsightsRebuildActuator:
+    """Actuator for the canonical durable session-insight materializer."""
+
+    operation: str = "mutate-rebuild-insights"
+    destructive_class: DestructiveClass = "maintenance"
+    required_confirmation: ConfirmationStrength = "role_only"
+
+    def prepare(self, args: InsightsRebuildArgs) -> MutationPlan:
+        if args.session_ids is None:
+            resolved = tuple(summary.session_id for summary in args.archive.list_summaries(limit=1_000_000))
+        else:
+            resolved = tuple(
+                dict.fromkeys(
+                    resolved_id
+                    for session_id in args.session_ids
+                    for resolved_id in _resolve_session_id(args.archive, session_id)
+                )
+            )
+        return build_plan(
+            operation=self.operation,
+            destructive_class="maintenance",
+            target_refs=tuple(make_target_ref("session", session_id) for session_id in resolved),
+            affected_tiers=("index",),
+            reversible=False,
+            context={"full_rebuild": args.session_ids is None, "session_ids": list(resolved)},
+        )
+
+    def apply(self, plan: MutationPlan, args: InsightsRebuildArgs) -> MutationReceipt:
+        from polylogue.storage.insights.session.rebuild import rebuild_session_insights_sync
+        from polylogue.storage.insights.session.runtime import SessionInsightCounts
+
+        session_ids = tuple(cast("list[str]", plan.context.get("session_ids") or ()))
+        if not session_ids and not bool(plan.context.get("full_rebuild")):
+            counts = SessionInsightCounts()
+        else:
+            counts = rebuild_session_insights_sync(
+                args.archive._conn,
+                session_ids=None if bool(plan.context.get("full_rebuild")) else session_ids,
+                progress_callback=args.progress_callback,
+            )
+        affected_count = counts.total()
+        return MutationReceipt(
+            operation=self.operation,
+            plan_hash=plan.plan_hash,
+            status="applied" if affected_count else "already_satisfied",
+            target_refs=plan.target_refs,
+            affected_count=affected_count,
+            detail=None if affected_count else "no_insight_rows_rebuilt",
+            receipt_ref=None,
+            applied_at=plan.prepared_at,
+            domain_receipt=counts.to_dict(),
+        )
+
+
+def _resolve_session_id(archive: ArchiveStore, session_id: str) -> tuple[str, ...]:
+    try:
+        return (archive.resolve_session_id(session_id),)
+    except KeyError:
+        return ()
+
+
 __all__ = [
     "AnnotationDeleteActuator",
     "AnnotationDeleteArgs",
@@ -1638,6 +1763,10 @@ __all__ = [
     "CorrectionsClearArgs",
     "IdentityResetActuator",
     "IdentityResetArgs",
+    "IndexRebuildActuator",
+    "IndexRebuildArgs",
+    "InsightsRebuildActuator",
+    "InsightsRebuildArgs",
     "MarkAddActuator",
     "MarkArgs",
     "MarkRemoveActuator",

--- a/polylogue/operations/mutation_transaction.py
+++ b/polylogue/operations/mutation_transaction.py
@@ -50,8 +50,9 @@ from typing import Literal, Protocol, TypeVar, runtime_checkable
 #: ``reset`` tombstones rebuildable rows while preserving durable evidence;
 #: ``delete`` permanently removes archive rows but re-ingest of the original
 #: source can resurrect them; ``excise`` is the durable, cross-tier,
-#: re-ingest-proof removal (right-to-forget).
-DestructiveClass = Literal["reversible", "reset", "delete", "excise"]
+#: re-ingest-proof removal (right-to-forget); ``maintenance`` rewrites
+#: rebuildable derived state without removing authored evidence.
+DestructiveClass = Literal["reversible", "maintenance", "reset", "delete", "excise"]
 
 #: Confirmation strength a caller can present at AUTHORIZE time, ordered
 #: weakest to strongest. Each :class:`MutationActuator` declares the floor it

--- a/polylogue/operations/specs.py
+++ b/polylogue/operations/specs.py
@@ -771,6 +771,75 @@ RUNTIME_OPERATION_SPECS: tuple[OperationSpec, ...] = (
         executor_status="executor-routed",
     ),
     OperationSpec(
+        name="mutate-rebuild-index",
+        kind=OperationKind.MAINTENANCE,
+        description=(
+            "Rebuild the derived block-FTS index from persisted blocks. The operation is idempotent and "
+            "routes its real ArchiveStore primitive through OperationExecutor/IndexRebuildActuator."
+        ),
+        consumes=("message_source_rows",),
+        produces=("message_fts",),
+        path_targets=("message-fts-readiness-loop",),
+        code_refs=(
+            "polylogue.api.ingest.PolylogueIngestMixin.rebuild_index",
+            "polylogue.mcp.server_cutover._dispatch_maintenance (operation=rebuild_index)",
+            "polylogue.operations.mutation_actuators.IndexRebuildActuator",
+        ),
+        surfaces=("facade", "mcp"),
+        mutates_state=True,
+        previewable=True,
+        idempotent=True,
+        effects=("DbRead", "DbWrite"),
+        safety_guards=("write_role_required",),
+        executor_status="executor-routed",
+    ),
+    OperationSpec(
+        name="mutate-update-index",
+        kind=OperationKind.MAINTENANCE,
+        description=(
+            "Reconcile the derived block-FTS index for the facade update route. The current storage "
+            "primitive rebuilds the complete index, and OperationExecutor binds the caller scope before it runs."
+        ),
+        consumes=("message_source_rows",),
+        produces=("message_fts",),
+        path_targets=("message-fts-readiness-loop",),
+        code_refs=(
+            "polylogue.api.archive.PolylogueArchiveMixin.update_index",
+            "polylogue.mcp.server_cutover._dispatch_maintenance (operation=update_index)",
+            "polylogue.operations.mutation_actuators.IndexRebuildActuator",
+        ),
+        surfaces=("facade", "mcp"),
+        mutates_state=True,
+        previewable=True,
+        idempotent=True,
+        effects=("DbRead", "DbWrite"),
+        safety_guards=("write_role_required",),
+        executor_status="executor-routed",
+    ),
+    OperationSpec(
+        name="mutate-rebuild-insights",
+        kind=OperationKind.MAINTENANCE,
+        description=(
+            "Rebuild durable session-insight read models for the requested session set. The canonical "
+            "materializer runs through OperationExecutor/InsightsRebuildActuator with a typed receipt."
+        ),
+        consumes=("session_insight_source_sessions",),
+        produces=("session_insight_rows", "session_insight_fts"),
+        path_targets=("session-insight-repair-loop",),
+        code_refs=(
+            "polylogue.api.archive.PolylogueArchiveMixin.rebuild_insights",
+            "polylogue.mcp.server_cutover._dispatch_maintenance (operation=rebuild_insights)",
+            "polylogue.operations.mutation_actuators.InsightsRebuildActuator",
+        ),
+        surfaces=("facade", "mcp"),
+        mutates_state=True,
+        previewable=True,
+        idempotent=True,
+        effects=("DbRead", "DbWrite"),
+        safety_guards=("write_role_required",),
+        executor_status="executor-routed",
+    ),
+    OperationSpec(
         name="mutate-resolve-raw-authority-blocker",
         kind=OperationKind.MAINTENANCE,
         description=(

--- a/tests/unit/api/test_operation_executor_routes.py
+++ b/tests/unit/api/test_operation_executor_routes.py
@@ -1,0 +1,96 @@
+"""Production facade routes for derived maintenance mutations.
+
+These tests deliberately enter the public async facade. They fail if a route
+stops constructing the real actuator or bypasses ``OperationExecutor`` and
+calls the storage rebuild primitive directly.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.api import Polylogue
+from polylogue.operations.mutation_transaction import OperationExecutor
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+
+def _seed_archive(archive_root: Path, *, native_id: str) -> str:
+    source_db = archive_root / "source.db"
+    index_db = archive_root / "index.db"
+    initialize_archive_database(source_db, ArchiveTier.SOURCE)
+    initialize_archive_database(index_db, ArchiveTier.INDEX)
+    raw_id = f"raw-{native_id}"
+    session_id = f"codex-session:{native_id}"
+    with sqlite3.connect(source_db) as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms
+            ) VALUES (?, 'codex-session', ?, ?, zeroblob(32), 0, 1000)
+            """,
+            (raw_id, native_id, str(archive_root / f"{native_id}.jsonl")),
+        )
+    with sqlite3.connect(index_db) as conn:
+        conn.execute(
+            """
+            INSERT INTO sessions (
+                native_id, origin, raw_id, title, content_hash, created_at_ms, updated_at_ms
+            ) VALUES (?, 'codex-session', ?, ?, zeroblob(32), 1000, 2000)
+            """,
+            (native_id, raw_id, f"Maintenance route {native_id}"),
+        )
+    return session_id
+
+
+@pytest.mark.asyncio
+async def test_facade_rebuild_and_update_index_use_executor_and_real_routes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive_root = tmp_path / "archive"
+    archive_root.mkdir()
+    session_id = _seed_archive(archive_root, native_id="route-index")
+    archive = Polylogue(archive_root=archive_root, db_path=archive_root / "index.db")
+    calls: list[str] = []
+    original_execute = OperationExecutor.execute
+
+    def record_execute(self: OperationExecutor, actuator, plan, authorization, args):  # type: ignore[no-untyped-def]
+        calls.append(actuator.operation)
+        return original_execute(self, actuator, plan, authorization, args)
+
+    monkeypatch.setattr(OperationExecutor, "execute", record_execute)
+    try:
+        assert await archive.rebuild_index() is True
+        assert await archive.update_index([session_id]) is True
+    finally:
+        await archive.close()
+
+    assert calls == ["mutate-rebuild-index", "mutate-update-index"]
+
+
+@pytest.mark.asyncio
+async def test_facade_rebuild_insights_uses_executor_and_real_materializer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive_root = tmp_path / "archive"
+    archive_root.mkdir()
+    session_id = _seed_archive(archive_root, native_id="route-insights")
+    archive = Polylogue(archive_root=archive_root, db_path=archive_root / "index.db")
+    calls: list[str] = []
+    original_execute = OperationExecutor.execute
+
+    def record_execute(self: OperationExecutor, actuator, plan, authorization, args):  # type: ignore[no-untyped-def]
+        calls.append(actuator.operation)
+        return original_execute(self, actuator, plan, authorization, args)
+
+    monkeypatch.setattr(OperationExecutor, "execute", record_execute)
+    try:
+        counts = await archive.rebuild_insights(session_ids=[session_id])
+    finally:
+        await archive.close()
+
+    assert calls == ["mutate-rebuild-insights"]
+    assert counts.total() >= 0

--- a/tests/unit/operations/test_mutation_actuators.py
+++ b/tests/unit/operations/test_mutation_actuators.py
@@ -49,6 +49,10 @@ from polylogue.operations.mutation_actuators import (
     CorrectionsClearArgs,
     IdentityResetActuator,
     IdentityResetArgs,
+    IndexRebuildActuator,
+    IndexRebuildArgs,
+    InsightsRebuildActuator,
+    InsightsRebuildArgs,
     MarkAddActuator,
     MarkArgs,
     MarkRemoveActuator,
@@ -1688,3 +1692,82 @@ class TestCorrectionActuators:
             # Refused before mutation: both corrections are still present.
             remaining = archive.list_corrections(session_id=session_id)
             assert {correction.kind.value for correction in remaining} == {"tag_reject", "tag_accept"}
+
+
+class TestDerivedMaintenanceActuators:
+    """Real derived-tier effects remain behind the shared executor."""
+
+    def test_index_rebuild_actuator_rebuilds_real_fts_and_returns_receipt(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        archive_root.mkdir()
+        _seed_archive_session(archive_root, native_id="maintenance-index")
+
+        with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+            actuator = IndexRebuildActuator()
+            args = IndexRebuildArgs(archive=archive, session_ids=("maintenance-index",))
+            executor = OperationExecutor()
+            plan = executor.prepare(actuator, args)
+            authorization = executor.authorize(
+                actuator,
+                plan,
+                actor="test",
+                role="write",
+                capability="archive.rebuild_index",
+                confirmation_strength="role_only",
+            )
+            receipt = executor.execute(actuator, plan, authorization, args)
+            indexed = archive.index_status()
+
+        assert receipt.operation == "mutate-rebuild-index"
+        assert receipt.status == "applied"
+        assert receipt.domain_receipt["indexed_rows"] == 0
+        assert indexed["exists"] is True
+
+    def test_index_rebuild_binds_requested_scope_before_execution(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        archive_root.mkdir()
+        _seed_archive_session(archive_root, native_id="maintenance-scope")
+
+        with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+            actuator = IndexRebuildActuator(operation="mutate-update-index")
+            prepared_args = IndexRebuildArgs(archive=archive, session_ids=("first",))
+            execute_args = IndexRebuildArgs(archive=archive, session_ids=("second",))
+            executor = OperationExecutor()
+            plan = executor.prepare(actuator, prepared_args)
+            authorization = executor.authorize(
+                actuator,
+                plan,
+                actor="test",
+                role="write",
+                capability="archive.update_index",
+                confirmation_strength="role_only",
+            )
+
+            with pytest.raises(PlanStaleError):
+                executor.execute(actuator, plan, authorization, execute_args)
+
+    def test_insights_rebuild_actuator_uses_real_materializer(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        archive_root.mkdir()
+        session_id = _seed_archive_session(archive_root, native_id="maintenance-insights")
+
+        with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+            actuator = InsightsRebuildActuator()
+            args = InsightsRebuildArgs(archive=archive, session_ids=(session_id,))
+            executor = OperationExecutor()
+            plan = executor.prepare(actuator, args)
+            authorization = executor.authorize(
+                actuator,
+                plan,
+                actor="test",
+                role="write",
+                capability="archive.rebuild_insights",
+                confirmation_strength="role_only",
+            )
+            receipt = executor.execute(actuator, plan, authorization, args)
+            profile_count = archive._conn.execute("SELECT COUNT(*) FROM session_profiles").fetchone()[0]
+
+        assert receipt.operation == "mutate-rebuild-insights"
+        assert receipt.status in {"applied", "already_satisfied"}
+        assert receipt.affected_count == sum(int(cast("int", value)) for value in receipt.domain_receipt.values())
+        assert profile_count >= 0

--- a/tests/unit/operations/test_mutation_census.py
+++ b/tests/unit/operations/test_mutation_census.py
@@ -62,3 +62,10 @@ def test_named_t46_9_routes_are_executor_routed() -> None:
     rows = {row["operation"]: row for row in _load_rows()}
     for operation in ("mutate-delete-session", "mutate-session-excision", "mutate-identity-reset"):
         assert rows[operation]["status"] == "executor-routed"
+
+
+def test_derived_maintenance_facade_routes_are_executor_routed() -> None:
+    rows = {row["operation"]: row for row in _load_rows()}
+    for operation in ("rebuild_index", "update_index", "rebuild_insights"):
+        assert rows[operation]["status"] == "executor-routed"
+        assert rows[operation]["actuator"].startswith("polylogue.operations.mutation_actuators.")

--- a/tests/unit/operations/test_specs.py
+++ b/tests/unit/operations/test_specs.py
@@ -48,6 +48,9 @@ def test_runtime_operation_catalog_covers_the_current_runtime_paths() -> None:
         "mutate-save-annotation",
         "mutate-delete-annotation",
         "mutate-blackboard-post",
+        "mutate-rebuild-index",
+        "mutate-update-index",
+        "mutate-rebuild-insights",
         "mutate-resolve-raw-authority-blocker",
         "mutate-save-saved-view",
         "mutate-delete-saved-view",
@@ -109,6 +112,12 @@ def test_runtime_operation_catalog_covers_the_current_runtime_paths() -> None:
         "message-fts-readiness-loop",
         "retrieval-band-readiness-loop",
     )
+    for operation in ("mutate-rebuild-index", "mutate-update-index", "mutate-rebuild-insights"):
+        assert specs[operation].mutates_state is True
+        assert specs[operation].previewable is True
+        assert specs[operation].idempotent is True
+        assert specs[operation].effects == ("DbRead", "DbWrite")
+        assert specs[operation].executor_status == "executor-routed"
 
 
 def test_runtime_operation_catalog_has_declared_surfaces_and_code_refs() -> None:


### PR DESCRIPTION
## Summary
Route the facade and MCP `rebuild_index`, `update_index`, and `rebuild_insights` mutation family through `OperationExecutor` using typed maintenance actuators, declared operation specs, receipts, and census entries.

## Problem
These derived-tier rebuild routes called real storage/materializer primitives outside the shared PREPARE, AUTHORIZE, EXECUTE lifecycle. The MCP surface retained confirmation checks, but the facade path lacked shared target planning, capability binding, effect identity, and receipt coverage.

## Solution
Add a `maintenance` mutation class plus `IndexRebuildActuator` and `InsightsRebuildActuator`. The facade methods now execute those actuators through the existing gateway or explicit executor lifecycle. The MCP routes continue to use their existing confirmation gates before entering the facade. Add three runtime `OperationSpec` declarations, update `docs/plans/mutation-census.yaml`, and regenerate `docs/test-quality-workflows.md` through the canonical renderer.

The actuators call the existing `ArchiveStore.rebuild_index` and canonical session-insight materializer. Delete, excision, reset, storage guards, and confirmation-token behavior were left unchanged.

## Verification
- `python -m devtools test tests/unit/api/test_operation_executor_routes.py tests/unit/operations/test_mutation_actuators.py tests/unit/operations/test_mutation_census.py tests/unit/operations/test_specs.py` -> `65 passed in 2.94s` after the final rebase.
- `python -m devtools verify --quick` -> all 21 steps passed, including ruff format, ruff check, mypy, render all, layering, policy checks, and schema promotion audit. Pre-push completed with exit 0.
- Anti-vacuity: `tests/unit/api/test_operation_executor_routes.py` enters the real `Polylogue` facade with seeded `source.db` and `index.db`, records each `OperationExecutor.execute` call, and exercises the real FTS and insight materializers. Removing executor dispatch from `rebuild_index`, `update_index`, or `rebuild_insights` fails the route assertions. `test_mutation_actuators.py` verifies real receipts and rejects a changed update scope with `PlanStaleError` before APPLY.

## Acceptance criteria for this slice
- Satisfied: the three changed facade/MCP routes have declared specs, actuator, capability, maintenance class, previewable/idempotent policy, affected tier, effect identity, and receipt coverage.
- Satisfied: facade and MCP index/insight rebuild calls share the executor-backed gateway and existing MCP confirmation behavior.
- Satisfied: real-route anti-vacuity coverage proves executor dispatch, target planning, and effect scheduling.
- Satisfied: the maintenance class uses role-only executor authorization because these operations rewrite rebuildable derived state without deleting authored evidence. MCP full-effect confirmation remains required where it existed.
- Satisfied: existing storage rebuild primitives remain behind the actuator; delete, excision, reset, and storage guards are unchanged.
- Deferred: bound destructive tokens, durable audit-row persistence, and partial-failure resume remain outside this derived maintenance slice.

## Deferred residuals
`capture_assertion_candidate` and `import_annotation_batch` remain declared-not-routed because their candidate/provenance contracts need separate typed adapters. Resumable `maintenance run` across CLI, daemon, and MCP remains declared-not-routed because its operation-id, cursor, failure-isolation, and partial-resume contract differs from these facade rebuilds. File-tier `ops reset` remains an open target-vocabulary decision. The broader bound-token migration and durable audit persistence remain open.

Ref polylogue-t46.9
