### PR TITLE
test(mcp): prove registered read payload contracts

### DIFF
--- a/tests/unit/mcp/test_mcp_call_log.py
+++ b/tests/unit/mcp/test_mcp_call_log.py
@@ -40,6 +40,7 @@ from polylogue.storage.sqlite.archive_tiers.ops_write import (
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 from tests.infra.mcp import MCPServerUnderTest, invoke_surface
+from tests.infra.storage_records import SessionBuilder
 
 
 @contextmanager
@@ -124,6 +125,50 @@ def test_registered_tools_persist_success_and_typed_failure_through_daemon(
     assert by_tool["read"].error_detail == "not_found"
     session_calls = _read_calls(workspace_env["archive_root"], session_id="codex-session:missing")
     assert [entry.tool_name for entry in session_calls] == ["read"]
+
+
+def test_all_registered_read_transactions_emit_durable_telemetry(
+    workspace_env: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Capture one durable telemetry event for every live read transaction.
+
+    Production dependencies exercised: the actual FastMCP registration, the
+    six cutover handlers, the daemon HTTP telemetry endpoint, and the ops-tier
+    MCP call-log table. Removing a declared handler, changing its telemetry
+    name, bypassing ``_async_safe_call``, or dropping durable delivery makes
+    the complete six-tool set assertion fail.
+    """
+    session_id = "codex-session:mcp-read-telemetry"
+    SessionBuilder(workspace_env["archive_root"] / "index.db", "mcp-read-telemetry").provider(
+        "codex-session"
+    ).add_message(text="mcp read telemetry needle").save()
+
+    with _running_daemon() as daemon_url:
+        monkeypatch.setenv("POLYLOGUE_DAEMON_URL", daemon_url)
+        _set_runtime_services(None)
+        try:
+            server = cast(MCPServerUnderTest, build_server())
+            tools = server._tool_manager._tools
+            uri = f"polylogue://session/{session_id}"
+            calls = (
+                ("query", {"expression": "messages where text:telemetry", "limit": 1}),
+                ("read", {"ref": uri}),
+                ("get", {"ref": uri}),
+                ("explain", {"subject": "query", "expression": "messages where text:telemetry"}),
+                ("context", {"intent": "lookup", "recipient_ref": "agent:nobody"}),
+                ("status", {"scope": "archive"}),
+            )
+            for name, arguments in calls:
+                payload = json.loads(invoke_surface(tools[name].fn, **arguments))
+                assert payload.get("is_error") is not True, (name, payload)
+            assert flush_mcp_call_log(timeout=5.0)
+        finally:
+            _set_runtime_services(None)
+
+    read_calls = _read_calls(workspace_env["archive_root"])
+    by_tool = {entry.tool_name: entry for entry in read_calls}
+    assert set(by_tool) >= {"query", "read", "get", "explain", "context", "status"}
+    assert all(by_tool[name].success for name in ("query", "read", "get", "explain", "context", "status"))
 
 
 def test_session_tools_and_successor_preamble_are_queryable_by_session(

--- a/tests/unit/mcp/test_server_surfaces.py
+++ b/tests/unit/mcp/test_server_surfaces.py
@@ -15,10 +15,10 @@ from tests.infra.mcp import MCP_TOOL_NAME_BASELINE, MCPServerUnderTest, invoke_s
 from tests.infra.storage_records import SessionBuilder
 
 
-def _write_message(archive_root: Path, native_id: str, text: str) -> None:
-    SessionBuilder(archive_root / "index.db", native_id).provider("codex-session").add_message(
-        role="user", text=text
-    ).save()
+def _write_message(archive_root: Path, native_id: str, text: str) -> str:
+    builder = SessionBuilder(archive_root / "index.db", native_id).provider("codex-session")
+    builder.add_message(role="user", text=text).save()
+    return builder.native_session_id()
 
 
 @pytest.fixture
@@ -501,3 +501,140 @@ async def test_get_default_projection_surfaces_display_name_when_title_absent(
         payload = json.loads(await invoke_surface_async(mcp_server._tool_manager._tools["get"].fn, ref=uri))
 
     assert payload["title"] == "greedy-squishing-hamming"
+
+
+@pytest.mark.asyncio
+async def test_registered_read_transactions_match_production_goldens(tmp_path: Path) -> None:
+    """Exercise every declared read transaction through its live registration.
+
+    Production dependencies exercised: ``build_server`` creates the declared
+    FastMCP handlers, ``ArchiveStore`` writes the seeded index, and each call
+    resolves through the configured ``RuntimeServices`` facade. Removing a
+    handler registration, changing a stable result identity, routing a read
+    around the bounded transaction, or replacing a production payload with a
+    metadata-only response makes one of these assertions fail.
+    """
+    archive_root = tmp_path / "archive"
+    with ArchiveStore(archive_root):
+        session_id = _write_message(archive_root, "read-contract-golden", "read contract golden needle")
+
+    from polylogue import Polylogue
+    from polylogue.mcp.server import build_server
+
+    with (
+        patch(
+            "polylogue.mcp.server._get_config",
+            return_value=SimpleNamespace(archive_root=archive_root, db_path=archive_root / "index.db"),
+        ),
+        patch("polylogue.mcp.server._get_polylogue", return_value=Polylogue(archive_root=archive_root)),
+    ):
+        server = cast(MCPServerUnderTest, build_server())
+        tools = server._tool_manager._tools
+        read_uri = f"polylogue://session/{session_id}"
+        query_expression = "messages where text:golden"
+
+        results = {
+            "query": json.loads(await invoke_surface_async(tools["query"].fn, expression=query_expression, limit=1)),
+            "read": json.loads(await invoke_surface_async(tools["read"].fn, ref=read_uri)),
+            "get": json.loads(await invoke_surface_async(tools["get"].fn, ref=read_uri)),
+            "explain": json.loads(
+                await invoke_surface_async(tools["explain"].fn, subject="query", expression=query_expression)
+            ),
+            "context": json.loads(
+                await invoke_surface_async(
+                    tools["context"].fn,
+                    intent="lookup",
+                    query="read contract golden needle",
+                    budget_tokens=256,
+                )
+            ),
+            "status": json.loads(await invoke_surface_async(tools["status"].fn, scope="archive")),
+        }
+
+        resource = server._resource_manager._templates["polylogue://session/{conv_id}"]
+        resource_body = json.loads(await invoke_surface_async(resource.fn, conv_id=session_id))
+        message_get = json.loads(
+            await invoke_surface_async(
+                tools["get"].fn,
+                ref=f"message:{session_id}:m1",
+            )
+        )
+
+    assert set(results) == {"query", "read", "get", "explain", "context", "status"}
+    assert all(body.get("is_error") is not True for body in results.values()), results
+
+    query = results["query"]
+    assert query["items"] and len(query["items"]) == 1
+    assert query["items"][0]["message_id"].endswith(":m1")
+    assert query["total"] == 1
+    assert query["query_ref"].startswith("query:")
+    assert query["result_ref"].startswith("result:")
+    assert query.get("continuation") is None
+
+    assert results["read"] == results["get"]
+    assert results["read"]["ref"] == f"session:{session_id}"
+    assert results["read"]["payload_kind"] == "session-summary"
+    assert results["read"]["payload"]["id"] == session_id
+    assert results["read"]["payload"]["message_count"] == 1
+    assert results["read"]["payload"]["target_ref"]["identity_key"] == f"session:{session_id}"
+    assert message_get["payload_kind"] == "message"
+    assert message_get["payload"]["id"] == f"{session_id}:m1"
+    assert message_get["payload"]["text"] == "read contract golden needle"
+    assert message_get["payload"]["content_blocks"][0]["text"] == "read contract golden needle"
+    assert results["explain"]["subject"] == "query"
+    assert results["explain"]["explanation"]
+
+    context = results["context"]
+    assert context["spec"]["seed_query"] == "read contract golden needle"
+    assert isinstance(context["segments"], list)
+    assert context["token_estimate"] <= 256
+
+    status = results["status"]
+    assert status["scope"] == "archive"
+    assert status["archive"]["total_sessions"] == 1
+    assert status["archive"]["total_messages"] == 1
+
+    assert resource_body["id"] == session_id
+    assert resource_body["origin"]
+    assert resource_body["title"]
+    assert resource_body["message_count"] == 1
+    assert resource_body["target_ref"]["identity_key"] == f"session:{session_id}"
+
+
+@pytest.mark.asyncio
+async def test_query_resource_golden_fails_when_shared_transaction_is_bypassed(tmp_path: Path) -> None:
+    """Pin live query and URI resource handlers to the shared transaction.
+
+    This is an anti-vacuity mutation: if the registered handler stops calling
+    ``QueryTransaction.run`` and silently invokes a surface-local executor,
+    this injected failure will not reach the MCP response and the assertions
+    below will fail. The resource assertion covers its separate resolver
+    registration, which also owns a bounded transaction.
+    """
+    archive_root = tmp_path / "archive"
+    with ArchiveStore(archive_root):
+        _write_message(archive_root, "shared-transaction", "shared transaction needle")
+
+    from polylogue.mcp.server import build_server
+
+    server = cast(MCPServerUnderTest, build_server())
+    with patch(
+        "polylogue.archive.query.transaction.QueryTransaction.run",
+        side_effect=RuntimeError("shared query transaction disabled"),
+    ):
+        response = json.loads(
+            await invoke_surface_async(
+                server._tool_manager._tools["query"].fn,
+                expression="messages where text:needle",
+                limit=1,
+            )
+        )
+        resource_response = json.loads(
+            await invoke_surface_async(
+                server._resource_manager._templates["polylogue://session/{conv_id}"].fn,
+                conv_id="codex-session:shared-transaction",
+            )
+        )
+
+    assert response["code"] == "internal_error"
+    assert resource_response["code"] == "internal_error"


### PR DESCRIPTION
## Summary

Add production-shaped MCP read-contract goldens and durable telemetry coverage for the six registered read transactions plus the session URI resource. Ref polylogue-t46.8.2.

## Problem

The six-tool cutover had live registration and individual contract tests, but the remaining proof did not exercise every registered read handler against one seeded archive or verify durable delivery for the complete read set. The bead notes also left payload fidelity and shared transaction dependency evidence incomplete.

## Solution

- `tests/unit/mcp/test_server_surfaces.py` builds the real FastMCP server, invokes the registered `query`, `read`, `get`, `explain`, `context`, and `status` handlers, and invokes the registered `polylogue://session/{conv_id}` resource against `ArchiveStore` data.
- The golden checks stable query and object identities, bounded context, archive totals, session summary fields, and seeded authored message text and content blocks.
- A mutation guard disables `QueryTransaction.run` and requires both the registered query handler and URI resource to return typed internal errors.
- `tests/unit/mcp/test_mcp_call_log.py` drives all six registered handlers through the daemon telemetry path and checks durable ops-tier call-log delivery and success.

This slice deliberately does not recreate retired aliases or claim equivalence telemetry against routes that no longer exist. No production mutation authority, storage DDL, daemon similarity, or generated source was changed.

## Verification

- `TMPDIR=/realm/tmp devtools test tests/unit/mcp/test_server_surfaces.py tests/unit/mcp/test_mcp_call_log.py tests/unit/mcp/test_tool_declarations.py tests/unit/mcp/test_tool_discovery.py tests/unit/mcp/test_contract_evidence.py` passed: 59 tests, 8 warnings.
- `devtools render mcp-equivalence --check` passed: sync OK.
- `devtools render mcp-tool-index --check` passed: sync OK.
- `devtools verify layering` passed with 306 pre-existing baselined violations exempted.
- `devtools lab policy schema-versioning` passed with zero policy violations.
- `TMPDIR=/realm/tmp devtools verify --quick` passed all 21 steps at rebased HEAD `0d28e2217f2c8851e22b4da089b352f34ac327a4`.
- Two independent adversarial closure reviews found no remaining flaw in this partial slice after the payload assertions were tightened.

## AC disposition

- AC1: Partially evidenced. The canonical six read transactions and URI resource are exercised with stable identities and bounded payload assertions. Full retired-tool coverage remains in the parent bead.
- AC2: Not addressed by this slice. Discovery-only workflow and incident replay evidence remain open.
- AC3: Not addressed by this slice. Oversized paging and incident-scale resource bounds remain open.
- AC4: Partially evidenced. Live production-shaped payload goldens and durable per-tool telemetry now exist. Retired-route shadow equivalence and cold-model discovery evidence remain open.
- AC5: Not addressed by this slice. Default profile and duplicate-semantics accounting remain parent-bead scope.
- AC6: Partially evidenced. The registered query and URI resource paths fail when the shared transaction is disabled. Declaration, cursor, cancellation, and cleanup ownership mutation coverage remain open.
- AC7: Not addressed by this slice. Repeated incident-scale concurrency and cancellation measurements remain open.

The bead remains open for the explicitly listed residual acceptance criteria.
