### PR TITLE
test(antigravity): cover acquisition admission contracts (#3717)

### DIFF
--- a/tests/unit/daemon/test_antigravity_conversation_acquisition.py
+++ b/tests/unit/daemon/test_antigravity_conversation_acquisition.py
@@ -25,6 +25,7 @@ from polylogue.daemon.antigravity_conversation_acquisition import (
     acquire_antigravity_conversations_once,
 )
 from polylogue.sources.parsers.antigravity import AntigravitySessionSummary
+from polylogue.storage.blob_store import BlobStore
 
 
 class _FakeLanguageServerClient:
@@ -57,15 +58,17 @@ def _touch_conversation_pb(antigravity_root: Path, *cascade_ids: str) -> None:
         (conversations / f"{cascade_id}.pb").write_bytes(b"fake-protobuf-bytes-" + cascade_id.encode())
 
 
-def _raw_source_paths(source_db: Path) -> list[str]:
+def _raw_pb_blobs_by_source_path(source_db: Path) -> dict[str, str]:
     import sqlite3
 
     conn = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
     try:
-        rows = conn.execute("SELECT source_path FROM raw_sessions WHERE origin = 'antigravity-session'").fetchall()
+        rows = conn.execute(
+            "SELECT source_path, blob_hash FROM raw_sessions WHERE origin = 'antigravity-session'"
+        ).fetchall()
     finally:
         conn.close()
-    return [row[0] for row in rows]
+    return {str(source_path): bytes(blob_hash).hex() for source_path, blob_hash in rows}
 
 
 @pytest.fixture
@@ -105,8 +108,16 @@ def test_acquires_real_pb_conversations_not_yet_in_raw_sessions(
     acquired = acquire_antigravity_conversations_once(archive_root)
 
     assert acquired == 2
-    source_paths = _raw_source_paths(archive_root / "source.db")
-    assert sorted(source_paths) == sorted(str(antigravity_root / "conversations" / f"cascade-{i}.pb") for i in range(2))
+    expected_payloads = {
+        str(path): path.read_bytes() for path in sorted((antigravity_root / "conversations").glob("*.pb"))
+    }
+    raw_blobs = _raw_pb_blobs_by_source_path(archive_root / "source.db")
+
+    assert sorted(raw_blobs) == sorted(expected_payloads)
+    blob_store = BlobStore(archive_root / "blob")
+    assert {
+        source_path: blob_store.read_all(blob_hash) for source_path, blob_hash in raw_blobs.items()
+    } == expected_payloads
 
 
 def test_rerun_after_full_acquisition_is_a_noop(

--- a/tests/unit/sources/test_artifact_taxonomy.py
+++ b/tests/unit/sources/test_artifact_taxonomy.py
@@ -1,7 +1,16 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 from polylogue.archive.artifact_taxonomy import ArtifactKind, classify_artifact, classify_artifact_path
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONValue
+from polylogue.schemas.observation_identity import resolve_provider_config
+from polylogue.schemas.observation_models import ObservationTerminalStatus
+from polylogue.schemas.sampling_db import _iter_schema_units_from_db
+from polylogue.sources.live.batch_support import _parse_path_as_session_artifact
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
 
 def test_relationship_index_jsonl_is_metadata_not_session_stream() -> None:
@@ -181,27 +190,16 @@ def test_workflow_run_snapshot_never_classifies_as_session() -> None:
     assert artifact.parse_as_session is False
 
 
-def test_antigravity_brain_metadata_sidecar_never_schema_eligible_or_session() -> None:
-    """Regression pin for polylogue-3m3de: a real ``brain/<uuid>/*.md.metadata
-    .json`` sidecar (content shape verified against this machine's real
-    ``~/.gemini/antigravity/brain`` corpus, 940 files, 0 leaks) must never
-    become a session, AND must never be ``schema_eligible`` -- the latter is
-    what keeps it out of schema-inference sampling
-    (``schemas/sampling_db.py``'s ``_iter_schema_units_from_db`` already
-    excludes any ``classify_artifact_path`` result with
-    ``schema_eligible=False``, which this pins for antigravity specifically).
+def test_antigravity_brain_metadata_sidecar_is_rejected_from_live_and_schema_routes(
+    tmp_path: Path, workspace_env: dict[str, Path]
+) -> None:
+    """polylogue-3m3de: a realistic brain sidecar is rejected before both
+    live session parsing and schema inference.
 
-    polylogue-3m3de's live measurement (232 growing ``raw_sessions`` rows,
-    zero ``.pb`` conversations acquired) is raw-tier acquisition volume --
-    ``source.db`` durably retains every acquired file regardless of
-    classification, by design -- not evidence that this classification gate
-    is missing; this test locks in that the gate itself is intact. The
-    unaddressed half is acquiring the real ``.pb`` conversations at all: the
-    live daemon watcher only watches ``antigravity`` sources for
-    ``.metadata.json`` (``sources/live/watcher.py``), never ``.pb`` -- a
-    separate acquisition-wiring gap, not a classification one, and out of
-    this fix's scope (would need the language-server RPC bridge wired into
-    the live daemon, not merely a classification tightening).
+    If the path-specific Antigravity sidecar rule is removed, the production
+    classifier admits this payload as a session document. The test therefore
+    traverses real admission boundaries instead of asserting a fixture that
+    neither route consumes.
     """
     real_metadata: JSONValue = {
         "artifactType": "ARTIFACT_TYPE_OTHER",
@@ -213,16 +211,78 @@ def test_antigravity_brain_metadata_sidecar_never_schema_eligible_or_session() -
         ),
         "updatedAt": "2026-01-07T19:08:15.216541610Z",
     }
+    metadata_path = (
+        tmp_path
+        / ".gemini"
+        / "antigravity"
+        / "brain"
+        / "03c22aa3-8b7f-438d-baa8-d12567249cd9"
+        / "comprehensive_audit.md.metadata.json"
+    )
+    metadata_path.parent.mkdir(parents=True)
+    payload = json.dumps(real_metadata).encode("utf-8")
+    metadata_path.write_bytes(payload)
 
     artifact = classify_artifact(
         real_metadata,
-        provider="antigravity",
-        source_path="/tmp/.gemini/antigravity/brain/03c22aa3-8b7f-438d-baa8-d12567249cd9/comprehensive_audit.md.metadata.json",
+        provider=Provider.ANTIGRAVITY,
+        source_path=metadata_path,
     )
 
     assert artifact.kind is ArtifactKind.AGENT_SIDECAR_META
     assert artifact.parse_as_session is False
     assert artifact.schema_eligible is False
+    assert _parse_path_as_session_artifact(metadata_path, provider=Provider.ANTIGRAVITY) is False
+    assert (
+        classify_artifact(
+            real_metadata,
+            provider=Provider.ANTIGRAVITY,
+            source_path=metadata_path.with_name("comprehensive_audit.json"),
+        ).parse_as_session
+        is True
+    )
+
+    archive_root = workspace_env["archive_root"]
+    with ArchiveStore(archive_root) as archive:
+        raw_id = archive.write_raw_payload(
+            provider=Provider.ANTIGRAVITY,
+            payload=payload,
+            source_path=str(metadata_path),
+            acquired_at_ms=1_767_798_895_216,
+        )
+
+    terminals: list[tuple[str, ObservationTerminalStatus, str | None, str | None]] = []
+
+    def record_terminal(
+        *,
+        raw_id: str,
+        status: ObservationTerminalStatus,
+        reason: str | None,
+        artifact_kind: str | None,
+        source_path: str | None,
+    ) -> None:
+        del source_path
+        terminals.append((raw_id, status, reason, artifact_kind))
+
+    units = list(
+        _iter_schema_units_from_db(
+            Provider.ANTIGRAVITY,
+            db_path=archive_root / "index.db",
+            config=resolve_provider_config(Provider.ANTIGRAVITY),
+            terminal_recorder=record_terminal,
+        )
+    )
+
+    assert units == []
+    assert terminals == [
+        (
+            raw_id,
+            "intentionally_excluded",
+            "artifact_taxonomy:Antigravity brain-artifact metadata sidecar "
+            "(superseded by language-server conversation export; polylogue-eo81)",
+            ArtifactKind.AGENT_SIDECAR_META.value,
+        )
+    ]
 
 
 def test_tool_result_sidecar_never_classifies_as_session_even_when_content_looks_like_one() -> None:


### PR DESCRIPTION
## Summary

Strengthens the Antigravity test contract for periodic `.pb` conversation acquisition and metadata-sidecar admission.

## Problem

The previous coverage retained `.pb` source paths but did not prove the blob bytes came from those files. The sidecar test stopped at the classifier and did not traverse the live admission or schema-sampling routes.

## Solution

The periodic-acquisition test reads back each retained source blob and compares it with its discovered `conversations/*.pb` bytes. The sidecar test writes a realistic `brain/<id>/<name>.md.metadata.json` payload into a throwaway archive, proves the live batch gate refuses it, and records schema sampling's taxonomy exclusion. It deliberately proves the same payload becomes session-admissible without the sidecar filename rule.

Ref polylogue-3m3de.

## Verification

- `devtools test tests/unit/daemon/test_antigravity_conversation_acquisition.py` (4 passed)
- `devtools test tests/unit/sources/test_artifact_taxonomy.py -k antigravity` (1 passed)
- `devtools test tests/unit/sources/test_parsers_local_agent.py -k antigravity` (5 passed)
- `devtools test tests/unit/storage/test_antigravity_phantom_sweep.py` (5 passed)
- `devtools verify --commit` (ruff format, ruff check, mypy passed)
- The broader testmon seed could not run because its in-progress cache lacks the checkout marker required by its own guard. The four focused selectors above passed.

## Anti-vacuity

- The `.pb` contract fails if `iter_antigravity_language_server_sessions` stops snapshotting the discovered protobuf file as the raw payload, such as a mutation that retains the exported Markdown bytes instead.
- The sidecar contract fails if the Antigravity `*.md.metadata.json` path rule stops classifying brain metadata as `agent_sidecar_meta`, because the live batch fallback admits the realistic payload and the sampler no longer records taxonomy exclusion.
