### PR TITLE
fix(daemon): expose configured health tiers (#3721)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -235,7 +235,7 @@ max_per_hour = 12
 
 [health]
 check_interval_s = 300
-check_tiers = "fast,medium" # add ",expensive" to also poll DB/blob/embedding checks
+check_tiers = "fast,medium" # set "fast" to opt out of MEDIUM; add ",expensive" for DB/blob/embedding checks
 blob_integrity_sample_size = 100
 
 # Convergence-debt alert thresholds. The daemon raises a typed HealthAlert

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -534,6 +534,11 @@ check_interval_s = 300
 check_tiers = "fast,medium"
 ```
 
+`polylogued status` reports every tier as `healthy`, `degraded`, `not_run`, or
+`disabled`. Set `check_tiers = "fast"` only when an operator deliberately
+wants to disable MEDIUM probes; status will show `medium=disabled` rather than
+presenting it as a healthy tier.
+
 ### Judgment Automation
 
 `polylogue/daemon/judgment_automation.py` (polylogue-6qjc) is the automated

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -2637,7 +2637,9 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
 
         Returns 200 when the configured health-check tiers pass, 503 when any
         non-OK health alert is present. Suitable for health check endpoints in
-        Docker, systemd, and CI pipelines. The default config runs FAST only.
+        Docker, systemd, and CI pipelines. The default config runs FAST and
+        MEDIUM; operators can set ``health.check_tiers = "fast"`` to opt out
+        of MEDIUM probes explicitly.
         """
         try:
             from polylogue.config import load_polylogue_config

--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -40,7 +40,7 @@ from polylogue.daemon.cursor_lag_status import CursorLagSummary as CursorLagSumm
 from polylogue.daemon.cursor_lag_status import cursor_lag_summary_info
 from polylogue.daemon.embedding_readiness import embedding_readiness_info
 from polylogue.daemon.fts_status import FTSReadiness, fts_readiness_info
-from polylogue.daemon.health import DaemonHealth, HealthAlert, HealthSeverity, check_health
+from polylogue.daemon.health import DaemonHealth, HealthAlert, HealthSeverity, HealthTier, check_health
 from polylogue.daemon.live_ingest_attempt_models import (
     LiveIngestAttemptState,
 )
@@ -91,6 +91,37 @@ _LIVE_CURSOR_FAILURE_SAMPLE_LIMIT = 50
 # same way coordination/envelope.py's _ARCHIVE_EVIDENCE_DEADLINE_S is patched
 # to exercise the timed-out/refreshing/fresh resumability sequence quickly.
 _EMBEDDING_READINESS_DEADLINE_S = 2.0
+
+
+def _configured_health_tiers(*, include_expensive: bool = False) -> set[HealthTier]:
+    """Resolve the tier set shared by status and the periodic health loop."""
+    from polylogue.config import load_polylogue_config
+    from polylogue.daemon.health import resolve_health_tiers
+
+    tiers = resolve_health_tiers(load_polylogue_config().health_check_tiers)
+    if include_expensive:
+        tiers.add(HealthTier.EXPENSIVE)
+    return tiers
+
+
+def _health_tier_states(health: DaemonHealth, configured: set[HealthTier]) -> dict[str, str]:
+    """Classify every tier so disabled coverage never resembles healthy work."""
+    states: dict[str, str] = {}
+    for tier in HealthTier:
+        tier_name = tier.value
+        if tier not in configured:
+            states[tier_name] = "disabled"
+            continue
+        summary = health.tier_summary.get(tier_name)
+        if summary is None:
+            states[tier_name] = "not_run"
+            continue
+        states[tier_name] = (
+            "healthy"
+            if all(summary.get(severity, 0) == 0 for severity in ("warning", "error", "critical"))
+            else "degraded"
+        )
+    return states
 
 
 def _active_status_db_path() -> Path:
@@ -458,6 +489,7 @@ class DaemonStatus(BaseModel):
     raw_failure_samples: list[RawFailureSample] = Field(default_factory=list)
     raw_detection_warnings: int = 0
     health: DaemonHealth = Field(default_factory=DaemonHealth)
+    health_tiers: set[HealthTier] = Field(default_factory=set)
     # Whether the running interpreter has the GIL enabled; False means a
     # free-threaded (PEP 703) build such as 3.14t (polylogue-dcz5).
     gil_enabled: bool = True
@@ -2366,20 +2398,20 @@ def periodic_status_component_registry() -> StatusComponentRegistry:
     Built once per process (lazily, on first call) with the same collection
     parameters ``refresh_status_snapshot`` always passes
     (``include_raw_replay_backlog=False``,
-    ``include_exact_raw_materialization_readiness=False``, fast-tier health
-    only) -- direct one-shot CLI/API status calls are unaffected, since they
-    never pass a ``registry`` into ``build_daemon_status``/
-    ``daemon_status_payload`` and keep their existing fresh-per-call
-    ephemeral-registry contract.
+    ``include_exact_raw_materialization_readiness=False``). Its health
+    collector resolves ``health_check_tiers`` on every refresh, matching the
+    daemon's periodic health loop. Direct one-shot CLI/API status calls are
+    unaffected, since they never pass a ``registry`` into
+    ``build_daemon_status``/``daemon_status_payload`` and keep their existing
+    fresh-per-call ephemeral-registry contract.
     """
     global _PERIODIC_STATUS_REGISTRY
     with _PERIODIC_STATUS_REGISTRY_LOCK:
         if _PERIODIC_STATUS_REGISTRY is None:
-            from polylogue.daemon.health import HealthTier
 
             def _checked_health() -> DaemonHealth:
                 try:
-                    return check_health(tiers={HealthTier.FAST})
+                    return check_health(tiers=_configured_health_tiers())
                 except Exception as exc:
                     logger.warning("status: check_health() failed: %s", exc, exc_info=True)
                     return DaemonHealth(
@@ -2455,13 +2487,10 @@ def build_daemon_status(
     )
     active_db = _active_status_db_path()
 
-    # Build health status. Keep the default bounded; medium includes exact
-    # FTS invariant scans and must be requested explicitly by operator paths.
-    from polylogue.daemon.health import HealthTier
-
-    health_tiers: set[HealthTier] = {HealthTier.FAST}
-    if include_expensive_health:
-        health_tiers.update({HealthTier.MEDIUM, HealthTier.EXPENSIVE})
+    # Status observes the configured health schedule. This keeps MEDIUM
+    # readiness and cursor-lag evidence visible by default, while a deliberate
+    # ``check_tiers = "fast"`` configuration remains an explicit opt-out.
+    health_tiers = _configured_health_tiers(include_expensive=include_expensive_health)
 
     def _checked_health() -> DaemonHealth:
         try:
@@ -2663,6 +2692,7 @@ def build_daemon_status(
             live_ingest_attempts=live_ingest_attempts,
         ),
         health=health,
+        health_tiers=health_tiers,
         browser_capture_active=browser_capture_active,
         rss_current_mb=rss_current_mb,
         rss_peak_mb=rss_peak_mb,
@@ -2819,6 +2849,8 @@ def daemon_status_payload(
                 "alert_count": sum(1 for a in status.health.alerts if a.severity != HealthSeverity.OK),
                 "checks_run": len(status.health.alerts),
                 "tier_summary": status.health.tier_summary,
+                "configured_tiers": [tier.value for tier in HealthTier if tier in status.health_tiers],
+                "tiers": _health_tier_states(status.health, status.health_tiers),
             },
             "raw_parse_failures": status.raw_parse_failures,
             "raw_validation_failures": status.raw_validation_failures,
@@ -3220,6 +3252,13 @@ def format_daemon_status_lines(payload: JSONDocument) -> list[str]:
     if isinstance(health, dict):
         health_overall = str(health.get("overall_status", "unknown"))
         lines.append(f"Health: {health_overall} ({health.get('alert_count', 0)} alerts)")
+        tier_states = health.get("tiers")
+        if isinstance(tier_states, dict):
+            rendered_tiers = [
+                f"{tier}={tier_states[tier]}" for tier in ("fast", "medium", "expensive") if tier in tier_states
+            ]
+            if rendered_tiers:
+                lines.append("  Tiers: " + ", ".join(rendered_tiers))
     # Raw failure summary
     raw_parse = _safe_int(payload.get("raw_parse_failures"))
     raw_val = _safe_int(payload.get("raw_validation_failures"))

--- a/tests/unit/daemon/test_cursor_lag_integration.py
+++ b/tests/unit/daemon/test_cursor_lag_integration.py
@@ -9,10 +9,12 @@ issue #1349 are pinned here.
 
 from __future__ import annotations
 
+import asyncio
 import sqlite3
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from datetime import datetime, timedelta
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -26,7 +28,7 @@ from polylogue.daemon.cursor_lag_status import (
     CursorLagSummary,
     cursor_lag_summary_info,
 )
-from polylogue.daemon.health import HealthSeverity, _check_cursor_lag_medium
+from polylogue.daemon.health import DaemonHealth, HealthSeverity, HealthTier, _check_cursor_lag_medium
 from tests.infra.frozen_clock import FrozenClock
 
 # Pin ``datetime.now`` everywhere the cursor-lag stack reads it so the
@@ -254,6 +256,59 @@ anomaly_enabled = true
     # family per tick.
     assert len(row) == 1
     assert row[0][1] == 1
+
+
+@pytest.mark.asyncio
+async def test_default_periodic_health_schedule_runs_medium_probes_and_records_cursor_lag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, frozen_clock: FrozenClock
+) -> None:
+    """The real daemon health schedule must not regress to FAST-only.
+
+    This drives one scheduler tick against an isolated archive. The check runs
+    the production MEDIUM tier, proves FTS readiness was evaluated, and proves
+    the cursor-lag probe wrote its durable ops sample rather than merely
+    reporting a configured tier string.
+    """
+    from polylogue.daemon import cli as daemon_cli
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+    db = _isolated_archive(tmp_path, monkeypatch)
+    with ArchiveStore(db.parent):
+        pass
+    now = frozen_clock.now()
+    _seed_live_cursor(
+        db,
+        rows=[
+            ("/x/a.jsonl", 1000, 500, 0, 0, (now - timedelta(seconds=600)).isoformat()),
+        ],
+    )
+
+    observed: dict[str, object] = {}
+
+    class _OneTickCoordinator:
+        async def run_sync(self, actor: str, check: Callable[..., object], **kwargs: object) -> object:
+            assert actor == "maintenance.health_check"
+            observed["tiers"] = kwargs["tiers"]
+            health = check(**kwargs)
+            observed["health"] = health
+            raise asyncio.CancelledError
+
+    async def _immediate_sleep(interval: float) -> None:
+        assert interval == 300
+
+    monkeypatch.setattr(daemon_cli, "daemon_write_coordinator", lambda: _OneTickCoordinator())
+    monkeypatch.setattr("polylogue.daemon.cli.asyncio.sleep", _immediate_sleep)
+    monkeypatch.setattr("polylogue.daemon.notifications.send_notifications", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(asyncio.CancelledError):
+        await daemon_cli._periodic_health_check()
+
+    assert observed["tiers"] == {HealthTier.FAST, HealthTier.MEDIUM}
+    health = cast(DaemonHealth, observed["health"])
+    assert any(alert.check_name == "fts_readiness" for alert in health.alerts)
+    with sqlite3.connect(str(db.with_name("ops.db"))) as conn:
+        sample_count = conn.execute("SELECT COUNT(*) FROM cursor_lag_samples").fetchone()[0]
+    assert sample_count == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -622,6 +622,48 @@ def test_health_alert_count_reflects_a_real_problem_not_ok(tmp_path: Path) -> No
     assert not any("ok (" in line and "1" in line for line in lines if line.startswith("Health:"))
 
 
+@pytest.mark.parametrize(
+    ("configured", "summary", "expected_tiers", "expected_states"),
+    [
+        (
+            "fast,medium",
+            {
+                "fast": {"ok": 1, "warning": 0, "error": 0, "critical": 0},
+                "medium": {"ok": 1, "warning": 0, "error": 0, "critical": 0},
+            },
+            ["fast", "medium"],
+            {"fast": "healthy", "medium": "healthy", "expensive": "disabled"},
+        ),
+        (
+            "fast",
+            {"fast": {"ok": 1, "warning": 0, "error": 0, "critical": 0}},
+            ["fast"],
+            {"fast": "healthy", "medium": "disabled", "expensive": "disabled"},
+        ),
+    ],
+)
+def test_status_labels_configured_and_disabled_health_tiers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    configured: str,
+    summary: dict[str, dict[str, int]],
+    expected_tiers: list[str],
+    expected_states: dict[str, str],
+) -> None:
+    """MEDIUM opt-out is visible as disabled, never as an empty healthy tier."""
+    configured_set = {HealthTier(tier) for tier in configured.split(",")}
+    monkeypatch.setattr(status_module, "_configured_health_tiers", lambda **_kwargs: configured_set)
+    health = DaemonHealth(overall_status=HealthSeverity.OK, checked_at="now", tier_summary=summary)
+
+    payload = _health_payload(tmp_path, health)
+    health_payload = cast(dict[str, Any], payload["health"])
+
+    assert health_payload["configured_tiers"] == expected_tiers
+    assert health_payload["tiers"] == expected_states
+    lines = format_daemon_status_lines(payload)
+    assert "  Tiers: " + ", ".join(f"{tier}={state}" for tier, state in expected_states.items()) in lines
+
+
 def test_daemon_status_payload_and_plain_output_include_failed_files(tmp_path: Path) -> None:
     db = tmp_path / "index.db"
     failed = tmp_path / "failed.jsonl"


### PR DESCRIPTION
## Summary

Daemon status and periodic status snapshots now use the configured health tier set. Status reports each tier as healthy, degraded, not_run, or disabled.

## Problem

The daemon configuration defaults to FAST plus MEDIUM, but status hard-coded FAST-only health checks. This hid MEDIUM probe execution from status and made an operator opt-out indistinguishable from a healthy tier.

## Solution

Status resolves health.check_tiers for direct and periodic collection, exposes configured_tiers plus per-tier state in the payload, and renders the state in plain output. The focused scheduler test drives a real isolated archive through one periodic tick and proves MEDIUM FTS readiness runs while cursor-lag sampling writes to ops.db.

## Verification

- `devtools test tests/unit/daemon/test_cursor_lag_integration.py tests/unit/daemon/test_daemon_status.py tests/unit/daemon/test_health_check_endpoint_tiers.py tests/unit/daemon/test_health_contracts.py tests/unit/core/test_config.py` -> `189 passed in 7.63s`
- `devtools verify --quick` -> success
- Pre-push `devtools verify --quick` -> success

## Acceptance criteria

- Default scheduler selects FAST and MEDIUM and executes FTS plus cursor-lag probes.
- `check_tiers = "fast"` remains an opt-out and status reports `medium=disabled`.

Ref polylogue-y0ven