### PR TITLE
fix(devtools): register raw-append-chain-backfill-apply command

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -1040,6 +1040,30 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
+        "workspace raw-append-chain-backfill-apply",
+        "workspace",
+        "Promote membershipless append raws proven correct by live-source verification.",
+        "devtools.raw_append_chain_backfill_apply",
+        use_when=(
+            "polylogue-lb39z (Phase 1, item 3): 2,712 raw_sessions rows (measured 2026-08-02) are "
+            "revision_kind='append', revision_authority='quarantined', and have no "
+            "raw_session_memberships row at all -- a genuine fixed point, because the only mechanism "
+            "that ever promotes an append raw (_promote_contiguous_append_evidence) requires its "
+            "byte-contiguous predecessor to already be byte_proven. This proves each such row's own "
+            "claimed byte range directly against its live source file's current bytes, independent of "
+            "any ancestor's authority. Default is dry-run; --apply requires --backup-manifest pointing "
+            "at a verified source-tier backup (polylogue backup --output-dir <dir> --verify). Writes an "
+            "immutable per-row receipt (raw_append_chain_backfill_receipts); never runs blob GC or "
+            "VACUUM -- that is a separate, later step."
+        ),
+        examples=(
+            "devtools workspace raw-append-chain-backfill-apply",
+            "devtools workspace raw-append-chain-backfill-apply --json",
+            "devtools workspace raw-append-chain-backfill-apply --apply "
+            "--backup-manifest /realm/staging/polylogue-backup/manifest.json",
+        ),
+    ),
+    CommandSpec(
         "workspace raw-byte-duplicate-supersession-apply",
         "workspace",
         "Promote quarantined, logical-key-less raws proven byte-identical to an already-indexed raw.",

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -245,6 +245,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools workspace merge` | Merge boundary wrapper: refuses `gh pr merge` without a fresh merge-gate receipt. |
 | `devtools workspace merge-conductor` | Mechanical-conflict triage for the PR merge train (dry-run by default). |
 | `devtools workspace merge-gate` | Structural pre-merge safety check: fresh local-verification receipt + no late review comments. |
+| `devtools workspace raw-append-chain-backfill-apply` | Promote membershipless append raws proven correct by live-source verification. |
 | `devtools workspace raw-authority-daemon-health-proof` | Prove daemon status/health HTTP responsiveness during a real raw-authority drain. |
 | `devtools workspace raw-authority-restart-proof` | Prove raw-authority crash recovery and conserved fixed-point convergence. |
 | `devtools workspace raw-authority-scale-proof` | Run bounded raw-authority replay to a two-census fixed point. |


### PR DESCRIPTION
## Summary
Wires the existing `devtools/raw_append_chain_backfill_apply.py` actuator into `command_catalog.py` so `devtools workspace raw-append-chain-backfill-apply` actually exists as a runnable command.

## Problem
The actuator module worked standalone (has its own `main()`/argparse) but was never registered, so the command referenced by `polylogue-lb39z`'s own notes (item 3 of the Phase 1 quarantine drain) did not exist. Found this while about to actually run the drain.

## Solution
Added a `CommandSpec` entry mirroring the two sibling actuators already registered (`raw-membership-writeback-apply`, `raw-byte-duplicate-supersession-apply`) — same dry-run-default / `--apply` + `--backup-manifest`-required shape. Regenerated `docs/devtools.md`.

## Verification
`devtools verify --quick` — exit 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `workspace raw-append-chain-backfill-apply` command.
  * Supports previewing changes with dry-run mode and applying verified backfills.
  * Requires a verified backup manifest before applying changes.
  * Records immutable receipts for each processed record.
* **Documentation**
  * Added the new command to the workspace command catalog documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->