### PR TITLE
fix(devtools): isolate uv project routing in lane init

### DIFF
--- a/devtools/lane_init.py
+++ b/devtools/lane_init.py
@@ -151,6 +151,11 @@ def _lane_env(worktree: Path) -> dict[str, str]:
     env.pop("VIRTUAL_ENV", None)
     env.pop("PYTHONHOME", None)
     env.pop("PYTHONPATH", None)
+    # uv's project-routing environment variables override subprocess.cwd.
+    # Leaving either behind can install the coordinator checkout into this
+    # lane's otherwise correctly selected .venv.
+    env.pop("UV_PROJECT", None)
+    env.pop("UV_WORKING_DIR", None)
     env["UV_PROJECT_ENVIRONMENT"] = str(worktree / ".venv")
     return env
 

--- a/tests/unit/devtools/test_lane_init.py
+++ b/tests/unit/devtools/test_lane_init.py
@@ -10,6 +10,28 @@ import pytest
 from devtools import lane_init
 
 
+def _write_minimal_uv_project(root: Path) -> None:
+    (root / "polylogue").mkdir(parents=True)
+    (root / "polylogue" / "__init__.py").write_text("", encoding="utf-8")
+    (root / "pyproject.toml").write_text(
+        """\
+[project]
+name = "polylogue"
+version = "0.0.0"
+requires-python = ">=3.14"
+
+[project.optional-dependencies]
+dev-common = []
+speed = []
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+""",
+        encoding="utf-8",
+    )
+
+
 def test_recommended_workers_fair_share_floor_and_cap() -> None:
     assert lane_init.recommended_workers(16, cpu_count=24) == 1
     assert lane_init.recommended_workers(8, cpu_count=24) == 3
@@ -95,3 +117,18 @@ def test_provision_venv_forces_the_lane_environment(tmp_path: Path, monkeypatch:
     assert "PYTHONHOME" not in env
     assert "PYTHONPATH" not in env
     assert env["UV_PROJECT_ENVIRONMENT"] == str(lane / ".venv")
+
+
+def test_provision_venv_ignores_inherited_uv_project_and_guard_uses_lane(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A coordinator's UV_PROJECT must not install its editable source in a lane venv."""
+    coordinator = tmp_path / "coordinator"
+    lane = tmp_path / "lane"
+    _write_minimal_uv_project(coordinator)
+    _write_minimal_uv_project(lane)
+    monkeypatch.setenv("UV_PROJECT", str(coordinator))
+    monkeypatch.setenv("UV_WORKING_DIR", str(coordinator))
+
+    assert lane_init._provision_venv(lane) is None
+    assert lane_init._guard_check(lane) is None


### PR DESCRIPTION
## Summary

Keep lane provisioning pinned to the lane project when coordinator environments export uv project-routing variables.

## Problem

UV_PROJECT and UV_WORKING_DIR override the subprocess working directory. A coordinator setting could install the coordinator checkout into a lane-local virtual environment, making the import guard resolve Polylogue outside the lane.

## Solution

Lane environment construction now removes both uv routing variables while retaining the explicit lane-local virtual-environment path. The regression creates two minimal uv projects, poisons both inherited variables with the coordinator path, provisions the lane through the real seam, and verifies the lane import guard resolves its own package.

## Verification

- `devtools test tests/unit/devtools/test_lane_init.py` — 6 passed.
- `devtools verify --quick` — passed on run `20260804T050507Z-quick-1101861-00238adc`.
