### PR TITLE
test(daemon): remove stale threads health expectation

### DIFF
--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -1772,7 +1772,6 @@ def test_daemon_status_payload_reuses_bounded_probe_results(tmp_path: Path) -> N
             "indexed_surface": "messages_fts",
             "messages_ready": True,
             "session_work_events_ready": True,
-            "threads_ready": True,
             "invariant_ready": True,
             "message_indexed_count": 4,
             "message_indexable_count": 4,
@@ -1808,7 +1807,6 @@ def test_daemon_status_payload_reuses_bounded_probe_results(tmp_path: Path) -> N
     assert isinstance(fts_readiness, dict)
     assert fts_readiness["messages_ready"] is True
     assert fts_readiness["session_work_events_ready"] is True
-    assert fts_readiness["threads_ready"] is True
     assert fts_readiness["invariant_ready"] is True
     assert fts_readiness["message_indexed_count"] == 4
     assert fts_readiness["message_indexable_count"] == 4


### PR DESCRIPTION
Summary\nAlign the daemon status regression test with the v63 removal of threads_fts.\n\nProblem\nThe production payload no longer reports threads_ready, but one test still required that removed field.\n\nSolution\nRemove the obsolete fixture key and assertion.\n\nVerification\ndevtools test tests/unit/daemon/test_daemon_status.py -k daemon_status_payload_reuses_bounded_probe_results; devtools verify --quick.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated daemon status tests to reflect the current full-text search readiness response.
  * Removed an outdated readiness-field assertion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->