### PR TITLE
feat(maintenance): add guarded hook-payload reconciliation

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -136,6 +136,28 @@ reclassifies under `BEGIN IMMEDIATE` before fsyncing the prepared receipt and
 deleting the exact candidate set. Review the receipt's final `committed` line
 before treating the pass as complete.
 
+### `polylogue ops maintenance hook-payload-ref-reconcile` - legacy hook-ref repair
+
+Read-only by default. It classifies historical orphaned `raw_payload` refs and
+only re-keys a row when its deterministic legacy id exactly matches one
+unambiguous `raw_hook_events` candidate. Unmatched rows remain untouched.
+
+```bash
+polylogue ops maintenance hook-payload-ref-reconcile --output-format json
+polylogue ops maintenance hook-payload-ref-reconcile --apply \
+  --backup-manifest /path/to/verified-source-backup-manifest.json \
+  --receipt-file /path/to/new/hook-payload-reconciliation.jsonl \
+  --output-format json
+```
+
+Apply requires the daemon and all archive writers to be offline, a verified
+backup manifest for the current `source.db`, and a new receipt destination.
+The receipt records the tool version, backup-manifest identity, exact
+pre/post classifications, reconciled hook ids, and a terminal committed or
+recovered state. If an interrupted apply leaves a prepared receipt, rerun the
+same command with that receipt path to record recovery; use a fresh path only
+after reviewing the recovered terminal state.
+
 ### `polylogue ops maintenance preview` — staleness inventory
 
 Read-only. Produces a per-model inventory of stale, missing, orphan,

--- a/polylogue/cli/commands/maintenance/__init__.py
+++ b/polylogue/cli/commands/maintenance/__init__.py
@@ -116,6 +116,12 @@ _COMMANDS: tuple[tuple[str, str, str, str], ...] = (
         "Classify source-tier orphan refs; apply only with backup and receipt.",
     ),
     (
+        "hook-payload-ref-reconcile",
+        "_hook_payload_ref_reconciliation",
+        "hook_payload_ref_reconcile_command",
+        "Classify legacy hook refs; apply exact matches with backup and receipt.",
+    ),
+    (
         "attachment-acquisition-debt",
         "_blob_integrity",
         "attachment_acquisition_debt_command",

--- a/polylogue/cli/commands/maintenance/_hook_payload_ref_reconciliation.py
+++ b/polylogue/cli/commands/maintenance/_hook_payload_ref_reconciliation.py
@@ -1,0 +1,64 @@
+"""CLI adapter for the guarded hook-payload reference reconciler."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+
+from polylogue.paths import archive_root
+
+
+@click.command("hook-payload-ref-reconcile")
+@click.option(
+    "--apply", "apply_changes", is_flag=True, help="Apply only exact hook-payload matches; default is read-only."
+)
+@click.option(
+    "--backup-manifest",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Verified source-tier backup manifest required with --apply.",
+)
+@click.option(
+    "--receipt-file",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="New immutable JSONL receipt path required with --apply.",
+)
+@click.option(
+    "--output-format",
+    type=click.Choice(["plain", "json"]),
+    default="plain",
+    show_default=True,
+)
+def hook_payload_ref_reconcile_command(
+    apply_changes: bool,
+    backup_manifest: Path | None,
+    receipt_file: Path | None,
+    output_format: str,
+) -> None:
+    """Classify historical hook refs, or reconcile exact matches with safeguards."""
+    from polylogue.maintenance.hook_payload_ref_reconciliation_apply import apply_hook_payload_ref_reconciliation
+
+    report = apply_hook_payload_ref_reconciliation(
+        archive_root(),
+        backup_manifest=backup_manifest,
+        receipt_path=receipt_file,
+        dry_run=not apply_changes,
+    )
+    payload = {"mode": "hook_payload_ref_reconciliation", "mutates": report.applied, **report.to_dict()}
+    if output_format == "json":
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    click.echo("Hook-payload reference reconciliation")
+    click.echo(f"Mode:       {'apply' if report.applied else 'dry-run'}")
+    click.echo(f"Scanned:    {report.scanned_count:,} orphaned raw_payload ref(s)")
+    click.echo(f"Exact:      {report.matched_count:,} ref(s), {report.matched_bytes:,} bytes")
+    click.echo(f"Unmatched:  {report.unmatched_count:,} ref(s) left untouched")
+    click.echo(f"Reconciled: {len(report.reconciled_hook_event_ids):,} hook event(s)")
+    if report.receipt_path is not None:
+        click.echo(f"Receipt:    {report.receipt_path}")
+
+
+__all__ = ["hook_payload_ref_reconcile_command"]

--- a/polylogue/maintenance/hook_payload_ref_reconciliation_apply.py
+++ b/polylogue/maintenance/hook_payload_ref_reconciliation_apply.py
@@ -16,11 +16,9 @@ source-tier repair actuators (``raw_append_chain_backfill_apply``,
   same shape ``write_source_hook_event`` writes for a hook event captured
   after v22.
 
-Unlike the byte-proof actuators above, this module does not mint a receipt
-row: there is no external evidence being witnessed, just an exact-match
-recomputation of an existing deterministic id from data already in the
-archive. The re-keyed ``blob_refs``/``raw_hook_events`` rows are themselves
-the durable record of what changed.
+Every apply writes an exclusive, fsynced JSONL receipt before mutation. The
+receipt records the verified backup identity and exact pre/post classifier
+counts, then receives a committed, aborted, or recovered terminal record.
 
 This module never runs against the live archive as part of any automated
 pipeline -- applying it is an explicit operator action
@@ -31,10 +29,19 @@ package.
 from __future__ import annotations
 
 import sqlite3
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 
 from polylogue.config import Config
+from polylogue.maintenance.hook_payload_ref_reconciliation_receipt import (
+    HookPayloadRefReconciliationReceiptError,
+    append_terminal_receipt,
+    backup_manifest_identity,
+    classification_counts,
+    recover_prepared_receipt,
+    write_prepared_receipt,
+)
 from polylogue.maintenance.offline_guard import offline_maintenance_block_reason
 from polylogue.paths import render_root
 from polylogue.storage.hook_payload_ref_reconciliation import (
@@ -60,6 +67,21 @@ class HookPayloadRefReconciliationApplyReport:
     reconciled_hook_event_ids: tuple[str, ...]
     applied: bool
     backup_manifest: Path | None = None
+    receipt_path: Path | None = None
+    post_classification: dict[str, int] | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "scanned_count": self.scanned_count,
+            "matched_count": self.matched_count,
+            "matched_bytes": self.matched_bytes,
+            "unmatched_count": self.unmatched_count,
+            "reconciled_hook_event_ids": list(self.reconciled_hook_event_ids),
+            "applied": self.applied,
+            "backup_manifest": str(self.backup_manifest) if self.backup_manifest is not None else None,
+            "receipt_path": str(self.receipt_path) if self.receipt_path is not None else None,
+            "post_classification": self.post_classification,
+        }
 
     @classmethod
     def from_plan(
@@ -69,6 +91,8 @@ class HookPayloadRefReconciliationApplyReport:
         applied: bool,
         reconciled_hook_event_ids: tuple[str, ...] | None = None,
         backup_manifest: Path | None = None,
+        receipt_path: Path | None = None,
+        post_plan: HookPayloadRefReconciliationPlan | None = None,
     ) -> HookPayloadRefReconciliationApplyReport:
         reconciled = (
             tuple(c.hook_event_id for c in plan.matched)
@@ -83,6 +107,8 @@ class HookPayloadRefReconciliationApplyReport:
             reconciled_hook_event_ids=reconciled,
             applied=applied,
             backup_manifest=backup_manifest,
+            receipt_path=receipt_path,
+            post_classification=classification_counts(post_plan) if post_plan is not None else None,
         )
 
 
@@ -94,6 +120,7 @@ def apply_hook_payload_ref_reconciliation(
     archive_root: Path,
     *,
     backup_manifest: Path | None = None,
+    receipt_path: Path | None = None,
     dry_run: bool = True,
 ) -> HookPayloadRefReconciliationApplyReport:
     """Re-key the provable subset of orphaned hook-payload blob refs.
@@ -101,9 +128,9 @@ def apply_hook_payload_ref_reconciliation(
     ``dry_run=True`` (the default) never opens a write transaction; it runs
     the same classifier a real apply would and reports what it would do.
 
-    ``dry_run=False`` requires ``backup_manifest`` and re-runs classification
-    live, inside the same ``BEGIN IMMEDIATE`` write transaction the re-key
-    UPDATE/DELETE/INSERT triples run in.
+    ``dry_run=False`` requires ``backup_manifest`` plus a new ``receipt_path``.
+    It re-runs classification live, inside the same ``BEGIN IMMEDIATE`` write
+    transaction the re-key UPDATE/DELETE/INSERT triples run in.
     """
     source_db = archive_root / "source.db"
     if not source_db.exists():
@@ -112,20 +139,35 @@ def apply_hook_payload_ref_reconciliation(
     if dry_run:
         conn = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
         try:
-            plan = plan_hook_payload_ref_reconciliation(conn)
+            dry_run_plan = plan_hook_payload_ref_reconciliation(conn)
         finally:
             conn.close()
-        return HookPayloadRefReconciliationApplyReport.from_plan(plan, applied=False)
+        return HookPayloadRefReconciliationApplyReport.from_plan(dry_run_plan, applied=False)
 
     if backup_manifest is None:
         raise HookPayloadRefReconciliationApplyError(
             "applying hook-payload-ref-reconciliation requires a verified backup manifest (--backup-manifest)"
         )
+    if receipt_path is None:
+        raise HookPayloadRefReconciliationApplyError(
+            "applying hook-payload-ref-reconciliation requires an explicit receipt output (--receipt-file)"
+        )
     if reason := offline_maintenance_block_reason(_offline_config(archive_root), active=True, dry_run=False):
         raise HookPayloadRefReconciliationApplyError(reason)
+    if receipt_path.exists():
+        try:
+            outcome = recover_prepared_receipt(source_db, receipt_path)
+        except HookPayloadRefReconciliationReceiptError as exc:
+            raise HookPayloadRefReconciliationApplyError(str(exc)) from exc
+        raise HookPayloadRefReconciliationApplyError(
+            f"recovered existing prepared receipt as {outcome}: {receipt_path}; choose a fresh receipt path before retrying"
+        )
 
     conn = sqlite3.connect(source_db)
     reconciled: list[str] = []
+    plan: HookPayloadRefReconciliationPlan | None = None
+    post_plan: HookPayloadRefReconciliationPlan | None = None
+    prepared = False
     try:
         try:
             row = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
@@ -142,6 +184,14 @@ def apply_hook_payload_ref_reconciliation(
             validate_migration_backup_manifest(backup_manifest, ArchiveTier.SOURCE, connection=conn)
 
             plan = plan_hook_payload_ref_reconciliation(conn)
+            write_prepared_receipt(
+                receipt_path,
+                source_db=source_db,
+                tool_version=TOOL_VERSION,
+                backup_manifest=backup_manifest_identity(backup_manifest),
+                plan=plan,
+            )
+            prepared = True
             for candidate in plan.matched:
                 deleted = conn.execute(
                     "DELETE FROM blob_refs WHERE blob_hash = ? AND ref_type = 'raw_payload' AND ref_id = ?",
@@ -172,6 +222,8 @@ def apply_hook_payload_ref_reconciliation(
                 )
                 reconciled.append(candidate.hook_event_id)
 
+            post_plan = plan_hook_payload_ref_reconciliation(conn)
+
             quick_check = conn.execute("PRAGMA quick_check").fetchone()
             if quick_check is None or str(quick_check[0]).lower() != "ok":
                 raise HookPayloadRefReconciliationApplyError(
@@ -183,14 +235,34 @@ def apply_hook_payload_ref_reconciliation(
             raise
         else:
             conn.commit()
+    except Exception as exc:
+        if prepared:
+            with suppress(OSError):
+                append_terminal_receipt(receipt_path, terminal_state="aborted", error=str(exc))
+        raise
     finally:
         conn.close()
 
+    assert plan is not None
+    assert post_plan is not None
+    try:
+        append_terminal_receipt(
+            receipt_path,
+            terminal_state="committed",
+            post_plan=post_plan,
+            reconciled_hook_event_ids=tuple(reconciled),
+        )
+    except OSError as exc:
+        raise HookPayloadRefReconciliationApplyError(
+            f"source.db committed but could not finalize receipt {receipt_path}"
+        ) from exc
     return HookPayloadRefReconciliationApplyReport.from_plan(
         plan,
         applied=True,
         reconciled_hook_event_ids=tuple(reconciled),
         backup_manifest=backup_manifest,
+        receipt_path=receipt_path,
+        post_plan=post_plan,
     )
 
 

--- a/polylogue/maintenance/hook_payload_ref_reconciliation_receipt.py
+++ b/polylogue/maintenance/hook_payload_ref_reconciliation_receipt.py
@@ -1,0 +1,237 @@
+"""Crash-recoverable receipts for hook-payload reference reconciliation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import time
+from pathlib import Path
+
+from polylogue.storage.hook_payload_ref_reconciliation import (
+    HookPayloadRefReconciliationCandidate,
+    HookPayloadRefReconciliationPlan,
+    plan_hook_payload_ref_reconciliation,
+)
+
+RECEIPT_KIND = "hook_payload_ref_reconciliation"
+
+
+class HookPayloadRefReconciliationReceiptError(RuntimeError):
+    """Raised when a reconciliation receipt cannot be safely created or recovered."""
+
+
+def classification_counts(plan: HookPayloadRefReconciliationPlan) -> dict[str, int]:
+    """Return the complete count projection recorded before and after apply."""
+    return {
+        "scanned_count": plan.scanned_count,
+        "matched_count": len(plan.matched),
+        "matched_bytes": plan.matched_bytes,
+        "unmatched_count": plan.unmatched_count,
+    }
+
+
+def _candidate_dict(candidate: HookPayloadRefReconciliationCandidate) -> dict[str, object]:
+    return {
+        "blob_hash": candidate.blob_hash.hex(),
+        "orphaned_ref_id": candidate.orphaned_ref_id,
+        "source_path": candidate.source_path,
+        "size_bytes": candidate.size_bytes,
+        "acquired_at_ms": candidate.acquired_at_ms,
+        "hook_event_id": candidate.hook_event_id,
+    }
+
+
+def _candidate_digest(candidates: tuple[HookPayloadRefReconciliationCandidate, ...]) -> str:
+    payload = sorted(
+        (_candidate_dict(candidate) for candidate in candidates),
+        key=lambda candidate: (
+            str(candidate["hook_event_id"]),
+            str(candidate["orphaned_ref_id"]),
+            str(candidate["blob_hash"]),
+        ),
+    )
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def reconciled_ids_digest(hook_event_ids: tuple[str, ...] | list[str]) -> str:
+    """Return a stable digest for the exact ids reconciled by one transaction."""
+    encoded = json.dumps(sorted(hook_event_ids), separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def backup_manifest_identity(backup_manifest: Path) -> dict[str, object]:
+    """Return the byte identity of the manifest just accepted by validation."""
+    manifest_path = backup_manifest / "manifest.json" if backup_manifest.is_dir() else backup_manifest
+    try:
+        manifest_bytes = manifest_path.read_bytes()
+    except OSError as exc:
+        raise HookPayloadRefReconciliationReceiptError(
+            f"could not read validated backup manifest identity: {manifest_path}"
+        ) from exc
+    return {
+        "path": str(manifest_path.resolve(strict=True)),
+        "sha256": hashlib.sha256(manifest_bytes).hexdigest(),
+        "size_bytes": len(manifest_bytes),
+    }
+
+
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def write_prepared_receipt(
+    receipt_path: Path,
+    *,
+    source_db: Path,
+    tool_version: str,
+    backup_manifest: dict[str, object],
+    plan: HookPayloadRefReconciliationPlan,
+) -> None:
+    """Exclusively write and fsync the immutable plan before database mutation."""
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    header = {
+        "kind": RECEIPT_KIND,
+        "phase": "prepared",
+        "tool_version": tool_version,
+        "source_db": str(source_db.resolve(strict=True)),
+        "backup_manifest": backup_manifest,
+        "prepared_at_ms": int(time.time() * 1000),
+        "pre_classification": classification_counts(plan),
+        "candidate_count": len(plan.matched),
+        "candidate_digest": _candidate_digest(plan.matched),
+    }
+    try:
+        with receipt_path.open("x", encoding="utf-8") as handle:
+            handle.write(json.dumps(header, sort_keys=True, separators=(",", ":")))
+            handle.write("\n")
+            for candidate in plan.matched:
+                handle.write(
+                    json.dumps(
+                        {"kind": "candidate", **_candidate_dict(candidate)}, sort_keys=True, separators=(",", ":")
+                    )
+                )
+                handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        _fsync_directory(receipt_path.parent)
+    except FileExistsError as exc:
+        raise HookPayloadRefReconciliationReceiptError(f"receipt already exists: {receipt_path}") from exc
+
+
+def append_terminal_receipt(
+    receipt_path: Path,
+    *,
+    terminal_state: str,
+    post_plan: HookPayloadRefReconciliationPlan | None = None,
+    reconciled_hook_event_ids: tuple[str, ...] | None = None,
+    error: str | None = None,
+) -> None:
+    """Append the only terminal receipt record and sync it to durable storage."""
+    payload: dict[str, object] = {
+        "kind": RECEIPT_KIND,
+        "phase": terminal_state,
+        "terminal_state": terminal_state,
+        "completed_at_ms": int(time.time() * 1000),
+    }
+    if post_plan is not None:
+        payload["post_classification"] = classification_counts(post_plan)
+    if reconciled_hook_event_ids is not None:
+        payload["reconciled_hook_event_ids"] = list(reconciled_hook_event_ids)
+        payload["reconciled_ids_digest"] = reconciled_ids_digest(reconciled_hook_event_ids)
+    if error is not None:
+        payload["error"] = error
+    with receipt_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    _fsync_directory(receipt_path.parent)
+
+
+def _load_prepared_candidates(receipt_path: Path) -> list[dict[str, object]]:
+    try:
+        rows = [json.loads(line) for line in receipt_path.read_text(encoding="utf-8").splitlines() if line]
+    except (OSError, json.JSONDecodeError) as exc:
+        raise HookPayloadRefReconciliationReceiptError(f"could not read receipt: {receipt_path}") from exc
+    if not rows or rows[0].get("kind") != RECEIPT_KIND or rows[0].get("phase") != "prepared":
+        raise HookPayloadRefReconciliationReceiptError(
+            f"receipt is not a prepared hook reconciliation receipt: {receipt_path}"
+        )
+    terminal_states = {"committed", "aborted", "recovered_committed", "recovered_rolled_back", "indeterminate"}
+    if any(row.get("terminal_state") in terminal_states for row in rows[1:]):
+        raise HookPayloadRefReconciliationReceiptError(f"receipt is already terminal: {receipt_path}")
+    candidates = [row for row in rows[1:] if row.get("kind") == "candidate"]
+    if len(candidates) != rows[0].get("candidate_count"):
+        raise HookPayloadRefReconciliationReceiptError(f"receipt candidate count is invalid: {receipt_path}")
+    return candidates
+
+
+def recover_prepared_receipt(source_db: Path, receipt_path: Path) -> str:
+    """Determine the outcome of a prepared receipt without making DB changes."""
+    candidates = _load_prepared_candidates(receipt_path)
+    committed = 0
+    rolled_back = 0
+    with sqlite3.connect(f"file:{source_db}?mode=ro", uri=True) as conn:
+        for candidate in candidates:
+            blob_hash = bytes.fromhex(str(candidate["blob_hash"]))
+            hook_event_id = str(candidate["hook_event_id"])
+            orphaned_ref_id = str(candidate["orphaned_ref_id"])
+            canonical = conn.execute(
+                "SELECT 1 FROM blob_refs WHERE blob_hash = ? AND ref_type = 'hook_payload' AND ref_id = ?",
+                (blob_hash, hook_event_id),
+            ).fetchone()
+            stale = conn.execute(
+                "SELECT 1 FROM blob_refs WHERE blob_hash = ? AND ref_type = 'raw_payload' AND ref_id = ?",
+                (blob_hash, orphaned_ref_id),
+            ).fetchone()
+            event = conn.execute(
+                "SELECT blob_hash FROM raw_hook_events WHERE hook_event_id = ?", (hook_event_id,)
+            ).fetchone()
+            if (
+                canonical is not None
+                and stale is None
+                and event is not None
+                and event[0] is not None
+                and bytes(event[0]) == blob_hash
+            ):
+                committed += 1
+            elif canonical is None and stale is not None:
+                rolled_back += 1
+    if committed == len(candidates):
+        terminal_state = "recovered_committed"
+    elif rolled_back == len(candidates):
+        terminal_state = "recovered_rolled_back"
+    else:
+        terminal_state = "indeterminate"
+    with sqlite3.connect(f"file:{source_db}?mode=ro", uri=True) as conn:
+        post_plan = plan_hook_payload_ref_reconciliation(conn)
+    reconciled_ids = (
+        tuple(str(candidate["hook_event_id"]) for candidate in candidates)
+        if terminal_state == "recovered_committed"
+        else None
+    )
+    append_terminal_receipt(
+        receipt_path,
+        terminal_state=terminal_state,
+        post_plan=post_plan,
+        reconciled_hook_event_ids=reconciled_ids,
+    )
+    return terminal_state
+
+
+__all__ = [
+    "HookPayloadRefReconciliationReceiptError",
+    "append_terminal_receipt",
+    "backup_manifest_identity",
+    "classification_counts",
+    "reconciled_ids_digest",
+    "recover_prepared_receipt",
+    "write_prepared_receipt",
+]

--- a/tests/unit/cli/test_hook_payload_ref_reconciliation_cli.py
+++ b/tests/unit/cli/test_hook_payload_ref_reconciliation_cli.py
@@ -1,0 +1,83 @@
+"""Real CLI coverage for guarded hook-payload reference reconciliation."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from polylogue.cli.click_app import cli
+from polylogue.storage.sqlite.archive_tiers.source_write import deterministic_blob_hash, deterministic_raw_session_id
+
+
+def _seed_exact_hook_ref(archive_root: Path) -> None:
+    payload = b'{"event":"PostToolUse"}'
+    blob_hash = deterministic_blob_hash(payload)
+    source_path = "/hooks/cli.jsonl"
+    native_id = "cli-native"
+    ref_id = deterministic_raw_session_id("codex-session", source_path, 0, blob_hash, native_id)
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_hook_events (
+                hook_event_id, origin, native_id, session_native_id, source_path, event_type,
+                payload_json, observed_at_ms
+            ) VALUES ('cli-hook', 'codex-session', ?, 'session-1', ?, 'PostToolUse', '{}', 1)
+            """,
+            (native_id, source_path),
+        )
+        conn.execute(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, ?, 'raw_payload', ?, ?, 1)
+            """,
+            (blob_hash, ref_id, source_path, len(payload)),
+        )
+        conn.commit()
+
+
+def test_hook_payload_reconcile_cli_defaults_to_read_only_json(
+    cli_workspace: dict[str, Path], cli_runner: CliRunner
+) -> None:
+    archive_root = cli_workspace["archive_root"]
+    _seed_exact_hook_ref(archive_root)
+
+    result = cli_runner.invoke(
+        cli,
+        ["--plain", "ops", "maintenance", "hook-payload-ref-reconcile", "--output-format", "json"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["mode"] == "hook_payload_ref_reconciliation"
+    assert payload["mutates"] is False
+    assert payload["applied"] is False
+    assert payload["matched_count"] == 1
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        assert conn.execute("SELECT ref_type FROM blob_refs").fetchone() == ("raw_payload",)
+
+
+def test_hook_payload_reconcile_cli_apply_requires_receipt_file(
+    cli_workspace: dict[str, Path], cli_runner: CliRunner
+) -> None:
+    _seed_exact_hook_ref(cli_workspace["archive_root"])
+
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "hook-payload-ref-reconcile",
+            "--apply",
+            "--backup-manifest",
+            str(cli_workspace["archive_root"] / "not-used-manifest.json"),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert result.exception is not None
+    assert "receipt output" in str(result.exception)

--- a/tests/unit/cli/test_maintenance_registration.py
+++ b/tests/unit/cli/test_maintenance_registration.py
@@ -6,6 +6,7 @@ import click
 from click.testing import CliRunner
 
 from polylogue.cli.click_app import cli as root_cli
+from polylogue.cli.commands.maintenance._hook_payload_ref_reconciliation import hook_payload_ref_reconcile_command
 from polylogue.cli.commands.maintenance._plan import plan_command
 from polylogue.cli.commands.maintenance._run import run_command
 from polylogue.cli.commands.maintenance._run_preview import run_preview_command
@@ -100,12 +101,18 @@ def test_maintenance_status_is_click_command() -> None:
     assert isinstance(status_command, click.Command)
 
 
+def test_hook_payload_reconcile_is_click_command() -> None:
+    """hook-payload-ref-reconcile is a Click Command on the maintenance group."""
+    assert isinstance(hook_payload_ref_reconcile_command, click.Command)
+
+
 def test_maintenance_group_has_status() -> None:
     """maintenance group lists status as a subcommand (#1197)."""
     maintenance_group = _registered_maintenance_command()
     ctx = click.Context(maintenance_group)
     cmds = maintenance_group.list_commands(ctx)  # type: ignore[attr-defined]
     assert "status" in cmds
+    assert "hook-payload-ref-reconcile" in cmds
 
 
 def test_maintenance_status_help_output() -> None:

--- a/tests/unit/maintenance/test_hook_payload_ref_reconciliation_apply.py
+++ b/tests/unit/maintenance/test_hook_payload_ref_reconciliation_apply.py
@@ -13,6 +13,7 @@ Builds the exact pre-v22 orphan shape (see
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from pathlib import Path
 
@@ -22,6 +23,11 @@ from polylogue.maintenance.hook_payload_ref_reconciliation_apply import (
     HookPayloadRefReconciliationApplyError,
     apply_hook_payload_ref_reconciliation,
 )
+from polylogue.maintenance.hook_payload_ref_reconciliation_receipt import (
+    backup_manifest_identity,
+    write_prepared_receipt,
+)
+from polylogue.storage.hook_payload_ref_reconciliation import plan_hook_payload_ref_reconciliation
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
 from polylogue.storage.sqlite.archive_tiers.source_write import (
     deterministic_blob_hash,
@@ -77,6 +83,23 @@ def _blob_refs_rows(archive_root: Path) -> set[tuple[str, str]]:
         return {(row[0], row[1]) for row in conn.execute("SELECT ref_type, ref_id FROM blob_refs")}
 
 
+def _manifest(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('{"manifest":"test"}', encoding="utf-8")
+    return path
+
+
+def _accept_manifest(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_validate(manifest: Path, tier: object, *, connection: sqlite3.Connection) -> Path:
+        assert connection.execute("SELECT 1").fetchone() == (1,)
+        return manifest.with_name("verification-receipt.json")
+
+    monkeypatch.setattr(
+        "polylogue.maintenance.hook_payload_ref_reconciliation_apply.validate_migration_backup_manifest",
+        _fake_validate,
+    )
+
+
 def test_dry_run_never_mutates(tmp_path: Path) -> None:
     archive_root = _build_fixture_archive(tmp_path)
     before = _blob_refs_rows(archive_root)
@@ -93,22 +116,26 @@ def test_dry_run_never_mutates(tmp_path: Path) -> None:
 
 def test_apply_rekeys_only_the_confirmed_match(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     archive_root = _build_fixture_archive(tmp_path)
-
-    def _fake_validate(manifest: Path, tier: object, *, connection: sqlite3.Connection) -> Path:
-        assert connection.execute("SELECT 1").fetchone() == (1,)
-        return manifest.with_name("verification-receipt.json")
-
-    monkeypatch.setattr(
-        "polylogue.maintenance.hook_payload_ref_reconciliation_apply.validate_migration_backup_manifest",
-        _fake_validate,
+    _accept_manifest(monkeypatch)
+    manifest = _manifest(tmp_path / "verified-backup" / "manifest.json")
+    receipt_path = tmp_path / "receipts" / "apply.jsonl"
+    report = apply_hook_payload_ref_reconciliation(
+        archive_root,
+        backup_manifest=manifest,
+        receipt_path=receipt_path,
+        dry_run=False,
     )
-
-    manifest = tmp_path / "verified-backup" / "manifest.json"
-    report = apply_hook_payload_ref_reconciliation(archive_root, backup_manifest=manifest, dry_run=False)
 
     assert report.applied is True
     assert report.matched_count == 1
     assert report.reconciled_hook_event_ids == ("hook-matched",)
+    assert report.receipt_path == receipt_path
+    assert report.post_classification == {
+        "scanned_count": 1,
+        "matched_count": 0,
+        "matched_bytes": 0,
+        "unmatched_count": 1,
+    }
 
     rows = _blob_refs_rows(archive_root)
     assert ("hook_payload", "hook-matched") in rows
@@ -121,12 +148,200 @@ def test_apply_rekeys_only_the_confirmed_match(tmp_path: Path, monkeypatch: pyte
         ).fetchone()[0]
         assert blob_hash is not None
 
+    receipt = [json.loads(line) for line in receipt_path.read_text(encoding="utf-8").splitlines()]
+    assert receipt[0]["phase"] == "prepared"
+    assert receipt[0]["tool_version"] == "hook-payload-ref-reconciliation-apply-v1"
+    assert receipt[0]["backup_manifest"]["path"] == str(manifest.resolve())
+    assert receipt[0]["pre_classification"] == {
+        "scanned_count": 2,
+        "matched_count": 1,
+        "matched_bytes": len(b'{"event":"PostToolUse","n":1}'),
+        "unmatched_count": 1,
+    }
+    assert receipt[-1]["terminal_state"] == "committed"
+    assert receipt[-1]["post_classification"] == report.post_classification
+    assert receipt[-1]["reconciled_hook_event_ids"] == ["hook-matched"]
+    assert len(receipt[-1]["reconciled_ids_digest"]) == 64
+
 
 def test_apply_refuses_without_backup_manifest(tmp_path: Path) -> None:
     archive_root = _build_fixture_archive(tmp_path)
     before = _blob_refs_rows(archive_root)
 
     with pytest.raises(HookPayloadRefReconciliationApplyError, match="backup manifest"):
-        apply_hook_payload_ref_reconciliation(archive_root, backup_manifest=None, dry_run=False)
+        apply_hook_payload_ref_reconciliation(
+            archive_root,
+            backup_manifest=None,
+            receipt_path=tmp_path / "receipt.jsonl",
+            dry_run=False,
+        )
 
     assert _blob_refs_rows(archive_root) == before
+
+
+def test_apply_refuses_without_explicit_receipt_output(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    archive_root = _build_fixture_archive(tmp_path)
+    before = _blob_refs_rows(archive_root)
+    _accept_manifest(monkeypatch)
+
+    with pytest.raises(HookPayloadRefReconciliationApplyError, match="receipt output"):
+        apply_hook_payload_ref_reconciliation(
+            archive_root,
+            backup_manifest=_manifest(tmp_path / "verified-backup" / "manifest.json"),
+            dry_run=False,
+        )
+
+    assert _blob_refs_rows(archive_root) == before
+
+
+def test_apply_refuses_when_manifest_validation_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    archive_root = _build_fixture_archive(tmp_path)
+    before = _blob_refs_rows(archive_root)
+    manifest = _manifest(tmp_path / "verified-backup" / "manifest.json")
+    receipt_path = tmp_path / "receipts" / "apply.jsonl"
+
+    def _reject_manifest(_manifest_path: Path, _tier: object, *, connection: sqlite3.Connection) -> Path:
+        assert connection.execute("SELECT 1").fetchone() == (1,)
+        raise ValueError("backup manifest does not match source.db")
+
+    monkeypatch.setattr(
+        "polylogue.maintenance.hook_payload_ref_reconciliation_apply.validate_migration_backup_manifest",
+        _reject_manifest,
+    )
+    with pytest.raises(ValueError, match="does not match"):
+        apply_hook_payload_ref_reconciliation(
+            archive_root,
+            backup_manifest=manifest,
+            receipt_path=receipt_path,
+            dry_run=False,
+        )
+
+    assert _blob_refs_rows(archive_root) == before
+    assert not receipt_path.exists()
+
+
+def test_apply_refuses_when_offline_guard_blocks(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    archive_root = _build_fixture_archive(tmp_path)
+    before = _blob_refs_rows(archive_root)
+    _accept_manifest(monkeypatch)
+    monkeypatch.setattr(
+        "polylogue.maintenance.hook_payload_ref_reconciliation_apply.offline_maintenance_block_reason",
+        lambda *_args, **_kwargs: "source maintenance requires the daemon to be offline",
+    )
+
+    with pytest.raises(HookPayloadRefReconciliationApplyError, match="daemon to be offline"):
+        apply_hook_payload_ref_reconciliation(
+            archive_root,
+            backup_manifest=_manifest(tmp_path / "verified-backup" / "manifest.json"),
+            receipt_path=tmp_path / "receipts" / "apply.jsonl",
+            dry_run=False,
+        )
+
+    assert _blob_refs_rows(archive_root) == before
+
+
+def test_apply_leaves_same_path_non_exact_orphan_untouched(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    archive_root = _build_fixture_archive(tmp_path)
+    _accept_manifest(monkeypatch)
+    wrong_blob_hash = deterministic_blob_hash(b"same source path, wrong deterministic identity")
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, 'not-the-exact-hook-id', 'raw_payload', '/hooks/matched.jsonl', 3, 1)
+            """,
+            (wrong_blob_hash,),
+        )
+        conn.commit()
+
+    apply_hook_payload_ref_reconciliation(
+        archive_root,
+        backup_manifest=_manifest(tmp_path / "verified-backup" / "manifest.json"),
+        receipt_path=tmp_path / "receipts" / "apply.jsonl",
+        dry_run=False,
+    )
+
+    assert ("raw_payload", "not-the-exact-hook-id") in _blob_refs_rows(archive_root)
+
+
+def test_existing_prepared_receipt_is_recovered_after_committed_transaction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive_root = _build_fixture_archive(tmp_path)
+    _accept_manifest(monkeypatch)
+    manifest = _manifest(tmp_path / "verified-backup" / "manifest.json")
+    receipt_path = tmp_path / "receipts" / "prepared.jsonl"
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        plan = plan_hook_payload_ref_reconciliation(conn)
+        candidate = plan.matched[0]
+        write_prepared_receipt(
+            receipt_path,
+            source_db=archive_root / "source.db",
+            tool_version="hook-payload-ref-reconciliation-apply-v1",
+            backup_manifest=backup_manifest_identity(manifest),
+            plan=plan,
+        )
+        conn.execute(
+            "DELETE FROM blob_refs WHERE blob_hash = ? AND ref_type = 'raw_payload' AND ref_id = ?",
+            (candidate.blob_hash, candidate.orphaned_ref_id),
+        )
+        conn.execute(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, ?, 'hook_payload', ?, ?, ?)
+            """,
+            (
+                candidate.blob_hash,
+                candidate.hook_event_id,
+                candidate.source_path,
+                candidate.size_bytes,
+                candidate.acquired_at_ms,
+            ),
+        )
+        conn.execute(
+            "UPDATE raw_hook_events SET blob_hash = ? WHERE hook_event_id = ?",
+            (candidate.blob_hash, candidate.hook_event_id),
+        )
+        conn.commit()
+
+    with pytest.raises(
+        HookPayloadRefReconciliationApplyError, match="recovered existing prepared receipt as recovered_committed"
+    ):
+        apply_hook_payload_ref_reconciliation(
+            archive_root,
+            backup_manifest=manifest,
+            receipt_path=receipt_path,
+            dry_run=False,
+        )
+
+    receipt = [json.loads(line) for line in receipt_path.read_text(encoding="utf-8").splitlines()]
+    assert receipt[-1]["terminal_state"] == "recovered_committed"
+    assert receipt[-1]["post_classification"] == {
+        "scanned_count": 1,
+        "matched_count": 0,
+        "matched_bytes": 0,
+        "unmatched_count": 1,
+    }
+
+
+def test_apply_records_empty_reconciliation_digest(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    archive_root = _build_fixture_archive(tmp_path)
+    _accept_manifest(monkeypatch)
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        conn.execute("DELETE FROM blob_refs WHERE ref_id = ?", ("raw-no-candidate",))
+        conn.execute("DELETE FROM blob_refs WHERE ref_type = 'raw_payload' AND ref_id != ?", ("raw-no-candidate",))
+        conn.commit()
+
+    receipt_path = tmp_path / "receipts" / "empty.jsonl"
+    report = apply_hook_payload_ref_reconciliation(
+        archive_root,
+        backup_manifest=_manifest(tmp_path / "verified-backup" / "manifest.json"),
+        receipt_path=receipt_path,
+        dry_run=False,
+    )
+
+    assert report.reconciled_hook_event_ids == ()
+    receipt = [json.loads(line) for line in receipt_path.read_text(encoding="utf-8").splitlines()]
+    assert receipt[-1]["terminal_state"] == "committed"
+    assert receipt[-1]["reconciled_hook_event_ids"] == []
+    assert len(receipt[-1]["reconciled_ids_digest"]) == 64


### PR DESCRIPTION
## Summary

Adds `polylogue ops maintenance hook-payload-ref-reconcile`, a dry-run-first operator command for historical hook-payload blob-reference re-keying.

## Problem

Historical hook payloads can retain orphaned `raw_payload` references. The existing exact-match actuator had no CLI entrypoint or recoverable external receipt for a source-tier apply.

## Solution

The command emits plain or JSON classification output by default without mutation. `--apply` requires offline maintenance status, a verified source backup manifest, and a fresh `--receipt-file`. The apply path writes and fsyncs an exclusive prepared JSONL receipt before its locked re-key transaction, then records exact post-classification counts and a committed or recovered terminal state. The receipt includes the tool version, backup-manifest SHA-256 identity, candidate/reconciled identifiers and stable digests.

Acceptance criteria:

- [x] Registered dry-run CLI with plain and JSON output.
- [x] Apply gate: offline status, verified source manifest, explicit receipt path.
- [x] Recoverable immutable receipt with pre/post counts and terminal state.
- [x] Exact-match reclassification remains inside one `BEGIN IMMEDIATE` transaction with `quick_check`; unmatched rows remain untouched.
- [x] CLI and source-tier transaction tests cover regression removal of every required guard.

## Verification

- `direnv exec . devtools test tests/unit/maintenance/test_hook_payload_ref_reconciliation_apply.py tests/unit/cli/test_hook_payload_ref_reconciliation_cli.py tests/unit/cli/test_maintenance_registration.py` : 24 passed.
- `direnv exec . devtools test tests/unit/maintenance/test_hook_payload_ref_reconciliation_apply.py` : 9 passed after the zero-match receipt regression test.
- `direnv exec . devtools verify docs-coverage` : every public surface reachable.
- `direnv exec . devtools verify --quick` : success.

No production archive data was accessed or mutated.

## Adversarial review notes

Local closure review found that a successful zero-match apply did not serialize an explicit reconciled-id digest. The final patch records an empty id list and digest, with regression coverage. Independent runtime review was unavailable because the local Codex worker could not initialize its read-only system-skill directory and the local Claude runtime had exhausted its weekly allowance.