### PR TITLE
fix(schema): drop dead session_provider_usage_events billing columns

### DIFF
--- a/docs/examples/demo-tour/command-output/01-claim-versus-receipt.txt
+++ b/docs/examples/demo-tour/command-output/01-claim-versus-receipt.txt
@@ -29,7 +29,7 @@ source material:
   blob_sha256: 9fd0dbdb080058070935924534a903cc63a8dcba571f6b2734f92a96576b59d7
 
 completion-claim experiment:
-  sample manifest: c90564d29c2d5bdb5caf2f7ed373d86933e018622ab845e889827979b7808f74
+  sample manifest: f02a3b758dda41ca63078fdeeac8b9cd027274987db3b91fa1050a3e2d518bb6
   denominator: 2
 unsupported by structural evidence: 0 (0.0%)
 neutral prior outcome: 0 (0.0%)

--- a/docs/examples/demo-tour/report.json
+++ b/docs/examples/demo-tour/report.json
@@ -28,7 +28,7 @@
     "result": "pass",
     "triggered": false
   },
-  "first_result_s": 4.83,
+  "first_result_s": 2.121,
   "non_claims": [
     "The deterministic tour does not establish field prevalence, production scale, or provider completeness.",
     "The deterministic tour does not establish memory uplift, invoice accuracy, selective deletion, or the Sinex backend.",
@@ -385,7 +385,7 @@
         "demo",
         "receipts"
       ],
-      "duration_s": 4.83,
+      "duration_s": 2.121,
       "exit_code": 0,
       "name": "claim versus receipt",
       "output_path": "command-output/01-claim-versus-receipt.txt"
@@ -396,7 +396,7 @@
         "polylogue",
         "actions where is_error:true | group by tool | count"
       ],
-      "duration_s": 4.118,
+      "duration_s": 2.907,
       "exit_code": 0,
       "name": "failed actions aggregate",
       "output_path": "command-output/02-failed-actions-aggregate.txt"
@@ -411,7 +411,7 @@
         "--view",
         "chronicle"
       ],
-      "duration_s": 4.479,
+      "duration_s": 2.582,
       "exit_code": 0,
       "name": "composed lineage",
       "output_path": "command-output/03-composed-lineage.txt"
@@ -423,13 +423,13 @@
         "analyze",
         "--facets"
       ],
-      "duration_s": 2.436,
+      "duration_s": 2.585,
       "exit_code": 0,
       "name": "archive facets",
       "output_path": "command-output/04-archive-facets.txt"
     }
   ],
-  "total_duration_s": 29.609,
+  "total_duration_s": 11.307,
   "transcript_path": "transcript.txt",
   "verify": {
     "absolute_path_leaks": [],

--- a/docs/examples/demo-tour/report.md
+++ b/docs/examples/demo-tour/report.md
@@ -40,8 +40,8 @@ The semantic fixture verifier runs before the narrated commands and checks plant
 
 ## Timings
 
-- First evidence result: 4.830s (budget 30s)
-- Full tour: 29.609s (budget 420s)
+- First evidence result: 2.121s (budget 30s)
+- Full tour: 11.307s (budget 420s)
 
 ## Archive
 
@@ -55,10 +55,10 @@ The semantic fixture verifier runs before the narrated commands and checks plant
 
 | Step | Exit | Duration | Bytes | Output |
 | --- | ---: | ---: | ---: | --- |
-| claim versus receipt | 0 | 4.830s | 1399 | `command-output/01-claim-versus-receipt.txt` |
-| failed actions aggregate | 0 | 4.118s | 62 | `command-output/02-failed-actions-aggregate.txt` |
-| composed lineage | 0 | 4.479s | 936 | `command-output/03-composed-lineage.txt` |
-| archive facets | 0 | 2.436s | 1652 | `command-output/04-archive-facets.txt` |
+| claim versus receipt | 0 | 2.121s | 1399 | `command-output/01-claim-versus-receipt.txt` |
+| failed actions aggregate | 0 | 2.907s | 62 | `command-output/02-failed-actions-aggregate.txt` |
+| composed lineage | 0 | 2.582s | 936 | `command-output/03-composed-lineage.txt` |
+| archive facets | 0 | 2.585s | 1652 | `command-output/04-archive-facets.txt` |
 
 ## Problems
 

--- a/docs/examples/demo-tour/transcript.txt
+++ b/docs/examples/demo-tour/transcript.txt
@@ -38,7 +38,7 @@ source material:
   blob_sha256: 9fd0dbdb080058070935924534a903cc63a8dcba571f6b2734f92a96576b59d7
 
 completion-claim experiment:
-  sample manifest: c90564d29c2d5bdb5caf2f7ed373d86933e018622ab845e889827979b7808f74
+  sample manifest: f02a3b758dda41ca63078fdeeac8b9cd027274987db3b91fa1050a3e2d518bb6
   denominator: 2
 unsupported by structural evidence: 0 (0.0%)
 neutral prior outcome: 0 (0.0%)

--- a/polylogue/sources/parsers/codex.py
+++ b/polylogue/sources/parsers/codex.py
@@ -489,11 +489,6 @@ def _compact_response_payload(
             compact["last_token_usage"] = last_usage
         if total_usage:
             compact["total_token_usage"] = total_usage
-        context_window = _optional_int_field(info, "model_context_window") or _optional_int_field(
-            payload, "model_context_window"
-        )
-        if context_window is not None:
-            compact["model_context_window"] = context_window
         # Rate-limit windows are quota telemetry Codex reports alongside each
         # token_count tick -- small, bounded, and otherwise invisible.
         rate_limits = _dict_record(payload.get("rate_limits"))

--- a/polylogue/storage/sqlite/archive_tiers/index.py
+++ b/polylogue/storage/sqlite/archive_tiers/index.py
@@ -385,7 +385,48 @@ from polylogue.storage.sqlite.delegation_facts import delegation_facts_insert_sq
 # priced_at_ms, a different pair of columns with a real production reader
 # (daemon/http.py's session-insights panel) -- see the price_catalogs
 # removal comment above session_model_usage's DDL for the full distinction.
-INDEX_SCHEMA_VERSION = 61
+# polylogue-664l: v62 batches two column-level dead-weight removals found by
+# the 2026-07-31 producer/consumer audit, both clone-safe (no re-parse of raw
+# evidence needed -- remaining/unchanged columns carry byte-identical values):
+#  - session_provider_usage_events drops 9 write-only columns:
+#    model_context_window plus the 8 Hermes billing-provenance columns
+#    (estimated_cost_usd, actual_cost_usd, cost_status, cost_source,
+#    pricing_version, billing_provider, billing_base_url, billing_mode).
+#    Every write site (`_provider_usage_event_row` in write.py) populates
+#    them from `ParsedSessionEvent.payload`, but no reader anywhere in the
+#    repo ever selects them -- confirmed by re-auditing `storage/usage.py`
+#    (the only production reader of this table), which reads only the
+#    `last_*`/`total_*` token counters. Same "cache/copy with zero readers"
+#    shape as v41's `action_pairs` text-copy removal.
+#  - attachment_native_ids.id_kind's CHECK narrows from 5 members to 4,
+#    dropping 'source'. Re-auditing confirmed 'url' IS read (the generic
+#    `search_attachment_identity_evidence_hits` identity-search query in
+#    `storage/sqlite/queries/attachment_records.py` joins ALL id_kind rows,
+#    not just attachment/file/drive, contrary to the audit's original
+#    "readers pull attachment/file/drive only" claim for 'url') -- so 'url'
+#    is kept. 'source' has zero producers anywhere in the repo
+#    (`_write_attachment_native_ids` in write.py only ever writes
+#    attachment/file/drive/url) and zero live rows can exist by
+#    construction, so narrowing the CHECK rejects nothing on any real
+#    archive -- CONSTRAINT_ONLY, the same v33/v36/v51/v52 "tightening over
+#    unchanged values" precedent.
+#  - The other two column-level findings from the same audit (bead
+#    polylogue-664l) were re-verified and found stale on current source, so
+#    no DDL change accompanies them here: `insight_materialization`'s CHECK
+#    vocabulary (9 values) is fully live (every value has a real writer in
+#    `rebuild.py`/`write.py`); the registry entries with no per-session
+#    ledger row are either `readiness_exempt=True` (query-time aggregates
+#    with no separate materialized state to go stale: archive_coverage,
+#    tool_usage, session_costs, cost_rollups, usage_timeline, archive_debt)
+#    or `session_tag_rollups`, which has its own dedicated non-session-scoped
+#    staleness query (`STALE_SESSION_TAG_ROLLUP_COUNT_SQL` in
+#    `storage/insights/session/status.py`) because it isn't keyed by
+#    session_id at all. `input_high_water_mark_source` is read broadly
+#    across public surfaces (`insights/archive.py`'s `time_confidence_for_
+#    source`, `daemon/http.py` status payloads), not confined to
+#    repair/status internals. price_catalogs metadata is out of scope here
+#    (table-level finding, tracked separately by polylogue-resk).
+INDEX_SCHEMA_VERSION = 62
 
 # polylogue-v6i3: shared WHEN-clause fragment gating the blocks_command_trigram
 # trigger BODIES on the same dedicated bulk-build guard row messages_fts's
@@ -1239,7 +1280,7 @@ CREATE TABLE IF NOT EXISTS attachment_refs (
 
 CREATE TABLE IF NOT EXISTS attachment_native_ids (
     ref_id     TEXT NOT NULL REFERENCES attachment_refs(ref_id) ON DELETE CASCADE,
-    id_kind    TEXT NOT NULL CHECK(id_kind IN ('attachment', 'file', 'drive', 'source', 'url')),
+    id_kind    TEXT NOT NULL CHECK(id_kind IN ('attachment', 'file', 'drive', 'url')),
     native_id  TEXT NOT NULL,
     PRIMARY KEY(ref_id, id_kind, native_id)
 ) STRICT;
@@ -1350,15 +1391,6 @@ CREATE TABLE IF NOT EXISTS session_provider_usage_events (
     total_cache_write_tokens       INTEGER NOT NULL DEFAULT 0 CHECK(total_cache_write_tokens >= 0),
     total_reasoning_output_tokens  INTEGER NOT NULL DEFAULT 0 CHECK(total_reasoning_output_tokens >= 0),
     total_tokens                   INTEGER NOT NULL DEFAULT 0 CHECK(total_tokens >= 0),
-    model_context_window           INTEGER CHECK(model_context_window IS NULL OR model_context_window >= 0),
-    estimated_cost_usd              REAL,
-    actual_cost_usd                 REAL,
-    cost_status                     TEXT,
-    cost_source                     TEXT,
-    pricing_version                 TEXT,
-    billing_provider                TEXT,
-    billing_base_url                TEXT,
-    billing_mode                    TEXT,
     occurred_at_ms                 INTEGER,
     PRIMARY KEY(session_id, position)
 ) STRICT;

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -4282,7 +4282,7 @@ def _write_session_events(
                 event,
                 provider_usage_baseline=provider_usage_baseline,
             )
-            if _provider_usage_event_row_has_evidence(row, event):
+            if _provider_usage_event_row_has_evidence(row):
                 provider_usage_rows.append(row)
                 wrote_provider_usage_events = True
         position += 1
@@ -4320,10 +4320,9 @@ _PROVIDER_USAGE_EVENT_INSERT_SQL = """
         last_input_tokens, last_output_tokens, last_cached_input_tokens,
         last_cache_write_tokens, last_reasoning_output_tokens, last_total_tokens,
         total_input_tokens, total_output_tokens, total_cached_input_tokens,
-        total_cache_write_tokens, total_reasoning_output_tokens, total_tokens, model_context_window,
-        estimated_cost_usd, actual_cost_usd, cost_status, cost_source, pricing_version,
-        billing_provider, billing_base_url, billing_mode, occurred_at_ms
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        total_cache_write_tokens, total_reasoning_output_tokens, total_tokens,
+        occurred_at_ms
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 """
 
 
@@ -4368,38 +4367,12 @@ def _provider_usage_event_row(
         total_cache_write,
         total_reasoning,
         total_tokens,
-        _payload_optional_int(event.payload, "model_context_window"),
-        _payload_optional_float(event.payload, "estimated_cost_usd"),
-        _payload_optional_float(event.payload, "actual_cost_usd"),
-        _sqlite_text(_payload_string(event.payload, "cost_status")),
-        _sqlite_text(_payload_string(event.payload, "cost_source")),
-        _sqlite_text(_payload_string(event.payload, "pricing_version")),
-        _sqlite_text(_payload_string(event.payload, "billing_provider")),
-        _sqlite_text(_payload_string(event.payload, "billing_base_url")),
-        _sqlite_text(_payload_string(event.payload, "billing_mode")),
         _timestamp_ms(event.timestamp),
     )
 
 
-_PROVIDER_USAGE_PROVENANCE_KEYS = (
-    "estimated_cost_usd",
-    "actual_cost_usd",
-    "cost_status",
-    "cost_source",
-    "pricing_version",
-    "billing_provider",
-    "billing_base_url",
-    "billing_mode",
-)
-
-
-def _provider_usage_event_row_has_evidence(
-    row: tuple[object, ...],
-    event: ParsedSessionEvent,
-) -> bool:
-    if any(isinstance(value, int) and value for value in row[5:17]):
-        return True
-    return any(event.payload.get(key) is not None for key in _PROVIDER_USAGE_PROVENANCE_KEYS)
+def _provider_usage_event_row_has_evidence(row: tuple[object, ...]) -> bool:
+    return any(isinstance(value, int) and value for value in row[5:17])
 
 
 def _provider_usage_cumulative_baseline(
@@ -6262,14 +6235,6 @@ def _reextract_provider_usage_tail_db(
           AND total_cache_write_tokens = 0
           AND total_reasoning_output_tokens = 0
           AND total_tokens = 0
-          AND estimated_cost_usd IS NULL
-          AND actual_cost_usd IS NULL
-          AND cost_status IS NULL
-          AND cost_source IS NULL
-          AND pricing_version IS NULL
-          AND billing_provider IS NULL
-          AND billing_base_url IS NULL
-          AND billing_mode IS NULL
         """,
         (child_session_id,),
     )

--- a/polylogue/storage/sqlite/lifecycle.py
+++ b/polylogue/storage/sqlite/lifecycle.py
@@ -784,6 +784,56 @@ INDEX_DELTA_DECLARATIONS: tuple[IndexDeltaDeclaration, ...] = (
             ),
         ),
     ),
+    IndexDeltaDeclaration(
+        version=62,
+        # polylogue-664l: batches two column-level dead-weight removals from
+        # the 2026-07-31 producer/consumer audit -- see INDEX_SCHEMA_VERSION's
+        # v62 comment (archive_tiers/index.py) for the full writeup and
+        # re-audit evidence for all four originally-named findings.
+        #  - session_provider_usage_events drops 9 write-only columns
+        #    (model_context_window + 8 Hermes billing-provenance columns).
+        #    No reader ever selected them; the remaining columns (the
+        #    last_*/total_* token counters every production reader actually
+        #    uses) are unaffected -- CACHE_REMOVAL, the v41 `action_pairs`
+        #    text-copy-removal precedent.
+        #  - attachment_native_ids.id_kind's CHECK drops the 'source' member,
+        #    which has zero producers anywhere in the repo, so zero live rows
+        #    can exist with that value on any real archive -- CONSTRAINT_ONLY,
+        #    the v33/v36/v51/v52 "tightening over unchanged values" precedent.
+        # Both REPLACE_TABLE operations below use the generic shared-column
+        # copy-forward (`_apply_replace_table`): it naturally drops columns
+        # the canonical DDL no longer declares while preserving every
+        # remaining column's values byte-for-byte, so this whole version is
+        # eligible for fast-forward with no reprocess debt.
+        classes=(DerivedDeltaClass.CACHE_REMOVAL, DerivedDeltaClass.CONSTRAINT_ONLY),
+        operations=(
+            FastForwardOperation(
+                name="v62-provider-usage-events-billing-columns",
+                kind=FastForwardOperationKind.REPLACE_TABLE,
+                objects=(("table", "session_provider_usage_events"),),
+            ),
+            # _apply_replace_table's DROP TABLE step also drops every index
+            # defined on the table; re-declare them explicitly instead of
+            # relying on runtime_indexes.py's narrower ensure-on-connect list
+            # (which only covers the source_message/time_model pair, not the
+            # base session_id/position index).
+            FastForwardOperation(
+                name="v62-provider-usage-events-billing-columns",
+                kind=FastForwardOperationKind.CREATE_INDEX,
+                objects=(("index", "idx_session_provider_usage_events_session"),),
+            ),
+            FastForwardOperation(
+                name="v62-attachment-native-ids-source-kind",
+                kind=FastForwardOperationKind.REPLACE_TABLE,
+                objects=(("table", "attachment_native_ids"),),
+            ),
+            FastForwardOperation(
+                name="v62-attachment-native-ids-source-kind",
+                kind=FastForwardOperationKind.CREATE_INDEX,
+                objects=(("index", "idx_attachment_native_ids_native"),),
+            ),
+        ),
+    ),
 )
 
 

--- a/polylogue/storage/usage.py
+++ b/polylogue/storage/usage.py
@@ -252,7 +252,6 @@ _PROVIDER_USAGE_COVERAGE: tuple[ProviderUsageCoverage, ...] = (
         request_semantics="Codex last_token_usage is request/current-window telemetry and can be summed by request when present.",
         cumulative_semantics="Codex total_token_usage is cumulative and session-global; rollups take the latest total per session to avoid double-counting.",
         cache_semantics="cached_input_tokens and cache write/cache creation aliases are preserved as separate lanes and are not folded into generic input/output.",
-        notes=("model_context_window is carried on token_count events when the provider supplies it.",),
     ),
     ProviderUsageCoverage(
         origin=Origin.CHATGPT_EXPORT.value,

--- a/tests/infra/storage_records.py
+++ b/tests/infra/storage_records.py
@@ -668,8 +668,6 @@ def upsert_attachment(conn: sqlite3.Connection, record: AttachmentRecord) -> boo
             native_rows.append((ref_id, "file", record.file_native_id))
         if record.drive_native_id:
             native_rows.append((ref_id, "drive", record.drive_native_id))
-        if record.path:
-            native_rows.append((ref_id, "source", record.path))
         conn.executemany(
             """
             INSERT OR IGNORE INTO attachment_native_ids (ref_id, id_kind, native_id)

--- a/tests/unit/pipeline/test_hermes_raw_identity.py
+++ b/tests/unit/pipeline/test_hermes_raw_identity.py
@@ -177,23 +177,6 @@ async def test_identical_hermes_profiles_persist_and_reprocess_independently(tmp
         assert {str(row["raw_id"]) for row in rows} == set(acquired.raw_ids)
         session_ids = [str(row["session_id"]) for row in rows]
 
-        async def durable_cost_payloads() -> list[dict[str, object]]:
-            async with backend.connection() as conn:
-                event_rows = list(
-                    await (
-                        await conn.execute(
-                            """
-                            SELECT estimated_cost_usd, actual_cost_usd, cost_status, cost_source,
-                                   pricing_version, billing_provider, billing_base_url, billing_mode
-                            FROM session_provider_usage_events
-                            WHERE provider_event_type = 'token_count'
-                            ORDER BY session_id, position
-                            """
-                        )
-                    ).fetchall()
-                )
-            return [{key: value for key, value in dict(row).items() if value is not None} for row in event_rows]
-
         async def durable_cost_typed_totals() -> list[dict[str, object]]:
             async with backend.connection() as conn:
                 event_rows = list(
@@ -278,40 +261,19 @@ async def test_identical_hermes_profiles_persist_and_reprocess_independently(tmp
                 result[str(row["session_id"])]["states"].append((str(row["source_message_id"]), str(row["state"])))
             return result
 
-        expected_cost_provenance = {
-            "estimated_cost_usd": 0.002,
-            "actual_cost_usd": 0.0015,
-            "cost_status": "estimated",
-            "cost_source": "litellm",
-            "pricing_version": "2026-07-10",
-            "billing_provider": "openrouter",
-            "billing_base_url": "https://openrouter.ai/api/v1",
-            "billing_mode": "metered",
-        }
-        cost_payloads = await durable_cost_payloads()
-        assert len(cost_payloads) == len(session_ids)
-        assert all(
-            {key: payload[key] for key in expected_cost_provenance} == expected_cost_provenance
-            for payload in cost_payloads
-        )
-        # The billing-provenance keys are their own nullable typed columns
-        # (polylogue-ei0d / polylogue-c3ip, index v45): every other field of
-        # the raw provider event (total_token_usage, model, type, ...) is
-        # redundant with a typed column on the same row, so only these eight
-        # columns carry Hermes cost-provenance evidence -- no JSON blob.
-        assert all(set(payload) == set(expected_cost_provenance) for payload in cost_payloads)
-        assert all(
-            totals
-            == {
-                "total_cached_input_tokens": 0,
-                "total_cache_write_tokens": 0,
-                "total_input_tokens": 0,
-                "total_output_tokens": 0,
-                "total_reasoning_output_tokens": 0,
-                "total_tokens": 0,
-            }
-            for totals in await durable_cost_typed_totals()
-        )
+        # polylogue-664l: the eight Hermes billing-provenance columns
+        # (estimated_cost_usd, actual_cost_usd, cost_status, cost_source,
+        # pricing_version, billing_provider, billing_base_url, billing_mode)
+        # were dropped from session_provider_usage_events (index v61) -- a
+        # 2026-07-31 producer/consumer audit found zero production readers
+        # anywhere in the repo. This fixture's Hermes session carries only
+        # billing evidence and zero real token counts, so with the billing
+        # columns gone there is no evidence left to write a row for at all:
+        # `_provider_usage_event_row_has_evidence` now gates purely on the
+        # token counters, and an all-zero-counter row with no billing data
+        # would carry no information. The pipeline correctly writes zero
+        # session_provider_usage_events rows for this fixture now.
+        assert await durable_cost_typed_totals() == []
 
         hermes_events = await durable_hermes_events()
         assert set(hermes_events) == set(session_ids)
@@ -367,8 +329,7 @@ async def test_identical_hermes_profiles_persist_and_reprocess_independently(tmp
         session_count = int(session_row[0])
         assert raw_count == 2
         assert session_count == 2
-        rebuilt_cost_payloads = await durable_cost_payloads()
-        assert rebuilt_cost_payloads == cost_payloads
+        assert await durable_cost_typed_totals() == []
         assert await durable_hermes_events() == hermes_events
         assert await durable_message_state() == message_state
     finally:

--- a/tests/unit/sources/test_parsers_codex.py
+++ b/tests/unit/sources/test_parsers_codex.py
@@ -1491,7 +1491,7 @@ class TestEdgeCases:
             "uncached_input_tokens": 80,
             "output_tokens": 40,
         }
-        assert usage_event.payload["model_context_window"] == 200000
+        assert "model_context_window" not in usage_event.payload
 
     def test_token_count_event_preserves_nested_usage_counters(self) -> None:
         payload = [
@@ -1540,7 +1540,6 @@ class TestEdgeCases:
                 "reasoning_output_tokens": 40,
                 "total_tokens": 10340,
             },
-            "model_context_window": 200000,
         }
 
 

--- a/tests/unit/storage/test_archive_tiers_write.py
+++ b/tests/unit/storage/test_archive_tiers_write.py
@@ -1184,7 +1184,6 @@ def test_archive_tiers_writer_materializes_provider_usage_events(tmp_path: Path)
                         "reasoning_output_tokens": 40,
                         "total_tokens": 190,
                     },
-                    "model_context_window": 200000,
                 },
             )
         ],
@@ -1198,7 +1197,7 @@ def test_archive_tiers_writer_materializes_provider_usage_events(tmp_path: Path)
                last_input_tokens, last_output_tokens, last_cached_input_tokens,
                last_cache_write_tokens, last_reasoning_output_tokens, last_total_tokens,
                total_input_tokens, total_output_tokens, total_cached_input_tokens,
-               total_cache_write_tokens, total_reasoning_output_tokens, total_tokens, model_context_window,
+               total_cache_write_tokens, total_reasoning_output_tokens, total_tokens,
                occurred_at_ms
         FROM session_provider_usage_events
         WHERE session_id = ?
@@ -1222,7 +1221,6 @@ def test_archive_tiers_writer_materializes_provider_usage_events(tmp_path: Path)
         "total_cache_write_tokens": 10,
         "total_reasoning_output_tokens": 40,
         "total_tokens": 190,
-        "model_context_window": 200000,
         "occurred_at_ms": 1_767_225_603_000,
     }
 

--- a/tests/unit/storage/test_lineage_normalization.py
+++ b/tests/unit/storage/test_lineage_normalization.py
@@ -1224,17 +1224,21 @@ def test_child_before_parent_reextracts_provider_usage_tail(tmp_path: Path) -> N
         "cache_read_tokens": 10,
         "cost_provenance": "priced",
     }
-    provenance_rows = conn.execute(
-        """
-        SELECT actual_cost_usd
-        FROM session_provider_usage_events
-        WHERE session_id = ?
-          AND actual_cost_usd IS NOT NULL
-        """,
+    # polylogue-664l: session_provider_usage_events dropped its 8 Hermes
+    # billing-provenance columns (index v61, zero production readers). The
+    # third session_event above carries only billing evidence (no token
+    # counts), so `_provider_usage_event_row_has_evidence` -- now gated
+    # purely on the token counters -- correctly writes no row for it. Of the
+    # two remaining events, the "c1" one is deleted by the prefix-tail
+    # reextraction (its source message is in the shared parent prefix); only
+    # the divergent-tail "cy" event survives, with baseline subtraction
+    # applied against the parent's cumulative totals.
+    remaining = conn.execute(
+        "SELECT total_input_tokens, total_tokens FROM session_provider_usage_events WHERE session_id = ?",
         (child_id,),
     ).fetchall()
-    assert len(provenance_rows) == 1
-    assert provenance_rows[0]["actual_cost_usd"] == 0.125
+    assert len(remaining) == 1
+    assert dict(remaining[0]) == {"total_input_tokens": 60, "total_tokens": 75}
 
 
 def test_parent_reingest_keeps_child_composing(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_store_ops.py
+++ b/tests/unit/storage/test_store_ops.py
@@ -1002,19 +1002,6 @@ def test_upsert_optional_and_attachment_contracts(test_conn: sqlite3.Connection)
     assert att_row["mime_type"] == "image/jpeg"
     assert att_row["size_bytes"] == 2048
     assert att_row["path"] == "path.jpg"
-    source_native = test_conn.execute(
-        """
-        SELECT ani.native_id
-        FROM attachment_refs ar
-        JOIN attachment_native_ids ani ON ani.ref_id = ar.ref_id
-        WHERE ar.attachment_id = ? AND ani.id_kind = 'source'
-        ORDER BY ani.native_id DESC
-        LIMIT 1
-        """,
-        (att_row["attachment_id"],),
-    ).fetchone()
-    assert source_native is not None
-    assert source_native["native_id"] == "new/path.jpg"
     assert att_row["ref_count"] == 2
 
 


### PR DESCRIPTION
## Summary

Drops 9 write-only columns from `session_provider_usage_events` (index v61) and narrows `attachment_native_ids.id_kind`'s CHECK to drop the never-written `'source'` value, per the column-level audit findings in polylogue-664l. The other two findings in that bead (`insight_materialization` CHECK vs registry, `input_high_water_mark_source` read scope) were re-verified against current source and found stale, so no change accompanies them.

## Problem

Bead polylogue-664l's 2026-07-31 producer/consumer audit named 4 column-level findings. Re-verifying each against current source (drift was likely, per the dispatch instructions):

1. **`session_provider_usage_events` billing columns** — confirmed live: `model_context_window` + 8 Hermes billing-provenance columns (`estimated_cost_usd`, `actual_cost_usd`, `cost_status`, `cost_source`, `pricing_version`, `billing_provider`, `billing_base_url`, `billing_mode`) are written by `_provider_usage_event_row` (write.py) from `ParsedSessionEvent.payload`, but `storage/usage.py` — the sole production reader of this table — only ever selects the `last_*`/`total_*` token counters. No other production code reads these columns.
2. **`attachment_native_ids.id_kind='url'`** — the audit's claim ("readers pull attachment/file/drive only") is **stale**: `search_attachment_identity_evidence_hits` (a live production search path reachable from `SessionRepository`) joins ALL `id_kind` rows generically, including `'url'`. `'source'`, however, has zero producers anywhere in the repo — `_write_attachment_native_ids` only ever writes `attachment`/`file`/`drive`/`url` — so it's genuinely dead CHECK vocabulary.
3. **`insight_materialization` CHECK vs registry** — **stale**. The CHECK's 9 values are all live (every one has a real writer in `rebuild.py`/`write.py`). The registry entries with no per-session ledger row are either `readiness_exempt=True` (query-time aggregates with no separate materialized state: `archive_coverage`, `tool_usage`, `session_costs`, `cost_rollups`, `usage_timeline`, `archive_debt`) or `session_tag_rollups`, which has its own dedicated non-session-scoped staleness query (`STALE_SESSION_TAG_ROLLUP_COUNT_SQL`) because it isn't keyed by `session_id`. `input_high_water_mark_source` is read broadly (`insights/archive.py`'s `time_confidence_for_source`, `daemon/http.py` status payloads), not confined to repair/status internals.
4. **`price_catalogs` metadata** — out of scope here; overlaps with polylogue-resk's table-level finding on the same table, which is being handled by a separate lane.

## Solution

- `polylogue/storage/sqlite/archive_tiers/index.py`: drops the 9 dead columns from `session_provider_usage_events`'s DDL and narrows `attachment_native_ids.id_kind`'s CHECK; bumps `INDEX_SCHEMA_VERSION` to 61 with a documented header.
- `polylogue/storage/sqlite/lifecycle.py`: declares v61 as `(CACHE_REMOVAL, CONSTRAINT_ONLY)` with `REPLACE_TABLE` fast-forward operations for both tables, plus explicit `CREATE_INDEX` re-declarations — `_apply_replace_table`'s DROP TABLE step also drops the table's indexes, so they're re-declared rather than left to the narrower `runtime_indexes.py` ensure-on-connect list (which doesn't cover the base `session_id`/`position` index or `attachment_native_ids`'s index at all).
- `polylogue/storage/sqlite/archive_tiers/write.py`: drops the billing columns from the INSERT SQL and row builder; simplifies `_provider_usage_event_row_has_evidence` to gate purely on token counters (previously it also treated billing-only evidence as "has evidence" — with billing columns gone, an all-zero-counter row carries no information, so it correctly no longer materializes).
- `polylogue/sources/parsers/codex.py`: stops computing `model_context_window` in the parsed payload (fully dead once the storage column is gone).
- `polylogue/storage/usage.py`: removes a stale coverage-report note claiming `model_context_window` is "carried" on events.
- Test fixtures updated across `tests/unit/pipeline/test_hermes_raw_identity.py`, `tests/unit/sources/test_parsers_codex.py`, `tests/unit/storage/test_archive_tiers_write.py`, `tests/unit/storage/test_lineage_normalization.py`; `tests/infra/storage_records.py`'s test-only `upsert_attachment()` helper also wrote `id_kind='source'` (a real, if test-only, producer the original audit missed by only grepping `polylogue/`) — stopped writing it, updated `test_store_ops.py` accordingly.
- `docs/examples/demo-tour/` regenerated: the demo's completion-claim sample-manifest hash is derived in part from `PRAGMA user_version`, so it drifts on any schema bump (confirmed by reverting locally and observing the freshness check pass clean before this change).

**Alternative considered and rejected**: keeping the billing columns as "unfinished work" per this repo's completion-over-deletion default. Rejected because (a) it's a rebuildable index-tier column, not durable/irreplaceable data, (b) the bead measured only ~103 live rows populate them, and (c) the operator explicitly scoped this session's work as a schema-pruning pass ("purge everything we can't argue is useful/relevant") — a write-only column with a genuine round-trip test but zero production consumer is exactly what that pass targets.

## Verification

- `python3 -m mypy --strict` on all touched production and test files — no issues.
- `devtools test` on the full affected slice: `test_hermes_raw_identity.py`, `test_parsers_codex.py`, `test_archive_tiers_write.py`, `test_archive_tiers_ddl.py`, `test_attachment_first_class_ids.py`, `test_schema_policy_contracts.py`, `test_index_fast_forward_executor.py`, `test_index_fast_forward_lifecycle.py`, `test_lineage_normalization.py`, `test_store_ops.py`, plus the broader usage/pricing/cost-reconciliation/incremental-rebuild slice — all pass (two failures during the run, `test_insights.py::test_insights_profiles_plain_output_shows_session_time_axis` and `test_store_ops.py::TestInfraTagAssignment::test_tag_assignment_roundtrip_and_counts`, were confirmed pre-existing/host-contention-flaky by reproducing against unmodified `master` / rerunning in isolation).
- `devtools lab policy schema-versioning` passes.
- `devtools verify --quick` passes (22/22 steps, exit 0) — including on the final push via the pre-push hook.

Ref polylogue-664l