### PR TITLE
fix(daemon): distinguish deferred convergence debt (#3714)

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -1452,6 +1452,7 @@ def _archive_hermes_integration_health(config: Config) -> HermesIntegrationHealt
     debt = convergence_debt_summary_info(archive_root / "source.db")
     family_summary = next((item for item in debt.family_summaries if item.family == hermes_family), None)
     convergence_debt_failed_count = family_summary.failed_count if family_summary is not None else 0
+    convergence_debt_deferred_count = family_summary.deferred_count if family_summary is not None else 0
     convergence_debt_retry_due_count = sum(
         1
         for item in debt.recent
@@ -1462,6 +1463,7 @@ def _archive_hermes_integration_health(config: Config) -> HermesIntegrationHealt
         archive_root,
         hermes_root=hermes_root,
         convergence_debt_failed_count=convergence_debt_failed_count,
+        convergence_debt_deferred_count=convergence_debt_deferred_count,
         convergence_debt_retry_due_count=convergence_debt_retry_due_count,
     )
 

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -1268,6 +1268,16 @@ def _show_daemon_status(env: AppEnv, status: dict[str, Any], *, compact: bool = 
             if parts:
                 env.ui.console.print(f"  Ingest: {', '.join(parts)}")
 
+    convergence = status.get("convergence", {})
+    if isinstance(convergence, dict):
+        failed_count = int(convergence.get("failed_count", 0) or 0)
+        deferred_count = int(convergence.get("deferred_count", 0) or 0)
+        retry_due_count = int(convergence.get("retry_due_count", 0) or 0)
+        if failed_count or deferred_count:
+            env.ui.console.print(
+                f"  Convergence debt: {failed_count} failed, {deferred_count} deferred, {retry_due_count} retry due"
+            )
+
     # FTS
     fts = status.get("fts_readiness", {})
     if isinstance(fts, dict):

--- a/polylogue/daemon/convergence_debt_alert.py
+++ b/polylogue/daemon/convergence_debt_alert.py
@@ -223,6 +223,8 @@ def aggregate_debt_by_family(summary: ConvergenceDebtSummary) -> dict[str, int]:
     """
     counts: dict[str, int] = {}
     for item in summary.recent:
+        if item.status != "failed":
+            continue
         family = source_family_for_subject(item.subject_type, item.subject_id)
         counts[family] = counts.get(family, 0) + 1
     return counts

--- a/polylogue/daemon/convergence_debt_status.py
+++ b/polylogue/daemon/convergence_debt_status.py
@@ -20,6 +20,7 @@ logger = get_logger(__name__)
 class ConvergenceDebtStageSummary(BaseModel):
     stage: str
     failed_count: int = 0
+    deferred_count: int = 0
     retry_due_count: int = 0
 
 
@@ -28,6 +29,7 @@ class ConvergenceDebtFamilySummary(BaseModel):
 
     family: str
     failed_count: int = 0
+    deferred_count: int = 0
 
 
 class ConvergenceDebtItem(BaseModel):
@@ -44,6 +46,7 @@ class ConvergenceDebtItem(BaseModel):
 
 class ConvergenceDebtSummary(BaseModel):
     failed_count: int = 0
+    deferred_count: int = 0
     retry_due_count: int = 0
     stage_summaries: list[ConvergenceDebtStageSummary] = Field(default_factory=list)
     family_summaries: list[ConvergenceDebtFamilySummary] = Field(default_factory=list)
@@ -105,26 +108,36 @@ def _archive_convergence_debt_summary_info(dbf: Path, ops_db: Path) -> Convergen
             last_error=_optional_str(row[6]),
         )
         for row in rows
-        if _required_str(row[3]) == "failed"
     ]
     if not items:
         return ConvergenceDebtSummary()
 
     now = datetime.now(UTC)
-    recent = [item.model_copy(update={"retry_due": _retry_due(item.next_retry_at, now=now)}) for item in items[:10]]
+    recent = [
+        item.model_copy(update={"retry_due": item.status == "failed" and _retry_due(item.next_retry_at, now=now)})
+        for item in items[:10]
+    ]
     failed_by_stage: dict[str, int] = {}
+    deferred_by_stage: dict[str, int] = {}
     retry_due_by_stage: dict[str, int] = {}
     for item in items:
-        failed_by_stage[item.stage] = failed_by_stage.get(item.stage, 0) + 1
-        if _retry_due(item.next_retry_at, now=now):
-            retry_due_by_stage[item.stage] = retry_due_by_stage.get(item.stage, 0) + 1
+        if item.status == "failed":
+            failed_by_stage[item.stage] = failed_by_stage.get(item.stage, 0) + 1
+            if _retry_due(item.next_retry_at, now=now):
+                retry_due_by_stage[item.stage] = retry_due_by_stage.get(item.stage, 0) + 1
+        elif item.status == "deferred":
+            deferred_by_stage[item.stage] = deferred_by_stage.get(item.stage, 0) + 1
     stage_summaries = [
         ConvergenceDebtStageSummary(
             stage=stage,
-            failed_count=failed_count,
+            failed_count=failed_by_stage.get(stage, 0),
+            deferred_count=deferred_by_stage.get(stage, 0),
             retry_due_count=retry_due_by_stage.get(stage, 0),
         )
-        for stage, failed_count in sorted(failed_by_stage.items(), key=lambda item: (-item[1], item[0]))
+        for stage in sorted(
+            set(failed_by_stage) | set(deferred_by_stage),
+            key=lambda stage: (-(failed_by_stage.get(stage, 0) + deferred_by_stage.get(stage, 0)), stage),
+        )
     ]
     return _summary_from_parts(stage_summaries=stage_summaries, recent=recent)
 
@@ -141,17 +154,26 @@ def _summary_from_parts(
     # operators can correlate alert messages with status output directly.
     from polylogue.daemon.convergence_debt_alert import source_family_for_subject
 
-    family_counts: dict[str, int] = {}
+    family_counts: dict[str, dict[str, int]] = {}
     for item in recent:
         family = source_family_for_subject(item.subject_type, item.subject_id)
-        family_counts[family] = family_counts.get(family, 0) + 1
+        counts = family_counts.setdefault(family, {"failed": 0, "deferred": 0})
+        if item.status in counts:
+            counts[item.status] += 1
     family_summaries = [
-        ConvergenceDebtFamilySummary(family=family, failed_count=count)
-        for family, count in sorted(family_counts.items(), key=lambda kv: (-kv[1], kv[0]))
+        ConvergenceDebtFamilySummary(
+            family=family,
+            failed_count=counts["failed"],
+            deferred_count=counts["deferred"],
+        )
+        for family, counts in sorted(
+            family_counts.items(), key=lambda kv: (-(kv[1]["failed"] + kv[1]["deferred"]), kv[0])
+        )
     ]
 
     return ConvergenceDebtSummary(
         failed_count=sum(item.failed_count for item in stage_summaries),
+        deferred_count=sum(item.deferred_count for item in stage_summaries),
         retry_due_count=sum(item.retry_due_count for item in stage_summaries),
         stage_summaries=stage_summaries,
         family_summaries=family_summaries,

--- a/polylogue/daemon/metrics.py
+++ b/polylogue/daemon/metrics.py
@@ -44,7 +44,7 @@ varies on a known-bounded dimension):
 - ``polylogue_live_ingest_storage_route_total`` (counter) — labels: route
 - ``polylogue_live_ingest_attempt_duration_seconds`` (gauge buckets:
   min, mean, max derived from recent completed attempts)
-- ``polylogue_convergence_debt_count`` (gauge) — labels: stage
+- ``polylogue_convergence_debt_count`` (gauge) — labels: stage, status
 - ``polylogue_fts_trigger_present`` (gauge) — labels: trigger
 - ``polylogue_fts_triggers_all_present`` (gauge, 0/1)
 - ``polylogue_fts_freshness_ready`` (gauge, 0/1) — labels: surface
@@ -372,7 +372,7 @@ def _ops_recent_attempt_durations(ops_db: Path, *, limit: int = 50) -> list[floa
     return [max(0.0, (int(row[1]) - int(row[0])) / 1000.0) for row in rows if row[0] is not None and row[1] is not None]
 
 
-def _convergence_debt_by_stage(conn: sqlite3.Connection, *, ops_db: Path | None = None) -> list[tuple[str, int]]:
+def _convergence_debt_by_stage(conn: sqlite3.Connection, *, ops_db: Path | None = None) -> list[tuple[str, str, int]]:
     ops_rows = _ops_convergence_debt_by_stage(ops_db) if ops_db is not None else []
     if ops_rows:
         return ops_rows
@@ -380,17 +380,17 @@ def _convergence_debt_by_stage(conn: sqlite3.Connection, *, ops_db: Path | None 
         return []
     rows = conn.execute(
         """
-        SELECT stage, COUNT(*)
+        SELECT stage, status, COUNT(*)
         FROM live_convergence_debt
-        WHERE status != 'resolved'
-        GROUP BY stage
-        ORDER BY stage
+        WHERE status IN ('failed', 'deferred')
+        GROUP BY stage, status
+        ORDER BY stage, status
         """
     ).fetchall()
-    return [(str(row[0] or "unknown"), int(row[1] or 0)) for row in rows]
+    return [(str(row[0] or "unknown"), str(row[1] or "unknown"), int(row[2] or 0)) for row in rows]
 
 
-def _ops_convergence_debt_by_stage(ops_db: Path | None) -> list[tuple[str, int]]:
+def _ops_convergence_debt_by_stage(ops_db: Path | None) -> list[tuple[str, str, int]]:
     if ops_db is None or not ops_db.exists():
         return []
     from polylogue.storage.sqlite.connection_profile import open_readonly_connection
@@ -402,10 +402,10 @@ def _ops_convergence_debt_by_stage(ops_db: Path | None) -> list[tuple[str, int]]
                 return []
             rows = conn.execute(
                 """
-                SELECT stage, COUNT(*)
+                SELECT stage, status, COUNT(*)
                 FROM convergence_debt
-                GROUP BY stage
-                ORDER BY stage
+                GROUP BY stage, status
+                ORDER BY stage, status
                 """
             ).fetchall()
         finally:
@@ -413,7 +413,7 @@ def _ops_convergence_debt_by_stage(ops_db: Path | None) -> list[tuple[str, int]]
     except sqlite3.Error as exc:
         logger.warning("metrics: ops convergence-debt-by-stage query failed for %s: %s", ops_db, exc, exc_info=True)
         return []
-    return [(str(row[0] or "unknown"), int(row[1] or 0)) for row in rows]
+    return [(str(row[0] or "unknown"), str(row[1] or "unknown"), int(row[2] or 0)) for row in rows]
 
 
 def _fts_trigger_presence(conn: sqlite3.Connection) -> dict[str, bool]:
@@ -1201,15 +1201,15 @@ def format_metrics(
             _emit_metric(
                 lines,
                 name="polylogue_convergence_debt_count",
-                help_text="Unresolved convergence-debt rows by stage.",
+                help_text="Unresolved convergence-debt rows by stage and status.",
                 metric_type="gauge",
-                samples=[({"stage": stage}, count) for stage, count in debt],
+                samples=[({"stage": stage, "status": status}, count) for stage, status, count in debt],
             )
         else:
             _emit_metric(
                 lines,
                 name="polylogue_convergence_debt_count",
-                help_text="Unresolved convergence-debt rows by stage.",
+                help_text="Unresolved convergence-debt rows by stage and status.",
                 metric_type="gauge",
                 samples=[(None, 0)],
             )
@@ -1326,9 +1326,9 @@ def _format_ops_only_metrics(lines: list[str], ops_db: Path) -> str | None:
     _emit_metric(
         lines,
         name="polylogue_convergence_debt_count",
-        help_text="Unresolved convergence-debt rows by stage.",
+        help_text="Unresolved convergence-debt rows by stage and status.",
         metric_type="gauge",
-        samples=[({"stage": stage}, count) for stage, count in debt] if debt else [(None, 0)],
+        samples=[({"stage": stage, "status": status}, count) for stage, status, count in debt] if debt else [(None, 0)],
     )
     _emit_metric(
         lines,

--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -3087,8 +3087,9 @@ def format_daemon_status_lines(payload: JSONDocument) -> list[str]:
     convergence = payload.get("convergence")
     if isinstance(convergence, dict):
         failed_count = _safe_int(convergence.get("failed_count"))
+        deferred_count = _safe_int(convergence.get("deferred_count"))
         retry_due_count = _safe_int(convergence.get("retry_due_count"))
-        lines.append(f"Convergence debt: {failed_count} failed, {retry_due_count} retry due")
+        lines.append(f"Convergence debt: {failed_count} failed, {deferred_count} deferred, {retry_due_count} retry due")
         stages = convergence.get("stage_summaries")
         if isinstance(stages, list):
             for stage in stages[:5]:
@@ -3096,6 +3097,7 @@ def format_daemon_status_lines(payload: JSONDocument) -> list[str]:
                     lines.append(
                         "  "
                         f"{stage.get('stage')}: {stage.get('failed_count', 0)} failed, "
+                        f"{stage.get('deferred_count', 0)} deferred, "
                         f"{stage.get('retry_due_count', 0)} retry due"
                     )
         families = convergence.get("family_summaries")
@@ -3103,7 +3105,10 @@ def format_daemon_status_lines(payload: JSONDocument) -> list[str]:
             lines.append("  by source family:")
             for family in families[:5]:
                 if isinstance(family, dict):
-                    lines.append(f"    {family.get('family')}: {family.get('failed_count', 0)} failed")
+                    lines.append(
+                        f"    {family.get('family')}: {family.get('failed_count', 0)} failed, "
+                        f"{family.get('deferred_count', 0)} deferred"
+                    )
     # Cursor lag summary (#1232) — degraded cursors are outside the lag SLO,
     # but must be surfaced even when no ordinary cursor is stuck.
     cursor_lag = payload.get("cursor_lag")

--- a/polylogue/insights/hermes_integration_health.py
+++ b/polylogue/insights/hermes_integration_health.py
@@ -131,6 +131,7 @@ class HermesIntegrationHealth:
     parser_failures: tuple[HermesParserFailure, ...] = ()
     fidelity_capabilities: tuple[HermesFidelityCapabilityStatus, ...] = ()
     convergence_debt_failed_count: int = 0
+    convergence_debt_deferred_count: int = 0
     convergence_debt_retry_due_count: int = 0
     lifecycle_debt: HermesLifecycleDebtSummary = field(
         default_factory=lambda: HermesLifecycleDebtSummary(0, 0, 0, 0, ())
@@ -212,6 +213,7 @@ def build_hermes_integration_health(
     source_limit: int = _DEFAULT_SOURCE_LIMIT,
     session_limit: int = _DEFAULT_SESSION_LIMIT,
     convergence_debt_failed_count: int = 0,
+    convergence_debt_deferred_count: int = 0,
     convergence_debt_retry_due_count: int = 0,
 ) -> HermesIntegrationHealth:
     """Project one bounded Hermes integration health rollup.
@@ -223,7 +225,8 @@ def build_hermes_integration_health(
     filenames, not absolute paths, and evidence refs/ids, never rendered
     bytes or transcript text.
 
-    ``convergence_debt_failed_count``/``convergence_debt_retry_due_count``
+    ``convergence_debt_failed_count``/``convergence_debt_deferred_count``/
+    ``convergence_debt_retry_due_count``
     are pre-computed by the caller (bucketed to the Hermes source family via
     :func:`polylogue.daemon.convergence_debt_status.convergence_debt_summary_info`)
     because this module may not import ``polylogue.daemon`` directly.
@@ -355,6 +358,7 @@ def build_hermes_integration_health(
         parser_failures=parser_failures,
         fidelity_capabilities=tuple(sorted(capability_totals.values(), key=lambda item: item.capability)),
         convergence_debt_failed_count=convergence_debt_failed_count,
+        convergence_debt_deferred_count=convergence_debt_deferred_count,
         convergence_debt_retry_due_count=convergence_debt_retry_due_count,
         lifecycle_debt=lifecycle_debt,
         delivery_correlation=delivery_correlation,

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -1649,6 +1649,23 @@ class TestNoArchiveStatus:
 
         assert "87.5% indexed" in _combined_calls(env)
 
+    def test_daemon_status_renders_failed_and_deferred_convergence_debt_separately(self) -> None:
+        env = _make_app_env()
+
+        _show_daemon_status(
+            env,
+            {
+                "daemon_liveness": True,
+                "convergence": {
+                    "failed_count": 1,
+                    "deferred_count": 2,
+                    "retry_due_count": 1,
+                },
+            },
+        )
+
+        assert "Convergence debt: 1 failed, 2 deferred, 1 retry due" in _combined_calls(env)
+
     def test_daemon_status_treats_null_fts_coverage_as_unknown_progress(self) -> None:
         """A null coverage_pct must render as explicitly unknown, never a
         fabricated percentage (polylogue-roax): defaulting an unmeasured

--- a/tests/unit/daemon/test_convergence_debt_alert.py
+++ b/tests/unit/daemon/test_convergence_debt_alert.py
@@ -88,7 +88,8 @@ def test_convergence_debt_summary_does_not_count_deferred_as_failed(tmp_path: Pa
     summary = convergence_debt_summary_info(db_path)
 
     assert summary.failed_count == 1
-    assert [item.subject_id for item in summary.recent] == ["conv-failed"]
+    assert summary.deferred_count == 1
+    assert {item.status for item in summary.recent} == {"failed", "deferred"}
 
 
 def test_convergence_debt_summary_prefers_populated_archive_ops(tmp_path: Path) -> None:
@@ -209,7 +210,8 @@ def test_convergence_debt_summary_treats_archive_deferred_as_authoritative(tmp_p
     summary = convergence_debt_summary_info(db_path)
 
     assert summary.failed_count == 0
-    assert summary.recent == []
+    assert summary.deferred_count == 1
+    assert summary.recent[0].status == "deferred"
 
 
 def test_convergence_debt_summary_ignores_old_single_file_debt_when_ops_empty(tmp_path: Path) -> None:
@@ -350,6 +352,17 @@ def test_evaluate_emits_no_alerts_when_below_warning() -> None:
     thresholds = ConvergenceDebtThresholds(default_warning=5, default_error=10)
     state = AlertDedupState()
     summary = _summary([_item(subject_id="/x/a.jsonl")])  # only one item
+
+    alerts = evaluate_convergence_debt(summary, thresholds=thresholds, state=state, now=0.0)
+
+    assert alerts == []
+
+
+def test_evaluate_ignores_deliberate_deferred_debt() -> None:
+    thresholds = ConvergenceDebtThresholds(default_warning=1, default_error=1)
+    state = AlertDedupState()
+    deferred = _item(subject_id="/x/deferred.jsonl").model_copy(update={"status": "deferred", "retry_due": False})
+    summary = ConvergenceDebtSummary(deferred_count=1, recent=[deferred])
 
     alerts = evaluate_convergence_debt(summary, thresholds=thresholds, state=state, now=0.0)
 

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -1301,6 +1301,13 @@ def test_daemon_status_reports_convergence_debt_separately(tmp_path: Path) -> No
         subject_id=str(source),
         error="legacy payload missing provenance",
     )
+    cursor.record_convergence_debt(
+        stage="fts",
+        subject_type="source_path",
+        subject_id=str(source),
+        error="bounded work deferred",
+        deferred=True,
+    )
 
     with (
         patch("polylogue.daemon.status.archive_root", return_value=db.parent),
@@ -1315,19 +1322,20 @@ def test_daemon_status_reports_convergence_debt_separately(tmp_path: Path) -> No
     convergence = payload["convergence"]
     assert isinstance(convergence, dict)
     assert convergence["failed_count"] == 1
+    assert convergence["deferred_count"] == 1
     stages = convergence["stage_summaries"]
     assert isinstance(stages, list)
-    first_stage = stages[0]
-    assert isinstance(first_stage, dict)
-    assert first_stage["stage"] == "insights"
+    assert {stage["stage"] for stage in stages if isinstance(stage, dict)} == {"fts", "insights"}
     recent = convergence["recent"]
     assert isinstance(recent, list)
     first_recent = recent[0]
     assert isinstance(first_recent, dict)
     assert first_recent["subject_id"] == str(source)
+    assert {item["status"] for item in recent if isinstance(item, dict)} == {"failed", "deferred"}
     lines = format_daemon_status_lines(payload)
-    assert "Convergence debt: 1 failed, 0 retry due" in lines
-    assert "  insights: 1 failed, 0 retry due" in lines
+    assert "Convergence debt: 1 failed, 1 deferred, 0 retry due" in lines
+    assert "  insights: 1 failed, 0 deferred, 0 retry due" in lines
+    assert "  fts: 0 failed, 1 deferred, 0 retry due" in lines
 
 
 def test_daemon_status_payload_exposes_claim_guard_block(tmp_path: Path) -> None:

--- a/tests/unit/daemon/test_metrics_endpoint.py
+++ b/tests/unit/daemon/test_metrics_endpoint.py
@@ -403,6 +403,7 @@ class TestFormatMetricsReadsArchiveState:
                     ("d1", "parse", "failed"),
                     ("d2", "parse", "failed"),
                     ("d3", "convergence", "failed"),
+                    ("d5", "convergence", "deferred"),
                     ("d4", "convergence", "resolved"),  # filtered
                 ],
             )
@@ -483,8 +484,9 @@ class TestFormatMetricsReadsArchiveState:
 
     def test_convergence_debt_grouped_by_stage(self, tmp_path: Path) -> None:
         body = format_metrics(self._make_db(tmp_path))
-        assert 'polylogue_convergence_debt_count{stage="convergence"} 1' in body
-        assert 'polylogue_convergence_debt_count{stage="parse"} 2' in body
+        assert 'polylogue_convergence_debt_count{stage="convergence",status="failed"} 1' in body
+        assert 'polylogue_convergence_debt_count{stage="convergence",status="deferred"} 1' in body
+        assert 'polylogue_convergence_debt_count{stage="parse",status="failed"} 2' in body
 
     def test_convergence_debt_prefers_archive_ops(self, tmp_path: Path) -> None:
         from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
@@ -511,10 +513,20 @@ class TestFormatMetricsReadsArchiveState:
                 attempts=1,
                 created_at_ms=1_770_000_001_000,
             )
+            add_convergence_debt(
+                conn,
+                stage="session_profile",
+                target_type="session_id",
+                target_id="conv-3",
+                status="deferred",
+                attempts=1,
+                created_at_ms=1_770_000_002_000,
+            )
 
         body = format_metrics(db)
 
-        assert 'polylogue_convergence_debt_count{stage="session_profile"} 2' in body
+        assert 'polylogue_convergence_debt_count{stage="session_profile",status="failed"} 2' in body
+        assert 'polylogue_convergence_debt_count{stage="session_profile",status="deferred"} 1' in body
         assert 'polylogue_convergence_debt_count{stage="parse"}' not in body
 
     def test_live_ingest_metrics_prefer_archive_ops_when_present(self, tmp_path: Path) -> None:
@@ -623,7 +635,7 @@ class TestFormatMetricsReadsArchiveState:
 
         assert 'polylogue_live_ingest_attempts_total{status="running"} 1' in body
         assert "polylogue_live_ingest_attempts_in_flight 1" in body
-        assert 'polylogue_convergence_debt_count{stage="session_profile"} 1' in body
+        assert 'polylogue_convergence_debt_count{stage="session_profile",status="failed"} 1' in body
 
     def test_fts_trigger_presence_partial(self, tmp_path: Path) -> None:
         body = format_metrics(self._make_db(tmp_path))

--- a/tests/unit/insights/test_hermes_integration_health.py
+++ b/tests/unit/insights/test_hermes_integration_health.py
@@ -92,6 +92,21 @@ def test_unavailable_when_archive_root_is_absent(tmp_path: Path) -> None:
     assert any("archive root does not exist" in caveat for caveat in health.caveats)
 
 
+def test_deferred_convergence_debt_is_reported_without_degrading(workspace_env: dict[str, Path]) -> None:
+    hermes_root = workspace_env["data_root"] / "hermes-deferred-debt"
+    hermes_root.mkdir(parents=True)
+
+    health = build_hermes_integration_health(
+        workspace_env["archive_root"],
+        hermes_root=hermes_root,
+        convergence_debt_deferred_count=2,
+    )
+
+    assert health.convergence_debt_failed_count == 0
+    assert health.convergence_debt_deferred_count == 2
+    assert health.verdict == "healthy"
+
+
 def test_malformed_event_renders_explicit_parser_failure(workspace_env: dict[str, Path]) -> None:
     """A non-JSON file under the Hermes root is surfaced as a named parser failure, not dropped."""
 

--- a/tests/unit/sources/test_convergence_debt_deferred_vocabulary.py
+++ b/tests/unit/sources/test_convergence_debt_deferred_vocabulary.py
@@ -17,6 +17,7 @@ independent of any one stage's error text.
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 from polylogue.daemon.convergence import FileState, StageState
@@ -26,6 +27,8 @@ from polylogue.sources.live.convergence_debt import (
     convergence_debt_from_states,
     is_deferred_stage_state,
 )
+from polylogue.sources.live.convergence_outcome import record_convergence_outcome
+from polylogue.sources.live.cursor import CursorStore
 
 
 def test_is_deferred_stage_state_true_only_for_pending() -> None:
@@ -102,3 +105,50 @@ def test_convergence_debt_from_states_propagates_deferred_flag() -> None:
 
     assert len(debts) == 1
     assert debts[0].deferred is True
+
+
+def test_record_convergence_outcome_persists_deferred_and_failed_statuses(tmp_path: Path) -> None:
+    """The post-ingest route must preserve classification in the ops ledger.
+
+    This exercises the production bridge from ``FileState`` classification
+    through ``record_convergence_outcome`` and ``CursorStore``. A test that
+    only checks the dataclass flag would pass even if the writer silently
+    converted every row back to ``status = 'failed'``.
+    """
+    deferred_path = tmp_path / "deferred.jsonl"
+    failed_path = tmp_path / "failed.jsonl"
+    deferred_debts = convergence_debt_from_state(
+        deferred_path,
+        FileState(
+            path=deferred_path,
+            stages={"fts": StageState.PENDING},
+            last_error="stage fts returned False",
+        ),
+    )
+    failed_debts = convergence_debt_from_state(
+        failed_path,
+        FileState(
+            path=failed_path,
+            stages={"fts": StageState.FAILED},
+            last_error="fts writer failed",
+        ),
+    )
+    cursor = CursorStore(tmp_path / "live.sqlite")
+
+    record_convergence_outcome(cursor, deferred_path, deferred_debts)
+    record_convergence_outcome(cursor, failed_path, failed_debts)
+
+    with sqlite3.connect(tmp_path / "ops.db") as conn:
+        rows = dict(
+            conn.execute(
+                """
+                SELECT target_id, status
+                FROM convergence_debt
+                WHERE target_type = 'source_path'
+                """
+            ).fetchall()
+        )
+    assert rows == {
+        str(deferred_path): "deferred",
+        str(failed_path): "failed",
+    }


### PR DESCRIPTION
## Summary

Preserve the convergence-debt status taxonomy through the writer and every operator-facing read surface. Deliberate bounded-work deferrals are reported as `deferred`; genuine failures remain the only alertable debt.

## Problem

`convergence_debt` accepts `failed` and `deferred`, but intentional `false_means_pending` work had been operationally indistinguishable from stage exceptions. Status and metrics could not give operators a trustworthy failure signal.

## Solution

- Cherry-pick the predecessor regression test that drives `FileState` through `record_convergence_outcome` and `CursorStore` into the ops ledger.
- Project failed and deferred counts, per-stage summaries, families, and recent debt separately.
- Restrict health alert aggregation to `failed`, while daemon and CLI status report both statuses.
- Add the `status` label to `polylogue_convergence_debt_count` and carry deferred debt through the Hermes API health response without degrading its verdict.

## Acceptance criteria

| Criterion | Status | Evidence |
| --- | --- | --- |
| Intentional pending work persists as `deferred`; exceptions persist as `failed` | Satisfied | Production writer regression test |
| Health alerts only on genuine failures | Satisfied | Deferred-only alert evaluation test |
| Status, CLI, API, and metrics distinguish both states | Satisfied | Status and CLI rendering tests, Hermes health payload test, metrics exposition tests |
| Excluded areas remain untouched | Satisfied | No raw authority, blob namespace, audit tier, canary, or schema-inference changes |

## Verification

- `direnv exec . devtools test tests/unit/sources/test_convergence_debt_deferred_vocabulary.py tests/unit/daemon/test_convergence_debt_alert.py tests/unit/daemon/test_daemon_status.py::test_daemon_status_reports_convergence_debt_separately tests/unit/daemon/test_metrics_endpoint.py::TestFormatMetricsReadsArchiveState::test_convergence_debt_grouped_by_stage tests/unit/daemon/test_metrics_endpoint.py::TestFormatMetricsReadsArchiveState::test_convergence_debt_prefers_archive_ops tests/unit/insights/test_hermes_integration_health.py::test_deferred_convergence_debt_is_reported_without_degrading tests/unit/cli/test_status.py::TestNoArchiveStatus::test_daemon_status_renders_failed_and_deferred_convergence_debt_separately` -> `34 passed`.
- `direnv exec . ruff check <touched paths>` -> `All checks passed!`.
- `direnv exec . ruff format --check <touched paths>` -> `13 files already formatted`.

A broader focused-file run confirmed these unrelated baseline failures in `tests/unit/daemon/test_metrics_endpoint.py`: three archive-layout fixture expectations and an embedding catch-up status constraint. The exact rerun reproduced all four; this PR does not touch their code paths.