### PR TITLE
refactor(sources): unify Claude Code eager and streaming parsers

### DIFF
--- a/docs/examples/demo-tour/command-output/01-claim-versus-receipt.txt
+++ b/docs/examples/demo-tour/command-output/01-claim-versus-receipt.txt
@@ -29,7 +29,7 @@ source material:
   blob_sha256: 9fd0dbdb080058070935924534a903cc63a8dcba571f6b2734f92a96576b59d7
 
 completion-claim experiment:
-  sample manifest: 0986e1bcddee5e4c5696c0a3a599777c4e910aac6d1f690313d57a33d35ab6ec
+  sample manifest: b52182a9f71d19071c0698e26cdf8b753d73d3fc673ce77eb7c8edee1b65fdef
   denominator: 2
 unsupported by structural evidence: 0 (0.0%)
 neutral prior outcome: 0 (0.0%)

--- a/docs/examples/demo-tour/transcript.txt
+++ b/docs/examples/demo-tour/transcript.txt
@@ -1,12 +1,12 @@
 # prepare deterministic proof archive
-Seeded 19 sessions, 71 messages, and 8 user-state assertions in 13.598s. Fixture audit: 40/40 declared constructs satisfied.
+Seeded 19 sessions, 71 messages, and 8 user-state assertions in 6.280s. Fixture audit: 40/40 declared constructs satisfied.
 
 # verify evidence before presenting it
-Verification passed in 0.147s; 0 path leaks and 0 semantic problems. The complete fixture and verification audit remains in report.json.
+Verification passed in 0.020s; 0 path leaks and 0 semantic problems. The complete fixture and verification audit remains in report.json.
 
 $ polylogue demo receipts
 Start with a falsifiable disagreement: assistant prose claims the tests pass, while the provider-normalized tool result says exit 1. A later run repairs the result, and a prose-only 'error' control demonstrates why keyword matching is not the oracle.
-exit=0 duration=4.830s bytes=1399
+exit=0 duration=2.046s bytes=1399
 Polylogue evidence receipt
 archive: <demo-archive>
 verdict: contradicted_at_claim_time_then_repaired
@@ -38,7 +38,7 @@ source material:
   blob_sha256: 9fd0dbdb080058070935924534a903cc63a8dcba571f6b2734f92a96576b59d7
 
 completion-claim experiment:
-  sample manifest: 0986e1bcddee5e4c5696c0a3a599777c4e910aac6d1f690313d57a33d35ab6ec
+  sample manifest: b52182a9f71d19071c0698e26cdf8b753d73d3fc673ce77eb7c8edee1b65fdef
   denominator: 2
 unsupported by structural evidence: 0 (0.0%)
 neutral prior outcome: 0 (0.0%)
@@ -47,14 +47,14 @@ contradicted without recorded repair: 1 (50.0%)
 
 $ polylogue 'actions where is_error:true | group by tool | count'
 Now aggregate the same structural field across providers. This query counts normalized failed actions; it does not search prose for the word 'error'.
-exit=0 duration=4.118s bytes=62
+exit=0 duration=2.762s bytes=62
 tool=Bash count=4
 tool=exec_command count=2
 tool=Edit count=1
 
 $ polylogue --id codex-session:demo-lineage-fork read --view chronicle
 Read a fork as one logical chronicle: inherited parent messages remain attributable to their origin while the fork contributes only its divergent tail.
-exit=0 duration=4.479s bytes=936
+exit=0 duration=2.509s bytes=936
 # Session Chronicle
 
 - Sessions: 1
@@ -101,7 +101,7 @@ _No distinct matching prose in the last edge._
 
 $ polylogue analyze --facets
 Only after inspecting evidence, zoom out to the archive across 8 origins, with deferred families labeled rather than silently guessed.
-exit=0 duration=2.436s bytes=1652
+exit=0 duration=2.394s bytes=1652
 Facets (global) — matched result set:
   readiness: ready (cost_class=cheap; budget 0.01s/2.00s)
   sessions: 19  messages: 71

--- a/polylogue/sources/dispatch.py
+++ b/polylogue/sources/dispatch.py
@@ -38,11 +38,12 @@ from .parsers.base import (
     extract_messages_from_list,
     mark_last_occurrence_as_active_leaf,
 )
+from .parsers.claude import code_parser as claude_code_parser
 from .parsers.claude.code_parser import apply_tool_result_sidecars
 
 if TYPE_CHECKING:
     from polylogue.schemas.packages import SchemaResolution
-    from polylogue.sources.live.tool_result_sidecars import SidecarJoinResult
+    from polylogue.sources.live.tool_result_sidecars import SidecarJoinResult, ToolResultIndexAccumulator
 
 logger = get_logger(__name__)
 
@@ -70,7 +71,6 @@ RECORD_DETECTOR_PROVIDER_ORDER = (
     Provider.GEMINI,
 )
 _MAX_PARSE_DEPTH = 10
-_NO_LOOKAHEAD = object()
 
 PayloadRecord: TypeAlias = JSONDocument
 PayloadSequence: TypeAlias = list[JSONValue]
@@ -79,6 +79,7 @@ LoweredPayloadMode: TypeAlias = Literal[
     "browser_capture",
     "chatgpt_codex_task",
     "chunked_prompt",
+    "claude_code_multiway",
     "generic_messages",
     "grouped_records",
     "local_artifact_document",
@@ -94,11 +95,16 @@ class LoweredPayloadSpec:
     mode: LoweredPayloadMode
     payload: PayloadRecord | PayloadSequence
     source_path: str | None = None
-    # bd polylogue-jc4q: set by ``_claude_code_grouped_record_specs`` when
-    # ``fallback_id`` is a composite it has already anchored to a resume/
-    # fork/usage-limit boundary carryover fragment's own identity -- see
-    # ``code_parser.py``'s ``trust_fallback_id`` for why this must be an
-    # explicit signal rather than an inferred one.
+    # bd polylogue-jc4q: true when ``fallback_id`` is a composite already
+    # anchored to a resume/fork/usage-limit boundary carryover fragment's
+    # own identity -- see ``code_parser.py``'s ``trust_fallback_id`` for why
+    # this must be an explicit signal rather than an inferred one. Claude
+    # Code's multi-session-per-file case (``mode="claude_code_multiway"``)
+    # resolves this per group internally in
+    # ``_claude_code_multiway_parse``/``_claude_code_new_group_identity``
+    # instead of through this field, which stays relevant only for the
+    # always-single-group ``mode="grouped_records"`` fallback (a dict-shaped
+    # Claude Code payload, or any other grouped provider).
     trust_fallback_id: bool = False
 
 
@@ -590,122 +596,6 @@ def _join_claude_code_sidecars(payloads: PayloadSequence, source_path: str | Non
     return join_tool_result_sidecars_session_scoped(payloads, tool_results_dir, source_path)
 
 
-def _claude_code_grouped_record_specs(
-    payloads: PayloadSequence,
-    fallback_id: str,
-    *,
-    source_path: str | None = None,
-) -> list[LoweredPayloadSpec]:
-    """Split concatenated Claude Code JSONL aggregates into session streams.
-
-    Records are grouped by their own ``sessionId``. The largest group by
-    record count is this file's real content ("primary"); every other group
-    keeps its bare content id UNLESS it looks like a resume/fork/usage-limit
-    boundary carryover from an ANCESTOR session rather than a second,
-    independent session (bd polylogue-jc4q) -- either because it occurs
-    BEFORE the primary group's own first record (the common shape: Claude
-    Code opens a resumed/forked file by replaying one boundary record still
-    tagged with the parent's sessionId, referencing a parent uuid this file
-    never itself produced), or because its own root record's ``parentUuid``
-    resolves to a uuid the primary group DID produce (the shape found
-    mid-file: a `/exit` sent right after a "usage limit reached" notice gets
-    re-stamped with the ancestor's id even though it is chained straight off
-    this file's own preceding record). Composing such a run's identity from
-    its bare content id collided every one of these carryover fragments --
-    from every fork/resume/quirk descendant of one ancestor -- onto that
-    ancestor's own `logical_source_key`, which is what made
-    claude-code-session revision membership see them as one irreconcilable
-    cohort instead of the unrelated fragments they are. Qualifying the
-    carryover run's id with this file's own ``fallback_id`` keeps it
-    distinct; the ancestor id becomes the ``parent_session_id`` lineage hint
-    (code_parser.py) instead.
-
-    A genuinely independent interleaved session -- no positional or
-    parentUuid evidence connecting it to the primary group at all -- keeps
-    its own bare content id exactly as before.
-    """
-    current_session_id: str | None = None
-    groups: dict[str, PayloadSequence] = {}
-    pending_prefix: PayloadSequence = []
-
-    for payload in payloads:
-        record = _payload_record(payload)
-        session_id = optional_string(record.get("sessionId")) if record is not None else None
-        if session_id is None:
-            if current_session_id is None:
-                pending_prefix.append(payload)
-            else:
-                groups.setdefault(current_session_id, []).append(payload)
-            continue
-
-        if current_session_id is None:
-            groups.setdefault(session_id, []).extend(pending_prefix)
-            pending_prefix = []
-
-        current_session_id = session_id
-        groups.setdefault(session_id, []).append(payload)
-
-    if len(groups) <= 1:
-        return [_grouped_records_spec(Provider.CLAUDE_CODE, payloads, fallback_id, source_path=source_path)]
-
-    if fallback_id.startswith("agent-"):
-        # Subagent/self-compaction files have their OWN identity scheme
-        # (``code_parser.py``'s ``is_agent`` branch composes
-        # ``f"{session_id}:{fallback_id}"`` unconditionally) that this
-        # bead does not touch -- ``fallback_id`` here is never itself a
-        # bare session id to anchor a "primary" against, so the carryover
-        # detection below does not apply. Preserve the long-standing rule:
-        # the first-encountered group carries the caller's fallback_id,
-        # every other group keeps its own bare content id.
-        return [
-            _grouped_records_spec(
-                Provider.CLAUDE_CODE,
-                group_payloads,
-                fallback_id if index == 0 else group_id,
-                source_path=source_path,
-            )
-            for index, (group_id, group_payloads) in enumerate(groups.items())
-        ]
-
-    group_order = list(groups.keys())
-    primary_group_id = max(groups, key=lambda group_id: len(groups[group_id]))
-    primary_index = group_order.index(primary_group_id)
-    primary_uuids = {
-        uuid
-        for group_payload in groups[primary_group_id]
-        if (record := _payload_record(group_payload)) is not None
-        and (uuid := optional_string(record.get("uuid"))) is not None
-    }
-
-    def _group_identity(group_id: str, group_payloads: PayloadSequence) -> tuple[str, bool]:
-        if group_id == primary_group_id:
-            return fallback_id, False
-        if group_order.index(group_id) < primary_index:
-            # This group's records occurred before the primary group ever
-            # started -- a boundary carryover opening the file, referencing
-            # a parent uuid this file never itself produced.
-            return f"{group_id}:{fallback_id}", True
-        root_record = _payload_record(group_payloads[0]) if group_payloads else None
-        root_parent_uuid = optional_string(root_record.get("parentUuid")) if root_record is not None else None
-        if root_parent_uuid is not None and root_parent_uuid in primary_uuids:
-            return f"{group_id}:{fallback_id}", True
-        return group_id, False
-
-    specs = []
-    for group_id, group_payloads in groups.items():
-        group_fallback_id, trust = _group_identity(group_id, group_payloads)
-        specs.append(
-            _grouped_records_spec(
-                Provider.CLAUDE_CODE,
-                group_payloads,
-                group_fallback_id,
-                source_path=source_path,
-                trust_fallback_id=trust,
-            )
-        )
-    return specs
-
-
 #  bd polylogue-t5lg: rank a chunk's own resolved title the same way
 # ``_parse_code_records`` ranks candidates within a single pass (custom-title
 # > ai-title > agent-name > first-human-message heuristic > raw id), so that
@@ -814,55 +704,140 @@ def merge_parsed_session_chunks(sessions: Iterable[ParsedSession]) -> list[Parse
                 "ingest_flags": sorted({*existing.ingest_flags, *session.ingest_flags}),
             }
         )
-    sessions = list(merged.values())
-    return [
-        claude.reconcile_code_session_chunks(session) if session.source_name is Provider.CLAUDE_CODE else session
-        for session in sessions
-    ]
+    # bd polylogue-taj0o Stage 2: Claude Code streaming used to be chunked
+    # into contiguous-run parses and glued back together here, needing a
+    # trailing `claude.reconcile_code_session_chunks` pass to re-fold the
+    # summary session_events (background completions, delegation progress,
+    # parse coverage, session_kind) each chunk had recomputed locally.
+    # `_claude_code_multiway_parse` now keys one ``_SessionAccumulator`` per
+    # session id across the whole record stream directly, so a Claude Code
+    # session is finalized exactly once and never reaches this function at
+    # all -- the generic merge above (title-evidence ranking, active-leaf
+    # recomputation, etc.) stays for any other provider that still needs to
+    # fold two same-identity ``ParsedSession``s together.
+    return list(merged.values())
 
 
-def _claude_code_stream_sessions(
+def _claude_code_new_group_identity(
+    group_id: str,
+    record: PayloadRecord | None,
+    *,
+    fallback_id: str,
+    is_agent_fallback: bool,
+    is_first_group: bool,
+    primary_started: bool,
+    primary_uuids: set[str],
+) -> tuple[str, bool, bool]:
+    """Resolve a newly-encountered Claude Code group's identity.
+
+    Returns ``(group_fallback_id, trust_fallback_id, provisional)``.
+    ``provisional`` is true only when the decision genuinely cannot be made
+    yet (this group's own sessionId differs from ``fallback_id`` and the
+    primary group hasn't started -- it might be a boundary carryover opening
+    the file, or ``fallback_id`` might never appear in the file at all, in
+    which case every such group is independent). The caller must defer
+    finalizing ``fallback_id``/``trust_fallback_id`` on those accumulators
+    until the whole stream has been walked -- see
+    ``_claude_code_multiway_parse``.
+
+    Mirrors the identity rules the former ``_claude_code_grouped_record_specs``
+    (eager) and ``_claude_code_stream_sessions`` (streaming) each implemented
+    separately (bd polylogue-jc4q), collapsed onto ONE canonical primary
+    definition: the group whose own ``sessionId`` equals ``fallback_id`` --
+    streaming's former rule, not eager's former max-by-record-count rule.
+    Eager's rule could pick the wrong group as primary for a small main
+    session sharing a file with a huge subagent transcript (the "three-way
+    duplication" finding, bd polylogue-taj0o notes); fallback_id-match is
+    also the only one of the two that a genuine single forward pass can
+    decide without full materialization, since it depends only on the
+    caller's own already-known identity for this file, not on record counts
+    that aren't known until the file ends.
+    """
+    if is_agent_fallback:
+        # Subagent/self-compaction files have their own identity scheme
+        # (code_parser.py's is_agent branch) that carryover detection below
+        # does not apply to: the first-encountered group carries the
+        # caller's fallback_id, every other group keeps its own bare
+        # content id.
+        if is_first_group:
+            return fallback_id, False, False
+        return group_id, False, False
+
+    if group_id == fallback_id:
+        return fallback_id, False, False
+
+    if not primary_started:
+        # Ambiguous until the whole stream is known: either a boundary
+        # carryover opening the file (if the primary group shows up later)
+        # or a genuinely independent session (if it never does).
+        return group_id, False, True
+
+    # Primary content has already streamed -- decide by the
+    # parentUuid-chains-into-primary signal (the mid-file shape: a `/exit`
+    # sent right after a "usage limit reached" notice gets re-stamped with
+    # the ancestor's id even though it is chained straight off this file's
+    # own preceding record).
+    root_parent_uuid = optional_string(record.get("parentUuid")) if record is not None else None
+    if root_parent_uuid is not None and root_parent_uuid in primary_uuids:
+        return f"{group_id}:{fallback_id}", True, False
+    return group_id, False, False
+
+
+def _claude_code_multiway_parse(
     payloads: Iterable[object],
     fallback_id: str,
     *,
     source_path: str | None = None,
 ) -> Iterator[ParsedSession]:
-    """Parse Claude Code JSONL records without materializing the full stream.
+    """Walk a Claude Code record stream exactly once, routing every record to
+    a per-session ``_SessionAccumulator`` keyed by its own ``sessionId``, and
+    finalize each accumulator only once the stream is exhausted
+    (bd polylogue-taj0o Stage 2).
 
-    The eager ``parse_payload`` path preserves the strongest non-contiguous
-    grouping semantics for already-materialized payloads. Raw JSONL ingest and
-    repair, however, can be multi-GiB; for that path we split only on contiguous
-    ``sessionId`` changes and feed each group to the provider parser as an
-    iterator. Per-session record-index and UUID continuation state retains no
-    raw payload bytes; its size is proportional to unique record identifiers and
-    makes an interleaved stream semantically identical to eager grouping.
+    Replaces two former shortcuts that each re-implemented a slice of this:
+    eager grouping (``_claude_code_grouped_record_specs``, which
+    materialized a ``dict[str, list]`` of every record up front, then parsed
+    each group's full list independently) and streaming's contiguous-run
+    chunker (``_claude_code_stream_sessions``, which fed each contiguous run
+    of one sessionId to its own ``_parse_code_records`` call and glued the
+    per-chunk results back together after the fact via
+    ``merge_parsed_session_chunks``/``reconcile_code_session_chunks``, since
+    each chunk's summary session_events -- background completions,
+    delegation-progress ticks, parse coverage, session_kind -- were computed
+    per chunk instead of per whole session). Keying one persistent
+    ``_SessionAccumulator`` per session id instead means ``_fold_code_record``
+    folds every record for that session into the SAME accumulator no matter
+    how many times its sessionId reappears in the file, so
+    ``_finalize_code_session`` runs its post-loop summary logic exactly once,
+    seeing the whole session -- there is nothing left to reconcile. This
+    also means genuinely interleaved records (not just contiguous runs) are
+    now handled correctly by construction, not merely approximated.
 
-    Sidecar join (polylogue-wjgf): the raw payload is never materialized here,
-    so ``join_tool_result_sidecars`` (which needs the full ``tool_use_id``
-    index) can't run against it directly. Instead each group's records are
-    teed through a ``ToolResultIndexAccumulator`` as they stream past
-    (``observe_tool_result_stream``), and the join runs against the resulting
-    index only after the group's iterator is fully consumed -- no raw record
-    retention, same memory bound as the rest of this path.
+    ``payloads`` may be a materialized list (the eager path) or a true
+    one-pass iterator (the streaming path, multi-GiB raw JSONL); ``for item
+    in payloads`` calls ``next()`` exactly once per record either way, so
+    this single function serves both callers -- mirroring
+    ``polylogue/sources/parsers/codex.py``'s ``parse``/``parse_stream``
+    pattern of one shared walk-and-fold implementation.
 
-    Identity (bd polylogue-jc4q): mirrors ``_claude_code_grouped_record_specs``
-    without its full-file lookahead -- a contiguous run tagged with the SAME
-    ``sessionId`` as ``fallback_id`` is this file's own real content
-    ("primary"); every other run keeps its bare content id UNLESS it is a
-    resume/fork/quirk boundary carryover from an ancestor. Once primary
-    content has streamed, that is detected by the run's root record's
-    ``parentUuid`` resolving to a uuid the primary has already produced (the
-    mid-file shape). Before any primary content has streamed, a differing
-    run is materialized (bounded -- these leading runs are always a handful
-    of records) and the run immediately after it is peeked at: if THAT run
-    is the primary, this leading run is a carryover opening the file (the
-    common shape); if the stream never produces a run matching
-    ``fallback_id`` at all, there is no primary to anchor against and the
-    run is a genuinely independent, bare-id session. Composing a carryover
-    run's identity from its bare content id would collide it onto that
-    ancestor's own `logical_source_key`.
+    Identity/carryover (bd polylogue-jc4q): see
+    ``_claude_code_new_group_identity`` for the per-group decision rule.
+    Records with no ``sessionId`` at all queue in a prefix buffer and are
+    folded into whichever group is encountered first, exactly like both
+    former implementations.
+
+    Sidecar join (polylogue-wjgf): built per accumulator (one
+    ``ToolResultIndexAccumulator`` per session id, observing every record
+    folded into that session as it streams past) rather than per chunk --
+    the former streaming chunker built and joined a fresh index per
+    contiguous run, which under-joined a session split across more than one
+    run. Session-scoped (``join_session_scoped``): a subagent transcript
+    only matches sidecars it owns; the root/parent transcript builds a
+    session-wide union index from sibling files on disk.
     """
-    tool_results_dir = None
+    is_agent_fallback = fallback_id.startswith("agent-")
+
+    tool_results_dir: Path | None = None
     if source_path is not None:
         from polylogue.sources.live.tool_result_sidecars import resolve_tool_results_dir
 
@@ -870,185 +845,120 @@ def _claude_code_stream_sessions(
         if tool_results_dir is not None and not tool_results_dir.is_dir():
             tool_results_dir = None
 
-    iterator = iter(payloads)
-    lookahead: object = _NO_LOOKAHEAD
+    def new_sidecar_accumulator() -> ToolResultIndexAccumulator:
+        from polylogue.sources.live.tool_result_sidecars import ToolResultIndexAccumulator
+
+        return ToolResultIndexAccumulator()
+
+    sidecar_accumulators: dict[str, ToolResultIndexAccumulator] | None = {} if tool_results_dir is not None else None
+
+    accumulators: dict[str, claude_code_parser._SessionAccumulator] = {}
+    group_order: list[str] = []
+    provisional_groups: set[str] = set()
     pending_prefix: list[object] = []
-    record_counts_by_session: dict[str, int] = {}
-    seen_record_uuids_by_session: dict[str, set[str]] = {}
-    # Subagent/self-compaction files have their own identity scheme
-    # (code_parser.py's is_agent branch) that carryover detection below
-    # does not apply to -- see the matching guard in
-    # _claude_code_grouped_record_specs for the full rationale.
-    is_agent_fallback = fallback_id.startswith("agent-")
-    first_group = True
-    # uuids produced so far by runs whose own sessionId equals fallback_id.
+    current_group_id: str | None = None
+    primary_started = False
     primary_uuids: set[str] = set()
 
-    def track_primary_uuid(item: object) -> None:
+    def new_accumulator(group_fallback_id: str, trust: bool) -> claude_code_parser._SessionAccumulator:
+        return claude_code_parser._SessionAccumulator(
+            fallback_id=group_fallback_id,
+            trust_fallback_id=trust,
+            is_agent=group_fallback_id.startswith("agent-"),
+            is_acompact=group_fallback_id.startswith("agent-acompact-"),
+        )
+
+    def fold_into(group_id: str, index: int, item: object) -> None:
+        if sidecar_accumulators is not None:
+            sidecar_accumulators[group_id].observe(item)
         record = _payload_record(item)
-        if record is None:
-            return
-        uuid = optional_string(record.get("uuid"))
-        if uuid is not None:
-            primary_uuids.add(uuid)
+        if record is not None and not is_agent_fallback and group_id == fallback_id:
+            uuid = optional_string(record.get("uuid"))
+            if uuid is not None:
+                primary_uuids.add(uuid)
+        if isinstance(item, dict):
+            claude_code_parser._fold_code_record(accumulators[group_id], index, item)
 
-    def next_item() -> object:
-        nonlocal lookahead
-        if lookahead is not _NO_LOOKAHEAD:
-            item = lookahead
-            lookahead = _NO_LOOKAHEAD
-            return item
-        return next(iterator)
+    record_index = 0
+    for item in payloads:
+        record_index += 1
+        record = _payload_record(item)
+        session_id = optional_string(record.get("sessionId")) if record is not None else None
 
-    def parse_group(
-        records: Iterator[object],
-        group_fallback_id: str,
-        *,
-        record_index_start: int = 0,
-        seen_record_uuids: set[str] | None = None,
-        trust_fallback_id: bool = False,
-    ) -> ParsedSession:
-        if tool_results_dir is None:
-            return claude.parse_code_stream(
-                records,
-                group_fallback_id,
-                record_index_start=record_index_start,
-                seen_record_uuids=seen_record_uuids,
-                trust_fallback_id=trust_fallback_id,
-            )
-        from polylogue.sources.live.tool_result_sidecars import (
-            ToolResultIndexAccumulator,
-            observe_tool_result_stream,
-        )
-
-        accumulator = ToolResultIndexAccumulator()
-        session = claude.parse_code_stream(
-            observe_tool_result_stream(records, accumulator),
-            group_fallback_id,
-            record_index_start=record_index_start,
-            seen_record_uuids=seen_record_uuids,
-            trust_fallback_id=trust_fallback_id,
-        )
-        assert source_path is not None  # tool_results_dir is only set when source_path is
-        return apply_tool_result_sidecars(session, accumulator.join_session_scoped(tool_results_dir, source_path))
-
-    while True:
-        try:
-            first = next_item()
-        except StopIteration:
-            if pending_prefix:
-                yield parse_group(iter(pending_prefix), fallback_id)
-            return
-
-        first_record = _payload_record(first)
-        first_session_id = optional_string(first_record.get("sessionId")) if first_record is not None else None
-        if first_session_id is None:
-            pending_prefix.append(first)
+        if session_id is None:
+            if current_group_id is None:
+                pending_prefix.append(item)
+                continue
+            fold_into(current_group_id, record_index, item)
             continue
 
-        group_session_id = first_session_id
-        is_primary_group = group_session_id == fallback_id
-        trust_group_fallback_id = False
-        prefix = pending_prefix
-        pending_prefix = []
-        materialized_group: list[object] | None = None
+        if session_id not in accumulators:
+            group_fallback_id, trust, provisional = _claude_code_new_group_identity(
+                session_id,
+                record,
+                fallback_id=fallback_id,
+                is_agent_fallback=is_agent_fallback,
+                is_first_group=not accumulators,
+                primary_started=primary_started,
+                primary_uuids=primary_uuids,
+            )
+            accumulators[session_id] = new_accumulator(group_fallback_id, trust)
+            group_order.append(session_id)
+            if sidecar_accumulators is not None:
+                sidecar_accumulators[session_id] = new_sidecar_accumulator()
+            if provisional:
+                provisional_groups.add(session_id)
+            if not is_agent_fallback and session_id == fallback_id:
+                primary_started = True
+            prefix_index = record_index - len(pending_prefix)
+            for prefix_item in pending_prefix:
+                prefix_index += 1
+                fold_into(session_id, prefix_index, prefix_item)
+            pending_prefix = []
 
-        if is_agent_fallback:
-            # Preserve the long-standing rule for subagent/self-compaction
-            # files: the first-encountered group carries the caller's
-            # fallback_id, every other group keeps its own bare content id.
-            group_fallback_id = fallback_id if first_group else group_session_id
-            first_group = False
-        elif is_primary_group:
-            group_fallback_id = fallback_id
-        elif primary_uuids:
-            # Primary content has already streamed -- decide by the
-            # parentUuid-chains-into-primary signal (the mid-file shape: a
-            # `/exit` sent right after a "usage limit reached" notice gets
-            # re-stamped with the ancestor's id even though it is chained
-            # straight off this file's own preceding record).
-            root_parent_uuid = optional_string(first_record.get("parentUuid")) if first_record is not None else None
-            if root_parent_uuid is not None and root_parent_uuid in primary_uuids:
-                group_fallback_id = f"{group_session_id}:{fallback_id}"
-                trust_group_fallback_id = True
-            else:
-                group_fallback_id = group_session_id
+        current_group_id = session_id
+        fold_into(session_id, record_index, item)
+
+    if not accumulators:
+        # No sessionId ever appeared -- either a genuinely empty stream or
+        # one that only ever produced prefix records (e.g. a lone
+        # ``summary`` row). Both former implementations still emit exactly
+        # one (possibly zero-message) session for this fallback_id.
+        accumulators[fallback_id] = new_accumulator(fallback_id, False)
+        group_order.append(fallback_id)
+        if sidecar_accumulators is not None:
+            sidecar_accumulators[fallback_id] = new_sidecar_accumulator()
+        for index, prefix_item in enumerate(pending_prefix, start=1):
+            fold_into(fallback_id, index, prefix_item)
+
+    # Provisional groups (non-agent, own sessionId != fallback_id, first
+    # encountered before the primary group had started) can only be
+    # resolved now that the whole stream is known: a carryover fragment of
+    # the primary if the primary showed up anywhere in the file, otherwise
+    # a genuinely independent session with no primary to anchor against.
+    # Folding never reads ``fallback_id``/``trust_fallback_id`` off the
+    # accumulator (only ``is_agent``/``is_acompact``, already correctly
+    # False for every provisional group -- neither a bare sessionId nor
+    # ``f"{group_id}:{fallback_id}"`` can start with "agent-" when
+    # ``fallback_id`` itself doesn't), so mutating them here is safe.
+    for group_id in provisional_groups:
+        acc = accumulators[group_id]
+        if primary_started:
+            acc.fallback_id = f"{group_id}:{fallback_id}"
+            acc.trust_fallback_id = True
         else:
-            # No primary content has streamed yet, so there is nothing to
-            # chain a parentUuid into. Materialize this one run -- Claude
-            # Code boundary-carryover runs opening a file are always small,
-            # a handful of records -- and peek at whether the run right
-            # after it is this file's own primary content (the common
-            # shape: a resume/fork file opens with one boundary record
-            # still tagged with the parent's sessionId, then switches to
-            # its own for the rest of the file). If the stream never
-            # produces a run matching ``fallback_id`` at all, there is no
-            # primary to anchor against and this is a genuinely independent,
-            # bare-id session (e.g. two unrelated sessions concatenated
-            # under a caller-supplied bundle label).
-            materialized_group = [*prefix, first]
-            prefix = []
-            for item in iterator:
-                record = _payload_record(item)
-                session_id = optional_string(record.get("sessionId")) if record is not None else None
-                if session_id is not None and session_id != group_session_id:
-                    lookahead = item
-                    break
-                materialized_group.append(item)
-            next_session_id: str | None = None
-            if lookahead is not _NO_LOOKAHEAD:
-                peek_record = _payload_record(lookahead)
-                next_session_id = optional_string(peek_record.get("sessionId")) if peek_record is not None else None
-            if next_session_id == fallback_id:
-                group_fallback_id = f"{group_session_id}:{fallback_id}"
-                trust_group_fallback_id = True
-            else:
-                group_fallback_id = group_session_id
+            acc.fallback_id = group_id
+            acc.trust_fallback_id = False
 
-        group_record_count = 0
-
-        def group_records(
-            prefix: list[object] = prefix,
-            first: object = first,
-            group_session_id: str = group_session_id,
-            is_primary_group: bool = is_primary_group,
-            materialized_group: list[object] | None = materialized_group,
-        ) -> Iterator[object]:
-            nonlocal group_record_count, lookahead
-            if materialized_group is not None:
-                group_record_count += len(materialized_group)
-                yield from materialized_group
-                return
-            for prefix_item in prefix:
-                group_record_count += 1
-                if is_primary_group:
-                    track_primary_uuid(prefix_item)
-                yield prefix_item
-            group_record_count += 1
-            if is_primary_group:
-                track_primary_uuid(first)
-            yield first
-            for item in iterator:
-                record = _payload_record(item)
-                session_id = optional_string(record.get("sessionId")) if record is not None else None
-                if session_id is not None and session_id != group_session_id:
-                    lookahead = item
-                    return
-                group_record_count += 1
-                if is_primary_group:
-                    track_primary_uuid(item)
-                yield item
-
-        record_index_start = record_counts_by_session.get(group_session_id, 0)
-        seen_record_uuids = seen_record_uuids_by_session.setdefault(group_session_id, set())
-        session = parse_group(
-            group_records(),
-            group_fallback_id,
-            record_index_start=record_index_start,
-            seen_record_uuids=seen_record_uuids,
-            trust_fallback_id=trust_group_fallback_id,
-        )
-        record_counts_by_session[group_session_id] = record_index_start + group_record_count
+    for group_id in group_order:
+        session = claude_code_parser._finalize_code_session(accumulators[group_id])
+        if sidecar_accumulators is not None:
+            # sidecar_accumulators is only set when tool_results_dir resolved, which itself
+            # only happens when source_path is not None.
+            assert tool_results_dir is not None
+            assert source_path is not None
+            join_result = sidecar_accumulators[group_id].join_session_scoped(tool_results_dir, source_path)
+            session = apply_tool_result_sidecars(session, join_result)
         yield session
 
 
@@ -1214,7 +1124,15 @@ def _lower_grouped_payload(
     payloads = _payload_sequence(shaped_payload)
     if payloads is not None:
         if provider is Provider.CLAUDE_CODE:
-            return _claude_code_grouped_record_specs(payloads, fallback_id, source_path=source_path)
+            return [
+                LoweredPayloadSpec(
+                    provider=Provider.CLAUDE_CODE,
+                    fallback_id=fallback_id,
+                    mode="claude_code_multiway",
+                    payload=payloads,
+                    source_path=source_path,
+                )
+            ]
         return [_grouped_records_spec(provider, payloads, fallback_id, source_path=source_path)]
 
     record = _payload_record(shaped_payload)
@@ -1545,6 +1463,12 @@ def _parse_lowered_spec(spec: LoweredPayloadSpec) -> list[ParsedSession]:
         record = _payload_record(spec.payload)
         return [chatgpt_codex_sidecar.parse_codex_task(record, spec.fallback_id)] if record is not None else []
 
+    if spec.mode == "claude_code_multiway":
+        payloads = _payload_sequence(spec.payload)
+        if payloads is None:
+            return []
+        return list(_claude_code_multiway_parse(payloads, spec.fallback_id, source_path=spec.source_path))
+
     if spec.provider is Provider.CHATGPT:
         record = _payload_record(spec.payload)
         return [chatgpt.parse(record, spec.fallback_id)] if record is not None else []
@@ -1769,7 +1693,7 @@ def parse_stream_payload(
     """
     runtime_provider = Provider.from_string(provider)
     if runtime_provider is Provider.CLAUDE_CODE:
-        return merge_parsed_session_chunks(_claude_code_stream_sessions(payloads, fallback_id, source_path=source_path))
+        return list(_claude_code_multiway_parse(payloads, fallback_id, source_path=source_path))
     if runtime_provider is Provider.CODEX:
         return [codex.parse_stream(payloads, fallback_id)]
     if runtime_provider is Provider.BEADS:

--- a/polylogue/sources/origin_specs.py
+++ b/polylogue/sources/origin_specs.py
@@ -417,7 +417,7 @@ def _claude_code_spec() -> OriginSpec:
         detector_tightness=60,
         parser_paths=("polylogue/sources/parsers/claude/code_parser.py",),
         stream_parser_path="polylogue/sources/parsers/claude/code_parser.py:parse_code_stream",
-        assembly_paths=("polylogue/sources/dispatch.py:merge_parsed_session_chunks",),
+        assembly_paths=("polylogue/sources/dispatch.py:_claude_code_multiway_parse",),
         fixture_paths=(
             "tests/unit/sources/test_parsers_claude_code_artifacts.py",
             "tests/unit/sources/test_assembly_claude_code_history.py",

--- a/polylogue/sources/parsers/claude/__init__.py
+++ b/polylogue/sources/parsers/claude/__init__.py
@@ -15,7 +15,7 @@ from .ai_parser import parse_ai as _parse_ai
 from .ai_parser import parse_design as _parse_design
 from .ai_parser import parse_memories as _parse_memories
 from .code_detection import looks_like_code
-from .code_parser import parse_code, parse_code_stream, reconcile_code_session_chunks
+from .code_parser import parse_code, parse_code_stream
 from .common import (
     extract_messages_from_chat_messages,
     extract_text_from_segments,
@@ -72,7 +72,6 @@ __all__ = [
     "parse_code_stream",
     "parse_design",
     "parse_memories",
-    "reconcile_code_session_chunks",
     "parse_sessions_index",
     "parse_claude_orchestration_artifact",
     "parse_claude_todo_artifact",

--- a/polylogue/sources/parsers/claude/code_parser.py
+++ b/polylogue/sources/parsers/claude/code_parser.py
@@ -1955,20 +1955,12 @@ def _parse_code_records(
     records: Iterable[object],
     fallback_id: str,
     *,
-    record_index_start: int = 0,
-    seen_record_uuids: set[str] | None = None,
     trust_fallback_id: bool = False,
 ) -> ParsedSession:
     """Parse Claude Code JSONL payloads into a canonical session model.
 
-    ``record_index_start`` and ``seen_record_uuids`` are compact streaming
-    continuation state used when one provider-native session is split by
-    interleaved JSONL rows. They preserve eager-path fallback identifiers and
-    first-record-wins UUID semantics without retaining raw records.
-
-    ``trust_fallback_id`` (bd polylogue-jc4q): dispatch.py's Claude Code
-    grouping (``_claude_code_grouped_record_specs`` /
-    ``_claude_code_stream_sessions``) sets this when ``fallback_id`` is a
+    ``trust_fallback_id`` (bd polylogue-jc4q): the caller (dispatch.py's
+    ``_claude_code_multiway_parse``) sets this when ``fallback_id`` is a
     composite it has already anchored to THIS file's own identity for a
     resume/fork/usage-limit boundary carryover fragment -- a run of records
     stamped with an ANCESTOR session's id even though it is not that
@@ -1980,16 +1972,22 @@ def _parse_code_records(
 
     This is a thin walk-and-fold wrapper (bd polylogue-taj0o Stage 1) over
     ``_fold_code_record``/``_finalize_code_session``, which carry the actual
-    per-record and post-loop logic against one ``_SessionAccumulator``.
+    per-record and post-loop logic against one ``_SessionAccumulator``. It
+    always sees one session's whole record set in a single call -- routing
+    the same raw ``records`` iterable to more than one logical session
+    (a file with interleaved sessionIds) is dispatch.py's
+    ``_claude_code_multiway_parse``'s job (bd polylogue-taj0o Stage 2), which
+    keys one ``_SessionAccumulator`` per session id directly via
+    ``_fold_code_record``/``_finalize_code_session`` instead of calling this
+    function per group.
     """
     acc = _SessionAccumulator(
         fallback_id=fallback_id,
         trust_fallback_id=trust_fallback_id,
         is_agent=fallback_id.startswith("agent-"),
         is_acompact=fallback_id.startswith("agent-acompact-"),
-        seen_uuids=seen_record_uuids if seen_record_uuids is not None else set(),
     )
-    for index, item in enumerate(records, start=record_index_start + 1):
+    for index, item in enumerate(records, start=1):
         if not isinstance(item, dict):
             continue
         _fold_code_record(acc, index, item)
@@ -2073,71 +2071,13 @@ def _sidecar_event_timestamp(file_mtime_ms: int | None) -> str | None:
     return format_timestamp(file_mtime_ms / 1000.0)
 
 
-def parse_code(
-    payload: Sequence[object],
-    fallback_id: str,
-    *,
-    tool_result_sidecars: SidecarJoinResult | None = None,
-    trust_fallback_id: bool = False,
-) -> ParsedSession:
-    session = _parse_code_records(payload, fallback_id, trust_fallback_id=trust_fallback_id)
-    if tool_result_sidecars is not None:
-        session = apply_tool_result_sidecars(session, tool_result_sidecars)
-    return session
-
-
-def _background_notification_from_event(
-    event: ParsedSessionEvent,
-) -> ClaudeCodeBackgroundTaskNotification | None:
-    if event.event_type != "background_task_completion":
-        return None
-    payload = event.payload
-    task_id = payload.get("task_id")
-    output_file = payload.get("output_file")
-    status = payload.get("status")
-    summary = payload.get("summary")
-    tool_use_id = payload.get("tool_use_id")
-    exit_code = payload.get("exit_code")
-    if not isinstance(task_id, str) or not task_id:
-        return None
-    if not isinstance(output_file, str) or not output_file:
-        return None
-    if not isinstance(status, str) or not status:
-        return None
-    if not isinstance(summary, str) or not summary:
-        return None
-    if tool_use_id is not None and not isinstance(tool_use_id, str):
-        return None
-    if exit_code is not None and not isinstance(exit_code, int):
-        return None
-    return ClaudeCodeBackgroundTaskNotification(
-        task_id=task_id,
-        tool_use_id=tool_use_id,
-        output_file=output_file,
-        status=status,
-        summary=summary,
-        exit_code=exit_code,
-    )
-
-
-# polylogue-4987i: eager parsing (_parse_code_records, single pass over a
-# session's whole record set) appends summary session_events -- background
-# completions, delegation progress, session_kind, coverage -- after its main
-# loop, in that fixed order, because it only sees "no more records" once, at
-# true end of input. Streaming parses non-contiguous chunks with the SAME
-# per-chunk logic, so each chunk appends its own summary events at that
-# chunk's local end; concatenating chunks in arrival order therefore
-# interleaves each chunk's local summary events with the next chunk's
-# ordinary events, a different permutation than eager's for identical
-# underlying records. There is no true "end of session" to wait for (a live
-# session can always grow another byte later, and both eager and streaming
-# only ever see whatever prefix of the file exists when parsing runs) -- so
-# the fix is not to defer harder, it is to make the final order depend only
-# on the parsed content, not on how many chunks it took to parse it: sort by
-# (timestamp, event-type tier, encounter order) rather than relying on
-# append order at all. This is idempotent for eager's own historical output
-# in the common case (record/timestamp order already coincides with the tier
-# order below) and chunk-count-invariant for streaming by construction.
+# polylogue-4987i: a session's summary session_events -- background
+# completions, delegation progress, session_kind, coverage -- are appended
+# after ``_fold_code_record``'s main loop, in that fixed order, because
+# ``_finalize_code_session`` only sees "no more records" once, at true end
+# of input. Sort by (timestamp, event-type tier, encounter order) rather
+# than relying on append order alone so the final order depends only on the
+# parsed content.
 _SESSION_EVENT_TYPE_ORDER_TIER: dict[str, int] = {
     "background_task_completion": 1,
     "claude_delegation_progress": 2,
@@ -2147,13 +2087,12 @@ _SESSION_EVENT_TYPE_ORDER_TIER: dict[str, int] = {
 
 
 def order_session_events(events: Sequence[ParsedSessionEvent]) -> list[ParsedSessionEvent]:
-    """Deterministic session_events order, independent of chunk count (polylogue-4987i).
+    """Deterministic session_events order (polylogue-4987i).
 
     Missing timestamps sort first (stable; matches prior append-order
     behavior for the rare untimestamped event). The trailing encounter index
     is an irreducible tiebreak: two same-type events genuinely stamped at
-    the same instant have no other ordering evidence, in either parsing
-    path.
+    the same instant have no other ordering evidence.
     """
 
     def sort_key(indexed: tuple[int, ParsedSessionEvent]) -> tuple[str, int, int]:
@@ -2163,167 +2102,29 @@ def order_session_events(events: Sequence[ParsedSessionEvent]) -> list[ParsedSes
     return [event for _, event in sorted(enumerate(events), key=sort_key)]
 
 
-def _merge_count_dicts(dicts: Iterable[object]) -> dict[str, int]:
-    merged: dict[str, int] = {}
-    for payload in dicts:
-        if not isinstance(payload, Mapping):
-            continue
-        for key, value in payload.items():
-            if isinstance(key, str) and isinstance(value, int):
-                merged[key] = merged.get(key, 0) + value
-    return dict(sorted(merged.items()))
-
-
-def reconcile_code_session_chunks(session: ParsedSession) -> ParsedSession:
-    """Finalize one Claude Code session after streaming chunk merge.
-
-    Every "whole-session summary" event type _parse_code_records emits after
-    its main loop -- background completions, delegation-progress ticks, parse
-    coverage counts -- is computed PER CHUNK when parsing is split into
-    non-contiguous chunks (polylogue-4987i): each chunk only sees its own
-    slice of records, so its coverage counts are a partial sum and its
-    background/delegation state resets at the chunk boundary instead of
-    accumulating across the whole session the way eager's single pass does.
-    Concatenating chunks therefore leaves eager and streaming BOTH
-    differently-ordered (fixed by `order_session_events` below) AND carrying
-    different per-event payloads/timestamps for the exact same session
-    (e.g. a stale chunk-local `claude_parse_coverage.updated_at` instead of
-    the session's true final `updated_at`) -- ordering alone cannot fix that,
-    each summary type needs the same fold-across-chunks eager already does
-    within one pass.
-
-    - `background_task_completion`: dedup by (task_id, tool_use_id), a later
-      completion overwrites an earlier start (unchanged from before).
-    - `claude_delegation_progress`: dedup+merge by `parent_tool_use_id`,
-      summing tick counts and taking min(first_seen)/max(last_seen) --
-      mirrors `_accumulate_delegation_progress`'s own accumulation.
-    - `claude_parse_coverage`: merge into at most one event, summing each
-      count dict per key and stamping the session-wide `updated_at` (already
-      correctly the true session max across chunks --
-      `merge_parsed_session_chunks` computes it via `max(updated_values)`
-      before this function runs).
-    - `claude_session_kind`: dedup to at most one (a session-wide constant
-      fact; any surviving instance carries the same value).
-    """
-    ordinary_events: list[ParsedSessionEvent] = []
-    completion_events: dict[tuple[str, str | None], ParsedSessionEvent] = {}
-    delegation_events: dict[str, ParsedSessionEvent] = {}
-    coverage_events: list[ParsedSessionEvent] = []
-    session_kind_event: ParsedSessionEvent | None = None
-    for event in session.session_events:
-        notification = _background_notification_from_event(event)
-        if notification is not None:
-            completion_events[(notification.task_id, notification.tool_use_id)] = event
-            continue
-        if event.event_type == "claude_delegation_progress":
-            parent_tool_use_id = event.payload.get("parent_tool_use_id")
-            if isinstance(parent_tool_use_id, str) and parent_tool_use_id:
-                existing_delegation = delegation_events.get(parent_tool_use_id)
-                if existing_delegation is None:
-                    delegation_events[parent_tool_use_id] = event
-                else:
-                    existing_payload = existing_delegation.payload
-                    tick_count = _safe_int(existing_payload.get("progress_tick_count")) + _safe_int(
-                        event.payload.get("progress_tick_count")
-                    )
-                    first_seen_values = [
-                        value
-                        for value in (existing_payload.get("first_seen"), event.payload.get("first_seen"))
-                        if isinstance(value, str) and value
-                    ]
-                    last_seen_values = [
-                        value
-                        for value in (existing_payload.get("last_seen"), event.payload.get("last_seen"))
-                        if isinstance(value, str) and value
-                    ]
-                    first_seen = min(first_seen_values) if first_seen_values else None
-                    last_seen = max(last_seen_values) if last_seen_values else None
-                    delegation_events[parent_tool_use_id] = existing_delegation.model_copy(
-                        update={
-                            "timestamp": last_seen or existing_delegation.timestamp,
-                            "payload": {
-                                "parent_tool_use_id": parent_tool_use_id,
-                                "progress_tick_count": tick_count,
-                                "first_seen": first_seen,
-                                "last_seen": last_seen,
-                                "summary": (
-                                    f"delegated work under tool_use {parent_tool_use_id} ({tick_count} progress ticks)"
-                                ),
-                            },
-                        }
-                    )
-                continue
-            ordinary_events.append(event)
-            continue
-        if event.event_type == "claude_parse_coverage":
-            coverage_events.append(event)
-            continue
-        if event.event_type == "claude_session_kind":
-            if session_kind_event is None:
-                session_kind_event = event
-            continue
-        ordinary_events.append(event)
-
-    final_events = list(completion_events.values())
-    notifications = [
-        notification
-        for event in final_events
-        if (notification := _background_notification_from_event(event)) is not None
-    ]
-    messages = _project_background_task_completions(session.messages, notifications)
-
-    merged_coverage_events: list[ParsedSessionEvent] = []
-    if coverage_events:
-        merged_coverage_events.append(
-            coverage_events[0].model_copy(
-                update={
-                    "timestamp": session.updated_at,
-                    "payload": {
-                        "sidecar_seen": _merge_count_dicts(
-                            event.payload.get("sidecar_seen", {}) for event in coverage_events
-                        ),
-                        "sidecar_persisted": _merge_count_dicts(
-                            event.payload.get("sidecar_persisted", {}) for event in coverage_events
-                        ),
-                        "empty_dropped_by_record_type": _merge_count_dicts(
-                            event.payload.get("empty_dropped_by_record_type", {}) for event in coverage_events
-                        ),
-                    },
-                }
-            )
-        )
-
-    ordered_events = order_session_events(
-        [
-            *ordinary_events,
-            *final_events,
-            *delegation_events.values(),
-            *([session_kind_event] if session_kind_event is not None else []),
-            *merged_coverage_events,
-        ]
-    )
-    return session.model_copy(update={"messages": messages, "session_events": ordered_events})
-
-
-def parse_code_stream(
-    records: Iterable[object],
+def parse_code(
+    payload: Iterable[object],
     fallback_id: str,
     *,
-    record_index_start: int = 0,
-    seen_record_uuids: set[str] | None = None,
     tool_result_sidecars: SidecarJoinResult | None = None,
     trust_fallback_id: bool = False,
 ) -> ParsedSession:
-    session = _parse_code_records(
-        records,
-        fallback_id,
-        record_index_start=record_index_start,
-        seen_record_uuids=seen_record_uuids,
-        trust_fallback_id=trust_fallback_id,
-    )
+    """Parse one Claude Code session's whole record set in a single pass.
+
+    Works identically whether ``payload`` is a materialized list or a true
+    one-pass iterator (bd polylogue-taj0o Stage 2: mirrors
+    ``polylogue/sources/parsers/codex.py``'s ``parse``/``parse_stream`` --
+    both names below are the same function). Splitting a raw record stream
+    that mixes more than one logical session (interleaved ``sessionId``\\s)
+    is dispatch.py's ``_claude_code_multiway_parse``'s job, not this one's.
+    """
+    session = _parse_code_records(payload, fallback_id, trust_fallback_id=trust_fallback_id)
     if tool_result_sidecars is not None:
         session = apply_tool_result_sidecars(session, tool_result_sidecars)
     return session
+
+
+parse_code_stream = parse_code
 
 
 __all__ = [
@@ -2331,5 +2132,4 @@ __all__ = [
     "order_session_events",
     "parse_code",
     "parse_code_stream",
-    "reconcile_code_session_chunks",
 ]

--- a/polylogue/storage/sqlite/archive_tiers/index.py
+++ b/polylogue/storage/sqlite/archive_tiers/index.py
@@ -350,7 +350,31 @@ from polylogue.storage.sqlite.delegation_facts import delegation_facts_insert_sq
 # streaming) and that were originally ingested via the streaming path with
 # the old buggy order -- same v42/v44/v45/v46/v48/v58 "SEMANTIC_REPARSE, no
 # clone-safe SQL delta" shape.
-INDEX_SCHEMA_VERSION = 59
+# polylogue-taj0o Stage 2: unifies Claude Code eager and streaming parsing
+# into ONE incremental multi-way merge (dispatch.py's
+# `_claude_code_multiway_parse`, replacing the former
+# `_claude_code_grouped_record_specs` eager grouping and
+# `_claude_code_stream_sessions` streaming chunker, plus
+# `merge_parsed_session_chunks`'s Claude-Code branch and
+# `reconcile_code_session_chunks`, both deleted). Folds every record for one
+# session id into the SAME `_SessionAccumulator` across the whole record
+# stream, finalizing once at true end of input -- eliminates the
+# eager-vs-streaming duplication v59 already fixed the *ordering* symptom
+# of. Also resolves the "three-way duplication" identity-conflict finding
+# (bd polylogue-taj0o notes): the canonical "primary" group for a file
+# containing more than one interleaved Claude Code session is now ALWAYS
+# the group whose own sessionId equals the caller's fallback_id (streaming's
+# former rule), never eager's former max-by-record-count rule, which could
+# pick the wrong group as primary for a small main session sharing a file
+# with a much larger subagent transcript. `provider_session_id`/
+# `parent_session_id`/`branch_type` can change for any already-materialized
+# claude-code-session whose raw file both interleaves more than one session
+# AND has a non-fallback_id-matching group with the largest record count --
+# SEMANTIC_REPARSE, not a free fast-forward: no DDL change, only re-parsing
+# already-acquired raw evidence recovers the corrected identity split.
+# `polylogue ops reset --index && polylogued run` is required; deliberately
+# NOT executed by this declaration.
+INDEX_SCHEMA_VERSION = 60
 
 # polylogue-v6i3: shared WHEN-clause fragment gating the blocks_command_trigram
 # trigger BODIES on the same dedicated bulk-build guard row messages_fts's

--- a/polylogue/storage/sqlite/lifecycle.py
+++ b/polylogue/storage/sqlite/lifecycle.py
@@ -751,6 +751,18 @@ INDEX_DELTA_DECLARATIONS: tuple[IndexDeltaDeclaration, ...] = (
         # requires `polylogue ops reset --index && polylogued run`.
         classes=(DerivedDeltaClass.SEMANTIC_REPARSE,),
     ),
+    IndexDeltaDeclaration(
+        version=60,
+        # polylogue-taj0o Stage 2: Claude Code eager and streaming parsing
+        # are unified into one incremental multi-way merge -- see
+        # INDEX_SCHEMA_VERSION's v60 comment (archive_tiers/index.py) for
+        # the full writeup, root cause (the eager/streaming primary-group
+        # definition conflict), and scope. No DDL change on any table, so
+        # there is nothing here for a fast-forward to do. Resolving
+        # already-materialized sessions affected by the identity-definition
+        # change requires `polylogue ops reset --index && polylogued run`.
+        classes=(DerivedDeltaClass.SEMANTIC_REPARSE,),
+    ),
 )
 
 

--- a/tests/unit/pipeline/test_archive_ingest_shared_raw.py
+++ b/tests/unit/pipeline/test_archive_ingest_shared_raw.py
@@ -3,7 +3,7 @@
 A Claude Code resume/fork JSONL file physically carries over ONE boundary
 record from its parent session (same content, but tagged with the PARENT's
 ``sessionId``) before switching to its own session id for the rest of the
-file. `_claude_code_grouped_record_specs` (dispatch.py) correctly splits such
+file. `_claude_code_multiway_parse` (dispatch.py) correctly splits such
 a file into two `ParsedSession`s that share the identical captured raw bytes.
 
 Before this fix, `pipeline/services/archive_ingest.py`'s one-shot importer

--- a/tests/unit/sources/test_dispatch_payloads.py
+++ b/tests/unit/sources/test_dispatch_payloads.py
@@ -251,6 +251,67 @@ def test_parse_stream_payload_splits_claude_code_aggregate_by_session_id() -> No
     assert [len(session.messages) for session in sessions] == [2, 1]
 
 
+def test_claude_code_primary_identity_is_fallback_id_match_not_max_record_count() -> None:
+    """bd polylogue-taj0o: the canonical "primary group" definition is the
+    group whose own ``sessionId`` equals the caller's ``fallback_id`` --
+    NOT the group with the most records (the former eager-only rule,
+    ``_claude_code_grouped_record_specs``'s deleted ``max(groups, key=len)``).
+
+    This file interleaves ``session-a`` (1 record, matches ``fallback_id``)
+    positioned BEFORE ``session-b`` (5 records -- strictly more). Under the
+    deleted max-by-count rule, eager would have picked ``session-b`` as
+    primary purely by size, which would then classify ``session-a`` -- the
+    file's OWN true identity -- as a boundary carryover of ``session-b``
+    (occurring positionally before the eager-chosen primary's first
+    record): a garbled, self-referential ``"session-a:session-a"`` composed
+    id (since ``fallback_id`` here literally equals ``session-a``'s own raw
+    id) with ``parent_session_provider_id="session-a"`` pointing at itself.
+    That is exactly the "wrong group as primary" bug the bead's notes
+    describe for "a small main session with a huge subagent transcript in
+    the same file".
+
+    The canonical fallback_id-match rule instead always recognizes
+    ``session-a`` as primary regardless of its record count or position,
+    and ``session-b`` -- with no ``parentUuid`` evidence chaining it to
+    ``session-a`` -- stays a genuinely independent session under its own
+    bare id.
+    """
+    payload: list[dict[str, object]] = [
+        {
+            "type": "user",
+            "sessionId": "session-a",
+            "uuid": "a-1",
+            "message": {"role": "user", "content": "the file's own real content"},
+        },
+    ]
+    for index in range(5):
+        payload.append(
+            {
+                "type": "user",
+                "sessionId": "session-b",
+                "uuid": f"b-{index}",
+                "message": {"role": "user", "content": f"unrelated session-b turn {index}"},
+            }
+        )
+
+    eager = parse_payload(Provider.CLAUDE_CODE, payload, "session-a")
+    streamed = parse_stream_payload(Provider.CLAUDE_CODE, iter(payload), "session-a")
+
+    for sessions, label in ((eager, "eager"), (streamed, "streamed")):
+        session_a = next(session for session in sessions if "session-a" in session.provider_session_id)
+        session_b = next(session for session in sessions if "session-b" in session.provider_session_id)
+        assert session_a.provider_session_id == "session-a", label
+        assert session_a.parent_session_provider_id is None, label
+        assert session_b.provider_session_id == "session-b", label
+        assert session_b.parent_session_provider_id is None, label
+        assert len(session_a.messages) == 1, label
+        assert len(session_b.messages) == 5, label
+
+    assert [session.model_dump(mode="json") for session in eager] == [
+        session.model_dump(mode="json") for session in streamed
+    ]
+
+
 _SIDECAR_NEEDLE = "zz_only_in_acquired_sidecar_body"
 
 
@@ -324,15 +385,16 @@ def test_parse_payload_without_source_path_skips_sidecar_join(tmp_path: Path) ->
 def test_parse_stream_payload_wires_claude_code_tool_result_sidecars(tmp_path: Path) -> None:
     """polylogue-wjgf: the streaming path must reach the same coverage as the batch path.
 
-    Production path: dispatch._claude_code_stream_sessions's ``parse_group``
-    closure, which tees each group's records through
+    Production path: dispatch._claude_code_multiway_parse's ``fold_into``
+    closure, which tees each record through
     ``ToolResultIndexAccumulator``/``observe_tool_result_stream`` (since the
-    streaming path never materializes the raw payload) and applies
-    ``apply_tool_result_sidecars`` after the group iterator is exhausted.
-    Mutation that breaks this: making ``parse_group`` always take the
-    ``tool_results_dir is None`` branch (i.e. skip sidecars for the stream
-    path) makes coverage depend on file size -- this test would then fail
-    because the block keeps its truncated preview text.
+    streaming path never materializes the raw payload) into a per-accumulator
+    (per session id) sidecar index, joined via ``apply_tool_result_sidecars``
+    once the whole stream is exhausted. Mutation that breaks this: making
+    the function always take the ``tool_results_dir is None`` branch (i.e.
+    skip sidecars for the stream path) makes coverage depend on file size --
+    this test would then fail because the block keeps its truncated preview
+    text.
     """
     session_path = tmp_path / "sess-sidecar.jsonl"
     session_path.write_text("", encoding="utf-8")
@@ -359,7 +421,7 @@ def test_parse_stream_payload_subagent_source_path_resolves_session_level_tool_r
 
     Production path: ``resolve_tool_results_dir`` in
     ``sources/live/tool_result_sidecars.py``, called from
-    ``dispatch._claude_code_stream_sessions``. Mutation that breaks this:
+    ``dispatch._claude_code_multiway_parse``. Mutation that breaks this:
     deriving the tool-results dir as a sibling of the subagent file itself
     (``.../subagents/tool-results/``, which Claude Code never creates) instead
     of walking up to the session directory -- this test would then find no

--- a/tests/unit/sources/test_source_laws.py
+++ b/tests/unit/sources/test_source_laws.py
@@ -6,7 +6,7 @@ import json
 import os
 import tempfile
 import zipfile
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Iterator, Mapping
 from decimal import Decimal
 from io import BytesIO
 from pathlib import Path
@@ -1498,32 +1498,33 @@ def test_session_emitter_reuses_jsonl_sniff_payloads_for_grouped_detection(
     assert len(emitted[0][1].messages) == 2
 
 
-def test_claude_code_stream_payload_does_not_materialize_whole_stream(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    def fail_eager_parse(_payload: object, _fallback_id: str) -> ParsedSession:
-        raise AssertionError("stream parse should not use eager Claude Code parsing")
+class _OneShotIterator:
+    """Wraps an iterable exposing ONLY ``__iter__``/``__next__`` -- no
+    ``__len__``, ``__getitem__``, or ``__reversed__``. Any code that tries to
+    treat this as a ``Sequence`` (random access, a count up front, more than
+    one full pass) raises ``TypeError``/``StopIteration`` immediately, which
+    is what makes this a mechanical proof of "consumed via plain iteration
+    only" rather than the weaker "happened not to be a ``list``".
+    """
 
-    seen_record_counts: list[int] = []
+    def __init__(self, items: Iterable[object]) -> None:
+        self._iterator = iter(items)
 
-    def fake_stream_parse(
-        records: Iterable[object],
-        fallback_id: str,
-        **_kwargs: object,
-    ) -> ParsedSession:
-        assert not isinstance(records, list)
-        seen_record_counts.append(sum(1 for _record in records))
-        return ParsedSession(
-            source_name=Provider.CLAUDE_CODE,
-            provider_session_id=fallback_id,
-            title=fallback_id,
-            messages=[],
-        )
+    def __iter__(self) -> Iterator[object]:
+        return self
 
-    monkeypatch.setattr(claude_parser, "parse_code", fail_eager_parse)
-    monkeypatch.setattr(claude_parser, "parse_code_stream", fake_stream_parse)
+    def __next__(self) -> object:
+        return next(self._iterator)
 
-    records = (
+
+def test_claude_code_stream_payload_does_not_materialize_whole_stream() -> None:
+    """bd polylogue-taj0o Stage 2: the streaming path (multi-GiB raw JSONL
+    ingest) must consume its record stream via plain iteration only, never
+    requiring random access or a full materialization up front --
+    ``_OneShotIterator`` mechanically enforces this (see its docstring)
+    rather than relying on "the input object happens not to be a list".
+    """
+    records = _OneShotIterator(
         {"type": "user", "sessionId": "session-1", "uuid": f"u-{index}", "message": {"role": "user", "content": "x"}}
         for index in range(3)
     )
@@ -1536,35 +1537,24 @@ def test_claude_code_stream_payload_does_not_materialize_whole_stream(
     sessions = parse_stream_payload(Provider.CLAUDE_CODE, records, "session-1")
 
     assert [session.provider_session_id for session in sessions] == ["session-1"]
-    assert seen_record_counts == [3]
+    assert len(sessions[0].messages) == 3
 
 
-def test_claude_code_stream_payload_splits_contiguous_session_groups(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    parsed_groups: list[tuple[str, list[str]]] = []
-
-    def fake_stream_parse(
-        records: Iterable[object],
-        fallback_id: str,
-        **_kwargs: object,
-    ) -> ParsedSession:
-        session_ids = [
-            str(record.get("sessionId"))
-            for record in records
-            if isinstance(record, dict) and record.get("sessionId") is not None
-        ]
-        parsed_groups.append((fallback_id, session_ids))
-        return ParsedSession(
-            source_name=Provider.CLAUDE_CODE,
-            provider_session_id=fallback_id,
-            title=fallback_id,
-            messages=[],
-        )
-
-    monkeypatch.setattr(claude_parser, "parse_code_stream", fake_stream_parse)
-
-    records: Iterable[object] = iter(
+def test_claude_code_stream_payload_splits_contiguous_session_groups() -> None:
+    """bd polylogue-taj0o Stage 2: a prior version of this test monkeypatched
+    ``claude_parser.parse_code_stream`` per contiguous run -- an
+    implementation detail of the deleted chunk-then-merge streaming
+    architecture (``_claude_code_stream_sessions``). The unified
+    ``_claude_code_multiway_parse`` folds records directly into one
+    accumulator per session id instead of calling ``parse_code_stream`` per
+    group, so this now asserts the real, observable production behavior
+    through ``parse_stream_payload`` alone: a one-shot iterator (proving no
+    materialization -- see ``_OneShotIterator``) that mixes a leading
+    id-less prefix record, a two-record ``session-1`` run, and a trailing
+    ``session-2`` record still splits into two correctly-identified,
+    correctly-populated sessions.
+    """
+    records = _OneShotIterator(
         [
             {"type": "summary", "uuid": "prefix", "message": {"role": "system", "content": "prefix"}},
             {"type": "user", "sessionId": "session-1", "uuid": "u-1", "message": {"role": "user", "content": "one"}},
@@ -1578,18 +1568,16 @@ def test_claude_code_stream_payload_splits_contiguous_session_groups(
         ]
     )
 
-    # bd polylogue-jc4q: fallback_id matches the LARGER group's own real
-    # content id (the production shape), so it is recognized as this file's
-    # primary content; "session-2" has no parentUuid evidence connecting it
-    # to the primary and keeps its own bare id as a genuinely independent
-    # session.
+    # bd polylogue-jc4q: fallback_id matches session-1's own real content id
+    # (the production shape), so it is recognized as this file's primary
+    # content; "session-2" has no parentUuid evidence connecting it to the
+    # primary and keeps its own bare id as a genuinely independent session.
     sessions = parse_stream_payload(Provider.CLAUDE_CODE, records, "session-1")
 
     assert [session.provider_session_id for session in sessions] == ["session-1", "session-2"]
-    assert parsed_groups == [
-        ("session-1", ["session-1", "session-1"]),
-        ("session-2", ["session-2"]),
-    ]
+    # session-1: the id-less prefix ("summary" -> a SUMMARY message) plus its
+    # own two records; session-2: its own one record.
+    assert [len(session.messages) for session in sessions] == [3, 1]
 
 
 def test_claude_code_stream_chunk_merge_preserves_git_branch_from_either_chunk() -> None:


### PR DESCRIPTION
## Summary

Replaces two duplicated Claude Code JSONL parsing paths in `dispatch.py` (eager grouping and streaming's contiguous-run chunker, plus the post-hoc chunk merge/reconcile the streaming path needed) with one function, `_claude_code_multiway_parse`, that walks a record stream exactly once and folds each record into a per-session-id `_SessionAccumulator`, finalizing once per session at true end of input.

## Problem

`dispatch.py` parsed Claude Code JSONL two different ways. Eager (`_claude_code_grouped_record_specs`) materialized the whole payload, grouped records by `sessionId`, and parsed each group independently. Streaming (`_claude_code_stream_sessions`) chunked contiguous `sessionId` runs, parsed each chunk with the same per-session parser, then glued chunks back together (`merge_parsed_session_chunks`) and re-folded per-chunk summary `session_events` (`reconcile_code_session_chunks`) to approximate what eager would have produced. Every time a new session-wide summary event type was added to the eager parser's main loop, `reconcile` had to be remembered and updated too, or eager and streaming would silently diverge for that event type — PR #3669 fixed three known cases this way, tactically, not structurally.

Auditing the two grouping algorithms also found they used genuinely different "primary group" definitions: eager picked the group with the most records, streaming picked the group whose own `sessionId` matched the caller's `fallback_id`. These are provably not equivalent (a file where the fallback_id-matching session has fewer records than another interleaved session resolves differently under each) — no live archive case was found actually diverging on it yet, but the divergence is real by inspection (bd polylogue-taj0o notes).

## Solution

- One function, `_claude_code_multiway_parse` (`polylogue/sources/dispatch.py`), works identically whether its input is a materialized list (eager) or a true one-pass iterator (streaming). Since every record for one session id now folds into the SAME accumulator no matter how many times its sessionId reappears in the file, `_finalize_code_session`'s post-loop summary logic (background completions, delegation progress, coverage, session_kind) runs exactly once per session, seeing the whole session — there is nothing left to reconcile. This is a direct generalization of the per-session accumulator Stage 1 (#3680) already extracted into `_fold_code_record`/`_finalize_code_session`.
- Canonical primary-group definition: the group whose own `sessionId` equals `fallback_id` (streaming's former rule), not eager's former max-by-record-count rule. This is the only one of the two a genuine single forward pass can decide without full materialization, and it is the mechanically safer rule — a new test constructs a file where a non-fallback-id session has more records than the fallback-id-matching session and shows the old max-by-count rule would have misclassified the file's own true identity as a self-referential carryover fragment of the larger, unrelated session.
- Groups whose identity can't be decided at first encounter (their own sessionId differs from `fallback_id` and the primary group hasn't started yet) are resolved once the whole stream is known: a carryover fragment of the primary if the primary group appeared anywhere in the file, otherwise a genuinely independent session.
- Deleted: `_claude_code_grouped_record_specs`, `_claude_code_stream_sessions`, `reconcile_code_session_chunks`, and `merge_parsed_session_chunks`'s Claude-Code-specific branch. `merge_parsed_session_chunks` itself stays — it is a generic multi-provider merge utility with its own direct test coverage (title-evidence-ranking tests in `test_source_laws.py`) and a revision-replay test call site (CODEX), neither of which reference Claude Code chunking.
- `parse_code`/`parse_code_stream` in `code_parser.py` collapse to the same function (`parse_code_stream = parse_code`), mirroring `codex.py`'s `parse`/`parse_stream = _parse_records` pattern. Their `record_index_start`/`seen_record_uuids` cross-chunk continuation parameters are removed as dead, since there is no more chunking to continue across.
- Tool-result sidecar joins now build one `ToolResultIndexAccumulator` per session id (observing every record folded into that session) instead of per contiguous run, closing a former under-join gap for a streaming session split across more than one run.
- `INDEX_SCHEMA_VERSION` bumped 59→60 (`SEMANTIC_REPARSE`, no DDL delta): `provider_session_id`/`parent_session_id`/`branch_type` can change for an already-materialized `claude-code-session` whose raw file both interleaves more than one session AND has a non-fallback_id-matching group with the largest record count. `polylogue ops reset --index && polylogued run` is required to apply the corrected identity split; deliberately not run by this change.

Two tests in `test_source_laws.py` monkeypatched `claude_parser.parse_code_stream` per contiguous run — an implementation detail of the deleted chunk-then-merge architecture. Rewritten against production `parse_stream_payload` output directly, using a new `_OneShotIterator` helper (exposes only `__iter__`/`__next__`) to keep the "streaming never materializes the whole stream" property mechanically enforced.

## Not in scope

- An actual bounded-memory "flush on explicit signal" mode for extremely long-lived files — the design doc's acknowledged first-cut deferral; current per-run memory stays proportional to unique record identifiers, the same bound the deleted streaming chunker already documented.
- A live-archive parity spot check comparing old-vs-new content_hash on real sessions — no read-only comparison harness from this session was reusable for a deleted-code-path comparison; the schema-version bump + declared `SEMANTIC_REPARSE` class is this repo's mechanism for making that divergence an explicit, auditable, opt-in `polylogue ops reset --index` event instead of a silent one.

## Verification

```
devtools test tests/unit/sources/test_dispatch_payloads.py tests/unit/sources/test_source_laws.py \
  tests/unit/sources/test_claude_code_normalization_laws.py tests/unit/sources/test_claude_code_sidecar_evidence.py \
  tests/unit/sources/test_claude_code_unread_wire_fields.py tests/unit/sources/test_parsers_claude_code_artifacts.py \
  tests/unit/pipeline/test_delegation_provider_fixtures.py tests/unit/pipeline/test_ingest_batch.py \
  tests/unit/sources/test_tool_result_sidecars.py tests/unit/sources/test_compaction.py \
  tests/unit/sources/test_provider_contracts.py tests/unit/storage/test_revision_replay.py \
  tests/unit/pipeline/test_archive_ingest_shared_raw.py tests/unit/storage/test_index_fast_forward_lifecycle.py \
  tests/unit/storage/test_index_fast_forward_executor.py tests/unit/sources/test_origin_specs.py
# -> 471 passed
```

```
mypy --strict polylogue/sources/dispatch.py polylogue/sources/parsers/claude/code_parser.py \
  polylogue/sources/parsers/claude/__init__.py polylogue/storage/sqlite/archive_tiers/index.py \
  polylogue/storage/sqlite/lifecycle.py
# -> Success: no issues found in 5 source files
```

```
devtools verify --quick
# -> exit_code 0 (format, lint, mypy, render all, layering, closure-matrix,
#    schema roundtrip/versioning/promotion, demo-tour-freshness, and the
#    other lab policy gates all green)
```

Ref polylogue-taj0o, polylogue-4987i