### PR TITLE
refactor: enforce canonical run lifecycle statuses

### DIFF
--- a/polylogue/cli/commands/embed.py
+++ b/polylogue/cli/commands/embed.py
@@ -168,7 +168,7 @@ class BackfillSessionPayload(TypedDict):
 
 
 class BackfillResultPayload(TypedDict):
-    status: str
+    status: Literal["complete", "stopped"]
     embedded_sessions: int
     skipped_sessions: int
     error_count: int
@@ -180,7 +180,7 @@ class BackfillResultPayload(TypedDict):
     sessions: list[BackfillSessionPayload]
 
 
-_ARCHIVE_BACKFILL_STATUS_MAP: dict[str, OperationStatus] = {
+_ARCHIVE_BACKFILL_STATUS_MAP: dict[Literal["complete", "stopped"], OperationStatus] = {
     "complete": OperationStatus.COMPLETED,
     "stopped": OperationStatus.INTERRUPTED,
 }
@@ -822,18 +822,22 @@ def _run_archive_backfill(
         if stopped_reason:
             break
 
-    payload = {
-        "status": "stopped" if stopped_reason else "complete",
-        "embedded_sessions": embedded,
-        "skipped_sessions": skipped,
-        "error_count": errors,
-        "estimated_cost_usd": round(cumulative_cost, 8),
-        "stopped_reason": stopped_reason,
-        "candidate_sessions": len(pending),
-        "processed_sessions": processed,
-        "preflight": _preflight_payload(report),
-        "sessions": session_payloads,
-    }
+    display_status: Literal["complete", "stopped"] = "stopped" if stopped_reason else "complete"
+    payload = cast(
+        BackfillResultPayload,
+        {
+            "status": display_status,
+            "embedded_sessions": embedded,
+            "skipped_sessions": skipped,
+            "error_count": errors,
+            "estimated_cost_usd": round(cumulative_cost, 8),
+            "stopped_reason": stopped_reason,
+            "candidate_sessions": len(pending),
+            "processed_sessions": processed,
+            "preflight": _preflight_payload(report),
+            "sessions": session_payloads,
+        },
+    )
     _record_archive_backfill_run(
         index_db,
         started_at_ms=started_at_ms,
@@ -858,7 +862,7 @@ def _record_archive_backfill_run(
     index_db: Path,
     *,
     started_at_ms: int,
-    status: str,
+    status: Literal["complete", "stopped"],
     processed_sessions: int,
     embedded_sessions: int,
     skipped_sessions: int,

--- a/polylogue/cli/commands/maintenance/_run.py
+++ b/polylogue/cli/commands/maintenance/_run.py
@@ -129,8 +129,8 @@ def _execute_and_render(
     ``run-preview``) rather than exposed as a CLI flag -- the command name
     is the read/write signal, not an option an operator can forget.
     """
+    from polylogue.core.enums import OperationStatus
     from polylogue.maintenance.envelope import envelope_from_operation
-    from polylogue.maintenance.planner import BackfillStatus
     from polylogue.maintenance.replay import execute_replay
 
     configure_logging()
@@ -172,7 +172,7 @@ def _execute_and_render(
     if output_format == "json":
         envelope = envelope_from_operation(result, origin="cli", mode="execute")
         click.echo(json.dumps(envelope.to_dict(), indent=2, sort_keys=True))
-        if result.status is BackfillStatus.FAILED:
+        if result.status is OperationStatus.FAILED:
             raise SystemExit(1)
         return
 
@@ -214,5 +214,5 @@ def _execute_and_render(
             elapsed = (completed - started).total_seconds()
             click.echo(f"\nElapsed: {elapsed:.1f}s")
 
-    if result.status is BackfillStatus.FAILED:
+    if result.status is OperationStatus.FAILED:
         raise SystemExit(1)

--- a/polylogue/core/enums.py
+++ b/polylogue/core/enums.py
@@ -34,6 +34,20 @@ OPERATION_LIFECYCLE_STATUSES: tuple[OperationStatus, ...] = (
 )
 
 
+def require_operation_lifecycle_status(value: OperationStatus | str) -> OperationStatus:
+    """Return one persisted run status, rejecting admission-only operation states.
+
+    ``cancelled`` remains a client-side cancellation term. A run that ends
+    before completion without an execution failure is recorded as
+    ``interrupted`` across the ops ledgers and planner-facing lifecycle.
+    """
+    status = value if isinstance(value, OperationStatus) else OperationStatus(value)
+    if status not in OPERATION_LIFECYCLE_STATUSES:
+        choices = ", ".join(item.value for item in OPERATION_LIFECYCLE_STATUSES)
+        raise ValueError(f"{status.value!r} is not a run lifecycle status; expected one of: {choices}")
+    return status
+
+
 def enum_values(enum_type: type[PolylogueStrEnum]) -> tuple[str, ...]:
     """Return persisted values for a closed enum."""
     return tuple(item.value for item in enum_type)
@@ -762,6 +776,7 @@ __all__ = [
     "Origin",
     "OperationStatus",
     "OPERATION_LIFECYCLE_STATUSES",
+    "require_operation_lifecycle_status",
     "PasteBoundary",
     "PlanStage",
     "PolylogueStrEnum",

--- a/polylogue/daemon/embedding_backlog.py
+++ b/polylogue/daemon/embedding_backlog.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from polylogue.config import load_polylogue_config
+from polylogue.core.enums import OperationStatus
 from polylogue.logging import get_logger
 from polylogue.sources.live.sqlite_locking import is_transient_sqlite_lock
 from polylogue.storage.introspection import table_exists as _table_exists
@@ -233,7 +234,7 @@ def _drain_archive_embedding_backlog_once(index_db: Path, *, archive_root: Path)
     started_at_ms = int(time.time() * 1000)
     run_id = _upsert_archive_embedding_catchup_run(
         ops_db,
-        status="running",
+        status=OperationStatus.RUNNING,
         started_at_ms=started_at_ms,
         scanned_sessions=0,
         embedded_messages=0,
@@ -250,7 +251,7 @@ def _drain_archive_embedding_backlog_once(index_db: Path, *, archive_root: Path)
         _upsert_archive_embedding_catchup_run(
             ops_db,
             run_id=run_id,
-            status="failed",
+            status=OperationStatus.FAILED,
             started_at_ms=started_at_ms,
             finished_at_ms=int(time.time() * 1000),
             error_message="vector provider unavailable",
@@ -306,7 +307,7 @@ def _drain_archive_embedding_backlog_once(index_db: Path, *, archive_root: Path)
     _upsert_archive_embedding_catchup_run(
         ops_db,
         run_id=run_id,
-        status="failed" if errors else "completed",
+        status=OperationStatus.FAILED if errors else OperationStatus.COMPLETED,
         started_at_ms=started_at_ms,
         finished_at_ms=int(time.time() * 1000),
         scanned_sessions=processed,
@@ -343,7 +344,7 @@ def _archive_embedding_catchup_estimated_cost_this_month(ops_db: Path) -> float:
 def _upsert_archive_embedding_catchup_run(
     ops_db: Path,
     *,
-    status: str,
+    status: OperationStatus,
     started_at_ms: int,
     run_id: str | None = None,
     finished_at_ms: int | None = None,

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -5234,8 +5234,9 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         dry_run: bool = bool(body.get("dry_run", False))
 
         from polylogue.config import Config
+        from polylogue.core.enums import OperationStatus
         from polylogue.maintenance.envelope import envelope_from_operation
-        from polylogue.maintenance.planner import BackfillStatus, execute_backfill
+        from polylogue.maintenance.planner import execute_backfill
         from polylogue.maintenance.scope import MaintenanceScopeFilter
         from polylogue.paths import archive_root, render_root
 
@@ -5256,7 +5257,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         # request, not a successful response describing a failure --
         # surface it as 422 so callers do not have to parse the body to
         # notice (polylogue-71ey AC 4).
-        status = HTTPStatus.UNPROCESSABLE_ENTITY if result.status is BackfillStatus.FAILED else HTTPStatus.OK
+        status = HTTPStatus.UNPROCESSABLE_ENTITY if result.status is OperationStatus.FAILED else HTTPStatus.OK
         self._send_json(status, envelope.to_dict())
 
     @daemon_safe_handler

--- a/polylogue/maintenance/cost_backfill.py
+++ b/polylogue/maintenance/cost_backfill.py
@@ -37,12 +37,12 @@ import uuid
 from dataclasses import dataclass
 from typing import Protocol
 
+from polylogue.core.enums import OperationStatus
 from polylogue.core.json import json_document
 from polylogue.maintenance.invalidation import InvalidationReason
 from polylogue.maintenance.planner import (
     BackfillKind,
     BackfillOperation,
-    BackfillStatus,
     MaintenanceScope,
 )
 from polylogue.maintenance.scope import MaintenanceScopeFilter
@@ -179,7 +179,7 @@ def plan_cost_backfill(
         operation_id=operation_id,
         kind=BackfillKind.DERIVED_REBUILD,
         targets=(SESSION_PROFILES_REBUILD_TARGET,),
-        status=BackfillStatus.PENDING,
+        status=OperationStatus.PENDING,
         affected_rows=affected,
         estimated_time_s=estimated_time_s,
         results=results,

--- a/polylogue/maintenance/planner.py
+++ b/polylogue/maintenance/planner.py
@@ -126,11 +126,6 @@ def _coerce_backfill_kind(value: object) -> BackfillKind:
         return _RETIRED_STORED_KIND_MAP.get(text, BackfillKind.DERIVED_REBUILD)
 
 
-# Compatibility name for callers that imported the former planner-local enum.
-# The operation model itself uses the canonical enum directly below.
-BackfillStatus = OperationStatus
-
-
 @dataclass(frozen=True)
 class MaintenanceScope:
     """Typed scope (target ids + typed filter) for a backfill.
@@ -446,7 +441,7 @@ def preview_backfill(
             operation_id=operation_id,
             kind=BackfillKind.DERIVED_REBUILD,
             targets=(),
-            status=BackfillStatus.FAILED,
+            status=OperationStatus.FAILED,
             error="No valid targets resolved from input",
             scope=MaintenanceScope(targets=(), filter=effective_filter),
         )
@@ -459,7 +454,7 @@ def preview_backfill(
             operation_id=operation_id,
             kind=BackfillKind.ARCHIVE_SUBSET,
             targets=resolved_names,
-            status=BackfillStatus.PENDING,
+            status=OperationStatus.PENDING,
             affected_rows=preview_result.repaired_count,
             estimated_time_s=0.0,
             results=[preview_result.to_dict()],
@@ -512,7 +507,7 @@ def preview_backfill(
         operation_id=operation_id,
         kind=BackfillKind.DERIVED_REBUILD,
         targets=resolved_names,
-        status=BackfillStatus.PENDING,
+        status=OperationStatus.PENDING,
         affected_rows=total_rows,
         estimated_time_s=estimated_time_s,
         results=preview_results,
@@ -549,7 +544,7 @@ def execute_backfill(
             operation_id=operation_id,
             kind=BackfillKind.DERIVED_REBUILD,
             targets=(),
-            status=BackfillStatus.FAILED,
+            status=OperationStatus.FAILED,
             error="No valid targets resolved from input",
             scope=MaintenanceScope(targets=(), filter=effective_filter),
         )
@@ -610,7 +605,7 @@ def execute_backfill(
             operation_id=operation_id,
             kind=BackfillKind.DERIVED_REBUILD,
             targets=resolved_names,
-            status=BackfillStatus.COMPLETED if all_success else BackfillStatus.FAILED,
+            status=OperationStatus.COMPLETED if all_success else OperationStatus.FAILED,
             progress=1.0,
             started_at=started_at,
             completed_at=completed_at,
@@ -632,7 +627,7 @@ def execute_backfill(
             operation_id=operation_id,
             kind=BackfillKind.DERIVED_REBUILD,
             targets=resolved_names,
-            status=BackfillStatus.FAILED,
+            status=OperationStatus.FAILED,
             progress=0.0,
             started_at=started_at,
             error=f"Backfill failed: {exc}",
@@ -681,7 +676,6 @@ __all__ = [
     "MAX_FAILURE_SAMPLES",
     "BackfillKind",
     "BackfillOperation",
-    "BackfillStatus",
     "BoundedFailureSamples",
     "FailureSample",
     "InvalidationReason",

--- a/polylogue/maintenance/registry.py
+++ b/polylogue/maintenance/registry.py
@@ -39,9 +39,10 @@ from pathlib import Path
 from typing import Final
 
 from polylogue.config import Config
+from polylogue.core.enums import OperationStatus
 from polylogue.core.json import JSONDocument, json_document, loads
 from polylogue.logging import get_logger
-from polylogue.maintenance.planner import BackfillOperation, BackfillStatus
+from polylogue.maintenance.planner import BackfillOperation
 
 logger = get_logger(__name__)
 
@@ -81,7 +82,7 @@ class OperationRecord:
         return self.operation.operation_id
 
     @property
-    def status(self) -> BackfillStatus:
+    def status(self) -> OperationStatus:
         return self.operation.status
 
     def to_dict(self) -> JSONDocument:
@@ -163,7 +164,7 @@ def _legacy_record_to_operation(raw: dict[str, object], path: Path) -> BackfillO
         operation_id=op_id,
         kind=BackfillKind.DERIVED_REBUILD,
         targets=targets,
-        status=BackfillStatus.RUNNING,
+        status=OperationStatus.RUNNING,
         started_at=started,
         resume_cursor=cursor,
         scope=MaintenanceScope(targets=targets),
@@ -246,7 +247,7 @@ class MaintenanceOperationRegistry:
             record = _load_record(path)
             if record is None:
                 continue
-            if record.status is not BackfillStatus.COMPLETED:
+            if record.status is not OperationStatus.COMPLETED:
                 continue
             updated_dt = _parse_updated_at(record.updated_at)
             if updated_dt is None:

--- a/polylogue/maintenance/replay.py
+++ b/polylogue/maintenance/replay.py
@@ -43,6 +43,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
 from polylogue.config import Config
+from polylogue.core.enums import OperationStatus
 from polylogue.core.json import JSONDocument, dumps, json_document, loads
 from polylogue.core.protocols import ProgressCallback as StageProgressCallback
 from polylogue.logging import get_logger
@@ -54,7 +55,6 @@ from polylogue.maintenance.invalidation import InvalidationReason
 from polylogue.maintenance.planner import (
     BackfillKind,
     BackfillOperation,
-    BackfillStatus,
     BoundedFailureSamples,
     FailureSample,
     MaintenanceScope,
@@ -514,7 +514,7 @@ def execute_replay(
             operation_id=op_id,
             kind=BackfillKind.DERIVED_REBUILD,
             targets=(),
-            status=BackfillStatus.FAILED,
+            status=OperationStatus.FAILED,
             error="No valid targets resolved from input",
             scope=MaintenanceScope(targets=(), filter=effective_filter),
         )
@@ -540,7 +540,7 @@ def execute_replay(
             operation_id=op_id,
             kind=BackfillKind.DERIVED_REBUILD,
             targets=resolved_names,
-            status=BackfillStatus.FAILED,
+            status=OperationStatus.FAILED,
             progress=0.0,
             started_at=started_at,
             completed_at=started_at,
@@ -607,7 +607,7 @@ def execute_replay(
 
     completed_at = datetime.now(timezone.utc).isoformat()
     successful = not state.failures
-    status = BackfillStatus.COMPLETED if successful else BackfillStatus.FAILED
+    status = OperationStatus.COMPLETED if successful else OperationStatus.FAILED
 
     progress = (len(resolved_names) - start_index) / len(resolved_names)
     logger.info(
@@ -843,20 +843,20 @@ def _build_in_progress_snapshot(
     Used by :func:`_checkpoint_state` to make sure every state file
     carries a rehydratable snapshot even mid-run (before
     :func:`execute_replay` has assembled its final return value). The
-    snapshot status is :data:`BackfillStatus.RUNNING` unless the
+    snapshot status is :data:`OperationStatus.RUNNING` unless the
     executor has finished all targets, in which case it surfaces as
-    :data:`BackfillStatus.COMPLETED` / :data:`BackfillStatus.FAILED`
+    :data:`OperationStatus.COMPLETED` / :data:`OperationStatus.FAILED`
     based on the in-flight failure count.
     """
 
     total = len(state.targets)
     cursor = state.cursor
     if cursor == CURSOR_DONE:
-        status = BackfillStatus.FAILED if state.failures else BackfillStatus.COMPLETED
+        status = OperationStatus.FAILED if state.failures else OperationStatus.COMPLETED
         progress = 1.0
         completed_at: str | None = datetime.now(timezone.utc).isoformat()
     else:
-        status = BackfillStatus.RUNNING
+        status = OperationStatus.RUNNING
         processed = _decode_cursor(cursor, total_targets=total)
         progress = processed / total if total > 0 else 0.0
         completed_at = None

--- a/polylogue/mcp/server_cutover.py
+++ b/polylogue/mcp/server_cutover.py
@@ -1976,7 +1976,8 @@ async def _dispatch_maintenance(hooks: ServerCallbacks, *, operation: str, kwarg
     config = Config(archive_root=archive_root(), render_root=render_root(), sources=[])
 
     if operation in ("preview", "execute"):
-        from polylogue.maintenance.planner import BackfillStatus, execute_backfill, preview_backfill
+        from polylogue.core.enums import OperationStatus
+        from polylogue.maintenance.planner import execute_backfill, preview_backfill
 
         targets = kwargs.get("targets")
         session_ids = kwargs.get("session_ids")
@@ -2007,7 +2008,7 @@ async def _dispatch_maintenance(hooks: ServerCallbacks, *, operation: str, kwarg
                     return confirm_error
             result = execute_backfill(config, targets=resolved_targets, dry_run=dry_run, scope_filter=scope_filter)
             envelope = envelope_from_operation(result, origin="mcp", mode="execute")
-            if result.status is BackfillStatus.FAILED:
+            if result.status is OperationStatus.FAILED:
                 # Typed failure: surface as an MCP error payload (not a
                 # bare 200-shaped success envelope) while still carrying
                 # the operation id and first failure/error detail so a

--- a/polylogue/storage/sqlite/archive_tiers/ops_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/ops_write.py
@@ -10,7 +10,7 @@ import sqlite3
 import uuid
 from dataclasses import dataclass
 
-from polylogue.core.enums import IngestOutcome, OperationStatus, Origin
+from polylogue.core.enums import IngestOutcome, OperationStatus, Origin, require_operation_lifecycle_status
 from polylogue.pipeline.ingest_outcomes import IngestAttemptDisposition
 
 MCP_CALL_LOG_RETENTION_MS = 90 * 24 * 60 * 60 * 1000
@@ -575,7 +575,7 @@ def record_ingest_attempt(
     """
     if attempt_id is None:
         attempt_id = str(uuid.uuid4())
-    status_value = status.value if isinstance(status, OperationStatus) else status
+    status_value = require_operation_lifecycle_status(status).value
     has_storage_route = _table_has_column(conn, "ingest_attempts", "storage_route")
     route_column = "storage_route,\n            " if has_storage_route else ""
     route_value = "?, " if has_storage_route else ""
@@ -1016,7 +1016,7 @@ def upsert_embedding_catchup_run(
     """Create or replace one ``embedding_catchup_runs`` row and return ``run_id``."""
     if run_id is None:
         run_id = str(uuid.uuid4())
-    status_value = status.value if isinstance(status, OperationStatus) else status
+    status_value = require_operation_lifecycle_status(status).value
     ensure_embedding_catchup_run_outcome_columns(conn)
     conn.execute(
         """
@@ -1070,7 +1070,7 @@ def upsert_embedding_catchup_run(
 def list_embedding_catchup_runs(
     conn: sqlite3.Connection,
     *,
-    status: str | None = None,
+    status: OperationStatus | str | None = None,
 ) -> tuple[ArchiveEmbeddingCatchupRun, ...]:
     """Return embedding catchup runs ordered by newest start first."""
     outcome_columns = _embedding_catchup_run_outcome_columns(conn)
@@ -1084,7 +1084,7 @@ def list_embedding_catchup_runs(
     params: tuple[object, ...] = ()
     if status is not None:
         query += " WHERE status = ?"
-        params = (status,)
+        params = (require_operation_lifecycle_status(status).value,)
     query += " ORDER BY started_at_ms DESC, run_id DESC"
 
     return tuple(ArchiveEmbeddingCatchupRun(*row) for row in conn.execute(query, params).fetchall())

--- a/tests/unit/cost/test_contract_suite.py
+++ b/tests/unit/cost/test_contract_suite.py
@@ -37,6 +37,7 @@ from polylogue.archive.semantic.pricing import (
     CostEstimatePayload,
     estimate_session_cost,
 )
+from polylogue.core.enums import OperationStatus
 from polylogue.cost.aggregation import session_costs_to_daily_usd
 from polylogue.cost.outlook import (
     CycleOutlook,
@@ -68,7 +69,7 @@ from polylogue.maintenance.cost_backfill import (
     plan_cost_backfill,
 )
 from polylogue.maintenance.invalidation import InvalidationReason
-from polylogue.maintenance.planner import BackfillKind, BackfillStatus
+from polylogue.maintenance.planner import BackfillKind
 from tests.infra.builders import make_conv, make_msg
 
 # ---------------------------------------------------------------------------
@@ -616,7 +617,7 @@ def test_plan_cost_backfill_emits_typed_backfill() -> None:
     )
     op = plan_cost_backfill(rows)
     assert op.kind is BackfillKind.DERIVED_REBUILD
-    assert op.status is BackfillStatus.PENDING
+    assert op.status is OperationStatus.PENDING
     assert op.targets == (SESSION_PROFILES_REBUILD_TARGET,)
     assert op.affected_rows == 2
     assert op.reason is InvalidationReason.STALE_MATERIALIZER_VERSION
@@ -636,5 +637,5 @@ def test_plan_cost_backfill_empty_input_produces_zero_affected() -> None:
     op = plan_cost_backfill(())
     assert op.affected_rows == 0
     assert op.estimated_time_s == 0.0
-    assert op.status is BackfillStatus.PENDING
+    assert op.status is OperationStatus.PENDING
     assert op.results == []

--- a/tests/unit/daemon/test_maintenance_endpoints.py
+++ b/tests/unit/daemon/test_maintenance_endpoints.py
@@ -94,13 +94,14 @@ class TestMaintenanceAPIRoutes:
         handler = _make_handler("/api/maintenance/plan", body={"targets": ["session_insights"]})
         with patch.object(handler, "_send_json") as mock:
             with patch("polylogue.maintenance.planner.preview_backfill") as mock_preview:
-                from polylogue.maintenance.planner import BackfillKind, BackfillOperation, BackfillStatus
+                from polylogue.core.enums import OperationStatus
+                from polylogue.maintenance.planner import BackfillKind, BackfillOperation
 
                 fake_op = BackfillOperation(
                     operation_id="test-001",
                     kind=BackfillKind.DERIVED_REBUILD,
                     targets=("session_insights",),
-                    status=BackfillStatus.PENDING,
+                    status=OperationStatus.PENDING,
                     affected_rows=10,
                     estimated_time_s=0.2,
                 )
@@ -117,13 +118,14 @@ class TestMaintenanceAPIRoutes:
         handler = _make_handler("/api/maintenance/run", body={"targets": ["fts_repair"], "dry_run": False})
         with patch.object(handler, "_send_json") as mock:
             with patch("polylogue.maintenance.planner.execute_backfill") as mock_exec:
-                from polylogue.maintenance.planner import BackfillKind, BackfillOperation, BackfillStatus
+                from polylogue.core.enums import OperationStatus
+                from polylogue.maintenance.planner import BackfillKind, BackfillOperation
 
                 fake_op = BackfillOperation(
                     operation_id="test-002",
                     kind=BackfillKind.INDEX_REPAIR,
                     targets=("fts_repair",),
-                    status=BackfillStatus.COMPLETED,
+                    status=OperationStatus.COMPLETED,
                     affected_rows=42,
                     started_at="2026-01-01T00:00:00+00:00",
                     completed_at="2026-01-01T00:00:01+00:00",
@@ -239,11 +241,11 @@ class TestMaintenanceRegistryEndpoints:
     def test_status_returns_envelope_with_metadata(self, tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
         """A persisted op returns the shared envelope plus updated_at / state_path."""
         from polylogue.config import Config
+        from polylogue.core.enums import OperationStatus
         from polylogue.core.json import dumps as json_dumps
         from polylogue.maintenance.planner import (
             BackfillKind,
             BackfillOperation,
-            BackfillStatus,
             MaintenanceScope,
         )
         from polylogue.maintenance.replay import state_path_for
@@ -256,7 +258,7 @@ class TestMaintenanceRegistryEndpoints:
             operation_id="op-h1",
             kind=BackfillKind.DERIVED_REBUILD,
             targets=("session_insights",),
-            status=BackfillStatus.RUNNING,
+            status=OperationStatus.RUNNING,
             scope=MaintenanceScope(targets=("session_insights",)),
         )
         path = state_path_for(config, "op-h1")

--- a/tests/unit/daemon/test_metrics_endpoint.py
+++ b/tests/unit/daemon/test_metrics_endpoint.py
@@ -441,7 +441,7 @@ class TestFormatMetricsReadsArchiveState:
                 conn,
                 started_at_ms=1,
                 finished_at_ms=2,
-                status="cancelled",
+                status="interrupted",
                 scanned_sessions=3,
                 embedded_sessions=2,
                 error_count=1,
@@ -680,7 +680,7 @@ class TestFormatMetricsReadsArchiveState:
         assert "polylogue_embedding_retrieval_ready 1" in body
         # Archive catch-up runs track outcome session counts but not rebuild
         # mode, planned/skipped breakdowns, or planned message counts.
-        assert 'polylogue_embedding_latest_catchup_run_info{rebuild="false",status="cancelled"} 1' in body
+        assert 'polylogue_embedding_latest_catchup_run_info{rebuild="false",status="interrupted"} 1' in body
         assert 'polylogue_embedding_latest_catchup_sessions{state="planned"} 3' in body
         assert 'polylogue_embedding_latest_catchup_sessions{state="processed"} 3' in body
         assert 'polylogue_embedding_latest_catchup_sessions{state="embedded"} 2' in body

--- a/tests/unit/maintenance/test_envelope_contracts.py
+++ b/tests/unit/maintenance/test_envelope_contracts.py
@@ -32,6 +32,7 @@ from pydantic import ValidationError
 
 from polylogue.cli.commands.maintenance import maintenance_group
 from polylogue.config import Config
+from polylogue.core.enums import OperationStatus
 from polylogue.maintenance.envelope import (
     EnvelopeMode,
     EnvelopeOrigin,
@@ -42,7 +43,6 @@ from polylogue.maintenance.envelope import (
 from polylogue.maintenance.planner import (
     BackfillKind,
     BackfillOperation,
-    BackfillStatus,
     BoundedFailureSamples,
     FailureSample,
     MaintenanceScope,
@@ -285,7 +285,7 @@ def _example_operation(
         operation_id="op-1",
         kind=BackfillKind.DERIVED_REBUILD,
         targets=("session_insights",),
-        status=BackfillStatus.PENDING,
+        status=OperationStatus.PENDING,
         progress=0.0,
         started_at=None,
         completed_at=None,

--- a/tests/unit/maintenance/test_idempotency.py
+++ b/tests/unit/maintenance/test_idempotency.py
@@ -22,10 +22,10 @@ from unittest.mock import patch
 import pytest
 
 from polylogue.config import Config
+from polylogue.core.enums import OperationStatus
 from polylogue.maintenance.models import MaintenanceCategory
 from polylogue.maintenance.planner import (
     MAX_FAILURE_SAMPLES,
-    BackfillStatus,
 )
 from polylogue.maintenance.replay import (
     UnsupportedReplayTargetError,
@@ -98,7 +98,7 @@ def test_second_run_makes_no_further_changes(tmp_path: Path, converging_dispatch
         targets=("session_insights", "message_type_backfill"),
         operation_id="op-first",
     )
-    assert first.status is BackfillStatus.COMPLETED
+    assert first.status is OperationStatus.COMPLETED
     assert first.affected_rows == 7 + 5
 
     # A fresh operation id on the same converged archive must report
@@ -108,7 +108,7 @@ def test_second_run_makes_no_further_changes(tmp_path: Path, converging_dispatch
         targets=("session_insights", "message_type_backfill"),
         operation_id="op-second",
     )
-    assert second.status is BackfillStatus.COMPLETED
+    assert second.status is OperationStatus.COMPLETED
     assert second.affected_rows == 0
     # Each target was called exactly twice (once per op), not more.
     assert converging_dispatch["session_insights"] == 2
@@ -145,7 +145,7 @@ def test_single_target_failure_does_not_abort_others(tmp_path: Path) -> None:
 
     # The bad target failed but the surrounding targets still ran.
     assert calls == ["session_insights", "message_type_backfill", "empty_sessions"]
-    assert op.status is BackfillStatus.FAILED
+    assert op.status is OperationStatus.FAILED
     assert op.affected_rows == 6  # only the two good targets contributed
     assert len(op.failure_samples.samples) == 1
     failure = op.failure_samples.samples[0]
@@ -173,7 +173,7 @@ def test_repair_reported_failure_surfaces_as_failure_sample(tmp_path: Path) -> N
             operation_id="op-soft-fail",
         )
 
-    assert op.status is BackfillStatus.FAILED
+    assert op.status is OperationStatus.FAILED
     assert op.failure_samples.samples[0].kind == "RepairReportedFailure"
     assert "schema mismatch" in op.failure_samples.samples[0].message
 
@@ -188,7 +188,7 @@ def test_replay_refuses_offline_repair_while_daemon_runs(monkeypatch: pytest.Mon
         operation_id="op-live-daemon",
     )
 
-    assert op.status is BackfillStatus.FAILED
+    assert op.status is OperationStatus.FAILED
     assert op.affected_rows == 0
     assert op.results[0]["name"] == "session_insights"
     assert op.failure_samples.samples[0].kind == "OfflineMaintenanceBlocked"
@@ -205,7 +205,7 @@ def test_unwired_target_is_typed_failure_not_silent(tmp_path: Path) -> None:
             operation_id="op-unsupported",
         )
 
-    assert op.status is BackfillStatus.FAILED
+    assert op.status is OperationStatus.FAILED
     sample = op.failure_samples.samples[0]
     assert sample.kind == UnsupportedReplayTargetError.__name__
     assert sample.locator == "target:session_insights"
@@ -268,6 +268,6 @@ def test_failure_samples_remain_bounded(tmp_path: Path) -> None:
             persist_state=False,
         )
 
-    assert op.status is BackfillStatus.FAILED
+    assert op.status is OperationStatus.FAILED
     assert len(op.failure_samples.samples) == MAX_FAILURE_SAMPLES
     assert op.failure_samples.truncated is True

--- a/tests/unit/maintenance/test_planner_contract.py
+++ b/tests/unit/maintenance/test_planner_contract.py
@@ -14,13 +14,13 @@ from typing import cast
 import pytest
 
 from polylogue.config import Config
+from polylogue.core.enums import OperationStatus
 from polylogue.maintenance.invalidation import InvalidationReason
 from polylogue.maintenance.models import DerivedModelStatus
 from polylogue.maintenance.planner import (
     MAX_FAILURE_SAMPLES,
     BackfillKind,
     BackfillOperation,
-    BackfillStatus,
     BoundedFailureSamples,
     FailureSample,
     MaintenanceScope,
@@ -325,7 +325,7 @@ class TestEmptyTargetsFastFail:
     def test_preview_with_no_resolvable_targets_returns_failed(self, tmp_path: Path) -> None:
         config = _make_config(tmp_path)
         op = preview_backfill(config, targets=("does-not-exist",))
-        assert op.status is BackfillStatus.FAILED
+        assert op.status is OperationStatus.FAILED
         assert op.targets == ()
         assert op.scope is not None
         assert op.scope.targets == ()
@@ -333,7 +333,7 @@ class TestEmptyTargetsFastFail:
     def test_execute_with_no_resolvable_targets_returns_failed(self, tmp_path: Path) -> None:
         config = _make_config(tmp_path)
         op = execute_backfill(config, targets=("does-not-exist",))
-        assert op.status is BackfillStatus.FAILED
+        assert op.status is OperationStatus.FAILED
         assert op.targets == ()
 
 
@@ -383,7 +383,7 @@ class TestConfigThreading:
 
         operation = execute_backfill(config, targets=("empty_sessions",), dry_run=True)
 
-        assert operation.status is BackfillStatus.COMPLETED
+        assert operation.status is OperationStatus.COMPLETED
         assert operation.affected_rows == 1
         assert operation.results[0]["name"] == "empty_sessions"
 

--- a/tests/unit/maintenance/test_registry.py
+++ b/tests/unit/maintenance/test_registry.py
@@ -20,11 +20,11 @@ from pathlib import Path
 import pytest
 
 from polylogue.config import Config
+from polylogue.core.enums import OperationStatus
 from polylogue.core.json import dumps
 from polylogue.maintenance.planner import (
     BackfillKind,
     BackfillOperation,
-    BackfillStatus,
     BoundedFailureSamples,
     FailureSample,
     MaintenanceScope,
@@ -48,7 +48,7 @@ def _write_legacy_state(config: Config, operation_id: str, *, updated_at: str, s
         operation_id=operation_id,
         kind=BackfillKind.DERIVED_REBUILD,
         targets=("session_insights",),
-        status=BackfillStatus(status),
+        status=OperationStatus(status),
         progress=1.0 if status != "running" else 0.5,
         started_at="2026-05-17T00:00:00+00:00",
         completed_at=updated_at if status != "running" else None,
@@ -84,7 +84,7 @@ class TestRegistryRoundTrip:
         record = registry.get_operation("op-1")
         assert record is not None
         assert record.operation_id == "op-1"
-        assert record.status is BackfillStatus.COMPLETED
+        assert record.status is OperationStatus.COMPLETED
         assert record.operation.targets == ("session_insights",)
         assert record.operation.affected_rows == 7
 
@@ -230,7 +230,7 @@ class TestRegistryPreservesScope:
             operation_id="op-scope",
             kind=BackfillKind.DERIVED_REBUILD,
             targets=("session_insights",),
-            status=BackfillStatus.RUNNING,
+            status=OperationStatus.RUNNING,
             scope=MaintenanceScope(
                 targets=("session_insights",),
                 filter=MaintenanceScopeFilter(origin="claude-code-session"),
@@ -268,7 +268,7 @@ class TestRegistryFailureSamplesPersist:
             operation_id="op-fails",
             kind=BackfillKind.DERIVED_REBUILD,
             targets=("session_insights",),
-            status=BackfillStatus.FAILED,
+            status=OperationStatus.FAILED,
             failure_samples=BoundedFailureSamples.from_samples(
                 [FailureSample(kind="RuntimeError", locator="target:session_insights", message="boom")]
             ),

--- a/tests/unit/maintenance/test_resume.py
+++ b/tests/unit/maintenance/test_resume.py
@@ -20,8 +20,8 @@ from unittest.mock import patch
 import pytest
 
 from polylogue.config import Config
+from polylogue.core.enums import OperationStatus
 from polylogue.maintenance.models import MaintenanceCategory
-from polylogue.maintenance.planner import BackfillStatus
 from polylogue.maintenance.replay import (
     CURSOR_DONE,
     ReplayProgress,
@@ -93,7 +93,7 @@ def test_clean_run_persists_done_and_clears_state(tmp_path: Path, patched_dispat
         operation_id="op-clean",
     )
 
-    assert op.status is BackfillStatus.COMPLETED
+    assert op.status is OperationStatus.COMPLETED
     assert op.resume_cursor == CURSOR_DONE
     # State file is removed after successful completion.
     assert not state_path_for(config, "op-clean").exists()
@@ -127,7 +127,7 @@ def test_kill_mid_run_resumes_from_persisted_cursor(tmp_path: Path, patched_disp
             operation_id="op-resume",
         )
 
-    assert first.status is BackfillStatus.FAILED
+    assert first.status is OperationStatus.FAILED
     assert patched_dispatch["session_insights"] == ["live"]
     assert patched_dispatch["empty_sessions"] == ["live"]
     assert len(boom_calls) == 1
@@ -151,7 +151,7 @@ def test_kill_mid_run_resumes_from_persisted_cursor(tmp_path: Path, patched_disp
             operation_id="op-resume",
         )
 
-    assert second.status is BackfillStatus.COMPLETED
+    assert second.status is OperationStatus.COMPLETED
     assert second.resume_cursor == CURSOR_DONE
     # session_insights was not invoked a second time.
     assert patched_dispatch["session_insights"] == ["live"]
@@ -177,7 +177,7 @@ def test_explicit_resume_cursor_overrides_persisted_state(
         resume_cursor="target:1",
     )
 
-    assert op.status is BackfillStatus.COMPLETED
+    assert op.status is OperationStatus.COMPLETED
     # Only the second target was executed (skipped session_insights).
     assert patched_dispatch["session_insights"] == []
     assert patched_dispatch["message_type_backfill"] == ["live"]
@@ -194,7 +194,7 @@ def test_progress_callback_fires_per_target(tmp_path: Path, patched_dispatch: di
         progress_callback=snapshots.append,
     )
 
-    assert op.status is BackfillStatus.COMPLETED
+    assert op.status is OperationStatus.COMPLETED
     assert [s.target for s in snapshots] == ["session_insights", "message_type_backfill"]
     assert snapshots[0].processed == 1 and snapshots[0].total == 2
     assert snapshots[-1].cursor == CURSOR_DONE
@@ -236,7 +236,7 @@ def test_session_insight_progress_is_forwarded_within_target(
         progress_callback=snapshots.append,
     )
 
-    assert op.status is BackfillStatus.COMPLETED
+    assert op.status is OperationStatus.COMPLETED
     assert [snapshot.progress_desc for snapshot in snapshots] == [
         "rebuild: materialized 17/42 session profiles",
         None,
@@ -277,7 +277,7 @@ def test_replay_operation_metrics_include_result_metrics(
         operation_id="op-metrics",
     )
 
-    assert op.status is BackfillStatus.COMPLETED
+    assert op.status is OperationStatus.COMPLETED
     assert op.metrics["repaired_count"] == 2.0
     assert op.metrics["rebuilt_profiles"] == 100.0
     assert op.metrics["source_sessions"] == 1_609_582_167.0
@@ -290,7 +290,7 @@ def test_replay_operation_metrics_include_result_metrics(
 def test_unresolved_targets_short_circuit(tmp_path: Path) -> None:
     config = _make_config(tmp_path)
     op = execute_replay(config, targets=("does-not-exist",))
-    assert op.status is BackfillStatus.FAILED
+    assert op.status is OperationStatus.FAILED
     assert op.targets == ()
     assert op.error == "No valid targets resolved from input"
 

--- a/tests/unit/maintenance/test_scope_filter.py
+++ b/tests/unit/maintenance/test_scope_filter.py
@@ -29,11 +29,11 @@ from pydantic import ValidationError
 
 from polylogue.cli.commands.maintenance import maintenance_group
 from polylogue.config import Config
+from polylogue.core.enums import OperationStatus
 from polylogue.maintenance.envelope import envelope_from_operation
 from polylogue.maintenance.planner import (
     BackfillKind,
     BackfillOperation,
-    BackfillStatus,
     MaintenanceScope,
     preview_backfill,
 )
@@ -276,7 +276,7 @@ def _example_operation_with_filter(scope_filter: MaintenanceScopeFilter) -> Back
         operation_id="op-1",
         kind=BackfillKind.DERIVED_REBUILD,
         targets=("session_insights",),
-        status=BackfillStatus.PENDING,
+        status=OperationStatus.PENDING,
         scope=MaintenanceScope(targets=("session_insights",), filter=scope_filter),
     )
 

--- a/tests/unit/maintenance/test_scope_filter_envelope_contract.py
+++ b/tests/unit/maintenance/test_scope_filter_envelope_contract.py
@@ -33,11 +33,11 @@ from click.testing import CliRunner
 
 from polylogue.cli.commands.maintenance import maintenance_group
 from polylogue.config import Config
+from polylogue.core.enums import OperationStatus
 from polylogue.maintenance.envelope import envelope_from_operation
 from polylogue.maintenance.planner import (
     BackfillKind,
     BackfillOperation,
-    BackfillStatus,
     MaintenanceScope,
 )
 from polylogue.maintenance.scope import MaintenanceScopeFilter
@@ -68,7 +68,7 @@ def _operation_for(scope_filter: MaintenanceScopeFilter) -> BackfillOperation:
         operation_id="op-fixed",
         kind=BackfillKind.DERIVED_REBUILD,
         targets=("session_insights",),
-        status=BackfillStatus.PENDING,
+        status=OperationStatus.PENDING,
         scope=MaintenanceScope(targets=("session_insights",), filter=scope_filter),
     )
 

--- a/tests/unit/operations/test_operation_contract.py
+++ b/tests/unit/operations/test_operation_contract.py
@@ -13,6 +13,10 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from polylogue.core.enums import (
+    OPERATION_LIFECYCLE_STATUSES,
+    require_operation_lifecycle_status,
+)
 from polylogue.core.enums import OperationStatus as CoreOperationStatus
 from polylogue.operations import (
     ImportAck,
@@ -256,3 +260,14 @@ class TestOperationStatusEnum:
             "failed",
             "interrupted",
         }
+
+    def test_lifecycle_subset_excludes_admission_states(self) -> None:
+        assert OPERATION_LIFECYCLE_STATUSES == (
+            OperationStatus.RUNNING,
+            OperationStatus.COMPLETED,
+            OperationStatus.FAILED,
+            OperationStatus.INTERRUPTED,
+        )
+        assert require_operation_lifecycle_status(OperationStatus.INTERRUPTED) is OperationStatus.INTERRUPTED
+        with pytest.raises(ValueError, match="not a run lifecycle status"):
+            require_operation_lifecycle_status(OperationStatus.ACCEPTED)

--- a/tests/unit/storage/test_archive_tiers_ops_write.py
+++ b/tests/unit/storage/test_archive_tiers_ops_write.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from polylogue.core.enums import Origin
+from polylogue.core.enums import OperationStatus, Origin
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database, initialize_archive_tier
 from polylogue.storage.sqlite.archive_tiers.ops_write import (
     ROUTE_OBSERVATION_ROW_CAP,
@@ -93,11 +93,6 @@ def test_existing_ops_db_converges_old_status_checks_and_preserves_rows(tmp_path
             PRAGMA user_version = 1;
             """
         )
-        with pytest.raises(sqlite3.IntegrityError):
-            conn.execute(
-                "INSERT INTO embedding_catchup_runs (run_id, started_at_ms, status) "
-                "VALUES ('rejected', 1, 'interrupted')"
-            )
         conn.execute(
             "INSERT INTO ingest_attempts (attempt_id, status, started_at_ms) VALUES ('legacy-attempt', 'completed', 1)"
         )
@@ -126,8 +121,8 @@ def test_existing_ops_db_converges_old_status_checks_and_preserves_rows(tmp_path
             "completed",
         )
 
-        record_ingest_attempt(conn, attempt_id="new-attempt", status="interrupted", started_at_ms=3)
-        upsert_embedding_catchup_run(conn, run_id="new-run", status="interrupted", started_at_ms=4)
+        record_ingest_attempt(conn, attempt_id="new-attempt", status=OperationStatus.INTERRUPTED, started_at_ms=3)
+        upsert_embedding_catchup_run(conn, run_id="new-run", status=OperationStatus.INTERRUPTED, started_at_ms=4)
 
         assert conn.execute("SELECT status FROM ingest_attempts WHERE attempt_id = 'new-attempt'").fetchone() == (
             "interrupted",
@@ -171,11 +166,37 @@ def test_ops_upsert_ingest_cursor_updates_single_row(tmp_path: Path) -> None:
     assert conn.execute("SELECT COUNT(*) FROM ingest_cursor").fetchone()[0] == 1
 
 
+def test_ops_lifecycle_checks_reject_non_lifecycle_statuses(tmp_path: Path) -> None:
+    """The fresh disposable bootstrap DDL rejects values outside the lifecycle subset."""
+    conn = _connect(tmp_path / "ops.db")
+
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO ingest_attempts (attempt_id, status, started_at_ms) VALUES (?, ?, ?)",
+            ("pending-attempt", OperationStatus.PENDING.value, 1),
+        )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO embedding_catchup_runs (run_id, status, started_at_ms) VALUES (?, ?, ?)",
+            ("cancelled-run", "cancelled", 1),
+        )
+
+
+def test_ops_writers_reject_admission_only_statuses(tmp_path: Path) -> None:
+    """Writer validation keeps admission states from bypassing the ledger contract."""
+    conn = _connect(tmp_path / "ops.db")
+
+    with pytest.raises(ValueError, match="not a run lifecycle status"):
+        record_ingest_attempt(conn, attempt_id="pending-attempt", status=OperationStatus.PENDING, started_at_ms=1)
+    with pytest.raises(ValueError, match="not a run lifecycle status"):
+        upsert_embedding_catchup_run(conn, run_id="pending-run", status=OperationStatus.PENDING, started_at_ms=1)
+
+
 def test_record_ingest_attempt_records_one_row(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "ops.db")
     attempt_id = record_ingest_attempt(
         conn,
-        status="running",
+        status=OperationStatus.RUNNING,
         source_path="/tmp/source-a.jsonl",
         origin=Origin.CHATGPT_EXPORT,
         phase="planning",
@@ -337,7 +358,7 @@ def test_record_daemon_stage_event_writes_reads_and_filters(tmp_path: Path) -> N
         event_id="stage-1",
         attempt_id="attempt-1",
         stage="parse",
-        status="running",
+        status=OperationStatus.RUNNING,
         observed_at_ms=1_700_000_070,
         payload={"queued": 3},
     )
@@ -394,7 +415,7 @@ def test_read_compact_state_reads_one_row_per_ops_helper(tmp_path: Path) -> None
     attempt_id = record_ingest_attempt(
         conn,
         attempt_id="attempt-1",
-        status="running",
+        status=OperationStatus.RUNNING,
         source_path="/tmp/source-a.jsonl",
         origin=Origin.CLAUDE_CODE_SESSION,
         started_at_ms=1_700_000_101,
@@ -433,7 +454,7 @@ def test_upsert_embedding_catchup_run_writes_and_reads_row(tmp_path: Path) -> No
     run_id = upsert_embedding_catchup_run(
         conn,
         run_id="run-1",
-        status="running",
+        status=OperationStatus.RUNNING,
         started_at_ms=1_700_000_500,
         finished_at_ms=None,
         origin=Origin.CLAUDE_CODE_SESSION,
@@ -450,7 +471,7 @@ def test_upsert_embedding_catchup_run_writes_and_reads_row(tmp_path: Path) -> No
         run_id="run-1",
         started_at_ms=1_700_000_500,
         finished_at_ms=None,
-        status="running",
+        status=OperationStatus.RUNNING,
         origin=Origin.CLAUDE_CODE_SESSION.value,
         scanned_sessions=2,
         embedded_sessions=1,
@@ -475,7 +496,7 @@ def test_upsert_embedding_catchup_run_refreshes_status_and_list_filters(tmp_path
     upsert_embedding_catchup_run(
         conn,
         run_id="run-2",
-        status="completed",
+        status=OperationStatus.COMPLETED,
         started_at_ms=1_700_000_600,
         finished_at_ms=1_700_000_700,
         scanned_sessions=2,
@@ -486,12 +507,12 @@ def test_upsert_embedding_catchup_run_refreshes_status_and_list_filters(tmp_path
     upsert_embedding_catchup_run(
         conn,
         run_id="run-3",
-        status="failed",
+        status=OperationStatus.FAILED,
         started_at_ms=1_700_000_501,
         error_message="temporary issue",
     )
 
-    completed_runs = list_embedding_catchup_runs(conn, status="completed")
+    completed_runs = list_embedding_catchup_runs(conn, status=OperationStatus.COMPLETED)
     assert len(completed_runs) == 1
     assert completed_runs[0] == ArchiveEmbeddingCatchupRun(
         run_id="run-2",


### PR DESCRIPTION
## Summary

Enforce one canonical typed lifecycle boundary for ingest attempts, embedding catch-up runs, and planner backfills. Ref polylogue-oj4oo.

## Problem

The ops ledgers had generated lifecycle checks but their writer and filter APIs still accepted generic operation states. Planner code also retained the former BackfillStatus spelling, and a metrics fixture encoded the retired cancelled database value.

## Solution

OperationStatus remains the canonical operation vocabulary. Ledger boundaries now validate its lifecycle subset only: running, completed, failed, and interrupted. Accepted, rejected, and pending remain admission/planning states and cannot be written to ingest_attempts or embedding_catchup_runs. The CLI retains its intentional complete and stopped display strings through a typed mapping; stopped persists as interrupted. Cancelled remains reserved for client/request cancellation and historical read-only surfaces. ops.db stays on its disposable bootstrap/convergence path, with no durable migration.

## Verification

- `direnv exec . devtools test tests/unit/storage/test_archive_tiers_ops_write.py tests/unit/cli/test_embed_status_fast.py tests/unit/maintenance/test_planner_contract.py tests/unit/operations/test_operation_contract.py tests/unit/daemon/test_metrics_endpoint.py` -> 144 passed.
- `direnv exec . devtools lab policy schema-versioning` -> Schema evolution policy intact.
- `direnv exec . devtools verify --quick` -> format, lint, mypy, render, layering, schema roundtrip, policy checks, and promotion audit passed.
- The new production-ledger tests bootstrap real ops.db tables, write/read the ingest and embedding surfaces, and prove direct inserts of pending and cancelled fail their actual SQLite checks.

## Acceptance matrix

| Criterion | Result |
| --- | --- |
| Canonical typed lifecycle across ledgers, planner, and operation status | Satisfied |
| Interrupted versus cancelled resolved deliberately | Satisfied |
| SQLite checks and anti-vacuity coverage | Satisfied |
| Raw authority, convergence debt, rebuild ownership, and generic executors unchanged | Satisfied |