### PR TITLE
feat(drive): add JSON-structural revision-diff classifier for Drive re-acquisition

### DIFF
--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -53,6 +53,7 @@ from polylogue.sinex.models import PublicationMode, PublicationPayload
 from polylogue.sinex.obligations import AsyncSqlConnection, stage_payload_async
 from polylogue.sinex.service import PublicationService
 from polylogue.sinex.transport import resolve_configured_transport
+from polylogue.sources.drive.structural_diff import DriveStructuralRelation, classify_drive_structural_relation
 from polylogue.sources.parsers.base import ParsedMessage, ParsedSession
 from polylogue.storage.blob_publication import ArchiveBlobPublisher, consume_blob_publication_receipt
 from polylogue.storage.raw.models import RawSessionStateUpdate
@@ -586,6 +587,68 @@ class _DriveRevisionGovernanceAdapter:
         )
 
 
+def _drive_structural_growth_predecessor(
+    source_conn: sqlite3.Connection,
+    blob_publisher: ArchiveBlobPublisher,
+    *,
+    raw_id: str,
+    logical_source_key: str,
+) -> tuple[str, int, str] | None:
+    """Find a unique JSON-structural predecessor for ``raw_id``, if any.
+
+    polylogue-1fijp AC (b): ``_bind_drive_revision_lineage``'s legacy path
+    (below) only ever proves lineage via
+    ``classify_raw_revision_cohort_for_live_watch``'s byte-prefix classifier
+    (``archive/revision_authority.py``), which -- per PR #3656's finding --
+    can never recognize the realistic ``_inject_live_drive_attachment_bytes``
+    growth shape (a whole-document JSON re-serialization, not a byte-append).
+    This looks for exactly one existing ``revision_kind='full'`` sibling for
+    ``logical_source_key`` whose bytes are a JSON-structural predecessor of
+    ``raw_id``'s own bytes (see ``sources.drive.structural_diff``) and, if
+    found, returns ``(predecessor_raw_id, predecessor_generation,
+    baseline_raw_id)`` for the caller to bind directly.
+
+    Returns ``None`` on zero or more-than-one structural match (never guess
+    between competing candidates), or when ``raw_id``'s own row cannot be
+    found -- the caller falls through to the existing byte-prefix
+    quarantine-then-classify path unchanged in every such case, so this is a
+    strictly additive typed-lineage improvement, never a narrowing of what
+    the legacy path already proves.
+    """
+    new_row = source_conn.execute(
+        "SELECT lower(hex(blob_hash)) FROM raw_sessions WHERE raw_id = ?",
+        (raw_id,),
+    ).fetchone()
+    if new_row is None or new_row[0] is None:
+        return None
+    sibling_rows = source_conn.execute(
+        """
+        SELECT raw_id, lower(hex(blob_hash)), acquisition_generation, baseline_raw_id
+        FROM raw_sessions
+        WHERE logical_source_key = ? AND revision_kind = 'full' AND raw_id != ?
+        """,
+        (logical_source_key, raw_id),
+    ).fetchall()
+    if not sibling_rows:
+        return None
+    new_bytes = blob_publisher.read_all(str(new_row[0]))
+    matches: list[tuple[str, int, str]] = []
+    for row in sibling_rows:
+        sibling_blob_hash = row[1]
+        if sibling_blob_hash is None:
+            continue
+        sibling_raw_id = str(row[0])
+        sibling_bytes = blob_publisher.read_all(str(sibling_blob_hash))
+        relation = classify_drive_structural_relation(sibling_bytes, new_bytes)
+        if relation is DriveStructuralRelation.STRUCTURAL_GROWTH:
+            generation = int(row[2]) if row[2] is not None else 0
+            baseline_raw_id = str(row[3]) if row[3] else sibling_raw_id
+            matches.append((sibling_raw_id, generation, baseline_raw_id))
+    if len(matches) != 1:
+        return None
+    return matches[0]
+
+
 def _bind_drive_revision_lineage(
     session_to_write: ParsedSession,
     *,
@@ -637,6 +700,20 @@ def _bind_drive_revision_lineage(
     Drive session's ``source_name`` is ``Provider.GEMINI``, not
     ``Provider.DRIVE`` (both map to the same ``Origin.AISTUDIO_DRIVE``, see
     ``core/sources.py``). Gate on the value actually observed on the wire.
+
+    polylogue-1fijp AC (b): before falling back to the legacy byte-prefix
+    quarantine-then-classify dance, this first tries
+    ``_drive_structural_growth_predecessor`` -- a JSON-structural-diff-aware
+    check for the exact realistic re-acquisition shape (whole-document
+    re-serialization, not a byte-append) that the byte-prefix classifier can
+    never prove. A unique structural match is bound directly as a
+    ``FULL``/``ASSERTED`` revision with a real ``predecessor_raw_id`` --
+    ``ASSERTED``, not ``BYTE_PROVEN``, because the proof is JSON-structural,
+    not byte-level (the existing byte-relation vocabulary in
+    ``archive/revision_authority.py``/``storage/sqlite/archive_tiers/
+    raw_admission.py`` deliberately reserves ``BYTE_PROVEN`` for the
+    ``bytes.startswith()`` relation). When no unique structural match exists,
+    behavior is byte-for-byte identical to before this change.
     """
     if source_conn is None or blob_publisher is None:
         return None
@@ -649,6 +726,32 @@ def _bind_drive_revision_lineage(
     try:
         if raw_membership_raw_ids(adapter, logical_source_key):
             return None
+        structural_match = _drive_structural_growth_predecessor(
+            source_conn,
+            blob_publisher,
+            raw_id=raw_id,
+            logical_source_key=logical_source_key,
+        )
+        if structural_match is not None:
+            predecessor_raw_id, predecessor_generation, baseline_raw_id = structural_match
+            bind_raw_revision(
+                adapter,
+                raw_id,
+                RawRevisionEnvelope(
+                    logical_source_key=logical_source_key,
+                    kind=RawRevisionKind.FULL,
+                    source_revision=raw_id,
+                    predecessor_raw_id=predecessor_raw_id,
+                    baseline_raw_id=baseline_raw_id,
+                    acquisition_generation=predecessor_generation + 1,
+                    authority=RawRevisionAuthority.ASSERTED,
+                ),
+            )
+            return RevisionReplayPlan(
+                logical_source_key=logical_source_key,
+                applications=(),
+                accepted_chain=(raw_id,),
+            )
         bind_raw_revision(
             adapter,
             raw_id,

--- a/polylogue/sources/drive/structural_diff.py
+++ b/polylogue/sources/drive/structural_diff.py
@@ -1,0 +1,118 @@
+"""JSON-structural growth classifier for Drive re-acquisition bytes.
+
+polylogue-1fijp AC (b): ``iter_drive_raw_data``'s live-attachment backfill
+(``_inject_live_drive_attachment_bytes``) re-serializes the WHOLE Gemini/
+AI-Studio JSON document on every re-acquisition pass that resolves a new
+Drive-hosted attachment reference, rather than byte-appending at the
+document's end (see ``_bind_drive_revision_lineage`` in
+``pipeline/services/ingest_batch/_core.py`` and its citing PR #3656,
+polylogue-sp72). The archive's existing revision classifier
+(``archive/revision_authority.py``'s ``classify_historical_full_revision_streams``
+and the byte-relation arms in ``storage/sqlite/archive_tiers/raw_admission.py``)
+is strictly ``bytes.startswith()``-based, so this realistic growth shape is
+*never* a byte-prefix superset of its predecessor even when the underlying
+conversation genuinely only grew -- it lands ``ambiguous``/``quarantined``
+with the byte classifier alone.
+
+This module proves growth at the JSON-structural level instead of the byte
+level: one JSON document is a *structural extension* of another when every
+piece of information the old document asserts is still present, unchanged,
+in the new one -- new dict keys, new trailing list elements (e.g. new
+``chunkedPrompt.chunks`` entries for a conversation that grew), and values
+that moved from absent/``null`` to populated are all allowed growth; any
+value that existed and *changed* (a scalar mutated, a list element removed
+or reordered, a dict key's value replaced with something not itself a
+structural extension of the old value) breaks the proof and the relation is
+``AMBIGUOUS`` -- exactly the same fail-closed posture as the byte-prefix
+classifier it complements, just proven a different way.
+
+This is a pure, standalone comparison over two JSON documents. It knows
+nothing about ``raw_sessions``, revision envelopes, or SQLite -- callers
+(``_bind_drive_revision_lineage``) are responsible for resolving which two
+raws to compare and for deciding what typed lineage a ``STRUCTURAL_GROWTH``
+verdict earns.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from polylogue.core.json import JSONDecodeError, JSONValue, loads
+
+
+class DriveStructuralRelation(StrEnum):
+    """The exhaustive, typed outcome of comparing two JSON documents."""
+
+    #: Byte-identical payloads (also true, vacuously, of identical JSON
+    #: structures reached via different byte encodings -- e.g. re-serialized
+    #: with different key order -- since this module compares decoded
+    #: values, not bytes).
+    IDENTICAL = "identical"
+    #: ``new`` is a proven structural extension of ``old``: every key/value
+    #: and list element ``old`` asserts is still present, unchanged, in
+    #: ``new``, which additionally carries new dict keys, new trailing list
+    #: elements, and/or populated values where ``old`` had ``null``/absent.
+    STRUCTURAL_GROWTH = "structural_growth"
+    #: Neither identical nor a proven extension -- some old value changed,
+    #: was removed, or the payloads are not both valid JSON. Never treated
+    #: as growth; callers must fall back to their existing ambiguity
+    #: handling (typed refusal, not a silent accept).
+    AMBIGUOUS = "ambiguous"
+
+
+def _is_structural_extension(old: JSONValue, new: JSONValue) -> bool:
+    """Return whether ``new`` structurally contains everything ``old`` asserts.
+
+    Recursive, positional-prefix growth for lists (mirrors the byte-prefix
+    classifier's "extends as a prefix" semantics one level up: a genuinely
+    new conversation turn is a *trailing* addition, never an insertion or
+    reorder), key-superset growth for dicts (new keys are always allowed;
+    every existing key's value must itself satisfy this relation), exact
+    equality for scalars, and a `None -> anything` escape hatch for the one
+    legitimate "field was unpopulated, now resolved" shape this module
+    exists to recognize (e.g. a Drive-hosted attachment reference that had
+    no fetched bytes yet).
+    """
+    if old == new:
+        return True
+    if old is None:
+        return True
+    if isinstance(old, dict) and isinstance(new, dict):
+        return all(key in new and _is_structural_extension(value, new[key]) for key, value in old.items())
+    if isinstance(old, list) and isinstance(new, list):
+        if len(new) < len(old):
+            return False
+        return all(_is_structural_extension(old_item, new[index]) for index, old_item in enumerate(old))
+    # Differing types (including old being a scalar and new a
+    # dict/list, or two different scalar values) are never growth --
+    # only a `None -> anything` widening is allowed, and that is
+    # already handled above.
+    return False
+
+
+def classify_drive_structural_relation(old_bytes: bytes, new_bytes: bytes) -> DriveStructuralRelation:
+    """Classify the structural relation of ``new_bytes`` to ``old_bytes``.
+
+    Both inputs must decode as JSON for anything but ``AMBIGUOUS`` to be
+    possible -- a decode failure on either side is itself proof of nothing
+    and always yields ``AMBIGUOUS``, never a crash the caller has to guard
+    against.
+    """
+    if old_bytes == new_bytes:
+        return DriveStructuralRelation.IDENTICAL
+    try:
+        old_doc = loads(old_bytes)
+        new_doc = loads(new_bytes)
+    except JSONDecodeError:
+        return DriveStructuralRelation.AMBIGUOUS
+    if old_doc == new_doc:
+        return DriveStructuralRelation.IDENTICAL
+    if _is_structural_extension(old_doc, new_doc):
+        return DriveStructuralRelation.STRUCTURAL_GROWTH
+    return DriveStructuralRelation.AMBIGUOUS
+
+
+__all__ = [
+    "DriveStructuralRelation",
+    "classify_drive_structural_relation",
+]

--- a/tests/unit/sources/test_drive_ops.py
+++ b/tests/unit/sources/test_drive_ops.py
@@ -373,26 +373,27 @@ def test_iter_drive_raw_data_two_revision_fixture_gets_real_lineage(tmp_path: Pa
     problem shape.
 
     Both raws MUST carry a real, non-NULL ``logical_source_key`` (the
-    concrete, durable fix: they are no longer invisible to
+    concrete, durable fix from #3656: they are no longer invisible to
     ``raw_revision_heads``/future arbitration) and ``revision_kind='full'``
-    (never the pre-fix ``'unknown'``). Whether the second raw also gets a
-    proven ``predecessor_raw_id`` depends on whether its bytes are a literal
-    byte-prefix continuation of the first's, per
-    ``classify_historical_full_revision_streams``
-    (``archive/revision_authority.py``) -- and a full JSON re-serialization
-    that injects the resolved attachment bytes into the MIDDLE of the
-    document (not appended at the very end) is generally NOT a byte-prefix
-    superset of the original, so this real fixture is expected to land
-    ``revision_authority='quarantined'`` with no predecessor link, same as
-    before this PR for this exact non-prefix shape -- what changed is that
-    the identity (``logical_source_key``) is now recorded at all, so a
-    future consumer (or a classifier upgraded to recognize JSON-structural
-    supersets, not just byte-literal ones -- polylogue-1fijp's larger
-    raw-admission-chokepoint scope) can still find and arbitrate this
-    cohort. This is intentionally NOT asserted as "predecessor-linked" --
-    doing so would be a false claim about what the current byte-prefix-only
-    classifier can prove for this shape; see the PR description for the
-    scope boundary this test exists to keep honest.
+    (never the pre-fix ``'unknown'``).
+
+    A full JSON re-serialization that injects the resolved attachment bytes
+    into the MIDDLE of the document (not appended at the very end) is NOT a
+    byte-prefix superset of the original, so the byte-prefix classifier
+    (``classify_historical_full_revision_streams``,
+    ``archive/revision_authority.py``) alone lands
+    ``revision_authority='quarantined'`` with no predecessor link for this
+    exact shape (that residual gap was #3656's documented scope boundary,
+    deferred to polylogue-1fijp). polylogue-1fijp AC (b) closes it: this
+    fixture's second raw is exactly the shape
+    ``sources.drive.structural_diff.classify_drive_structural_relation``
+    exists to recognize -- the first raw's ``driveDocument`` dict is a
+    structural subset of the second's (same keys/values, plus the injected
+    fetch-data field) -- so ``_bind_drive_revision_lineage``'s new
+    structural-growth pre-check now binds the second raw directly as a
+    ``FULL``/``ASSERTED`` revision with a real ``predecessor_raw_id``
+    pointing at the first raw, instead of falling through to the
+    byte-prefix quarantine path.
     """
     payload = {
         "chunkedPrompt": {
@@ -493,21 +494,27 @@ def test_iter_drive_raw_data_two_revision_fixture_gets_real_lineage(tmp_path: Pa
             (first_raw_id,),
         ).fetchone()
         second_row = verify_conn.execute(
-            "SELECT logical_source_key, revision_kind, predecessor_raw_id FROM raw_sessions WHERE raw_id = ?",
+            """
+            SELECT logical_source_key, revision_kind, predecessor_raw_id, revision_authority
+            FROM raw_sessions WHERE raw_id = ?
+            """,
             (second_raw_id,),
         ).fetchone()
 
     provider_session_id = first_sessions[0].provider_session_id
     expected_logical_source_key = f"{Provider.GEMINI.value}:{provider_session_id}"
     # The durable fix: both raws now carry the real identity key and a typed
-    # revision_kind, no longer NULL/'unknown' -- regardless of whether the
-    # byte-prefix classifier can additionally prove a predecessor link for
-    # this non-append-shaped fixture.
+    # revision_kind, no longer NULL/'unknown'.
     assert first_row["logical_source_key"] == expected_logical_source_key
     assert second_row["logical_source_key"] == expected_logical_source_key
     assert first_row["revision_kind"] == "full"
     assert second_row["revision_kind"] == "full"
-    # Documented, expected residual gap (see docstring): a mid-document JSON
-    # re-serialization is not byte-prefix provable, so no predecessor link is
-    # established for THIS shape yet.
-    assert second_row["predecessor_raw_id"] is None
+    # polylogue-1fijp AC (b): the JSON-structural-diff classifier proves the
+    # second raw is a genuine structural extension of the first (the
+    # attachment-injected chunk's dict grew a key, nothing existing changed
+    # or was removed), so it gets typed, predecessor-linked lineage --
+    # never the pre-fix quarantined-unknown outcome, and no longer even the
+    # #3656 interim outcome (typed identity, but no predecessor) for this
+    # exact shape.
+    assert second_row["predecessor_raw_id"] == first_raw_id
+    assert second_row["revision_authority"] == "asserted"

--- a/tests/unit/sources/test_drive_structural_diff.py
+++ b/tests/unit/sources/test_drive_structural_diff.py
@@ -1,0 +1,234 @@
+"""Contracts for the JSON-structural-diff classifier (polylogue-1fijp AC (b)).
+
+``classify_drive_structural_relation`` is the fix for the exact gap PR #3656
+(polylogue-sp72) documented and deferred: Drive's live-attachment backfill
+re-serializes the WHOLE JSON document on every re-acquisition pass that
+resolves a Drive-hosted attachment reference, so a genuinely-grown
+conversation is never a byte-prefix superset of its predecessor -- the
+existing byte-prefix classifier (``archive/revision_authority.py``) can only
+ever see it as ambiguous. These tests prove the structural classifier's
+semantics directly (no SQLite/archive machinery involved -- pure JSON-in,
+enum-out), including one fixture built through the REAL production
+attachment-injection code path
+(``polylogue.sources.drive.attachment_fetch.fetch_live_drive_attachment_bytes``),
+not a hand-rolled approximation of it.
+"""
+
+from __future__ import annotations
+
+import json
+
+from polylogue.core.json import JSONValue
+from polylogue.sources.drive.attachment_fetch import fetch_live_drive_attachment_bytes
+from polylogue.sources.drive.structural_diff import (
+    DriveStructuralRelation,
+    classify_drive_structural_relation,
+)
+
+
+def _bytes(doc: object) -> bytes:
+    return json.dumps(doc).encode("utf-8")
+
+
+def test_identical_bytes_are_identical() -> None:
+    payload = _bytes({"chunkedPrompt": {"chunks": [{"role": "user", "text": "hi"}]}})
+    assert classify_drive_structural_relation(payload, payload) is DriveStructuralRelation.IDENTICAL
+
+
+def test_identical_structure_different_key_order_is_identical() -> None:
+    """Structural comparison decodes both sides -- key order is not byte order."""
+    old = _bytes({"a": 1, "b": 2})
+    new = _bytes({"b": 2, "a": 1})
+    assert old != new
+    assert classify_drive_structural_relation(old, new) is DriveStructuralRelation.IDENTICAL
+
+
+def test_new_trailing_chunk_is_structural_growth() -> None:
+    """A conversation that gained a new turn: old chunks list is a strict
+    positional prefix of the new one."""
+    old = _bytes({"chunkedPrompt": {"chunks": [{"role": "user", "text": "hi"}]}})
+    new = _bytes(
+        {
+            "chunkedPrompt": {
+                "chunks": [
+                    {"role": "user", "text": "hi"},
+                    {"role": "model", "text": "hello"},
+                ]
+            }
+        }
+    )
+    assert classify_drive_structural_relation(old, new) is DriveStructuralRelation.STRUCTURAL_GROWTH
+
+
+def test_enriched_existing_chunk_is_structural_growth() -> None:
+    """Same chunk count, but an existing chunk's dict gained a key (the real
+    attachment-injection shape) without changing anything that was already
+    there -- this is the exact case a byte-prefix classifier cannot prove."""
+    old = _bytes(
+        {
+            "chunkedPrompt": {
+                "chunks": [
+                    {"role": "model", "driveDocument": {"id": "att-1", "name": "doc.txt"}},
+                ]
+            }
+        }
+    )
+    new = _bytes(
+        {
+            "chunkedPrompt": {
+                "chunks": [
+                    {
+                        "role": "model",
+                        "driveDocument": {"id": "att-1", "name": "doc.txt", "__fetchedData": "aGVsbG8="},
+                    },
+                ]
+            }
+        }
+    )
+    assert not new.startswith(old)  # confirms this is genuinely not a byte-prefix relation
+    assert classify_drive_structural_relation(old, new) is DriveStructuralRelation.STRUCTURAL_GROWTH
+
+
+def test_combined_enrichment_and_new_trailing_chunk_is_structural_growth() -> None:
+    old = _bytes(
+        {
+            "chunkedPrompt": {
+                "chunks": [
+                    {"role": "user", "text": "hi"},
+                    {"role": "model", "driveDocument": {"id": "att-1"}},
+                ]
+            }
+        }
+    )
+    new = _bytes(
+        {
+            "chunkedPrompt": {
+                "chunks": [
+                    {"role": "user", "text": "hi"},
+                    {"role": "model", "driveDocument": {"id": "att-1", "__fetchedData": "AA=="}},
+                    {"role": "user", "text": "thanks"},
+                ]
+            }
+        }
+    )
+    assert classify_drive_structural_relation(old, new) is DriveStructuralRelation.STRUCTURAL_GROWTH
+
+
+def test_null_to_populated_value_is_structural_growth() -> None:
+    old = _bytes({"cachedContent": None, "chunkedPrompt": {"chunks": []}})
+    new = _bytes({"cachedContent": {"id": "cache-1"}, "chunkedPrompt": {"chunks": []}})
+    assert classify_drive_structural_relation(old, new) is DriveStructuralRelation.STRUCTURAL_GROWTH
+
+
+def test_new_top_level_key_is_structural_growth() -> None:
+    old = _bytes({"chunkedPrompt": {"chunks": []}})
+    new = _bytes({"chunkedPrompt": {"chunks": []}, "runSettings": {"temperature": 0.5}})
+    assert classify_drive_structural_relation(old, new) is DriveStructuralRelation.STRUCTURAL_GROWTH
+
+
+def test_changed_scalar_value_is_ambiguous() -> None:
+    """A real content mutation (not growth) must never be accepted as growth."""
+    old = _bytes({"chunkedPrompt": {"chunks": [{"role": "user", "text": "hi"}]}})
+    new = _bytes({"chunkedPrompt": {"chunks": [{"role": "model", "text": "hi"}]}})
+    assert classify_drive_structural_relation(old, new) is DriveStructuralRelation.AMBIGUOUS
+
+
+def test_removed_trailing_chunk_is_ambiguous() -> None:
+    old = _bytes(
+        {
+            "chunkedPrompt": {
+                "chunks": [
+                    {"role": "user", "text": "hi"},
+                    {"role": "model", "text": "hello"},
+                ]
+            }
+        }
+    )
+    new = _bytes({"chunkedPrompt": {"chunks": [{"role": "user", "text": "hi"}]}})
+    assert classify_drive_structural_relation(old, new) is DriveStructuralRelation.AMBIGUOUS
+
+
+def test_populated_to_null_is_ambiguous() -> None:
+    """A value regressing from populated to null is a real change, not growth."""
+    old = _bytes({"cachedContent": {"id": "cache-1"}})
+    new = _bytes({"cachedContent": None})
+    assert classify_drive_structural_relation(old, new) is DriveStructuralRelation.AMBIGUOUS
+
+
+def test_reordered_chunks_is_ambiguous() -> None:
+    """Growth is positional-prefix only, matching the byte-prefix classifier's
+    'extends as a prefix' semantics one level up -- reordering existing
+    entries is never growth, even though the same elements are all present."""
+    old = _bytes({"chunks": [{"n": 1}, {"n": 2}]})
+    new = _bytes({"chunks": [{"n": 2}, {"n": 1}]})
+    assert classify_drive_structural_relation(old, new) is DriveStructuralRelation.AMBIGUOUS
+
+
+def test_unrelated_documents_are_ambiguous() -> None:
+    old = _bytes({"chunkedPrompt": {"chunks": [{"role": "user", "text": "hi"}]}})
+    new = _bytes({"totally": "different", "shape": [1, 2, 3]})
+    assert classify_drive_structural_relation(old, new) is DriveStructuralRelation.AMBIGUOUS
+
+
+def test_non_json_bytes_are_ambiguous_not_a_crash() -> None:
+    assert classify_drive_structural_relation(b"not json", b"also not json {") is DriveStructuralRelation.AMBIGUOUS
+    assert classify_drive_structural_relation(b"", _bytes({"a": 1})) is DriveStructuralRelation.AMBIGUOUS
+
+
+def test_real_attachment_injection_fixture_is_structural_growth() -> None:
+    """Build the before/after bytes through the REAL production injector
+    (``fetch_live_drive_attachment_bytes``), not a hand-rolled dict edit --
+    proves the classifier against the actual mutation shape Drive produces,
+    matching PR #3656's finding that this shape is not byte-prefix provable."""
+    payload: JSONValue = {
+        "chunkedPrompt": {
+            "chunks": [
+                {"role": "user", "text": "Hi"},
+                {
+                    "role": "model",
+                    "text": "Here is the file",
+                    "driveDocument": {"id": "att-1", "name": "doc.txt", "mimeType": "text/plain"},
+                },
+            ]
+        }
+    }
+    old_bytes = _bytes(payload)
+    resolved, stats = fetch_live_drive_attachment_bytes(payload, lambda file_id: b"the actual attachment bytes")
+    assert stats.fetched_count == 1
+    new_bytes = json.dumps(resolved).encode("utf-8")
+
+    assert new_bytes != old_bytes
+    assert not new_bytes.startswith(old_bytes)  # confirms the real non-byte-prefix shape
+    assert classify_drive_structural_relation(old_bytes, new_bytes) is DriveStructuralRelation.STRUCTURAL_GROWTH
+
+
+def test_two_independent_attachment_fetches_in_sequence_stay_growth() -> None:
+    """A document with two Drive-hosted attachments, resolved one at a time
+    across two re-acquisition passes (a realistic multi-attachment Drive
+    session), stays structural growth at every step."""
+    payload: JSONValue = {
+        "chunkedPrompt": {
+            "chunks": [
+                {"role": "model", "driveDocument": {"id": "att-1"}},
+                {"role": "model", "driveDocument": {"id": "att-2"}},
+            ]
+        }
+    }
+    gen0 = _bytes(payload)
+
+    def fetch_att1_only(file_id: str) -> bytes:
+        if file_id == "att-1":
+            return b"first attachment bytes"
+        raise RuntimeError("not yet fetchable")
+
+    resolved1, stats1 = fetch_live_drive_attachment_bytes(payload, fetch_att1_only)
+    assert stats1.fetched_count == 1
+    gen1 = json.dumps(resolved1).encode("utf-8")
+    assert classify_drive_structural_relation(gen0, gen1) is DriveStructuralRelation.STRUCTURAL_GROWTH
+
+    resolved2, stats2 = fetch_live_drive_attachment_bytes(resolved1, lambda file_id: b"second attachment bytes")
+    assert stats2.fetched_count == 1
+    gen2 = json.dumps(resolved2).encode("utf-8")
+    assert classify_drive_structural_relation(gen1, gen2) is DriveStructuralRelation.STRUCTURAL_GROWTH
+    # And transitively across both generations at once.
+    assert classify_drive_structural_relation(gen0, gen2) is DriveStructuralRelation.STRUCTURAL_GROWTH


### PR DESCRIPTION
## Summary

Adds a JSON-structural growth classifier for Drive/Gemini re-acquisition bytes and wires it into `_bind_drive_revision_lineage` so a genuine Drive re-acquisition growth (the live-attachment-backfill shape, not a byte-append) gets typed, predecessor-linked lineage instead of falling straight through to the byte-prefix classifier's ambiguous/quarantined outcome. This satisfies polylogue-1fijp AC (b) ("drive re-acquire with changed bytes produces typed lineage, not quarantined-unknown"), which PR #3668 explicitly left unattempted and PR #3656 explicitly deferred.

## Problem

`iter_drive_raw_data`'s live-attachment backfill (`_inject_live_drive_attachment_bytes`) re-serializes the WHOLE Gemini/AI-Studio JSON document on every re-acquisition pass that resolves a Drive-hosted attachment reference, rather than byte-appending at the document's end. PR #3656 (polylogue-sp72) proved this concretely with a real fixture threaded through the production write path (`test_iter_drive_raw_data_two_revision_fixture_gets_real_lineage`): the second raw's bytes are not a byte-prefix superset of the first's (`not second_bytes.startswith(first_bytes)`), so the archive's existing byte-prefix revision classifier (`classify_historical_full_revision_streams`, `archive/revision_authority.py`) lands `revision_authority='quarantined'` with no `predecessor_raw_id` for this exact, realistic shape — even though the underlying conversation genuinely only grew.

## Solution

- `polylogue/sources/drive/structural_diff.py`: `classify_drive_structural_relation(old_bytes, new_bytes)` decodes both payloads as JSON and proves whether `new` is a *structural extension* of `old` — every dict key/value and list element `old` asserts is still present, unchanged, in `new`; new dict keys, new trailing list elements (a conversation growing a `chunkedPrompt.chunks` entry), and null-to-populated values are allowed growth. Any changed or removed existing value breaks the proof and the relation is `AMBIGUOUS` — the same fail-closed posture as the byte-prefix classifier it complements, proven a different way. Pure function, no SQLite/archive coupling.
- `polylogue/pipeline/services/ingest_batch/_core.py`: `_bind_drive_revision_lineage` now tries `_drive_structural_growth_predecessor` first — it looks for exactly one existing `revision_kind='full'` sibling raw for the logical source key whose bytes are a proven structural predecessor of the new raw's bytes. A unique match is bound directly as a `FULL`/`ASSERTED` revision with a real `predecessor_raw_id` and `baseline_raw_id` (`ASSERTED`, not `BYTE_PROVEN` — the proof is JSON-structural, not byte-level, and that vocabulary distinction is deliberate: `BYTE_PROVEN` is reserved for the `bytes.startswith()` relation elsewhere in `archive/revision_authority.py`/`storage/sqlite/archive_tiers/raw_admission.py`). Zero or multiple structural matches fall through unchanged to the existing byte-prefix quarantine-then-classify dance — strictly additive, no existing behavior narrowed.
- Updated `test_iter_drive_raw_data_two_revision_fixture_gets_real_lineage` (PR #3656's own end-to-end fixture, through the real `_write_session` production path) to assert the now-typed predecessor link instead of the documented residual gap it previously proved.
- `tests/unit/sources/test_drive_structural_diff.py`: 15 focused tests on the classifier's semantics directly — trailing-append growth, dict-enrichment growth, combined growth, null→populated growth, new top-level keys, and the ambiguous/rejection cases (scalar mutation, removed/reordered elements, unrelated documents, non-JSON bytes, populated→null regression) — including one fixture built through the *real* production `fetch_live_drive_attachment_bytes` injector (not a hand-rolled approximation) and a two-generation sequential-fetch fixture.

## Scope / what's not attempted

Per the bead's own fallback guidance, this is a scoped, real, well-tested slice, not the full raw-admission-chokepoint migration:

- The new structural pre-check lives only in the Drive-specific `_bind_drive_revision_lineage` adapter function — it does not touch the shared `_classify_raw_revision_cohort`/`classify_historical_full_revision_streams` byte-prefix machinery used by every other origin's live-watch/rebuild-repair paths. That shared function's blast radius (every provider, both live-watch and rebuild-repair callers) made it too risky to modify for a Drive-only concern in this pass.
- Drive acquisition is still not routed through `admit_raw_observation()` (PR #3668's chokepoint) — it continues to use the `bind_raw_revision`/`classify_raw_revision_cohort_for_live_watch` adapter path, now with the structural pre-check inserted ahead of it. Full chokepoint migration for Drive remains open scope on polylogue-1fijp.
- The 157 already-contaminated `aistudio-drive` raw pairs mentioned in PR #3656 need a live re-measure/backfill after deploy — not attempted here (retroactive durable-tier cleanup needs its own explicit-consent process per this repo's schema regime).

## Verification

- `mypy --strict polylogue/sources/drive/structural_diff.py polylogue/pipeline/services/ingest_batch/_core.py tests/unit/sources/test_drive_structural_diff.py tests/unit/sources/test_drive_ops.py` — `Success: no issues found in 4 source files`.
- `devtools test tests/unit/sources/test_drive_structural_diff.py tests/unit/sources/test_drive_ops.py tests/unit/pipeline/test_ingest_batch.py` — 89 passed.
- `devtools test -k "drive or revision_governance or raw_admission"` — 308 passed, 1 failed (`tests/integration/test_blob_lifecycle_e2e.py::TestOrphanedBlobsCatalogRouting::test_catalog_resolution_drives_end_to_end_cleanup`), confirmed pre-existing/unrelated: reproduces identically on a clean checkout with no changes applied (same failure PR #3656 already documented as pre-existing).
- `devtools verify --quick` — `exit_code: 0`.

Ref polylogue-1fijp

Co-Authored-By: Claude <noreply@anthropic.com>