### PR TITLE
fix: propagate Audit tier contracts

### DIFF
--- a/devtools/daemon_workload_probe.py
+++ b/devtools/daemon_workload_probe.py
@@ -124,6 +124,15 @@ _ARCHIVE_OBSERVABILITY_TABLES: dict[ArchiveTier, tuple[str, ...]] = {
         "daemon_events",
         "embedding_catchup_runs",
     ),
+    ArchiveTier.AUDIT: (
+        "archive_authority",
+        "operation_previews",
+        "operation_authorizations",
+        "operation_runs",
+        "operation_targets",
+        "operation_attempts",
+        "operation_events",
+    ),
 }
 
 

--- a/devtools/ingest_amplification_probe.py
+++ b/devtools/ingest_amplification_probe.py
@@ -49,7 +49,7 @@ _DEFAULT_MESSAGES_MAX = 8
 
 # Stable tier ordering for the report, sourced from the canonical tier specs.
 _TIER_ORDER: tuple[str, ...] = tuple(tier.value for tier in ARCHIVE_TIER_SPECS)
-# Attributed write surfaces: the five tier DB files plus the content-addressed
+# Attributed write surfaces: the archive tier DB files plus the content-addressed
 # blob store. Raw payloads land in the blob store (filesystem), not source.db,
 # so excluding it would understate write amplification.
 _BLOB_COMPONENT = "blob_store"
@@ -200,7 +200,7 @@ def measure_ingest_amplification(
 
         reset_blob_store()
 
-        # Bootstrap the five-tier archive file set up front so per-batch deltas
+        # Bootstrap the archive file set up front so per-batch deltas
         # exclude the one-time schema-DDL cost.
         ArchiveStore.open_existing(archive_root, read_only=False).close()
 

--- a/devtools/ingest_throughput_probe.py
+++ b/devtools/ingest_throughput_probe.py
@@ -384,7 +384,7 @@ def measure_ingest_throughput(
 
         reset_blob_store()
 
-        # Bootstrap the five-tier archive file set up front so per-batch timings
+        # Bootstrap the archive file set up front so per-batch timings
         # exclude the one-time schema-DDL cost.
         ArchiveStore.open_existing(archive_root, read_only=False).close()
 

--- a/polylogue/daemon/backup.py
+++ b/polylogue/daemon/backup.py
@@ -29,7 +29,11 @@ from pydantic import BaseModel
 
 from polylogue.logging import get_logger
 from polylogue.paths import archive_root
-from polylogue.storage.backup_attestation import VERIFICATION_RECEIPT_FORMAT, sign_verification_receipt
+from polylogue.storage.backup_attestation import (
+    VERIFICATION_RECEIPT_FORMAT,
+    archive_tier_paths,
+    sign_verification_receipt,
+)
 from polylogue.storage.blob_integrity import BlobReferenceDebtReport, referenced_blob_hashes, scan_blob_reference_debt
 from polylogue.storage.blob_store import BlobStore
 
@@ -194,14 +198,7 @@ def _json_str_list(value: object) -> list[str]:
 
 
 def _all_archive_tiers(root: Path) -> dict[str, Path]:
-    return {
-        "source": root / "source.db",
-        "index": root / "index.db",
-        "embeddings": root / "embeddings.db",
-        "user": root / "user.db",
-        "ops": root / "ops.db",
-        "audit": root / "audit.db",
-    }
+    return archive_tier_paths(root)
 
 
 def _profile_archive_tiers(root: Path, profile: BackupProfile) -> dict[str, Path]:

--- a/polylogue/daemon/metrics.py
+++ b/polylogue/daemon/metrics.py
@@ -112,7 +112,7 @@ logger = get_logger(__name__)
 
 # Derived from the canonical tier specs so the expected schema version per tier
 # can never drift from ARCHIVE_VERSION_BY_TIER. (tier, filename, expected_version,
-# backup_required), preserving the source→index→embeddings→user→ops order.
+# backup_required), preserving the canonical archive-tier order.
 _ARCHIVE_TIER_FILES: tuple[tuple[str, str, int, bool], ...] = tuple(
     (spec.tier.value, spec.filename, spec.version, spec.backup_required) for spec in ARCHIVE_TIER_SPECS.values()
 )

--- a/polylogue/storage/archive_layout.py
+++ b/polylogue/storage/archive_layout.py
@@ -21,8 +21,8 @@ from pathlib import Path
 
 from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS
 
-# Canonical tier order (source -> index -> embeddings -> user -> ops), taken
-# straight from the spec registry so it never diverges from the runtime tiers.
+# Canonical tier order, taken straight from the spec registry so it never
+# diverges from the runtime tiers.
 ARCHIVE_TIER_ORDER: tuple[str, ...] = tuple(spec.tier.value for spec in ARCHIVE_TIER_SPECS.values())
 
 # Tiers whose absence is itself a layout blocker because they carry

--- a/polylogue/storage/backup_attestation.py
+++ b/polylogue/storage/backup_attestation.py
@@ -37,6 +37,13 @@ def _canonical_bytes(payload: object) -> bytes:
     return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
 
 
+def archive_tier_paths(root: Path) -> dict[str, Path]:
+    """Resolve the complete archive file set from the canonical tier specs."""
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS
+
+    return {spec.tier.value: root / spec.filename for spec in ARCHIVE_TIER_SPECS.values()}
+
+
 def tier_attestation_id(live_tier_path: Path) -> str:
     """Return the stable local identity for one resolved durable tier."""
     canonical = str(live_tier_path.expanduser().resolve(strict=False)).encode("utf-8")
@@ -172,6 +179,7 @@ __all__ = [
     "ATTESTATION_FORMAT",
     "BackupAttestationError",
     "VERIFICATION_RECEIPT_FORMAT",
+    "archive_tier_paths",
     "attestation_key_path",
     "load_attestation_key",
     "load_or_mint_attestation_key",

--- a/polylogue/storage/sqlite/archive_tiers/archive_plan.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive_plan.py
@@ -67,7 +67,7 @@ def build_archive_init_plan(
     blockers: list[str] = []
 
     tier_plans: list[ArchiveTierPlan] = []
-    for tier in ArchiveTier:
+    for tier in ARCHIVE_TIER_SPECS:
         tier_plan = _plan_tier(
             archive_root=resolved_archive_root,
             tier=tier,

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -27,13 +27,13 @@ from polylogue.storage.sqlite.archive_tiers.archive_init import (
     ArchiveTierInitResult,
 )
 from polylogue.storage.sqlite.archive_tiers.archive_plan import ArchiveInitAction, ArchiveInitPlan
-from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS, initialize_archive_tier
 from polylogue.storage.sqlite.archive_tiers.source_write import write_source_raw_session_blob_ref
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.user import USER_SCHEMA_VERSION
 from polylogue.storage.sqlite.archive_tiers.user_write import AssertionKind, upsert_assertion
 
-_ARCHIVE_TIERS = ("source.db", "index.db", "embeddings.db", "ops.db", "user.db")
+_ARCHIVE_TIERS = tuple(spec.filename for spec in ARCHIVE_TIER_SPECS.values())
 
 
 def test_raw_authority_census_cli_resolves_receipt_handle(
@@ -569,25 +569,11 @@ def test_archive_plan_cli_reports_tier_targets(cli_workspace: dict[str, Path], c
     payload = json.loads(result.stdout)
     assert payload["ready"] is True
     assert {tier["tier"]: tier["action"] for tier in payload["tiers"]} == {
-        "source": "create",
-        "index": "create",
-        "embeddings": "create",
-        "user": "create",
-        "ops": "create",
+        spec.tier.value: "create" for spec in ARCHIVE_TIER_SPECS.values()
     }
-    assert {Path(tier["path"]).name for tier in payload["tiers"]} == {
-        "source.db",
-        "index.db",
-        "embeddings.db",
-        "user.db",
-        "ops.db",
-    }
+    assert {Path(tier["path"]).name for tier in payload["tiers"]} == set(_ARCHIVE_TIERS)
     assert {tier["tier"]: tier["durability"] for tier in payload["tiers"]} == {
-        "source": "irreplaceable",
-        "index": "rebuildable",
-        "embeddings": "expensive_rebuild",
-        "user": "human",
-        "ops": "disposable",
+        spec.tier.value: spec.durability for spec in ARCHIVE_TIER_SPECS.values()
     }
     assert all(isinstance(tier["expected_user_version"], int) for tier in payload["tiers"])
 

--- a/tests/unit/daemon/test_backup.py
+++ b/tests/unit/daemon/test_backup.py
@@ -19,7 +19,17 @@ from polylogue.storage.backup_attestation import attestation_key_path
 from polylogue.storage.blob_publication import ArchiveBlobPublisher
 from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from tests.infra.storage_records import SessionBuilder, db_setup
+
+
+def _tier_files(*tiers: ArchiveTier) -> list[str]:
+    return [ARCHIVE_TIER_SPECS[tier].filename for tier in tiers]
+
+
+def _tier_integrity(*tiers: ArchiveTier) -> dict[str, bool]:
+    return {tier.value: True for tier in tiers}
 
 
 @pytest.mark.contract
@@ -39,14 +49,14 @@ def test_backup_archive_copy_can_be_opened_and_queried(
     result = backup_archive(output_dir=tmp_path / "backups")
 
     # The archive backup is an archive directory: it copies the precious
-    # tiers (source/user/embeddings) and omits the rebuildable index/ops
+    # tiers (source/user/embeddings/audit) and omits the rebuildable index/ops
     # tiers. Each copied tier must open cleanly and pass integrity_check.
     assert result.ok
     assert result.backup_mode == "archive_file_set"
     assert result.output_path is not None
     backup_path = Path(result.output_path)
     assert backup_path.is_dir()
-    for tier in ("source.db", "user.db", "embeddings.db"):
+    for tier in _tier_files(ArchiveTier.SOURCE, ArchiveTier.USER, ArchiveTier.EMBEDDINGS, ArchiveTier.AUDIT):
         tier_path = backup_path / tier
         assert tier_path.exists(), f"backup missing precious tier {tier}"
         with sqlite3.connect(f"file:{tier_path}?mode=ro", uri=True) as conn:
@@ -278,20 +288,19 @@ def test_backup_archive_copies_precious_tiers_and_referenced_blobs(
     assert result.backup_profile == "rebuildable_cache_exclude"
     assert result.verified is True
     assert result.verification["ok"] is True
-    assert result.verification["tier_integrity"] == {
-        "source": True,
-        "user": True,
-        "embeddings": True,
-    }
+    assert result.verification["tier_integrity"] == _tier_integrity(
+        ArchiveTier.SOURCE, ArchiveTier.USER, ArchiveTier.EMBEDDINGS, ArchiveTier.AUDIT
+    )
     assert result.verification["omitted_tiers_absent"] is True
     assert result.verification["restored_blob_count"] == 1
     assert result.output_path is not None
     backup_root = Path(result.output_path)
     assert backup_root.is_dir()
-    assert result.omitted_tiers == ["index.db", "ops.db"]
+    assert result.omitted_tiers == _tier_files(ArchiveTier.INDEX, ArchiveTier.OPS)
     assert (backup_root / "source.db").exists()
     assert (backup_root / "user.db").exists()
     assert (backup_root / "embeddings.db").exists()
+    assert (backup_root / "audit.db").exists()
     assert not (backup_root / "index.db").exists()
     assert not (backup_root / "ops.db").exists()
     assert (backup_root / "blob" / blob_hash[:2] / blob_hash[2:]).read_bytes() == payload
@@ -318,6 +327,7 @@ def test_backup_archive_copies_precious_tiers_and_referenced_blobs(
         f"blob/{blob_hash[:2]}/{blob_hash[2:]}",
         "blob-inventory.json",
         "embeddings.db",
+        "audit.db",
         "manifest.json",
         "source.db",
         "user.db",
@@ -328,6 +338,7 @@ def test_backup_archive_copies_precious_tiers_and_referenced_blobs(
         "source.db",
         "user.db",
         "embeddings.db",
+        "audit.db",
     }
     for artifact in receipt["tier_artifacts"]:
         fingerprint = artifact["source_fingerprint"]
@@ -355,8 +366,10 @@ def test_backup_archive_copies_precious_tiers_and_referenced_blobs(
     manifest = json.loads((backup_root / "manifest.json").read_text(encoding="utf-8"))
     assert manifest["mode"] == "archive_file_set"
     assert manifest["profile"] == "rebuildable_cache_exclude"
-    assert manifest["included_tiers"] == ["source.db", "user.db", "embeddings.db"]
-    assert manifest["omitted_tiers"] == ["index.db", "ops.db"]
+    assert manifest["included_tiers"] == _tier_files(
+        ArchiveTier.SOURCE, ArchiveTier.USER, ArchiveTier.EMBEDDINGS, ArchiveTier.AUDIT
+    )
+    assert manifest["omitted_tiers"] == _tier_files(ArchiveTier.INDEX, ArchiveTier.OPS)
     assert manifest["blob_count"] == 1
 
 
@@ -377,25 +390,13 @@ def test_backup_archive_full_evidence_profile_includes_all_tiers(
     assert result.backup_profile == "full_evidence"
     assert result.omitted_tiers == []
     assert result.verified is True
-    assert result.verification["tier_integrity"] == {
-        "source": True,
-        "index": True,
-        "embeddings": True,
-        "user": True,
-        "ops": True,
-    }
+    assert result.verification["tier_integrity"] == _tier_integrity(*ARCHIVE_TIER_SPECS)
     assert result.output_path is not None
     backup_root = Path(result.output_path)
-    assert {path.name for path in backup_root.glob("*.db")} == {
-        "source.db",
-        "index.db",
-        "embeddings.db",
-        "user.db",
-        "ops.db",
-    }
+    assert {path.name for path in backup_root.glob("*.db")} == {spec.filename for spec in ARCHIVE_TIER_SPECS.values()}
     manifest = json.loads((backup_root / "manifest.json").read_text(encoding="utf-8"))
     assert manifest["profile"] == "full_evidence"
-    assert manifest["included_tiers"] == ["source.db", "index.db", "embeddings.db", "user.db", "ops.db"]
+    assert manifest["included_tiers"] == _tier_files(*ARCHIVE_TIER_SPECS)
     assert manifest["omitted_tiers"] == []
 
 
@@ -455,17 +456,16 @@ def test_backup_archive_full_evidence_profile_treats_ops_as_optional(
     assert result.backup_profile == "full_evidence"
     assert result.omitted_tiers == ["ops.db"]
     assert result.verified is True
-    assert result.verification["tier_integrity"] == {
-        "source": True,
-        "index": True,
-        "embeddings": True,
-        "user": True,
-    }
+    assert result.verification["tier_integrity"] == _tier_integrity(
+        ArchiveTier.SOURCE, ArchiveTier.INDEX, ArchiveTier.EMBEDDINGS, ArchiveTier.USER, ArchiveTier.AUDIT
+    )
     assert result.output_path is not None
     backup_root = Path(result.output_path)
     assert not (backup_root / "ops.db").exists()
     manifest = json.loads((backup_root / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["included_tiers"] == ["source.db", "index.db", "embeddings.db", "user.db"]
+    assert manifest["included_tiers"] == _tier_files(
+        ArchiveTier.SOURCE, ArchiveTier.INDEX, ArchiveTier.EMBEDDINGS, ArchiveTier.USER, ArchiveTier.AUDIT
+    )
     assert manifest["omitted_tiers"] == ["ops.db"]
 
 
@@ -479,7 +479,7 @@ def test_backup_archive_user_overlays_profile_copies_only_user_tier(
     assert result.ok
     assert result.backup_profile == "user_overlays"
     assert result.verified is True
-    assert result.verification["tier_integrity"] == {"user": True}
+    assert result.verification["tier_integrity"] == _tier_integrity(ArchiveTier.USER, ArchiveTier.AUDIT)
     assert result.output_path is not None
     backup_root = Path(result.output_path)
     assert (backup_root / "user.db").exists()
@@ -490,8 +490,10 @@ def test_backup_archive_user_overlays_profile_copies_only_user_tier(
     assert not (backup_root / "blob").exists()
     manifest = json.loads((backup_root / "manifest.json").read_text(encoding="utf-8"))
     assert manifest["profile"] == "user_overlays"
-    assert manifest["included_tiers"] == ["user.db"]
-    assert manifest["omitted_tiers"] == ["source.db", "index.db", "embeddings.db", "ops.db"]
+    assert manifest["included_tiers"] == _tier_files(ArchiveTier.USER, ArchiveTier.AUDIT)
+    assert manifest["omitted_tiers"] == _tier_files(
+        ArchiveTier.SOURCE, ArchiveTier.INDEX, ArchiveTier.EMBEDDINGS, ArchiveTier.OPS
+    )
 
 
 def test_backup_archive_verify_false_does_not_write_success_receipt(
@@ -530,7 +532,9 @@ def test_backup_archive_diagnostics_profile_copies_only_ops_tier(
     manifest = json.loads((backup_root / "manifest.json").read_text(encoding="utf-8"))
     assert manifest["profile"] == "diagnostics_bundle"
     assert manifest["included_tiers"] == ["ops.db"]
-    assert manifest["omitted_tiers"] == ["source.db", "index.db", "embeddings.db", "user.db"]
+    assert manifest["omitted_tiers"] == _tier_files(
+        ArchiveTier.SOURCE, ArchiveTier.INDEX, ArchiveTier.EMBEDDINGS, ArchiveTier.USER, ArchiveTier.AUDIT
+    )
 
 
 def test_backup_verification_scratch_stays_near_backup_output(

--- a/tests/unit/daemon/test_metrics_endpoint.py
+++ b/tests/unit/daemon/test_metrics_endpoint.py
@@ -37,8 +37,10 @@ from polylogue.daemon.metrics import (
     PROMETHEUS_CONTENT_TYPE,
     format_metrics,
 )
+from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS, initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.embeddings import EMBEDDINGS_SCHEMA_VERSION
 from polylogue.storage.sqlite.archive_tiers.source import SOURCE_SCHEMA_VERSION
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 
 pytestmark = pytest.mark.uses_real_clock(
     "Metrics endpoint test records a live rebuild-ingest heartbeat timestamp; production readiness and metrics intentionally compare it against the host clock."
@@ -169,17 +171,11 @@ class TestFormatMetricsExpositionShape:
             assert len(labels["revision"]) == 40
 
     def test_archive_storage_metrics_report_archive_file_sets(self, tmp_path: Path) -> None:
-        from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
         from polylogue.storage.sqlite.archive_tiers.ops_write import record_ingest_attempt
-        from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 
-        for filename, tier in (
-            ("source.db", ArchiveTier.SOURCE),
-            ("index.db", ArchiveTier.INDEX),
-            ("user.db", ArchiveTier.USER),
-            ("ops.db", ArchiveTier.OPS),
-        ):
-            initialize_archive_database(tmp_path / filename, tier)
+        for spec in ARCHIVE_TIER_SPECS.values():
+            if spec.tier is not ArchiveTier.EMBEDDINGS:
+                initialize_archive_database(tmp_path / spec.filename, spec.tier)
         with sqlite3.connect(tmp_path / "embeddings.db") as conn:
             conn.execute(f"PRAGMA user_version = {EMBEDDINGS_SCHEMA_VERSION}")
             conn.commit()
@@ -189,7 +185,7 @@ class TestFormatMetricsExpositionShape:
         assert 'polylogue_archive_tier_present{tier="source"} 1' in body
         assert 'polylogue_archive_tier_present{tier="index"} 1' in body
         assert 'polylogue_archive_tier_present{tier="embeddings"} 1' in body
-        assert 'polylogue_archive_tier_count{state="present"} 5' in body
+        assert f'polylogue_archive_tier_count{{state="present"}} {len(ARCHIVE_TIER_SPECS)}' in body
         assert 'polylogue_archive_tier_count{state="missing"} 0' in body
         assert f'polylogue_archive_tier_user_version{{tier="source"}} {SOURCE_SCHEMA_VERSION}' in body
         assert 'polylogue_archive_storage_layout{layout="archive_complete"} 1' in body
@@ -227,9 +223,6 @@ class TestFormatMetricsExpositionShape:
         assert "polylogue_archive_ready 0" in rebuilding_body
 
     def test_db_space_metrics_report_wal_and_planner_stats(self, tmp_path: Path) -> None:
-        from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
-        from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
-
         index_db = tmp_path / "index.db"
         initialize_archive_database(index_db, ArchiveTier.INDEX)
         with sqlite3.connect(index_db) as conn:
@@ -242,9 +235,6 @@ class TestFormatMetricsExpositionShape:
 
     def test_archive_storage_metrics_report_layout_blockers(self, tmp_path: Path) -> None:
         """Partial archive roots expose blockers without activating unrelated files."""
-        from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
-        from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
-
         initialize_archive_database(tmp_path / "ops.db", ArchiveTier.OPS)
         unrelated_db = tmp_path / "custom.sqlite"
         with sqlite3.connect(unrelated_db) as conn:
@@ -255,7 +245,7 @@ class TestFormatMetricsExpositionShape:
 
         assert 'polylogue_archive_tier_present{tier="ops"} 1' in body
         assert 'polylogue_archive_tier_count{state="present"} 1' in body
-        assert 'polylogue_archive_tier_count{state="missing"} 4' in body
+        assert f'polylogue_archive_tier_count{{state="missing"}} {len(ARCHIVE_TIER_SPECS) - 1}' in body
         assert 'polylogue_archive_storage_layout{layout="archive_partial"} 1' in body
         assert 'polylogue_archive_storage_layout{layout="archive_missing"} 0' in body
         assert 'polylogue_archive_storage_ready{state="archive_runtime"} 0' in body
@@ -264,22 +254,16 @@ class TestFormatMetricsExpositionShape:
         assert 'polylogue_archive_active_store{store="empty"} 1' in body
         assert 'polylogue_archive_active_tier_role{role="unknown"} 1' in body
         assert "polylogue_archive_ready 0" in body
-        assert "polylogue_archive_blocker_count 4" in body
+        assert (
+            f"polylogue_archive_blocker_count {1 + sum(spec.backup_required for spec in ARCHIVE_TIER_SPECS.values())}"
+            in body
+        )
         assert 'polylogue_archive_blocker{blocker="missing_archive_tiers"} 1' in body
         assert 'polylogue_archive_blocker{blocker="missing_backup_required_tier:source"} 1' in body
 
     def test_archive_storage_metrics_gate_runtime_readiness_on_schema_match(self, tmp_path: Path) -> None:
-        from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
-        from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
-
-        for filename, tier in (
-            ("source.db", ArchiveTier.SOURCE),
-            ("index.db", ArchiveTier.INDEX),
-            ("embeddings.db", ArchiveTier.EMBEDDINGS),
-            ("user.db", ArchiveTier.USER),
-            ("ops.db", ArchiveTier.OPS),
-        ):
-            initialize_archive_database(tmp_path / filename, tier)
+        for spec in ARCHIVE_TIER_SPECS.values():
+            initialize_archive_database(tmp_path / spec.filename, spec.tier)
         with sqlite3.connect(tmp_path / "index.db") as conn:
             conn.execute("PRAGMA user_version = 1")
 

--- a/tests/unit/devtools/test_daemon_workload_probe.py
+++ b/tests/unit/devtools/test_daemon_workload_probe.py
@@ -20,7 +20,7 @@ from devtools.daemon_workload_probe import (
 from polylogue.sources.live.cursor import CursorStore
 from polylogue.storage.blob_integrity import BlobReferenceDebtReport
 from polylogue.storage.blob_store import BlobStore
-from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS, initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.ops_write import (
     add_convergence_debt,
     record_cursor_lag_sample,
@@ -113,6 +113,12 @@ def _minimal_compare_payload() -> dict[str, Any]:
         "archive_tiers": {},
         "source_path_churn": [],
     }
+
+
+def test_archive_observability_inventory_covers_canonical_tiers() -> None:
+    """The probe must inspect every production tier, including durable Audit."""
+    assert set(workload_probe._ARCHIVE_OBSERVABILITY_TABLES) == set(ARCHIVE_TIER_SPECS)
+    assert "operation_runs" in workload_probe._ARCHIVE_OBSERVABILITY_TABLES[ArchiveTier.AUDIT]
 
 
 def test_daemon_workload_probe_reports_attempts_and_plan_shape(tmp_path: Path) -> None:
@@ -404,7 +410,9 @@ def test_daemon_workload_probe_reports_ops_tier_from_db_anchor(tmp_path: Path) -
     assert payload["archive_tiers"]["present"] is True
     assert payload["archive_tiers"]["tiers"]["ops"]["exists"] is True
     assert payload["archive_tiers"]["tiers"]["ops"]["table_counts"]["ingest_attempts"] == 1
-    assert payload["archive_tiers"]["missing_backup_required"] == ["source", "embeddings", "user"]
+    assert payload["archive_tiers"]["missing_backup_required"] == [
+        spec.tier.value for spec in ARCHIVE_TIER_SPECS.values() if spec.backup_required
+    ]
     layout = payload["archive_tiers"]["layout_readiness"]
     assert layout["archive_ready"] is False
     assert "missing_archive_tiers" in layout["blockers"]
@@ -521,7 +529,7 @@ def test_daemon_workload_probe_reports_archive_tier_inventory(tmp_path: Path) ->
     assert tiers["complete"] is False
     assert tiers["present_count"] == 4
     assert tiers["observed_tier"] == "index"
-    assert tiers["missing_backup_required"] == ["embeddings"]
+    assert tiers["missing_backup_required"] == ["embeddings", "audit"]
     layout = tiers["layout_readiness"]
     assert layout["state"] == "not_archive_ready"
     assert layout["archive_ready"] is False
@@ -630,7 +638,7 @@ def test_daemon_workload_probe_reports_archive_tier_inventory(tmp_path: Path) ->
     assert tiers["tiers"]["embeddings"]["exists"] is False
 
 
-def test_daemon_workload_probe_reports_layout_ready_for_clean_five_tier_archive(tmp_path: Path) -> None:
+def test_daemon_workload_probe_reports_layout_ready_for_complete_archive(tmp_path: Path) -> None:
     db = tmp_path / "index.db"
     for tier in ArchiveTier:
         initialize_archive_database(tmp_path / f"{tier.value}.db", tier)
@@ -643,8 +651,8 @@ def test_daemon_workload_probe_reports_layout_ready_for_clean_five_tier_archive(
         "archive_ready": True,
         "blockers": [],
         "evidence": {
-            "present_count": 5,
-            "expected_count": 5,
+            "present_count": len(ARCHIVE_TIER_SPECS),
+            "expected_count": len(ARCHIVE_TIER_SPECS),
             "complete": True,
             "schema_mismatch_count": 0,
             "missing_backup_required_count": 0,

--- a/tests/unit/devtools/test_ingest_amplification_probe.py
+++ b/tests/unit/devtools/test_ingest_amplification_probe.py
@@ -12,8 +12,10 @@ from devtools.ingest_amplification_probe import (
     main,
     measure_ingest_amplification,
 )
+from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS
 
-_COMPONENTS = {"source", "index", "embeddings", "user", "ops", "blob_store"}
+_TIER_NAMES = tuple(spec.tier.value for spec in ARCHIVE_TIER_SPECS.values())
+_COMPONENTS = {*_TIER_NAMES, "blob_store"}
 _DELTA_KEYS = {"allocated_bytes", "wal_bytes", "total_bytes"}
 
 
@@ -24,7 +26,7 @@ def test_measure_emits_expected_shape(tmp_path: Path) -> None:
     assert report["report_version"] == REPORT_VERSION
     assert report["tool"] == "bench ingest-amplification"
     assert set(report["components"]) == _COMPONENTS
-    assert report["tiers"] == ["source", "index", "embeddings", "user", "ops"]
+    assert report["tiers"] == list(_TIER_NAMES)
 
     batches = report["batches"]
     assert len(batches) == 3

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -47,12 +47,33 @@ from polylogue.storage.raw_authority import RAW_AUTHORITY_PARSER_FINGERPRINT
 from polylogue.storage.sqlite.archive_tiers import archive as archive_tier_module
 from polylogue.storage.sqlite.archive_tiers import revision_governance as archive_revision_governance
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
-from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
-from polylogue.storage.sqlite.archive_tiers.embeddings import EMBEDDINGS_SCHEMA_VERSION
+from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS, initialize_active_archive_root
 from polylogue.storage.sqlite.archive_tiers.index import INDEX_SCHEMA_VERSION
 from polylogue.storage.sqlite.archive_tiers.source import SOURCE_SCHEMA_VERSION
 from polylogue.storage.sqlite.archive_tiers.source_write import read_archive_raw_session_envelope
-from polylogue.storage.sqlite.archive_tiers.user import USER_SCHEMA_VERSION
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+_ARCHIVE_STORAGE_TIERS = ",".join(spec.tier.value for spec in ARCHIVE_TIER_SPECS.values())
+
+
+def _archive_storage_probe_fields(
+    *,
+    present: set[ArchiveTier],
+    versions: dict[ArchiveTier, int | None],
+) -> dict[str, object]:
+    return {
+        "storage_tiers": _ARCHIVE_STORAGE_TIERS,
+        "archive_present_tiers": ",".join(
+            spec.tier.value for spec in ARCHIVE_TIER_SPECS.values() if spec.tier in present
+        ),
+        "archive_missing_tiers": ",".join(
+            spec.tier.value for spec in ARCHIVE_TIER_SPECS.values() if spec.tier not in present
+        ),
+        "archive_tier_user_versions_json": json.dumps(
+            {spec.tier.value: versions.get(spec.tier) for spec in ARCHIVE_TIER_SPECS.values()},
+            sort_keys=True,
+        ),
+    }
 
 
 def _write_archive_blob(archive_root: Path, blob_hash: bytes | str, payload: bytes) -> None:
@@ -605,27 +626,22 @@ def test_full_ingest_writes_archive_with_route_observability(
     probe_event = next(payload for phase, payload in stage_events if phase == "full_archive_storage_probe")
     assert probe_event == {
         "storage_route": "archive_full",
-        "storage_tiers": "source,index,embeddings,user,ops",
         "storage_write_tiers": "source,index",
         "archive_active": True,
         "archive_bootstrapped": False,
-        "archive_present_tiers": "source,index,ops",
-        "archive_missing_tiers": "embeddings,user",
-        "archive_tier_user_versions_json": json.dumps(
-            {
-                "embeddings": None,
-                "index": INDEX_SCHEMA_VERSION,
-                "ops": 1,
-                "source": SOURCE_SCHEMA_VERSION,
-                "user": None,
+        **_archive_storage_probe_fields(
+            present={ArchiveTier.SOURCE, ArchiveTier.INDEX, ArchiveTier.OPS},
+            versions={
+                ArchiveTier.SOURCE: SOURCE_SCHEMA_VERSION,
+                ArchiveTier.INDEX: INDEX_SCHEMA_VERSION,
+                ArchiveTier.OPS: 1,
             },
-            sort_keys=True,
         ),
     }
     write_event = next(payload for phase, payload in stage_events if phase == "full_archive_write")
     assert write_event == {
         "storage_route": "archive_full",
-        "storage_tiers": "source,index,embeddings,user,ops",
+        "storage_tiers": _ARCHIVE_STORAGE_TIERS,
         "storage_write_tiers": "source,index",
         "input_file_count": 1,
         "payload_available_file_count": 1,
@@ -635,7 +651,7 @@ def test_full_ingest_writes_archive_with_route_observability(
     completed_event = next(payload for phase, payload in stage_events if phase == "full_archive_write_completed")
     assert completed_event == {
         "storage_route": "archive_full",
-        "storage_tiers": "source,index,embeddings,user,ops",
+        "storage_tiers": _ARCHIVE_STORAGE_TIERS,
         "storage_write_tiers": "source,index",
         "written_raw_count": 1,
         "ingested_session_count": 1,
@@ -703,27 +719,22 @@ def test_streaming_full_ingest_writes_archive_from_blob(
     probe_event = next(payload for phase, payload in stage_events if phase == "full_archive_storage_probe")
     assert probe_event == {
         "storage_route": "archive_full",
-        "storage_tiers": "source,index,embeddings,user,ops",
         "storage_write_tiers": "source,index",
         "archive_active": True,
         "archive_bootstrapped": False,
-        "archive_present_tiers": "source,index,ops",
-        "archive_missing_tiers": "embeddings,user",
-        "archive_tier_user_versions_json": json.dumps(
-            {
-                "embeddings": None,
-                "index": INDEX_SCHEMA_VERSION,
-                "ops": 1,
-                "source": SOURCE_SCHEMA_VERSION,
-                "user": None,
+        **_archive_storage_probe_fields(
+            present={ArchiveTier.SOURCE, ArchiveTier.INDEX, ArchiveTier.OPS},
+            versions={
+                ArchiveTier.SOURCE: SOURCE_SCHEMA_VERSION,
+                ArchiveTier.INDEX: INDEX_SCHEMA_VERSION,
+                ArchiveTier.OPS: 1,
             },
-            sort_keys=True,
         ),
     }
     write_event = next(payload for phase, payload in stage_events if phase == "full_archive_write")
     assert write_event == {
         "storage_route": "archive_full",
-        "storage_tiers": "source,index,embeddings,user,ops",
+        "storage_tiers": _ARCHIVE_STORAGE_TIERS,
         "storage_write_tiers": "source,index",
         "input_file_count": 1,
         "payload_available_file_count": 0,
@@ -733,7 +744,7 @@ def test_streaming_full_ingest_writes_archive_from_blob(
     completed_event = next(payload for phase, payload in stage_events if phase == "full_archive_write_completed")
     assert completed_event == {
         "storage_route": "archive_full",
-        "storage_tiers": "source,index,embeddings,user,ops",
+        "storage_tiers": _ARCHIVE_STORAGE_TIERS,
         "storage_write_tiers": "source,index",
         "written_raw_count": 1,
         "ingested_session_count": 1,
@@ -1049,26 +1060,17 @@ def test_full_ingest_bootstraps_archive_root(
     result = processor._ingest_full_paths_sync([source], source_name="codex", heartbeat=heartbeat)
 
     assert result.succeeded == [source]
-    for filename in ("source.db", "index.db", "embeddings.db", "user.db", "ops.db"):
+    for filename in (spec.filename for spec in ARCHIVE_TIER_SPECS.values()):
         assert (tmp_path / filename).exists()
     probe_event = next(payload for phase, payload in stage_events if phase == "full_archive_storage_probe")
     assert probe_event == {
         "storage_route": "archive_full",
-        "storage_tiers": "source,index,embeddings,user,ops",
         "storage_write_tiers": "source,index",
         "archive_active": True,
         "archive_bootstrapped": True,
-        "archive_present_tiers": "source,index,embeddings,user,ops",
-        "archive_missing_tiers": "",
-        "archive_tier_user_versions_json": json.dumps(
-            {
-                "embeddings": EMBEDDINGS_SCHEMA_VERSION,
-                "index": INDEX_SCHEMA_VERSION,
-                "ops": 1,
-                "source": SOURCE_SCHEMA_VERSION,
-                "user": USER_SCHEMA_VERSION,
-            },
-            sort_keys=True,
+        **_archive_storage_probe_fields(
+            present=set(ARCHIVE_TIER_SPECS),
+            versions={tier: spec.version for tier, spec in ARCHIVE_TIER_SPECS.items()},
         ),
     }
 
@@ -5287,7 +5289,7 @@ def test_append_ingest_bootstraps_archive_root(
     assert result.succeeded == []
     assert result.deferred == [plan]
     assert result.failed == []
-    for filename in ("source.db", "index.db", "embeddings.db", "user.db", "ops.db"):
+    for filename in (spec.filename for spec in ARCHIVE_TIER_SPECS.values()):
         assert (tmp_path / filename).exists()
     with sqlite3.connect(tmp_path / "index.db") as conn:
         assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 0

--- a/tests/unit/storage/test_archive_layout.py
+++ b/tests/unit/storage/test_archive_layout.py
@@ -10,42 +10,43 @@ from __future__ import annotations
 from pathlib import Path
 
 from polylogue.storage import archive_layout
+from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS
 
 
 def test_tier_vocabulary_is_derived_from_specs() -> None:
-    assert archive_layout.ARCHIVE_TIER_ORDER == ("source", "index", "embeddings", "user", "ops")
-    assert archive_layout.BACKUP_REQUIRED_TIERS == ("source", "embeddings", "user")
-    assert archive_layout.ARCHIVE_ACTIVE_TIER_ROLES == (
-        "source",
-        "index",
-        "embeddings",
-        "user",
-        "ops",
-        "unknown",
+    assert tuple(spec.tier.value for spec in ARCHIVE_TIER_SPECS.values()) == archive_layout.ARCHIVE_TIER_ORDER
+    assert (
+        tuple(spec.tier.value for spec in ARCHIVE_TIER_SPECS.values() if spec.backup_required)
+        == archive_layout.BACKUP_REQUIRED_TIERS
     )
+    assert (
+        *(spec.tier.value for spec in ARCHIVE_TIER_SPECS.values()),
+        "unknown",
+    ) == archive_layout.ARCHIVE_ACTIVE_TIER_ROLES
     assert archive_layout.ARCHIVE_STORAGE_LAYOUTS == (
         "archive_missing",
         "archive_partial",
         "archive_complete",
     )
-    assert archive_layout.ARCHIVE_LAYOUT_BLOCKER_LABELS == (
+    assert (
         "no_archive_tiers_present",
         "missing_archive_tiers",
-        "schema_mismatch:source",
-        "schema_mismatch:index",
-        "schema_mismatch:embeddings",
-        "schema_mismatch:user",
-        "schema_mismatch:ops",
-        "missing_backup_required_tier:source",
-        "missing_backup_required_tier:embeddings",
-        "missing_backup_required_tier:user",
-    )
+        *(f"schema_mismatch:{spec.tier.value}" for spec in ARCHIVE_TIER_SPECS.values()),
+        *(
+            f"missing_backup_required_tier:{spec.tier.value}"
+            for spec in ARCHIVE_TIER_SPECS.values()
+            if spec.backup_required
+        ),
+    ) == archive_layout.ARCHIVE_LAYOUT_BLOCKER_LABELS
 
 
 def test_classify_storage_layout() -> None:
     assert archive_layout.classify_storage_layout(present_count=0, final_shape_ready=False) == "archive_missing"
     assert archive_layout.classify_storage_layout(present_count=3, final_shape_ready=False) == "archive_partial"
-    assert archive_layout.classify_storage_layout(present_count=5, final_shape_ready=True) == "archive_complete"
+    assert (
+        archive_layout.classify_storage_layout(present_count=len(ARCHIVE_TIER_SPECS), final_shape_ready=True)
+        == "archive_complete"
+    )
 
 
 def test_blockers_for_empty_archive_match_cli_contract() -> None:
@@ -53,14 +54,12 @@ def test_blockers_for_empty_archive_match_cli_contract() -> None:
     blockers = archive_layout.archive_layout_blockers(
         present_count=0,
         final_shape_ready=False,
-        missing_backup_required=("source", "embeddings", "user"),
+        missing_backup_required=archive_layout.BACKUP_REQUIRED_TIERS,
     )
     assert blockers == [
         "no_archive_tiers_present",
         "missing_archive_tiers",
-        "missing_backup_required_tier:source",
-        "missing_backup_required_tier:embeddings",
-        "missing_backup_required_tier:user",
+        *(f"missing_backup_required_tier:{tier}" for tier in archive_layout.BACKUP_REQUIRED_TIERS),
     ]
 
 
@@ -81,7 +80,7 @@ def test_blockers_include_schema_mismatch_in_tier_order() -> None:
 
 
 def test_blockers_empty_for_complete_archive() -> None:
-    assert archive_layout.archive_layout_blockers(present_count=5, final_shape_ready=True) == []
+    assert archive_layout.archive_layout_blockers(present_count=len(ARCHIVE_TIER_SPECS), final_shape_ready=True) == []
 
 
 def test_active_tier_role_resolves_known_and_unknown(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_archive_tier_init.py
+++ b/tests/unit/storage/test_archive_tier_init.py
@@ -10,6 +10,7 @@ from polylogue.storage.sqlite.archive_tiers.archive_init import (
     ArchiveInitBlockedError,
     initialize_archive_tier_files,
 )
+from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS
 
 
 def _fake_initialize_archive_database(path: Path, tier: object) -> None:
@@ -33,14 +34,8 @@ def test_initialize_archive_tier_files_creates_all_tiers(
     result = initialize_archive_tier_files(archive_root=tmp_path)
 
     assert not (tmp_path / "stray.sqlite.retired.bak").exists()
-    assert {tier.path.name for tier in result.tier_results} == {
-        "source.db",
-        "index.db",
-        "embeddings.db",
-        "user.db",
-        "ops.db",
-    }
-    for name in ("source.db", "index.db", "embeddings.db", "user.db", "ops.db"):
+    assert {tier.path.name for tier in result.tier_results} == {spec.filename for spec in ARCHIVE_TIER_SPECS.values()}
+    for name in (spec.filename for spec in ARCHIVE_TIER_SPECS.values()):
         conn = sqlite3.connect(tmp_path / name)
         try:
             assert conn.execute("SELECT COUNT(*) FROM initialized").fetchone()[0] == 1
@@ -52,11 +47,8 @@ def test_initialize_archive_tier_files_backs_up_replaceable_targets(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    (tmp_path / "source.db").write_text("existing source target", encoding="utf-8")
-    (tmp_path / "index.db").write_text("existing index target", encoding="utf-8")
-    (tmp_path / "embeddings.db").write_text("existing embeddings target", encoding="utf-8")
-    (tmp_path / "user.db").write_text("existing user target", encoding="utf-8")
-    (tmp_path / "ops.db").write_text("existing ops target", encoding="utf-8")
+    for spec in ARCHIVE_TIER_SPECS.values():
+        (tmp_path / spec.filename).write_text(f"existing {spec.tier.value} target", encoding="utf-8")
     monkeypatch.setattr(archive_init, "initialize_archive_database", _fake_initialize_archive_database)
 
     result = initialize_archive_tier_files(
@@ -67,6 +59,7 @@ def test_initialize_archive_tier_files_backs_up_replaceable_targets(
     assert (tmp_path / "source.db.pre-archive-init.bak").read_text(encoding="utf-8") == "existing source target"
     assert (tmp_path / "embeddings.db.pre-archive-init.bak").read_text(encoding="utf-8") == "existing embeddings target"
     assert (tmp_path / "user.db.pre-archive-init.bak").read_text(encoding="utf-8") == "existing user target"
+    assert (tmp_path / "audit.db.pre-archive-init.bak").read_text(encoding="utf-8") == "existing audit target"
     assert not (tmp_path / "index.db.pre-archive-init.bak").exists()
     assert not (tmp_path / "ops.db.pre-archive-init.bak").exists()
     assert {tier.initialized for tier in result.tier_results} == {True}

--- a/tests/unit/storage/test_archive_tier_plan.py
+++ b/tests/unit/storage/test_archive_tier_plan.py
@@ -4,6 +4,7 @@ import sqlite3
 from pathlib import Path
 
 from polylogue.storage.sqlite.archive_tiers.archive_plan import ArchiveInitAction, build_archive_init_plan
+from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 
 
@@ -24,13 +25,9 @@ def test_archive_plan_creates_absent_tier_targets(tmp_path: Path) -> None:
 
     assert plan.ready is True
     assert plan.blockers == ()
-    assert {tier_plan.tier: tier_plan.action for tier_plan in plan.tiers} == {
-        ArchiveTier.SOURCE: ArchiveInitAction.CREATE,
-        ArchiveTier.INDEX: ArchiveInitAction.CREATE,
-        ArchiveTier.EMBEDDINGS: ArchiveInitAction.CREATE,
-        ArchiveTier.USER: ArchiveInitAction.CREATE,
-        ArchiveTier.OPS: ArchiveInitAction.CREATE,
-    }
+    assert {tier_plan.tier: tier_plan.action for tier_plan in plan.tiers} == dict.fromkeys(
+        ARCHIVE_TIER_SPECS, ArchiveInitAction.CREATE
+    )
 
 
 def test_archive_plan_blocks_existing_targets_by_default(tmp_path: Path) -> None:
@@ -46,11 +43,8 @@ def test_archive_plan_blocks_existing_targets_by_default(tmp_path: Path) -> None
 
 
 def test_archive_plan_classifies_replace_existing_by_durability(tmp_path: Path) -> None:
-    _planted_db(tmp_path / "source.db", user_version=1)
-    _planted_db(tmp_path / "index.db", user_version=1)
-    _planted_db(tmp_path / "embeddings.db", user_version=1)
-    _planted_db(tmp_path / "user.db", user_version=1)
-    _planted_db(tmp_path / "ops.db", user_version=1)
+    for spec in ARCHIVE_TIER_SPECS.values():
+        _planted_db(tmp_path / spec.filename, user_version=1)
 
     plan = build_archive_init_plan(
         archive_root=tmp_path,
@@ -59,11 +53,8 @@ def test_archive_plan_classifies_replace_existing_by_durability(tmp_path: Path) 
 
     assert plan.ready is True
     assert {tier_plan.tier: tier_plan.action for tier_plan in plan.tiers} == {
-        ArchiveTier.SOURCE: ArchiveInitAction.REPLACE_WITH_BACKUP,
-        ArchiveTier.INDEX: ArchiveInitAction.RECREATE_DISPOSABLE,
-        ArchiveTier.EMBEDDINGS: ArchiveInitAction.REPLACE_WITH_BACKUP,
-        ArchiveTier.USER: ArchiveInitAction.REPLACE_WITH_BACKUP,
-        ArchiveTier.OPS: ArchiveInitAction.RECREATE_DISPOSABLE,
+        tier: (ArchiveInitAction.REPLACE_WITH_BACKUP if spec.backup_required else ArchiveInitAction.RECREATE_DISPOSABLE)
+        for tier, spec in ARCHIVE_TIER_SPECS.items()
     }
 
 

--- a/tests/unit/storage/test_archive_tiers_ddl.py
+++ b/tests/unit/storage/test_archive_tiers_ddl.py
@@ -732,11 +732,13 @@ def test_archive_tier_specs_capture_file_and_backup_policy() -> None:
         ArchiveTier.EMBEDDINGS: "embeddings.db",
         ArchiveTier.USER: "user.db",
         ArchiveTier.OPS: "ops.db",
+        ArchiveTier.AUDIT: "audit.db",
     }
     assert {tier.value for tier, spec in ARCHIVE_TIER_SPECS.items() if spec.backup_required} == {
         "source",
         "embeddings",
         "user",
+        "audit",
     }
 
 


### PR DESCRIPTION
## Summary

Propagates the Audit tier through archive initialization, backup profiles, workload and ingestion observability, metrics, and their contracts.

## Problem

ArchiveTier.AUDIT was already canonical but several consumers still assumed a five-tier archive. The workload probe therefore had no Audit table inventory and could raise a KeyError, while backup and surface contracts described stale tier sets.

## Solution

Tier planning, backup path resolution, ingestion observability, metrics, layout, and contract expectations now derive inventories from canonical tier specifications where possible. The workload probe observes Audit authority and operation tables, and its contract fails if a canonical tier is omitted from the production inventory.

## Verification

- `direnv exec . devtools test …` covering tier planning/init, archive layout, the Archive plan CLI, workload, ingestion observability, metrics, and backup profiles: 35 passed.
- `direnv exec . devtools test tests/unit/daemon/test_backup.py::…`: 6 passed after the layering-safe backup path refactor.
- `direnv exec . devtools verify --quick`: passed.
- The pre-push quick verification baseline also passed.

## Residual baseline failures

The seeded non-integration receipt had separate failures in malformed runtime code references, campaign fixture paths, duplicate raw-artifact admission, FTS/search coverage, session-insight behavior, and unrelated CLI snapshot, health, and status-vocabulary contracts. This PR does not alter those surfaces.

Ref polylogue-cozjx