### PR TITLE
refactor: relocate api-facade private symbols out of substrate reach

### DIFF
--- a/docs/plans/layering-surface-baseline.json
+++ b/docs/plans/layering-surface-baseline.json
@@ -27,16 +27,6 @@
   {
     "target": "polylogue/api",
     "file": "polylogue/api/archive.py",
-    "import": "polylogue.storage.archive_identity"
-  },
-  {
-    "target": "polylogue/api",
-    "file": "polylogue/api/archive.py",
-    "import": "polylogue.storage.insights.session.rebuild"
-  },
-  {
-    "target": "polylogue/api",
-    "file": "polylogue/api/archive.py",
     "import": "polylogue.storage.insights.session.records"
   },
   {

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -27,6 +27,7 @@ from polylogue.archive.query.transaction import archive_read_context, run_archiv
 from polylogue.archive.semantic.content_projection import ContentProjectionSpec, project_message_content
 from polylogue.archive.session.branch_type import BranchType
 from polylogue.archive.session.domain_models import Session, SessionSummary
+from polylogue.config import active_archive_root as _active_archive_root
 from polylogue.context.compiler import (
     DEFAULT_CONTEXT_IMAGE_MAX_CHARS_PER_MESSAGE,
     DEFAULT_CONTEXT_IMAGE_MAX_MESSAGES_PER_SESSION,
@@ -53,7 +54,6 @@ from polylogue.insights.archive import (
 from polylogue.insights.archive_models import ArchiveInsightModel
 from polylogue.insights.feedback import LearningCorrection, parse_correction_kind
 from polylogue.paths import archive_file_set_index_available_for_paths
-from polylogue.storage.archive_identity import archive_file_set_root
 from polylogue.storage.insights.session.records import SessionProfileRecord
 from polylogue.storage.insights.session.runtime import SessionInsightStatusSnapshot
 from polylogue.storage.query_models import SessionRecordQuery
@@ -410,20 +410,6 @@ def _archive_action_sequence(values: Sequence[str]) -> tuple[str, ...]:
 
 def _archive_index_available(config: Config) -> bool:
     return archive_file_set_index_available_for_paths(archive_root_path=config.archive_root, db_anchor=config.db_path)
-
-
-def _active_archive_root(config: Config) -> Path:
-    """Return the archive file-set root housing the currently active database.
-
-    Deliberately follows ``config.db_path`` (not ``config.archive_root``),
-    matching the ``polylogue-yla8.1`` split-root contract used by
-    :func:`polylogue.storage.repair._raw_materialization_archive_root` and
-    :func:`polylogue.storage.raw_reconciler._archive_root`: an explicit
-    ``Config(db_path=...)`` override must be honored, and the ordinary case
-    already resolves ``config.db_path`` correctly (``.index-active-pointer``
-    -aware) inside ``Config.__init__``.
-    """
-    return archive_file_set_root(archive_root=config.archive_root, db_path=config.db_path)
 
 
 def _archive_context_message_window(
@@ -2318,45 +2304,6 @@ def _actions_for_session(session: Session) -> tuple[Action, ...]:
         )
         events.extend(build_actions(message, calls))
     return tuple(events)
-
-
-def _rebuild_archive_session_insights(
-    archive: Any,
-    *,
-    session_ids: Sequence[str] | None = None,
-    progress_callback: ProgressCallback | None = None,
-) -> SessionInsightCounts:
-    """Rebuild durable session insights via the canonical materializer.
-
-    This is a thin adapter over
-    ``polylogue.storage.insights.session.rebuild.rebuild_session_insights_sync``
-    — the single rebuild stack shared with daemon convergence (#1743 P13). It
-    resolves any session-id aliases against the archive, then delegates the
-    whole rebuild (profiles, latency, work events, phases, threads +
-    thread_sessions + 'thread' markers, tag rollups, provider-day aggregates)
-    to the canonical path, which commits internally.
-    """
-    from polylogue.storage.insights.session.rebuild import rebuild_session_insights_sync
-    from polylogue.storage.insights.session.runtime import SessionInsightCounts
-
-    resolved_ids = _archive_rebuild_session_ids(archive, session_ids) if session_ids is not None else None
-    if session_ids is not None and not resolved_ids:
-        return SessionInsightCounts()
-    return rebuild_session_insights_sync(
-        archive._conn,
-        session_ids=resolved_ids,
-        progress_callback=progress_callback,
-    )
-
-
-def _archive_rebuild_session_ids(archive: Any, session_ids: Sequence[str] | None) -> tuple[str, ...]:
-    if session_ids is None:
-        return tuple(summary.session_id for summary in archive.list_summaries(limit=1_000_000))
-    resolved: list[str] = []
-    for session_id in session_ids:
-        with suppress(KeyError):
-            resolved.append(archive.resolve_session_id(str(session_id)))
-    return tuple(dict.fromkeys(resolved))
 
 
 def _archive_message_matches(

--- a/polylogue/api/ingest.py
+++ b/polylogue/api/ingest.py
@@ -37,7 +37,7 @@ class PolylogueIngestMixin:
             source_name = file_path.stem
 
         source = Source(name=source_name, path=file_path)
-        from polylogue.api.archive import _active_archive_root
+        from polylogue.config import active_archive_root as _active_archive_root
         from polylogue.pipeline.services.archive_ingest import parse_sources_archive
 
         return await parse_sources_archive(_active_archive_root(self.config), [source])
@@ -52,14 +52,14 @@ class PolylogueIngestMixin:
             sources = self.config.sources
 
         del download_assets
-        from polylogue.api.archive import _active_archive_root
+        from polylogue.config import active_archive_root as _active_archive_root
         from polylogue.pipeline.services.archive_ingest import parse_sources_archive
 
         return await parse_sources_archive(_active_archive_root(self.config), sources)
 
     async def rebuild_index(self) -> bool:
         """Rebuild the derived block-FTS index through the mutation executor."""
-        from polylogue.api.archive import _active_archive_root
+        from polylogue.config import active_archive_root as _active_archive_root
         from polylogue.operations.mutation_actuators import IndexRebuildActuator, IndexRebuildArgs
         from polylogue.operations.mutation_transaction import OperationExecutor
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore

--- a/polylogue/api/insights.py
+++ b/polylogue/api/insights.py
@@ -6,10 +6,10 @@ from collections.abc import Sequence
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Protocol
 
-from polylogue.api.archive import _active_archive_root
 from polylogue.archive.query.spec import parse_query_date
 from polylogue.archive.query.transaction import run_archive_read
 from polylogue.archive.session.branch_type import BranchType
+from polylogue.config import active_archive_root as _active_archive_root
 from polylogue.core.types import SessionId
 from polylogue.cost.aggregation import session_costs_to_daily_usd
 from polylogue.cost.outlook import CycleOutlook, ProjectionMethod, build_cycle_outlook

--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -21,7 +21,7 @@ import tomllib
 from .core.errors import PolylogueError
 from .core.loopback import bind_hosts_overlap, is_loopback_host
 from .paths import GEMINI_DRIVE_FOLDER
-from .storage.archive_identity import resolve_active_index_path
+from .storage.archive_identity import archive_file_set_root, resolve_active_index_path
 
 
 class ConfigError(PolylogueError):
@@ -151,6 +151,24 @@ class Config:
             drive_config=self.drive_config,
             index_config=self.index_config,
         )
+
+
+def active_archive_root(config: Config) -> Path:
+    """Return the archive file-set root housing the currently active database.
+
+    Deliberately follows ``config.db_path`` (not ``config.archive_root``),
+    matching the ``polylogue-yla8.1`` split-root contract used by
+    :func:`polylogue.storage.repair._raw_materialization_archive_root` and
+    :func:`polylogue.storage.raw_reconciler._archive_root`: an explicit
+    ``Config(db_path=...)`` override must be honored, and the ordinary case
+    already resolves ``config.db_path`` correctly (``.index-active-pointer``
+    -aware) inside ``Config.__init__``.
+
+    Runtime-root resolution, not facade-specific -- lives in ``config`` (the
+    core of the config ring) rather than ``polylogue.api`` so substrate rings
+    that need it are not forced to import the API facade (polylogue-exb).
+    """
+    return archive_file_set_root(archive_root=config.archive_root, db_path=config.db_path)
 
 
 def get_sources(runtime: ResolvedRuntimeConfig) -> list[Source]:

--- a/polylogue/insights/correlation_view.py
+++ b/polylogue/insights/correlation_view.py
@@ -22,7 +22,7 @@ def run_correlation_view(
     github_api: bool = True,
 ) -> None:
     """Show git commits and GitHub refs within the session's time window (#1690)."""
-    from polylogue.api.sync.bridge import run_coroutine_sync
+    from polylogue.core.async_bridge import run_coroutine_sync
     from polylogue.insights.session_commit import (
         bridge_session_ids_from_events,
         build_correlation_result,

--- a/polylogue/insights/registry.py
+++ b/polylogue/insights/registry.py
@@ -737,7 +737,7 @@ def fetch_insights(
 ) -> list[ArchiveInsightModel]:
     """Fetch insight items using the registry dispatch metadata."""
 
-    from polylogue.api.sync.bridge import run_coroutine_sync
+    from polylogue.core.async_bridge import run_coroutine_sync
 
     query = _build_query(insight_type, **kwargs)
     method = getattr(operations, insight_type.operations_method_name)

--- a/polylogue/pipeline/ingest_support.py
+++ b/polylogue/pipeline/ingest_support.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-from polylogue.api.sync.bridge import run_coroutine_sync
 from polylogue.config import Config, Source
+from polylogue.core.async_bridge import run_coroutine_sync
 
 INGEST_STAGE_SEQUENCES: dict[str, tuple[str, ...]] = {
     "acquire": ("acquire",),

--- a/polylogue/storage/embeddings/materialization.py
+++ b/polylogue/storage/embeddings/materialization.py
@@ -1287,7 +1287,7 @@ def embed_session_sync(
     ``fetch_title=True`` issues an extra ``view`` lookup so callers can
     display a friendly label; when False the title field is left ``None``.
     """
-    from polylogue.api.sync.bridge import run_coroutine_sync
+    from polylogue.core.async_bridge import run_coroutine_sync
 
     title: str | None = None
     if fetch_title:

--- a/polylogue/storage/insights/session/rebuild.py
+++ b/polylogue/storage/insights/session/rebuild.py
@@ -10,8 +10,9 @@ import time
 from collections import defaultdict
 from collections.abc import AsyncIterator, Callable, Iterable, Iterator, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import suppress
 from dataclasses import dataclass
-from typing import TypeVar
+from typing import Any, TypeVar
 
 import aiosqlite
 
@@ -2017,6 +2018,46 @@ def rebuild_session_insights_sync(
     )
 
 
+def _resolve_archive_rebuild_session_ids(archive: Any, session_ids: Sequence[str] | None) -> tuple[str, ...]:
+    if session_ids is None:
+        return tuple(summary.session_id for summary in archive.list_summaries(limit=1_000_000))
+    resolved: list[str] = []
+    for session_id in session_ids:
+        with suppress(KeyError):
+            resolved.append(archive.resolve_session_id(str(session_id)))
+    return tuple(dict.fromkeys(resolved))
+
+
+def rebuild_archive_session_insights(
+    archive: Any,
+    *,
+    session_ids: Sequence[str] | None = None,
+    progress_callback: ProgressCallback | None = None,
+) -> SessionInsightCounts:
+    """Rebuild durable session insights via the canonical materializer.
+
+    This is a thin adapter over :func:`rebuild_session_insights_sync` — the
+    single rebuild stack shared with daemon convergence (#1743 P13). It
+    resolves any session-id aliases against the archive, then delegates the
+    whole rebuild (profiles, latency, work events, phases, threads +
+    thread_sessions + 'thread' markers, tag rollups, provider-day aggregates)
+    to the canonical path, which commits internally.
+
+    Both :mod:`polylogue.api` (the async facade) and
+    :mod:`polylogue.storage.repair` (maintenance/doctor repair orchestration)
+    call this primitive downward instead of duplicating it or reaching across
+    ring boundaries for a private symbol (polylogue-exb).
+    """
+    resolved_ids = _resolve_archive_rebuild_session_ids(archive, session_ids) if session_ids is not None else None
+    if session_ids is not None and not resolved_ids:
+        return SessionInsightCounts()
+    return rebuild_session_insights_sync(
+        archive._conn,
+        session_ids=resolved_ids,
+        progress_callback=progress_callback,
+    )
+
+
 async def rebuild_session_insights_async(
     conn: aiosqlite.Connection,
     *,
@@ -2191,6 +2232,7 @@ __all__ = [
     "iter_hydrated_session_profiles_sync",
     "load_async_batch",
     "load_sync_batch",
+    "rebuild_archive_session_insights",
     "rebuild_session_insights_async",
     "rebuild_session_insights_sync",
     "refresh_session_insight_aggregates_sync",

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -5837,10 +5837,12 @@ def repair_session_insights(
     without first giving thread/tag-rollup/day-summary aggregate
     staleness its own automatic convergence mechanism.
     """
-    from polylogue.api.archive import _rebuild_archive_session_insights
     from polylogue.paths import archive_root as _resolve_archive_root
     from polylogue.storage.archive_identity import resolve_active_index_path
-    from polylogue.storage.insights.session.rebuild import refresh_session_insight_aggregates_sync
+    from polylogue.storage.insights.session.rebuild import (
+        rebuild_archive_session_insights,
+        refresh_session_insight_aggregates_sync,
+    )
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
     try:
@@ -5909,7 +5911,7 @@ def repair_session_insights(
                 )
 
             rebuild_session_ids = session_ids if session_ids is not None else targeted_session_ids
-            rebuilt = _rebuild_archive_session_insights(
+            rebuilt = rebuild_archive_session_insights(
                 archive,
                 session_ids=rebuild_session_ids,
                 progress_callback=progress_callback,

--- a/tests/unit/cli/test_check.py
+++ b/tests/unit/cli/test_check.py
@@ -54,11 +54,11 @@ def cli_runner() -> CliRunner:
 
 def _rebuild_native_insights(db_path: Path) -> None:
     """Materialize session insights for a seeded index.db."""
-    from polylogue.api.archive import _rebuild_archive_session_insights
+    from polylogue.storage.insights.session.rebuild import rebuild_archive_session_insights
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
     with ArchiveStore.open_existing(db_path.parent, read_only=False) as archive:
-        _rebuild_archive_session_insights(archive)
+        rebuild_archive_session_insights(archive)
 
 
 def _find_named_check(payload: JSONDocument, name: str) -> JSONDocument:

--- a/tests/unit/cli/test_continue_absorption.py
+++ b/tests/unit/cli/test_continue_absorption.py
@@ -7,8 +7,8 @@ from pathlib import Path
 
 from click.testing import CliRunner
 
-from polylogue.api.archive import _rebuild_archive_session_insights
 from polylogue.cli.click_app import cli
+from polylogue.storage.insights.session.rebuild import rebuild_archive_session_insights
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from tests.infra.archive_scenarios import native_session_id_for
 from tests.infra.storage_records import SessionBuilder
@@ -38,7 +38,7 @@ def _seed_continuation_session(db_path: Path) -> None:
         .save()
     )
     with ArchiveStore.open_existing(db_path.parent, read_only=False) as archive:
-        _rebuild_archive_session_insights(archive)
+        rebuild_archive_session_insights(archive)
 
 
 def test_continue_emits_interactive_resume_command(cli_workspace: dict[str, Path]) -> None:

--- a/tests/unit/cli/test_insights.py
+++ b/tests/unit/cli/test_insights.py
@@ -11,12 +11,12 @@ import click
 import pytest
 from click.testing import CliRunner, Result
 
-from polylogue.api.archive import _rebuild_archive_session_insights
 from polylogue.cli.click_app import cli
 from polylogue.cli.commands.insights import _make_callback
 from polylogue.insights.archive import ArchiveCoverageInsight
 from polylogue.insights.archive_models import ARCHIVE_INSIGHT_CONTRACT_VERSION
 from polylogue.insights.registry import get_insight_type, insight_items_payload
+from polylogue.storage.insights.session.rebuild import rebuild_archive_session_insights
 from polylogue.storage.insights.session.runtime import SessionInsightCounts, SessionInsightStatusSnapshot
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.write import upsert_session_profile_costs
@@ -54,7 +54,7 @@ def _rebuild_insights(db_path: Path, **kwargs: Any) -> SessionInsightCounts:
     ``session_work_events``, ``session_phases``, and ``threads``.
     """
     with ArchiveStore.open_existing(db_path.parent, read_only=False) as archive:
-        return _rebuild_archive_session_insights(archive, **kwargs)
+        return rebuild_archive_session_insights(archive, **kwargs)
 
 
 def _insight_status(db_path: Path) -> SessionInsightStatusSnapshot:

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -3194,7 +3194,7 @@ def test_repair_session_insights_clears_scoped_convergence_debt(
         lambda _archive_root, read_only=False: FakeArchive(),
     )
     monkeypatch.setattr(
-        "polylogue.api.archive._rebuild_archive_session_insights",
+        "polylogue.storage.insights.session.rebuild.rebuild_archive_session_insights",
         lambda _archive, **_kwargs: SessionInsightCounts(profiles=1),
     )
 
@@ -3326,7 +3326,7 @@ def test_repair_session_insights_uses_candidate_session_ids(monkeypatch: pytest.
         lambda _archive_root, read_only=False: FakeArchive(),
     )
     monkeypatch.setattr(
-        "polylogue.api.archive._rebuild_archive_session_insights",
+        "polylogue.storage.insights.session.rebuild.rebuild_archive_session_insights",
         fake_rebuild,
     )
 
@@ -3442,7 +3442,7 @@ def test_repair_session_insights_targets_stale_thread_materialization(
         lambda _archive_root, read_only=False: FakeArchive(),
     )
     monkeypatch.setattr(
-        "polylogue.api.archive._rebuild_archive_session_insights",
+        "polylogue.storage.insights.session.rebuild.rebuild_archive_session_insights",
         fake_rebuild,
     )
     result = repair_mod.repair_session_insights(_config(tmp_path), dry_run=False)
@@ -3515,7 +3515,7 @@ def test_repair_session_insights_uses_stale_profile_candidates(monkeypatch: pyte
         lambda _archive_root, read_only=False: FakeArchive(),
     )
     monkeypatch.setattr(
-        "polylogue.api.archive._rebuild_archive_session_insights",
+        "polylogue.storage.insights.session.rebuild.rebuild_archive_session_insights",
         fake_rebuild,
     )
 

--- a/tests/visual/conftest.py
+++ b/tests/visual/conftest.py
@@ -526,11 +526,11 @@ def seed_reader_archive(
 def _rebuild_reader_insights(workspace: ReaderWorkspace) -> None:
     """Materialize archive session insights so cost/insights reader panels read
     a populated profile/timeline/phases/threads set."""
-    from polylogue.api.archive import _rebuild_archive_session_insights
+    from polylogue.storage.insights.session.rebuild import rebuild_archive_session_insights
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
     with ArchiveStore.open_existing(workspace.archive_root, read_only=False) as archive:
-        _rebuild_archive_session_insights(archive)
+        rebuild_archive_session_insights(archive)
 
 
 @contextmanager


### PR DESCRIPTION
## Summary
Relocates three private symbols that substrate rings (storage/pipeline/insights) were reaching into `polylogue.api` for, per the layering direction in `docs/plans/layering.yaml` (substrate must not import surface adapters, storage/pipeline/sources/insights should never need to reach up into `polylogue.api`).

## Problem
polylogue-exb documented six inward-import sites where substrate code imported from `polylogue.api`, including two private-symbol reaches. Re-auditing the current tree (some of the bead's original six sites no longer exist after prior refactors) confirmed three still-live problems this PR addresses, plus two additional drift sites of the same class found by grep during implementation:

- `_active_archive_root` lived in `polylogue/api/archive.py` even though it is pure runtime-root resolution over a `Config`, with no facade dependency.
- `_rebuild_archive_session_insights` lived in `polylogue/api/archive.py` as a thin adapter over `polylogue.storage.insights.session.rebuild.rebuild_session_insights_sync`, but `polylogue/storage/repair.py` (substrate) imported the *private* symbol from `polylogue.api.archive` to call it.
- `run_coroutine_sync`'s real implementation already lives in `polylogue.core.async_bridge` (dependency-free), but four substrate call sites (`storage/embeddings/materialization.py`, `insights/correlation_view.py`, `insights/registry.py`, `pipeline/ingest_support.py`) still imported it via `polylogue.api.sync.bridge`, forcing the whole `polylogue.api` package (and its `Polylogue` facade import cost, ~1.7-2.8s) to load for a helper that only needs `asyncio`/`threading`.

Two of the bead's original six sites (`storage/embeddings/preflight.py` importing `select_pending_embedding_session_window`, and `sources/live/batch.py` importing the whole `Polylogue` facade) are deliberately **out of scope** here — the bead's own design notes these as harder problems needing either an alias-vs-source flip (item 4) or dependency injection at a daemon composition root (item 5), not a mechanical relocation. A third drift site not mentioned in the bead at all, `polylogue/insights/cost_enrichment.py` importing the private `polylogue.api.archive._archive_session_to_session`, plus `polylogue/sources/live/watcher.py`'s facade import (same class as batch.py), were found during this audit and are also left for follow-up — they are a different symbol/pattern than the three named moves this PR executes.

## Solution
- `polylogue/config.py`: added `active_archive_root(config: Config) -> Path`, the runtime-root resolver, moved verbatim from `api/archive.py`. `polylogue/api/archive.py`, `api/ingest.py`, and `api/insights.py` now import it as `active_archive_root as _active_archive_root` rather than defining/duplicating it.
- `polylogue/storage/insights/session/rebuild.py`: added `rebuild_archive_session_insights(archive, ...)`, the id-alias-resolving adapter over `rebuild_session_insights_sync`, moved from `api/archive.py`. `polylogue/storage/repair.py` now imports and calls it directly from `storage.insights.session.rebuild` instead of reaching into `polylogue.api.archive`'s private symbol. `api/archive.py` no longer defines or re-exports it — nothing else in `api/` called it.
- Four substrate call sites now import `run_coroutine_sync` from `polylogue.core.async_bridge` directly instead of `polylogue.api.sync.bridge`.
- `docs/plans/layering-surface-baseline.json`: pruned 2 stale baseline entries (`polylogue/api/archive.py` importing `polylogue.storage.archive_identity` and `polylogue.storage.insights.session.rebuild`) that no longer reproduce now that those imports were removed from `api/archive.py`. Two other stale entries reported by `devtools verify layering` (`daemon/similarity.py`, `mcp/server_prompts.py`) are pre-existing drift unrelated to this change and were left alone.
- No entries needed adding to `layering.yaml`'s disallow lists for storage/pipeline/sources/insights against `polylogue/api`, because no such rule exists yet (that's the rest of polylogue-exb's scope, gated on items 4/5 above being resolved first — adding the rule now would break on the two deliberately-deferred sites).

## Verification
- `mypy --strict polylogue/config.py polylogue/api/archive.py polylogue/api/ingest.py polylogue/api/insights.py polylogue/storage/repair.py polylogue/storage/insights/session/rebuild.py polylogue/storage/embeddings/materialization.py polylogue/insights/correlation_view.py polylogue/insights/registry.py polylogue/pipeline/ingest_support.py` → `Success: no issues found in 10 source files`
- `devtools test tests/unit/storage/test_repair.py tests/unit/cli/test_continue_absorption.py tests/unit/cli/test_check.py tests/unit/cli/test_insights.py tests/unit/insights/test_tool_usage.py` and `devtools test tests/unit/core/test_facade_api.py tests/unit/pipeline/test_ingest_batch.py` → all green except 5 pre-existing failures (4 in `test_insights.py`, 1 in `test_facade_api.py`) independently reproduced on the unmodified worktree via `git stash` before these changes (real-wall-clock-date test hazards, unrelated to this diff).
- `devtools verify layering` → `No layering violations found.` (304 pre-existing baselined violations exempted; 2 pre-existing stale baseline entries unrelated to this PR).
- `devtools verify --quick` (format + lint + mypy + render-all-check + layering + other static gates) → exit 0, ran again automatically via the pre-push hook.

Ref polylogue-exb