### PR TITLE
fix(devtools): isolate lane virtual environments

### DIFF
--- a/devtools/checkout_guard.py
+++ b/devtools/checkout_guard.py
@@ -407,13 +407,12 @@ def assert_polylogue_matches_checkout(
     *,
     context: str,
     python_executable: Path | None = None,
-) -> Path:
+) -> CheckoutEnvironmentFingerprint:
     """Raise loudly when import or environment provenance does not match ``repo_root``.
 
-    Returns the resolved package path on success, so callers can also use it
-    as the "print the resolved path in the receipt" observability hook
-    (requirement (3) of the worktree-import hazard fix) without importing
-    ``polylogue`` a second time.
+    Returns the validated environment fingerprint on success, so callers can
+    persist the exact provenance the guard checked without reading the
+    filesystem a second time.
     """
     resolved_root = repo_root.resolve()
     resolved_pkg = resolved_polylogue_path()
@@ -443,4 +442,4 @@ def assert_polylogue_matches_checkout(
         python_executable=python_executable,
     )
     _raise_environment_mismatch(context, fingerprint)
-    return resolved_pkg
+    return fingerprint

--- a/devtools/checkout_guard.py
+++ b/devtools/checkout_guard.py
@@ -60,6 +60,10 @@ call); a script that wants the guarantee can import and call
 
 from __future__ import annotations
 
+import json
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
 from pathlib import Path
 
 import tomllib
@@ -67,6 +71,66 @@ import tomllib
 
 class CheckoutImportMismatchError(RuntimeError):
     """``import polylogue`` resolved to a package outside the invoking checkout."""
+
+
+class CheckoutEnvironmentMismatchError(CheckoutImportMismatchError):
+    """The checkout contains environment state that makes results untrustworthy."""
+
+
+@dataclass(frozen=True, slots=True)
+class EnvironmentArtifact:
+    """One checkout-local artifact that can poison a linked-worktree run."""
+
+    kind: str
+    path: Path
+    detail: str
+    remediation: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "kind": self.kind,
+            "path": str(self.path),
+            "detail": self.detail,
+            "remediation": self.remediation,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CheckoutEnvironmentFingerprint:
+    """Provenance and contamination evidence attached to verification receipts."""
+
+    checkout_root: Path
+    polylogue_import_path: Path
+    python_executable: Path
+    python_environment_root: Path | None
+    linked_worktree: bool
+    testmon_state_origin: Path | None
+    verify_state_origin: Path | None
+    artifacts: tuple[EnvironmentArtifact, ...]
+
+    @property
+    def clean(self) -> bool:
+        return not self.artifacts
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "checkout_root": str(self.checkout_root),
+            "polylogue_import_path": str(self.polylogue_import_path),
+            "python_executable": str(self.python_executable),
+            "python_environment_root": (
+                str(self.python_environment_root) if self.python_environment_root is not None else None
+            ),
+            "linked_worktree": self.linked_worktree,
+            "testmon_state_origin": str(self.testmon_state_origin) if self.testmon_state_origin else None,
+            "verify_state_origin": str(self.verify_state_origin) if self.verify_state_origin else None,
+            "artifacts": [artifact.as_dict() for artifact in self.artifacts],
+        }
+
+
+_TESTMON_STATE_DIR = Path(".cache/testmon")
+_TESTMON_STATE_MARKER = _TESTMON_STATE_DIR / "seed.json"
+_VERIFY_STATE_DIR = Path(".cache/verify")
+_VERIFY_STATE_MARKER = _VERIFY_STATE_DIR / "current-run.json"
 
 
 def resolved_polylogue_path() -> Path:
@@ -155,8 +219,196 @@ def find_git_worktree_root(start: Path) -> Path | None:
     return None
 
 
-def assert_polylogue_matches_checkout(repo_root: Path, *, context: str) -> Path:
-    """Raise loudly when the imported ``polylogue`` package lives outside ``repo_root``.
+def _is_linked_worktree(repo_root: Path) -> bool:
+    """Return whether ``repo_root`` has Git's linked-worktree ``.git`` file."""
+    try:
+        return (repo_root / ".git").is_file()
+    except OSError:
+        return False
+
+
+def _python_environment_root(executable: Path) -> Path | None:
+    """Return the checkout owning a ``.venv`` executable, when identifiable."""
+    # Keep the lexical ``.venv`` component. Nix/direnv Python launchers are
+    # symlinks into the Nix store, so resolving first would erase the checkout
+    # boundary and falsely classify a valid lane-local interpreter as foreign.
+    candidate = executable if executable.is_absolute() else Path.cwd() / executable
+    for parent in (candidate, *candidate.parents):
+        if parent.name == ".venv":
+            return parent.parent.resolve()
+    return None
+
+
+def _marker_origin(marker: Path) -> Path | None:
+    """Read a marker's checkout origin, returning ``None`` for legacy state."""
+    try:
+        payload = json.loads(marker.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, Mapping):
+        return None
+    raw = payload.get("checkout_root")
+    if raw is None:
+        fingerprint = payload.get("environment_fingerprint")
+        if isinstance(fingerprint, Mapping):
+            raw = fingerprint.get("checkout_root")
+    if not isinstance(raw, str) or not raw:
+        return None
+    return Path(raw).resolve()
+
+
+def _cache_artifact(
+    *,
+    repo_root: Path,
+    state_dir: Path,
+    marker: Path,
+    kind: str,
+    remediation: str,
+) -> tuple[Path | None, EnvironmentArtifact | None]:
+    """Classify one cache directory by its explicit checkout-root marker."""
+    state_path = repo_root / state_dir
+    if not state_path.exists():
+        return None, None
+    try:
+        if state_path.is_dir() and not any(state_path.iterdir()):
+            return None, None
+    except OSError:
+        pass
+    origin = _marker_origin(repo_root / marker)
+    if origin == repo_root:
+        return origin, None
+    if origin is None:
+        detail = f"{state_path} has no verifiable checkout-root marker"
+    else:
+        detail = f"{state_path} was produced by checkout {origin}, not {repo_root}"
+    return (
+        origin,
+        EnvironmentArtifact(
+            kind=kind,
+            path=repo_root / marker if (repo_root / marker).exists() else state_path,
+            detail=detail,
+            remediation=remediation,
+        ),
+    )
+
+
+def checkout_environment_fingerprint(
+    repo_root: Path,
+    *,
+    polylogue_import_path: Path | None = None,
+    python_executable: Path | None = None,
+) -> CheckoutEnvironmentFingerprint:
+    """Collect cheap, deterministic provenance and contamination evidence.
+
+    Artifact checks are intentionally scoped to linked worktrees. The main
+    checkout owns the shared development environment and its caches; a lane
+    worktree must either have a lane-local interpreter/cache marker or refuse
+    before verification starts.
+    """
+    resolved_root = repo_root.resolve()
+    resolved_pkg = (polylogue_import_path or resolved_polylogue_path()).resolve()
+    executable_input = python_executable or Path(sys.executable)
+    environment_root = _python_environment_root(executable_input)
+    executable = executable_input.resolve()
+    linked = _is_linked_worktree(resolved_root)
+    artifacts: list[EnvironmentArtifact] = []
+    testmon_origin: Path | None = None
+    verify_origin: Path | None = None
+
+    if linked:
+        if environment_root is not None and environment_root != resolved_root:
+            artifacts.append(
+                EnvironmentArtifact(
+                    kind="interpreter_from_other_checkout",
+                    path=executable,
+                    detail=(
+                        f"interpreter environment {environment_root} belongs to another checkout; "
+                        f"this run executes code from {resolved_root}"
+                    ),
+                    remediation=(f"run `cd {resolved_root} && direnv allow` to provision this worktree's venv"),
+                )
+            )
+        local_venv = resolved_root / ".venv"
+        if local_venv.exists() and environment_root != resolved_root:
+            artifacts.append(
+                EnvironmentArtifact(
+                    kind="stray_venv",
+                    path=local_venv,
+                    detail="checkout-local .venv is present but is not the active interpreter environment",
+                    remediation=(
+                        f"remove {local_venv} and run `cd {resolved_root} && direnv allow`, "
+                        "or activate its own venv before verifying"
+                    ),
+                )
+            )
+        node_modules = resolved_root / "node_modules"
+        if node_modules.exists():
+            artifacts.append(
+                EnvironmentArtifact(
+                    kind="stray_node_modules",
+                    path=node_modules,
+                    detail="root-level node_modules is untracked lane state and can be inherited from another checkout",
+                    remediation=f"remove {node_modules} before running the lane verification",
+                )
+            )
+        testmon_origin, testmon_artifact = _cache_artifact(
+            repo_root=resolved_root,
+            state_dir=_TESTMON_STATE_DIR,
+            marker=_TESTMON_STATE_MARKER,
+            kind="inherited_testmon_cache",
+            remediation=(
+                f"remove {resolved_root / _TESTMON_STATE_DIR} and let `devtools verify --seed-testmon` "
+                "or the managed bootstrap recreate it"
+            ),
+        )
+        verify_origin, verify_artifact = _cache_artifact(
+            repo_root=resolved_root,
+            state_dir=_VERIFY_STATE_DIR,
+            marker=_VERIFY_STATE_MARKER,
+            kind="inherited_verify_cache",
+            remediation=f"remove {resolved_root / _VERIFY_STATE_DIR} and rerun the managed devtools command",
+        )
+        if testmon_artifact is not None:
+            artifacts.append(testmon_artifact)
+        if verify_artifact is not None:
+            artifacts.append(verify_artifact)
+
+    return CheckoutEnvironmentFingerprint(
+        checkout_root=resolved_root,
+        polylogue_import_path=resolved_pkg,
+        python_executable=executable,
+        python_environment_root=environment_root,
+        linked_worktree=linked,
+        testmon_state_origin=testmon_origin,
+        verify_state_origin=verify_origin,
+        artifacts=tuple(artifacts),
+    )
+
+
+def _raise_environment_mismatch(context: str, fingerprint: CheckoutEnvironmentFingerprint) -> None:
+    if fingerprint.clean:
+        return
+    lines = [
+        f"{context}: checkout environment is untrustworthy; refusing to run before it is repaired.",
+    ]
+    for artifact in fingerprint.artifacts:
+        lines.extend(
+            (
+                f"  offending path : {artifact.path}",
+                f"  reason         : {artifact.detail}",
+                f"  remediation    : {artifact.remediation}",
+            )
+        )
+    raise CheckoutEnvironmentMismatchError("\n".join(lines))
+
+
+def assert_polylogue_matches_checkout(
+    repo_root: Path,
+    *,
+    context: str,
+    python_executable: Path | None = None,
+) -> Path:
+    """Raise loudly when import or environment provenance does not match ``repo_root``.
 
     Returns the resolved package path on success, so callers can also use it
     as the "print the resolved path in the receipt" observability hook
@@ -185,4 +437,10 @@ def assert_polylogue_matches_checkout(repo_root: Path, *, context: str) -> Path:
             f"  - re-install editable from THIS checkout so its own `.pth` entry "
             f"wins: `uv pip install -e {resolved_root}`.\n"
         ) from None
+    fingerprint = checkout_environment_fingerprint(
+        repo_root,
+        polylogue_import_path=resolved_pkg,
+        python_executable=python_executable,
+    )
+    _raise_environment_mismatch(context, fingerprint)
     return resolved_pkg

--- a/devtools/lane_init.py
+++ b/devtools/lane_init.py
@@ -145,19 +145,23 @@ def _ensure_worktree(root: Path, worktree: Path, branch: str, base: str) -> str 
     return None
 
 
+def _lane_env(worktree: Path) -> dict[str, str]:
+    """Return an environment that cannot inherit another checkout's Python."""
+    env = os.environ.copy()
+    env.pop("VIRTUAL_ENV", None)
+    env.pop("PYTHONHOME", None)
+    env.pop("PYTHONPATH", None)
+    env["UV_PROJECT_ENVIRONMENT"] = str(worktree / ".venv")
+    return env
+
+
 def _provision_venv(worktree: Path) -> str | None:
     # dev-common+speed = the devshell's effective test/verify surface without
     # platform-fragile extras (atheris has no cp314t wheel).
     cmd = ["uv", "sync", "--extra", "dev-common", "--extra", "speed"]
     if (worktree / "uv.lock").exists():
         cmd.append("--frozen")
-    env = os.environ.copy()
-    # A coordinator commonly has its own editable venv activated. Letting uv
-    # inherit it recreates the shared-venv escape lane-init is meant to prevent.
-    env.pop("VIRTUAL_ENV", None)
-    env.pop("PYTHONHOME", None)
-    env["UV_PROJECT_ENVIRONMENT"] = str(worktree / ".venv")
-    result = _run(cmd, cwd=worktree, env=env)
+    result = _run(cmd, cwd=worktree, env=_lane_env(worktree))
     if result.returncode != 0:
         return f"uv sync failed: {result.stderr.strip()[-800:]}"
     return None
@@ -168,8 +172,9 @@ def _guard_check(worktree: Path) -> str | None:
     if not python.exists():
         return f"no venv python at {python}"
     result = _run(
-        [str(python), "-c", "import polylogue, sys; print(polylogue.__file__)"],
+        [str(python), "-P", "-c", "import polylogue; print(polylogue.__file__)"],
         cwd=worktree,
+        env=_lane_env(worktree),
     )
     if result.returncode != 0:
         return f"lane venv cannot import polylogue: {result.stderr.strip()[-400:]}"

--- a/devtools/lane_init.py
+++ b/devtools/lane_init.py
@@ -156,7 +156,10 @@ def _guard_check(worktree: Path) -> str | None:
     python = worktree / ".venv" / "bin" / "python"
     if not python.exists():
         return f"no venv python at {python}"
-    result = _run([str(python), "-c", "import polylogue, sys; print(polylogue.__file__)"])
+    result = _run(
+        [str(python), "-c", "import polylogue, sys; print(polylogue.__file__)"],
+        cwd=worktree,
+    )
     if result.returncode != 0:
         return f"lane venv cannot import polylogue: {result.stderr.strip()[-400:]}"
     resolved = result.stdout.strip()

--- a/devtools/lane_init.py
+++ b/devtools/lane_init.py
@@ -116,8 +116,13 @@ def append_ledger(root: Path, record: dict[str, object]) -> Path:
     return path
 
 
-def _run(cmd: Sequence[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(list(cmd), cwd=cwd, text=True, capture_output=True, check=False)
+def _run(
+    cmd: Sequence[str],
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(list(cmd), cwd=cwd, env=env, text=True, capture_output=True, check=False)
 
 
 def _branch_exists(root: Path, branch: str) -> bool:
@@ -146,7 +151,13 @@ def _provision_venv(worktree: Path) -> str | None:
     cmd = ["uv", "sync", "--extra", "dev-common", "--extra", "speed"]
     if (worktree / "uv.lock").exists():
         cmd.append("--frozen")
-    result = _run(cmd, cwd=worktree)
+    env = os.environ.copy()
+    # A coordinator commonly has its own editable venv activated. Letting uv
+    # inherit it recreates the shared-venv escape lane-init is meant to prevent.
+    env.pop("VIRTUAL_ENV", None)
+    env.pop("PYTHONHOME", None)
+    env["UV_PROJECT_ENVIRONMENT"] = str(worktree / ".venv")
+    result = _run(cmd, cwd=worktree, env=env)
     if result.returncode != 0:
         return f"uv sync failed: {result.stderr.strip()[-800:]}"
     return None

--- a/devtools/run_tests.py
+++ b/devtools/run_tests.py
@@ -31,7 +31,11 @@ import time
 from collections.abc import Iterator
 from pathlib import Path
 
-from devtools.checkout_guard import CheckoutImportMismatchError, assert_polylogue_matches_checkout
+from devtools.checkout_guard import (
+    CheckoutImportMismatchError,
+    assert_polylogue_matches_checkout,
+    checkout_environment_fingerprint,
+)
 from devtools.verify import (
     PYTEST_CONTAINMENT_PATH,
     PYTEST_EVENTS_PATH,
@@ -127,6 +131,10 @@ def main(argv: list[str] | None = None) -> int:
     except CheckoutImportMismatchError as exc:
         sys.stderr.write(f"{exc}\n")
         return 125
+    environment_fingerprint = checkout_environment_fingerprint(
+        ROOT,
+        polylogue_import_path=polylogue_import_path,
+    ).as_dict()
     sys.stderr.write(f"devtools test: polylogue package → {polylogue_import_path}\n")
 
     selection = list(sys.argv[1:] if argv is None else argv)
@@ -153,6 +161,7 @@ def main(argv: list[str] | None = None) -> int:
             git_head=git_head(ROOT),
             root=ROOT,
             polylogue_import_path=str(polylogue_import_path),
+            environment_fingerprint=environment_fingerprint,
         )
         started = time.monotonic()
         rc, _elapsed, metadata = _run("pytest focused", cmd, cwd=str(ROOT), run=run)

--- a/devtools/run_tests.py
+++ b/devtools/run_tests.py
@@ -34,7 +34,6 @@ from pathlib import Path
 from devtools.checkout_guard import (
     CheckoutImportMismatchError,
     assert_polylogue_matches_checkout,
-    checkout_environment_fingerprint,
 )
 from devtools.verify import (
     PYTEST_CONTAINMENT_PATH,
@@ -127,14 +126,12 @@ def _run_lock(*, enabled: bool) -> Iterator[None]:
 
 def main(argv: list[str] | None = None) -> int:
     try:
-        polylogue_import_path = assert_polylogue_matches_checkout(ROOT, context="devtools test")
+        fingerprint = assert_polylogue_matches_checkout(ROOT, context="devtools test")
     except CheckoutImportMismatchError as exc:
         sys.stderr.write(f"{exc}\n")
         return 125
-    environment_fingerprint = checkout_environment_fingerprint(
-        ROOT,
-        polylogue_import_path=polylogue_import_path,
-    ).as_dict()
+    polylogue_import_path = fingerprint.polylogue_import_path
+    environment_fingerprint = fingerprint.as_dict()
     sys.stderr.write(f"devtools test: polylogue package → {polylogue_import_path}\n")
 
     selection = list(sys.argv[1:] if argv is None else argv)

--- a/devtools/testmon_bootstrap.py
+++ b/devtools/testmon_bootstrap.py
@@ -125,6 +125,18 @@ def _atomic_copy_bytes(src: Path, dst: Path) -> None:
     tmp.replace(dst)
 
 
+def _stamp_seed_checkout_origin(seed_stamp: Path, *, checkout_root: Path, inherited_from: Path) -> None:
+    """Mark a copied seed with its destination checkout and source provenance."""
+    payload = json.loads(seed_stamp.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"testmon seed stamp has invalid shape: {seed_stamp}")
+    payload["checkout_root"] = str(checkout_root.resolve())
+    payload["inherited_from"] = str(inherited_from.resolve())
+    tmp = seed_stamp.with_name(f"{seed_stamp.name}.{os.getpid()}.tmp")
+    tmp.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    tmp.replace(seed_stamp)
+
+
 def _atomic_copy_sqlite_db(src: Path, dst: Path) -> None:
     """Copy a (possibly concurrently-written) sqlite db via the online backup API.
 
@@ -154,6 +166,8 @@ def bootstrap_testmon_seed_files(
     *,
     local_testmon_data: Path,
     local_seed_stamp: Path,
+    checkout_root: Path | None = None,
+    inherited_from: Path | None = None,
 ) -> None:
     """Perform the copy `decision` describes. No-op unless `should_bootstrap`."""
     if not decision.should_bootstrap:
@@ -162,6 +176,8 @@ def bootstrap_testmon_seed_files(
     assert decision.main_seed_stamp is not None
     _atomic_copy_sqlite_db(decision.main_testmon_data, local_testmon_data)
     _atomic_copy_bytes(decision.main_seed_stamp, local_seed_stamp)
+    if checkout_root is not None and inherited_from is not None:
+        _stamp_seed_checkout_origin(local_seed_stamp, checkout_root=checkout_root, inherited_from=inherited_from)
 
 
 def _git_worktree_info(repo_root: Path) -> tuple[bool, Path] | None:
@@ -233,6 +249,8 @@ def maybe_bootstrap_testmon_seed(
         decision,
         local_testmon_data=local_testmon_data,
         local_seed_stamp=local_seed_stamp,
+        checkout_root=repo_root,
+        inherited_from=main_checkout,
     )
     return (
         f"verify: bootstrapped pytest-testmon seed from main checkout {main_checkout} "

--- a/devtools/testmon_bootstrap.py
+++ b/devtools/testmon_bootstrap.py
@@ -125,16 +125,30 @@ def _atomic_copy_bytes(src: Path, dst: Path) -> None:
     tmp.replace(dst)
 
 
-def _stamp_seed_checkout_origin(seed_stamp: Path, *, checkout_root: Path, inherited_from: Path) -> None:
+def _stamp_seed_checkout_origin(
+    seed_stamp: Path,
+    *,
+    checkout_root: Path,
+    inherited_from: Path | None = None,
+) -> bool:
     """Mark a copied seed with its destination checkout and source provenance."""
-    payload = json.loads(seed_stamp.read_text(encoding="utf-8"))
+    try:
+        payload = json.loads(seed_stamp.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return False
     if not isinstance(payload, dict):
-        raise ValueError(f"testmon seed stamp has invalid shape: {seed_stamp}")
+        return False
     payload["checkout_root"] = str(checkout_root.resolve())
-    payload["inherited_from"] = str(inherited_from.resolve())
+    if inherited_from is not None:
+        payload["inherited_from"] = str(inherited_from.resolve())
     tmp = seed_stamp.with_name(f"{seed_stamp.name}.{os.getpid()}.tmp")
-    tmp.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
-    tmp.replace(seed_stamp)
+    try:
+        tmp.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        tmp.replace(seed_stamp)
+    except OSError:
+        tmp.unlink(missing_ok=True)
+        return False
+    return True
 
 
 def _atomic_copy_sqlite_db(src: Path, dst: Path) -> None:
@@ -168,16 +182,17 @@ def bootstrap_testmon_seed_files(
     local_seed_stamp: Path,
     checkout_root: Path | None = None,
     inherited_from: Path | None = None,
-) -> None:
-    """Perform the copy `decision` describes. No-op unless `should_bootstrap`."""
+) -> bool:
+    """Perform the copy `decision` describes and report whether it was stamped."""
     if not decision.should_bootstrap:
-        return
+        return True
     assert decision.main_testmon_data is not None
     assert decision.main_seed_stamp is not None
     _atomic_copy_sqlite_db(decision.main_testmon_data, local_testmon_data)
     _atomic_copy_bytes(decision.main_seed_stamp, local_seed_stamp)
     if checkout_root is not None and inherited_from is not None:
-        _stamp_seed_checkout_origin(local_seed_stamp, checkout_root=checkout_root, inherited_from=inherited_from)
+        return _stamp_seed_checkout_origin(local_seed_stamp, checkout_root=checkout_root, inherited_from=inherited_from)
+    return True
 
 
 def _git_worktree_info(repo_root: Path) -> tuple[bool, Path] | None:
@@ -244,14 +259,32 @@ def maybe_bootstrap_testmon_seed(
         protocol_version=protocol_version,
     )
     if not decision.should_bootstrap:
+        if local_testmon_data.is_file() and _is_valid_complete_seed_stamp(
+            local_seed_stamp, protocol_version=protocol_version
+        ):
+            try:
+                local_payload = json.loads(local_seed_stamp.read_text(encoding="utf-8"))
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+                return None
+            if (
+                isinstance(local_payload, dict)
+                and not local_payload.get("checkout_root")
+                and _stamp_seed_checkout_origin(local_seed_stamp, checkout_root=repo_root)
+            ):
+                return f"verify: migrated legacy pytest-testmon seed marker in {local_seed_stamp.parent}"
         return None
-    bootstrap_testmon_seed_files(
+    stamped = bootstrap_testmon_seed_files(
         decision,
         local_testmon_data=local_testmon_data,
         local_seed_stamp=local_seed_stamp,
         checkout_root=repo_root,
         inherited_from=main_checkout,
     )
+    if not stamped:
+        return (
+            f"verify: bootstrapped pytest-testmon seed into {local_testmon_data.parent}, "
+            "but could not record its checkout provenance"
+        )
     return (
         f"verify: bootstrapped pytest-testmon seed from main checkout {main_checkout} "
         f"into {local_testmon_data.parent} (worktree had no local seed)"

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -44,7 +44,6 @@ from typing import Any
 from devtools.checkout_guard import (
     CheckoutImportMismatchError,
     assert_polylogue_matches_checkout,
-    checkout_environment_fingerprint,
 )
 from devtools.pytest_supervisor import (
     SupervisorLaunch,
@@ -2543,15 +2542,19 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--json", action="store_true", default=None, help="Write structured JSON to stdout.")
     args = parser.parse_args(sys.argv[1:] if argv is None else argv)
 
+    bootstrap_message = maybe_bootstrap_testmon_seed(
+        ROOT,
+        protocol_version=TESTMON_SEED_PROTOCOL_VERSION,
+    )
+    if bootstrap_message is not None:
+        sys.stderr.write(bootstrap_message + "\n")
     try:
-        polylogue_import_path = assert_polylogue_matches_checkout(ROOT, context="devtools verify")
+        fingerprint = assert_polylogue_matches_checkout(ROOT, context="devtools verify")
     except CheckoutImportMismatchError as exc:
         sys.stderr.write(f"verify: {exc}\n")
         return 125
-    environment_fingerprint = checkout_environment_fingerprint(
-        ROOT,
-        polylogue_import_path=polylogue_import_path,
-    ).as_dict()
+    polylogue_import_path = fingerprint.polylogue_import_path
+    environment_fingerprint = fingerprint.as_dict()
     sys.stderr.write(f"verify: polylogue package → {polylogue_import_path}\n")
 
     if args.history:
@@ -2576,12 +2579,6 @@ def main(argv: list[str] | None = None) -> int:
         tier = "testmon"
 
     full_pytest = bool(args.all or args.full)
-    bootstrap_message = maybe_bootstrap_testmon_seed(
-        ROOT,
-        protocol_version=TESTMON_SEED_PROTOCOL_VERSION,
-    )
-    if bootstrap_message is not None:
-        sys.stderr.write(bootstrap_message + "\n")
     preflight_error = _testmon_preflight(
         seed_testmon=bool(args.seed_testmon),
         full_pytest=full_pytest,

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -41,7 +41,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from devtools.checkout_guard import CheckoutImportMismatchError, assert_polylogue_matches_checkout
+from devtools.checkout_guard import (
+    CheckoutImportMismatchError,
+    assert_polylogue_matches_checkout,
+    checkout_environment_fingerprint,
+)
 from devtools.pytest_supervisor import (
     SupervisorLaunch,
     build_supervisor_launch,
@@ -2489,6 +2493,7 @@ def _finalize_testmon_seed_attempt(
             "protocol_version": TESTMON_SEED_PROTOCOL_VERSION,
             "status": "complete",
             "timestamp": payload["finished_at"],
+            "checkout_root": str(ROOT.resolve()),
             "git_head": dict(prepared["identity"]).get("git_head"),
             "identity": prepared["identity"],
             "expected_count": payload["expected_count"],
@@ -2543,6 +2548,10 @@ def main(argv: list[str] | None = None) -> int:
     except CheckoutImportMismatchError as exc:
         sys.stderr.write(f"verify: {exc}\n")
         return 125
+    environment_fingerprint = checkout_environment_fingerprint(
+        ROOT,
+        polylogue_import_path=polylogue_import_path,
+    ).as_dict()
     sys.stderr.write(f"verify: polylogue package → {polylogue_import_path}\n")
 
     if args.history:
@@ -2590,6 +2599,7 @@ def main(argv: list[str] | None = None) -> int:
         argv=list(sys.argv[1:] if argv is None else argv),
         git_head=head,
         polylogue_import_path=str(polylogue_import_path),
+        environment_fingerprint=environment_fingerprint,
     )
     seed_identity: dict[str, Any] | None = None
     resume_testmon_seed = False

--- a/devtools/verify_runs.py
+++ b/devtools/verify_runs.py
@@ -189,6 +189,10 @@ class VerifyRun:
             # caller and this fired for a different process boundary.
             "polylogue_import_path": polylogue_import_path,
             "environment_fingerprint": dict(environment_fingerprint) if environment_fingerprint is not None else None,
+            # A VerifyRun can be constructed by maintenance/test helpers that
+            # do not have a checkout fingerprint. Keep its current-run marker
+            # attributable to this checkout either way.
+            "checkout_root": str(self.root.resolve()),
             "owner_pid": os.getpid(),
             "started_at": utc_now(),
             "status": "running",

--- a/devtools/verify_runs.py
+++ b/devtools/verify_runs.py
@@ -171,6 +171,7 @@ class VerifyRun:
         git_head: str | None,
         root: Path | None = None,
         polylogue_import_path: str | None = None,
+        environment_fingerprint: Mapping[str, Any] | None = None,
     ) -> None:
         self.root = root or Path.cwd()
         self.run_id = make_run_id(tier=tier)
@@ -187,6 +188,7 @@ class VerifyRun:
             # even where the live preflight already refused for an in-process
             # caller and this fired for a different process boundary.
             "polylogue_import_path": polylogue_import_path,
+            "environment_fingerprint": dict(environment_fingerprint) if environment_fingerprint is not None else None,
             "owner_pid": os.getpid(),
             "started_at": utc_now(),
             "status": "running",

--- a/tests/unit/devtools/test_checkout_guard.py
+++ b/tests/unit/devtools/test_checkout_guard.py
@@ -35,8 +35,8 @@ def test_resolved_polylogue_path_matches_the_running_package() -> None:
 
 def test_assert_matches_checkout_passes_for_the_real_checkout() -> None:
     repo_root = Path(polylogue.__file__).resolve().parents[1]
-    resolved = assert_polylogue_matches_checkout(repo_root, context="test")
-    assert resolved == Path(polylogue.__file__).resolve()
+    fingerprint = assert_polylogue_matches_checkout(repo_root, context="test")
+    assert fingerprint.polylogue_import_path == Path(polylogue.__file__).resolve()
 
 
 def test_assert_matches_checkout_raises_for_an_unrelated_root(tmp_path: Path) -> None:
@@ -209,18 +209,37 @@ def test_checkout_preflight_reports_seeded_artifacts_and_main_interpreter(
 
 
 def test_verify_run_persists_environment_fingerprint(tmp_path: Path) -> None:
+    root = _fake_linked_checkout(tmp_path)
+    (root / "node_modules").mkdir()
     fingerprint = checkout_environment_fingerprint(
-        tmp_path,
-        polylogue_import_path=tmp_path / "polylogue" / "__init__.py",
+        root,
+        polylogue_import_path=root / "polylogue" / "__init__.py",
         python_executable=Path("/usr/bin/python"),
     )
     run = VerifyRun(
         tier="environment-fingerprint",
         argv=["--quick"],
         git_head="head",
-        root=tmp_path,
+        root=root,
         environment_fingerprint=fingerprint.as_dict(),
     )
 
     payload = json.loads((run.run_dir / "run.json").read_text())
+    assert fingerprint.artifacts
     assert payload["environment_fingerprint"] == fingerprint.as_dict()
+    assert payload["checkout_root"] == str(root.resolve())
+
+
+def test_verify_run_marker_is_attributable_without_a_fingerprint(tmp_path: Path) -> None:
+    root = _fake_linked_checkout(tmp_path)
+    run = VerifyRun(tier="legacy-marker", argv=[], git_head=None, root=root)
+
+    fingerprint = checkout_environment_fingerprint(
+        root,
+        polylogue_import_path=root / "polylogue" / "__init__.py",
+        python_executable=root / ".venv" / "bin" / "python",
+    )
+
+    assert fingerprint.clean
+    assert fingerprint.verify_state_origin == root.resolve()
+    assert json.loads((root / ".cache" / "verify" / "current-run.json").read_text())["run_id"] == run.run_id

--- a/tests/unit/devtools/test_checkout_guard.py
+++ b/tests/unit/devtools/test_checkout_guard.py
@@ -9,6 +9,7 @@ point at a different checkout than the one a tool is actually invoked from
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -18,11 +19,14 @@ import devtools.run_tests as run_tests
 import devtools.verify as verify
 import polylogue
 from devtools.checkout_guard import (
+    CheckoutEnvironmentMismatchError,
     CheckoutImportMismatchError,
     assert_polylogue_matches_checkout,
+    checkout_environment_fingerprint,
     find_git_worktree_root,
     resolved_polylogue_path,
 )
+from devtools.verify_runs import VerifyRun
 
 
 def test_resolved_polylogue_path_matches_the_running_package() -> None:
@@ -151,3 +155,72 @@ def test_verify_main_refuses_on_checkout_mismatch(
     exit_code = verify.main(["--quick"])
     assert exit_code == 125
     assert "mismatch against" in capsys.readouterr().err
+
+
+def _fake_linked_checkout(tmp_path: Path) -> Path:
+    root = tmp_path / "lane"
+    root.mkdir()
+    (root / ".git").write_text("gitdir: /main/.git/worktrees/lane\n")
+    return root
+
+
+def test_checkout_environment_fingerprint_accepts_clean_linked_worktree(tmp_path: Path) -> None:
+    root = _fake_linked_checkout(tmp_path)
+    fingerprint = checkout_environment_fingerprint(
+        root,
+        polylogue_import_path=root / "polylogue" / "__init__.py",
+        python_executable=root / ".venv" / "bin" / "python",
+    )
+
+    assert fingerprint.clean
+    assert fingerprint.linked_worktree is True
+    assert fingerprint.python_environment_root == root
+
+
+def test_checkout_preflight_reports_seeded_artifacts_and_main_interpreter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _fake_linked_checkout(tmp_path)
+    main = tmp_path / "main-checkout"
+    main_venv = main / ".venv" / "bin"
+    main_venv.mkdir(parents=True)
+    main_python = main_venv / "python"
+    (root / ".venv").mkdir()
+    (root / "node_modules").mkdir()
+    (root / ".cache" / "testmon").mkdir(parents=True)
+    (root / ".cache" / "testmon" / "seed.json").write_text(json.dumps({"status": "complete"}))
+    (root / ".cache" / "verify").mkdir(parents=True)
+    verify_marker = root / ".cache" / "verify" / "current-run.json"
+    verify_marker.write_text(json.dumps({"checkout_root": str(main)}))
+    package_path = root / "polylogue" / "__init__.py"
+    monkeypatch.setattr("devtools.checkout_guard.resolved_polylogue_path", lambda: package_path)
+
+    with pytest.raises(CheckoutEnvironmentMismatchError) as excinfo:
+        assert_polylogue_matches_checkout(root, context="seeded lane", python_executable=main_python)
+
+    message = str(excinfo.value)
+    assert str(main_python) in message
+    assert str(root / ".venv") in message
+    assert str(root / "node_modules") in message
+    assert str(root / ".cache" / "testmon" / "seed.json") in message
+    assert str(verify_marker) in message
+    assert "direnv allow" in message
+    assert "remediation" in message
+
+
+def test_verify_run_persists_environment_fingerprint(tmp_path: Path) -> None:
+    fingerprint = checkout_environment_fingerprint(
+        tmp_path,
+        polylogue_import_path=tmp_path / "polylogue" / "__init__.py",
+        python_executable=Path("/usr/bin/python"),
+    )
+    run = VerifyRun(
+        tier="environment-fingerprint",
+        argv=["--quick"],
+        git_head="head",
+        root=tmp_path,
+        environment_fingerprint=fingerprint.as_dict(),
+    )
+
+    payload = json.loads((run.run_dir / "run.json").read_text())
+    assert payload["environment_fingerprint"] == fingerprint.as_dict()

--- a/tests/unit/devtools/test_lane_init.py
+++ b/tests/unit/devtools/test_lane_init.py
@@ -52,10 +52,19 @@ def test_guard_check_runs_lane_interpreter_from_lane_root(tmp_path: Path) -> Non
     lane = tmp_path / "lane"
     python = lane / ".venv" / "bin" / "python"
     python.parent.mkdir(parents=True)
-    python.write_text("#!/bin/sh\nprintf '%s/polylogue/__init__.py\\n' \"$PWD\"\n")
+    python.write_text(
+        "#!/bin/sh\n"
+        'if [ -n "$PYTHONPATH" ]; then\n'
+        "  printf '%s\\n' /foreign/polylogue/__init__.py\n"
+        "else\n"
+        "  printf '%s/polylogue/__init__.py\\n' \"$PWD\"\n"
+        "fi\n"
+    )
     python.chmod(0o755)
 
-    assert lane_init._guard_check(lane) is None
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setenv("PYTHONPATH", "/foreign")
+        assert lane_init._guard_check(lane) is None
 
 
 def test_provision_venv_forces_the_lane_environment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -63,6 +72,7 @@ def test_provision_venv_forces_the_lane_environment(tmp_path: Path, monkeypatch:
     lane.mkdir()
     monkeypatch.setenv("VIRTUAL_ENV", "/coordinator/.venv")
     monkeypatch.setenv("PYTHONHOME", "/coordinator/pythonhome")
+    monkeypatch.setenv("PYTHONPATH", "/coordinator/pythonpath")
     monkeypatch.setenv("UV_PROJECT_ENVIRONMENT", "/coordinator/.venv")
     captured: dict[str, object] = {}
 
@@ -78,8 +88,10 @@ def test_provision_venv_forces_the_lane_environment(tmp_path: Path, monkeypatch:
     monkeypatch.setattr(lane_init, "_run", fake_run)
 
     assert lane_init._provision_venv(lane) is None
+    assert captured["cwd"] == lane
     env = captured["env"]
     assert isinstance(env, dict)
     assert "VIRTUAL_ENV" not in env
     assert "PYTHONHOME" not in env
+    assert "PYTHONPATH" not in env
     assert env["UV_PROJECT_ENVIRONMENT"] == str(lane / ".venv")

--- a/tests/unit/devtools/test_lane_init.py
+++ b/tests/unit/devtools/test_lane_init.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from pathlib import Path
 from subprocess import CompletedProcess
+
+import pytest
 
 from devtools import lane_init
 
@@ -55,7 +58,7 @@ def test_guard_check_runs_lane_interpreter_from_lane_root(tmp_path: Path) -> Non
     assert lane_init._guard_check(lane) is None
 
 
-def test_provision_venv_forces_the_lane_environment(tmp_path: Path, monkeypatch) -> None:
+def test_provision_venv_forces_the_lane_environment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     lane = tmp_path / "lane"
     lane.mkdir()
     monkeypatch.setenv("VIRTUAL_ENV", "/coordinator/.venv")
@@ -64,7 +67,7 @@ def test_provision_venv_forces_the_lane_environment(tmp_path: Path, monkeypatch)
     captured: dict[str, object] = {}
 
     def fake_run(
-        cmd: object,
+        cmd: Sequence[str],
         *,
         cwd: Path | None = None,
         env: dict[str, str] | None = None,

--- a/tests/unit/devtools/test_lane_init.py
+++ b/tests/unit/devtools/test_lane_init.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from subprocess import CompletedProcess
 
 from devtools import lane_init
 
@@ -52,3 +53,25 @@ def test_guard_check_runs_lane_interpreter_from_lane_root(tmp_path: Path) -> Non
     python.chmod(0o755)
 
     assert lane_init._guard_check(lane) is None
+
+
+def test_provision_venv_forces_the_lane_environment(tmp_path: Path, monkeypatch) -> None:
+    lane = tmp_path / "lane"
+    lane.mkdir()
+    monkeypatch.setenv("VIRTUAL_ENV", "/coordinator/.venv")
+    monkeypatch.setenv("PYTHONHOME", "/coordinator/pythonhome")
+    monkeypatch.setenv("UV_PROJECT_ENVIRONMENT", "/coordinator/.venv")
+    captured: dict[str, object] = {}
+
+    def fake_run(cmd, *, cwd=None, env=None):
+        captured.update(cmd=cmd, cwd=cwd, env=env)
+        return CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(lane_init, "_run", fake_run)
+
+    assert lane_init._provision_venv(lane) is None
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert "VIRTUAL_ENV" not in env
+    assert "PYTHONHOME" not in env
+    assert env["UV_PROJECT_ENVIRONMENT"] == str(lane / ".venv")

--- a/tests/unit/devtools/test_lane_init.py
+++ b/tests/unit/devtools/test_lane_init.py
@@ -42,3 +42,13 @@ def test_guard_check_flags_escaped_resolution(tmp_path: Path) -> None:
     python.chmod(0o755)
     error = lane_init._guard_check(lane)
     assert error is not None and "guard violation" in error
+
+
+def test_guard_check_runs_lane_interpreter_from_lane_root(tmp_path: Path) -> None:
+    lane = tmp_path / "lane"
+    python = lane / ".venv" / "bin" / "python"
+    python.parent.mkdir(parents=True)
+    python.write_text("#!/bin/sh\nprintf '%s/polylogue/__init__.py\\n' \"$PWD\"\n")
+    python.chmod(0o755)
+
+    assert lane_init._guard_check(lane) is None

--- a/tests/unit/devtools/test_lane_init.py
+++ b/tests/unit/devtools/test_lane_init.py
@@ -63,7 +63,12 @@ def test_provision_venv_forces_the_lane_environment(tmp_path: Path, monkeypatch)
     monkeypatch.setenv("UV_PROJECT_ENVIRONMENT", "/coordinator/.venv")
     captured: dict[str, object] = {}
 
-    def fake_run(cmd, *, cwd=None, env=None):
+    def fake_run(
+        cmd: object,
+        *,
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+    ) -> CompletedProcess[str]:
         captured.update(cmd=cmd, cwd=cwd, env=env)
         return CompletedProcess(cmd, 0, "", "")
 

--- a/tests/unit/devtools/test_testmon_bootstrap.py
+++ b/tests/unit/devtools/test_testmon_bootstrap.py
@@ -19,6 +19,9 @@ import json
 import sqlite3
 from pathlib import Path
 
+import pytest
+
+import devtools.testmon_bootstrap as testmon_bootstrap
 from devtools.testmon_bootstrap import (
     BootstrapDecision,
     bootstrap_testmon_seed_files,
@@ -247,6 +250,53 @@ def test_bootstrap_seed_files_marks_destination_and_source_checkout(tmp_path: Pa
     payload = json.loads(local_stamp.read_text())
     assert payload["checkout_root"] == str((tmp_path / "lane").resolve())
     assert payload["inherited_from"] == str((tmp_path / "main").resolve())
+    source = json.loads(main_stamp.read_text())
+    assert {key: payload[key] for key in source} == source
+
+
+def test_bootstrap_seed_files_keeps_copied_state_when_stamp_turns_invalid(tmp_path: Path) -> None:
+    main_data = tmp_path / "main" / "testmondata"
+    main_stamp = tmp_path / "main" / "seed.json"
+    _write_sqlite_db(main_data)
+    main_stamp.parent.mkdir(parents=True, exist_ok=True)
+    main_stamp.write_text("{concurrent rewrite")
+    local_data = tmp_path / "lane" / "testmondata"
+    local_stamp = tmp_path / "lane" / "seed.json"
+
+    stamped = bootstrap_testmon_seed_files(
+        BootstrapDecision(True, "test", main_testmon_data=main_data, main_seed_stamp=main_stamp),
+        local_testmon_data=local_data,
+        local_seed_stamp=local_stamp,
+        checkout_root=tmp_path / "lane",
+        inherited_from=tmp_path / "main",
+    )
+
+    assert stamped is False
+    assert local_data.is_file()
+    assert local_stamp.read_text() == "{concurrent rewrite"
+
+
+def test_maybe_bootstrap_migrates_a_valid_legacy_local_stamp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    lane = tmp_path / "lane"
+    main = tmp_path / "main"
+    local_data = lane / "cache" / "testmondata"
+    local_stamp = lane / "cache" / "seed.json"
+    _write_sqlite_db(local_data)
+    _write_valid_seed_stamp(local_stamp)
+    monkeypatch.setattr(testmon_bootstrap, "_git_worktree_info", lambda _root: (True, main))
+
+    message = testmon_bootstrap.maybe_bootstrap_testmon_seed(
+        lane,
+        testmon_data_relpath="cache/testmondata",
+        seed_stamp_relpath="cache/seed.json",
+        protocol_version=PROTOCOL_VERSION,
+    )
+
+    payload = json.loads(local_stamp.read_text())
+    assert message is not None and "migrated legacy" in message
+    assert payload["checkout_root"] == str(lane.resolve())
+    assert payload["protocol_version"] == PROTOCOL_VERSION
+    assert payload["status"] == "complete"
 
 
 def test_bootstrap_seed_files_noop_when_decision_says_no(tmp_path: Path) -> None:

--- a/tests/unit/devtools/test_testmon_bootstrap.py
+++ b/tests/unit/devtools/test_testmon_bootstrap.py
@@ -228,6 +228,27 @@ def test_bootstrap_seed_files_copies_db_and_stamp(tmp_path: Path) -> None:
     assert sorted(p.name for p in local_data.parent.iterdir()) == ["seed.json", "testmondata"]
 
 
+def test_bootstrap_seed_files_marks_destination_and_source_checkout(tmp_path: Path) -> None:
+    main_data = tmp_path / "main" / "testmondata"
+    main_stamp = tmp_path / "main" / "seed.json"
+    _write_sqlite_db(main_data)
+    _write_valid_seed_stamp(main_stamp)
+    local_data = tmp_path / "lane" / "testmondata"
+    local_stamp = tmp_path / "lane" / "seed.json"
+
+    bootstrap_testmon_seed_files(
+        BootstrapDecision(True, "test", main_testmon_data=main_data, main_seed_stamp=main_stamp),
+        local_testmon_data=local_data,
+        local_seed_stamp=local_stamp,
+        checkout_root=tmp_path / "lane",
+        inherited_from=tmp_path / "main",
+    )
+
+    payload = json.loads(local_stamp.read_text())
+    assert payload["checkout_root"] == str((tmp_path / "lane").resolve())
+    assert payload["inherited_from"] == str((tmp_path / "main").resolve())
+
+
 def test_bootstrap_seed_files_noop_when_decision_says_no(tmp_path: Path) -> None:
     local_data = tmp_path / "local" / "testmondata"
     local_stamp = tmp_path / "local" / "seed.json"


### PR DESCRIPTION
## Summary

Ensure every fanout lane provisions and verifies against its own editable Python environment.

## Problem

`lane-init` could inherit the coordinator's active `VIRTUAL_ENV`, allowing `uv sync` to retain the coordinator checkout's editable install. The lane then appeared provisioned but resolved `polylogue` from the wrong checkout, making verification untrustworthy.

## Solution

Clear inherited Python environment variables and force `UV_PROJECT_ENVIRONMENT` to the lane-local `.venv`. The existing preflight guard is also exercised from the lane root. Regression coverage proves that inherited coordinator settings cannot leak into provisioning.

## Verification

- `direnv exec . devtools test tests/unit/devtools/test_lane_init.py` produced `5 passed`.
- The pre-push quick gate completed successfully for `a4e593f4`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added checkout environment verification for linked worktrees.
  * Verification records interpreter, import path, worktree, cache origins, and detected environment artifacts.
  * Added actionable mismatch errors identifying affected paths and remediation steps.
  * Verify-run records now include environment provenance and test cache source details.

* **Bug Fixes**
  * Lane setup now consistently uses its own virtual environment and working directory.
  * Prevented inherited environment settings from affecting lane provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->