### PR TITLE
feat(storage): wire user_settings + subscription_tier cost consumer

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -208,6 +208,7 @@ Commands:
     agent        Install executable agent guidance.
     annotations  Import typed annotation batches.
     compare      Blind pairwise comparative judgment and calibration.
+    setting      Get, set, and list durable user settings.
 ```
 
 ## Analyze Verb

--- a/docs/cost-model.md
+++ b/docs/cost-model.md
@@ -153,6 +153,29 @@ tier.monthly_fee_usd`, default the Pro tier) so every surface reporting a
 subscription-equivalent dollar figure uses the same tier assumption; see the
 [Caveats](#caveats) below — this is not vendor-authoritative billing.
 
+#### Recording your actual subscription tier
+
+`credits_to_usd()`'s default tier assumption (`pro`, the cheapest/most
+conservative plan) is a fallback, not a claim about your real plan. Record
+the tier you actually pay for as a durable `user_settings` row (polylogue-at44)
+so `polylogue analyze usage` / `ProviderUsageReport.subscription_credit_usd`
+price against it instead:
+
+```
+polylogue setting set subscription_tier max_5x   # or pro / max_20x
+polylogue setting get subscription_tier
+polylogue setting list
+```
+
+`setting set` rejects any value outside the closed `SUBSCRIPTION_TIERS`
+registry (`polylogue/archive/semantic/subscription_pricing.py`) — this is
+deliberately a typed key registry (`subscription_tier` is the only key today),
+not a free-form key-value store. `polylogue.api.Polylogue.get_setting` /
+`.set_setting` / `.list_settings` expose the same read/write pair to Python
+callers; `polylogue/storage/sqlite/archive_tiers/user_settings_write.py` is
+the underlying sync storage module both the CLI and the async facade route
+through.
+
 ### Codex disjoint billing lanes
 
 Codex (OpenAI) `token_count` events report **overlapping** token counts:

--- a/docs/plans/layering-surface-baseline.json
+++ b/docs/plans/layering-surface-baseline.json
@@ -92,6 +92,11 @@
   {
     "target": "polylogue/api",
     "file": "polylogue/api/archive.py",
+    "import": "polylogue.storage.sqlite.archive_tiers.user_settings_write"
+  },
+  {
+    "target": "polylogue/api",
+    "file": "polylogue/api/archive.py",
     "import": "polylogue.storage.sqlite.archive_tiers.user_write"
   },
   {
@@ -443,6 +448,11 @@
     "target": "polylogue/cli",
     "file": "polylogue/cli/commands/reset.py",
     "import": "polylogue.storage.archive_identity"
+  },
+  {
+    "target": "polylogue/cli",
+    "file": "polylogue/cli/commands/setting.py",
+    "import": "polylogue.storage.sqlite.archive_tiers.user_settings_write"
   },
   {
     "target": "polylogue/cli",

--- a/docs/plans/layering.yaml
+++ b/docs/plans/layering.yaml
@@ -109,6 +109,12 @@ writer_modules:
           durability: durable
           interruption: atomic
       entrypoints: [write_context_delivery]
+    - path: polylogue/storage/sqlite/archive_tiers/user_settings_write.py
+      surfaces:
+        - tier: user
+          durability: durable
+          interruption: atomic
+      entrypoints: [set_user_setting]
     - path: polylogue/storage/sqlite/archive_tiers/ops_write.py
       surfaces:
         - tier: ops

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -34,7 +34,7 @@ from polylogue.context.compiler import (
 )
 from polylogue.core.enums import AssertionKind, AssertionStatus, MaterialOrigin, Origin, TitleSource
 from polylogue.core.errors import PolylogueError
-from polylogue.core.json import JSONDocument
+from polylogue.core.json import JSONDocument, JSONValue
 from polylogue.core.refs import (
     EvidenceRef,
     ObjectRef,
@@ -127,6 +127,7 @@ if TYPE_CHECKING:
         ArchiveSessionSummary,
         ArchiveStore,
     )
+    from polylogue.storage.sqlite.archive_tiers.user_settings_write import ArchiveUserSettingEnvelope
     from polylogue.storage.sqlite.archive_tiers.user_write import (
         ArchiveAssertionBulkJudgmentEnvelope,
         ArchiveAssertionCandidateReviewEnvelope,
@@ -1249,6 +1250,75 @@ def _archive_correlate_hermes_context_deliveries(
             exc_info=True,
         )
         return ()
+
+
+def _archive_get_setting(config: Config, setting_key: str) -> ArchiveUserSettingEnvelope | None:
+    """Read one durable ``user_settings`` row, or ``None`` when unset (polylogue-at44)."""
+
+    from polylogue.storage.sqlite.archive_tiers.user_settings_write import get_user_setting
+
+    user_db = _active_archive_root(config) / "user.db"
+    if not user_db.exists():
+        return None
+    try:
+        conn = open_readonly_connection(user_db)
+        conn.row_factory = sqlite3.Row
+        try:
+            return get_user_setting(conn, setting_key)
+        finally:
+            conn.close()
+    except (sqlite3.Error, ValueError):
+        return None
+
+
+def _archive_list_settings(config: Config) -> list[ArchiveUserSettingEnvelope]:
+    """List every stored ``user_settings`` row, ordered by key."""
+
+    from polylogue.storage.sqlite.archive_tiers.user_settings_write import list_user_settings
+
+    user_db = _active_archive_root(config) / "user.db"
+    if not user_db.exists():
+        return []
+    try:
+        conn = open_readonly_connection(user_db)
+        conn.row_factory = sqlite3.Row
+        try:
+            return list_user_settings(conn)
+        finally:
+            conn.close()
+    except (sqlite3.Error, ValueError):
+        return []
+
+
+def _archive_set_setting(
+    config: Config,
+    setting_key: str,
+    value: object,
+    *,
+    author_ref: str = "user:local",
+) -> ArchiveUserSettingEnvelope:
+    """Insert-or-update one typed ``user_settings`` row.
+
+    ``user.db`` must already be initialized (an archive that has never
+    ingested anything has no durable tier to write into yet).
+    """
+
+    from polylogue.storage.sqlite.archive_tiers.user_settings_write import set_user_setting
+
+    user_db = _active_archive_root(config) / "user.db"
+    if not user_db.exists():
+        raise ValueError("user settings tier is not initialized")
+    try:
+        conn = open_connection(user_db)
+        conn.row_factory = sqlite3.Row
+        try:
+            envelope = set_user_setting(conn, setting_key, cast(JSONValue, value), author_ref=author_ref)
+            conn.commit()
+            return envelope
+        finally:
+            conn.close()
+    except sqlite3.Error as exc:
+        raise RuntimeError(f"failed to set user setting {setting_key!r}: {exc}") from exc
 
 
 def _archive_reconcile_hermes_session_lifecycle(
@@ -7456,3 +7526,34 @@ class PolylogueArchiveMixin:
             if limit > 0 and len(notes) >= limit:
                 break
         return notes
+
+    async def get_setting(self, setting_key: str) -> ArchiveUserSettingEnvelope | None:
+        """Read one durable ``user_settings`` row, or ``None`` when unset (polylogue-at44).
+
+        This is the liveness slice: a closed, typed registry of setting
+        keys (``subscription_tier`` today), not a free-form key-value store.
+        The full scope x actor x override resolver belongs to the w8db epic.
+        """
+
+        return _archive_get_setting(self.config, setting_key)
+
+    async def list_settings(self) -> list[ArchiveUserSettingEnvelope]:
+        """List every stored ``user_settings`` row, ordered by key."""
+
+        return _archive_list_settings(self.config)
+
+    async def set_setting(
+        self,
+        setting_key: str,
+        value: object,
+        *,
+        author_ref: str = "user:local",
+    ) -> ArchiveUserSettingEnvelope:
+        """Insert-or-update one typed ``user_settings`` row.
+
+        Raises :class:`ValueError` for an unknown ``setting_key`` or a
+        value the key's validator rejects (see
+        :mod:`polylogue.storage.sqlite.archive_tiers.user_settings_write`).
+        """
+
+        return _archive_set_setting(self.config, setting_key, value, author_ref=author_ref)

--- a/polylogue/archive/semantic/cost_compute.py
+++ b/polylogue/archive/semantic/cost_compute.py
@@ -34,6 +34,7 @@ def compute_session_cost(
     session_estimate: CostEstimatePayload | None = None,
     estimate_if_missing: bool = True,
     model_usage: Sequence[ModelUsageTotals] | None = None,
+    subscription_tier: str | None = None,
 ) -> SessionCostSummary:
     """Compute per-model cost breakdown and aggregate cost summary.
 
@@ -49,6 +50,14 @@ def compute_session_cost(
     (its real usage arrives as periodic cumulative ``token_count`` events, not
     per-message ``usage`` blocks), which is what made the per-message fallback
     ~1000x too small for Codex sessions when it was the only source.
+
+    ``subscription_tier`` selects the plan whose ``monthly_fee_usd /
+    credit_pool`` ratio prices the subscription-equivalent figure
+    (:func:`polylogue.archive.semantic.subscription_pricing.credits_to_usd`).
+    ``None`` keeps the conservative ``pro`` default rather than guessing --
+    callers that know the archive owner's actual plan (e.g. one that has
+    read the ``subscription_tier`` :mod:`user_settings` row, polylogue-at44)
+    should pass it explicitly.
     """
     estimate = session_estimate or (estimate_session_cost(session) if estimate_if_missing else None)
     if estimate is not None and estimate.status == "exact":
@@ -135,7 +144,7 @@ def compute_session_cost(
         sub_equivalent = 0.0
         credit_rate = get_credit_rate(norm) if norm else None
         if credit_rate and credit_cost > 0:
-            sub_equivalent = round(credits_to_usd(credit_cost), 6)
+            sub_equivalent = round(credits_to_usd(credit_cost, tier=subscription_tier or "pro"), 6)
 
         updated = SessionCostBreakdown(
             normalized_model=norm,

--- a/polylogue/cli/click_command_registration.py
+++ b/polylogue/cli/click_command_registration.py
@@ -115,6 +115,7 @@ _SHORT_HELP: dict[str, str] = {
     "reconcile_work_effects": "Reconcile a work-evidence graph against observed git/Beads effects.",
     "reset": "Reset local archive state.",
     "scan_secrets": "Scan a session for credential-shaped content (polylogue-27m).",
+    "setting": "Get, set, and list durable user settings.",
     "status": "Show daemon and archive status.",
     "tutorial": "Inspect first-run setup state.",
 }
@@ -137,6 +138,7 @@ _GROUP_ATTRS: dict[str, str] = {
     "insights": "ops_insights_command",
     "maintenance": "maintenance_group",
     "ops": "ops_command",
+    "setting": "setting_command",
 }
 
 _COMMAND_ATTRS: dict[str, str] = {
@@ -178,6 +180,7 @@ ROOT_COMMANDS: tuple[click.Command, ...] = (
     _L("manual"),
     _L("note"),
     _L("ops"),
+    _L("setting"),
     _L("status"),
     _L("tutorial"),
 )

--- a/polylogue/cli/commands/setting.py
+++ b/polylogue/cli/commands/setting.py
@@ -1,0 +1,122 @@
+"""Get/set/list durable ``user_settings`` rows (polylogue-at44 liveness slice).
+
+This is deliberately a closed, typed registry -- see
+``polylogue.storage.sqlite.archive_tiers.user_settings_write`` for the key
+registry and validators. The full scope x actor x override resolver design
+belongs to the w8db epic; this command is only the liveness surface.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import click
+
+from polylogue.paths import archive_root
+
+
+def _print_envelope(env: object, *, output_format: str) -> None:
+    from polylogue.storage.sqlite.archive_tiers.user_settings_write import ArchiveUserSettingEnvelope
+
+    assert isinstance(env, ArchiveUserSettingEnvelope)
+    if output_format == "json":
+        click.echo(
+            json.dumps(
+                {
+                    "setting_key": env.setting_key,
+                    "value": env.value,
+                    "updated_at_ms": env.updated_at_ms,
+                    "author_ref": env.author_ref,
+                },
+                ensure_ascii=False,
+                sort_keys=True,
+            )
+        )
+        return
+    click.echo(f"{env.setting_key} = {env.value!r} (author={env.author_ref}, updated_at_ms={env.updated_at_ms})")
+
+
+@click.group("setting")
+def setting_command() -> None:
+    """Get, set, and list durable user settings (e.g. ``subscription_tier``)."""
+
+
+@setting_command.command("get")
+@click.argument("setting_key")
+@click.option("--format", "output_format", type=click.Choice(("text", "json")), default="text", show_default=True)
+def setting_get_command(setting_key: str, output_format: str) -> None:
+    """Print one setting's stored value, or report it as unset."""
+
+    from polylogue.api import Polylogue
+
+    async def run() -> object | None:
+        async with Polylogue(archive_root=archive_root()) as poly:
+            return await poly.get_setting(setting_key)
+
+    envelope = asyncio.run(run())
+    if envelope is None:
+        if output_format == "json":
+            click.echo(json.dumps({"setting_key": setting_key, "value": None}))
+        else:
+            click.echo(f"{setting_key} is unset")
+        return
+    _print_envelope(envelope, output_format=output_format)
+
+
+@setting_command.command("set")
+@click.argument("setting_key")
+@click.argument("value")
+@click.option("--format", "output_format", type=click.Choice(("text", "json")), default="text", show_default=True)
+def setting_set_command(setting_key: str, value: str, output_format: str) -> None:
+    """Insert-or-update one typed setting row (rejects unknown keys/values)."""
+
+    from polylogue.api import Polylogue
+
+    async def run() -> object:
+        async with Polylogue(archive_root=archive_root()) as poly:
+            return await poly.set_setting(setting_key, value)
+
+    try:
+        envelope = asyncio.run(run())
+    except (ValueError, RuntimeError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    _print_envelope(envelope, output_format=output_format)
+
+
+@setting_command.command("list")
+@click.option("--format", "output_format", type=click.Choice(("text", "json")), default="text", show_default=True)
+def setting_list_command(output_format: str) -> None:
+    """List every stored setting row."""
+
+    from polylogue.api import Polylogue
+
+    async def run() -> list[object]:
+        async with Polylogue(archive_root=archive_root()) as poly:
+            return list(await poly.list_settings())
+
+    envelopes = asyncio.run(run())
+    if output_format == "json":
+        from polylogue.storage.sqlite.archive_tiers.user_settings_write import ArchiveUserSettingEnvelope
+
+        payload = []
+        for env in envelopes:
+            assert isinstance(env, ArchiveUserSettingEnvelope)
+            payload.append(
+                {
+                    "setting_key": env.setting_key,
+                    "value": env.value,
+                    "updated_at_ms": env.updated_at_ms,
+                    "author_ref": env.author_ref,
+                }
+            )
+        click.echo(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+        return
+    if not envelopes:
+        click.echo("no settings stored")
+        return
+    for env in envelopes:
+        _print_envelope(env, output_format="text")
+
+
+__all__ = ["setting_command"]

--- a/polylogue/storage/sqlite/archive_tiers/user_settings_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/user_settings_write.py
@@ -1,0 +1,153 @@
+"""Durable read/write helpers for the ``user_settings`` table.
+
+``user_settings`` (migration ``004_user_settings.sql``) predates any runtime
+caller (polylogue-at44): DDL and migration existed, nothing read or wrote it.
+This module is the liveness slice only -- a typed key registry with get/set/
+list helpers, deliberately narrow so the table cannot silently become a
+free-form global key-value junk drawer (guardrail recorded on polylogue-at44).
+The full scope x actor x override resolver design belongs to the w8db epic;
+this module owns exactly one settings surface: a closed registry of setting
+keys, each with its own validator, one row per key.
+
+Writer module: user.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from polylogue.core.json import JSONValue
+
+#: Closed registry of allowed setting keys. Adding a new setting means adding
+#: a validator here, not accepting an arbitrary caller-supplied key --
+#: keeping ``user_settings`` a typed registry rather than a junk drawer.
+SETTING_KEY_SUBSCRIPTION_TIER = "subscription_tier"
+
+
+def _validate_subscription_tier(value: JSONValue) -> None:
+    from polylogue.archive.semantic.subscription_pricing import SUBSCRIPTION_TIERS
+
+    if not isinstance(value, str) or value not in SUBSCRIPTION_TIERS:
+        choices = ", ".join(sorted(SUBSCRIPTION_TIERS))
+        raise ValueError(f"subscription_tier must be one of: {choices}")
+
+
+_SETTING_VALIDATORS: dict[str, Callable[[JSONValue], None]] = {
+    SETTING_KEY_SUBSCRIPTION_TIER: _validate_subscription_tier,
+}
+
+
+def known_setting_keys() -> frozenset[str]:
+    """Return the closed set of setting keys this registry accepts."""
+
+    return frozenset(_SETTING_VALIDATORS)
+
+
+def _validate_setting(setting_key: str, value: JSONValue) -> None:
+    validator = _SETTING_VALIDATORS.get(setting_key)
+    if validator is None:
+        choices = ", ".join(sorted(_SETTING_VALIDATORS))
+        raise ValueError(f"unknown setting key {setting_key!r}; known keys: {choices}")
+    validator(value)
+
+
+@dataclass(frozen=True, slots=True)
+class ArchiveUserSettingEnvelope:
+    setting_key: str
+    value: JSONValue
+    updated_at_ms: int
+    author_ref: str
+
+
+def _now_ms() -> int:
+    return int(datetime.now(UTC).timestamp() * 1000)
+
+
+def set_user_setting(
+    conn: sqlite3.Connection,
+    setting_key: str,
+    value: JSONValue,
+    *,
+    author_ref: str = "user:local",
+    now_ms: int | None = None,
+) -> ArchiveUserSettingEnvelope:
+    """Insert-or-update one typed setting row.
+
+    Rejects unknown keys and validator-rejected values -- there is no
+    untyped write path into ``user_settings``.
+    """
+
+    _validate_setting(setting_key, value)
+    timestamp = now_ms if now_ms is not None else _now_ms()
+    value_json = json.dumps(value, sort_keys=True)
+    conn.execute(
+        """
+        INSERT INTO user_settings (setting_key, value_json, updated_at_ms, author_ref)
+        VALUES (?, ?, ?, ?)
+        ON CONFLICT(setting_key) DO UPDATE SET
+            value_json = excluded.value_json,
+            updated_at_ms = excluded.updated_at_ms,
+            author_ref = excluded.author_ref
+        """,
+        (setting_key, value_json, timestamp, author_ref),
+    )
+    envelope = get_user_setting(conn, setting_key)
+    if envelope is None:
+        raise RuntimeError("user_settings insert did not round-trip")
+    return envelope
+
+
+def get_user_setting(conn: sqlite3.Connection, setting_key: str) -> ArchiveUserSettingEnvelope | None:
+    """Read one setting row, or ``None`` when unset."""
+
+    row = conn.execute(
+        "SELECT setting_key, value_json, updated_at_ms, author_ref FROM user_settings WHERE setting_key = ?",
+        (setting_key,),
+    ).fetchone()
+    if row is None:
+        return None
+    return ArchiveUserSettingEnvelope(
+        setting_key=str(row[0]),
+        value=json.loads(str(row[1])),
+        updated_at_ms=int(row[2]),
+        author_ref=str(row[3]),
+    )
+
+
+def get_user_setting_value(conn: sqlite3.Connection, setting_key: str, *, default: JSONValue) -> JSONValue:
+    """Read one setting's value, falling back to ``default`` when unset."""
+
+    envelope = get_user_setting(conn, setting_key)
+    return default if envelope is None else envelope.value
+
+
+def list_user_settings(conn: sqlite3.Connection) -> list[ArchiveUserSettingEnvelope]:
+    """List every stored setting row, ordered by key."""
+
+    rows = conn.execute(
+        "SELECT setting_key, value_json, updated_at_ms, author_ref FROM user_settings ORDER BY setting_key"
+    ).fetchall()
+    return [
+        ArchiveUserSettingEnvelope(
+            setting_key=str(row[0]),
+            value=json.loads(str(row[1])),
+            updated_at_ms=int(row[2]),
+            author_ref=str(row[3]),
+        )
+        for row in rows
+    ]
+
+
+__all__ = [
+    "SETTING_KEY_SUBSCRIPTION_TIER",
+    "ArchiveUserSettingEnvelope",
+    "get_user_setting",
+    "get_user_setting_value",
+    "known_setting_keys",
+    "list_user_settings",
+    "set_user_setting",
+]

--- a/polylogue/storage/usage.py
+++ b/polylogue/storage/usage.py
@@ -8,6 +8,7 @@ rollups.  It is an audit surface, not a billing estimator.
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
 from collections import Counter, defaultdict
 from collections.abc import Iterable, Sequence
@@ -45,6 +46,8 @@ from polylogue.core.evidence_value import (
 )
 from polylogue.core.refs import ObjectRef
 from polylogue.storage.table_existence import table_exists as _table_exists
+
+logger = logging.getLogger(__name__)
 
 UsageReportDetail = Literal["headline", "full"]
 
@@ -803,6 +806,42 @@ def _round_optional(value: float | None) -> float | None:
     return None if value is None else round(value, 6)
 
 
+def _resolve_subscription_tier_setting(archive_root: Path) -> str | None:
+    """Best-effort read of the ``subscription_tier`` user setting.
+
+    Returns ``None`` (letting downstream pricing fall back to the
+    conservative ``pro`` default) whenever ``user.db`` is missing, the table
+    isn't there yet, or the row is unset -- this is a read-only audit report,
+    never a place to raise on a durable-tier hiccup.
+    """
+
+    user_db = Path(archive_root) / "user.db"
+    if not user_db.exists():
+        return None
+    try:
+        from polylogue.storage.sqlite.archive_tiers.user_settings_write import (
+            SETTING_KEY_SUBSCRIPTION_TIER,
+            get_user_setting,
+        )
+
+        uri = user_db.resolve().as_uri() + "?mode=ro"
+        conn = sqlite3.connect(uri, uri=True)
+        try:
+            envelope = get_user_setting(conn, SETTING_KEY_SUBSCRIPTION_TIER)
+        finally:
+            conn.close()
+        if envelope is None or not isinstance(envelope.value, str):
+            return None
+        return envelope.value
+    except sqlite3.Error:
+        logger.warning(
+            "subscription_tier user setting read failed (falling back to the pro default): user_db=%s",
+            user_db,
+            exc_info=True,
+        )
+        return None
+
+
 def origin_usage_report_for_archive_root(
     archive_root: Path,
     *,
@@ -810,7 +849,12 @@ def origin_usage_report_for_archive_root(
     limit: int | None = 25,
     detail: UsageReportDetail = "full",
 ) -> ProviderUsageReport:
-    """Read ``archive_root/index.db`` and return a provider usage audit report."""
+    """Read ``archive_root/index.db`` and return a provider usage audit report.
+
+    Prices subscription-equivalent lanes against the archive owner's stored
+    ``subscription_tier`` setting when one is recorded (polylogue-at44),
+    falling back to the conservative ``pro`` default otherwise.
+    """
 
     index_db = Path(archive_root) / "index.db"
     if not index_db.exists():
@@ -819,12 +863,18 @@ def origin_usage_report_for_archive_root(
             origins=(),
             caveats=(f"index.db not found at {index_db}",),
         )
+    subscription_tier = _resolve_subscription_tier_setting(Path(archive_root))
     uri = index_db.resolve().as_uri() + "?mode=ro"
     conn = sqlite3.connect(uri, uri=True)
     conn.row_factory = sqlite3.Row
     try:
         return origin_usage_report_from_connection(
-            conn, archive_root=archive_root, origin=origin, limit=limit, detail=detail
+            conn,
+            archive_root=archive_root,
+            origin=origin,
+            limit=limit,
+            detail=detail,
+            subscription_tier=subscription_tier,
         )
     finally:
         conn.close()
@@ -838,8 +888,17 @@ def origin_usage_report_from_connection(
     limit: int | None = 25,
     detail: UsageReportDetail = "full",
     observed_at: str | None = None,
+    subscription_tier: str | None = None,
 ) -> ProviderUsageReport:
-    """Return a provider usage report for an already-open index connection."""
+    """Return a provider usage report for an already-open index connection.
+
+    ``subscription_tier`` selects the plan priced into the subscription-
+    equivalent lanes below (polylogue-at44); ``None`` keeps the conservative
+    ``pro`` default. Callers holding the archive's ``user_settings`` value
+    (see :mod:`polylogue.storage.sqlite.archive_tiers.user_settings_write`)
+    should resolve and pass it -- this function itself only reads ``conn``
+    (the ``index.db`` connection) and does not cross tiers to look it up.
+    """
 
     conn.row_factory = sqlite3.Row
     report_observed_at = observed_at or datetime.now(UTC).isoformat()
@@ -867,9 +926,17 @@ def origin_usage_report_from_connection(
     logical_model_by_origin = _logical_model_rollup_stats(conn, origin) if model_table_present else {}
     model_counts_by_origin = _model_row_counts(conn, origin) if model_table_present else {}
     multi_model_by_origin = _multi_model_session_counts(conn, origin) if model_table_present else {}
-    pricing_lanes = _pricing_lane_reports(conn, origin, observed_at=report_observed_at) if model_table_present else ()
+    pricing_lanes = (
+        _pricing_lane_reports(conn, origin, observed_at=report_observed_at, subscription_tier=subscription_tier)
+        if model_table_present
+        else ()
+    )
     logical_pricing_lanes = (
-        _pricing_lane_reports(conn, origin, logical=True, observed_at=report_observed_at) if model_table_present else ()
+        _pricing_lane_reports(
+            conn, origin, logical=True, observed_at=report_observed_at, subscription_tier=subscription_tier
+        )
+        if model_table_present
+        else ()
     )
     raw_by_origin, raw_samples, raw_caveat = _source_raw_stats(
         conn, archive_root=Path(archive_root), origin=origin, limit=limit
@@ -1619,6 +1686,7 @@ def _pricing_lane_reports(
     *,
     logical: bool = False,
     observed_at: str,
+    subscription_tier: str | None = None,
 ) -> tuple[PricingLaneReport, ...]:
     if logical:
         session_count_rows = conn.execute(
@@ -1769,7 +1837,7 @@ def _pricing_lane_reports(
                 usage.cache_write_tokens,
             )
             if credit_cost > 0:
-                bucket.subscription_credit_usd += credits_to_usd(credit_cost)
+                bucket.subscription_credit_usd += credits_to_usd(credit_cost, tier=subscription_tier or "pro")
 
     result: list[PricingLaneReport] = []
     for provenance, bucket in sorted(

--- a/tests/unit/api/test_settings_surface.py
+++ b/tests/unit/api/test_settings_surface.py
@@ -1,0 +1,97 @@
+"""Facade wiring for the durable ``user_settings`` liveness slice (polylogue-at44).
+
+``user_settings`` had DDL + a migration but no runtime caller before this
+module -- these tests exercise the write-capable facade methods
+(``set_setting``/``get_setting``/``list_settings``) end-to-end against a real
+archive, proving the async ``Polylogue`` facade and the sync storage helpers
+in ``user_settings_write.py`` agree (the "STORAGE TWINS" wiring the bead
+calls out).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue import Polylogue
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.archive_tiers.user_settings_write import ArchiveUserSettingEnvelope
+
+
+def _init_tiers(archive_root: Path, *, with_user: bool = True) -> None:
+    archive_root.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        initialize_archive_tier(conn, ArchiveTier.SOURCE)
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        initialize_archive_tier(conn, ArchiveTier.INDEX)
+    if with_user:
+        with sqlite3.connect(archive_root / "user.db") as conn:
+            initialize_archive_tier(conn, ArchiveTier.USER)
+
+
+async def test_get_setting_returns_none_when_unset(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    _init_tiers(archive_root)
+
+    async with Polylogue(archive_root=archive_root, db_path=archive_root / "index.db") as poly:
+        assert await poly.get_setting("subscription_tier") is None
+        assert await poly.list_settings() == []
+
+
+async def test_set_and_get_setting_round_trip(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    _init_tiers(archive_root)
+
+    async with Polylogue(archive_root=archive_root, db_path=archive_root / "index.db") as poly:
+        written = await poly.set_setting("subscription_tier", "max_5x")
+        assert isinstance(written, ArchiveUserSettingEnvelope)
+        assert written.value == "max_5x"
+
+        fetched = await poly.get_setting("subscription_tier")
+        assert fetched == written
+
+        updated = await poly.set_setting("subscription_tier", "pro")
+        assert updated.value == "pro"
+
+        listed = await poly.list_settings()
+        assert [row.setting_key for row in listed] == ["subscription_tier"]
+        assert listed[0].value == "pro"
+
+
+async def test_set_setting_rejects_unknown_key(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    _init_tiers(archive_root)
+
+    async with Polylogue(archive_root=archive_root, db_path=archive_root / "index.db") as poly:
+        with pytest.raises(ValueError, match="unknown setting key"):
+            await poly.set_setting("not_a_real_setting", "anything")
+
+
+async def test_set_setting_rejects_invalid_subscription_tier(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    _init_tiers(archive_root)
+
+    async with Polylogue(archive_root=archive_root, db_path=archive_root / "index.db") as poly:
+        with pytest.raises(ValueError, match="subscription_tier must be one of"):
+            await poly.set_setting("subscription_tier", "not-a-real-tier")
+
+
+async def test_set_setting_raises_when_user_tier_missing(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    _init_tiers(archive_root, with_user=False)
+
+    async with Polylogue(archive_root=archive_root, db_path=archive_root / "index.db") as poly:
+        with pytest.raises(ValueError, match="user settings tier is not initialized"):
+            await poly.set_setting("subscription_tier", "pro")
+
+
+async def test_get_setting_returns_none_when_user_tier_missing(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    _init_tiers(archive_root, with_user=False)
+
+    async with Polylogue(archive_root=archive_root, db_path=archive_root / "index.db") as poly:
+        assert await poly.get_setting("subscription_tier") is None
+        assert await poly.list_settings() == []

--- a/tests/unit/cli/test_setting_command.py
+++ b/tests/unit/cli/test_setting_command.py
@@ -1,0 +1,49 @@
+"""Behavioral proof for the ``polylogue setting`` get/set/list command (polylogue-at44)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import cast
+
+from click.testing import CliRunner
+
+from polylogue.cli import cli
+
+
+def _run(args: list[str]) -> dict[str, object] | list[object]:
+    result = CliRunner().invoke(cli, ["--plain", "setting", *args], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+    return cast("dict[str, object] | list[object]", json.loads(result.output))
+
+
+def test_setting_get_reports_unset(cli_workspace: dict[str, Path]) -> None:
+    payload = _run(["get", "subscription_tier", "--format", "json"])
+    assert payload == {"setting_key": "subscription_tier", "value": None}
+
+
+def test_setting_set_then_get_round_trips(cli_workspace: dict[str, Path]) -> None:
+    written = _run(["set", "subscription_tier", "max_5x", "--format", "json"])
+    assert isinstance(written, dict)
+    assert written["setting_key"] == "subscription_tier"
+    assert written["value"] == "max_5x"
+
+    fetched = _run(["get", "subscription_tier", "--format", "json"])
+    assert isinstance(fetched, dict)
+    assert fetched["value"] == "max_5x"
+
+    listed = _run(["list", "--format", "json"])
+    assert isinstance(listed, list)
+    assert listed == [written]
+
+
+def test_setting_set_rejects_unknown_key(cli_workspace: dict[str, Path]) -> None:
+    result = CliRunner().invoke(cli, ["--plain", "setting", "set", "not_a_real_setting", "x"])
+    assert result.exit_code != 0
+    assert "unknown setting key" in result.output
+
+
+def test_setting_set_rejects_invalid_tier_value(cli_workspace: dict[str, Path]) -> None:
+    result = CliRunner().invoke(cli, ["--plain", "setting", "set", "subscription_tier", "not-a-tier"])
+    assert result.exit_code != 0
+    assert "subscription_tier must be one of" in result.output

--- a/tests/unit/core/test_cost_compute.py
+++ b/tests/unit/core/test_cost_compute.py
@@ -169,3 +169,41 @@ def test_compute_session_cost_downgrades_to_partial_when_one_model_unknown_along
     confidences = {b.confidence for b in summary.per_model}
     assert "reported" in confidences
     assert "unknown" in confidences
+
+
+def test_compute_session_cost_defaults_to_pro_tier_subscription_equivalent() -> None:
+    """No explicit ``subscription_tier`` keeps the conservative ``pro`` default
+    (polylogue-at44 AC: "cost compute reads it with a sane default")."""
+
+    model_usage = [ModelUsageTotals(model_name="claude-sonnet-4-5", input_tokens=1_000_000, output_tokens=0)]
+    session = make_conv(id="sub-tier-default-session", provider="claude-code", messages=[])
+
+    default_summary = compute_session_cost(session, estimate_if_missing=False, model_usage=model_usage)
+    pro_summary = compute_session_cost(
+        session, estimate_if_missing=False, model_usage=model_usage, subscription_tier="pro"
+    )
+
+    assert default_summary.total_subscription_equivalent_usd > 0
+    assert default_summary.total_subscription_equivalent_usd == pro_summary.total_subscription_equivalent_usd
+
+
+def test_compute_session_cost_honors_explicit_subscription_tier() -> None:
+    """A caller that knows the archive owner's real plan (e.g. read from the
+    ``subscription_tier`` user setting) gets that plan's cheaper per-credit
+    rate reflected in the subscription-equivalent figure, not the hardcoded
+    ``pro`` ratio (polylogue-at44)."""
+
+    model_usage = [ModelUsageTotals(model_name="claude-sonnet-4-5", input_tokens=1_000_000, output_tokens=0)]
+    session = make_conv(id="sub-tier-explicit-session", provider="claude-code", messages=[])
+
+    pro_summary = compute_session_cost(
+        session, estimate_if_missing=False, model_usage=model_usage, subscription_tier="pro"
+    )
+    max20_summary = compute_session_cost(
+        session, estimate_if_missing=False, model_usage=model_usage, subscription_tier="max_20x"
+    )
+
+    # Same credit cost either way; only the USD conversion ratio differs.
+    assert pro_summary.total_credit_cost == max20_summary.total_credit_cost
+    assert max20_summary.total_subscription_equivalent_usd < pro_summary.total_subscription_equivalent_usd
+    assert max20_summary.total_subscription_equivalent_usd > 0

--- a/tests/unit/storage/test_origin_usage_report.py
+++ b/tests/unit/storage/test_origin_usage_report.py
@@ -1082,3 +1082,108 @@ def test_provider_usage_coverage_matrix_marks_estimate_only_exports(tmp_path: Pa
     assert row.coverage_state == "estimate_only"
     assert row.provider_event_count == 0
     assert "exact provider telemetry unavailable" in " ".join(row.caveats)
+
+
+def _seed_priced_claude_session(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        INSERT INTO sessions (
+            origin, native_id, title, session_kind,
+            created_at_ms, updated_at_ms, message_count, word_count, content_hash
+        ) VALUES ('claude-code-session', 'priced', 'priced', 'standard', 1, 1, 1, 1, zeroblob(32))
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO price_catalogs (catalog_id, catalog_hash, source_name, loaded_at_ms)
+        VALUES ('test-catalog', 'test-hash', 'test', 0)
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO session_model_usage (
+            session_id, model_name, input_tokens, output_tokens,
+            cache_read_tokens, cache_write_tokens, message_count, cost_provenance, cost_usd, priced_with
+        ) VALUES ('claude-code-session:priced', 'claude-sonnet-4-5', 1000, 100, 2000, 0, 1, 'priced', 1.25, 'test-catalog')
+        """
+    )
+
+
+def test_origin_usage_report_subscription_tier_param_reprices_subscription_credit(tmp_path: Path) -> None:
+    """polylogue-at44: ``subscription_tier`` selects the plan priced into the
+    subscription-credit lane, replacing the hardcoded ``pro`` ratio."""
+    conn = _connect(tmp_path / "index.db")
+    _seed_priced_claude_session(conn)
+
+    default_report = origin_usage_report_from_connection(conn, archive_root=tmp_path, detail="headline", limit=0)
+    pro_report = origin_usage_report_from_connection(
+        conn, archive_root=tmp_path, detail="headline", limit=0, subscription_tier="pro"
+    )
+    max20_report = origin_usage_report_from_connection(
+        conn, archive_root=tmp_path, detail="headline", limit=0, subscription_tier="max_20x"
+    )
+
+    assert default_report.subscription_credit_usd == pytest.approx(pro_report.subscription_credit_usd)
+    assert max20_report.subscription_credit_usd is not None
+    assert pro_report.subscription_credit_usd is not None
+    assert max20_report.subscription_credit_usd < pro_report.subscription_credit_usd
+    assert max20_report.subscription_credit_usd > 0
+
+
+def test_origin_usage_report_for_archive_root_reads_subscription_tier_user_setting(tmp_path: Path) -> None:
+    """The archive-root entry point resolves ``subscription_tier`` from the
+    durable ``user_settings`` row (polylogue-at44) rather than always
+    assuming ``pro``."""
+    from polylogue.storage.sqlite.archive_tiers.user_settings_write import set_user_setting
+    from polylogue.storage.usage import origin_usage_report_for_archive_root
+
+    archive_root = tmp_path / "archive"
+    archive_root.mkdir()
+    index_conn = _connect(archive_root / "index.db")
+    _seed_priced_claude_session(index_conn)
+    index_conn.commit()
+    index_conn.close()
+
+    user_conn = sqlite3.connect(archive_root / "user.db")
+    initialize_archive_tier(user_conn, ArchiveTier.USER)
+    set_user_setting(user_conn, "subscription_tier", "max_20x")
+    user_conn.commit()
+    user_conn.close()
+
+    report = origin_usage_report_for_archive_root(archive_root, detail="headline", limit=0)
+    default_conn = _connect(tmp_path / "no-setting-index.db")
+    _seed_priced_claude_session(default_conn)
+    pro_baseline = origin_usage_report_from_connection(
+        default_conn, archive_root=tmp_path, detail="headline", limit=0, subscription_tier="pro"
+    )
+
+    assert report.subscription_credit_usd is not None
+    assert pro_baseline.subscription_credit_usd is not None
+    assert report.subscription_credit_usd < pro_baseline.subscription_credit_usd
+
+
+def test_origin_usage_report_for_archive_root_defaults_when_setting_unset(tmp_path: Path) -> None:
+    """No stored ``subscription_tier`` row falls back to the conservative
+    ``pro`` default, not an error."""
+    from polylogue.storage.usage import origin_usage_report_for_archive_root
+
+    archive_root = tmp_path / "archive"
+    archive_root.mkdir()
+    index_conn = _connect(archive_root / "index.db")
+    _seed_priced_claude_session(index_conn)
+    index_conn.commit()
+    index_conn.close()
+
+    user_conn = sqlite3.connect(archive_root / "user.db")
+    initialize_archive_tier(user_conn, ArchiveTier.USER)
+    user_conn.commit()
+    user_conn.close()
+
+    report = origin_usage_report_for_archive_root(archive_root, detail="headline", limit=0)
+    pro_conn = _connect(tmp_path / "pro-index.db")
+    _seed_priced_claude_session(pro_conn)
+    pro_report = origin_usage_report_from_connection(
+        pro_conn, archive_root=tmp_path, detail="headline", limit=0, subscription_tier="pro"
+    )
+
+    assert report.subscription_credit_usd == pytest.approx(pro_report.subscription_credit_usd)

--- a/tests/unit/storage/test_user_settings_write.py
+++ b/tests/unit/storage/test_user_settings_write.py
@@ -1,0 +1,83 @@
+"""Liveness tests for ``user_settings`` read/write helpers (polylogue-at44).
+
+``user_settings`` had DDL + migration but zero runtime callers before this
+module. These tests exercise the typed registry directly against the real
+``USER_DDL``, proving get/set/list round-trip and that unknown keys /
+invalid values are rejected rather than silently accepted into a junk-drawer
+table.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from polylogue.storage.sqlite.archive_tiers.user import USER_DDL, USER_SCHEMA_VERSION
+from polylogue.storage.sqlite.archive_tiers.user_settings_write import (
+    SETTING_KEY_SUBSCRIPTION_TIER,
+    get_user_setting,
+    get_user_setting_value,
+    known_setting_keys,
+    list_user_settings,
+    set_user_setting,
+)
+
+
+def _conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(USER_DDL)
+    conn.execute(f"PRAGMA user_version = {USER_SCHEMA_VERSION}")
+    return conn
+
+
+def test_get_user_setting_returns_none_when_unset() -> None:
+    conn = _conn()
+    assert get_user_setting(conn, SETTING_KEY_SUBSCRIPTION_TIER) is None
+    assert get_user_setting_value(conn, SETTING_KEY_SUBSCRIPTION_TIER, default="pro") == "pro"
+    assert list_user_settings(conn) == []
+
+
+def test_set_user_setting_round_trips_and_upserts() -> None:
+    conn = _conn()
+    written = set_user_setting(conn, SETTING_KEY_SUBSCRIPTION_TIER, "max_5x", now_ms=100)
+    assert written.setting_key == SETTING_KEY_SUBSCRIPTION_TIER
+    assert written.value == "max_5x"
+    assert written.updated_at_ms == 100
+    assert written.author_ref == "user:local"
+
+    read = get_user_setting(conn, SETTING_KEY_SUBSCRIPTION_TIER)
+    assert read == written
+    assert get_user_setting_value(conn, SETTING_KEY_SUBSCRIPTION_TIER, default="pro") == "max_5x"
+
+    updated = set_user_setting(conn, SETTING_KEY_SUBSCRIPTION_TIER, "max_20x", now_ms=200, author_ref="agent:codex")
+    assert updated.value == "max_20x"
+    assert updated.updated_at_ms == 200
+    assert updated.author_ref == "agent:codex"
+    # Upsert, not a second row.
+    assert [row.setting_key for row in list_user_settings(conn)] == [SETTING_KEY_SUBSCRIPTION_TIER]
+
+
+def test_set_user_setting_rejects_unknown_key() -> None:
+    conn = _conn()
+    with pytest.raises(ValueError, match="unknown setting key"):
+        set_user_setting(conn, "not_a_real_setting", "anything")
+
+
+def test_set_user_setting_rejects_invalid_subscription_tier_value() -> None:
+    conn = _conn()
+    with pytest.raises(ValueError, match="subscription_tier must be one of"):
+        set_user_setting(conn, SETTING_KEY_SUBSCRIPTION_TIER, "not-a-real-tier")
+    with pytest.raises(ValueError, match="subscription_tier must be one of"):
+        set_user_setting(conn, SETTING_KEY_SUBSCRIPTION_TIER, 42)
+
+
+def test_known_setting_keys_is_the_closed_registry() -> None:
+    assert known_setting_keys() == frozenset({SETTING_KEY_SUBSCRIPTION_TIER})
+
+
+def test_list_user_settings_orders_by_key() -> None:
+    conn = _conn()
+    set_user_setting(conn, SETTING_KEY_SUBSCRIPTION_TIER, "pro", now_ms=1)
+    rows = list_user_settings(conn)
+    assert [row.setting_key for row in rows] == sorted(row.setting_key for row in rows)


### PR DESCRIPTION
## Summary

`user_settings` has had DDL and migration 004 since 2026-07-05 with zero runtime read/write helpers -- the table has been silently empty and unwired. This PR adds the liveness slice: typed sync CRUD helpers, an async facade surface, a CLI command, and a first real consumer (`subscription_tier` priced into subscription-equivalent cost figures, replacing the hardcoded Pro-plan assumption).

## Problem

Verified live: `rg user_settings` over `polylogue/` previously found only the DDL (`user.py`), the migration, and an unrelated filename string -- no reader, no writer. Meanwhile `credits_to_usd()` always priced subscription-equivalent cost against the cheapest Pro-tier ratio (21,700,000 credits / $20/mo) regardless of which plan the archive owner actually pays for (bead polylogue-at44).

## Solution

- `polylogue/storage/sqlite/archive_tiers/user_settings_write.py` (new): sync get/set/list helpers over `user_settings`, with a closed setting-key registry (`subscription_tier` only today, each key with its own validator) so the table cannot silently become a free-form key-value drawer -- mirrors the existing `context_delivery_write.py` pattern in the same package.
- `polylogue/api/archive.py`: `get_setting`/`set_setting`/`list_settings` on `PolylogueArchiveMixin`, following the `_archive_get_context_delivery` free-function + async-method convention already used for the other user-tier durable ledgers.
- `polylogue/cli/commands/setting.py` (new): `polylogue setting get/set/list`, registered as a root command in `click_command_registration.py`.
- `polylogue/archive/semantic/cost_compute.py`: `compute_session_cost` accepts an optional `subscription_tier` (default `None` preserves the existing `pro` behavior).
- `polylogue/storage/usage.py`: `_pricing_lane_reports` / `origin_usage_report_from_connection` thread the same optional parameter; `origin_usage_report_for_archive_root` (the top-level entry point behind the provider-usage report) resolves it from the durable `user_settings` row when present, logging and falling back to `pro` when `user.db` is missing or unreadable (this is a read-only audit report, never raises on a durable-tier hiccup).
- `docs/cost-model.md`: documents the new `polylogue setting` commands next to the existing subscription-credit-basis explanation.

Deliberately out of scope (per the bead's "liveness + first consumer only" framing, and the `w8db` epic which owns the full scope x actor x override resolver design): the deep per-session profile rebuild paths (`archive/session/runtime.py`, `storage/insights/session/rebuild.py`) still default to `pro` -- threading a tier-aware `user.db` lookup through the per-session index-rebuild hot path is a materially larger change than this bead's slice.

## Verification

- `mypy --strict` on every touched production file -- no issues found.
- `devtools test tests/unit/storage/test_user_settings_write.py tests/unit/api/test_settings_surface.py tests/unit/core/test_cost_compute.py tests/unit/storage/test_origin_usage_report.py tests/unit/cli/test_setting_command.py` -> `44 passed`.
- `devtools verify --quick` -> `exit_code: 0` (this required two follow-up fixes beyond the storage/API/CLI code itself: a `docs/plans/layering.yaml` writer-module declaration + two `docs/plans/layering-surface-baseline.json` entries for the new module's imports, and a log call on the best-effort `user_settings` read's `except sqlite3.Error` branch to satisfy the `degrade-loudly` gate).
- `devtools render all --check` -> no `out of sync` surfaces; `docs/cli-reference.md` regenerated for the new `setting` root command.

Ref polylogue-at44