### PR TITLE
feat(storage): route antigravity acquisition through raw-admission chokepoint

### DIFF
--- a/docs/plans/layering.yaml
+++ b/docs/plans/layering.yaml
@@ -36,7 +36,7 @@ writer_modules:
           durability: durable
           interruption: atomic
       entrypoints:
-        [apply_raw_membership_classification, apply_raw_revision_replay,
+        [admit_raw_and_parsed_result, apply_raw_membership_classification, apply_raw_revision_replay,
         classify_raw_revision_cohort_for_live_watch, classify_raw_revision_cohort_for_rebuild_repair,
         release_provisional_full_revisions, replace_raw_membership_census,
         write_parsed_for_retained_raw, write_parsed_for_retained_raw_result, write_raw_and_parsed,

--- a/polylogue/daemon/antigravity_conversation_acquisition.py
+++ b/polylogue/daemon/antigravity_conversation_acquisition.py
@@ -156,11 +156,18 @@ def acquire_antigravity_conversations_once(archive_root: Path) -> int:
             source_path = _archive_raw_source_path(raw_data, source)
             source_index = _archive_raw_source_index(raw_data)
             try:
-                archive.write_raw_and_parsed_result(
+                # polylogue-1fijp: this loop only ever visits cascade ids not
+                # already present in raw_sessions (see missing_ids above), so
+                # no prior head can exist for this logical source key --
+                # admit_raw_and_parsed_result's BASELINE-only chokepoint path
+                # is the correct fit (vs. write_raw_and_parsed_result's bare
+                # revision=None write).
+                archive.admit_raw_and_parsed_result(
                     session,
                     payload=payload,
                     source_path=source_path,
                     acquired_at_ms=acquired_at_ms,
+                    logical_source_key=f"{Origin.ANTIGRAVITY_SESSION.value}:{source_path}",
                     source_index=source_index,
                     blob_publication_receipt_id=(
                         raw_data.blob_publication_receipt_id if raw_data is not None else None

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -174,6 +174,7 @@ from polylogue.storage.sqlite.archive_tiers.revision_governance import (
     _raw_revision_payload_digest_and_size,
     _raw_revision_source_path_has_divergent_evidence,
     _write_parsed_precedence_result,
+    admit_raw_and_parsed_result,
     admit_raw_artifact_payload,
     apply_raw_membership_classification,
     apply_raw_revision_replay,
@@ -2521,6 +2522,43 @@ class ArchiveStore:
             acquired_at_ms=acquired_at_ms,
             source_index=source_index,
             raw_id=raw_id,
+            stage_timings_s=stage_timings_s,
+            stage_timing_prefix=stage_timing_prefix,
+            manage_transaction=manage_transaction,
+            blob_publication_receipt_id=blob_publication_receipt_id,
+            finalize_raw_parse=finalize_raw_parse,
+        )
+
+    def admit_raw_and_parsed_result(
+        self,
+        session: ParsedSession,
+        *,
+        payload: bytes,
+        source_path: str,
+        acquired_at_ms: int,
+        logical_source_key: str,
+        source_index: int = 0,
+        stage_timings_s: dict[str, float] | None = None,
+        stage_timing_prefix: str = "append",
+        manage_transaction: bool = True,
+        blob_publication_receipt_id: str | None = None,
+        finalize_raw_parse: bool = True,
+    ) -> ArchiveRawParsedWriteResult:
+        """Write raw bytes through the raw-admission chokepoint, then index.
+
+        See :func:`polylogue.storage.sqlite.archive_tiers.revision_governance.admit_raw_and_parsed_result`.
+        Restricted to first-observation callers (no prior head exists for
+        ``logical_source_key``); use :meth:`write_raw_and_parsed_result` for
+        callers with revision-chain/dedup semantics of their own.
+        """
+        return admit_raw_and_parsed_result(
+            self,
+            session,
+            payload=payload,
+            source_path=source_path,
+            acquired_at_ms=acquired_at_ms,
+            logical_source_key=logical_source_key,
+            source_index=source_index,
             stage_timings_s=stage_timings_s,
             stage_timing_prefix=stage_timing_prefix,
             manage_transaction=manage_transaction,

--- a/polylogue/storage/sqlite/archive_tiers/raw_admission.py
+++ b/polylogue/storage/sqlite/archive_tiers/raw_admission.py
@@ -85,6 +85,7 @@ from polylogue.core.enums import ArtifactSupportStatus, Origin, Provider
 from polylogue.storage.artifacts.inspection import artifact_observation_id
 from polylogue.storage.sqlite.archive_tiers.source_write import (
     ArchiveSourceArtifact,
+    ArchiveSourceBlobRef,
     deterministic_blob_hash,
     write_source_raw_session,
 )
@@ -166,6 +167,7 @@ def admit_raw_observation(
     prior_head: PriorRawHead | None = None,
     artifact: ArtifactClassification | None = None,
     blob_publication_receipt_id: str | None = None,
+    additional_blob_refs: tuple[ArchiveSourceBlobRef, ...] = (),
     reacquire: Callable[[], bytes | None] | None = None,
     manage_transaction: bool = True,
 ) -> RawAdmissionResult:
@@ -175,6 +177,13 @@ def admit_raw_observation(
     outcomes that do not compare against a prior head -- every write this
     function makes carries a real revision envelope, never the nullable
     ``revision=None`` fallback the lower-level writers otherwise default to.
+
+    ``additional_blob_refs`` forwards through to the underlying
+    ``write_source_raw_session`` call for the session-content arms (BASELINE/
+    APPEND/SUPERSEDE/REFUSED_AMBIGUOUS) -- e.g. attachment blobs preacquired
+    by the caller alongside the primary payload. It is not accepted by the
+    ``ARTIFACT`` arm: a non-conversational artifact payload has no parsed
+    attachments of its own.
     """
     if not logical_source_key:
         raise ValueError("logical_source_key is required for raw admission")
@@ -205,6 +214,7 @@ def admit_raw_observation(
             acquired_at_ms=acquired_at_ms,
             native_id=native_id,
             blob_publication_receipt_id=blob_publication_receipt_id,
+            additional_blob_refs=additional_blob_refs,
             revision=RawRevisionEnvelope(
                 logical_source_key=logical_source_key,
                 kind=RawRevisionKind.FULL,
@@ -254,6 +264,7 @@ def admit_raw_observation(
             acquired_at_ms=acquired_at_ms,
             native_id=native_id,
             blob_publication_receipt_id=blob_publication_receipt_id,
+            additional_blob_refs=additional_blob_refs,
             revision=RawRevisionEnvelope(
                 logical_source_key=logical_source_key,
                 kind=RawRevisionKind.APPEND,
@@ -286,6 +297,7 @@ def admit_raw_observation(
             acquired_at_ms=acquired_at_ms,
             native_id=native_id,
             blob_publication_receipt_id=blob_publication_receipt_id,
+            additional_blob_refs=additional_blob_refs,
             revision=RawRevisionEnvelope(
                 logical_source_key=logical_source_key,
                 kind=RawRevisionKind.FULL,
@@ -325,6 +337,7 @@ def admit_raw_observation(
         acquired_at_ms=acquired_at_ms,
         native_id=native_id,
         blob_publication_receipt_id=blob_publication_receipt_id,
+        additional_blob_refs=additional_blob_refs,
         revision=RawRevisionEnvelope(
             logical_source_key=logical_source_key,
             kind=RawRevisionKind.UNKNOWN,

--- a/polylogue/storage/sqlite/archive_tiers/revision_governance.py
+++ b/polylogue/storage/sqlite/archive_tiers/revision_governance.py
@@ -146,7 +146,11 @@ from polylogue.storage.sqlite.archive_tiers.ingest_precedence import (
     should_skip_stale_replace,
     stored_message_count,
 )
-from polylogue.storage.sqlite.archive_tiers.raw_admission import RawAdmissionResult, admit_raw_observation
+from polylogue.storage.sqlite.archive_tiers.raw_admission import (
+    RawAdmissionArm,
+    RawAdmissionResult,
+    admit_raw_observation,
+)
 from polylogue.storage.sqlite.archive_tiers.revision_application import (
     FullSnapshotFoldAuthorization,
     RevisionApplicationReceipt,
@@ -2972,6 +2976,101 @@ def write_raw_and_parsed_result(
         store,
         session,
         raw_id=raw_id,
+        source_index=source_index,
+        stage_timings_s=stage_timings_s,
+        stage_timing_prefix=stage_timing_prefix,
+        manage_transaction=manage_transaction,
+        preacquired_attachment_blobs=preacquired_attachments,
+        finalize_raw_parse=finalize_raw_parse,
+    )
+    add_timing("index_parsed_write", t0)
+    return result
+
+
+def admit_raw_and_parsed_result(
+    store: RawRevisionGovernanceHost,
+    session: ParsedSession,
+    *,
+    payload: bytes,
+    source_path: str,
+    acquired_at_ms: int,
+    logical_source_key: str,
+    source_index: int = 0,
+    stage_timings_s: dict[str, float] | None = None,
+    stage_timing_prefix: str = "append",
+    manage_transaction: bool = True,
+    blob_publication_receipt_id: str | None = None,
+    finalize_raw_parse: bool = True,
+) -> ArchiveRawParsedWriteResult:
+    """Write raw acquisition bytes through the raw-admission chokepoint, then index.
+
+    polylogue-1fijp: :func:`write_raw_and_parsed_result` always writes a bare
+    ``FULL``/``revision=None`` raw row -- the exact nullable "figure it out
+    later" limbo :func:`~polylogue.storage.sqlite.archive_tiers.raw_admission.admit_raw_observation`
+    exists to eliminate. This entrypoint instead resolves
+    ``admit_raw_observation``'s typed arms against ``prior_head=None``, so it
+    is restricted to callers that, by construction, only ever observe a
+    ``logical_source_key`` for the first time -- the caller has already
+    filtered to not-yet-acquired source paths/native ids, so no prior head
+    exists to compare against and the APPEND/SUPERSEDE/duplicate/ambiguous
+    arms are structurally unreachable here (enforced below: any non-BASELINE
+    outcome is a caller contract violation, not a silently accepted result).
+
+    Callers that need revision-chain comparison against a real prior head
+    (the live-watcher's append tracking in ``sources/live/``, Drive lineage
+    binding) have their own governed paths and are explicitly out of scope
+    for this entrypoint -- see the module docstring of ``raw_admission.py``
+    and polylogue-1fijp's call-site survey notes.
+    """
+
+    def add_timing(name: str, started_at: float) -> None:
+        if stage_timings_s is not None:
+            key = f"{stage_timing_prefix}.{name}"
+            stage_timings_s[key] = stage_timings_s.get(key, 0.0) + (time.perf_counter() - started_at)
+
+    if store._blob_publisher is None:
+        raise RuntimeError("raw archive writes require a writable archive publisher")
+    if blob_publication_receipt_id is None:
+        raw_hash, _raw_size = store._blob_publisher.write_from_bytes(payload)
+        blob_publication_receipt_id = store._blob_publisher.receipt_id(raw_hash)
+    preacquired_attachments, attachment_blob_refs = store._preacquire_attachment_blobs(
+        session,
+        source_path=source_path,
+        acquired_at_ms=acquired_at_ms,
+    )
+    store._blob_publisher.flush()
+    t0 = time.perf_counter()
+    source_conn = store._ensure_source_conn()
+    add_timing("source_connect", t0)
+    t0 = time.perf_counter()
+    admission = admit_raw_observation(
+        source_conn,
+        origin=origin_from_provider(session.source_name),
+        capture_mode=session.source_name,
+        source_path=source_path,
+        source_index=source_index,
+        payload=payload,
+        acquired_at_ms=acquired_at_ms,
+        native_id=session.provider_session_id,
+        logical_source_key=logical_source_key,
+        prior_head=None,
+        blob_publication_receipt_id=blob_publication_receipt_id,
+        additional_blob_refs=attachment_blob_refs,
+        manage_transaction=True,
+    )
+    add_timing("source_raw_write", t0)
+    if admission.arm is not RawAdmissionArm.BASELINE:
+        raise RuntimeError(
+            f"admit_raw_and_parsed_result: expected a BASELINE admission for "
+            f"logical_source_key={logical_source_key!r} (prior_head=None), got "
+            f"{admission.arm!r} instead -- the caller must guarantee no prior raw "
+            "observation exists for this key before calling this entrypoint"
+        )
+    t0 = time.perf_counter()
+    result = _index_parsed_for_retained_raw(
+        store,
+        session,
+        raw_id=admission.raw_id,
         source_index=source_index,
         stage_timings_s=stage_timings_s,
         stage_timing_prefix=stage_timing_prefix,


### PR DESCRIPTION
## Summary

Migrates one real production call site (`antigravity_conversation_acquisition.py`) off the direct `write_raw_and_parsed_result()` writer onto polylogue-1fijp's raw-admission chokepoint (`admit_raw_observation()`, mechanism landed in #3668), and audits the bead/PR's own cited call-site list against current source.

## Problem

PR #3668 landed `admit_raw_observation()` with one routed call site (Claude Code fact-artifact admission) and surveyed 11+ other `write_source_raw_session` call sites as not-yet-migrated. Re-grepping current source for this dispatch found that survey has drifted: `codex_title_census.py`, `context/codex_spawn_edge_correlation.py`, `context/hermes_delivery_correlation.py`, `daemon/antigravity_conversation_acquisition.py` (as originally listed), `sources/hooks.py`, `storage/repair.py`, `storage/raw_reconciler.py`, and `storage/hook_payload_ref_reconciliation.py` do **not** call `write_source_raw_session` or any raw-write wrapper at all today — they only read/reference the `raw_sessions` table (SELECT queries, comments). The real remaining direct callers of `write_source_raw_session` are exclusively the two generic writer primitives inside `revision_governance.py` itself (`write_raw_payload`, `write_raw_and_parsed_result`); production feature code reaches raw writes only through those or `sources/live/*`.

## Solution

- `polylogue/storage/sqlite/archive_tiers/raw_admission.py`: widened `admit_raw_observation()` to accept and forward `additional_blob_refs` (attachment blob refs) to its four session-content `write_source_raw_session` calls (BASELINE/APPEND/SUPERSEDE/REFUSED_AMBIGUOUS). The chokepoint previously silently dropped this parameter relative to `write_source_raw_session`'s own capability — migrating any attachment-bearing call site without this fix would have quietly lost attachment blob refs on the raw row.
- `polylogue/storage/sqlite/archive_tiers/revision_governance.py`: added `admit_raw_and_parsed_result()`, a narrower sibling of `write_raw_and_parsed_result()` that resolves `admit_raw_observation()`'s typed arms against `prior_head=None` and raises if the caller's BASELINE-only contract is violated. Wired an `ArchiveStore.admit_raw_and_parsed_result` wrapper (mirrors the existing `admit_raw_artifact_payload` shape from #3668).
- `polylogue/daemon/antigravity_conversation_acquisition.py`: switched `acquire_antigravity_conversations_once` to the new entrypoint. This call site is structurally BASELINE-only — it pre-filters to `.pb` cascade ids not already present in `raw_sessions`, so no prior head ever exists to compare against.
- `docs/plans/layering.yaml`: declared the new entrypoint (`devtools verify layering`'s writer-module-entrypoint-inventory check requires it).

## Scope / call-site status (acceptance-criteria honesty)

- **Migrated**: `daemon/antigravity_conversation_acquisition.py` (arm: BASELINE only).
- **Reviewed, NOT migrated** (documented, not force-fit):
  - `sources/live/append_ingest.py` / `sources/live/batch.py` — both resolve real prior-head revision chains (`bind_raw_revision`/`classify_raw_revision_cohort_for_live_watch`) that require a *parsed* session's `provider_session_id` to derive `logical_source_key`, i.e. the decision depends on content only available *after* parsing. `admit_raw_observation` is a single synchronous pre-parse call — architecturally incompatible. The bead itself calls this family "mostly compliant"; explicitly out of scope per the dispatch.
  - `pipeline/services/archive_ingest.py`'s main session-ingest path (`write_pair`'s `write_raw_and_parsed_result` call) — uses content-addressed `deterministic_raw_session_id` + `shared_raw_ids` in-batch dedup, a different idempotency mechanism than revision-chain byte comparison against a mutable head. Forcing it through the typed arms would be an architecture mismatch, not a mechanical swap, and it's the highest-traffic write path in the system.
  - `storage/repair.py`'s `raw_sessions` INSERT (browser-origin repair `copy_forward`) — constructs a synthetic row from already byte-proven evidence during repair, not a fresh acquisition observation; doesn't fit the "compare fresh payload to prior head" model at all.
  - `sources/drive/__init__.py` / `pipeline/services/ingest_batch/_core.py` Drive lineage bind — explicitly excluded per dispatch (separate JSON-structural-diff classifier lane, per #3668's own scope notes).
  - `codex_title_census.py`, `context/*_correlation.py`, `sources/hooks.py`, `storage/raw_reconciler.py`, `storage/hook_payload_ref_reconciliation.py` — verified via grep against current source: **no `write_source_raw_session`/raw-write-wrapper calls exist in these files at all**. The bead/PR #3668's cited list had drifted; nothing to migrate here.

## AC status (polylogue-1fijp)

- (a) grep proves no raw_sessions INSERT outside the chokepoint module: still **partially satisfied** — one additional real call site now routed; the batch-import, live-watcher, and repair paths remain direct writers for the architecture-mismatch reasons above, not because they were skipped.

## Verification

- `devtools test tests/unit/daemon/test_antigravity_conversation_acquisition.py tests/unit/storage/test_raw_admission.py` -> 13 passed
- `devtools test -k "revision_governance or raw_admission or archive_ingest or antigravity"` -> 132 passed
- `mypy --strict` on `raw_admission.py`, `revision_governance.py`, `archive.py`, `antigravity_conversation_acquisition.py` -> `Success: no issues found in 4 source files`
- `devtools verify --quick` -> `exit_code: 0`
- `devtools verify layering` -> `No layering violations found` (306 pre-existing baselined-import violations / 2 stale-baseline entries unchanged from before this PR, unrelated)

Ref polylogue-1fijp