### PR TITLE
feat(operations): add durable mutation authority foundation

### DIFF
--- a/polylogue/cli/commands/maintenance/_backup_plan.py
+++ b/polylogue/cli/commands/maintenance/_backup_plan.py
@@ -94,6 +94,11 @@ def _backup_plan_payload(root: Path) -> dict[str, Any]:
             "policy": "diagnostics_only",
             "restore_role": "daemon cursors, convergence debt, and runtime telemetry",
         },
+        ArchiveTier.AUDIT: {
+            "backup_class": "critical_authority",
+            "policy": "always_back_up",
+            "restore_role": "mutation previews, authorizations, runs, attempts, and events",
+        },
     }
 
     tier_payloads = []

--- a/polylogue/daemon/backup.py
+++ b/polylogue/daemon/backup.py
@@ -1,9 +1,9 @@
 """Backup and portability operations for the Polylogue archive.
 
 Provides a local-first backup command for tiered archives.
-Backups copy only the precious tiers plus referenced blobs: source.db, user.db,
-embeddings.db, and blob files. Rebuildable index.db and disposable ops.db are
-omitted by design.
+Backups copy the authority and precious tiers plus referenced blobs: audit.db,
+source.db, user.db, embeddings.db, and blob files. Rebuildable index.db and
+disposable ops.db are omitted by profiles that do not request full evidence.
 
 Each SQLite tier is checkpointed and copied while its write lock is held, so
 the copied bytes and recorded source fingerprint describe the same state.
@@ -200,6 +200,7 @@ def _all_archive_tiers(root: Path) -> dict[str, Path]:
         "embeddings": root / "embeddings.db",
         "user": root / "user.db",
         "ops": root / "ops.db",
+        "audit": root / "audit.db",
     }
 
 
@@ -208,21 +209,26 @@ def _profile_archive_tiers(root: Path, profile: BackupProfile) -> dict[str, Path
     if profile == "full_evidence":
         return all_tiers
     if profile == "user_overlays":
-        return {"user": all_tiers["user"]}
+        return {"user": all_tiers["user"], "audit": all_tiers["audit"]}
     if profile == "diagnostics_bundle":
         return {"ops": all_tiers["ops"]}
     return {
         "source": all_tiers["source"],
         "user": all_tiers["user"],
         "embeddings": all_tiers["embeddings"],
+        "audit": all_tiers["audit"],
     }
 
 
 def _optional_profile_tiers(profile: BackupProfile) -> set[str]:
     if profile == "full_evidence":
-        return {"ops"}
+        return {"ops", "audit"}
     if profile == "rebuildable_cache_exclude":
-        return {"embeddings"}
+        return {"embeddings", "audit"}
+    if profile == "user_overlays":
+        return {"audit"}
+    if profile == "diagnostics_bundle":
+        return {"audit"}
     return set()
 
 

--- a/polylogue/operations/audit.py
+++ b/polylogue/operations/audit.py
@@ -167,7 +167,7 @@ class AuditRepository:
         if authorization.token is None:
             raise ValueError("bound authorization requires a token")
         authorization_id = f"authorization:{secrets.token_urlsafe(18)}"
-        issued_at_ms = authorization.expires_at_ms - 60_000 if authorization.expires_at_ms is not None else 0
+        issued_at_ms = int(time.time() * 1000)
         with self._connection() as conn:
             conn.execute("BEGIN IMMEDIATE")
             preview_row = conn.execute(

--- a/polylogue/operations/audit.py
+++ b/polylogue/operations/audit.py
@@ -1,0 +1,551 @@
+"""Durable audit.db repository for mutation authority and lifecycle evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import secrets
+import sqlite3
+import time
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Literal
+
+from polylogue.operations.mutation_transaction import (
+    MutationAuthorization,
+    MutationPlan,
+    MutationPreview,
+    MutationPrincipal,
+    MutationReceipt,
+)
+from polylogue.storage.sqlite.archive_tiers.audit import AUDIT_DDL, AUDIT_SCHEMA_VERSION
+
+AuditTargetState = Literal[
+    "pending",
+    "running",
+    "applied",
+    "already_satisfied",
+    "rejected",
+    "failed",
+    "unknown",
+    "acknowledged",
+    "cancelled",
+]
+
+
+def token_sha256(token: str) -> str:
+    """Return the only representation of a bearer token accepted for storage."""
+
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+class AuditRepository:
+    """Small synchronous repository whose methods make audit transactions explicit."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    @contextmanager
+    def _connection(self) -> Iterator[sqlite3.Connection]:
+        conn = sqlite3.connect(self.path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.executescript(AUDIT_DDL)
+        conn.execute(f"PRAGMA user_version = {AUDIT_SCHEMA_VERSION}")
+        conn.commit()
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    def ensure_archive_authority(self, *, now_ms: int, archive_instance_id: str | None = None) -> str:
+        """Create or return the immutable archive lineage id."""
+
+        with self._connection() as conn:
+            row = conn.execute("SELECT archive_instance_id FROM archive_authority LIMIT 1").fetchone()
+            if row is not None:
+                existing = str(row[0])
+                if archive_instance_id is not None and archive_instance_id != existing:
+                    raise ValueError("audit archive instance identity changed")
+                return existing
+            instance_id = archive_instance_id or f"archive:{secrets.token_hex(16)}"
+            conn.execute(
+                "INSERT INTO archive_authority(archive_instance_id, created_at_ms, authority_format) VALUES (?, ?, 1)",
+                (instance_id, now_ms),
+            )
+            conn.commit()
+            return instance_id
+
+    def create_preview(self, plan: MutationPlan, principal: MutationPrincipal) -> str:
+        """Persist a bounded preview and its normalized target/capability rows."""
+
+        preview_id = f"preview:{secrets.token_urlsafe(18)}"
+        with self._connection() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                """
+                INSERT INTO operation_previews (
+                    preview_id, operation_name, operation_version, archive_instance_id,
+                    archive_identity_digest, plan_hash, parameter_digest, target_digest,
+                    target_count, destructive_class, required_confirmation,
+                    required_capability_count, principal_actor_ref, principal_surface,
+                    role_label, state, created_at_ms, expires_at_ms, plan_format, plan_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'prepared', ?, ?,
+                          'polylogue.mutation-plan/v1', ?)
+                """,
+                (
+                    preview_id,
+                    plan.operation,
+                    plan.operation_version,
+                    plan.archive_instance_id,
+                    plan.archive_identity_digest,
+                    plan.plan_hash,
+                    plan.parameter_digest,
+                    plan.target_digest or plan.plan_hash,
+                    plan.target_count,
+                    plan.destructive_class,
+                    plan.required_confirmation,
+                    len(plan.required_capabilities),
+                    principal.actor_ref,
+                    principal.surface,
+                    principal.role_label,
+                    plan.prepared_at_ms,
+                    plan.expires_at_ms,
+                    json.dumps(
+                        {
+                            "operation": plan.operation,
+                            "operation_version": plan.operation_version,
+                            "archive_instance_id": plan.archive_instance_id,
+                            "archive_identity_digest": plan.archive_identity_digest,
+                            "parameter_digest": plan.parameter_digest,
+                            "target_digest": plan.target_digest,
+                            "target_refs": list(plan.target_refs),
+                            "affected_tiers": list(plan.affected_tiers),
+                        },
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ),
+                ),
+            )
+            for ordinal, target in enumerate(plan.targets):
+                conn.execute(
+                    """
+                    INSERT INTO operation_preview_targets(
+                        preview_id, ordinal, target_kind, target_ref, identity_digest,
+                        effect_identity, durability, recovery_policy
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        preview_id,
+                        ordinal,
+                        target.kind,
+                        target.ref,
+                        target.identity_digest,
+                        target.effect_identity,
+                        target.durability,
+                        target.recovery,
+                    ),
+                )
+            for capability in plan.required_capabilities:
+                conn.execute(
+                    "INSERT INTO operation_preview_capabilities(preview_id, capability) VALUES (?, ?)",
+                    (preview_id, capability),
+                )
+            conn.commit()
+        return preview_id
+
+    def issue_authorization(
+        self,
+        preview: MutationPreview,
+        principal: MutationPrincipal,
+        authorization: MutationAuthorization,
+    ) -> str:
+        """Persist token digest and exact proved capabilities, never token material."""
+
+        if authorization.token is None:
+            raise ValueError("bound authorization requires a token")
+        authorization_id = f"authorization:{secrets.token_urlsafe(18)}"
+        issued_at_ms = authorization.expires_at_ms - 60_000 if authorization.expires_at_ms is not None else 0
+        with self._connection() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            preview_row = conn.execute(
+                "SELECT plan_hash, expires_at_ms, state, principal_actor_ref FROM operation_previews WHERE preview_id = ?",
+                (preview.preview_ref,),
+            ).fetchone()
+            if preview_row is None:
+                raise ValueError(f"unknown preview {preview.preview_ref!r}")
+            if str(preview_row[0]) != preview.plan.plan_hash:
+                raise ValueError("preview plan hash does not match its durable row")
+            if str(preview_row[2]) != "prepared":
+                raise ValueError("preview is not authorizable")
+            if principal.actor_ref != str(preview_row[3]):
+                raise ValueError("authorization principal differs from preview principal")
+            conn.execute(
+                """
+                INSERT INTO operation_authorizations(
+                    authorization_id, preview_id, actor_ref, surface, role_label,
+                    confirmation_strength, token_sha256, state, issued_at_ms,
+                    expires_at_ms, consumed_at_ms
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, NULL)
+                """,
+                (
+                    authorization_id,
+                    preview.preview_ref,
+                    principal.actor_ref,
+                    principal.surface,
+                    principal.role_label,
+                    authorization.confirmation_strength,
+                    token_sha256(authorization.token),
+                    issued_at_ms,
+                    authorization.expires_at_ms or issued_at_ms,
+                ),
+            )
+            for capability in authorization.capabilities:
+                conn.execute(
+                    "INSERT INTO operation_authorization_capabilities(authorization_id, capability) VALUES (?, ?)",
+                    (authorization_id, capability),
+                )
+            conn.commit()
+        return authorization_id
+
+    def consume_authorization_and_start(self, preview: MutationPreview, authorization: MutationAuthorization) -> str:
+        """Consume a token and create run, targets, and initial attempt atomically."""
+
+        if authorization.token is None:
+            raise ValueError("authorization token is missing")
+        operation_id = f"operation:{secrets.token_urlsafe(18)}"
+        attempt_id = f"attempt:{secrets.token_urlsafe(18)}"
+        now_ms = int(time.time() * 1000)
+        with self._connection() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                """
+                SELECT a.authorization_id, a.preview_id, a.actor_ref, a.surface,
+                       a.state, a.expires_at_ms, p.plan_hash
+                FROM operation_authorizations AS a
+                JOIN operation_previews AS p ON p.preview_id = a.preview_id
+                WHERE a.token_sha256 = ?
+                """,
+                (token_sha256(authorization.token),),
+            ).fetchone()
+            if row is None or str(row[1]) != preview.preview_ref:
+                raise ValueError("authorization token does not match preview")
+            if str(row[4]) != "active":
+                raise RuntimeError("authorization token is already consumed or revoked")
+            if int(row[5]) <= now_ms:
+                conn.execute(
+                    "UPDATE operation_authorizations SET state = 'expired' WHERE authorization_id = ?",
+                    (str(row[0]),),
+                )
+                conn.commit()
+                raise RuntimeError("authorization token is expired")
+            if str(row[2]) != authorization.actor or str(row[3]) != (authorization.surface or ""):
+                raise ValueError("authorization principal mismatch")
+            if str(row[6]) != preview.plan.plan_hash or authorization.plan_hash != preview.plan.plan_hash:
+                raise ValueError("authorization plan mismatch")
+            conn.execute(
+                "UPDATE operation_authorizations SET state = 'consumed', consumed_at_ms = ? WHERE authorization_id = ?",
+                (now_ms, str(row[0])),
+            )
+            conn.execute(
+                "UPDATE operation_previews SET state = 'consumed' WHERE preview_id = ?",
+                (preview.preview_ref,),
+            )
+            conn.execute(
+                """
+                INSERT INTO operation_runs(
+                    operation_id, preview_id, initial_authorization_id,
+                    operation_name, operation_version, archive_instance_id,
+                    archive_identity_digest, plan_hash, parameter_digest,
+                    target_digest, target_count, actor_ref, surface, role_label,
+                    status, requested_at_ms, started_at_ms, updated_at_ms
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'running', ?, ?, ?)
+                """,
+                (
+                    operation_id,
+                    preview.preview_ref,
+                    str(row[0]),
+                    preview.plan.operation,
+                    preview.plan.operation_version,
+                    preview.plan.archive_instance_id,
+                    preview.plan.archive_identity_digest,
+                    preview.plan.plan_hash,
+                    preview.plan.parameter_digest,
+                    preview.plan.target_digest or preview.plan.plan_hash,
+                    preview.plan.target_count,
+                    authorization.actor,
+                    authorization.surface,
+                    authorization.role,
+                    now_ms,
+                    now_ms,
+                    now_ms,
+                ),
+            )
+            for capability in authorization.capabilities:
+                conn.execute(
+                    "INSERT INTO operation_run_capabilities(operation_id, capability) VALUES (?, ?)",
+                    (operation_id, capability),
+                )
+            for ordinal, target in enumerate(preview.plan.targets):
+                conn.execute(
+                    """
+                    INSERT INTO operation_targets(
+                        operation_id, ordinal, target_kind, target_ref, identity_digest,
+                        effect_identity, state, attempt_count
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, 1)
+                    """,
+                    (
+                        operation_id,
+                        ordinal,
+                        target.kind,
+                        target.ref,
+                        target.identity_digest,
+                        target.effect_identity,
+                        "running" if ordinal == 0 else "pending",
+                    ),
+                )
+            conn.execute(
+                """
+                INSERT INTO operation_attempts(
+                    attempt_id, operation_id, target_ordinal, authorization_id,
+                    state, started_at_ms
+                ) VALUES (?, ?, ?, ?, 'running', ?)
+                """,
+                (attempt_id, operation_id, 0 if preview.plan.targets else None, str(row[0]), now_ms),
+            )
+            self._append_event(
+                conn,
+                operation_id=operation_id,
+                event_type="authorization_consumed",
+                to_state="running",
+                actor_ref=authorization.actor,
+                occurred_at_ms=now_ms,
+                detail={"target_count": preview.plan.target_count},
+            )
+            conn.commit()
+        return operation_id
+
+    def finalize_attempt(
+        self,
+        operation_id: str,
+        *,
+        status: str,
+        receipt: MutationReceipt | None = None,
+        error_summary: str | None = None,
+        unknown_reason: str | None = None,
+    ) -> None:
+        """Finalize one running attempt and parent run in one audit transaction."""
+
+        now_ms = int(time.time() * 1000)
+        target_state: AuditTargetState = (
+            "unknown" if status == "unknown" else "failed" if status == "failed" else "applied"
+        )
+        attempt_state = "unknown" if target_state == "unknown" else target_state
+        with self._connection() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            run = conn.execute(
+                "SELECT actor_ref FROM operation_runs WHERE operation_id = ?", (operation_id,)
+            ).fetchone()
+            if run is None:
+                raise ValueError(f"unknown operation {operation_id!r}")
+            target = conn.execute(
+                "SELECT ordinal FROM operation_targets WHERE operation_id = ? AND state = 'running' ORDER BY ordinal LIMIT 1",
+                (operation_id,),
+            ).fetchone()
+            ordinal = int(target[0]) if target is not None else None
+            conn.execute(
+                """
+                UPDATE operation_attempts
+                SET state = ?, finished_at_ms = ?, error_summary = ?, unknown_reason = ?
+                WHERE operation_id = ? AND state = 'running'
+                """,
+                (attempt_state, now_ms, error_summary, unknown_reason, operation_id),
+            )
+            if ordinal is not None:
+                conn.execute(
+                    """
+                    UPDATE operation_targets
+                    SET state = ?, completed_at_ms = ?, error_summary = ?, unknown_reason = ?,
+                        domain_receipt_ref = ?, domain_receipt_kind = ?
+                    WHERE operation_id = ? AND ordinal = ?
+                    """,
+                    (
+                        target_state,
+                        now_ms,
+                        error_summary,
+                        unknown_reason,
+                        None if receipt is None else receipt.receipt_ref,
+                        None if receipt is None else "mutation-receipt",
+                        operation_id,
+                        ordinal,
+                    ),
+                )
+            states = [
+                str(row[0])
+                for row in conn.execute("SELECT state FROM operation_targets WHERE operation_id = ?", (operation_id,))
+            ]
+            if "unknown" in states:
+                run_status, terminal_reason = "interrupted", "unknown_effect"
+            elif "failed" in states:
+                run_status, terminal_reason = "failed", "domain_failure"
+            elif states and all(state in {"applied", "already_satisfied"} for state in states):
+                run_status, terminal_reason = "completed", None
+            else:
+                run_status, terminal_reason = "running", None
+            conn.execute(
+                """
+                UPDATE operation_runs
+                SET status = ?, terminal_reason = ?, updated_at_ms = ?,
+                    completed_at_ms = CASE WHEN ? IN ('completed', 'failed', 'interrupted') THEN ? ELSE completed_at_ms END,
+                    failed_count = (SELECT COUNT(*) FROM operation_targets WHERE operation_id = ? AND state = 'failed'),
+                    unknown_count = (SELECT COUNT(*) FROM operation_targets WHERE operation_id = ? AND state = 'unknown'),
+                    affected_count = (SELECT COUNT(*) FROM operation_targets WHERE operation_id = ? AND state IN ('applied', 'already_satisfied')),
+                    error_summary = ?, unknown_reason = ?
+                WHERE operation_id = ?
+                """,
+                (
+                    run_status,
+                    terminal_reason,
+                    now_ms,
+                    run_status,
+                    now_ms,
+                    operation_id,
+                    operation_id,
+                    operation_id,
+                    error_summary,
+                    unknown_reason,
+                    operation_id,
+                ),
+            )
+            self._append_event(
+                conn,
+                operation_id=operation_id,
+                target_ordinal=ordinal,
+                event_type="attempt_finalized" if run_status != "interrupted" else "attempt_unknown",
+                from_state="running",
+                to_state=run_status,
+                actor_ref=str(run[0]),
+                occurred_at_ms=now_ms,
+                detail={"status": status, "reason": (unknown_reason or error_summary or "")[:512]},
+            )
+            conn.commit()
+
+    def reconcile_attempt(
+        self,
+        operation_id: str,
+        *,
+        outcome: Literal["applied", "absent", "unknown"],
+        domain_receipt_ref: str | None = None,
+        reason: str | None = None,
+    ) -> None:
+        """Persist an explicit applied/absent/unknown reconciliation decision."""
+
+        now_ms = int(time.time() * 1000)
+        with self._connection() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            target = conn.execute(
+                "SELECT ordinal FROM operation_targets WHERE operation_id = ? AND state = 'unknown' ORDER BY ordinal LIMIT 1",
+                (operation_id,),
+            ).fetchone()
+            ordinal = int(target[0]) if target is not None else None
+            if ordinal is None:
+                raise ValueError(f"operation {operation_id!r} has no unknown target to reconcile")
+            target_state = "applied" if outcome == "applied" else "pending" if outcome == "absent" else "unknown"
+            run_state = (
+                "completed" if target_state == "applied" else "running" if target_state == "pending" else "interrupted"
+            )
+            conn.execute(
+                "UPDATE operation_attempts SET state = 'reconciled', finished_at_ms = ?, unknown_reason = ? WHERE operation_id = ? AND state = 'unknown'",
+                (now_ms, reason, operation_id),
+            )
+            conn.execute(
+                "UPDATE operation_targets SET state = ?, domain_receipt_ref = ?, domain_receipt_kind = ?, completed_at_ms = ? WHERE operation_id = ? AND ordinal = ?",
+                (
+                    target_state,
+                    domain_receipt_ref,
+                    "domain" if domain_receipt_ref else None,
+                    now_ms if target_state == "applied" else None,
+                    operation_id,
+                    ordinal,
+                ),
+            )
+            conn.execute(
+                "UPDATE operation_runs SET status = ?, terminal_reason = ?, updated_at_ms = ?, completed_at_ms = CASE WHEN ? = 'completed' THEN ? ELSE completed_at_ms END WHERE operation_id = ?",
+                (
+                    run_state,
+                    None if run_state == "completed" else "reconciliation_unknown",
+                    now_ms,
+                    run_state,
+                    now_ms,
+                    operation_id,
+                ),
+            )
+            self._append_event(
+                conn,
+                operation_id=operation_id,
+                target_ordinal=ordinal,
+                event_type=f"reconciliation_{outcome}",
+                from_state="unknown",
+                to_state=target_state,
+                occurred_at_ms=now_ms,
+                detail={"reason": (reason or "")[:512]},
+            )
+            conn.commit()
+
+    def get_operation(self, operation_id: str) -> dict[str, object] | None:
+        with self._connection() as conn:
+            row = conn.execute("SELECT * FROM operation_runs WHERE operation_id = ?", (operation_id,)).fetchone()
+            return dict(row) if row is not None else None
+
+    def list_events(self, operation_id: str) -> tuple[dict[str, object], ...]:
+        with self._connection() as conn:
+            rows = conn.execute(
+                "SELECT * FROM operation_events WHERE operation_id = ? ORDER BY sequence", (operation_id,)
+            ).fetchall()
+            return tuple(dict(row) for row in rows)
+
+    @staticmethod
+    def _append_event(
+        conn: sqlite3.Connection,
+        *,
+        operation_id: str,
+        event_type: str,
+        occurred_at_ms: int,
+        detail: Mapping[str, object],
+        target_ordinal: int | None = None,
+        attempt_id: str | None = None,
+        from_state: str | None = None,
+        to_state: str | None = None,
+        actor_ref: str | None = None,
+    ) -> None:
+        sequence = int(
+            conn.execute(
+                "SELECT COALESCE(MAX(sequence), 0) + 1 FROM operation_events WHERE operation_id = ?",
+                (operation_id,),
+            ).fetchone()[0]
+        )
+        conn.execute(
+            """
+            INSERT INTO operation_events(
+                operation_id, sequence, target_ordinal, attempt_id, event_type,
+                from_state, to_state, actor_ref, occurred_at_ms, detail_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                operation_id,
+                sequence,
+                target_ordinal,
+                attempt_id,
+                event_type,
+                from_state,
+                to_state,
+                actor_ref,
+                occurred_at_ms,
+                json.dumps(dict(detail), sort_keys=True, separators=(",", ":")),
+            ),
+        )
+
+
+__all__ = ["AuditRepository", "AuditTargetState", "token_sha256"]

--- a/polylogue/operations/bindings.py
+++ b/polylogue/operations/bindings.py
@@ -1,0 +1,111 @@
+"""Validated OperationSpec to actuator bindings for mutation authority."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+from polylogue.operations.mutation_transaction import MutationActuator
+from polylogue.operations.specs import OperationSpec
+
+ArgsT = TypeVar("ArgsT", contravariant=True)
+ResultT = TypeVar("ResultT", covariant=True)
+
+
+class BindingValidationError(ValueError):
+    """A binding catalog cannot be made authoritative."""
+
+
+@dataclass(frozen=True, slots=True)
+class OperationBinding(Generic[ArgsT, ResultT]):
+    """One versioned OperationSpec joined to exactly one actuator."""
+
+    spec: OperationSpec
+    actuator: MutationActuator[ArgsT]
+    operation_version: int | None = None
+    declared_capabilities: tuple[str, ...] | None = None
+
+    def validate(self) -> None:
+        if not self.spec.mutates_state:
+            raise BindingValidationError(f"read-only operation cannot bind an actuator: {self.spec.name!r}")
+        if self.spec.executor_status != "executor-routed":
+            raise BindingValidationError(
+                f"operation {self.spec.name!r} is not declared executor-routed: {self.spec.executor_status!r}"
+            )
+        if not self.spec.target_authority:
+            raise BindingValidationError(f"operation {self.spec.name!r} has no target authority policy rows")
+        actuator_operation = getattr(self.actuator, "operation", None)
+        if actuator_operation != self.spec.name:
+            raise BindingValidationError(
+                f"actuator operation {actuator_operation!r} does not match spec {self.spec.name!r}"
+            )
+        actuator_version = getattr(self.actuator, "operation_version", self.spec.operation_version)
+        if self.operation_version is not None and self.operation_version != self.spec.operation_version:
+            raise BindingValidationError(
+                f"binding version {self.operation_version} does not match spec version {self.spec.operation_version}"
+            )
+        if actuator_version != self.spec.operation_version:
+            raise BindingValidationError(
+                f"actuator version {actuator_version} does not match spec version {self.spec.operation_version}"
+            )
+        policy_capabilities = tuple(
+            sorted({capability for policy in self.spec.target_authority for capability in policy.required_capabilities})
+        )
+        if self.declared_capabilities is not None and tuple(sorted(self.declared_capabilities)) != policy_capabilities:
+            raise BindingValidationError("binding capabilities do not equal the spec-owned capability rows")
+        if any(not capability.startswith("archive.") for capability in policy_capabilities):
+            raise BindingValidationError("binding contains a capability outside the archive capability namespace")
+        policy_keys = [policy.key for policy in self.spec.target_authority]
+        if len(policy_keys) != len(set(policy_keys)):
+            raise BindingValidationError(f"duplicate target authority policy for {self.spec.name!r}")
+
+
+@dataclass(frozen=True, slots=True)
+class OperationBindingCatalog:
+    """Immutable validated binding inventory used by composition roots."""
+
+    bindings: tuple[OperationBinding[object, object], ...]
+
+    @classmethod
+    def validate(cls, bindings: Iterable[OperationBinding[object, object]]) -> OperationBindingCatalog:
+        materialized = tuple(bindings)
+        names = [(binding.spec.name, binding.spec.operation_version) for binding in materialized]
+        if len(names) != len(set(names)):
+            raise BindingValidationError("duplicate OperationBinding for operation/version")
+        for binding in materialized:
+            binding.validate()
+        return cls(materialized)
+
+    def resolve(self, operation: str, operation_version: int = 1) -> OperationBinding[object, object]:
+        for binding in self.bindings:
+            if binding.spec.name == operation and binding.spec.operation_version == operation_version:
+                return binding
+        raise BindingValidationError(f"no registered actuator binding for {operation!r} v{operation_version}")
+
+
+def validate_operation_bindings(
+    specs: Iterable[OperationSpec], bindings: Iterable[OperationBinding[object, object]]
+) -> OperationBindingCatalog:
+    """Require exactly one binding for every executor-routed mutating spec."""
+
+    catalog = OperationBindingCatalog.validate(bindings)
+    required = {
+        (spec.name, spec.operation_version)
+        for spec in specs
+        if spec.mutates_state and spec.executor_status == "executor-routed"
+    }
+    actual = {(binding.spec.name, binding.spec.operation_version) for binding in catalog.bindings}
+    missing = sorted(required - actual)
+    unexpected = sorted(actual - required)
+    if missing or unexpected:
+        raise BindingValidationError(f"binding inventory mismatch: missing={missing}, unexpected={unexpected}")
+    return catalog
+
+
+__all__ = [
+    "BindingValidationError",
+    "OperationBinding",
+    "OperationBindingCatalog",
+    "validate_operation_bindings",
+]

--- a/polylogue/operations/mutation_transaction.py
+++ b/polylogue/operations/mutation_transaction.py
@@ -40,10 +40,15 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Mapping
-from dataclasses import dataclass, field
+import secrets
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
-from typing import Literal, Protocol, TypeVar, runtime_checkable
+from typing import TYPE_CHECKING, Literal, Protocol, TypeVar, runtime_checkable
+
+if TYPE_CHECKING:
+    from polylogue.operations.audit import AuditRepository
+    from polylogue.operations.bindings import OperationBinding
 
 #: Destructive/mutating classification. Ordered roughly by blast radius:
 #: ``reversible`` writes (tags/metadata) can be undone by another write;
@@ -52,7 +57,19 @@ from typing import Literal, Protocol, TypeVar, runtime_checkable
 #: source can resurrect them; ``excise`` is the durable, cross-tier,
 #: re-ingest-proof removal (right-to-forget); ``maintenance`` rewrites
 #: rebuildable derived state without removing authored evidence.
-DestructiveClass = Literal["reversible", "maintenance", "reset", "delete", "excise"]
+DestructiveClass = Literal["additive", "reversible", "maintenance", "reset", "delete", "excise"]
+
+Surface = Literal["cli", "api", "mcp", "daemon", "maintenance", "internal"]
+IdempotencyPolicy = Literal["none", "effect_key", "convergent", "compare_and_set"]
+RecoveryPolicy = Literal[
+    "rebuild",
+    "restore_verified_backup",
+    "reauthenticate",
+    "retry_convergent",
+    "reconcile_required",
+    "none",
+]
+TargetDurability = Literal["durable", "derived", "disposable", "external"]
 
 #: Confirmation strength a caller can present at AUTHORIZE time, ordered
 #: weakest to strongest. Each :class:`MutationActuator` declares the floor it
@@ -71,6 +88,15 @@ _STRENGTH_ORDER: dict[ConfirmationStrength, int] = {
     "role_only": 0,
     "confirm_flag": 1,
     "bound_token": 2,
+}
+
+_CLASS_ORDER: dict[DestructiveClass, int] = {
+    "additive": 0,
+    "reversible": 1,
+    "maintenance": 2,
+    "reset": 3,
+    "delete": 4,
+    "excise": 5,
 }
 
 #: Per-target outcome vocabulary for a mutation receipt (kwsb.2 AC3).
@@ -102,8 +128,132 @@ class AuthorizationMismatchError(MutationTransactionError):
     """EXECUTE was attempted with an authorization bound to a different plan."""
 
 
+class CapabilityDeniedError(MutationTransactionError):
+    """The authenticated principal lacks an exact capability declared by the spec."""
+
+
+class SurfaceDeniedError(MutationTransactionError):
+    """The operation is not declared for the requesting surface."""
+
+
+class TokenExpiredError(MutationTransactionError):
+    """A bound authorization is outside its short validity window."""
+
+
+class TokenConsumedError(MutationTransactionError):
+    """A bound authorization was already consumed."""
+
+
+class AuditFinalizationError(MutationTransactionError):
+    """The domain result could not be durably finalized in audit.db."""
+
+
+@dataclass(frozen=True, slots=True)
+class MutationPrincipal:
+    """Authenticated identity and exact capabilities for one mutation request."""
+
+    actor_ref: str
+    capabilities: frozenset[str]
+    surface: Surface
+    role_label: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.actor_ref:
+            raise ValueError("mutation principal actor_ref must not be empty")
+        if any(not capability for capability in self.capabilities):
+            raise ValueError("mutation principal capabilities must not contain empty values")
+
+
+@dataclass(frozen=True, slots=True)
+class TargetAuthorityPolicy:
+    """Spec-owned policy for one closed target-key vocabulary entry."""
+
+    key: str
+    target_kinds: tuple[str, ...]
+    required_capabilities: tuple[str, ...]
+    destructive_class: DestructiveClass
+    required_confirmation: ConfirmationStrength
+    allowed_durabilities: tuple[TargetDurability, ...]
+    allowed_recovery: tuple[RecoveryPolicy, ...]
+
+    def __post_init__(self) -> None:
+        if not self.key or not self.target_kinds or not self.required_capabilities:
+            raise ValueError("target authority policies require key, target kinds, and capabilities")
+        if len(set(self.required_capabilities)) != len(self.required_capabilities):
+            raise ValueError(f"duplicate capabilities in target policy {self.key!r}")
+
+
+@dataclass(frozen=True, slots=True)
+class MutationTarget:
+    """Canonical typed target included in a prepared plan and audit rows."""
+
+    kind: str
+    ref: str
+    policy_key: str
+    identity_digest: str
+    effect_identity: str
+    durability: TargetDurability
+    recovery: RecoveryPolicy
+
+    def canonical_dict(self) -> dict[str, object]:
+        return {
+            "kind": self.kind,
+            "ref": self.ref,
+            "policy_key": self.policy_key,
+            "identity_digest": self.identity_digest,
+            "effect_identity": self.effect_identity,
+            "durability": self.durability,
+            "recovery": self.recovery,
+        }
+
+
 def _utcnow_iso() -> str:
     return datetime.now(UTC).isoformat()
+
+
+def _canonical_json(payload: object) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _sha256_document(payload: object) -> str:
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def compute_target_digest(targets: tuple[MutationTarget, ...]) -> str:
+    """Hash ordered typed targets without stringifying arbitrary objects."""
+
+    return _sha256_document([target.canonical_dict() for target in targets])
+
+
+def compute_typed_plan_hash(
+    *,
+    operation: str,
+    operation_version: int,
+    archive_instance_id: str,
+    archive_identity_digest: str,
+    parameter_digest: str,
+    target_digest: str,
+    required_capabilities: tuple[str, ...],
+    destructive_class: DestructiveClass,
+    required_confirmation: ConfirmationStrength,
+    affected_tiers: tuple[str, ...],
+) -> str:
+    """Hash every authority-relevant field of a typed mutation plan."""
+
+    return _sha256_document(
+        {
+            "operation": operation,
+            "operation_version": operation_version,
+            "archive_instance_id": archive_instance_id,
+            "archive_identity_digest": archive_identity_digest,
+            "parameter_digest": parameter_digest,
+            "target_digest": target_digest,
+            "required_capabilities": list(required_capabilities),
+            "destructive_class": destructive_class,
+            "required_confirmation": required_confirmation,
+            "affected_tiers": list(affected_tiers),
+        }
+    )
 
 
 def compute_plan_hash(
@@ -152,6 +302,16 @@ class MutationPlan:
     prepared_at: str
     plan_hash: str
     context: Mapping[str, object] = field(default_factory=dict)
+    operation_version: int = 1
+    archive_instance_id: str = "legacy"
+    archive_identity_digest: str = "legacy"
+    required_capabilities: tuple[str, ...] = ()
+    required_confirmation: ConfirmationStrength = "role_only"
+    targets: tuple[MutationTarget, ...] = ()
+    parameter_digest: str = ""
+    target_digest: str = ""
+    prepared_at_ms: int = 0
+    expires_at_ms: int = 0
 
     @property
     def target_count(self) -> int:
@@ -168,7 +328,76 @@ class MutationPlan:
             "plan_hash": self.plan_hash,
             "target_count": self.target_count,
             "context": dict(self.context),
+            "operation_version": self.operation_version,
+            "archive_instance_id": self.archive_instance_id,
+            "archive_identity_digest": self.archive_identity_digest,
+            "required_capabilities": list(self.required_capabilities),
+            "required_confirmation": self.required_confirmation,
+            "targets": [target.canonical_dict() for target in self.targets],
+            "parameter_digest": self.parameter_digest,
+            "target_digest": self.target_digest,
+            "prepared_at_ms": self.prepared_at_ms,
+            "expires_at_ms": self.expires_at_ms,
         }
+
+
+@dataclass(frozen=True, slots=True)
+class MutationPreview:
+    """Durable preview reference and its immutable typed plan."""
+
+    preview_ref: str
+    plan: MutationPlan
+
+
+def build_typed_plan(
+    *,
+    operation: str,
+    operation_version: int,
+    archive_instance_id: str,
+    archive_identity_digest: str,
+    targets: tuple[MutationTarget, ...],
+    affected_tiers: tuple[str, ...],
+    parameter_digest: str,
+    required_capabilities: tuple[str, ...],
+    destructive_class: DestructiveClass,
+    required_confirmation: ConfirmationStrength,
+    prepared_at_ms: int,
+    expires_at_ms: int,
+) -> MutationPlan:
+    """Construct a plan whose hash covers the complete typed authority input."""
+
+    target_digest = compute_target_digest(targets)
+    plan_hash = compute_typed_plan_hash(
+        operation=operation,
+        operation_version=operation_version,
+        archive_instance_id=archive_instance_id,
+        archive_identity_digest=archive_identity_digest,
+        parameter_digest=parameter_digest,
+        target_digest=target_digest,
+        required_capabilities=required_capabilities,
+        destructive_class=destructive_class,
+        required_confirmation=required_confirmation,
+        affected_tiers=affected_tiers,
+    )
+    return MutationPlan(
+        operation=operation,
+        destructive_class=destructive_class,
+        target_refs=tuple(target.ref for target in targets),
+        affected_tiers=affected_tiers,
+        reversible=destructive_class in {"additive", "reversible"},
+        prepared_at=datetime.fromtimestamp(prepared_at_ms / 1000, UTC).isoformat(),
+        plan_hash=plan_hash,
+        operation_version=operation_version,
+        archive_instance_id=archive_instance_id,
+        archive_identity_digest=archive_identity_digest,
+        required_capabilities=required_capabilities,
+        required_confirmation=required_confirmation,
+        targets=targets,
+        parameter_digest=parameter_digest,
+        target_digest=target_digest,
+        prepared_at_ms=prepared_at_ms,
+        expires_at_ms=expires_at_ms,
+    )
 
 
 def build_plan(
@@ -212,6 +441,12 @@ class MutationAuthorization:
     capability: str
     confirmation_strength: ConfirmationStrength
     authorized_at: str
+    preview_ref: str | None = None
+    authorization_id: str | None = None
+    token: str | None = None
+    expires_at_ms: int | None = None
+    capabilities: tuple[str, ...] = ()
+    surface: Surface | None = None
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -221,6 +456,11 @@ class MutationAuthorization:
             "capability": self.capability,
             "confirmation_strength": self.confirmation_strength,
             "authorized_at": self.authorized_at,
+            "preview_ref": self.preview_ref,
+            "authorization_id": self.authorization_id,
+            "expires_at_ms": self.expires_at_ms,
+            "capabilities": list(self.capabilities),
+            "surface": self.surface,
         }
 
 
@@ -237,6 +477,7 @@ class MutationReceipt:
     receipt_ref: str | None
     applied_at: str
     domain_receipt: Mapping[str, object] = field(default_factory=dict)
+    operation_id: str | None = None
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -249,6 +490,7 @@ class MutationReceipt:
             "receipt_ref": self.receipt_ref,
             "applied_at": self.applied_at,
             "domain_receipt": dict(self.domain_receipt),
+            "operation_id": self.operation_id,
         }
 
 
@@ -298,10 +540,237 @@ class OperationExecutor:
     through this class. No adapter calls ``actuator.apply`` directly.
     """
 
+    def __init__(
+        self,
+        *,
+        audit: AuditRepository | None = None,
+        now_ms: Callable[[], int] | None = None,
+        token_factory: Callable[[], str] | None = None,
+    ) -> None:
+        self._audit = audit
+        self._now_ms = now_ms or (lambda: int(datetime.now(UTC).timestamp() * 1000))
+        self._token_factory = token_factory or (lambda: secrets.token_urlsafe(32))
+
     def prepare(self, actuator: MutationActuator[ArgsT], args: ArgsT) -> MutationPlan:
         """PREPARE: resolve exact targets from live state. Never mutates."""
 
         return actuator.prepare(args)
+
+    def prepare_bound(
+        self,
+        binding: OperationBinding[ArgsT, object],
+        args: ArgsT,
+        principal: MutationPrincipal,
+        *,
+        archive_instance_id: str,
+        archive_identity_digest: str,
+        parameter_digest: str,
+        expires_at_ms: int | None = None,
+    ) -> MutationPreview:
+        """Prepare and durably record a versioned, capability-bound preview."""
+
+        binding.validate()
+        if principal.surface not in binding.spec.allowed_surfaces:
+            raise SurfaceDeniedError(f"{binding.spec.name!r} is not allowed on {principal.surface!r}")
+        plan = self._typed_plan_from_actuator(
+            binding,
+            binding.actuator.prepare(args),
+            archive_instance_id=archive_instance_id,
+            archive_identity_digest=archive_identity_digest,
+            parameter_digest=parameter_digest,
+            expires_at_ms=expires_at_ms or self._now_ms() + 60_000,
+        )
+        if self._audit is None:
+            return MutationPreview(preview_ref=f"preview:{plan.plan_hash}", plan=plan)
+        preview_ref = self._audit.create_preview(plan, principal)
+        return MutationPreview(preview_ref=preview_ref, plan=plan)
+
+    def authorize_bound(
+        self,
+        binding: OperationBinding[ArgsT, object],
+        preview: MutationPreview,
+        principal: MutationPrincipal,
+        *,
+        confirmation_strength: ConfirmationStrength | None = None,
+    ) -> MutationAuthorization:
+        """Issue a random one-time token bound to the persisted preview."""
+
+        binding.validate()
+        plan = preview.plan
+        required = set(plan.required_capabilities)
+        if not required.issubset(principal.capabilities):
+            missing = sorted(required - principal.capabilities)
+            raise CapabilityDeniedError(f"principal lacks declared capabilities: {missing}")
+        if self._now_ms() >= plan.expires_at_ms:
+            raise TokenExpiredError("cannot authorize an expired preview")
+        strength = confirmation_strength or plan.required_confirmation
+        if _STRENGTH_ORDER[strength] < _STRENGTH_ORDER[plan.required_confirmation]:
+            raise ConfirmationRequiredError(
+                f"{binding.spec.name!r} requires {plan.required_confirmation!r}, got {strength!r}"
+            )
+        token = self._token_factory()
+        authorization = MutationAuthorization(
+            plan_hash=plan.plan_hash,
+            actor=principal.actor_ref,
+            role=principal.role_label or "",
+            capability=plan.required_capabilities[0] if plan.required_capabilities else "",
+            confirmation_strength=strength,
+            authorized_at=_utcnow_iso(),
+            preview_ref=preview.preview_ref,
+            token=token,
+            expires_at_ms=plan.expires_at_ms,
+            capabilities=tuple(sorted(required)),
+            surface=principal.surface,
+        )
+        if self._audit is not None:
+            authorization_id = self._audit.issue_authorization(preview, principal, authorization)
+            authorization = replace(authorization, authorization_id=authorization_id)
+        return authorization
+
+    def execute_bound(
+        self,
+        binding: OperationBinding[ArgsT, object],
+        preview: MutationPreview,
+        authorization: MutationAuthorization,
+        args: ArgsT,
+    ) -> MutationReceipt:
+        """Consume a bound token, journal intent, apply, and finalize honestly."""
+
+        binding.validate()
+        if authorization.preview_ref != preview.preview_ref or authorization.token is None:
+            raise AuthorizationMismatchError("authorization is not bound to this preview")
+        if authorization.expires_at_ms is not None and self._now_ms() >= authorization.expires_at_ms:
+            raise TokenExpiredError("authorization token is expired")
+        fresh_plan = self._typed_plan_from_actuator(
+            binding,
+            binding.actuator.prepare(args),
+            archive_instance_id=preview.plan.archive_instance_id,
+            archive_identity_digest=preview.plan.archive_identity_digest,
+            parameter_digest=preview.plan.parameter_digest,
+            expires_at_ms=preview.plan.expires_at_ms,
+        )
+        if fresh_plan.plan_hash != preview.plan.plan_hash:
+            raise PlanStaleError(
+                f"{binding.spec.name!r} preview {preview.plan.plan_hash!r} is stale; "
+                f"live state now resolves to {fresh_plan.plan_hash!r}"
+            )
+        operation_id: str | None = None
+        if self._audit is not None:
+            operation_id = self._audit.consume_authorization_and_start(preview, authorization)
+        try:
+            result = binding.actuator.apply(fresh_plan, args)
+        except Exception as exc:
+            if self._audit is not None and operation_id is not None:
+                self._audit.finalize_attempt(
+                    operation_id,
+                    status="unknown",
+                    error_summary=str(exc)[:512],
+                    unknown_reason="actuator exception after durable intent",
+                )
+            raise
+        receipt = result
+        if self._audit is not None and operation_id is not None:
+            try:
+                self._audit.finalize_attempt(operation_id, status=receipt.status, receipt=receipt)
+            except Exception as exc:
+                raise AuditFinalizationError(
+                    "domain effect is not reported completed without audit finalization"
+                ) from exc
+            receipt = replace(
+                receipt,
+                receipt_ref=f"mutation-operation:{operation_id}",
+                operation_id=operation_id,
+            )
+        return receipt
+
+    def reconcile_operation(
+        self,
+        operation_id: str,
+        *,
+        outcome: Literal["applied", "absent", "unknown"],
+        domain_receipt_ref: str | None = None,
+        reason: str | None = None,
+    ) -> None:
+        """Record explicit reconciliation without inferring success from a crash."""
+
+        if self._audit is None:
+            raise MutationTransactionError("reconciliation requires a durable audit repository")
+        self._audit.reconcile_attempt(
+            operation_id,
+            outcome=outcome,
+            domain_receipt_ref=domain_receipt_ref,
+            reason=reason,
+        )
+
+    def _typed_plan_from_actuator(
+        self,
+        binding: OperationBinding[ArgsT, object],
+        plan: MutationPlan,
+        *,
+        archive_instance_id: str,
+        archive_identity_digest: str,
+        parameter_digest: str,
+        expires_at_ms: int,
+    ) -> MutationPlan:
+        policies = {policy.key: policy for policy in binding.spec.target_authority}
+        targets = plan.targets
+        if not targets:
+            default = next(iter(policies.values()), None)
+            if default is None:
+                raise MutationTransactionError(f"{binding.spec.name!r} has no target authority policy")
+            targets = tuple(
+                MutationTarget(
+                    kind=ref.split(":", 1)[0],
+                    ref=ref,
+                    policy_key=default.key,
+                    identity_digest=_sha256_document({"ref": ref}),
+                    effect_identity=f"{binding.spec.name}:{ref}",
+                    durability="derived",
+                    recovery="none",
+                )
+                for ref in plan.target_refs
+            )
+        for target in targets:
+            policy = policies.get(target.policy_key)
+            if policy is None:
+                raise MutationTransactionError(f"actuator returned unregistered target policy {target.policy_key!r}")
+            if target.kind not in policy.target_kinds:
+                raise MutationTransactionError(f"target kind {target.kind!r} is not allowed by {policy.key!r}")
+            if target.durability not in policy.allowed_durabilities:
+                raise MutationTransactionError(
+                    f"target durability {target.durability!r} is not allowed by {policy.key!r}"
+                )
+            if target.recovery not in policy.allowed_recovery:
+                raise MutationTransactionError(f"target recovery {target.recovery!r} is not allowed by {policy.key!r}")
+        required_capabilities = tuple(
+            sorted(
+                {capability for target in targets for capability in policies[target.policy_key].required_capabilities}
+            )
+        )
+        destructive_class = max(
+            (policies[target.policy_key].destructive_class for target in targets),
+            key=lambda value: _CLASS_ORDER[value],
+            default=plan.destructive_class,
+        )
+        required_confirmation = max(
+            (policies[target.policy_key].required_confirmation for target in targets),
+            key=lambda value: _STRENGTH_ORDER[value],
+            default=plan.required_confirmation,
+        )
+        return build_typed_plan(
+            operation=binding.spec.name,
+            operation_version=binding.spec.operation_version,
+            archive_instance_id=archive_instance_id,
+            archive_identity_digest=archive_identity_digest,
+            targets=targets,
+            affected_tiers=binding.spec.affected_tiers or plan.affected_tiers,
+            parameter_digest=parameter_digest,
+            required_capabilities=required_capabilities,
+            destructive_class=destructive_class,
+            required_confirmation=required_confirmation,
+            prepared_at_ms=self._now_ms(),
+            expires_at_ms=expires_at_ms,
+        )
 
     def authorize(
         self,
@@ -371,18 +840,34 @@ def make_target_ref(kind: Literal["session", "message", "block", "source"], valu
 
 __all__ = [
     "AuthorizationMismatchError",
+    "AuditFinalizationError",
+    "CapabilityDeniedError",
     "ConfirmationRequiredError",
     "ConfirmationStrength",
     "DestructiveClass",
+    "IdempotencyPolicy",
     "MutationActuator",
     "MutationAuthorization",
+    "MutationPreview",
+    "MutationPrincipal",
     "MutationPlan",
     "MutationReceipt",
+    "MutationTarget",
     "MutationTargetStatus",
     "MutationTransactionError",
     "OperationExecutor",
     "PlanStaleError",
+    "RecoveryPolicy",
+    "Surface",
+    "SurfaceDeniedError",
+    "TargetAuthorityPolicy",
+    "TargetDurability",
+    "TokenConsumedError",
+    "TokenExpiredError",
     "build_plan",
+    "build_typed_plan",
     "compute_plan_hash",
+    "compute_target_digest",
+    "compute_typed_plan_hash",
     "make_target_ref",
 ]

--- a/polylogue/operations/specs.py
+++ b/polylogue/operations/specs.py
@@ -8,6 +8,11 @@ from functools import lru_cache
 from typing import Literal
 
 from polylogue.core.json import JSONDocument, JSONDocumentList, json_document
+from polylogue.operations.mutation_transaction import (
+    IdempotencyPolicy,
+    Surface,
+    TargetAuthorityPolicy,
+)
 
 Effect = Literal["Pure", "DbRead", "DbWrite", "FileWrite", "Network", "LiveArchive", "Destructive"]
 """Declared runtime effect of an operation.
@@ -70,6 +75,15 @@ class OperationSpec:
     safety_guards: tuple[SafetyGuard, ...] = ()
     executor_status: ExecutorStatus | None = None
     """t46.9 AC1: required (non-``None``) whenever ``mutates_state`` is ``True``."""
+    operation_version: int = 1
+    capability_family: Literal["write", "judge", "maintenance"] = "write"
+    allowed_surfaces: tuple[Surface, ...] = ()
+    target_authority: tuple[TargetAuthorityPolicy, ...] = ()
+    affected_tiers: tuple[str, ...] = ()
+    idempotency: IdempotencyPolicy = "none"
+    resumable: bool = False
+    receipt_schema: str = "polylogue.mutation-receipt/v1"
+    reconstructible: bool = False
 
     def to_dict(self) -> JSONDocument:
         return json_document(
@@ -88,6 +102,26 @@ class OperationSpec:
                 "effects": list(self.effects),
                 "safety_guards": list(self.safety_guards),
                 "executor_status": self.executor_status,
+                "operation_version": self.operation_version,
+                "capability_family": self.capability_family,
+                "allowed_surfaces": list(self.allowed_surfaces),
+                "target_authority": [
+                    {
+                        "key": policy.key,
+                        "target_kinds": list(policy.target_kinds),
+                        "required_capabilities": list(policy.required_capabilities),
+                        "destructive_class": policy.destructive_class,
+                        "required_confirmation": policy.required_confirmation,
+                        "allowed_durabilities": list(policy.allowed_durabilities),
+                        "allowed_recovery": list(policy.allowed_recovery),
+                    }
+                    for policy in self.target_authority
+                ],
+                "affected_tiers": list(self.affected_tiers),
+                "idempotency": self.idempotency,
+                "resumable": self.resumable,
+                "receipt_schema": self.receipt_schema,
+                "reconstructible": self.reconstructible,
             }
         )
 

--- a/polylogue/storage/archive_identity.py
+++ b/polylogue/storage/archive_identity.py
@@ -18,13 +18,14 @@ from polylogue.version import VERSION_INFO
 
 logger = logging.getLogger(__name__)
 
-ArchiveTierName = Literal["source", "index", "embeddings", "user", "ops"]
+ArchiveTierName = Literal["source", "index", "embeddings", "user", "ops", "audit"]
 TIER_FILENAMES: tuple[tuple[ArchiveTierName, str], ...] = (
     ("source", "source.db"),
     ("index", "index.db"),
     ("embeddings", "embeddings.db"),
     ("user", "user.db"),
     ("ops", "ops.db"),
+    ("audit", "audit.db"),
 )
 
 
@@ -231,6 +232,21 @@ class ArchiveIdentity:
     @property
     def durable_id(self) -> str:
         return "|".join((self.tier("source").stable_id, self.tier("user").stable_id))
+
+    @property
+    def authority_identity_digest(self) -> str:
+        """Digest the live archive identity without recursively including audit.db."""
+
+        import hashlib
+        import json
+
+        payload = {
+            "configured_root": str(self.configured_root.absolute()),
+            "active_generation": self.active_generation,
+            "durable_id": self.durable_id,
+            "tiers": {tier.name: tier.stable_id for tier in self.tiers if tier.name != "audit"},
+        }
+        return hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
 
     def conflicts_with(self, other: ArchiveIdentity) -> bool:
         shared_durable = self.tier("source").same_file(other.tier("source")) or self.tier("user").same_file(

--- a/polylogue/storage/sqlite/archive_tiers/__init__.py
+++ b/polylogue/storage/sqlite/archive_tiers/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
+from polylogue.storage.sqlite.archive_tiers.audit import AUDIT_DDL, AUDIT_SCHEMA_VERSION
 from polylogue.storage.sqlite.archive_tiers.embeddings import EMBEDDINGS_DDL, EMBEDDINGS_SCHEMA_VERSION
 from polylogue.storage.sqlite.archive_tiers.index import INDEX_DDL, INDEX_SCHEMA_VERSION
 from polylogue.storage.sqlite.archive_tiers.ops import OPS_DDL, OPS_SCHEMA_VERSION
@@ -17,6 +18,7 @@ ARCHIVE_DDL_BY_TIER: Mapping[ArchiveTier, str] = {
     ArchiveTier.EMBEDDINGS: EMBEDDINGS_DDL,
     ArchiveTier.USER: USER_DDL,
     ArchiveTier.OPS: OPS_DDL,
+    ArchiveTier.AUDIT: AUDIT_DDL,
 }
 
 ARCHIVE_VERSION_BY_TIER: Mapping[ArchiveTier, int] = {
@@ -25,6 +27,7 @@ ARCHIVE_VERSION_BY_TIER: Mapping[ArchiveTier, int] = {
     ArchiveTier.EMBEDDINGS: EMBEDDINGS_SCHEMA_VERSION,
     ArchiveTier.USER: USER_SCHEMA_VERSION,
     ArchiveTier.OPS: OPS_SCHEMA_VERSION,
+    ArchiveTier.AUDIT: AUDIT_SCHEMA_VERSION,
 }
 
 

--- a/polylogue/storage/sqlite/archive_tiers/audit.py
+++ b/polylogue/storage/sqlite/archive_tiers/audit.py
@@ -1,0 +1,219 @@
+"""Durable authority-journal DDL for ``audit.db``.
+
+The audit tier stores authority and lifecycle metadata only. Domain payloads
+remain in their owning tiers and are linked by typed receipt references.
+"""
+
+from __future__ import annotations
+
+AUDIT_SCHEMA_VERSION = 1
+
+AUDIT_DDL = """
+CREATE TABLE IF NOT EXISTS archive_authority (
+    archive_instance_id TEXT PRIMARY KEY,
+    created_at_ms       INTEGER NOT NULL CHECK(created_at_ms >= 0),
+    authority_format    INTEGER NOT NULL CHECK(authority_format = 1)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS operation_previews (
+    preview_id                 TEXT PRIMARY KEY,
+    operation_name             TEXT NOT NULL,
+    operation_version          INTEGER NOT NULL CHECK(operation_version >= 1),
+    archive_instance_id        TEXT NOT NULL,
+    archive_identity_digest    TEXT NOT NULL,
+    plan_hash                  TEXT NOT NULL,
+    parameter_digest           TEXT NOT NULL,
+    target_digest              TEXT NOT NULL,
+    target_count               INTEGER NOT NULL CHECK(target_count >= 0),
+    destructive_class          TEXT NOT NULL CHECK(destructive_class IN (
+        'additive', 'reversible', 'maintenance', 'reset', 'delete', 'excise'
+    )),
+    required_confirmation      TEXT NOT NULL CHECK(required_confirmation IN (
+        'role_only', 'confirm_flag', 'bound_token'
+    )),
+    required_capability_count  INTEGER NOT NULL CHECK(required_capability_count >= 0),
+    principal_actor_ref        TEXT NOT NULL,
+    principal_surface          TEXT NOT NULL CHECK(principal_surface IN (
+        'cli', 'api', 'mcp', 'daemon', 'maintenance', 'internal'
+    )),
+    role_label                 TEXT,
+    state                      TEXT NOT NULL CHECK(state IN (
+        'prepared', 'consumed', 'expired', 'stale', 'cancelled'
+    )),
+    created_at_ms              INTEGER NOT NULL CHECK(created_at_ms >= 0),
+    expires_at_ms              INTEGER NOT NULL CHECK(expires_at_ms >= created_at_ms),
+    plan_format                TEXT NOT NULL CHECK(plan_format = 'polylogue.mutation-plan/v1'),
+    plan_json                  TEXT NOT NULL,
+    UNIQUE(operation_name, operation_version, plan_hash, principal_actor_ref, created_at_ms)
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_operation_previews_plan_hash
+ON operation_previews(plan_hash);
+CREATE INDEX IF NOT EXISTS idx_operation_previews_state_expiry
+ON operation_previews(state, expires_at_ms);
+
+CREATE TABLE IF NOT EXISTS operation_preview_targets (
+    preview_id          TEXT NOT NULL REFERENCES operation_previews(preview_id) ON DELETE CASCADE,
+    ordinal             INTEGER NOT NULL CHECK(ordinal >= 0),
+    target_kind         TEXT NOT NULL,
+    target_ref          TEXT NOT NULL,
+    identity_digest     TEXT NOT NULL,
+    effect_identity     TEXT NOT NULL,
+    durability          TEXT NOT NULL CHECK(durability IN ('durable', 'derived', 'disposable', 'external')),
+    recovery_policy     TEXT NOT NULL CHECK(recovery_policy IN (
+        'rebuild', 'restore_verified_backup', 'reauthenticate',
+        'retry_convergent', 'reconcile_required', 'none'
+    )),
+    PRIMARY KEY(preview_id, ordinal)
+) STRICT;
+CREATE INDEX IF NOT EXISTS idx_operation_preview_targets_ref
+ON operation_preview_targets(target_ref);
+
+CREATE TABLE IF NOT EXISTS operation_preview_capabilities (
+    preview_id  TEXT NOT NULL REFERENCES operation_previews(preview_id) ON DELETE CASCADE,
+    capability  TEXT NOT NULL,
+    PRIMARY KEY(preview_id, capability)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS operation_authorizations (
+    authorization_id       TEXT PRIMARY KEY,
+    preview_id             TEXT NOT NULL REFERENCES operation_previews(preview_id),
+    actor_ref              TEXT NOT NULL,
+    surface                TEXT NOT NULL CHECK(surface IN ('cli', 'api', 'mcp', 'daemon', 'maintenance', 'internal')),
+    role_label             TEXT,
+    confirmation_strength  TEXT NOT NULL CHECK(confirmation_strength IN ('role_only', 'confirm_flag', 'bound_token')),
+    token_sha256           TEXT NOT NULL UNIQUE CHECK(length(token_sha256) = 64),
+    state                  TEXT NOT NULL CHECK(state IN ('active', 'consumed', 'expired', 'revoked')),
+    issued_at_ms           INTEGER NOT NULL CHECK(issued_at_ms >= 0),
+    expires_at_ms          INTEGER NOT NULL CHECK(expires_at_ms >= issued_at_ms),
+    consumed_at_ms         INTEGER
+) STRICT;
+CREATE INDEX IF NOT EXISTS idx_operation_authorizations_preview
+ON operation_authorizations(preview_id, state);
+
+CREATE TABLE IF NOT EXISTS operation_authorization_capabilities (
+    authorization_id  TEXT NOT NULL REFERENCES operation_authorizations(authorization_id) ON DELETE CASCADE,
+    capability        TEXT NOT NULL,
+    PRIMARY KEY(authorization_id, capability)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS operation_runs (
+    operation_id              TEXT PRIMARY KEY,
+    preview_id                TEXT NOT NULL REFERENCES operation_previews(preview_id),
+    initial_authorization_id  TEXT NOT NULL REFERENCES operation_authorizations(authorization_id),
+    parent_operation_id       TEXT REFERENCES operation_runs(operation_id),
+    operation_name            TEXT NOT NULL,
+    operation_version         INTEGER NOT NULL CHECK(operation_version >= 1),
+    archive_instance_id       TEXT NOT NULL,
+    archive_identity_digest   TEXT NOT NULL,
+    plan_hash                 TEXT NOT NULL,
+    parameter_digest          TEXT NOT NULL,
+    target_digest             TEXT NOT NULL,
+    target_count              INTEGER NOT NULL CHECK(target_count >= 0),
+    actor_ref                 TEXT NOT NULL,
+    surface                   TEXT NOT NULL CHECK(surface IN ('cli', 'api', 'mcp', 'daemon', 'maintenance', 'internal')),
+    role_label                TEXT,
+    idempotency_key_hash      TEXT,
+    status                    TEXT NOT NULL CHECK(status IN ('pending', 'running', 'completed', 'failed', 'interrupted')),
+    terminal_reason           TEXT,
+    affected_count            INTEGER NOT NULL DEFAULT 0 CHECK(affected_count >= 0),
+    rejected_count            INTEGER NOT NULL DEFAULT 0 CHECK(rejected_count >= 0),
+    failed_count              INTEGER NOT NULL DEFAULT 0 CHECK(failed_count >= 0),
+    unknown_count             INTEGER NOT NULL DEFAULT 0 CHECK(unknown_count >= 0),
+    effect_identity           TEXT,
+    domain_receipt_kind       TEXT,
+    domain_receipt_ref        TEXT,
+    requested_at_ms           INTEGER NOT NULL CHECK(requested_at_ms >= 0),
+    started_at_ms             INTEGER,
+    updated_at_ms             INTEGER NOT NULL CHECK(updated_at_ms >= requested_at_ms),
+    completed_at_ms           INTEGER,
+    cancel_requested_at_ms    INTEGER,
+    error_code                TEXT,
+    error_class               TEXT,
+    error_summary             TEXT,
+    unknown_reason            TEXT
+) STRICT;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_operation_runs_idempotency
+ON operation_runs(archive_instance_id, operation_name, operation_version, idempotency_key_hash)
+WHERE idempotency_key_hash IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS operation_run_capabilities (
+    operation_id  TEXT NOT NULL REFERENCES operation_runs(operation_id) ON DELETE CASCADE,
+    capability    TEXT NOT NULL,
+    PRIMARY KEY(operation_id, capability)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS operation_targets (
+    operation_id                 TEXT NOT NULL REFERENCES operation_runs(operation_id) ON DELETE CASCADE,
+    ordinal                      INTEGER NOT NULL CHECK(ordinal >= 0),
+    target_kind                  TEXT NOT NULL,
+    target_ref                   TEXT NOT NULL,
+    identity_digest              TEXT NOT NULL,
+    effect_identity              TEXT NOT NULL,
+    state                        TEXT NOT NULL CHECK(state IN (
+        'pending', 'running', 'applied', 'already_satisfied', 'rejected',
+        'failed', 'unknown', 'acknowledged', 'cancelled'
+    )),
+    attempt_count                INTEGER NOT NULL DEFAULT 0 CHECK(attempt_count >= 0),
+    current_attempt_id          TEXT,
+    domain_receipt_kind         TEXT,
+    domain_receipt_ref          TEXT,
+    pre_archive_identity_digest TEXT,
+    post_archive_identity_digest TEXT,
+    started_at_ms               INTEGER,
+    completed_at_ms             INTEGER,
+    error_code                  TEXT,
+    error_class                 TEXT,
+    error_summary               TEXT,
+    unknown_reason              TEXT,
+    acknowledged_by             TEXT,
+    acknowledged_at_ms          INTEGER,
+    acknowledgement_reason     TEXT,
+    PRIMARY KEY(operation_id, ordinal)
+) STRICT;
+CREATE INDEX IF NOT EXISTS idx_operation_targets_ref
+ON operation_targets(target_ref);
+CREATE INDEX IF NOT EXISTS idx_operation_targets_state
+ON operation_targets(operation_id, state, ordinal);
+
+CREATE TABLE IF NOT EXISTS operation_attempts (
+    attempt_id                    TEXT PRIMARY KEY,
+    operation_id                  TEXT NOT NULL REFERENCES operation_runs(operation_id) ON DELETE CASCADE,
+    target_ordinal                INTEGER,
+    authorization_id              TEXT NOT NULL REFERENCES operation_authorizations(authorization_id),
+    worker_id                     TEXT,
+    lease_expires_at_ms           INTEGER,
+    prepared_precondition_digest  TEXT,
+    state                         TEXT NOT NULL CHECK(state IN (
+        'running', 'applied', 'failed', 'unknown', 'reconciled', 'cancelled'
+    )),
+    started_at_ms                 INTEGER NOT NULL CHECK(started_at_ms >= 0),
+    finished_at_ms                INTEGER,
+    error_code                    TEXT,
+    error_class                   TEXT,
+    error_summary                 TEXT,
+    unknown_reason                TEXT
+) STRICT;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_operation_attempts_running_target
+ON operation_attempts(operation_id, target_ordinal)
+WHERE state = 'running';
+
+CREATE TABLE IF NOT EXISTS operation_events (
+    operation_id   TEXT NOT NULL REFERENCES operation_runs(operation_id) ON DELETE CASCADE,
+    sequence       INTEGER NOT NULL CHECK(sequence >= 1),
+    target_ordinal INTEGER,
+    attempt_id     TEXT,
+    event_type     TEXT NOT NULL,
+    from_state     TEXT,
+    to_state       TEXT,
+    actor_ref      TEXT,
+    occurred_at_ms INTEGER NOT NULL CHECK(occurred_at_ms >= 0),
+    detail_format  TEXT NOT NULL DEFAULT 'polylogue.audit-event/v1',
+    detail_json    TEXT NOT NULL DEFAULT '{}',
+    PRIMARY KEY(operation_id, sequence)
+) STRICT;
+CREATE INDEX IF NOT EXISTS idx_operation_events_type_time
+ON operation_events(event_type, occurred_at_ms);
+"""
+
+__all__ = ["AUDIT_DDL", "AUDIT_SCHEMA_VERSION"]

--- a/polylogue/storage/sqlite/archive_tiers/bootstrap.py
+++ b/polylogue/storage/sqlite/archive_tiers/bootstrap.py
@@ -65,6 +65,12 @@ ARCHIVE_TIER_SPECS: dict[ArchiveTier, ArchiveTierSpec] = {
         durability="disposable",
         backup_required=False,
     ),
+    ArchiveTier.AUDIT: ArchiveTierSpec(
+        ArchiveTier.AUDIT,
+        filename="audit.db",
+        durability="irreplaceable",
+        backup_required=True,
+    ),
 }
 
 

--- a/polylogue/storage/sqlite/archive_tiers/types.py
+++ b/polylogue/storage/sqlite/archive_tiers/types.py
@@ -14,6 +14,7 @@ class ArchiveTier(StrEnum):
     EMBEDDINGS = "embeddings"
     USER = "user"
     OPS = "ops"
+    AUDIT = "audit"
 
 
 # polylogue-u6tl: these two live here (a dependency-free leaf module) rather

--- a/polylogue/storage/sqlite/migration_runner.py
+++ b/polylogue/storage/sqlite/migration_runner.py
@@ -20,7 +20,7 @@ from polylogue.storage.backup_attestation import (
 from polylogue.storage.sqlite.archive_tiers import ARCHIVE_VERSION_BY_TIER
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 
-DURABLE_MIGRATION_TIERS: frozenset[ArchiveTier] = frozenset({ArchiveTier.SOURCE, ArchiveTier.USER})
+DURABLE_MIGRATION_TIERS: frozenset[ArchiveTier] = frozenset({ArchiveTier.SOURCE, ArchiveTier.USER, ArchiveTier.AUDIT})
 _MIGRATION_NAME_RE = re.compile(r"^(?P<version>\d{3,})_[a-z0-9_]+\.sql$")
 _VERIFICATION_RECEIPT_FILE = "verification-receipt.json"
 _SQLITE_SIDECAR_SUFFIXES = ("-wal", "-shm", "-journal")

--- a/polylogue/storage/sqlite/migrations/audit/__init__.py
+++ b/polylogue/storage/sqlite/migrations/audit/__init__.py
@@ -1,0 +1,5 @@
+"""Numbered additive migrations for the durable audit tier.
+
+Version 1 is a fresh-tier bootstrap. Future changes must add a numbered SQL
+file here and use the same verified-backup gate as source.db and user.db.
+"""

--- a/tests/unit/operations/test_operation_audit.py
+++ b/tests/unit/operations/test_operation_audit.py
@@ -168,3 +168,46 @@ def test_crash_after_intent_is_queryable_unknown_and_never_completed(tmp_path: P
     assert status == "interrupted"
     assert target_state == "unknown"
     assert audit.list_events(operation_id)[-1]["event_type"] == "attempt_unknown"
+
+
+def test_token_consumption_and_initial_attempt_roll_back_together(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    audit = AuditRepository(tmp_path / "audit.db")
+    actuator = _Actuator()
+    executor = OperationExecutor(audit=audit, token_factory=lambda: "rollback-token")
+    preview = executor.prepare_bound(
+        _binding(actuator),
+        object(),
+        _principal(),
+        archive_instance_id="archive:test",
+        archive_identity_digest="identity:test",
+        parameter_digest="params:test",
+    )
+    authorization = executor.authorize_bound(_binding(actuator), preview, _principal())
+
+    def fail_event(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("injected audit transaction failure")
+
+    monkeypatch.setattr(AuditRepository, "_append_event", staticmethod(fail_event))
+    with pytest.raises(RuntimeError, match="injected"):
+        audit.consume_authorization_and_start(preview, authorization)
+
+    conn = sqlite3.connect(tmp_path / "audit.db")
+    try:
+        auth_state = str(
+            conn.execute(
+                "SELECT state FROM operation_authorizations WHERE preview_id = ?", (preview.preview_ref,)
+            ).fetchone()[0]
+        )
+        run_count = int(conn.execute("SELECT COUNT(*) FROM operation_runs").fetchone()[0])
+        preview_state = str(
+            conn.execute(
+                "SELECT state FROM operation_previews WHERE preview_id = ?", (preview.preview_ref,)
+            ).fetchone()[0]
+        )
+    finally:
+        conn.close()
+    assert auth_state == "active"
+    assert preview_state == "prepared"
+    assert run_count == 0

--- a/tests/unit/operations/test_operation_audit.py
+++ b/tests/unit/operations/test_operation_audit.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from polylogue.operations.audit import AuditRepository
+from polylogue.operations.bindings import OperationBinding
+from polylogue.operations.mutation_transaction import (
+    CapabilityDeniedError,
+    ConfirmationStrength,
+    DestructiveClass,
+    MutationPlan,
+    MutationPrincipal,
+    MutationReceipt,
+    OperationExecutor,
+    PlanStaleError,
+    TargetAuthorityPolicy,
+    build_plan,
+)
+from polylogue.operations.specs import OperationKind, OperationSpec
+
+
+@dataclass
+class _Actuator:
+    operation: str = "mutate-fixture"
+    operation_version: int = 1
+    changed: bool = False
+    calls: int = 0
+    crash: bool = False
+    destructive_class: DestructiveClass = "reversible"
+    required_confirmation: ConfirmationStrength = "role_only"
+
+    def prepare(self, _args: object) -> MutationPlan:
+        target = "session:changed" if self.changed else "session:fixture"
+        return build_plan(
+            operation=self.operation,
+            destructive_class="reversible",
+            target_refs=(target,),
+            affected_tiers=("user",),
+            reversible=True,
+        )
+
+    def apply(self, plan: MutationPlan, _args: object) -> MutationReceipt:
+        self.calls += 1
+        if self.crash:
+            raise RuntimeError("simulated actuator crash")
+        return MutationReceipt(
+            operation=plan.operation,
+            plan_hash=plan.plan_hash,
+            status="applied",
+            target_refs=plan.target_refs,
+            affected_count=1,
+            detail=None,
+            receipt_ref=None,
+            applied_at="now",
+        )
+
+
+def _binding(actuator: _Actuator) -> OperationBinding[object, object]:
+    spec = OperationSpec(
+        name="mutate-fixture",
+        kind=OperationKind.MAINTENANCE,
+        description="fixture",
+        mutates_state=True,
+        executor_status="executor-routed",
+        allowed_surfaces=("internal",),
+        target_authority=(
+            TargetAuthorityPolicy(
+                key="session",
+                target_kinds=("session",),
+                required_capabilities=("archive.fixture.write",),
+                destructive_class="reversible",
+                required_confirmation="role_only",
+                allowed_durabilities=("derived",),
+                allowed_recovery=("none",),
+            ),
+        ),
+        affected_tiers=("user",),
+    )
+    return OperationBinding(spec, actuator)
+
+
+def _principal() -> MutationPrincipal:
+    return MutationPrincipal("actor:test", frozenset({"archive.fixture.write"}), "internal", "system")
+
+
+def test_token_is_digest_only_and_consumption_run_attempt_are_atomic(tmp_path: Path) -> None:
+    audit = AuditRepository(tmp_path / "audit.db")
+    audit.ensure_archive_authority(now_ms=1)
+    actuator = _Actuator()
+    executor = OperationExecutor(audit=audit, token_factory=lambda: "raw-secret-token")
+    preview = executor.prepare_bound(
+        _binding(actuator),
+        object(),
+        _principal(),
+        archive_instance_id="archive:test",
+        archive_identity_digest="identity:test",
+        parameter_digest="params:test",
+    )
+    authorization = executor.authorize_bound(_binding(actuator), preview, _principal())
+    assert "raw-secret-token" not in (tmp_path / "audit.db").read_bytes().decode("utf-8", errors="ignore")
+    receipt = executor.execute_bound(_binding(actuator), preview, authorization, object())
+    assert receipt.operation_id is not None
+    operation = audit.get_operation(receipt.operation_id)
+    assert operation is not None
+    assert operation["status"] == "completed"
+    assert operation["affected_count"] == 1
+    assert audit.list_events(receipt.operation_id)[-1]["event_type"] == "attempt_finalized"
+    with pytest.raises(RuntimeError, match="consumed"):
+        executor.execute_bound(_binding(actuator), preview, authorization, object())
+    assert actuator.calls == 1
+
+
+def test_invalid_capability_and_stale_preview_refuse_before_apply(tmp_path: Path) -> None:
+    audit = AuditRepository(tmp_path / "audit.db")
+    actuator = _Actuator()
+    executor = OperationExecutor(audit=audit, token_factory=lambda: "token")
+    preview = executor.prepare_bound(
+        _binding(actuator),
+        object(),
+        _principal(),
+        archive_instance_id="archive:test",
+        archive_identity_digest="identity:test",
+        parameter_digest="params:test",
+    )
+    with pytest.raises(CapabilityDeniedError):
+        executor.authorize_bound(
+            _binding(actuator),
+            preview,
+            MutationPrincipal("actor:bad", frozenset(), "internal"),
+        )
+    authorization = executor.authorize_bound(_binding(actuator), preview, _principal())
+    actuator.changed = True
+    with pytest.raises(PlanStaleError):
+        executor.execute_bound(_binding(actuator), preview, authorization, object())
+    assert actuator.calls == 0
+
+
+def test_crash_after_intent_is_queryable_unknown_and_never_completed(tmp_path: Path) -> None:
+    audit = AuditRepository(tmp_path / "audit.db")
+    actuator = _Actuator(crash=True)
+    executor = OperationExecutor(audit=audit, token_factory=lambda: "crash-token")
+    preview = executor.prepare_bound(
+        _binding(actuator),
+        object(),
+        _principal(),
+        archive_instance_id="archive:test",
+        archive_identity_digest="identity:test",
+        parameter_digest="params:test",
+    )
+    authorization = executor.authorize_bound(_binding(actuator), preview, _principal())
+    with pytest.raises(RuntimeError, match="simulated"):
+        executor.execute_bound(_binding(actuator), preview, authorization, object())
+    conn = sqlite3.connect(tmp_path / "audit.db")
+    try:
+        operation_id = str(conn.execute("SELECT operation_id FROM operation_runs").fetchone()[0])
+        status = str(
+            conn.execute("SELECT status FROM operation_runs WHERE operation_id = ?", (operation_id,)).fetchone()[0]
+        )
+        target_state = str(
+            conn.execute("SELECT state FROM operation_targets WHERE operation_id = ?", (operation_id,)).fetchone()[0]
+        )
+    finally:
+        conn.close()
+    assert status == "interrupted"
+    assert target_state == "unknown"
+    assert audit.list_events(operation_id)[-1]["event_type"] == "attempt_unknown"

--- a/tests/unit/operations/test_operation_bindings.py
+++ b/tests/unit/operations/test_operation_bindings.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from polylogue.operations.bindings import (
+    BindingValidationError,
+    OperationBinding,
+    OperationBindingCatalog,
+    validate_operation_bindings,
+)
+from polylogue.operations.mutation_transaction import (
+    ConfirmationStrength,
+    DestructiveClass,
+    MutationPlan,
+    MutationReceipt,
+    TargetAuthorityPolicy,
+    build_plan,
+)
+from polylogue.operations.specs import OperationKind, OperationSpec
+
+
+@dataclass
+class _Actuator:
+    operation: str = "mutate-fixture"
+    operation_version: int = 3
+    destructive_class: DestructiveClass = "reversible"
+    required_confirmation: ConfirmationStrength = "role_only"
+
+    def prepare(self, _args: object) -> MutationPlan:
+        return build_plan(
+            operation=self.operation,
+            destructive_class="reversible",
+            target_refs=("session:fixture",),
+            affected_tiers=("user",),
+            reversible=True,
+        )
+
+    def apply(self, plan: MutationPlan, _args: object) -> MutationReceipt:
+        return MutationReceipt(
+            operation=plan.operation,
+            plan_hash=plan.plan_hash,
+            status="applied",
+            target_refs=plan.target_refs,
+            affected_count=1,
+            detail=None,
+            receipt_ref=None,
+            applied_at="now",
+        )
+
+
+def _spec(*, policies: tuple[TargetAuthorityPolicy, ...] | None = None) -> OperationSpec:
+    return OperationSpec(
+        name="mutate-fixture",
+        kind=OperationKind.MAINTENANCE,
+        description="fixture",
+        mutates_state=True,
+        executor_status="executor-routed",
+        operation_version=3,
+        allowed_surfaces=("internal",),
+        target_authority=(
+            policies
+            if policies is not None
+            else (
+                TargetAuthorityPolicy(
+                    key="session",
+                    target_kinds=("session",),
+                    required_capabilities=("archive.fixture.write",),
+                    destructive_class="reversible",
+                    required_confirmation="role_only",
+                    allowed_durabilities=("derived",),
+                    allowed_recovery=("none",),
+                ),
+            )
+        ),
+    )
+
+
+def test_binding_rejects_unregistered_capability_and_missing_policy() -> None:
+    actuator = _Actuator()
+    with pytest.raises(BindingValidationError, match="outside the archive capability namespace"):
+        OperationBinding(
+            _spec(
+                policies=(
+                    TargetAuthorityPolicy(
+                        key="session",
+                        target_kinds=("session",),
+                        required_capabilities=("fake.capability",),
+                        destructive_class="reversible",
+                        required_confirmation="role_only",
+                        allowed_durabilities=("derived",),
+                        allowed_recovery=("none",),
+                    ),
+                )
+            ),
+            actuator,
+        ).validate()
+    with pytest.raises(BindingValidationError, match="no target authority"):
+        OperationBinding(_spec(policies=()), actuator).validate()
+
+
+def test_binding_rejects_version_mismatch_and_duplicate_catalog_entries() -> None:
+    binding: OperationBinding[object, object] = OperationBinding(_spec(), _Actuator())
+    with pytest.raises(BindingValidationError, match="binding version"):
+        OperationBinding(_spec(), _Actuator(), operation_version=2).validate()
+    with pytest.raises(BindingValidationError, match="duplicate"):
+        OperationBindingCatalog.validate((binding, binding))
+
+
+def test_catalog_requires_every_executor_routed_spec_and_resolves_only_registered_actuators() -> None:
+    binding: OperationBinding[object, object] = OperationBinding(_spec(), _Actuator())
+    catalog = validate_operation_bindings((_spec(),), (binding,))
+    assert catalog.resolve("mutate-fixture", 3) is binding
+    with pytest.raises(BindingValidationError, match="no registered actuator"):
+        catalog.resolve("mutate-other", 1)
+
+
+def test_catalog_rejects_missing_binding() -> None:
+    with pytest.raises(BindingValidationError, match="missing"):
+        validate_operation_bindings((_spec(),), ())

--- a/tests/unit/storage/test_audit_tier.py
+++ b/tests/unit/storage/test_audit_tier.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from polylogue.daemon.backup import _all_archive_tiers, _profile_archive_tiers
+from polylogue.storage.archive_identity import ArchiveIdentity
+from polylogue.storage.sqlite.archive_tiers import ARCHIVE_VERSION_BY_TIER
+from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS, initialize_archive_database
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.migration_runner import DURABLE_MIGRATION_TIERS
+
+
+def test_audit_tier_bootstrap_has_v1_authority_tables_and_is_durable(tmp_path: Path) -> None:
+    path = tmp_path / "audit.db"
+    initialize_archive_database(path, ArchiveTier.AUDIT)
+    conn = sqlite3.connect(path)
+    try:
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 1
+        tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
+    finally:
+        conn.close()
+    assert {
+        "archive_authority",
+        "operation_previews",
+        "operation_authorizations",
+        "operation_runs",
+        "operation_events",
+    } <= tables
+    assert ArchiveTier.AUDIT in DURABLE_MIGRATION_TIERS
+    assert ARCHIVE_VERSION_BY_TIER[ArchiveTier.AUDIT] == ARCHIVE_TIER_SPECS[ArchiveTier.AUDIT].version
+    assert ARCHIVE_TIER_SPECS[ArchiveTier.AUDIT].backup_required is True
+
+
+def test_audit_is_in_authority_backup_inventory_but_not_its_own_identity_digest(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    root.mkdir()
+    before = ArchiveIdentity.resolve(root).authority_identity_digest
+    (root / "audit.db").touch()
+    after = ArchiveIdentity.resolve(root).authority_identity_digest
+    assert before == after
+    all_tiers = _all_archive_tiers(root)
+    assert all_tiers["audit"] == root / "audit.db"
+    assert "audit" in _profile_archive_tiers(root, "full_evidence")
+    assert "audit" in _profile_archive_tiers(root, "user_overlays")
+    assert "audit" in _profile_archive_tiers(root, "rebuildable_cache_exclude")


### PR DESCRIPTION
## Summary

Land Slice F of t46.9: the durable audit.db v1 authority journal, typed mutation identity and plan inputs, versioned operation bindings, fail-closed validation, one-time authorization tokens, and generic durable lifecycle receipts.

## Problem

Mutation authority needs reset-proof evidence and validated binding metadata before destructive routes can migrate. Existing executor routes must remain compatible while the authority foundation is introduced. Audit state and domain state also live in separate SQLite tiers, so the contract must expose actual audit transaction boundaries without claiming cross-file atomicity.

## Solution

Added the audit tier with canonical strict DDL, fresh bootstrap policy, archive registration, durable backup inventory, and reset exclusion. Added typed principals, targets, policies, plans, bindings, and validation that rejects unregistered actuators, fake or mismatched capabilities, duplicate bindings, version mismatches, and missing policy rows. Added random short-lived authorization tokens stored only as digests and bound to preview, actor, capability, surface, archive identity, version, and expiry. Token consumption, run creation, and initial attempt creation share one audit.db transaction. Finalization and reconciliation record applied, failed, unknown, stale, expired, running, and interrupted lifecycle evidence. Existing high-level executor methods remain compatible, while bound methods provide the new authority path.

No annotation import, file reset, maintenance replay, surface integration, catalog, services, or domain route migration is included.

## Verification

- devtools test tests/unit/operations/test_operation_bindings.py tests/unit/operations/test_operation_audit.py tests/unit/storage/test_audit_tier.py: 9 passed.
- devtools test tests/unit/operations/test_operation_audit.py: 4 passed.
- devtools verify --quick: all 22 steps passed.
- Pre-push devtools verify --quick: all 22 steps passed, run 20260803T220957Z-quick-283693-27b53186.
- Full test suite was not run. Domain route migration and cross-file transaction behavior remain outside this slice.

## Ref

polylogue-t46.9