### PR TITLE
fix: reconcile orphaned source blob references

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -113,6 +113,29 @@ Heuristics:
 
 ## Subcommands
 
+### `polylogue ops maintenance blob-reference-liveness` - historical blob-ref reconciliation
+
+Read-only by default. It classifies source-tier `blob_refs` rows with the
+actual referent join for each `ref_type`; source-tier `attachment` refs join
+`raw_sessions.raw_id` because they are keyed by the parent raw acquisition,
+not by index-tier `attachment_refs`. Unknown or unavailable ref types block an
+apply. The command never deletes blob files.
+
+```bash
+polylogue ops maintenance blob-reference-liveness --output-format json
+polylogue ops maintenance blob-reference-liveness --apply \
+  --backup-manifest /path/to/verified-source-backup-manifest.json \
+  --receipt-file /path/to/new/blob-ref-liveness.jsonl \
+  --output-format json
+```
+
+The apply command requires the daemon and all archive writers to be stopped,
+an existing verified backup manifest covering the current `source.db`, and a
+new receipt path that does not already exist. It revalidates the backup and
+reclassifies under `BEGIN IMMEDIATE` before fsyncing the prepared receipt and
+deleting the exact candidate set. Review the receipt's final `committed` line
+before treating the pass as complete.
+
 ### `polylogue ops maintenance preview` — staleness inventory
 
 Read-only. Produces a per-model inventory of stale, missing, orphan,

--- a/polylogue/cli/commands/maintenance/__init__.py
+++ b/polylogue/cli/commands/maintenance/__init__.py
@@ -110,6 +110,12 @@ _COMMANDS: tuple[tuple[str, str, str, str], ...] = (
         "Classify missing referenced blobs without mutating the archive.",
     ),
     (
+        "blob-reference-liveness",
+        "_blob_integrity",
+        "blob_reference_liveness_command",
+        "Classify source-tier orphan refs; apply only with backup and receipt.",
+    ),
+    (
         "attachment-acquisition-debt",
         "_blob_integrity",
         "attachment_acquisition_debt_command",

--- a/polylogue/cli/commands/maintenance/_blob_integrity.py
+++ b/polylogue/cli/commands/maintenance/_blob_integrity.py
@@ -11,12 +11,87 @@ import click
 from polylogue.paths import archive_root
 
 if TYPE_CHECKING:
+    from polylogue.maintenance.blob_ref_liveness_reconciliation import BlobRefLivenessReconciliationReport
     from polylogue.storage.blob_integrity import (
         BlobReferenceDebtClassificationReport,
         BlobReferenceOrphanPruneReport,
         BlobReferenceRecoveryPlanReport,
         BlobReferenceSourceReplaceReport,
     )
+
+
+@click.command("blob-reference-liveness")
+@click.option("--apply", "apply_changes", is_flag=True, help="Apply the proven orphan set; default is read-only.")
+@click.option(
+    "--backup-manifest",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Verified source-tier backup manifest required with --apply.",
+)
+@click.option(
+    "--receipt-file",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="New JSONL receipt path required with --apply.",
+)
+@click.option("--sample-limit", type=int, default=30, show_default=True)
+@click.option(
+    "--output-format",
+    "output_format",
+    type=click.Choice(["plain", "json"]),
+    default="plain",
+    show_default=True,
+)
+def blob_reference_liveness_command(
+    apply_changes: bool,
+    backup_manifest: Path | None,
+    receipt_file: Path | None,
+    sample_limit: int,
+    output_format: str,
+) -> None:
+    """Classify source-tier orphan refs; apply only with backup and receipt."""
+    from polylogue.maintenance.blob_ref_liveness_reconciliation import reconcile_blob_ref_liveness
+
+    report = reconcile_blob_ref_liveness(
+        archive_root(),
+        backup_manifest=backup_manifest,
+        receipt_path=receipt_file,
+        dry_run=not apply_changes,
+    )
+    payload = {
+        "mode": "blob_reference_liveness",
+        "mutates": report.applied,
+        **report.to_dict(sample_limit=sample_limit),
+    }
+    if output_format == "json":
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    _render_blob_reference_liveness_plain(report, sample_limit=sample_limit)
+
+
+def _render_blob_reference_liveness_plain(report: BlobRefLivenessReconciliationReport, *, sample_limit: int) -> None:
+    click.echo("Blob reference liveness reconciliation")
+    click.echo(f"Source DB:    {report.source_db}")
+    click.echo(f"Mode:         {'apply' if report.applied else 'dry-run'}")
+    click.echo(f"Scanned:      {report.classification.scanned_count:,} blob_refs row(s)")
+    click.echo(f"Orphans:      {len(report.classification.candidates):,} row(s)")
+    click.echo(f"Deleted:      {report.deleted_count:,} row(s)")
+    click.echo(f"Safe to apply: {'yes' if report.classification.safe_to_apply else 'no'}")
+    if report.classification.orphaned_by_ref_type:
+        click.echo(
+            "By ref type:  "
+            + ", ".join(
+                f"{ref_type}={count:,}"
+                for ref_type, count in sorted(report.classification.orphaned_by_ref_type.items())
+            )
+        )
+    if report.receipt_path is not None:
+        click.echo(f"Receipt:      {report.receipt_path}")
+    for candidate in report.classification.candidates[: max(0, sample_limit)]:
+        click.echo(
+            f"  orphan {candidate.ref_type} ref_id={candidate.ref_id} "
+            f"join={candidate.referent_table}.{candidate.referent_column} blob={candidate.blob_hash}"
+        )
 
 
 @click.command("blob-reference-debt")

--- a/polylogue/cli/commands/maintenance/_blob_integrity.py
+++ b/polylogue/cli/commands/maintenance/_blob_integrity.py
@@ -77,6 +77,11 @@ def _render_blob_reference_liveness_plain(report: BlobRefLivenessReconciliationR
     click.echo(f"Orphans:      {len(report.classification.candidates):,} row(s)")
     click.echo(f"Deleted:      {report.deleted_count:,} row(s)")
     click.echo(f"Safe to apply: {'yes' if report.classification.safe_to_apply else 'no'}")
+    if report.classification.rekeyable_hook_payload_count:
+        click.echo(
+            "Hook refs:    "
+            f"{report.classification.rekeyable_hook_payload_count:,} legacy raw_payload ref(s) require re-keying"
+        )
     if report.classification.orphaned_by_ref_type:
         click.echo(
             "By ref type:  "

--- a/polylogue/maintenance/blob_ref_liveness_reconciliation.py
+++ b/polylogue/maintenance/blob_ref_liveness_reconciliation.py
@@ -1,0 +1,269 @@
+"""Dry-run-first reconciliation of historical source-tier blob references."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import time
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+
+from polylogue.config import Config
+from polylogue.maintenance.offline_guard import offline_maintenance_block_reason
+from polylogue.paths import render_root
+from polylogue.storage.blob_ref_liveness import (
+    BlobRefLivenessClassification,
+    classify_blob_ref_liveness,
+)
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.migration_runner import validate_migration_backup_manifest
+
+TOOL_VERSION = "blob-ref-liveness-reconciliation-v1"
+
+
+class BlobRefLivenessReconciliationError(RuntimeError):
+    """Raised when reconciliation cannot prove a safe source-tier apply."""
+
+
+@dataclass(frozen=True, slots=True)
+class BlobRefLivenessReconciliationReport:
+    source_db: str
+    dry_run: bool
+    classification: BlobRefLivenessClassification
+    applied: bool
+    deleted_count: int
+    receipt_path: Path | None = None
+    backup_manifest: Path | None = None
+
+    def to_dict(self, *, sample_limit: int = 30) -> dict[str, object]:
+        return {
+            "source_db": self.source_db,
+            "dry_run": self.dry_run,
+            "applied": self.applied,
+            "deleted_count": self.deleted_count,
+            "receipt_path": str(self.receipt_path) if self.receipt_path is not None else None,
+            "backup_manifest": str(self.backup_manifest) if self.backup_manifest is not None else None,
+            **self.classification.to_dict(sample_limit=sample_limit),
+        }
+
+
+def _offline_config(archive_root: Path) -> Config:
+    return Config(archive_root=archive_root, render_root=render_root(), sources=[])
+
+
+def _checkpoint_source_db(conn: sqlite3.Connection) -> None:
+    try:
+        row = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+    except sqlite3.Error as exc:
+        raise BlobRefLivenessReconciliationError("could not checkpoint source.db before backup validation") from exc
+    if row is None:
+        raise BlobRefLivenessReconciliationError("could not checkpoint source.db before backup validation")
+
+
+def _candidate_digest(classification: BlobRefLivenessClassification) -> str:
+    encoded = json.dumps(
+        [candidate.to_dict() for candidate in classification.candidates],
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _write_prepared_receipt(
+    receipt_path: Path,
+    source_db: Path,
+    classification: BlobRefLivenessClassification,
+    backup_manifest: Path,
+) -> None:
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    header = {
+        "kind": "blob_ref_liveness_reconciliation",
+        "phase": "prepared",
+        "tool_version": TOOL_VERSION,
+        "source_db": str(source_db),
+        "backup_manifest": str(backup_manifest),
+        "prepared_at_ms": int(time.time() * 1000),
+        "candidate_count": len(classification.candidates),
+        "candidate_digest": _candidate_digest(classification),
+        "orphaned_by_ref_type": dict(classification.orphaned_by_ref_type),
+        "referent_joins": [
+            {"ref_type": ref_type, "referent_table": table, "referent_column": column}
+            for ref_type, table, column in classification.ref_type_joins
+        ],
+    }
+    try:
+        with receipt_path.open("x", encoding="utf-8") as handle:
+            rows = [header]
+            rows.extend({"kind": "candidate", **candidate.to_dict()} for candidate in classification.candidates)
+            for row in rows:
+                handle.write(json.dumps(row, sort_keys=True, separators=(",", ":")))
+                handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+    except FileExistsError as exc:
+        raise BlobRefLivenessReconciliationError(f"receipt already exists: {receipt_path}") from exc
+
+
+def _append_receipt_footer(
+    receipt_path: Path,
+    *,
+    phase: str,
+    deleted_count: int | None = None,
+    error: str | None = None,
+) -> None:
+    payload: dict[str, object] = {
+        "kind": "blob_ref_liveness_reconciliation",
+        "phase": phase,
+        "completed_at_ms": int(time.time() * 1000),
+    }
+    if deleted_count is not None:
+        payload["deleted_count"] = deleted_count
+    if error is not None:
+        payload["error"] = error
+    with receipt_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def _delete_candidates(conn: sqlite3.Connection, classification: BlobRefLivenessClassification) -> int:
+    conn.execute(
+        """
+        CREATE TEMP TABLE blob_ref_liveness_candidates (
+            blob_hash BLOB NOT NULL,
+            ref_type TEXT NOT NULL,
+            ref_id TEXT NOT NULL,
+            PRIMARY KEY (blob_hash, ref_type, ref_id)
+        ) STRICT
+        """
+    )
+    conn.executemany(
+        "INSERT INTO blob_ref_liveness_candidates (blob_hash, ref_type, ref_id) VALUES (?, ?, ?)",
+        (
+            (bytes.fromhex(candidate.blob_hash), candidate.ref_type, candidate.ref_id)
+            for candidate in classification.candidates
+        ),
+    )
+    deleted = conn.execute(
+        """
+        DELETE FROM blob_refs
+        WHERE EXISTS (
+            SELECT 1
+            FROM blob_ref_liveness_candidates AS c
+            WHERE c.blob_hash = blob_refs.blob_hash
+              AND c.ref_type = blob_refs.ref_type
+              AND c.ref_id = blob_refs.ref_id
+        )
+        """
+    )
+    return max(0, int(deleted.rowcount))
+
+
+def reconcile_blob_ref_liveness(
+    archive_root: Path,
+    *,
+    backup_manifest: Path | None = None,
+    receipt_path: Path | None = None,
+    dry_run: bool = True,
+) -> BlobRefLivenessReconciliationReport:
+    """Classify orphaned source-tier refs, or apply the exact locked plan.
+
+    Apply requires both a verified source-tier backup manifest and a receipt
+    path. Classification is repeated after ``BEGIN IMMEDIATE`` and the
+    receipt is fsynced before the set-based DELETE starts.
+    """
+
+    source_db = archive_root / "source.db"
+    if not source_db.exists():
+        raise FileNotFoundError(f"no source.db at {source_db}")
+
+    if dry_run:
+        with sqlite3.connect(f"file:{source_db}?mode=ro", uri=True) as conn:
+            dry_classification = classify_blob_ref_liveness(conn)
+        return BlobRefLivenessReconciliationReport(
+            source_db=str(source_db),
+            dry_run=True,
+            classification=dry_classification,
+            applied=False,
+            deleted_count=0,
+        )
+
+    if backup_manifest is None:
+        raise BlobRefLivenessReconciliationError(
+            "applying blob-ref liveness reconciliation requires a verified backup manifest (--backup-manifest)"
+        )
+    if receipt_path is None:
+        raise BlobRefLivenessReconciliationError(
+            "applying blob-ref liveness reconciliation requires a receipt path (--receipt-file)"
+        )
+    if reason := offline_maintenance_block_reason(_offline_config(archive_root), active=True, dry_run=False):
+        raise BlobRefLivenessReconciliationError(reason)
+
+    conn = sqlite3.connect(source_db)
+    classification: BlobRefLivenessClassification | None = None
+    prepared = False
+    try:
+        _checkpoint_source_db(conn)
+        validate_migration_backup_manifest(backup_manifest, ArchiveTier.SOURCE, connection=conn)
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            validate_migration_backup_manifest(backup_manifest, ArchiveTier.SOURCE, connection=conn)
+            classification = classify_blob_ref_liveness(conn)
+            if not classification.safe_to_apply:
+                raise BlobRefLivenessReconciliationError(
+                    "ref types cannot be proven with source-tier joins: "
+                    f"unknown={classification.unknown_ref_types!r}, "
+                    f"unavailable={classification.unavailable_ref_types!r}"
+                )
+            _write_prepared_receipt(receipt_path, source_db, classification, backup_manifest)
+            prepared = True
+            deleted_count = _delete_candidates(conn, classification)
+            if deleted_count != len(classification.candidates):
+                raise BlobRefLivenessReconciliationError(
+                    f"candidate/delete count mismatch: planned={len(classification.candidates)} deleted={deleted_count}"
+                )
+            quick_check = conn.execute("PRAGMA quick_check").fetchone()
+            if quick_check is None or str(quick_check[0]).lower() != "ok":
+                raise BlobRefLivenessReconciliationError(f"source.db quick_check failed: {quick_check!r}")
+        except Exception:
+            if conn.in_transaction:
+                conn.rollback()
+            raise
+        else:
+            conn.commit()
+    except Exception as exc:
+        if prepared:
+            with suppress(OSError):
+                _append_receipt_footer(receipt_path, phase="aborted", error=str(exc))
+        raise
+    finally:
+        conn.close()
+
+    assert classification is not None
+    try:
+        _append_receipt_footer(receipt_path, phase="committed", deleted_count=len(classification.candidates))
+    except OSError as exc:
+        raise BlobRefLivenessReconciliationError(
+            f"source.db committed but could not finalize receipt {receipt_path}"
+        ) from exc
+    return BlobRefLivenessReconciliationReport(
+        source_db=str(source_db),
+        dry_run=False,
+        classification=classification,
+        applied=True,
+        deleted_count=len(classification.candidates),
+        receipt_path=receipt_path,
+        backup_manifest=backup_manifest,
+    )
+
+
+__all__ = [
+    "BlobRefLivenessReconciliationError",
+    "BlobRefLivenessReconciliationReport",
+    "TOOL_VERSION",
+    "reconcile_blob_ref_liveness",
+]

--- a/polylogue/maintenance/blob_ref_liveness_reconciliation.py
+++ b/polylogue/maintenance/blob_ref_liveness_reconciliation.py
@@ -72,6 +72,14 @@ def _candidate_digest(classification: BlobRefLivenessClassification) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
 def _write_prepared_receipt(
     receipt_path: Path,
     source_db: Path,
@@ -103,6 +111,7 @@ def _write_prepared_receipt(
                 handle.write("\n")
             handle.flush()
             os.fsync(handle.fileno())
+        _fsync_directory(receipt_path.parent)
     except FileExistsError as exc:
         raise BlobRefLivenessReconciliationError(f"receipt already exists: {receipt_path}") from exc
 
@@ -128,6 +137,48 @@ def _append_receipt_footer(
         handle.write("\n")
         handle.flush()
         os.fsync(handle.fileno())
+    _fsync_directory(receipt_path.parent)
+
+
+def _recover_prepared_receipt(source_db: Path, receipt_path: Path) -> str:
+    """Resolve the only crash window between SQLite commit and receipt footer.
+
+    The DELETE is one SQLite transaction, so every prepared candidate is either
+    still present (the transaction rolled back) or absent (it committed). A
+    mixture is external interference and remains deliberately indeterminate.
+    Recovery appends durable evidence but never performs another mutation.
+    """
+
+    rows = [json.loads(line) for line in receipt_path.read_text(encoding="utf-8").splitlines() if line]
+    if not rows or rows[0].get("kind") != "blob_ref_liveness_reconciliation":
+        raise BlobRefLivenessReconciliationError(f"receipt is not a liveness reconciliation receipt: {receipt_path}")
+    phases = [str(row.get("phase")) for row in rows if row.get("kind") == "blob_ref_liveness_reconciliation"]
+    if not phases or phases[0] != "prepared":
+        raise BlobRefLivenessReconciliationError(f"receipt does not contain a prepared plan: {receipt_path}")
+    if any(
+        phase in {"committed", "aborted", "recovered_committed", "recovered_rolled_back", "indeterminate"}
+        for phase in phases[1:]
+    ):
+        raise BlobRefLivenessReconciliationError(f"receipt is already terminal: {receipt_path}")
+    candidates = [row for row in rows if row.get("kind") == "candidate"]
+    with sqlite3.connect(f"file:{source_db}?mode=ro", uri=True) as conn:
+        still_present = [
+            candidate
+            for candidate in candidates
+            if conn.execute(
+                "SELECT 1 FROM blob_refs WHERE blob_hash = ? AND ref_type = ? AND ref_id = ?",
+                (bytes.fromhex(str(candidate["blob_hash"])), candidate["ref_type"], candidate["ref_id"]),
+            ).fetchone()
+            is not None
+        ]
+    if len(still_present) == len(candidates):
+        outcome = "recovered_rolled_back"
+    elif not still_present:
+        outcome = "recovered_committed"
+    else:
+        outcome = "indeterminate"
+    _append_receipt_footer(receipt_path, phase=outcome)
+    return outcome
 
 
 def _delete_candidates(conn: sqlite3.Connection, classification: BlobRefLivenessClassification) -> int:
@@ -200,6 +251,11 @@ def reconcile_blob_ref_liveness(
         raise BlobRefLivenessReconciliationError(
             "applying blob-ref liveness reconciliation requires a receipt path (--receipt-file)"
         )
+    if receipt_path.exists():
+        outcome = _recover_prepared_receipt(source_db, receipt_path)
+        raise BlobRefLivenessReconciliationError(
+            f"recovered existing prepared receipt as {outcome}: {receipt_path}; choose a fresh receipt path before retrying"
+        )
     if reason := offline_maintenance_block_reason(_offline_config(archive_root), active=True, dry_run=False):
         raise BlobRefLivenessReconciliationError(reason)
 
@@ -217,7 +273,9 @@ def reconcile_blob_ref_liveness(
                 raise BlobRefLivenessReconciliationError(
                     "ref types cannot be proven with source-tier joins: "
                     f"unknown={classification.unknown_ref_types!r}, "
-                    f"unavailable={classification.unavailable_ref_types!r}"
+                    f"unavailable={classification.unavailable_ref_types!r}, "
+                    f"rekeyable_hook_payloads={classification.rekeyable_hook_payload_count!r}. "
+                    "Run hook-payload reference reconciliation before deleting orphan refs."
                 )
             _write_prepared_receipt(receipt_path, source_db, classification, backup_manifest)
             prepared = True

--- a/polylogue/storage/blob_gc.py
+++ b/polylogue/storage/blob_gc.py
@@ -201,6 +201,10 @@ def _blob_refs_has_ref_type_column(conn: sqlite3.Connection) -> bool:
     return "ref_type" in columns and "ref_id" in columns
 
 
+def _table_has_blob_hash_column(conn: sqlite3.Connection, table: str) -> bool:
+    return any(str(row[1]) == "blob_hash" for row in conn.execute(f"PRAGMA table_info({table})"))
+
+
 def _blob_refs_still_live(conn: sqlite3.Connection, blob_bytes: bytes) -> bool:
     """Return True if some ``blob_refs`` row for this hash has a live referent.
 
@@ -243,8 +247,8 @@ def _archive_reference_surfaces(
         return []
 
     surfaces: list[str] = []
-    for table in ("raw_sessions", "attachments"):
-        if not _table_exists(conn, table):
+    for table in ("raw_sessions", "attachments", "raw_hook_events"):
+        if not _table_exists(conn, table) or not _table_has_blob_hash_column(conn, table):
             continue
         row = conn.execute(f"SELECT 1 FROM {table} WHERE blob_hash = ? LIMIT 1", (blob_bytes,)).fetchone()
         if row is not None:

--- a/polylogue/storage/blob_gc.py
+++ b/polylogue/storage/blob_gc.py
@@ -177,12 +177,15 @@ def _blob_hash_bytes(blob_hash: str) -> bytes | None:
 # row, so it joins the same table as 'raw_payload'. 'sidecar' has no
 # production writer today; it is included for completeness/forward-safety
 # against history_sidecars.sidecar_id, its only plausible referent.
-_BLOB_REF_LIVENESS_JOIN: tuple[tuple[str, str, str], ...] = (
+BLOB_REF_LIVENESS_JOIN: tuple[tuple[str, str, str], ...] = (
     ("raw_payload", "raw_sessions", "raw_id"),
     ("attachment", "raw_sessions", "raw_id"),
     ("hook_payload", "raw_hook_events", "hook_event_id"),
     ("sidecar", "history_sidecars", "sidecar_id"),
 )
+
+# Private alias retained for the GC implementation's existing local naming.
+_BLOB_REF_LIVENESS_JOIN = BLOB_REF_LIVENESS_JOIN
 
 
 def _blob_refs_has_ref_type_column(conn: sqlite3.Connection) -> bool:
@@ -689,6 +692,7 @@ def census_orphaned_blob_refs(conn: sqlite3.Connection) -> OrphanedBlobRefCensus
 
 __all__ = [
     "BlobGCResult",
+    "BLOB_REF_LIVENESS_JOIN",
     "MIN_AGE_S",
     "GCHistoryRow",
     "GCRunEvidence",

--- a/polylogue/storage/blob_ref_liveness.py
+++ b/polylogue/storage/blob_ref_liveness.py
@@ -1,0 +1,174 @@
+"""Set-based liveness classification for source-tier ``blob_refs`` rows.
+
+The source tier stores attachment blob refs against the parent ``raw_id``.
+That is a source acquisition reference, not an index-tier ``attachment_refs``
+edge. The canonical mapping is shared with blob GC so reconciliation and GC
+prove liveness with the same referent joins.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+from polylogue.storage.blob_gc import BLOB_REF_LIVENESS_JOIN
+from polylogue.storage.introspection import table_exists
+
+
+class BlobRefLivenessError(RuntimeError):
+    """Raised when the source-tier reference shape cannot be proven safe."""
+
+
+@dataclass(frozen=True, slots=True)
+class BlobRefLivenessCandidate:
+    """One blob-ref row whose actual source-tier referent is absent."""
+
+    blob_hash: str
+    ref_type: str
+    ref_id: str
+    source_path: str | None
+    size_bytes: int
+    acquired_at_ms: int
+    referent_table: str
+    referent_column: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "blob_hash": self.blob_hash,
+            "ref_type": self.ref_type,
+            "ref_id": self.ref_id,
+            "source_path": self.source_path,
+            "size_bytes": self.size_bytes,
+            "acquired_at_ms": self.acquired_at_ms,
+            "referent_table": self.referent_table,
+            "referent_column": self.referent_column,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BlobRefLivenessClassification:
+    """Complete read-only classification of source-tier blob references."""
+
+    scanned_count: int
+    ref_type_counts: dict[str, int]
+    orphaned_by_ref_type: dict[str, int]
+    ref_type_joins: tuple[tuple[str, str, str], ...]
+    unknown_ref_types: tuple[str, ...]
+    unavailable_ref_types: tuple[str, ...]
+    candidates: tuple[BlobRefLivenessCandidate, ...]
+
+    @property
+    def safe_to_apply(self) -> bool:
+        return not self.unknown_ref_types and not self.unavailable_ref_types
+
+    def to_dict(self, *, include_candidates: bool = False, sample_limit: int = 30) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "scanned_count": self.scanned_count,
+            "ref_type_counts": dict(self.ref_type_counts),
+            "orphaned_count": len(self.candidates),
+            "orphaned_by_ref_type": dict(self.orphaned_by_ref_type),
+            "ref_type_joins": [
+                {"ref_type": ref_type, "referent_table": table, "referent_column": column}
+                for ref_type, table, column in self.ref_type_joins
+            ],
+            "unknown_ref_types": list(self.unknown_ref_types),
+            "unavailable_ref_types": list(self.unavailable_ref_types),
+            "safe_to_apply": self.safe_to_apply,
+        }
+        if include_candidates:
+            payload["candidates"] = [candidate.to_dict() for candidate in self.candidates]
+        else:
+            payload["samples"] = [candidate.to_dict() for candidate in self.candidates[: max(0, sample_limit)]]
+        return payload
+
+
+def _blob_ref_columns(conn: sqlite3.Connection) -> set[str]:
+    return {str(row[1]) for row in conn.execute("PRAGMA table_info(blob_refs)")}
+
+
+def _referent_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def classify_blob_ref_liveness(conn: sqlite3.Connection) -> BlobRefLivenessClassification:
+    """Classify every ``blob_refs`` row using its mapped referent LEFT JOIN.
+
+    The SQL is set-based: one ``LEFT JOIN`` branch per known ref type, joined
+    on the actual referent table and key. Unknown ref types, missing referent
+    tables, and missing referent columns are reported and make an apply unsafe
+    rather than silently treating an unproven row as dead.
+    """
+
+    if not table_exists(conn, "blob_refs"):
+        return BlobRefLivenessClassification(0, {}, {}, (), (), (), ())
+    columns = _blob_ref_columns(conn)
+    required = {"blob_hash", "ref_id", "ref_type", "source_path", "size_bytes", "acquired_at_ms"}
+    missing = sorted(required - columns)
+    if missing:
+        raise BlobRefLivenessError(f"blob_refs is missing required columns: {', '.join(missing)}")
+
+    ref_type_counts = {
+        str(row[0]): int(row[1])
+        for row in conn.execute("SELECT ref_type, COUNT(*) FROM blob_refs GROUP BY ref_type ORDER BY ref_type")
+    }
+    known = {ref_type: (table, column) for ref_type, table, column in BLOB_REF_LIVENESS_JOIN}
+    unknown = tuple(sorted(set(ref_type_counts) - set(known)))
+    unavailable: list[str] = []
+    branches: list[str] = []
+    params: list[str] = []
+    ref_type_joins: list[tuple[str, str, str]] = []
+    for ref_type, (table, column) in known.items():
+        if not ref_type_counts.get(ref_type):
+            continue
+        if not table_exists(conn, table) or column not in _referent_columns(conn, table):
+            unavailable.append(ref_type)
+            continue
+        branches.append(
+            f"""
+            SELECT b.blob_hash, b.ref_type, b.ref_id, b.source_path, b.size_bytes,
+                   b.acquired_at_ms, '{table}' AS referent_table, '{column}' AS referent_column
+            FROM blob_refs AS b
+            LEFT JOIN {table} AS r ON r.{column} = b.ref_id
+            WHERE b.ref_type = ? AND r.{column} IS NULL
+            """
+        )
+        params.append(ref_type)
+        ref_type_joins.append((ref_type, table, column))
+
+    candidates: list[BlobRefLivenessCandidate] = []
+    if branches:
+        query = " UNION ALL ".join(branches) + " ORDER BY 2, 3, 1"
+        for row in conn.execute(query, tuple(params)):
+            blob_hash = bytes(row[0]).hex()
+            candidates.append(
+                BlobRefLivenessCandidate(
+                    blob_hash=blob_hash,
+                    ref_type=str(row[1]),
+                    ref_id=str(row[2]),
+                    source_path=str(row[3]) if row[3] is not None else None,
+                    size_bytes=int(row[4]),
+                    acquired_at_ms=int(row[5]),
+                    referent_table=str(row[6]),
+                    referent_column=str(row[7]),
+                )
+            )
+    orphaned_by_ref_type: dict[str, int] = {}
+    for candidate in candidates:
+        orphaned_by_ref_type[candidate.ref_type] = orphaned_by_ref_type.get(candidate.ref_type, 0) + 1
+    return BlobRefLivenessClassification(
+        scanned_count=sum(ref_type_counts.values()),
+        ref_type_counts=ref_type_counts,
+        orphaned_by_ref_type=orphaned_by_ref_type,
+        ref_type_joins=tuple(ref_type_joins),
+        unknown_ref_types=unknown,
+        unavailable_ref_types=tuple(sorted(unavailable)),
+        candidates=tuple(candidates),
+    )
+
+
+__all__ = [
+    "BlobRefLivenessCandidate",
+    "BlobRefLivenessClassification",
+    "BlobRefLivenessError",
+    "classify_blob_ref_liveness",
+]

--- a/polylogue/storage/blob_ref_liveness.py
+++ b/polylogue/storage/blob_ref_liveness.py
@@ -12,6 +12,7 @@ import sqlite3
 from dataclasses import dataclass
 
 from polylogue.storage.blob_gc import BLOB_REF_LIVENESS_JOIN
+from polylogue.storage.hook_payload_ref_reconciliation import plan_hook_payload_ref_reconciliation
 from polylogue.storage.introspection import table_exists
 
 
@@ -55,11 +56,12 @@ class BlobRefLivenessClassification:
     ref_type_joins: tuple[tuple[str, str, str], ...]
     unknown_ref_types: tuple[str, ...]
     unavailable_ref_types: tuple[str, ...]
+    rekeyable_hook_payload_count: int
     candidates: tuple[BlobRefLivenessCandidate, ...]
 
     @property
     def safe_to_apply(self) -> bool:
-        return not self.unknown_ref_types and not self.unavailable_ref_types
+        return not self.unknown_ref_types and not self.unavailable_ref_types and not self.rekeyable_hook_payload_count
 
     def to_dict(self, *, include_candidates: bool = False, sample_limit: int = 30) -> dict[str, object]:
         payload: dict[str, object] = {
@@ -73,6 +75,7 @@ class BlobRefLivenessClassification:
             ],
             "unknown_ref_types": list(self.unknown_ref_types),
             "unavailable_ref_types": list(self.unavailable_ref_types),
+            "rekeyable_hook_payload_count": self.rekeyable_hook_payload_count,
             "safe_to_apply": self.safe_to_apply,
         }
         if include_candidates:
@@ -100,7 +103,7 @@ def classify_blob_ref_liveness(conn: sqlite3.Connection) -> BlobRefLivenessClass
     """
 
     if not table_exists(conn, "blob_refs"):
-        return BlobRefLivenessClassification(0, {}, {}, (), (), (), ())
+        return BlobRefLivenessClassification(0, {}, {}, (), (), (), 0, ())
     columns = _blob_ref_columns(conn)
     required = {"blob_hash", "ref_id", "ref_type", "source_path", "size_bytes", "acquired_at_ms"}
     missing = sorted(required - columns)
@@ -135,16 +138,27 @@ def classify_blob_ref_liveness(conn: sqlite3.Connection) -> BlobRefLivenessClass
         params.append(ref_type)
         ref_type_joins.append((ref_type, table, column))
 
+    rekeyable_hook_payloads = {
+        (candidate.blob_hash.hex(), candidate.orphaned_ref_id)
+        for candidate in plan_hook_payload_ref_reconciliation(conn).matched
+    }
     candidates: list[BlobRefLivenessCandidate] = []
     if branches:
         query = " UNION ALL ".join(branches) + " ORDER BY 2, 3, 1"
         for row in conn.execute(query, tuple(params)):
             blob_hash = bytes(row[0]).hex()
+            ref_type = str(row[1])
+            ref_id = str(row[2])
+            # Pre-v22 hook refs were stored as raw_payload with a synthetic
+            # raw id. They are durable live payloads awaiting a provable
+            # re-key to hook_payload, never deletion candidates.
+            if (blob_hash, ref_id) in rekeyable_hook_payloads:
+                continue
             candidates.append(
                 BlobRefLivenessCandidate(
                     blob_hash=blob_hash,
-                    ref_type=str(row[1]),
-                    ref_id=str(row[2]),
+                    ref_type=ref_type,
+                    ref_id=ref_id,
                     source_path=str(row[3]) if row[3] is not None else None,
                     size_bytes=int(row[4]),
                     acquired_at_ms=int(row[5]),
@@ -162,6 +176,7 @@ def classify_blob_ref_liveness(conn: sqlite3.Connection) -> BlobRefLivenessClass
         ref_type_joins=tuple(ref_type_joins),
         unknown_ref_types=unknown,
         unavailable_ref_types=tuple(sorted(unavailable)),
+        rekeyable_hook_payload_count=len(rekeyable_hook_payloads),
         candidates=tuple(candidates),
     )
 

--- a/polylogue/storage/hook_payload_ref_reconciliation.py
+++ b/polylogue/storage/hook_payload_ref_reconciliation.py
@@ -83,12 +83,17 @@ def _orphaned_raw_payload_refs(conn: sqlite3.Connection) -> list[sqlite3.Row]:
     ).fetchall()
 
 
-def _hook_events_missing_blob_hash(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+def _hook_events_without_canonical_blob_ref(conn: sqlite3.Connection) -> list[sqlite3.Row]:
     return conn.execute(
         """
-        SELECT hook_event_id, origin, native_id, source_path
-        FROM raw_hook_events
-        WHERE blob_hash IS NULL
+        SELECT h.hook_event_id, h.origin, h.native_id, h.source_path, h.blob_hash
+        FROM raw_hook_events AS h
+        WHERE NOT EXISTS (
+            SELECT 1 FROM blob_refs AS b
+            WHERE b.blob_hash = h.blob_hash
+              AND b.ref_type = 'hook_payload'
+              AND b.ref_id = h.hook_event_id
+        )
         """
     ).fetchall()
 
@@ -108,7 +113,7 @@ def plan_hook_payload_ref_reconciliation(conn: sqlite3.Connection) -> HookPayloa
         return HookPayloadRefReconciliationPlan(scanned_count=0, matched=(), unmatched_count=0)
 
     candidates_by_source_path: dict[str | None, list[sqlite3.Row]] = {}
-    for row in _hook_events_missing_blob_hash(conn):
+    for row in _hook_events_without_canonical_blob_ref(conn):
         candidates_by_source_path.setdefault(row["source_path"], []).append(row)
 
     matched: list[HookPayloadRefReconciliationCandidate] = []
@@ -118,6 +123,12 @@ def plan_hook_payload_ref_reconciliation(conn: sqlite3.Connection) -> HookPayloa
         candidates = candidates_by_source_path.get(ref["source_path"], ())
         hits: list[str] = []
         for candidate in candidates:
+            # A completed post-v22 write already owns its canonical ref and
+            # was excluded above. An interrupted/historical re-key may have
+            # written the durable hash to the hook row but not restored that
+            # ref; it is the same payload only when the hashes agree.
+            if candidate["blob_hash"] is not None and bytes(candidate["blob_hash"]) != blob_hash:
+                continue
             recomputed = deterministic_raw_session_id(
                 candidate["origin"],
                 ref["source_path"] or "",

--- a/tests/unit/cli/test_blob_ref_liveness_cli.py
+++ b/tests/unit/cli/test_blob_ref_liveness_cli.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from polylogue.cli.click_app import cli
+
+
+def test_blob_reference_liveness_cli_defaults_to_read_only(
+    cli_workspace: dict[str, Path], cli_runner: CliRunner
+) -> None:
+    archive_root = cli_workspace["archive_root"]
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, 'historical-raw', 'raw_payload', '/historical', 1, 1)
+            """,
+            (b"h" * 32,),
+        )
+
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "blob-reference-liveness",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["mode"] == "blob_reference_liveness"
+    assert payload["mutates"] is False
+    assert payload["dry_run"] is True
+    assert payload["orphaned_by_ref_type"] == {"raw_payload": 1}
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        assert conn.execute("SELECT COUNT(*) FROM blob_refs").fetchone() == (1,)

--- a/tests/unit/storage/test_blob_gc_ref_type_liveness.py
+++ b/tests/unit/storage/test_blob_gc_ref_type_liveness.py
@@ -29,11 +29,19 @@ from pathlib import Path
 import pytest
 
 from polylogue.core.enums import Origin, Provider
+from polylogue.maintenance.blob_ref_liveness_reconciliation import (
+    BlobRefLivenessReconciliationError,
+    reconcile_blob_ref_liveness,
+)
 from polylogue.storage.blob_gc import census_orphaned_blob_refs, run_blob_gc
+from polylogue.storage.blob_ref_liveness import classify_blob_ref_liveness
 from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
-from polylogue.storage.sqlite.archive_tiers.source_write import ArchiveHookEvent
+from polylogue.storage.sqlite.archive_tiers.source_write import (
+    ArchiveHookEvent,
+    deterministic_raw_session_id,
+)
 
 pytestmark = pytest.mark.uses_real_clock(
     "backdates a real blob mtime via os.utime; blob_gc.py's age gate compares it against a real time.time() call"
@@ -109,6 +117,73 @@ def test_hook_payload_ref_survives_gc_while_hook_event_row_exists_then_is_reclai
     deleted = run_blob_gc(archive_root / "source.db", archive_root / "blob", max_batch=10)
     assert deleted == 1
     assert not blob_store.exists(blob_hash)
+
+
+def test_interrupted_hook_rekey_blocks_liveness_deletion_and_preserves_blob(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A hook hash without its canonical ref remains live and rekeyable.
+
+    This creates the state through the production hook writer, then removes
+    its canonical ref and restores the legacy raw-payload reference as an
+    interrupted historical re-key would leave it. The generic liveness
+    classifier must block deletion of that reference, and real blob GC must
+    keep the payload based on ``raw_hook_events.blob_hash`` until repair.
+    """
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+    source_path = "/hooks/interrupted.jsonl"
+    hook_event_id = "hook-interrupted"
+    native_id = f"{hook_event_id}:native"
+    payload = b'{"event":"PostToolUse","n":2}'
+    _write_hook_event(archive_root, hook_event_id=hook_event_id, source_path=source_path, payload=payload)
+
+    blob_store = BlobStore(archive_root / "blob")
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        blob_hash = conn.execute(
+            "SELECT blob_hash FROM raw_hook_events WHERE hook_event_id = ?", (hook_event_id,)
+        ).fetchone()[0]
+        legacy_ref_id = deterministic_raw_session_id("codex-session", source_path, 0, blob_hash, native_id)
+        conn.execute("DELETE FROM blob_refs WHERE ref_type = 'hook_payload' AND ref_id = ?", (hook_event_id,))
+        conn.execute(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, ?, 'raw_payload', ?, ?, ?)
+            """,
+            (blob_hash, legacy_ref_id, source_path, len(payload), 1_700_000_000_000),
+        )
+        classification = classify_blob_ref_liveness(conn)
+        conn.commit()
+
+    assert classification.rekeyable_hook_payload_count == 1
+    assert classification.safe_to_apply is False
+    assert all(candidate.ref_id != legacy_ref_id for candidate in classification.candidates)
+
+    monkeypatch.setattr(
+        "polylogue.maintenance.blob_ref_liveness_reconciliation.validate_migration_backup_manifest",
+        lambda *args, **kwargs: args[0],
+    )
+    monkeypatch.setattr(
+        "polylogue.maintenance.blob_ref_liveness_reconciliation.offline_maintenance_block_reason",
+        lambda *args, **kwargs: None,
+    )
+    with pytest.raises(BlobRefLivenessReconciliationError, match="rekeyable_hook_payloads=1"):
+        reconcile_blob_ref_liveness(
+            archive_root,
+            backup_manifest=tmp_path / "backup.json",
+            receipt_path=tmp_path / "liveness.jsonl",
+            dry_run=False,
+        )
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        assert conn.execute(
+            "SELECT COUNT(*) FROM blob_refs WHERE ref_type = 'raw_payload' AND ref_id = ?", (legacy_ref_id,)
+        ).fetchone() == (1,)
+
+    blob_hash_hex = blob_hash.hex()
+    _backdate(blob_store, blob_hash_hex)
+    deleted = run_blob_gc(archive_root / "source.db", archive_root / "blob", max_batch=10)
+    assert deleted == 0
+    assert blob_store.exists(blob_hash_hex)
 
 
 def test_attachment_ref_type_joins_against_raw_sessions_not_raw_artifacts(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_blob_ref_liveness.py
+++ b/tests/unit/storage/test_blob_ref_liveness.py
@@ -8,12 +8,14 @@ from pathlib import Path
 
 import pytest
 
+import polylogue.maintenance.blob_ref_liveness_reconciliation as liveness_reconciliation
 from polylogue.maintenance.blob_ref_liveness_reconciliation import (
     BlobRefLivenessReconciliationError,
     reconcile_blob_ref_liveness,
 )
 from polylogue.storage.blob_ref_liveness import classify_blob_ref_liveness
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from polylogue.storage.sqlite.archive_tiers.source_write import deterministic_raw_session_id
 
 
 def _source_archive(tmp_path: Path) -> Path:
@@ -100,12 +102,118 @@ def test_dry_run_is_read_only_and_reports_attachment_parent_join(tmp_path: Path)
     assert after == before
 
 
+def test_legacy_hook_payload_ref_is_rekeyable_not_a_delete_candidate(tmp_path: Path) -> None:
+    archive_root = _source_archive(tmp_path)
+    blob_hash = b"h" * 32
+    source_path = "/legacy-hook.jsonl"
+    native_id = "tool-call-1"
+    legacy_ref_id = deterministic_raw_session_id("codex-session", source_path, 0, blob_hash, native_id)
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_hook_events (
+                hook_event_id, origin, native_id, source_path, event_type, payload_json, observed_at_ms
+            ) VALUES ('hook-legacy', 'codex-session', ?, ?, 'PostToolUse', '{}', 1)
+            """,
+            (native_id, source_path),
+        )
+        conn.execute(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, ?, 'raw_payload', ?, 1, 1)
+            """,
+            (blob_hash, legacy_ref_id, source_path),
+        )
+        classification = classify_blob_ref_liveness(conn)
+
+    assert classification.rekeyable_hook_payload_count == 1
+    assert classification.safe_to_apply is False
+    assert all(candidate.ref_id != legacy_ref_id for candidate in classification.candidates)
+
+
 def test_apply_requires_backup_and_receipt_before_mutation(tmp_path: Path) -> None:
     archive_root = _source_archive(tmp_path)
     with pytest.raises(BlobRefLivenessReconciliationError, match="backup manifest"):
         reconcile_blob_ref_liveness(archive_root, dry_run=False, receipt_path=tmp_path / "receipt.jsonl")
     with sqlite3.connect(archive_root / "source.db") as conn:
         assert conn.execute("SELECT COUNT(*) FROM blob_refs").fetchone() == (8,)
+
+
+def test_restart_recovers_prepared_receipt_after_committed_delete(tmp_path: Path) -> None:
+    archive_root = _source_archive(tmp_path)
+    receipt = tmp_path / "receipts" / "interrupted.jsonl"
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        classification = classify_blob_ref_liveness(conn)
+    liveness_reconciliation._write_prepared_receipt(
+        receipt, archive_root / "source.db", classification, tmp_path / "backup.json"
+    )
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        for candidate in classification.candidates:
+            conn.execute(
+                "DELETE FROM blob_refs WHERE blob_hash = ? AND ref_type = ? AND ref_id = ?",
+                (bytes.fromhex(candidate.blob_hash), candidate.ref_type, candidate.ref_id),
+            )
+
+    with pytest.raises(BlobRefLivenessReconciliationError, match="recovered_committed"):
+        reconcile_blob_ref_liveness(
+            archive_root,
+            backup_manifest=tmp_path / "backup.json",
+            receipt_path=receipt,
+            dry_run=False,
+        )
+    rows = [json.loads(line) for line in receipt.read_text(encoding="utf-8").splitlines()]
+    assert rows[-1]["phase"] == "recovered_committed"
+
+
+def test_restart_recovers_prepared_receipt_after_rollback(tmp_path: Path) -> None:
+    archive_root = _source_archive(tmp_path)
+    receipt = tmp_path / "receipts" / "rolled-back.jsonl"
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        classification = classify_blob_ref_liveness(conn)
+    liveness_reconciliation._write_prepared_receipt(
+        receipt, archive_root / "source.db", classification, tmp_path / "backup.json"
+    )
+
+    with pytest.raises(BlobRefLivenessReconciliationError, match="recovered_rolled_back"):
+        reconcile_blob_ref_liveness(
+            archive_root,
+            backup_manifest=tmp_path / "backup.json",
+            receipt_path=receipt,
+            dry_run=False,
+        )
+    rows = [json.loads(line) for line in receipt.read_text(encoding="utf-8").splitlines()]
+    assert rows[-1]["phase"] == "recovered_rolled_back"
+
+
+def test_restart_marks_partial_prepared_plan_indeterminate(tmp_path: Path) -> None:
+    archive_root = _source_archive(tmp_path)
+    receipt = tmp_path / "receipts" / "partial.jsonl"
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        classification = classify_blob_ref_liveness(conn)
+    liveness_reconciliation._write_prepared_receipt(
+        receipt, archive_root / "source.db", classification, tmp_path / "backup.json"
+    )
+    candidate = classification.candidates[0]
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        conn.execute(
+            "DELETE FROM blob_refs WHERE blob_hash = ? AND ref_type = ? AND ref_id = ?",
+            (bytes.fromhex(candidate.blob_hash), candidate.ref_type, candidate.ref_id),
+        )
+
+    with pytest.raises(BlobRefLivenessReconciliationError, match="indeterminate"):
+        reconcile_blob_ref_liveness(
+            archive_root,
+            backup_manifest=tmp_path / "backup.json",
+            receipt_path=receipt,
+            dry_run=False,
+        )
+    with pytest.raises(BlobRefLivenessReconciliationError, match="already terminal"):
+        reconcile_blob_ref_liveness(
+            archive_root,
+            backup_manifest=tmp_path / "backup.json",
+            receipt_path=receipt,
+            dry_run=False,
+        )
 
 
 def test_apply_deletes_only_join_proven_orphans_and_persists_receipt(

--- a/tests/unit/storage/test_blob_ref_liveness.py
+++ b/tests/unit/storage/test_blob_ref_liveness.py
@@ -1,0 +1,191 @@
+"""Focused proofs for source-tier blob-ref liveness reconciliation."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.maintenance.blob_ref_liveness_reconciliation import (
+    BlobRefLivenessReconciliationError,
+    reconcile_blob_ref_liveness,
+)
+from polylogue.storage.blob_ref_liveness import classify_blob_ref_liveness
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+
+def _source_archive(tmp_path: Path) -> Path:
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_sessions (raw_id, origin, source_path, source_index, blob_hash, blob_size, acquired_at_ms)
+            VALUES ('raw-live', 'codex-session', '/live.jsonl', 0, ?, 10, 1)
+            """,
+            (b"l" * 32,),
+        )
+        conn.execute(
+            """
+            INSERT INTO raw_hook_events (
+                hook_event_id, origin, source_path, event_type, payload_json, observed_at_ms
+            ) VALUES ('hook-live', 'codex-session', '/hook.jsonl', 'PostToolUse', '{}', 1)
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO history_sidecars (
+                sidecar_id, origin, source_path, payload_json, observed_at_ms, content_hash
+            ) VALUES ('sidecar-live', 'codex-session', '/sidecar.json', '{}', 1, ?)
+            """,
+            (b"s" * 32,),
+        )
+        refs = (
+            (b"1" * 32, "raw-live", "raw_payload"),
+            (b"2" * 32, "raw-gone", "raw_payload"),
+            (b"3" * 32, "raw-live", "attachment"),
+            (b"4" * 32, "raw-gone", "attachment"),
+            (b"5" * 32, "hook-live", "hook_payload"),
+            (b"6" * 32, "hook-gone", "hook_payload"),
+            (b"7" * 32, "sidecar-live", "sidecar"),
+            (b"8" * 32, "sidecar-gone", "sidecar"),
+        )
+        conn.executemany(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, ?, ?, '/fixture', 1, 1)
+            """,
+            refs,
+        )
+    return archive_root
+
+
+def test_classifier_proves_each_source_ref_type_with_actual_referent_join(tmp_path: Path) -> None:
+    archive_root = _source_archive(tmp_path)
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        classification = classify_blob_ref_liveness(conn)
+
+    assert classification.scanned_count == 8
+    assert classification.orphaned_by_ref_type == {
+        "attachment": 1,
+        "hook_payload": 1,
+        "raw_payload": 1,
+        "sidecar": 1,
+    }
+    assert {
+        (candidate.ref_type, candidate.referent_table, candidate.referent_column)
+        for candidate in classification.candidates
+    } == {
+        ("raw_payload", "raw_sessions", "raw_id"),
+        ("attachment", "raw_sessions", "raw_id"),
+        ("hook_payload", "raw_hook_events", "hook_event_id"),
+        ("sidecar", "history_sidecars", "sidecar_id"),
+    }
+    assert classification.safe_to_apply is True
+
+
+def test_dry_run_is_read_only_and_reports_attachment_parent_join(tmp_path: Path) -> None:
+    archive_root = _source_archive(tmp_path)
+    before = sqlite3.connect(archive_root / "source.db").execute("SELECT COUNT(*) FROM blob_refs").fetchone()[0]
+
+    report = reconcile_blob_ref_liveness(archive_root)
+
+    assert report.dry_run is True
+    assert report.applied is False
+    assert report.deleted_count == 0
+    assert report.classification.orphaned_by_ref_type["attachment"] == 1
+    after = sqlite3.connect(archive_root / "source.db").execute("SELECT COUNT(*) FROM blob_refs").fetchone()[0]
+    assert after == before
+
+
+def test_apply_requires_backup_and_receipt_before_mutation(tmp_path: Path) -> None:
+    archive_root = _source_archive(tmp_path)
+    with pytest.raises(BlobRefLivenessReconciliationError, match="backup manifest"):
+        reconcile_blob_ref_liveness(archive_root, dry_run=False, receipt_path=tmp_path / "receipt.jsonl")
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        assert conn.execute("SELECT COUNT(*) FROM blob_refs").fetchone() == (8,)
+
+
+def test_apply_deletes_only_join_proven_orphans_and_persists_receipt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive_root = _source_archive(tmp_path)
+    manifest = tmp_path / "backup" / "source.json"
+    receipt = tmp_path / "receipts" / "liveness.jsonl"
+
+    def fake_validate(path: Path, tier: object, *, connection: sqlite3.Connection) -> Path:
+        assert connection.execute("SELECT 1").fetchone() == (1,)
+        return path
+
+    monkeypatch.setattr(
+        "polylogue.maintenance.blob_ref_liveness_reconciliation.validate_migration_backup_manifest",
+        fake_validate,
+    )
+    monkeypatch.setattr(
+        "polylogue.maintenance.blob_ref_liveness_reconciliation.offline_maintenance_block_reason",
+        lambda *args, **kwargs: None,
+    )
+
+    report = reconcile_blob_ref_liveness(
+        archive_root,
+        backup_manifest=manifest,
+        receipt_path=receipt,
+        dry_run=False,
+    )
+
+    assert report.applied is True
+    assert report.deleted_count == 4
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        remaining = conn.execute("SELECT ref_type, ref_id FROM blob_refs ORDER BY ref_type, ref_id").fetchall()
+    assert remaining == [
+        ("attachment", "raw-live"),
+        ("hook_payload", "hook-live"),
+        ("raw_payload", "raw-live"),
+        ("sidecar", "sidecar-live"),
+    ]
+    receipt_rows = [json.loads(line) for line in receipt.read_text(encoding="utf-8").splitlines()]
+    assert receipt_rows[0]["phase"] == "prepared"
+    assert receipt_rows[0]["candidate_count"] == 4
+    assert receipt_rows[0]["candidate_digest"]
+    assert receipt_rows[-1]["phase"] == "committed"
+    assert receipt_rows[-1]["deleted_count"] == 4
+
+
+def test_unknown_ref_type_blocks_apply_fail_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    source_db = tmp_path / "source.db"
+    with sqlite3.connect(source_db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE raw_sessions (raw_id TEXT PRIMARY KEY);
+            CREATE TABLE blob_refs (
+                blob_hash BLOB NOT NULL, ref_id TEXT NOT NULL, ref_type TEXT NOT NULL,
+                source_path TEXT, size_bytes INTEGER NOT NULL, acquired_at_ms INTEGER NOT NULL,
+                PRIMARY KEY (blob_hash, ref_type, ref_id)
+            );
+            INSERT INTO blob_refs VALUES (X'1111111111111111111111111111111111111111111111111111111111111111', 'gone', 'future_type', '/future', 1, 1);
+            """
+        )
+    archive_root = tmp_path
+    with sqlite3.connect(source_db) as conn:
+        classification = classify_blob_ref_liveness(conn)
+    assert classification.unknown_ref_types == ("future_type",)
+    assert classification.safe_to_apply is False
+
+    monkeypatch.setattr(
+        "polylogue.maintenance.blob_ref_liveness_reconciliation.validate_migration_backup_manifest",
+        lambda *args, **kwargs: args[0],
+    )
+    monkeypatch.setattr(
+        "polylogue.maintenance.blob_ref_liveness_reconciliation.offline_maintenance_block_reason",
+        lambda *args, **kwargs: None,
+    )
+    with pytest.raises(BlobRefLivenessReconciliationError, match="cannot be proven"):
+        reconcile_blob_ref_liveness(
+            archive_root,
+            backup_manifest=tmp_path / "backup.json",
+            receipt_path=tmp_path / "blocked.jsonl",
+            dry_run=False,
+        )
+    assert not (tmp_path / "blocked.jsonl").exists()


### PR DESCRIPTION
## Summary

Add a fail-closed source-tier reconciliation path for historical `blob_refs` rows whose actual referents no longer exist, while preserving legacy hook-payload rows for dedicated rekey and GC protection.

## Problem

The prior GC liveness oracle treated a `blob_refs` row as proof of itself. Historical reference drift prevents an honest pristine-blobstore audit. Legacy hook payloads are a distinct migration case, including interrupted states where `raw_hook_events.blob_hash` exists but its canonical reference does not.

## Solution

Classify each reference through canonical referent joins, including attachments through their parent raw session. Reclassify provable hook-payload legacy raw references as rekeyable and block generic apply until dedicated hook reconciliation completes. Treat a hook event hash as live for GC and block generic deletion of an incomplete historical rekey. Apply requires an offline archive, a verified source-tier backup, a fresh receipt, repeated locked classification, exact delete count, recovery of interrupted prepared receipts, and `quick_check`. No blob files are deleted.

## Verification

- `devtools test tests/unit/storage/test_blob_gc_ref_type_liveness.py tests/unit/storage/test_blob_ref_liveness.py tests/unit/storage/test_hook_payload_ref_reconciliation.py tests/unit/storage/test_hook_payload_ref_reconciliation_apply.py` produced `21 passed`.
- `devtools verify --quick` completed successfully at `b92251f6f`.
- `git diff --check` completed successfully.

Ref polylogue-0v4tn