### PR TITLE
fix(storage): close hook-event blob ref lifecycle (#3711)

### DIFF
--- a/docs/plans/layering.yaml
+++ b/docs/plans/layering.yaml
@@ -56,7 +56,8 @@ writer_modules:
       entrypoints:
         [apply_source_raw_state_update, bind_source_raw_revision, record_capture_mode_observation,
         record_excised_blob_hash, write_history_sidecar,
-        write_source_blob_refs, write_source_hook_event, write_source_raw_session, write_source_raw_session_blob_ref]
+        delete_source_hook_event, write_source_blob_refs, write_source_hook_event, write_source_raw_session,
+        write_source_raw_session_blob_ref]
     - path: polylogue/storage/sqlite/archive_tiers/write.py
       surfaces:
         - tier: index

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -227,6 +227,7 @@ from polylogue.storage.sqlite.archive_tiers.revision_governance import (
 from polylogue.storage.sqlite.archive_tiers.source_write import (
     ArchiveHookEvent,
     ArchiveSourceBlobRef,
+    delete_source_hook_event,
     deterministic_blob_hash,
     deterministic_raw_session_id,
     list_hook_events,
@@ -2151,6 +2152,10 @@ class ArchiveStore:
             blob_publication_receipt_id=receipt_id,
             manage_transaction=True,
         )
+
+    def delete_hook_event(self, hook_event_id: str) -> bool:
+        """Delete a hook event and its source-tier payload reference."""
+        return delete_source_hook_event(self._ensure_source_conn(), hook_event_id)
 
     def write_raw_blob_ref(
         self,

--- a/polylogue/storage/sqlite/archive_tiers/source_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/source_write.py
@@ -669,6 +669,14 @@ def write_source_hook_event(
         raise ContentExcisedError(blob_hash=blob_hash, source_path=source_path)
     blob_size = len(payload)
     with conn if manage_transaction else nullcontext():
+        # A replay can update an existing hook_event_id with a newer payload.
+        # Remove the previous content-addressed ref first so the upsert cannot
+        # leave an old hook_payload ref with no matching raw_hook_events blob.
+        conn.execute(
+            "DELETE FROM blob_refs WHERE ref_type = 'hook_payload' AND ref_id = ?",
+            (hook_event.hook_event_id,),
+        )
+        _insert_hook_event(conn, hook_event, blob_hash=blob_hash)
         _insert_blob_ref(
             conn,
             ArchiveSourceBlobRef(
@@ -681,8 +689,30 @@ def write_source_hook_event(
                 publication_receipt_id=blob_publication_receipt_id,
             ),
         )
-        _insert_hook_event(conn, hook_event, blob_hash=blob_hash)
     return raw_id
+
+
+def delete_source_hook_event(
+    conn: sqlite3.Connection,
+    hook_event_id: str,
+    *,
+    manage_transaction: bool = True,
+) -> bool:
+    """Delete one hook event and its owned payload ref as one source-tier write.
+
+    Hook events do not have a foreign key to ``blob_refs`` because the source
+    tier stores the reference by ``ref_type``/``ref_id``. Keep their delete
+    route paired with the reference cleanup so a removed event cannot leave a
+    durable ``hook_payload`` row behind to pin its blob.
+    """
+    conn.execute("PRAGMA foreign_keys = ON")
+    with conn if manage_transaction else nullcontext():
+        cursor = conn.execute("DELETE FROM raw_hook_events WHERE hook_event_id = ?", (hook_event_id,))
+        conn.execute(
+            "DELETE FROM blob_refs WHERE ref_type = 'hook_payload' AND ref_id = ?",
+            (hook_event_id,),
+        )
+    return cursor.rowcount == 1
 
 
 def write_source_raw_session_blob_ref(

--- a/tests/unit/storage/test_blob_gc_ref_type_liveness.py
+++ b/tests/unit/storage/test_blob_gc_ref_type_liveness.py
@@ -132,6 +132,10 @@ def test_hook_payload_ref_survives_gc_while_hook_event_row_exists_then_is_reclai
     # Delete through the source-tier route. The hook event's own ref must be
     # removed with the event, so GC sees the payload as truly dead.
     assert _delete_hook_event(archive_root, hook_event_id="hook-live") is True
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        assert conn.execute(
+            "SELECT COUNT(*) FROM blob_refs WHERE ref_type = 'hook_payload' AND ref_id = 'hook-live'"
+        ).fetchone() == (0,)
 
     deleted = run_blob_gc(archive_root / "source.db", archive_root / "blob", max_batch=10)
     assert deleted == 1

--- a/tests/unit/storage/test_blob_gc_ref_type_liveness.py
+++ b/tests/unit/storage/test_blob_gc_ref_type_liveness.py
@@ -40,6 +40,7 @@ from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
 from polylogue.storage.sqlite.archive_tiers.source_write import (
     ArchiveHookEvent,
+    deterministic_blob_hash,
     deterministic_raw_session_id,
 )
 
@@ -74,6 +75,11 @@ def _write_hook_event(archive_root: Path, *, hook_event_id: str, source_path: st
         )
 
 
+def _delete_hook_event(archive_root: Path, *, hook_event_id: str) -> bool:
+    with ArchiveStore(archive_root) as archive:
+        return archive.delete_hook_event(hook_event_id)
+
+
 def test_hook_payload_ref_written_as_hook_payload_not_raw_payload(tmp_path: Path) -> None:
     archive_root = tmp_path / "archive"
     initialize_active_archive_root(archive_root)
@@ -84,6 +90,22 @@ def test_hook_payload_ref_written_as_hook_payload_not_raw_payload(tmp_path: Path
         assert rows == [("hook_payload", "hook-1")]
         blob_hash = conn.execute("SELECT blob_hash FROM raw_hook_events WHERE hook_event_id = 'hook-1'").fetchone()[0]
         assert blob_hash is not None
+
+
+def test_hook_payload_replacement_removes_previous_ref(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+    _write_hook_event(archive_root, hook_event_id="hook-replaced", source_path="/hooks/a.jsonl", payload=b"old")
+    _write_hook_event(archive_root, hook_event_id="hook-replaced", source_path="/hooks/a.jsonl", payload=b"new")
+
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        refs = conn.execute("SELECT ref_type, ref_id, blob_hash FROM blob_refs ORDER BY ref_type, ref_id").fetchall()
+        event_hash = conn.execute(
+            "SELECT blob_hash FROM raw_hook_events WHERE hook_event_id = 'hook-replaced'"
+        ).fetchone()[0]
+
+    assert refs == [("hook_payload", "hook-replaced", event_hash)]
+    assert event_hash == deterministic_blob_hash(b"new")
 
 
 def test_hook_payload_ref_survives_gc_while_hook_event_row_exists_then_is_reclaimed_once_deleted(
@@ -107,12 +129,9 @@ def test_hook_payload_ref_survives_gc_while_hook_event_row_exists_then_is_reclai
     assert deleted == 0
     assert blob_store.exists(blob_hash)
 
-    # Simulate the hook event row being gone (a since-deleted/repaired row --
-    # exactly the shape a genuinely dead ref takes): the blob_refs row is now
-    # a true orphan and must no longer protect the blob.
-    with sqlite3.connect(archive_root / "source.db") as conn:
-        conn.execute("DELETE FROM raw_hook_events WHERE hook_event_id = 'hook-live'")
-        conn.commit()
+    # Delete through the source-tier route. The hook event's own ref must be
+    # removed with the event, so GC sees the payload as truly dead.
+    assert _delete_hook_event(archive_root, hook_event_id="hook-live") is True
 
     deleted = run_blob_gc(archive_root / "source.db", archive_root / "blob", max_batch=10)
     assert deleted == 1


### PR DESCRIPTION
## Summary

Repair the source-tier ownership lifecycle for hook-event payload blob references.

## Problem

`polylogue-tfzw0` identified a preventative write-path gap: replaying a `hook_event_id` could leave its previous `hook_payload` reference behind, and the source-tier API had no paired delete route for a hook event and its owned reference.

## Solution

`write_source_hook_event` removes the current event id's prior `hook_payload` reference before upserting the event and its replacement reference. `ArchiveStore.delete_hook_event` delegates to a source-tier transactional delete that removes both the `raw_hook_events` row and its `hook_payload` ref. The layering plan now declares this writer entrypoint.

Ref polylogue-tfzw0

## Acceptance matrix

| Acceptance criterion | Result | Evidence |
| --- | --- | --- |
| A hook event owns one canonical `hook_payload` ref | Satisfied | Existing real-route creation regression remains green. |
| Replaying an event id removes the prior payload ref | Satisfied | Focused regression writes `old` then `new` payloads and asserts one ref with the new deterministic hash. |
| Deleting a hook event removes its owned reference | Satisfied | New facade route deletes the source row and its ref in one transaction; regression asserts zero matching refs. |
| Physical blob removal remains an existing GC concern | Satisfied | The regression verifies reclamation only after the source-tier delete on a scratch archive. No GC logic changed. |
| Production archive data remains untouched | Satisfied | This PR changes source write code and isolated tests only. |

## Verification

- `direnv exec . devtools test tests/unit/storage/test_blob_gc_ref_type_liveness.py`
  - `6 passed in 1.18s`
- `direnv exec . devtools verify --quick`
  - Verification receipt status: `success`

No full suite was run; the change is covered by the focused real write/replay/delete storage route and the quick gate.