### PR TITLE
fix(schemas): make session-dir fallback opt-in for explicit db_path

### DIFF
--- a/polylogue/schemas/generation/cluster_collection.py
+++ b/polylogue/schemas/generation/cluster_collection.py
@@ -38,6 +38,7 @@ def _collect_cluster_accumulators(
     full_corpus: bool = False,
     journal: ObservationJournal | None = None,
     progress_callback: Callable[[JSONDocument], None] | None = None,
+    allow_session_dir_fallback: bool = False,
 ) -> tuple[dict[str, _ClusterAccumulator], Sequence[_UnitMembership], int, dict[str, int]]:
     result = collect_cluster_analysis(
         provider,
@@ -45,6 +46,7 @@ def _collect_cluster_accumulators(
         max_samples=max_samples,
         full_corpus=full_corpus,
         journal=journal,
+        allow_session_dir_fallback=allow_session_dir_fallback,
         progress_callback=progress_callback,
     )
     return result.clusters, result.memberships, result.sample_count, result.artifact_counts
@@ -58,6 +60,7 @@ def collect_cluster_analysis(
     full_corpus: bool = False,
     journal: ObservationJournal | None = None,
     progress_callback: Callable[[JSONDocument], None] | None = None,
+    allow_session_dir_fallback: bool = False,
 ) -> ClusterCollectionResult:
     from polylogue.schemas.sampling import iter_schema_units
 
@@ -106,6 +109,7 @@ def collect_cluster_analysis(
         max_samples=max_samples,
         full_corpus=full_corpus,
         terminal_recorder=journal.record_terminal if journal is not None else None,
+        allow_session_dir_fallback=allow_session_dir_fallback,
     )
     if journal is None:
         retained_units = list(observed_units)

--- a/polylogue/schemas/generation/provider_bundle.py
+++ b/polylogue/schemas/generation/provider_bundle.py
@@ -81,6 +81,11 @@ def _build_provider_bundle(
             str(provider_token),
             error=f"Unknown provider: {provider}. Known: {[str(item) for item in PROVIDERS]}",
         )
+    # polylogue-kmqwm: only a caller-omitted (``None``) db_path -- i.e. "use
+    # the default archive path" -- may fall back to a real session-directory
+    # scan on a zero-unit result. An explicitly-supplied db_path is
+    # DB-authoritative and must never widen into a filesystem scan.
+    allow_session_dir_fallback = db_path is None
     if db_path is None:
         db_path = index_db_path()
     if not GENSON_AVAILABLE:
@@ -141,6 +146,7 @@ def _build_provider_bundle(
                 full_corpus=full_corpus,
                 journal=journal,
                 progress_callback=observe_progress,
+                allow_session_dir_fallback=allow_session_dir_fallback,
             )
             complete_phase(
                 "observe_and_cluster",

--- a/polylogue/schemas/sampling.py
+++ b/polylogue/schemas/sampling.py
@@ -34,8 +34,19 @@ def iter_schema_units(
     max_samples: int | None = None,
     full_corpus: bool = False,
     terminal_recorder: ObservationTerminalRecorder | None = None,
+    allow_session_dir_fallback: bool = False,
 ) -> Iterator[SchemaUnit]:
-    """Yield schema units for a provider from DB, with session fallback."""
+    """Yield schema units for a provider from DB, with optional session fallback.
+
+    ``allow_session_dir_fallback`` is opt-in and defaults to ``False``: an
+    explicitly-passed ``db_path`` means DB-authoritative, so a zero-unit DB
+    result never silently substitutes a scan of the real
+    ``config.session_dir`` (e.g. the operator's live ``~/.codex/sessions``).
+    Callers that genuinely want the legacy "empty archive, scan the real
+    session directory" CLI behavior (only sensible when the caller never
+    supplied a ``db_path`` of its own -- i.e. the default archive path is in
+    play) must set this explicitly (polylogue-kmqwm).
+    """
     source_name = Provider.from_string(source_name)
     if db_path is None:
         db_path = index_db_path()
@@ -84,7 +95,12 @@ def iter_schema_units(
     # contexts (tests, cloud sandboxes) that never intended to touch local
     # session directories at all. `row_seen` distinguishes "the DB had zero
     # matching rows" from "the DB had rows but none produced a unit".
-    if yielded_any or row_seen or config.session_dir is None:
+    #
+    # polylogue-kmqwm: on top of that, the fallback is opt-in
+    # (`allow_session_dir_fallback`). A zero-unit DB result must never
+    # silently widen into a real filesystem scan unless the caller
+    # explicitly asked for that legacy behavior.
+    if yielded_any or row_seen or config.session_dir is None or not allow_session_dir_fallback:
         return
 
     yield from _iter_schema_units_from_sessions(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -518,6 +518,27 @@ def _clear_polylogue_env(
     SchemaValidator._cache.clear()
     reset_registry_cache()
 
+    # polylogue-kmqwm: PROVIDERS' ``session_dir`` entries are computed once at
+    # import time from ``Path.home()`` (e.g. ``~/.codex/sessions``,
+    # ``~/.gemini/tmp``) -- long before any per-test XDG/env patching above
+    # takes effect. Point every provider's session_dir at an inert per-test
+    # tmp path so any residual schema-inference session-directory fallback
+    # (opt-in via ``allow_session_dir_fallback``, see
+    # ``polylogue/schemas/sampling.py``) can never read this operator's real
+    # local session directories from inside the test suite, even from a test
+    # that deliberately exercises the fallback path.
+    from polylogue.schemas.observation_models import PROVIDERS
+
+    harness_session_dir_root = tmp_path / "harness-session-dir-guard"
+    for provider_config in PROVIDERS.values():
+        if provider_config.session_dir is not None:
+            monkeypatch.setattr(
+                provider_config,
+                "session_dir",
+                harness_session_dir_root / provider_config.name.value,
+                raising=False,
+            )
+
     # Reset blob store singleton to prevent cross-test pollution when
     # tests write blobs to the temp XDG_DATA_HOME. Only reset if we're
     # about to set new XDG paths (i.e., after we've set up the env above).

--- a/tests/unit/core/test_sampling.py
+++ b/tests/unit/core/test_sampling.py
@@ -539,6 +539,53 @@ class TestLoadSamplesFromDb:
             }
         ]
 
+    def test_explicit_db_path_zero_units_does_not_scan_session_dir(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """polylogue-kmqwm: an explicitly-passed ``db_path`` is DB-authoritative.
+
+        Before the fix, a zero-unit result from an explicit ``db_path`` (no
+        matching ``raw_sessions`` rows at all) unconditionally fell through
+        to scanning the provider's real ``config.session_dir`` -- e.g. the
+        operator's actual ``~/.codex/sessions`` -- silently substituting
+        real, unrelated filesystem data for what should be an empty,
+        DB-scoped result. This proves the filesystem fallback is never
+        reached implicitly: only an explicit
+        ``allow_session_dir_fallback=True`` opt-in may trigger it.
+        """
+        from collections.abc import Iterator as _Iterator
+
+        from polylogue.schemas.observation_models import SchemaUnit as _SchemaUnit
+
+        db = _archive_index_db(tmp_path)  # genuinely empty: no raw_sessions rows inserted
+
+        scan_calls: list[object] = []
+
+        def _fake_session_scan(*args: object, **kwargs: object) -> _Iterator[_SchemaUnit]:
+            scan_calls.append(kwargs.get("session_dir", args[1] if len(args) > 1 else None))
+            yield from ()
+
+        monkeypatch.setattr(
+            "polylogue.schemas.sampling._iter_schema_units_from_sessions",
+            _fake_session_scan,
+        )
+
+        # Default: no opt-in -> must stay empty and must never scan.
+        result = list(iter_schema_units("codex", db_path=db))
+        assert result == []
+        assert scan_calls == [], (
+            "iter_schema_units scanned the session_dir despite an explicit db_path "
+            "and no allow_session_dir_fallback opt-in"
+        )
+
+        # Explicit opt-in still reaches the (mocked) fallback -- proves the
+        # capability is preserved, just no longer automatic.
+        result_with_fallback = list(iter_schema_units("codex", db_path=db, allow_session_dir_fallback=True))
+        assert result_with_fallback == []
+        assert len(scan_calls) == 1
+
 
 class TestLoadSamplesFromSessions:
     def test_nonexistent_dir_returns_empty(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Makes the schema-inference session-directory filesystem fallback in `iter_schema_units()` opt-in instead of automatic, and defends the test harness against the class of hazard it enabled.

## Problem

`polylogue/schemas/sampling.py`'s `iter_schema_units()` fell through to scanning the provider's real `config.session_dir` (e.g. the operator's actual `~/.codex/sessions`) whenever a DB query yielded zero schema units, with no distinction for whether the caller had explicitly passed a `db_path`. A caller that explicitly scoped a DB-only query (a test, a script, a cloud sandbox) could silently get real, unexpected filesystem data instead of an empty/error result. Verified live on this workstation: a reproduction of the hazard (see the new red-first test, checked out against the pre-fix code) actually touched `/home/sinity/.codex/sessions`.

An earlier fix (`polylogue-o8c3m`, already on `master`) narrowed the trigger condition (`row_seen` distinguishes "zero DB rows" from "rows existed but none decoded"), but did not address the underlying issue: even a genuinely-zero-row DB with an explicit `db_path` still fell through automatically.

## Solution

- `polylogue/schemas/sampling.py`: `iter_schema_units()` gains `allow_session_dir_fallback: bool = False`. The filesystem fallback now requires this explicit opt-in on top of the existing `yielded_any`/`row_seen` guards.
- `polylogue/schemas/generation/provider_bundle.py`: `_build_provider_bundle()` captures whether its own `db_path` argument was `None` (caller-omitted, i.e. "use the default archive") *before* resolving it to `index_db_path()`, and threads that boolean down as `allow_session_dir_fallback`. This is the layer where the "explicit vs default" signal is actually available -- by the time `iter_schema_units()` is reached, every call site in the current codebase always supplies a concrete `Path`, so the flag has to be captured higher up the chain, not inferred from `db_path is None` at the leaf.
- `polylogue/schemas/generation/cluster_collection.py`: threads the same flag through `_collect_cluster_accumulators` / `collect_cluster_analysis`.
- `tests/conftest.py`: the existing autouse `_clear_polylogue_env` fixture now monkeypatches every `PROVIDERS` entry's `session_dir` (computed once at import time from `Path.home()`, so ordinary env patching can't touch it) to a per-test tmp path. This is defense-in-depth: even a test that deliberately sets `allow_session_dir_fallback=True`, or a future regression that re-widens the default, can never reach a real local session directory from inside the suite.

No alternative design considered seriously: threading a boolean was the smallest change that preserves the genuine "empty real archive" CLI behavior (no `db_path` anywhere in the call chain) while closing the isolation gap for every other caller.

## Verification

- Red-first: `tests/unit/core/test_sampling.py::TestLoadSamplesFromDb::test_explicit_db_path_zero_units_does_not_scan_session_dir` checked out against the pre-fix production code (git stash of the 3 production commits) and confirmed it failed by actually invoking the mocked session scan with `/home/sinity/.codex/sessions`.
- `devtools test tests/unit/core/test_sampling.py` -> `45 passed in 5.31s`
- `devtools test tests/unit/core/test_schema_generation.py tests/unit/core/test_schema_observation_journal.py` -> `51 passed, 1 skipped in 37.27s`
- `mypy --strict polylogue/schemas/sampling.py polylogue/schemas/generation/cluster_collection.py polylogue/schemas/generation/provider_bundle.py tests/conftest.py` -> `Success: no issues found in 4 source files`
- `devtools verify --quick` -> `exit_code: 0` (21 steps, all ok)

Not run: `devtools verify` (testmon) -- this worktree's testmon cache wasn't seeded and the auto-bootstrap from the main checkout didn't pick it up; substituted with the explicit focused-test runs above plus `verify --quick`.

Ref polylogue-kmqwm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Explicit database paths are now respected, preventing unintended session-directory scanning when results are empty.
  * Session-directory fallback is now opt-in, improving predictability and data-source control.
  * Default archive-path behavior continues to support fallback when appropriate.

* **Tests**
  * Added regression coverage for database path authority and opt-in fallback behavior.
  * Improved test isolation by redirecting session directories to temporary locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->