### PR TITLE
fix(sources): preserve Codex Cloud sidecar authorship

### DIFF
--- a/polylogue/sources/parsers/chatgpt_codex_sidecar.py
+++ b/polylogue/sources/parsers/chatgpt_codex_sidecar.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 
+from polylogue.archive.message.artifacts import classify_material_origin
+from polylogue.archive.message.types import MessageType
 from polylogue.core.enums import BlockType, Provider, Role, SessionRefKind, WebConstructType
 
 from .base import (
@@ -36,6 +38,7 @@ from .base import (
     ParsedSessionEvent,
     ParsedSessionRef,
     ParsedWebConstruct,
+    human_authored_override,
 )
 
 INGEST_FLAG = "capture:chatgpt-codex-cloud-task"
@@ -132,11 +135,28 @@ def _turn_message(turn: Mapping[str, object], *, position: int, parent_id: str |
     blocks: list[ParsedContentBlock] = []
     if constructs:
         blocks.append(ParsedContentBlock(type=BlockType.TEXT, web_constructs=constructs))
+    message_type = MessageType.MESSAGE
     return ParsedMessage(
         provider_message_id=turn_id,
         role=role,
         text=text or None,
         blocks=blocks,
+        message_type=message_type,
+        # codex.json is a ChatGPT-export sidecar, not a local agent transcript:
+        # a role=user MESSAGE turn is positive human evidence. Apply the same
+        # parser-level override as the main chat-export path so this independent
+        # construction route does not depend on ParsedSession's later broad
+        # export upgrade (polylogue-gzgyl continuation).
+        material_origin=human_authored_override(
+            role,
+            message_type,
+            classify_material_origin(
+                role=role,
+                message_type=message_type,
+                text=text or None,
+                block_types=tuple(block.type for block in blocks),
+            ),
+        ),
         parent_message_provider_id=parent_id,
         position=position,
     )

--- a/tests/unit/sources/test_chatgpt_codex_sidecar.py
+++ b/tests/unit/sources/test_chatgpt_codex_sidecar.py
@@ -4,8 +4,11 @@ delivered inside the ChatGPT export.
 
 from __future__ import annotations
 
+from polylogue.archive.message.artifacts import classify_material_origin
 from polylogue.archive.message.roles import Role
-from polylogue.core.enums import Provider, SessionRefKind
+from polylogue.archive.message.types import MessageType
+from polylogue.core.enums import MaterialOrigin, Provider, SessionRefKind
+from polylogue.sources.parsers import chatgpt_codex_sidecar as sidecar_parser
 from polylogue.sources.parsers import codex as codex_parser
 from polylogue.sources.parsers.chatgpt import looks_like_fragment as chatgpt_looks_like_fragment
 from polylogue.sources.parsers.chatgpt_codex_sidecar import INGEST_FLAG, looks_like, parse_codex_task
@@ -100,6 +103,36 @@ class TestParseCodexTask:
         assert [m.role for m in session.messages] == [Role.USER, Role.ASSISTANT]
         assert session.messages[0].text == "Fix the bug."
         assert "Fixed it." in (session.messages[1].text or "")
+
+    def test_turn_builder_records_positive_user_authorship_before_session_upgrade(self) -> None:
+        """The sidecar's own builder must carry the evidence, not only its wrapper.
+
+        ``ParsedSession`` has a broader ChatGPT-export compatibility upgrade,
+        so asserting only on ``parse_codex_task`` would stay green if this
+        independent parser route regressed to the shared UNKNOWN default.
+        Calling the production turn builder directly makes the red twin target
+        the mutation this slice owns.
+        """
+        turns = _TASK["turns"]
+        assert isinstance(turns, list)
+        turn = turns[0]
+        assert isinstance(turn, dict)
+
+        message = sidecar_parser._turn_message(turn, position=0, parent_id=None)
+
+        assert message is not None
+        assert message.material_origin is MaterialOrigin.HUMAN_AUTHORED
+        assert message.material_origin is not classify_material_origin(
+            role=Role.USER,
+            message_type=MessageType.MESSAGE,
+            text="Fix the bug.",
+        )
+
+    def test_full_route_preserves_assistant_authorship(self) -> None:
+        session = parse_codex_task(_TASK, "fallback-0")
+
+        assert session.messages[0].material_origin is MaterialOrigin.HUMAN_AUTHORED
+        assert session.messages[1].material_origin is MaterialOrigin.ASSISTANT_AUTHORED
 
     def test_identity_and_tagging(self) -> None:
         session = parse_codex_task(_TASK, "fallback-0")


### PR DESCRIPTION
## Summary

Preserve parser-level authorship evidence for ChatGPT-export `codex.json` Codex Cloud task turns.

## Problem

The independent sidecar turn builder left genuine user `MESSAGE` turns as `UNKNOWN` until a later `ParsedSession` compatibility upgrade. Its assistant turn was correct only incidentally through the generic wrapper.

## Solution

Classify each sidecar turn with the shared material-origin classifier, then apply the established positive-evidence human override only to a genuine plain user turn. Assistant, tool, and runtime classifications retain the shared classifier result. Focused tests assert authoredness through `parse_codex_task` and call the production builder directly only to catch a regression hidden by the session wrapper.

## Verification

- `devtools test tests/unit/sources/test_chatgpt_codex_sidecar.py` : 20 passed.
- `devtools verify --quick` : exit code 0.
- Pre-push `devtools verify --quick` : exit code 0.