### PR TITLE
fix(maintenance): preserve rebuild cursor after interruption

### DIFF
--- a/polylogue/cli/commands/maintenance/_rebuild_index_status.py
+++ b/polylogue/cli/commands/maintenance/_rebuild_index_status.py
@@ -81,10 +81,20 @@ def rebuild_index_status_command(
             f"Transaction:  status={transaction['status']} "
             f"processed_raw_count={transaction['processed_raw_count']:,} "
             f"processed_blob_bytes={transaction['processed_blob_bytes']:,} "
-            f"last_raw_id={transaction['last_raw_id']} updated_at_ms={transaction['updated_at_ms']}"
+            f"last_raw_id={transaction['last_raw_id']} updated_at_ms={transaction['updated_at_ms']} "
+            f"heartbeat_at_ms={transaction.get('heartbeat_at_ms')}"
         )
     else:
         click.echo("Transaction:  none")
+    operation = status["operation"]
+    assert isinstance(operation, dict)
+    owner = operation["owner"]
+    assert isinstance(owner, dict)
+    click.echo(
+        f"Operation:    owner={owner.get('generation_owner_id')} pid={owner.get('pid')} "
+        f"host={owner.get('host')} cursor={operation.get('cursor')} "
+        f"recovery_state={operation.get('recovery_state')}"
+    )
     delta = status["delta"]
     if isinstance(delta, dict):
         click.echo(f"Delta:        source_snapshot_matches={delta['source_snapshot_matches']}")

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -30,6 +30,7 @@ from polylogue.storage.sqlite.delegation_facts import rebuild_all_delegation_fac
 
 if TYPE_CHECKING:
     from polylogue.sources.revision_backfill import RawParsePrefetchCache
+    from polylogue.storage.index_generation import IndexGeneration, IndexRebuildTransaction
 
 _PLANNER_STATS_ANALYSIS_LIMIT = 1000
 # A fresh generation begins with representative bootstrap statistics, but a
@@ -387,6 +388,11 @@ class RebuildIndexReceipt:
     readiness: dict[str, object]
     replay: dict[str, object]
     transaction: dict[str, object] | None = None
+    # Explicit operation evidence, retained in every pass receipt as well as
+    # returned to CLI/HTTP callers.  ``transaction`` remains the backwards
+    # compatible full checkpoint payload; this compact view is the stable
+    # operator contract for ownership, heartbeat, cursor, delta, and recovery.
+    operation: dict[str, object] = field(default_factory=dict)
     #: Wall-clock seconds per rebuild stage for THIS pass.
     #:
     #: Three full rebuilds ran without this, so the only cost breakdown
@@ -410,9 +416,51 @@ class RebuildIndexReceipt:
             "generation": self.generation,
             "readiness": self.readiness,
             "transaction": self.transaction,
+            "operation": self.operation,
             "timings_s": self.timings_s,
             **self.replay,
         }
+
+
+def _operation_evidence(
+    root: Path,
+    *,
+    generation: IndexGeneration | None,
+    transaction: IndexRebuildTransaction | None,
+    recovery_state: str,
+) -> dict[str, object]:
+    """Return the compact, durable operation receipt shared by every pass.
+
+    This is intentionally assembled from the existing archive-root lease and
+    transaction checkpoint.  It adds no competing ownership mechanism and
+    keeps the full checkpoint in ``transaction`` for callers that need it.
+    """
+    from polylogue.storage.index_generation import rebuild_lease_status, source_revision_snapshot
+
+    transaction_payload = asdict(transaction) if transaction is not None else {}
+    generation_payload = asdict(generation) if generation is not None else {}
+    source_snapshot = transaction_payload.get("source_snapshot") or generation_payload.get("source_snapshot")
+    current_snapshot = source_revision_snapshot(root) if (root / "source.db").exists() else None
+    return {
+        "owner": {
+            "generation_owner_id": transaction_payload.get("generation_owner_id") or generation_payload.get("owner_id"),
+            "pid": transaction_payload.get("owner_pid"),
+            "host": transaction_payload.get("owner_host"),
+            "lease": rebuild_lease_status(root).to_dict(),
+        },
+        "generation": {
+            "generation_id": generation_payload.get("generation_id"),
+            "state": generation_payload.get("state"),
+        },
+        "heartbeat": {"at_ms": transaction_payload.get("heartbeat_at_ms")},
+        "cursor": transaction.cursor if transaction is not None else None,
+        "delta": {
+            "source_snapshot_matches": current_snapshot == source_snapshot if current_snapshot is not None else None,
+            "current_source_snapshot": current_snapshot,
+            "transaction_source_snapshot": source_snapshot,
+        },
+        "recovery_state": recovery_state,
+    }
 
 
 def validate_rebuild_index_request(request: RebuildIndexRequest) -> None:
@@ -553,6 +601,7 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
     the *location* it resolved, catching e.g. a concurrent devtools campaign
     or a foreign/rotated root before this rebuild can act on stale identity).
     """
+    from polylogue.storage.index_generation import RebuildLease
     from polylogue.storage.sqlite.connection_profile import (
         check_mapped_bytes_budget_against_cgroup_limit,
         log_mapped_bytes_budget_check,
@@ -575,12 +624,17 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
     if reason := offline_maintenance_block_reason(active_config, active=True, dry_run=False):
         raise RuntimeError(reason)
 
-    owned = OwnedArchiveLocation.acquire(location)
-    try:
-        assert_owns_archive_location(owned, location)
-        return await _rebuild_index_from_source_owned(request, root=root, owned=owned)
-    finally:
-        owned.release()
+    # This is deliberately outside archive-location acquisition and
+    # generation-store construction.  Those steps can create/rewrite archive
+    # bookkeeping, so a competing ArchiveStore writer must fail before the
+    # rebuild's first lifecycle mutation, not only during replay.
+    with RebuildLease(root):
+        owned = OwnedArchiveLocation.acquire(location)
+        try:
+            assert_owns_archive_location(owned, location)
+            return await _rebuild_index_from_source_owned(request, root=root, owned=owned)
+        finally:
+            owned.release()
 
 
 async def _rebuild_index_from_source_owned(
@@ -591,11 +645,15 @@ async def _rebuild_index_from_source_owned(
     from polylogue.maintenance.replay import rebuild_index_from_source as replay_source
     from polylogue.sources.revision_backfill import RebuildDeadlineExceededError
     from polylogue.storage.archive_readiness import archive_readiness_status
-    from polylogue.storage.index_generation import IndexGenerationStore, RebuildLease, source_revision_snapshot
+    from polylogue.storage.index_generation import IndexGenerationStore, source_revision_snapshot
     from polylogue.storage.repair import repair_session_insights
 
     generation_store = IndexGenerationStore(owned.location)
-    with RebuildLease(root):
+    # ``rebuild_index_from_source`` already acquired this root's
+    # ``RebuildLease`` before any operation mutation.  Retain this scope only
+    # to preserve the body's indentation and make the outer ownership boundary
+    # explicit at the public entry point.
+    with contextlib.nullcontext():
         raw_count = count_source_raw_sessions(root)
         if raw_count == 0:
             return RebuildIndexReceipt(
@@ -609,6 +667,7 @@ async def _rebuild_index_from_source_owned(
                 generation={},
                 readiness={},
                 replay={},
+                operation=_operation_evidence(root, generation=None, transaction=None, recovery_state="empty-source"),
             )
         resumable_full_source = not request.raw_ids and not request.only_missing and request.max_blob_mb is None
         transaction = None
@@ -868,6 +927,9 @@ async def _rebuild_index_from_source_owned(
                             "deferred_reason": "pass-deadline-mid-replay",
                         },
                         transaction=cast(dict[str, object], asdict(transaction)),
+                        operation=_operation_evidence(
+                            root, generation=generation, transaction=transaction, recovery_state="deferred"
+                        ),
                         timings_s=cast(dict[str, float], pass_cost.to_dict()),
                     )
                     generation_store.save_pass_receipt(transaction.operation_id, pass_receipt.to_dict())
@@ -944,6 +1006,9 @@ async def _rebuild_index_from_source_owned(
                         readiness={},
                         replay=replay,
                         transaction=cast(dict[str, object], asdict(transaction)),
+                        operation=_operation_evidence(
+                            root, generation=generation, transaction=transaction, recovery_state=status
+                        ),
                         timings_s=cast(dict[str, float], pass_cost.to_dict()),
                     )
                     generation_store.save_pass_receipt(transaction.operation_id, pass_receipt.to_dict())
@@ -1067,6 +1132,12 @@ async def _rebuild_index_from_source_owned(
         except Exception:
             if transaction is not None and not source_drifted:
                 with contextlib.suppress(Exception):
+                    # A process can fail after ``checkpoint_transaction`` has
+                    # atomically published the output batch but before this
+                    # frame receives its returned replacement object.  Never
+                    # let this stale local value rewind that committed cursor
+                    # while recording recovery state.
+                    transaction = generation_store.load_transaction(transaction.operation_id)
                     generation_store.checkpoint_transaction(
                         transaction,
                         status="failed",
@@ -1088,6 +1159,12 @@ async def _rebuild_index_from_source_owned(
         readiness=cast(dict[str, object], readiness),
         replay=replay,
         transaction=cast(dict[str, object], asdict(transaction)) if transaction is not None else None,
+        operation=_operation_evidence(
+            root,
+            generation=generation,
+            transaction=transaction,
+            recovery_state="promoted" if request.promote else "ready",
+        ),
         timings_s={key: round(value, 3) for key, value in terminal_timings_s.items()},
     )
     if transaction is not None:
@@ -1162,6 +1239,7 @@ def rebuild_status(
 
     transaction_payload: dict[str, object] | None = None
     delta: dict[str, object] | None = None
+    transaction = None
     if resolved_operation_id is not None:
         try:
             transaction = store.load_transaction(resolved_operation_id)
@@ -1205,6 +1283,12 @@ def rebuild_status(
         "schema_version": schema_version,
         "operation_id": resolved_operation_id,
         "transaction": transaction_payload,
+        "operation": _operation_evidence(
+            archive_root,
+            generation=None,
+            transaction=transaction,
+            recovery_state=(str(transaction_payload["status"]) if transaction_payload is not None else "idle"),
+        ),
         "delta": delta,
         "recovery": recovery,
     }

--- a/polylogue/storage/index_generation.py
+++ b/polylogue/storage/index_generation.py
@@ -117,6 +117,13 @@ class IndexRebuildTransaction:
     pass_byte_budget: int | None = None
     pass_deadline_ms: int | None = None
     error: str | None = None
+    # The transaction record is also the durable operation receipt.  Keep the
+    # operating process separate from the opaque generation owner so a status
+    # reader can tell a retained candidate from the process that last made
+    # progress on it.
+    owner_pid: int | None = None
+    owner_host: str | None = None
+    heartbeat_at_ms: int | None = None
     # polylogue-v6i3: set once a RESUMED pass has explicitly emptied this
     # generation's messages_fts/blocks_command_trigram (defensive idempotent
     # bookkeeping -- a fresh generation starts empty by construction and never
@@ -461,6 +468,9 @@ class IndexGenerationStore:
             updated_at_ms=now,
             pass_byte_budget=pass_byte_budget,
             pass_deadline_ms=pass_deadline_ms,
+            owner_pid=os.getpid(),
+            owner_host=socket.gethostname(),
+            heartbeat_at_ms=now,
         )
         self.save_transaction(transaction)
         return transaction
@@ -494,7 +504,16 @@ class IndexGenerationStore:
 
     def save_transaction(self, transaction: IndexRebuildTransaction) -> IndexRebuildTransaction:
         """Atomically checkpoint a transaction after one bounded replay pass."""
-        updated = IndexRebuildTransaction(**{**asdict(transaction), "updated_at_ms": int(time.time() * 1000)})
+        now = int(time.time() * 1000)
+        updated = IndexRebuildTransaction(
+            **{
+                **asdict(transaction),
+                "updated_at_ms": now,
+                "owner_pid": os.getpid(),
+                "owner_host": socket.gethostname(),
+                "heartbeat_at_ms": now,
+            }
+        )
         path = self._transaction_path(transaction.operation_id)
         path.parent.mkdir(parents=True, exist_ok=True)
         temporary = path.with_suffix(".json.tmp")

--- a/tests/unit/maintenance/test_rebuild_index_ownership.py
+++ b/tests/unit/maintenance/test_rebuild_index_ownership.py
@@ -41,7 +41,9 @@ def test_rebuild_refuses_when_archive_location_already_owned(tmp_path: Path) -> 
             rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root))
         # Failure happened before any generation bookkeeping was created.
         assert not (root / ".index-generations").exists()
-        assert not (root / ".index-rebuild.lock").exists()
+        # The rebuild lease is now deliberately acquired before the general
+        # archive-location ownership attempt.  Its released lock file may
+        # remain as a diagnostic artifact, but no generation may be created.
     finally:
         owned.release()
 

--- a/tests/unit/maintenance/test_rebuild_index_resume_correctness.py
+++ b/tests/unit/maintenance/test_rebuild_index_resume_correctness.py
@@ -1,0 +1,171 @@
+"""Real raw-replay recovery proof for ``polylogue-b5l.1``.
+
+The route under test is the production offline rebuild orchestrator.  The
+fixture interrupts immediately after the first replay page is durably
+checkpointed, then resumes the same candidate and compares its promoted
+semantic output with an independently clean rebuild.  It deliberately checks
+rows, topology, public FTS reads, and insight materialization rather than a
+test-only cursor counter.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from polylogue.core.enums import Provider
+from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
+from polylogue.storage.index_generation import IndexGenerationStore
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+
+class InjectedInterruptError(RuntimeError):
+    """Test-only process-death analogue raised after a durable checkpoint."""
+
+
+def _payload(native_id: str, text: str, *, parent_native_id: str | None = None) -> bytes:
+    cwd = "/realm/project/resume-fixture"
+    rows: list[dict[str, object]] = [
+        {
+            "type": "session_meta",
+            "payload": {"id": native_id, "timestamp": "2026-08-04T12:00:00Z", "cwd": cwd},
+        }
+    ]
+    if parent_native_id is not None:
+        rows.append(
+            {
+                "type": "session_meta",
+                "payload": {"id": parent_native_id, "timestamp": "2026-08-04T11:00:00Z", "cwd": cwd},
+            }
+        )
+    rows.append(
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "id": f"{native_id}-m0",
+                "role": "user",
+                "content": [{"type": "input_text", "text": text}],
+            },
+        },
+    )
+    return b"".join(json.dumps(row, sort_keys=True).encode() + b"\n" for row in rows)
+
+
+def _seed(root: Path) -> None:
+    initialize_active_archive_root(root)
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        for index, native_id, parent_native_id in (
+            (0, "resume-parent", None),
+            (1, "resume-child", "resume-parent"),
+            (2, "resume-standalone", None),
+        ):
+            archive.write_raw_payload(
+                provider=Provider.CODEX,
+                payload=_payload(native_id, f"resume-token-{index}", parent_native_id=parent_native_id),
+                source_path=f"resume/{index}.jsonl",
+                acquired_at_ms=index + 1,
+            )
+
+
+def _semantic_snapshot(root: Path) -> tuple[object, ...]:
+    with sqlite3.connect(root / "index.db") as conn:
+        rows = tuple(
+            tuple(conn.execute(query))
+            for query in (
+                "SELECT session_id, message_count, content_hash FROM sessions ORDER BY session_id",
+                "SELECT message_id, session_id, role, position FROM messages ORDER BY message_id",
+                "SELECT block_id, message_id, block_type, text FROM blocks ORDER BY block_id",
+                "SELECT src_session_id, dst_origin, dst_native_id, link_type, resolved_dst_session_id "
+                "FROM session_links ORDER BY src_session_id, dst_origin, dst_native_id, link_type",
+                "SELECT session_id, message_count, materializer_version FROM session_profiles ORDER BY session_id",
+                "SELECT insight_type, session_id, materializer_version "
+                "FROM insight_materialization ORDER BY insight_type, session_id",
+            )
+        )
+    with ArchiveStore.open_existing(root, read_only=True) as archive:
+        fts = tuple(
+            (f"resume-token-{index}", tuple(archive.search_blocks(f"resume-token-{index}"))) for index in range(3)
+        )
+    return (*rows, fts)
+
+
+def test_committed_page_interrupt_resumes_only_suffix_and_matches_clean_rebuild(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "resumed"
+    clean_root = tmp_path / "clean"
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
+    _seed(root)
+
+    original_checkpoint = IndexGenerationStore.checkpoint_transaction
+    interrupted = False
+
+    def interrupt_after_committed_page(self: IndexGenerationStore, transaction: object, **kwargs: object) -> object:
+        nonlocal interrupted
+        checkpointed = original_checkpoint(self, transaction, **kwargs)  # type: ignore[arg-type]
+        if not interrupted and kwargs.get("processed_raw_count") == 1:
+            interrupted = True
+            raise InjectedInterruptError("simulated process interruption after committed page")
+        return checkpointed
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(IndexGenerationStore, "checkpoint_transaction", interrupt_after_committed_page)
+        with pytest.raises(InjectedInterruptError, match="after committed page"):
+            rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, raw_batch_size=1))
+
+    store = IndexGenerationStore.for_archive_root(root)
+    operation_id = next(path.stem for path in store.transactions_root.glob("*.json"))
+    transaction = store.load_transaction(operation_id)
+    assert transaction.processed_raw_count == 1
+    assert transaction.cursor is not None
+    with sqlite3.connect(Path(store.load(transaction.generation_id).index_path)) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 1
+
+    # Each resumed pass can schedule only rows beyond the committed source
+    # cursor.  Recording the real replay call catches a cursor that merely
+    # reports progress while restarting from page one.
+    import polylogue.maintenance.replay as replay_module
+
+    replayed_raw_pages: list[tuple[str, ...]] = []
+    real_replay = replay_module.rebuild_index_from_source
+
+    async def recording_replay(*args: object, **kwargs: object) -> dict[str, object]:
+        replayed_raw_pages.append(tuple(cast(list[str], kwargs["raw_ids"])))
+        return await real_replay(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(replay_module, "rebuild_index_from_source", recording_replay)
+    while True:
+        receipt = rebuild_index_from_source_sync(
+            RebuildIndexRequest(archive_root=root, operation_id=operation_id, raw_batch_size=1)
+        )
+        if receipt.status == "replayed":
+            break
+        assert receipt.status == "paused"
+
+    assert [len(page) for page in replayed_raw_pages] == [1, 1]
+    assert len({raw_id for page in replayed_raw_pages for raw_id in page}) == 2
+    assert receipt.operation["cursor"] is not None
+    assert receipt.operation["heartbeat"]["at_ms"] is not None  # type: ignore[index]
+    assert receipt.operation["recovery_state"] == "promoted"
+
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(clean_root))
+    _seed(clean_root)
+    clean = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=clean_root, raw_batch_size=1))
+    assert clean.status == "paused"
+    assert clean.transaction is not None
+    clean_operation = clean.transaction["operation_id"]
+    assert isinstance(clean_operation, str)
+    while clean.status != "replayed":
+        clean = rebuild_index_from_source_sync(
+            RebuildIndexRequest(archive_root=clean_root, operation_id=clean_operation, raw_batch_size=1)
+        )
+
+    resumed_snapshot = _semantic_snapshot(root)
+    assert resumed_snapshot[3], "the real replay fixture must exercise a lineage link"
+    assert resumed_snapshot == _semantic_snapshot(clean_root)

--- a/tests/unit/maintenance/test_rebuild_status.py
+++ b/tests/unit/maintenance/test_rebuild_status.py
@@ -145,9 +145,15 @@ def test_reports_transaction_cursor_and_no_delta_when_source_unchanged(tmp_path:
     assert isinstance(txn_payload, dict)
     assert txn_payload["operation_id"] == "status-probe-op"
     assert txn_payload["processed_raw_count"] == 1
+    assert txn_payload["heartbeat_at_ms"] is not None
     delta = status["delta"]
     assert isinstance(delta, dict)
     assert delta["source_snapshot_matches"] is True
+    operation = status["operation"]
+    assert isinstance(operation, dict)
+    assert operation["cursor"] is not None
+    assert operation["heartbeat"] == {"at_ms": txn_payload["heartbeat_at_ms"]}
+    assert operation["recovery_state"] == "paused"
     assert status["recovery"] == []
 
 


### PR DESCRIPTION
## Summary

Make raw-replay rebuild ownership begin before archive-location or generation bookkeeping, preserve a committed cursor when recovery handles an immediately subsequent interruption, and expose a compact rebuild operation receipt.

## Problem

A failure after `checkpoint_transaction()` persisted a page but before the caller received the returned replacement transaction could overwrite the durable cursor with stale in-memory state. The rebuild lease began after archive-location setup, so early rebuild lifecycle work was outside the explicit archive-root lease interval. Ref polylogue-b5l.1.

## Solution

`rebuild_index_from_source()` now holds `RebuildLease` around archive-location ownership, replay, parity/readiness checks, and promotion. Recovery reloads the persisted transaction before recording failed state. Transaction checkpoints record owner pid/host and heartbeat. Rebuild receipts and status expose owner, generation, heartbeat, cursor, source delta, and recovery state. The raw membership selection remains unchanged, so existing superseded-revision semantics continue to govern resume debt.

## Acceptance criteria

| Criterion | Evidence |
| --- | --- |
| Archive-root exclusivity across lifecycle | Lease acquisition moved to the public rebuild boundary; existing deep-pass writer-lease probe remains focused on replay through terminal materialization. |
| Resume only the uncommitted suffix | New real replay test interrupts after the first durable checkpoint, verifies cursor/session state, and records the two later replay pages only. |
| Preserve superseded revision semantics | No raw-authority or membership classification code changed; existing `next_raw_page()` typed superseded-debt filter remains the selector. |
| Resumed versus clean parity | New lineage fixture compares sessions, messages, blocks, session links, public FTS hits, profiles, and insight materialization. |
| Receipt and status | Transaction checkpoints now carry pid, host, and heartbeat; CLI status renders the compact operation receipt. |
| Lease-bypass mutation | The existing deep-pass competing `ActiveWriterLease` test fails if the rebuild lease is narrowed or removed. |

## Production preconditions

Do not run this against the production archive until the existing offline-maintenance guard permits it, `polylogued` is stopped or the daemon owns the writer route, raw-authority/corpus/fingerprint gates are current, and the intended archive root has been independently verified. This PR used only isolated pytest archive roots and never opened production archive data.

## Verification

- `devtools test tests/unit/maintenance/test_rebuild_index_ownership.py tests/unit/maintenance/test_rebuild_index_lease_lifecycle.py tests/unit/maintenance/test_rebuild_index_resume_correctness.py tests/unit/maintenance/test_rebuild_status.py tests/unit/maintenance/test_rebuild_index_deadline.py` produced `12 passed`.
- `devtools test tests/unit/maintenance/test_rebuild_index_resume_correctness.py` produced `1 passed` after strengthening the fixture with a real lineage link.
- `devtools verify --quick` passed format, lint, mypy, generated-surface rendering, layering, and repository policy checks.
