### PR TITLE
fix(storage): verify canonical blob namespaces (#3708)

### DIFF
--- a/polylogue/storage/blob_integrity.py
+++ b/polylogue/storage/blob_integrity.py
@@ -27,14 +27,19 @@ from polylogue.core.json import JSONDecodeError as CoreJSONDecodeError
 from polylogue.core.json import dumps_bytes as json_dumps_bytes
 from polylogue.core.json import loads as json_loads
 from polylogue.logging import get_logger
-from polylogue.storage.blob_store import BlobStore
+from polylogue.storage.blob_store import BlobNamespaceEntry, BlobStore
 from polylogue.storage.introspection import column_exists as _column_exists
 from polylogue.storage.introspection import table_exists as _table_exists
 from polylogue.storage.sqlite.connection import open_read_connection
 
 logger = get_logger(__name__)
 
-BlobIntegrityKind = Literal["orphan_blobs", "missing_referenced_blobs", "hash_mismatch"]
+BlobIntegrityKind = Literal[
+    "orphan_blobs",
+    "missing_referenced_blobs",
+    "hash_mismatch",
+    "invalid_namespace_entries",
+]
 BlobIntegritySeverity = Literal["warning", "critical"]
 
 _DEFAULT_SAMPLE_SIZE = 100
@@ -2092,6 +2097,24 @@ def scan_blob_integrity(
                 count=len(hash_mismatches),
                 sample=tuple(hash_mismatches[:_MAX_FINDING_SAMPLE]),
                 suggested_action="replace corrupted blob files from backup or re-ingest the affected raw sources",
+            )
+        )
+
+    namespace_entries: Iterable[BlobNamespaceEntry] = blob_store.iter_namespace()
+    if not full:
+        namespace_entries = islice(namespace_entries, max(0, sample_size))
+    namespace_issues = [entry for entry in namespace_entries if entry.hash_hex is None]
+    if namespace_issues:
+        findings.append(
+            BlobIntegrityFinding(
+                kind="invalid_namespace_entries",
+                severity="critical",
+                count=len(namespace_issues),
+                sample=tuple(entry.relative_path for entry in namespace_issues[:_MAX_FINDING_SAMPLE]),
+                suggested_action=(
+                    "quiesce blob writers and classify the invalid entries; do not delete them without "
+                    "a verified cleanup plan and durable receipt"
+                ),
             )
         )
 

--- a/polylogue/storage/blob_store.py
+++ b/polylogue/storage/blob_store.py
@@ -337,6 +337,12 @@ class BlobStore:
         except FileNotFoundError:
             return
         except OSError:
+            yield BlobNamespaceEntry(
+                kind=BlobNamespaceEntryKind.INVALID_ROOT_ENTRY,
+                path=self.root,
+                relative_path=".",
+                issue=BlobNamespaceIssue.STAT_FAILED,
+            )
             return
 
         for shard_path in root_entries:

--- a/polylogue/storage/blob_store.py
+++ b/polylogue/storage/blob_store.py
@@ -20,11 +20,13 @@ import hashlib
 import logging
 import os
 import re
+import stat
 import tempfile
 import threading
 from collections.abc import Callable, Iterable, Iterator
 from contextlib import suppress
 from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
 from typing import IO, BinaryIO
 
@@ -38,6 +40,8 @@ _CHUNK_SIZE = 1024 * 1024  # 1 MiB
 # newline-suffixed hash is rejected at the boundary rather than silently
 # accepted (jsy).
 _VALID_HEX = re.compile(r"[0-9a-f]{64}")
+_VALID_SHARD = re.compile(r"[0-9a-f]{2}")
+_VALID_LEAF = re.compile(r"[0-9a-f]{62}")
 
 Heartbeat = Callable[[], None]
 
@@ -59,6 +63,41 @@ class PreparedBlob:
     hash_hex: str
     size_bytes: int
     temporary_path: Path
+
+
+class BlobNamespaceEntryKind(StrEnum):
+    """Classification for one direct entry in the blob namespace."""
+
+    BLOB = "blob"
+    INVALID_ROOT_ENTRY = "invalid_root_entry"
+    INVALID_SHARD_ENTRY = "invalid_shard_entry"
+
+
+class BlobNamespaceIssue(StrEnum):
+    """Why a filesystem entry is outside the canonical blob namespace."""
+
+    INVALID_SHARD_NAME = "invalid_shard_name"
+    NOT_DIRECTORY = "not_directory"
+    INVALID_LEAF_NAME = "invalid_leaf_name"
+    NOT_REGULAR_FILE = "not_regular_file"
+    STAT_FAILED = "stat_failed"
+
+
+@dataclass(frozen=True, slots=True)
+class BlobNamespaceEntry:
+    """One canonical blob or invalid direct namespace entry.
+
+    A valid blob is exactly ``{root}/{two lowercase hex chars}/{62 lowercase
+    hex chars}`` and its leaf is a regular file. Invalid entries retain their
+    on-disk path and issue for verification, but never carry a hash that could
+    be fed into content-addressed path construction.
+    """
+
+    kind: BlobNamespaceEntryKind
+    path: Path
+    relative_path: str
+    hash_hex: str | None = None
+    issue: BlobNamespaceIssue | None = None
 
 
 class BlobStore:
@@ -279,15 +318,102 @@ class BlobStore:
         return hasher.hexdigest() == hash_hex
 
     def iter_all(self) -> Iterator[str]:
-        """Yield all blob hashes present on disk."""
-        if not self.root.exists():
+        """Yield hashes for canonical regular blob files only."""
+        for entry in self.iter_namespace():
+            if entry.kind is BlobNamespaceEntryKind.BLOB:
+                assert entry.hash_hex is not None
+                yield entry.hash_hex
+
+    def iter_namespace(self) -> Iterator[BlobNamespaceEntry]:
+        """Classify direct namespace entries in deterministic path order.
+
+        This is deliberately stricter than a best-effort filesystem walk:
+        only two lowercase-hex shard directories containing 62 lowercase-hex
+        regular-file leaves qualify as blobs. Everything else is surfaced as a
+        typed invalid entry and never converted into a candidate blob hash.
+        """
+        try:
+            root_entries = sorted(self.root.iterdir(), key=lambda path: path.name)
+        except FileNotFoundError:
             return
-        for prefix_dir in sorted(self.root.iterdir()):
-            if not prefix_dir.is_dir() or len(prefix_dir.name) != 2:
+        except OSError:
+            return
+
+        for shard_path in root_entries:
+            try:
+                shard_mode = shard_path.stat(follow_symlinks=False).st_mode
+            except OSError:
+                yield BlobNamespaceEntry(
+                    kind=BlobNamespaceEntryKind.INVALID_ROOT_ENTRY,
+                    path=shard_path,
+                    relative_path=shard_path.name,
+                    issue=BlobNamespaceIssue.STAT_FAILED,
+                )
                 continue
-            for blob_file in sorted(prefix_dir.iterdir()):
-                if blob_file.is_file() and not blob_file.name.startswith(".blob."):
-                    yield prefix_dir.name + blob_file.name
+
+            if not _VALID_SHARD.fullmatch(shard_path.name):
+                yield BlobNamespaceEntry(
+                    kind=BlobNamespaceEntryKind.INVALID_ROOT_ENTRY,
+                    path=shard_path,
+                    relative_path=shard_path.name,
+                    issue=BlobNamespaceIssue.INVALID_SHARD_NAME,
+                )
+                continue
+            if not stat.S_ISDIR(shard_mode):
+                yield BlobNamespaceEntry(
+                    kind=BlobNamespaceEntryKind.INVALID_ROOT_ENTRY,
+                    path=shard_path,
+                    relative_path=shard_path.name,
+                    issue=BlobNamespaceIssue.NOT_DIRECTORY,
+                )
+                continue
+
+            try:
+                leaf_paths = sorted(shard_path.iterdir(), key=lambda path: path.name)
+            except OSError:
+                yield BlobNamespaceEntry(
+                    kind=BlobNamespaceEntryKind.INVALID_SHARD_ENTRY,
+                    path=shard_path,
+                    relative_path=shard_path.name,
+                    issue=BlobNamespaceIssue.STAT_FAILED,
+                )
+                continue
+
+            for leaf_path in leaf_paths:
+                relative_path = f"{shard_path.name}/{leaf_path.name}"
+                try:
+                    leaf_mode = leaf_path.stat(follow_symlinks=False).st_mode
+                except OSError:
+                    yield BlobNamespaceEntry(
+                        kind=BlobNamespaceEntryKind.INVALID_SHARD_ENTRY,
+                        path=leaf_path,
+                        relative_path=relative_path,
+                        issue=BlobNamespaceIssue.STAT_FAILED,
+                    )
+                    continue
+
+                if not _VALID_LEAF.fullmatch(leaf_path.name):
+                    yield BlobNamespaceEntry(
+                        kind=BlobNamespaceEntryKind.INVALID_SHARD_ENTRY,
+                        path=leaf_path,
+                        relative_path=relative_path,
+                        issue=BlobNamespaceIssue.INVALID_LEAF_NAME,
+                    )
+                    continue
+                if not stat.S_ISREG(leaf_mode):
+                    yield BlobNamespaceEntry(
+                        kind=BlobNamespaceEntryKind.INVALID_SHARD_ENTRY,
+                        path=leaf_path,
+                        relative_path=relative_path,
+                        issue=BlobNamespaceIssue.NOT_REGULAR_FILE,
+                    )
+                    continue
+                yield BlobNamespaceEntry(
+                    kind=BlobNamespaceEntryKind.BLOB,
+                    path=leaf_path,
+                    relative_path=relative_path,
+                    hash_hex=shard_path.name + leaf_path.name,
+                )
 
     def remove(self, hash_hex: str) -> bool:
         """Remove a blob from the store. Returns True if it existed."""
@@ -330,9 +456,26 @@ class BlobStore:
         checked_bytes = 0
         failures: list[BlobVerifyFailure] = []
 
-        for hash_hex in self.iter_all():
+        for entry in self.iter_namespace():
+            if entry.kind is not BlobNamespaceEntryKind.BLOB:
+                failures.append(
+                    BlobVerifyFailure(
+                        hash="",
+                        reason="invalid_namespace_entry",
+                        detail=(
+                            f"{entry.relative_path}: {entry.issue.value if entry.issue is not None else 'unknown'}"
+                        ),
+                        path=entry.relative_path,
+                    )
+                )
+                if len(failures) >= max_failures:
+                    break
+                continue
+
+            assert entry.hash_hex is not None
+            hash_hex = entry.hash_hex
             checked += 1
-            path = self.blob_path(hash_hex)
+            path = entry.path
             try:
                 file_size = path.stat().st_size
                 checked_bytes += file_size
@@ -493,8 +636,9 @@ class BlobVerifyFailure:
     """A single blob integrity verification failure."""
 
     hash: str
-    reason: str  # stat_failed | read_error | hash_mismatch
+    reason: str  # invalid_namespace_entry | stat_failed | read_error | hash_mismatch
     detail: str = ""
+    path: str = ""
 
 
 @dataclass(frozen=True)
@@ -575,6 +719,9 @@ def load_raw_content(raw_id: str) -> bytes:
 
 
 __all__ = [
+    "BlobNamespaceEntry",
+    "BlobNamespaceEntryKind",
+    "BlobNamespaceIssue",
     "BlobStore",
     "BlobVerifyAllResult",
     "BlobVerifyFailure",

--- a/tests/unit/sources/test_parsers_local_agent.py
+++ b/tests/unit/sources/test_parsers_local_agent.py
@@ -835,6 +835,28 @@ def test_hermes_state_db_source_iterator_snapshots_wal_before_parsing(tmp_path: 
         hermes_state.parse_state_db(corrupted_path, profile_root=db_path.parent)
 
 
+def test_hermes_snapshot_parse_route_leaves_only_canonical_blob_namespace_entries(tmp_path: Path) -> None:
+    """The production snapshot-to-retained-parse seam must not leave SQLite sidecars."""
+    db_path = tmp_path / "state.db"
+    blob_root = tmp_path / "blob"
+    _write_hermes_state_db(db_path)
+
+    rows = list(
+        iter_source_sessions_with_raw(
+            Source(name="hermes", path=db_path),
+            capture_raw=True,
+            blob_root=blob_root,
+        )
+    )
+
+    raw = rows[0][0]
+    assert raw is not None and raw.blob_hash is not None
+    store = BlobStore(blob_root)
+    entries = tuple(store.iter_namespace())
+    assert [(entry.kind, entry.hash_hex) for entry in entries] == [("blob", raw.blob_hash)]
+    assert store.verify_all().passed is True
+
+
 def test_hermes_state_db_raw_payload_envelope_uses_marker(tmp_path: Path) -> None:
     db_path = tmp_path / "state.db"
     _write_hermes_state_db(db_path)

--- a/tests/unit/storage/test_blob_integrity.py
+++ b/tests/unit/storage/test_blob_integrity.py
@@ -110,6 +110,20 @@ def test_scan_blob_integrity_reports_invalid_namespace_entries(tmp_path: Path) -
     assert finding.sample == (sidecar.name,)
 
 
+def test_scan_blob_integrity_reports_file_backed_root(tmp_path: Path) -> None:
+    db_path = tmp_path / "archive.db"
+    root = tmp_path / "blob"
+    root.write_bytes(b"not a directory")
+    _make_db(db_path).close()
+
+    report = scan_blob_integrity(db_path, store=BlobStore(root), full=True)
+
+    finding = next(finding for finding in report.findings if finding.kind == "invalid_namespace_entries")
+    assert finding.severity == "critical"
+    assert finding.count == 1
+    assert finding.sample == (".",)
+
+
 def test_scan_blob_integrity_bounds_default_probe_but_full_scans_everything(tmp_path: Path) -> None:
     db_path = tmp_path / "archive.db"
     store = BlobStore(tmp_path / "blob")

--- a/tests/unit/storage/test_blob_integrity.py
+++ b/tests/unit/storage/test_blob_integrity.py
@@ -94,6 +94,22 @@ def test_scan_blob_integrity_classifies_missing_orphan_and_hash_mismatch(tmp_pat
     assert by_kind["hash_mismatch"].sample == (corrupt_hash,)
 
 
+def test_scan_blob_integrity_reports_invalid_namespace_entries(tmp_path: Path) -> None:
+    db_path = tmp_path / "archive.db"
+    store = BlobStore(tmp_path / "blob")
+    _make_db(db_path).close()
+    blob_hash, _ = store.write_from_bytes(b"valid")
+    sidecar = store.root / f"{blob_hash}-wal"
+    sidecar.write_bytes(b"not a blob")
+
+    report = scan_blob_integrity(db_path, store=store, full=True)
+
+    finding = next(finding for finding in report.findings if finding.kind == "invalid_namespace_entries")
+    assert finding.severity == "critical"
+    assert finding.count == 1
+    assert finding.sample == (sidecar.name,)
+
+
 def test_scan_blob_integrity_bounds_default_probe_but_full_scans_everything(tmp_path: Path) -> None:
     db_path = tmp_path / "archive.db"
     store = BlobStore(tmp_path / "blob")

--- a/tests/unit/storage/test_blob_store.py
+++ b/tests/unit/storage/test_blob_store.py
@@ -10,6 +10,8 @@ from pathlib import Path
 import pytest
 
 from polylogue.storage.blob_store import (
+    BlobNamespaceEntryKind,
+    BlobNamespaceIssue,
     BlobStore,
     BlobVerifyAllResult,
     BlobVerifyFailure,
@@ -180,6 +182,49 @@ def test_verify_all_handles_removed_prefix_dir(tmp_path: Path) -> None:
     result = blob_store.verify_all()
     # The prefix dir is gone, so iter_all yields nothing
     assert result.checked == 0
+
+
+def test_verify_all_reports_malformed_leaf_without_hash_path_parsing(tmp_path: Path) -> None:
+    """A malformed leaf is a namespace fault, not a malformed hash exception."""
+    blob_store = BlobStore(tmp_path / "blobs")
+    valid_hash, _ = blob_store.write_from_bytes(b"valid")
+    shard = blob_store.root / valid_hash[:2]
+    malformed_leaf = shard / f"{valid_hash[2:]}-wal"
+    malformed_leaf.write_bytes(b"sqlite wal sidecar")
+
+    entries = tuple(blob_store.iter_namespace())
+    assert [(entry.kind, entry.relative_path, entry.issue) for entry in entries] == [
+        (BlobNamespaceEntryKind.BLOB, f"{valid_hash[:2]}/{valid_hash[2:]}", None),
+        (
+            BlobNamespaceEntryKind.INVALID_SHARD_ENTRY,
+            f"{valid_hash[:2]}/{valid_hash[2:]}-wal",
+            BlobNamespaceIssue.INVALID_LEAF_NAME,
+        ),
+    ]
+
+    result = blob_store.verify_all()
+
+    assert result.checked == 1
+    assert result.failed_count == 1
+    assert result.failures[0].hash == ""
+    assert result.failures[0].reason == "invalid_namespace_entry"
+    assert result.failures[0].path == f"{valid_hash[:2]}/{valid_hash[2:]}-wal"
+    assert result.failures[0].detail.endswith("invalid_leaf_name")
+
+
+def test_verify_all_reports_sqlite_sidecars_at_namespace_root(tmp_path: Path) -> None:
+    blob_store = BlobStore(tmp_path / "blobs")
+    blob_hash, _ = blob_store.write_from_bytes(b"valid")
+    for suffix in ("-wal", "-shm"):
+        (blob_store.root / f"{blob_hash}{suffix}").write_bytes(b"sidecar")
+
+    result = blob_store.verify_all()
+
+    assert result.checked == 1
+    assert [(failure.path, failure.detail) for failure in result.failures] == [
+        (f"{blob_hash}-shm", f"{blob_hash}-shm: invalid_shard_name"),
+        (f"{blob_hash}-wal", f"{blob_hash}-wal: invalid_shard_name"),
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/storage/test_blob_store.py
+++ b/tests/unit/storage/test_blob_store.py
@@ -184,6 +184,18 @@ def test_verify_all_handles_removed_prefix_dir(tmp_path: Path) -> None:
     assert result.checked == 0
 
 
+def test_verify_all_reports_file_backed_root(tmp_path: Path) -> None:
+    root = tmp_path / "blobs"
+    root.write_bytes(b"not a directory")
+
+    result = BlobStore(root).verify_all()
+
+    assert result.checked == 0
+    assert [(failure.reason, failure.path, failure.detail) for failure in result.failures] == [
+        ("invalid_namespace_entry", ".", ".: stat_failed")
+    ]
+
+
 def test_verify_all_reports_malformed_leaf_without_hash_path_parsing(tmp_path: Path) -> None:
     """A malformed leaf is a namespace fault, not a malformed hash exception."""
     blob_store = BlobStore(tmp_path / "blobs")


### PR DESCRIPTION
## Summary

Classify the blob filesystem namespace before integrity verification so reindex checks can report stray files safely.

## Problem

The verifier derived candidate hashes from permissive directory and filename shapes. SQLite sidecars and stranded staging files could therefore reach hash-path validation and abort the production reindex check.

## Solution

Add typed, sorted namespace entries that accept only lowercase-hex shard directories and lowercase-hex regular-file leaves. `verify_all` reports invalid entries as failures without converting them to hashes, while the read-only integrity scanner marks them critical. The SQLite source iterator regression exercises snapshot, retained-blob parsing, and namespace verification without changing snapshot behavior. No cleanup surface was added.


## Verification

- `direnv exec . devtools test tests/unit/storage/test_blob_store.py::test_verify_all_reports_file_backed_root tests/unit/storage/test_blob_store.py::test_verify_all_reports_malformed_leaf_without_hash_path_parsing tests/unit/storage/test_blob_store.py::test_verify_all_reports_sqlite_sidecars_at_namespace_root tests/unit/storage/test_blob_integrity.py::test_scan_blob_integrity_reports_file_backed_root tests/unit/storage/test_blob_integrity.py::test_scan_blob_integrity_reports_invalid_namespace_entries` produced `5 passed`.
- `direnv exec . git push --force-with-lease origin feature/fix/blob-namespace-integrity` ran the required pre-push `devtools verify --quick`, which completed with status `success`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blob storage integrity checks to detect malformed or unexpected files and directories.
  * Invalid entries are now clearly reported with their locations and recommended remediation.
  * Blob verification now distinguishes namespace errors from content and filesystem failures.
  * Blob enumeration ignores invalid entries, preventing them from being treated as valid blobs.
* **Tests**
  * Added coverage for malformed entries and snapshot parsing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

