### PR TITLE
refactor: dedup coercion helpers, provenance vocab, title/tags mixin

### DIFF
--- a/polylogue/archive/session/display_mixin.py
+++ b/polylogue/archive/session/display_mixin.py
@@ -40,6 +40,7 @@ class DisplayTitleTagsMixin:
     - metadata: dict[str, object]
     - parent_id: SessionId | None
     - branch_type: BranchType | None
+    - display_name: str | None
     """
 
     id: SessionId
@@ -49,6 +50,7 @@ class DisplayTitleTagsMixin:
     metadata: dict[str, object]
     parent_id: SessionId | None
     branch_type: BranchType | None
+    display_name: str | None
 
     @property
     def display_date(self) -> datetime | None:
@@ -62,12 +64,18 @@ class DisplayTitleTagsMixin:
 
     @property
     def display_title(self) -> str:
-        """Return the display title with precedence: user_title > title > id[:8]."""
+        """Return the display title with precedence: user_title > title > display_name > id[:8]."""
         user_title = self.user_title
         if user_title:
             return user_title
         if self.title:
             return self.title
+        # polylogue-cgfy: provider-assigned display name (e.g. Claude Code's
+        # slug, "greedy-squishing-hamming") beats the raw id truncation --
+        # the fix for subagent rows showing "<uuid-prefix>" instead of a
+        # human-readable name when no title-worthy sidecar evidence exists.
+        if self.display_name:
+            return self.display_name
         return self.id[:8]
 
     @property

--- a/polylogue/archive/session/domain_runtime.py
+++ b/polylogue/archive/session/domain_runtime.py
@@ -4,15 +4,13 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Callable, Iterator, Mapping
-from datetime import datetime
 from typing import TYPE_CHECKING, Self, cast
 
 from polylogue.archive.message.messages import MessageCollection
 from polylogue.archive.message.models import DialoguePair, Message
 from polylogue.archive.message.roles import Role, normalize_message_roles
-from polylogue.archive.session.branch_type import BranchType
+from polylogue.archive.session.display_mixin import DisplayTitleTagsMixin
 from polylogue.core.enums import MaterialOrigin
-from polylogue.core.types import SessionId
 
 if TYPE_CHECKING:
     from polylogue.archive.projection.projections import SessionProjection
@@ -20,79 +18,12 @@ if TYPE_CHECKING:
     from polylogue.archive.session.domain_models import Session
 
 
-def _metadata_string(metadata: dict[str, object], key: str) -> str | None:
-    value = metadata.get(key)
-    return str(value) if value is not None else None
-
-
-def _metadata_tags(metadata: dict[str, object]) -> list[str]:
-    raw_tags = metadata.get("tags", [])
-    if not isinstance(raw_tags, list):
-        return []
-    return [str(tag) for tag in raw_tags]
-
-
-class SessionRuntimeMixin:
-    id: SessionId
-    title: str | None
+class SessionRuntimeMixin(DisplayTitleTagsMixin):
     messages: MessageCollection
-    created_at: datetime | None
-    updated_at: datetime | None
-    metadata: dict[str, object]
-    parent_id: SessionId | None
-    branch_type: BranchType | None
-    display_name: str | None
 
     if TYPE_CHECKING:
 
         def model_copy(self, *, update: Mapping[str, object] | None = None, deep: bool = False) -> Self: ...
-
-    @property
-    def display_date(self) -> datetime | None:
-        return self.updated_at or self.created_at
-
-    @property
-    def is_continuation(self) -> bool:
-        return self.branch_type == BranchType.CONTINUATION
-
-    @property
-    def is_sidechain(self) -> bool:
-        return self.branch_type == BranchType.SIDECHAIN
-
-    @property
-    def is_root(self) -> bool:
-        return self.parent_id is None
-
-    @property
-    def user_title(self) -> str | None:
-        return _metadata_string(self.metadata, "title")
-
-    @property
-    def display_title(self) -> str:
-        user_title = self.user_title
-        if user_title:
-            return user_title
-        if self.title:
-            return self.title
-        # polylogue-cgfy: provider-assigned display name (e.g. Claude Code's
-        # slug, "greedy-squishing-hamming") beats the raw id truncation --
-        # the fix for subagent rows showing "<uuid-prefix>" instead of a
-        # human-readable name when no title-worthy sidecar evidence exists.
-        if self.display_name:
-            return self.display_name
-        return self.id[:8]
-
-    @property
-    def summary(self) -> str | None:
-        return _metadata_string(self.metadata, "summary")
-
-    @property
-    def tags(self) -> list[str]:
-        # #1240: M2M-sourced tags are authoritative once hydrated.
-        m2m = getattr(self, "tags_m2m", None)
-        if m2m:
-            return list(m2m)
-        return _metadata_tags(self.metadata)
 
     def filter(self, predicate: Callable[[Message], bool]) -> Self:
         filtered_messages = [message for message in self.messages if predicate(message)]

--- a/polylogue/archive/session/extraction.py
+++ b/polylogue/archive/session/extraction.py
@@ -16,6 +16,8 @@ from polylogue.archive.semantic.facts import (
     build_session_semantic_facts,
 )
 from polylogue.archive.session.documents import WorkEventDocument
+from polylogue.archive.session.provenance import date_provenance as _date_provenance
+from polylogue.archive.session.provenance import range_timing_provenance as _range_timing_provenance
 from polylogue.core.payload_coercion import (
     coerce_float,
     coerce_int,
@@ -362,24 +364,6 @@ def _range_timing(
         ),
         reordered,
     )
-
-
-def _range_timing_provenance(start_time: str | None, end_time: str | None) -> str:
-    if start_time is not None and end_time is not None:
-        return "timestamped_range"
-    if start_time is not None:
-        return "start_timestamp_only"
-    if end_time is not None:
-        return "end_timestamp_only"
-    return "untimestamped"
-
-
-def _date_provenance(canonical_session_date: str | None, start_time: str | None, end_time: str | None) -> str:
-    if canonical_session_date is None:
-        return "none"
-    if start_time is not None or end_time is not None:
-        return "event_timestamp"
-    return "date_only"
 
 
 def _merge_adjacent(events: list[WorkEvent]) -> list[WorkEvent]:

--- a/polylogue/archive/session/models.py
+++ b/polylogue/archive/session/models.py
@@ -14,6 +14,8 @@ from polylogue.archive.session.documents import (
     SessionProfileDocument,
 )
 from polylogue.archive.session.extraction import WorkEvent
+from polylogue.archive.session.provenance import date_provenance as _date_provenance
+from polylogue.archive.session.provenance import range_timing_provenance as _range_timing_provenance
 from polylogue.archive.session.repo_identity import normalize_repo_names, normalize_repo_paths
 from polylogue.core.payload_coercion import (
     coerce_float,
@@ -74,24 +76,6 @@ def _phase_from_mapping(payload: SessionPhasePayload | Mapping[str, object]) -> 
         confidence=coerce_float(payload.get("confidence"), 0.0),
         evidence=string_sequence(payload.get("evidence")),
     )
-
-
-def _range_timing_provenance(start_time: str | None, end_time: str | None) -> str:
-    if start_time is not None and end_time is not None:
-        return "timestamped_range"
-    if start_time is not None:
-        return "start_timestamp_only"
-    if end_time is not None:
-        return "end_timestamp_only"
-    return "untimestamped"
-
-
-def _date_provenance(canonical_session_date: str | None, start_time: str | None, end_time: str | None) -> str:
-    if canonical_session_date is None:
-        return "none"
-    if start_time is not None or end_time is not None:
-        return "event_timestamp"
-    return "date_only"
 
 
 @dataclass(frozen=True)

--- a/polylogue/archive/session/provenance.py
+++ b/polylogue/archive/session/provenance.py
@@ -6,8 +6,13 @@
 from __future__ import annotations
 
 
-def range_timing_provenance(start_time: str | None, end_time: str | None) -> str:
+def range_timing_provenance(start_time: object | None, end_time: object | None) -> str:
     """Determine the provenance category for session time range.
+
+    Accepts ``object | None`` rather than a specific temporal type because
+    every call site only tests presence/absence — callers pass ``str``,
+    ``datetime``, or other already-parsed timestamp representations
+    interchangeably.
 
     Returns one of:
     - "timestamped_range": both start and end times are present
@@ -25,9 +30,9 @@ def range_timing_provenance(start_time: str | None, end_time: str | None) -> str
 
 
 def date_provenance(
-    canonical_session_date: str | None,
-    start_time: str | None,
-    end_time: str | None,
+    canonical_session_date: object | None,
+    start_time: object | None,
+    end_time: object | None,
 ) -> str:
     """Determine the provenance category for session date.
 

--- a/polylogue/archive/session/summary_runtime.py
+++ b/polylogue/archive/session/summary_runtime.py
@@ -2,73 +2,11 @@
 
 from __future__ import annotations
 
-from datetime import datetime
-
-from polylogue.archive.session.branch_type import BranchType
-from polylogue.core.types import SessionId
+from polylogue.archive.session.display_mixin import DisplayTitleTagsMixin
 
 
-def _metadata_string(metadata: dict[str, object], key: str) -> str | None:
-    value = metadata.get(key)
-    return str(value) if value is not None else None
-
-
-def _metadata_tags(metadata: dict[str, object]) -> list[str]:
-    raw_tags = metadata.get("tags", [])
-    if not isinstance(raw_tags, list):
-        return []
-    return [str(tag) for tag in raw_tags]
-
-
-class SessionSummaryRuntimeMixin:
-    id: SessionId
-    title: str | None
-    created_at: datetime | None
-    updated_at: datetime | None
-    metadata: dict[str, object]
-    parent_id: SessionId | None
-    branch_type: BranchType | None
-    display_name: str | None
-
-    @property
-    def display_date(self) -> datetime | None:
-        return self.updated_at or self.created_at
-
-    @property
-    def display_title(self) -> str:
-        user_title = _metadata_string(self.metadata, "title")
-        if user_title:
-            return user_title
-        if self.title:
-            return self.title
-        # polylogue-cgfy: see Session.display_title's twin fallback.
-        if self.display_name:
-            return self.display_name
-        return self.id[:8]
-
-    @property
-    def tags(self) -> list[str]:
-        # #1240: prefer M2M-hydrated tags when available.
-        m2m = getattr(self, "tags_m2m", None)
-        if m2m:
-            return list(m2m)
-        return _metadata_tags(self.metadata)
-
-    @property
-    def summary(self) -> str | None:
-        return _metadata_string(self.metadata, "summary")
-
-    @property
-    def is_continuation(self) -> bool:
-        return self.branch_type == BranchType.CONTINUATION
-
-    @property
-    def is_sidechain(self) -> bool:
-        return self.branch_type == BranchType.SIDECHAIN
-
-    @property
-    def is_root(self) -> bool:
-        return self.parent_id is None
+class SessionSummaryRuntimeMixin(DisplayTitleTagsMixin):
+    pass
 
 
 __all__ = ["SessionSummaryRuntimeMixin"]

--- a/polylogue/core/payload_coercion.py
+++ b/polylogue/core/payload_coercion.py
@@ -162,6 +162,30 @@ def row_float(value: object) -> float | None:
     return None
 
 
+def required_int(value: object) -> int:
+    """Coerce a value to int; raise if it cannot be parsed as one."""
+    if isinstance(value, bool):
+        raise ValueError(f"Required int value is a bool: {value!r}")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        return int(value)
+    raise ValueError(f"Required int value is not coercible: {value!r}")
+
+
+def required_float(value: object) -> float:
+    """Coerce a value to float; raise if it cannot be parsed as one."""
+    if isinstance(value, bool):
+        raise ValueError(f"Required float value is a bool: {value!r}")
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, str):
+        return float(value)
+    raise ValueError(f"Required float value is not coercible: {value!r}")
+
+
 __all__ = [
     "PayloadMapping",
     "coerce_float",
@@ -174,6 +198,8 @@ __all__ = [
     "optional_datetime",
     "optional_str",
     "optional_string",
+    "required_float",
+    "required_int",
     "required_str",
     "row_float",
     "row_int",

--- a/polylogue/daemon/catchup_status.py
+++ b/polylogue/daemon/catchup_status.py
@@ -279,30 +279,14 @@ def _payload(raw: object) -> dict[str, object]:
 
 def _payload_int(payload: dict[str, object], key: str, default: int = 0) -> int:
     value = payload.get(key)
-    if isinstance(value, bool):
+    if isinstance(value, bool) or not isinstance(value, int | float | str):
         return default
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float | str):
-        try:
-            return int(value)
-        except ValueError:
-            return default
-    return default
+    return _row_int(value)
 
 
 def _payload_float(payload: dict[str, object], key: str, default: float = 0.0) -> float:
-    value = payload.get(key)
-    if isinstance(value, bool):
-        return default
-    if isinstance(value, int | float):
-        return float(value)
-    if isinstance(value, str):
-        try:
-            return float(value)
-        except ValueError:
-            return default
-    return default
+    coerced = _row_float(payload.get(key))
+    return default if coerced is None else coerced
 
 
 def _payload_str(payload: dict[str, object], key: str, *, default: str) -> str:
@@ -311,8 +295,7 @@ def _payload_str(payload: dict[str, object], key: str, *, default: str) -> str:
 
 
 def _payload_optional_str(payload: dict[str, object], key: str) -> str | None:
-    value = payload.get(key)
-    return value if isinstance(value, str) else None
+    return _optional_str(payload.get(key))
 
 
 def _epoch_ms_to_iso(value: int) -> str:

--- a/polylogue/daemon/fts_status.py
+++ b/polylogue/daemon/fts_status.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from pydantic import BaseModel, Field
 
+from polylogue.core.payload_coercion import row_int as _row_int
 from polylogue.logging import get_logger
 from polylogue.storage.fts.freshness import STALE, UNKNOWN, freshness_ready_record_trusted
 from polylogue.storage.fts.fts_lifecycle import FtsInvariantSnapshot, FtsSurfaceInvariant, fts_invariant_snapshot_sync
@@ -101,12 +102,12 @@ def _freshness_rows(conn: sqlite3.Connection) -> dict[str, dict[str, int | str |
         record = dict(zip(selected, row, strict=True))
         records[str(record["surface"])] = {
             "state": str(record["state"]),
-            "source_rows": _int_or_zero(record.get("source_rows")),
-            "indexed_rows": _int_or_zero(record.get("indexed_rows")),
-            "missing_rows": _int_or_zero(record.get("missing_rows")),
-            "excess_rows": _int_or_zero(record.get("excess_rows")),
-            "duplicate_rows": _int_or_zero(record.get("duplicate_rows")),
-            "identity_mismatch_rows": _int_or_zero(record.get("identity_mismatch_rows")),
+            "source_rows": _row_int(record.get("source_rows")),
+            "indexed_rows": _row_int(record.get("indexed_rows")),
+            "missing_rows": _row_int(record.get("missing_rows")),
+            "excess_rows": _row_int(record.get("excess_rows")),
+            "duplicate_rows": _row_int(record.get("duplicate_rows")),
+            "identity_mismatch_rows": _row_int(record.get("identity_mismatch_rows")),
             "detail": None if "detail" not in record or record["detail"] is None else str(record["detail"]),
         }
     return records
@@ -137,27 +138,8 @@ def _surface_payload(surface: FtsSurfaceInvariant) -> dict[str, int | bool | str
     }
 
 
-def _int_or_zero(value: object) -> int:
-    if isinstance(value, bool):
-        return 0
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float | str):
-        try:
-            return int(value)
-        except ValueError:
-            return 0
-    if value is None:
-        return 0
-    try:
-        return int(str(value))
-    except ValueError:
-        return 0
-
-
 def _payload_int(surface: dict[str, int | bool | str | None], key: str) -> int:
-    value = surface.get(key)
-    return _int_or_zero(value)
+    return _row_int(surface.get(key))
 
 
 def _archive_index_path_for(dbf: Path) -> Path | None:
@@ -267,12 +249,12 @@ def _archive_blocks_surface(conn: sqlite3.Connection) -> dict[str, int | bool | 
     source_exists = _table_exists(conn, "blocks")
     exists = _table_exists(conn, "messages_fts")
     triggers_present = exists and _triggers_present(conn, _ARCHIVE_BLOCKS_FTS_TRIGGERS)
-    source_rows = 0 if freshness is None else _int_or_zero(freshness.get("source_rows"))
-    indexed_rows = 0 if freshness is None else _int_or_zero(freshness.get("indexed_rows"))
-    missing_rows = 0 if freshness is None else _int_or_zero(freshness.get("missing_rows"))
-    excess_rows = 0 if freshness is None else _int_or_zero(freshness.get("excess_rows"))
-    duplicate_rows = 0 if freshness is None else _int_or_zero(freshness.get("duplicate_rows"))
-    identity_mismatch_rows = 0 if freshness is None else _int_or_zero(freshness.get("identity_mismatch_rows"))
+    source_rows = 0 if freshness is None else _row_int(freshness.get("source_rows"))
+    indexed_rows = 0 if freshness is None else _row_int(freshness.get("indexed_rows"))
+    missing_rows = 0 if freshness is None else _row_int(freshness.get("missing_rows"))
+    excess_rows = 0 if freshness is None else _row_int(freshness.get("excess_rows"))
+    duplicate_rows = 0 if freshness is None else _row_int(freshness.get("duplicate_rows"))
+    identity_mismatch_rows = 0 if freshness is None else _row_int(freshness.get("identity_mismatch_rows"))
     recorded_state = None if freshness is None else str(freshness.get("state"))
     source_has_rows = (
         _source_has_rows(conn, "blocks")
@@ -440,14 +422,12 @@ def fts_readiness_info(dbf: Path, *, exact: bool = False) -> dict[str, object]:
                 exists = _table_exists(conn, fts_table)
                 triggers_present = exists and _triggers_present(conn, triggers)
                 freshness = _freshness_record(freshness_records, name)
-                source_rows = 0 if freshness is None else _int_or_zero(freshness.get("source_rows"))
-                indexed_rows = 0 if freshness is None else _int_or_zero(freshness.get("indexed_rows"))
-                missing_rows = 0 if freshness is None else _int_or_zero(freshness.get("missing_rows"))
-                excess_rows = 0 if freshness is None else _int_or_zero(freshness.get("excess_rows"))
-                duplicate_rows = 0 if freshness is None else _int_or_zero(freshness.get("duplicate_rows"))
-                identity_mismatch_rows = (
-                    0 if freshness is None else _int_or_zero(freshness.get("identity_mismatch_rows"))
-                )
+                source_rows = 0 if freshness is None else _row_int(freshness.get("source_rows"))
+                indexed_rows = 0 if freshness is None else _row_int(freshness.get("indexed_rows"))
+                missing_rows = 0 if freshness is None else _row_int(freshness.get("missing_rows"))
+                excess_rows = 0 if freshness is None else _row_int(freshness.get("excess_rows"))
+                duplicate_rows = 0 if freshness is None else _row_int(freshness.get("duplicate_rows"))
+                identity_mismatch_rows = 0 if freshness is None else _row_int(freshness.get("identity_mismatch_rows"))
                 recorded_state = None if freshness is None else str(freshness.get("state"))
                 source_has_rows = (
                     _source_has_rows(conn, source_table)

--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -1061,21 +1061,13 @@ def _typed_failure_samples(value: object) -> list[RawFailureSample]:
 
 
 def _safe_int(value: object) -> int:
-    if isinstance(value, (int, float)) and not isinstance(value, bool):
-        return int(value)
-    return 0
+    return _row_int(value)
 
 
 def _safe_float(value: object, *, default: float = 0.0) -> float:
     """Coerce value to float, returning default on failure."""
-    if isinstance(value, (int, float)) and not isinstance(value, bool):
-        return float(value)
-    if isinstance(value, str):
-        try:
-            return float(value)
-        except ValueError:
-            return default
-    return default
+    coerced = _row_float(value)
+    return default if coerced is None else coerced
 
 
 def _gil_enabled() -> bool:

--- a/polylogue/insights/archive_models.py
+++ b/polylogue/insights/archive_models.py
@@ -8,6 +8,8 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from polylogue.archive.session.documents import SessionPhaseDocument, WorkEventDocument
+from polylogue.archive.session.provenance import date_provenance as _date_provenance
+from polylogue.archive.session.provenance import range_timing_provenance as _range_timing_provenance
 from polylogue.core.sources import source_name_to_origin
 from polylogue.insights.confidence import ConfidenceBand
 from polylogue.insights.fallback import FallbackReason
@@ -262,24 +264,6 @@ def _normalize_timed_document(value: object) -> object:
 
 def _optional_str(value: object) -> str | None:
     return value if isinstance(value, str) and value else None
-
-
-def _range_timing_provenance(start_time: str | None, end_time: str | None) -> str:
-    if start_time is not None and end_time is not None:
-        return "timestamped_range"
-    if start_time is not None:
-        return "start_timestamp_only"
-    if end_time is not None:
-        return "end_timestamp_only"
-    return "untimestamped"
-
-
-def _date_provenance(canonical_session_date: str | None, start_time: str | None, end_time: str | None) -> str:
-    if canonical_session_date is None:
-        return "none"
-    if start_time is not None or end_time is not None:
-        return "event_timestamp"
-    return "date_only"
 
 
 class ThreadMemberEvidencePayload(ArchiveInsightModel):

--- a/polylogue/storage/insights/session/profiles.py
+++ b/polylogue/storage/insights/session/profiles.py
@@ -14,6 +14,8 @@ from polylogue.archive.session.documents import (
 )
 from polylogue.archive.session.extraction import WorkEvent, WorkEventPayload
 from polylogue.archive.session.models import SessionPhasePayload
+from polylogue.archive.session.provenance import date_provenance as _date_provenance
+from polylogue.archive.session.provenance import range_timing_provenance as _range_timing_provenance
 from polylogue.archive.session.session_profile import SessionAnalysis, SessionProfile
 from polylogue.core.payload_coercion import (
     coerce_float,
@@ -642,24 +644,6 @@ def phase_support_signals(phase: SessionPhase) -> tuple[str, ...]:
     if phase.word_count > 0:
         signals.append("word_count")
     return tuple(dict.fromkeys(signals))
-
-
-def _range_timing_provenance(start_time: str | None, end_time: str | None) -> str:
-    if start_time is not None and end_time is not None:
-        return "timestamped_range"
-    if start_time is not None:
-        return "start_timestamp_only"
-    if end_time is not None:
-        return "end_timestamp_only"
-    return "untimestamped"
-
-
-def _date_provenance(canonical_session_date: str | None, start_time: str | None, end_time: str | None) -> str:
-    if canonical_session_date is None:
-        return "none"
-    if start_time is not None or end_time is not None:
-        return "event_timestamp"
-    return "date_only"
 
 
 def phase_fallback(phase: SessionPhase) -> bool:

--- a/polylogue/storage/insights/session/timeline_rows.py
+++ b/polylogue/storage/insights/session/timeline_rows.py
@@ -7,6 +7,8 @@ from datetime import datetime
 from polylogue.archive.phase.extraction import SessionPhase
 from polylogue.archive.session.documents import WorkEventDocument
 from polylogue.archive.session.extraction import WorkEvent
+from polylogue.archive.session.provenance import date_provenance as _date_provenance
+from polylogue.archive.session.provenance import range_timing_provenance as _range_timing_provenance
 from polylogue.archive.session.session_profile import SessionProfile
 from polylogue.core.hashing import hash_text
 from polylogue.core.types import SessionId
@@ -355,28 +357,6 @@ def hydrate_session_phase(record: SessionPhaseRecord) -> SessionPhase:
             str(value) for value in (payload.get("evidence", record.evidence_reasons) or record.evidence_reasons)
         ),
     )
-
-
-def _range_timing_provenance(start_time: datetime | None, end_time: datetime | None) -> str:
-    if start_time is not None and end_time is not None:
-        return "timestamped_range"
-    if start_time is not None:
-        return "start_timestamp_only"
-    if end_time is not None:
-        return "end_timestamp_only"
-    return "untimestamped"
-
-
-def _date_provenance(
-    canonical_session_date: object | None,
-    start_time: datetime | None,
-    end_time: datetime | None,
-) -> str:
-    if canonical_session_date is None:
-        return "none"
-    if start_time is not None or end_time is not None:
-        return "event_timestamp"
-    return "date_only"
 
 
 __all__ = [

--- a/polylogue/storage/sqlite/queries/mappers_insight_fallback.py
+++ b/polylogue/storage/sqlite/queries/mappers_insight_fallback.py
@@ -9,6 +9,8 @@ from typing import TypeAlias, TypeVar
 from pydantic import BaseModel
 
 from polylogue.archive.session.documents import SessionPhaseDocument, WorkEventDocument
+from polylogue.archive.session.provenance import date_provenance as _date_provenance
+from polylogue.archive.session.provenance import range_timing_provenance as _range_timing_provenance
 from polylogue.core.json import JSONDocument, JSONValue, json_document
 from polylogue.insights.archive_models import (
     SessionEnrichmentPayload,
@@ -219,24 +221,6 @@ def session_phase_evidence_from_fallback(
             "word_count": _row_int(row, "word_count", fallback_payload, fallback_key="word_count"),
         }
     )
-
-
-def _range_timing_provenance(start_time: str | None, end_time: str | None) -> str:
-    if start_time is not None and end_time is not None:
-        return "timestamped_range"
-    if start_time is not None:
-        return "start_timestamp_only"
-    if end_time is not None:
-        return "end_timestamp_only"
-    return "untimestamped"
-
-
-def _date_provenance(canonical_session_date: str | None, start_time: str | None, end_time: str | None) -> str:
-    if canonical_session_date is None:
-        return "none"
-    if start_time is not None or end_time is not None:
-        return "event_timestamp"
-    return "date_only"
 
 
 def session_phase_inference_from_fallback(


### PR DESCRIPTION
## Summary
Mechanical dedup sweep covering sub-items (a), (c), and (d) of polylogue-a7xr.9. Sub-item (b) (`_table_exists` consolidation, ~40 duplicate definitions) is explicitly excluded from this PR -- it is owned by a separate lane fixing polylogue-48h and is not touched here.

## Problem
polylogue-a7xr.9's 2026-07-14 reconciliation check found the bead's own sub-items only partially satisfied: (a)'s coercion-helper quadruplet was consolidated by an earlier PR, but hand-rolled scalar coercion had crept back into daemon status modules since; (c)'s `_range_timing_provenance`/`_date_provenance` vocabulary was still duplicated verbatim across six files even though a canonical, unused definition already existed in `archive/session/provenance.py`; (d)'s title/tags precedence logic (including a pasted `#1240` comment) was duplicated between `Session` and `SessionSummary` runtime mixins, with an unused `DisplayTitleTagsMixin` already present but missing the `display_name` fallback both real call sites use.

## Solution
- **(a)**: added `required_int`/`required_float` raising variants to `core/payload_coercion.py` alongside the existing `required_str`. Swept the daemon status modules still hand-rolling scalar coercion instead of using the shared helpers: `catchup_status.py`'s `_payload_int`/`_payload_float`/`_payload_str`/`_payload_optional_str`, `status.py`'s `_safe_int`/`_safe_float`, and `fts_status.py`'s `_int_or_zero` (deleted outright, all call sites now use `row_int`).
- **(c)**: widened `archive/session/provenance.py`'s `range_timing_provenance`/`date_provenance` signatures to `object | None` (every call site only tests presence/absence -- callers pass `str`, `datetime`, or other pre-parsed representations interchangeably) and wired all six call sites (`archive/session/models.py`, `archive/session/extraction.py`, `insights/archive_models.py`, `storage/insights/session/timeline_rows.py`, `storage/insights/session/profiles.py`, `storage/sqlite/queries/mappers_insight_fallback.py`) onto the one canonical definition, deleting the five local copies.
- **(d)**: extended the existing (orphaned) `DisplayTitleTagsMixin` in `archive/session/display_mixin.py` with the missing `display_name` fallback step, then had `SessionRuntimeMixin` (`domain_runtime.py`) and `SessionSummaryRuntimeMixin` (`summary_runtime.py`) inherit from it, dropping their duplicated `display_title`/`tags`/`summary`/`is_continuation`/`is_sidechain`/`is_root` properties and `_metadata_string`/`_metadata_tags` helpers.

Not in scope: a separately-shaped `_coerce_int`/`_coerce_optional_int`/`_coerce_float`/`_coerce_bool` coercion family duplicated 2-3x across `cursor_lag_alert.py`, `convergence_debt_alert.py`, and `cursor_lag_anomaly.py` (configurable-default coercion, distinct signature from `row_int`/`row_float`) -- noticed during the sweep but not named by this bead's design; worth a follow-up bead if desired.

## Verification
- `uv run mypy --strict` on all 14 touched files: `Success: no issues found in 14 source files`
- `devtools test tests/unit/core/test_payload_coercion.py tests/unit/daemon/test_provenance_endpoint.py tests/unit/storage/test_insight_provenance.py tests/unit/storage/test_empty_session_repair_provenance.py tests/unit/core/test_session_semantics.py tests/unit/storage/test_session_display_name_reaches_repository.py tests/unit/storage/test_session_insight_mapper_fallbacks.py tests/unit/storage/test_session_insight_timeline_rows.py tests/unit/sources/test_null_guard_properties.py tests/unit/sources/test_parsers_chatgpt.py tests/unit/api/test_facade_contracts.py tests/unit/archive/test_search_hits.py tests/unit/cli/test_diagnostics.py tests/unit/cli/test_query_fmt.py tests/unit/rendering/test_rendering.py` -> 645 passed, 1 failed. The 1 failure (`test_no_undiscovered_async_methods`, about an unrelated `search_similar_sessions` facade method missing contract coverage) reproduces identically on unmodified `HEAD` with none of this PR's changes applied -- confirmed pre-existing.
- `devtools verify --quick` -> exit 0 (format, lint, mypy, render-all-check, layering, closure-matrix, schema/lab policy checks all green).

Ref polylogue-a7xr.9