### PR TITLE
feat(api): govern semantic operation parity

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -229,6 +229,17 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         examples=("devtools render query-discovery", "devtools render query-discovery --check"),
     ),
     CommandSpec(
+        "render api-operation-parity",
+        "generated surfaces",
+        "Render the committed semantic-operation parity matrix and Python facade reference.",
+        "devtools.render_api_operation_parity",
+        use_when=(
+            "Refresh or verify stable Python API operation IDs, cross-surface bindings, intentional exclusions, "
+            "and the signature-aware generated section in docs/library-api.md."
+        ),
+        examples=("devtools render api-operation-parity", "devtools render api-operation-parity --check"),
+    ),
+    CommandSpec(
         "render mcp-equivalence",
         "generated surfaces",
         "Render docs/generated/mcp-equivalence.json from executable MCP declarations.",

--- a/devtools/generated_surfaces.py
+++ b/devtools/generated_surfaces.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 from devtools import (
     render_agent_manual,
+    render_api_operation_parity,
     render_cli_output_schemas,
     render_cli_reference,
     render_demo_corpus_datasheet,
@@ -40,6 +41,23 @@ class GeneratedSurface:
 
 
 GENERATED_SURFACES: tuple[GeneratedSurface, ...] = (
+    GeneratedSurface(
+        name="api-operation-parity",
+        label="Python API operation parity",
+        description="Render the semantic-operation matrix and generated Python facade reference.",
+        command=control_plane_argv("render api-operation-parity"),
+        main=render_api_operation_parity.main,
+        inputs=(
+            "polylogue/api/__init__.py",
+            "polylogue/api/archive.py",
+            "polylogue/api/embeddings.py",
+            "polylogue/api/ingest.py",
+            "polylogue/api/insights.py",
+            "polylogue/api/operation_parity.py",
+            "devtools/render_api_operation_parity.py",
+            "docs/library-api.md",
+        ),
+    ),
     GeneratedSurface(
         name="agent-manual",
         label="Agent manual",

--- a/devtools/render_api_operation_parity.py
+++ b/devtools/render_api_operation_parity.py
@@ -1,0 +1,191 @@
+"""Render and verify the semantic-operation parity map for the Python API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from dataclasses import asdict
+from pathlib import Path
+
+from devtools.command_catalog import control_plane_command
+from devtools.render_support import write_if_changed
+from polylogue.api.operation_parity import (
+    API_EXCLUSIONS,
+    API_OPERATIONS,
+    API_PARITY_AUTHORITY,
+    ApiOperation,
+    SurfaceBinding,
+    facade_callable_records,
+    validate_live_facade,
+)
+
+DEFAULT_OUTPUT_PATH = Path("docs/generated/api-operation-parity.json")
+DEFAULT_LIBRARY_API_PATH = Path("docs/library-api.md")
+SCHEMA_VERSION = 1
+BEGIN_MARKER = "<!-- BEGIN GENERATED API OPERATION PARITY -->"
+END_MARKER = "<!-- END GENERATED API OPERATION PARITY -->"
+
+
+def _binding_payload(binding: SurfaceBinding) -> dict[str, object]:
+    names = binding.names
+    absence = binding.intentional_absence_authority
+    return {"names": list(names), "intentional_absence_authority": absence}
+
+
+def build_parity_payload() -> dict[str, object]:
+    """Build the committed machine-readable operation matrix."""
+
+    validate_live_facade()
+    records = {
+        binding: {"signature": signature, "async": is_async}
+        for binding, signature, is_async in facade_callable_records()
+    }
+    operations: list[dict[str, object]] = []
+    for operation in API_OPERATIONS:
+        operations.append(
+            {
+                "operation_id": operation.operation_id,
+                "section": operation.section,
+                "summary": operation.summary,
+                "route_class": operation.route_class,
+                "python": [{"binding": binding, **records.get(binding, {})} for binding in operation.python_bindings],
+                "cli": _binding_payload(operation.cli),
+                "mcp": _binding_payload(operation.mcp),
+            }
+        )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_by": control_plane_command("render api-operation-parity"),
+        "authority": {
+            "operation_declarations": "polylogue/api/operation_parity.py",
+            "drift_owner": API_PARITY_AUTHORITY,
+            "facade": "polylogue.api.Polylogue",
+            "documentation": "docs/library-api.md",
+        },
+        "operation_count": len(operations),
+        "operations": operations,
+        "exclusions": [asdict(exclusion) for exclusion in API_EXCLUSIONS],
+    }
+
+
+def render_parity_output() -> str:
+    return json.dumps(build_parity_payload(), indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+
+def _display_binding(binding: SurfaceBinding) -> str:
+    names = binding.names
+    absence = binding.intentional_absence_authority
+    return ", ".join(f"`{name}`" for name in names) if names else f"Intentional absence: `{absence}`"
+
+
+def render_library_api_section() -> str:
+    """Render the signature- and asyncness-aware section in library-api.md."""
+
+    validate_live_facade()
+    records = {binding: (signature, is_async) for binding, signature, is_async in facade_callable_records()}
+    by_section: defaultdict[str, list[ApiOperation]] = defaultdict(list)
+    for operation in API_OPERATIONS:
+        by_section[operation.section].append(operation)
+
+    lines = [
+        BEGIN_MARKER,
+        "",
+        "## Generated facade operation index",
+        "",
+        "This reference is generated from `polylogue/api/operation_parity.py`. Each live public facade callable is bound to a stable semantic operation ID; exported data models and adapter helpers are listed as intentional exclusions in the committed [machine-readable matrix](generated/api-operation-parity.json).",
+        "",
+    ]
+    for section, operations in by_section.items():
+        lines.extend([f"### {section}", ""])
+        for operation in operations:
+            lines.extend(
+                [
+                    f"#### `{operation.operation_id}`",
+                    "",
+                    operation.summary,
+                    "",
+                    f"Route/tier class: `{operation.route_class}`. CLI: {_display_binding(operation.cli)}. MCP: {_display_binding(operation.mcp)}.",
+                    "",
+                ]
+            )
+            lines.extend(["| Python callable | Signature |", "|---|---|"])
+            for binding in operation.python_bindings:
+                if binding not in records:
+                    lines.append(f"| `{binding}` | Constructed facade builder |")
+                    continue
+                signature, is_async = records[binding]
+                prefix = "async " if is_async else ""
+                lines.append(f"| `{binding}` | `{prefix}{signature}` |")
+            lines.append("")
+    lines.extend(["### Intentional exclusions", "", "| Export | Reason | Authority |", "|---|---|---|"])
+    for exclusion in API_EXCLUSIONS:
+        lines.append(f"| `{exclusion.binding}` | {exclusion.reason} | `{exclusion.authority}` |")
+    lines.extend(["", END_MARKER])
+    return "\n".join(lines)
+
+
+def replace_library_api_section(current: str, section: str) -> str:
+    """Replace only the generated block, rejecting an unmarked duplicate surface."""
+
+    if current.count(BEGIN_MARKER) != 1 or current.count(END_MARKER) != 1:
+        raise ValueError("docs/library-api.md must contain exactly one API parity marker pair")
+    start = current.index(BEGIN_MARKER)
+    end = current.index(END_MARKER, start) + len(END_MARKER)
+    return current[:start] + section + current[end:]
+
+
+def render_library_api_output(path: Path) -> str:
+    return replace_library_api_section(path.read_text(encoding="utf-8"), render_library_api_section())
+
+
+def validate_library_api_section(contents: str) -> None:
+    """Reject a missing, mis-sectioned, stale-signature API reference."""
+
+    if contents.count(BEGIN_MARKER) != 1 or contents.count(END_MARKER) != 1:
+        raise ValueError("docs/library-api.md must contain exactly one API parity marker pair")
+    start = contents.index(BEGIN_MARKER)
+    end = contents.index(END_MARKER, start) + len(END_MARKER)
+    if contents[start:end] != render_library_api_section():
+        raise ValueError("docs/library-api.md generated API parity section does not match live facade signatures")
+
+
+def _check(path: Path, expected: str, label: str) -> bool:
+    actual = path.read_text(encoding="utf-8") if path.exists() else ""
+    if actual == expected:
+        print(f"render api-operation-parity: sync OK: {label}")
+        return True
+    print(f"render api-operation-parity: out of sync: {label}", file=sys.stderr)
+    return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Render the semantic-operation parity matrix for the Python API.")
+    parser.add_argument("--output-path", type=Path, default=DEFAULT_OUTPUT_PATH)
+    parser.add_argument("--library-api-path", type=Path, default=DEFAULT_LIBRARY_API_PATH)
+    parser.add_argument(
+        "--check", action="store_true", help="Exit non-zero when the artifact or API reference is out of sync."
+    )
+    args = parser.parse_args(argv)
+    try:
+        parity = render_parity_output()
+        library_api = render_library_api_output(args.library_api_path)
+        validate_library_api_section(library_api)
+    except (ValueError, OSError) as exc:
+        print(f"render api-operation-parity: {exc}", file=sys.stderr)
+        return 1
+    if args.check:
+        return (
+            0
+            if _check(args.output_path, parity, str(args.output_path))
+            and _check(args.library_api_path, library_api, str(args.library_api_path))
+            else 1
+        )
+    write_if_changed(args.output_path, parity)
+    write_if_changed(args.library_api_path, library_api)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -107,6 +107,7 @@ These are the commands worth remembering during normal repo work:
 | --- | --- |
 | `devtools render agent-manual` | Render the declaration-generated six-tool agent manual and packaged integration assets. |
 | `devtools render all` | Refresh or verify generated docs and agent files. |
+| `devtools render api-operation-parity` | Render the committed semantic-operation parity matrix and Python facade reference. |
 | `devtools render cli-output-schemas` | Render JSON Schema artifacts for stable CLI output payloads under docs/schemas/cli-output/. |
 | `devtools render cli-reference` | Render docs/cli-reference.md from live CLI help. |
 | `devtools render demo-corpus-datasheet` | Render docs/plans/demo-corpus-construct-audit.md from the demo family registry and a measured seed archive. |

--- a/docs/generated/api-operation-parity.json
+++ b/docs/generated/api-operation-parity.json
@@ -1,0 +1,1163 @@
+{
+  "authority": {
+    "documentation": "docs/library-api.md",
+    "drift_owner": "polylogue-s1kr",
+    "facade": "polylogue.api.Polylogue",
+    "operation_declarations": "polylogue/api/operation_parity.py"
+  },
+  "exclusions": [
+    {
+      "authority": "polylogue-s1kr",
+      "binding": "ArchiveStats",
+      "reason": "Result data model, not an executable archive operation."
+    },
+    {
+      "authority": "polylogue-s1kr",
+      "binding": "select_pending_embedding_session_window",
+      "reason": "Public adapter helper for daemon/CLI window selection. It is intentionally not a facade operation."
+    },
+    {
+      "authority": "polylogue-s1kr",
+      "binding": "Polylogue.__repr__",
+      "reason": "Diagnostic representation protocol, not an archive operation."
+    }
+  ],
+  "generated_by": "devtools render api-operation-parity",
+  "operation_count": 15,
+  "operations": [
+    {
+      "cli": {
+        "intentional_absence_authority": "polylogue-s1kr",
+        "names": []
+      },
+      "mcp": {
+        "intentional_absence_authority": "polylogue-s1kr",
+        "names": []
+      },
+      "operation_id": "api.lifecycle.construct",
+      "python": [
+        {
+          "binding": "Polylogue"
+        },
+        {
+          "async": false,
+          "binding": "Polylogue.__init__",
+          "signature": "(archive_root: 'str | Path | None' = None, db_path: 'str | Path | None' = None, *, runtime: 'ResolvedRuntimeConfig | None' = None) -> 'None'"
+        },
+        {
+          "async": false,
+          "binding": "Polylogue.open",
+          "signature": "(*, config: 'Config | None' = None, runtime: 'ResolvedRuntimeConfig | None' = None, **kwargs: 'object') -> 'Polylogue'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.__aenter__",
+          "signature": "(self) -> 'Polylogue'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.__aexit__",
+          "signature": "(self, exc_type: 'object', exc_val: 'object', exc_tb: 'object') -> 'None'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.close",
+          "signature": "(self) -> 'None'"
+        }
+      ],
+      "route_class": "lifecycle",
+      "section": "Lifecycle and builders",
+      "summary": "Construct, open, and close a facade bound to one archive runtime."
+    },
+    {
+      "cli": {
+        "intentional_absence_authority": null,
+        "names": [
+          "ops embed status"
+        ]
+      },
+      "mcp": {
+        "intentional_absence_authority": null,
+        "names": [
+          "status"
+        ]
+      },
+      "operation_id": "api.embedding.status",
+      "python": [
+        {
+          "async": false,
+          "binding": "Polylogue.embedding_status",
+          "signature": "(self, *, detail: 'bool' = False) -> 'dict[str, object]'"
+        }
+      ],
+      "route_class": "embedding-status",
+      "section": "Embedding readiness",
+      "summary": "Read the no-spend embedding readiness state."
+    },
+    {
+      "cli": {
+        "intentional_absence_authority": null,
+        "names": [
+          "ops embed preflight"
+        ]
+      },
+      "mcp": {
+        "intentional_absence_authority": null,
+        "names": [
+          "status"
+        ]
+      },
+      "operation_id": "api.embedding.preflight",
+      "python": [
+        {
+          "async": false,
+          "binding": "Polylogue.embedding_preflight",
+          "signature": "(self, *, rebuild: 'bool' = False, max_sessions: 'int | None' = None, max_messages: 'int | None' = None, max_cost_usd: 'float | None' = None) -> 'dict[str, object]'"
+        }
+      ],
+      "route_class": "embedding-preflight",
+      "section": "Embedding readiness",
+      "summary": "Calculate a bounded no-provider-call embedding catch-up window."
+    },
+    {
+      "cli": {
+        "intentional_absence_authority": null,
+        "names": [
+          "find similar"
+        ]
+      },
+      "mcp": {
+        "intentional_absence_authority": null,
+        "names": [
+          "query"
+        ]
+      },
+      "operation_id": "api.embedding.search",
+      "python": [
+        {
+          "async": true,
+          "binding": "Polylogue.search_similar_sessions",
+          "signature": "(self, session_id: 'str', *, limit: 'int' = 10, vector_provider: 'VectorProvider | None' = None, voyage_api_key: 'str | None' = None) -> 'dict[str, object]'"
+        }
+      ],
+      "route_class": "embedding-read",
+      "section": "Embedding retrieval",
+      "summary": "Search stored session vectors using the embeddings tier."
+    },
+    {
+      "cli": {
+        "intentional_absence_authority": null,
+        "names": [
+          "import"
+        ]
+      },
+      "mcp": {
+        "intentional_absence_authority": null,
+        "names": [
+          "run"
+        ]
+      },
+      "operation_id": "api.ingest.parse",
+      "python": [
+        {
+          "async": true,
+          "binding": "Polylogue.parse_file",
+          "signature": "(self, path: 'str | Path', *, source_name: 'str | None' = None) -> 'ParseResult'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.parse_sources",
+          "signature": "(self, sources: 'list[Source] | None' = None, *, download_assets: 'bool' = True) -> 'ParseResult'"
+        }
+      ],
+      "route_class": "source-index-write",
+      "section": "Ingestion and derived maintenance",
+      "summary": "Parse configured or explicit sources into source and index tiers."
+    },
+    {
+      "cli": {
+        "intentional_absence_authority": null,
+        "names": [
+          "ops reset --index"
+        ]
+      },
+      "mcp": {
+        "intentional_absence_authority": null,
+        "names": [
+          "maintenance"
+        ]
+      },
+      "operation_id": "api.index.rebuild",
+      "python": [
+        {
+          "async": true,
+          "binding": "Polylogue.rebuild_index",
+          "signature": "(self) -> 'bool'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.update_index",
+          "signature": "(self, session_ids: 'list[str]') -> 'bool'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.rebuild_insights",
+          "signature": "(self, session_ids: 'Sequence[str] | None' = None, *, progress_callback: 'ProgressCallback | None' = None) -> 'SessionInsightCounts'"
+        }
+      ],
+      "route_class": "index-write",
+      "section": "Ingestion and derived maintenance",
+      "summary": "Rebuild or update the derived index through the mutation executor."
+    },
+    {
+      "cli": {
+        "intentional_absence_authority": null,
+        "names": [
+          "find",
+          "read"
+        ]
+      },
+      "mcp": {
+        "intentional_absence_authority": null,
+        "names": [
+          "query",
+          "read",
+          "get",
+          "status"
+        ]
+      },
+      "operation_id": "api.archive.session-read",
+      "python": [
+        {
+          "async": true,
+          "binding": "Polylogue.get_session",
+          "signature": "(self, session_id: 'str', *, content_projection: 'ContentProjectionSpec | None' = None) -> 'Session | None'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_sessions",
+          "signature": "(self, session_ids: 'list[str]', *, content_projection: 'ContentProjectionSpec | None' = None) -> 'list[Session]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_actions_batch",
+          "signature": "(self, session_ids: 'builtins.list[str]') -> 'dict[str, tuple[Action, ...]]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_sessions",
+          "signature": "(self, origin: 'str | None' = None, limit: 'int | None' = None, content_projection: 'ContentProjectionSpec | None' = None) -> 'list[Session]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_summaries",
+          "signature": "(self, *, limit: 'int | None' = 50, offset: 'int' = 0, origin: 'str | None' = None) -> 'builtins.list[SessionSummary]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_sessions_for_spec",
+          "signature": "(self, spec: 'SessionQuerySpec', *, content_projection: 'ContentProjectionSpec | None' = None) -> 'list[Session]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.search_session_hits",
+          "signature": "(self, spec: 'SessionQuerySpec') -> 'builtins.list[SessionSearchHit]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.search",
+          "signature": "(self, query: 'str', *, limit: 'int' = 100, source: 'str | None' = None, since: 'str | None' = None) -> 'SearchResult'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.search_envelope",
+          "signature": "(self, query: 'str', *, limit: 'int' = 50, offset: 'int' = 0, origin: 'str | None' = None, since: 'str | None' = None, until: 'str | None' = None, retrieval_lane: 'str' = 'auto', sort: 'str | None' = None, cursor: 'str | None' = None) -> 'SearchEnvelope'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.archive_count_sessions",
+          "signature": "(self, *, origin: 'str | None' = None, excluded_origins: 'Sequence[str]' = (), tags: 'Sequence[str]' = (), excluded_tags: 'Sequence[str]' = (), repo_names: 'Sequence[str]' = (), project_refs: 'Sequence[str]' = (), has_types: 'Sequence[str]' = (), has_tool_use: 'bool' = False, has_thinking: 'bool' = False, has_paste: 'bool' = False, tool_terms: 'Sequence[str]' = (), excluded_tool_terms: 'Sequence[str]' = (), action_terms: 'Sequence[str]' = (), excluded_action_terms: 'Sequence[str]' = (), action_sequence: 'Sequence[str]' = (), action_text_terms: 'Sequence[str]' = (), referenced_paths: 'Sequence[str]' = (), cwd_prefix: 'str | None' = None, typed_only: 'bool' = False, message_type: 'str | None' = None, title: 'str | None' = None, min_messages: 'int | None' = None, max_messages: 'int | None' = None, min_words: 'int | None' = None, max_words: 'int | None' = None, since: 'str | None' = None, until: 'str | None' = None) -> 'int'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.archive_get_session",
+          "signature": "(self, session_id: 'str') -> 'ArchiveSessionEnvelope | None'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_messages_paginated",
+          "signature": "(self, session_id: 'str', *, message_role: 'MessageRoleFilter' = (), message_type: 'MessageTypeName | None' = None, material_origin: 'tuple[MaterialOrigin, ...]' = (), limit: 'int' = 50, offset: 'int' = 0, content_projection: 'ContentProjectionSpec | None' = None) -> 'tuple[list[Message], int, LineageCompleteness]'"
+        },
+        {
+          "async": false,
+          "binding": "Polylogue.iter_messages",
+          "signature": "(self, session_id: 'str', *, message_roles: 'MessageRoleFilter' = (), material_origin: 'tuple[MaterialOrigin, ...]' = (), limit: 'int | None' = None) -> 'AsyncIterator[Message]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.bulk_get_messages",
+          "signature": "(self, session_ids: 'Sequence[str]', *, since: 'str | None' = None, until: 'str | None' = None, message_role: 'MessageRoleFilter' = (), material_origin: 'tuple[MaterialOrigin, ...]' = (), content_projection: 'ContentProjectionSpec | None' = None) -> 'dict[str, list[Message]]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.query_sessions",
+          "signature": "(self, *, origin: 'str | None' = None, tag: 'str | None' = None, since: 'str | None' = None, until: 'str | None' = None, sort: 'str | None' = None, limit: 'int | None' = None, offset: 'int' = 0, has_tool_use: 'bool' = False, has_thinking: 'bool' = False, has_paste: 'bool' = False, typed_only: 'bool' = False, min_messages: 'int | None' = None, max_messages: 'int | None' = None, min_words: 'int | None' = None, **kwargs: 'object') -> 'builtins.list[dict[str, object]]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.count_sessions",
+          "signature": "(self, *, origin: 'str | None' = None, since: 'str | None' = None, until: 'str | None' = None, **kwargs: 'object') -> 'int'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_session_summary",
+          "signature": "(self, session_id: 'str') -> 'SessionSummary | None'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_session_stats",
+          "signature": "(self, session_id: 'str') -> 'dict[str, int]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_stats_by",
+          "signature": "(self, group_by: 'str' = 'origin') -> 'dict[str, int]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_index_status",
+          "signature": "(self) -> 'IndexStatus'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.stats",
+          "signature": "(self) -> 'ArchiveStats'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.storage_stats",
+          "signature": "(self) -> 'StorageArchiveStats'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.facets",
+          "signature": "(self, spec: 'SessionQuerySpec | None' = None, *, include_idf: 'bool' = True, include_deferred: 'bool' = True) -> 'FacetsResponse'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.health_check",
+          "signature": "(self) -> 'ReadinessReport'"
+        },
+        {
+          "async": false,
+          "binding": "Polylogue.filter",
+          "signature": "(self) -> 'SessionFilter'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_read_view_profiles",
+          "signature": "(self) -> 'list[JSONDocument]'"
+        }
+      ],
+      "route_class": "index-read",
+      "section": "Archive reads",
+      "summary": "Read sessions, summaries, messages, actions, and archive statistics from the index tier."
+    },
+    {
+      "cli": {
+        "intentional_absence_authority": null,
+        "names": [
+          "find",
+          "read",
+          "analyze"
+        ]
+      },
+      "mcp": {
+        "intentional_absence_authority": null,
+        "names": [
+          "query",
+          "read",
+          "get",
+          "explain"
+        ]
+      },
+      "operation_id": "api.archive.query-analysis",
+      "python": [
+        {
+          "async": true,
+          "binding": "Polylogue.explain_query_expression",
+          "signature": "(self, expression: 'str') -> 'JSONDocument'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.query_units",
+          "signature": "(self, expression: 'str | None' = None, *, limit: 'int | None' = None, offset: 'int | None' = None, origin: 'str | None' = None, origins: 'tuple[str, ...]' = (), excluded_origins: 'tuple[str, ...]' = (), tag: 'str | None' = None, tags: 'tuple[str, ...]' = (), excluded_tags: 'tuple[str, ...]' = (), repo: 'str | None' = None, repo_names: 'tuple[str, ...]' = (), project: 'str | None' = None, project_refs: 'tuple[str, ...]' = (), has_types: 'tuple[str, ...]' = (), tool_terms: 'tuple[str, ...]' = (), excluded_tool_terms: 'tuple[str, ...]' = (), action_terms: 'tuple[str, ...]' = (), excluded_action_terms: 'tuple[str, ...]' = (), action_sequence: 'tuple[str, ...]' = (), action_text_terms: 'tuple[str, ...]' = (), referenced_paths: 'tuple[str, ...]' = (), cwd_prefix: 'str | None' = None, title: 'str | None' = None, since: 'str | None' = None, until: 'str | None' = None, has_tool_use: 'bool' = False, has_thinking: 'bool' = False, has_paste: 'bool' = False, typed_only: 'bool' = False, min_messages: 'int | None' = None, max_messages: 'int | None' = None, min_words: 'int | None' = None, max_words: 'int | None' = None, message_type: 'str | None' = None, continuation: 'str | None' = None) -> 'QueryUnitResultEnvelope'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.query_completions",
+          "signature": "(self, kind: 'str', *, incomplete: 'str' = '', unit: 'str | None' = None, field: 'str | None' = None) -> 'JSONDocument'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.diagnose_query_miss",
+          "signature": "(self, spec: 'SessionQuerySpec', *, full: 'bool' = False) -> 'QueryMissDiagnostics'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.resolve_ref",
+          "signature": "(self, ref: 'str') -> 'PublicRefResolutionPayload'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.export_otel",
+          "signature": "(self, *, source_ref: 'str', expressions: 'Sequence[str]', limit: 'int' = 50, include_message_text: 'bool' = False) -> 'OtelProjectionPayload'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.neighbor_candidates",
+          "signature": "(self, *, session_id: 'str | None' = None, query: 'str | None' = None, origin: 'str | None' = None, limit: 'int' = 10, window_hours: 'int' = 24) -> 'list[SessionNeighborCandidate]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.neighbor_candidate_payloads",
+          "signature": "(self, *, session_id: 'str | None' = None, query: 'str | None' = None, origin: 'str | None' = None, limit: 'int' = 10, window_hours: 'int' = 24) -> 'list[JSONDocument]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.session_correlation_payload",
+          "signature": "(self, session_id: 'str', *, repo_path: 'str | None' = None, since_hours: 'int' = 2, confidence_threshold: 'float' = 0.3) -> 'JSONDocument | None'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.origin_usage_report",
+          "signature": "(self, *, origin: 'str | None' = None, limit: 'int | None' = 25, detail: 'str' = 'full') -> 'ProviderUsageReport'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.session_usage_reconciliation",
+          "signature": "(self, session_id: 'str') -> 'SessionUsageReconciliation'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.resume_brief",
+          "signature": "(self, session_id: 'str', *, related_limit: 'int' = 6, repo_path: 'str | None' = None, recent_files: 'Sequence[str]' = ()) -> 'ResumeBrief | None'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.find_resume_candidates",
+          "signature": "(self, *, repo_path: 'str', cwd: 'str | None' = None, recent_files: 'Sequence[str]' = (), limit: 'int' = 10) -> 'tuple[ResumeCandidate, ...]'"
+        }
+      ],
+      "route_class": "index-read",
+      "section": "Archive reads",
+      "summary": "Compile, explain, diagnose, and resolve archive query and reference projections."
+    },
+    {
+      "cli": {
+        "intentional_absence_authority": null,
+        "names": [
+          "read",
+          "analyze"
+        ]
+      },
+      "mcp": {
+        "intentional_absence_authority": null,
+        "names": [
+          "read",
+          "explain"
+        ]
+      },
+      "operation_id": "api.archive.source-evidence-read",
+      "python": [
+        {
+          "async": true,
+          "binding": "Polylogue.explain_import",
+          "signature": "(self, path: 'str | Path | None' = None, *, raw_ref: 'str | None' = None, source_path: 'str | None' = None, source_name: 'str' = 'unknown', limit: 'int' = 100, redact_paths: 'bool' = True) -> 'ImportExplainPayload'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_raw_artifacts_for_session",
+          "signature": "(self, session_id: 'str', *, limit: 'int' = 50, offset: 'int' = 0) -> 'tuple[list[dict[str, object]], int]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_hook_event_summary_for_session",
+          "signature": "(self, session_id: 'str') -> 'dict[str, object] | None'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_session_events",
+          "signature": "(self, session_id: 'str', *, event_type: 'str | None' = None, limit: 'int | None' = None) -> 'list[dict[str, object]] | None'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_file_edits",
+          "signature": "(self, session_id: 'str') -> 'list[dict[str, object]] | None'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_web_content_constructs",
+          "signature": "(self, session_id: 'str', *, construct_type: 'str | None' = None) -> 'list[dict[str, object]] | None'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_agent_policies",
+          "signature": "(self, session_id: 'str') -> 'list[dict[str, object]] | None'"
+        }
+      ],
+      "route_class": "source-read",
+      "section": "Source evidence reads",
+      "summary": "Read raw artifacts and provider-side evidence retained in the durable source tier."
+    },
+    {
+      "cli": {
+        "intentional_absence_authority": null,
+        "names": [
+          "analyze",
+          "read"
+        ]
+      },
+      "mcp": {
+        "intentional_absence_authority": null,
+        "names": [
+          "query",
+          "get",
+          "status",
+          "explain"
+        ]
+      },
+      "operation_id": "api.archive.insight-read",
+      "python": [
+        {
+          "async": true,
+          "binding": "Polylogue.get_session_insight_status",
+          "signature": "(self) -> 'SessionInsightStatusSnapshot'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_session_profile_insight",
+          "signature": "(self, session_id: 'str', *, tier: 'str' = 'merged') -> 'SessionProfileInsight | None'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_session_profile_record",
+          "signature": "(self, session_id: 'str') -> 'SessionProfileRecord | None'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_session_profile_insights",
+          "signature": "(self, query: 'SessionProfileInsightQuery | None' = None) -> 'list[SessionProfileInsight]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.insight_readiness_report",
+          "signature": "(self, query: 'InsightReadinessQuery | None' = None) -> 'InsightReadinessReport'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.insight_rigor_audit",
+          "signature": "(self, query: 'InsightRigorAuditQuery | None' = None) -> 'InsightRigorAuditReport'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.archive_debt",
+          "signature": "(self, *, kinds: 'Iterable[str] | None' = None, only_actionable: 'bool' = False, limit: 'int | None' = None, exact_fts: 'bool' = False) -> 'ArchiveDebtListPayload'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_session_work_event_insights",
+          "signature": "(self, session_id: 'str') -> 'list[SessionWorkEventInsight]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_session_work_event_insights",
+          "signature": "(self, query: 'SessionWorkEventInsightQuery | None' = None) -> 'list[SessionWorkEventInsight]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_session_phase_insights",
+          "signature": "(self, session_id: 'str') -> 'list[SessionPhaseInsight]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_session_phase_insights",
+          "signature": "(self, query: 'SessionPhaseInsightQuery | None' = None) -> 'list[SessionPhaseInsight]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_thread_insight",
+          "signature": "(self, thread_id: 'str') -> 'ThreadInsight | None'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_thread_insights",
+          "signature": "(self, query: 'ThreadInsightQuery | None' = None) -> 'list[ThreadInsight]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_session_tag_rollup_insights",
+          "signature": "(self, query: 'SessionTagRollupQuery | None' = None) -> 'list[SessionTagRollupInsight]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_archive_coverage_insights",
+          "signature": "(self, query: 'ArchiveCoverageInsightQuery | None' = None) -> 'list[ArchiveCoverageInsight]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_tool_usage_insights",
+          "signature": "(self, query: 'ToolUsageInsightQuery | None' = None) -> 'list[ToolUsageInsight]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_session_cost_insights",
+          "signature": "(self, query: 'SessionCostInsightQuery | None' = None) -> 'list[SessionCostInsight]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_session_latency_profile_insight",
+          "signature": "(self, session_id: 'str') -> 'SessionLatencyProfileInsight | None'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_session_latency_profile_insights",
+          "signature": "(self, query: 'SessionLatencyProfileInsightQuery | None' = None) -> 'list[SessionLatencyProfileInsight]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.find_stuck_session_latency_profile_insights",
+          "signature": "(self, query: 'SessionLatencyProfileInsightQuery | None' = None) -> 'list[SessionLatencyProfileInsight]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_cost_rollup_insights",
+          "signature": "(self, query: 'CostRollupInsightQuery | None' = None) -> 'list[CostRollupInsight]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_usage_timeline_insights",
+          "signature": "(self, query: 'UsageTimelineInsightQuery | None' = None) -> 'list[UsageTimelineInsight]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_archive_debt_insights",
+          "signature": "(self, query: 'ArchiveDebtInsightQuery | None' = None) -> 'list[ArchiveDebtInsight]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.cost_outlook",
+          "signature": "(self, plan_name: 'str', *, now: 'datetime | None' = None, method: 'ProjectionMethod' = <ProjectionMethod.linear: 'linear'>) -> 'CycleOutlook | None'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.aggregate_sessions",
+          "signature": "(self, *, group_by: 'str' = 'workflow_shape', since: 'str | None' = None, until: 'str | None' = None, origin: 'str | None' = None) -> 'dict[str, object]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.workflow_shape_distribution",
+          "signature": "(self, *, group_by: 'str' = 'week', since: 'str | None' = None, until: 'str | None' = None, origin: 'str | None' = None) -> 'dict[str, object]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.find_abandoned_sessions",
+          "signature": "(self, *, since: 'str | None' = None, repo_path: 'str | None' = None, min_severity: 'str' = 'question_left', limit: 'int' = 20) -> 'dict[str, object]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.tool_call_latency_distribution",
+          "signature": "(self, *, since: 'str | None' = None, until: 'str | None' = None, origin: 'str | None' = None, tool_category: 'str | None' = None, limit: 'int' = 500) -> 'dict[str, object]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.compare_sessions",
+          "signature": "(self, session_ids: 'Sequence[str]') -> 'dict[str, object]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.find_similar_sessions_by_metadata",
+          "signature": "(self, session_id: 'str', *, limit: 'int' = 10, candidate_pool_limit: 'int' = 200) -> 'dict[str, object] | None'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.correlate_sessions",
+          "signature": "(self, *, metric_x: 'str', metric_y: 'str', origin: 'str | None' = None, since: 'str | None' = None, until: 'str | None' = None) -> 'dict[str, object]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_session_topology",
+          "signature": "(self, session_id: 'str') -> 'SessionTopology | None'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_ancestors",
+          "signature": "(self, session_id: 'str') -> 'list[SessionRef]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_descendants",
+          "signature": "(self, session_id: 'str') -> 'list[SessionRef]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_siblings",
+          "signature": "(self, session_id: 'str') -> 'list[SessionRef]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_thread",
+          "signature": "(self, session_id: 'str') -> 'list[SessionRef]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_logical_session",
+          "signature": "(self, session_id: 'str') -> 'LogicalSession | None'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_session_tree",
+          "signature": "(self, session_id: 'str') -> 'list[Session]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.postmortem_bundle",
+          "signature": "(self, spec: 'SessionQuerySpec | None' = None, *, limit: 'int | None' = None) -> 'PostmortemBundle'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.pathology_report",
+          "signature": "(self, spec: 'SessionQuerySpec | None' = None, *, limit: 'int | None' = None) -> 'PathologyReport'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.portfolio_bundle",
+          "signature": "(self, spec: 'SessionQuerySpec | None' = None, *, limit: 'int | None' = None, top_n: 'int' = 10) -> 'PortfolioBundle'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.export_insight_bundle",
+          "signature": "(self, request: 'InsightExportBundleRequest') -> 'InsightExportBundleResult'"
+        }
+      ],
+      "route_class": "index-read",
+      "section": "Insights and topology",
+      "summary": "Read materialized archive insights, topology, and derived archive health from the index tier."
+    },
+    {
+      "cli": {
+        "intentional_absence_authority": null,
+        "names": [
+          "continue",
+          "read"
+        ]
+      },
+      "mcp": {
+        "intentional_absence_authority": null,
+        "names": [
+          "context",
+          "get",
+          "status"
+        ]
+      },
+      "operation_id": "api.context.delivery",
+      "python": [
+        {
+          "async": true,
+          "binding": "Polylogue.compile_context",
+          "signature": "(self, spec: 'ContextSpec') -> 'ContextImage'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.context_image_payload",
+          "signature": "(self, *, project_path: 'str | None' = None, project_repo: 'str | None' = None, since: 'str | None' = None, until: 'str | None' = None, origin: 'str | None' = None, query: 'str | None' = None, max_sessions: 'int' = 5, max_tokens: 'int | None' = None, max_messages_per_session: 'int | None' = 24, max_chars_per_message: 'int | None' = 1800, include_messages: 'bool' = True, include_assertions: 'bool' = True, redact_paths: 'bool' = True, seed_session_id: 'str | None' = None) -> 'ContextImage'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.context_preamble_payload",
+          "signature": "(self, session_id: 'str', *, related_limit: 'int' = 5) -> 'Any'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_context_delivery",
+          "signature": "(self, snapshot_ref: 'str', *, recipient_ref: 'str') -> 'ArchiveContextDeliveryEnvelope | None'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_context_deliveries",
+          "signature": "(self, *, recipient_ref: 'str | None' = None, assertion_ref: 'str | None' = None, limit: 'int' = 50) -> 'list[ArchiveContextDeliveryEnvelope]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.record_context_delivery",
+          "signature": "(self, *, image: 'ContextImage', boundary: 'str', recipient_ref: 'str', delivered_by_ref: 'str', run_ref: 'str | None' = None, inheritance_mode: 'str' = 'explicit') -> 'ArchiveContextDeliveryEnvelope'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.compile_and_record_context",
+          "signature": "(self, *, recipient_ref: 'str', delivered_by_ref: 'str', boundary: 'str', query: 'str | None' = None, max_sessions: 'int' = 5, max_tokens: 'int | None' = None, include_messages: 'bool' = True, include_assertions: 'bool' = True, redact_paths: 'bool' = True, seed_session_id: 'str | None' = None, run_ref: 'str | None' = None, inheritance_mode: 'str' = 'explicit') -> 'ArchiveContextDeliveryEnvelope'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.correlate_hermes_context_deliveries",
+          "signature": "(self, hermes_session_native_id: 'str') -> 'tuple[HermesContextDeliveryCorrelation, ...]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.reconcile_hermes_session_lifecycle",
+          "signature": "(self, hermes_session_native_id: 'str') -> 'HermesLifecycleReconciliation | None'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.reconcile_codex_spawn_edges",
+          "signature": "(self) -> 'CodexSpawnEdgeReconciliation | None'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.hermes_integration_health",
+          "signature": "(self) -> 'HermesIntegrationHealth'"
+        }
+      ],
+      "route_class": "cross-tier",
+      "section": "Context and evidence",
+      "summary": "Compile context and record or inspect durable delivery receipts."
+    },
+    {
+      "cli": {
+        "intentional_absence_authority": null,
+        "names": [
+          "mark",
+          "read"
+        ]
+      },
+      "mcp": {
+        "intentional_absence_authority": null,
+        "names": [
+          "write",
+          "judge",
+          "read"
+        ]
+      },
+      "operation_id": "api.assertion.review",
+      "python": [
+        {
+          "async": true,
+          "binding": "Polylogue.import_annotation_batch",
+          "signature": "(self, request: 'AnnotationBatchImportRequest', *, registry: 'AnnotationSchemaRegistry | None' = None) -> 'AnnotationBatchImportResult'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_assertion_claims",
+          "signature": "(self, *, kinds: 'Sequence[str | AssertionKind] | None' = None, target_ref: 'str | None' = None, scope_ref: 'str | None' = None, statuses: 'Sequence[str | AssertionStatus] | None' = ('active', 'candidate'), context_inject: 'bool | None' = None, limit: 'int | None' = None) -> 'list[ArchiveAssertionEnvelope]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_assertion_claim_payloads",
+          "signature": "(self, *, kinds: 'Sequence[str | AssertionKind] | None' = None, target_ref: 'str | None' = None, scope_ref: 'str | None' = None, statuses: 'Sequence[str | AssertionStatus] | None' = ('active', 'candidate'), context_inject: 'bool | None' = None, limit: 'int | None' = None) -> 'list[AssertionClaimPayload]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_assertion_candidates",
+          "signature": "(self, *, target_ref: 'str | None' = None, kinds: 'Sequence[str | AssertionKind] | None' = None, limit: 'int | None' = None) -> 'list[AssertionClaimPayload]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_assertion_candidate_reviews",
+          "signature": "(self, *, target_ref: 'str | None' = None, kinds: 'Sequence[str | AssertionKind] | None' = None, statuses: 'Sequence[str | AssertionStatus] | None' = None, limit: 'int | None' = None) -> 'AssertionCandidateReviewListPayload'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.assertion_candidate_queue_health",
+          "signature": "(self) -> 'AssertionCandidateQueueHealthPayload'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.judge_assertion_candidate",
+          "signature": "(self, *, candidate_ref: 'str', decision: 'str', reason: 'str | None' = None, actor_ref: 'str' = 'user:local', inject: 'bool' = False, replacement_kind: 'str | None' = None, replacement_body_text: 'str | None' = None, replacement_value: 'object | None' = None) -> 'AssertionJudgmentResultPayload'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.capture_assertion_candidate",
+          "signature": "(self, *, body_text: 'str', kind: 'AssertionKind', refs: 'Sequence[str]' = (), scope_refs: 'Sequence[str]' = (), cwd: 'Path | None' = None, author_ref: 'str' = 'user:local', author_kind: 'str' = 'user', idempotency_key: 'str | None' = None, ttl_seconds: 'int | None' = None) -> 'AssertionClaimPayload'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.judge_assertion_candidates",
+          "signature": "(self, *, items: 'Sequence[Any]') -> 'AssertionBulkJudgmentPayload'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.record_comparative_judgment",
+          "signature": "(self, judgment: 'ComparativeJudgment', *, author_kind: 'str' = 'user') -> 'ArchiveAssertionEnvelope'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_comparative_judgments",
+          "signature": "(self) -> 'list[ComparativeJudgment]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.join_typed_annotations",
+          "signature": "(self, *, schema_id: 'str', schema_version: 'int', statuses: 'Sequence[str | AssertionStatus]', target_kind: 'str | None' = None, group_by: \"Sequence[Literal['repo', 'model', 'time', 'origin']]\" = (), limit: 'int' = 500, offset: 'int' = 0) -> 'AnnotationStructuralJoinResult'"
+        }
+      ],
+      "route_class": "cross-tier",
+      "section": "Assertions and judgments",
+      "summary": "Read, capture, and judge durable assertions and comparative evidence."
+    },
+    {
+      "cli": {
+        "intentional_absence_authority": null,
+        "names": [
+          "delete"
+        ]
+      },
+      "mcp": {
+        "intentional_absence_authority": null,
+        "names": [
+          "write"
+        ]
+      },
+      "operation_id": "api.archive.session-delete",
+      "python": [
+        {
+          "async": true,
+          "binding": "Polylogue.delete_session",
+          "signature": "(self, session_id: 'str') -> 'bool'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.delete_session_safe",
+          "signature": "(self, session_id: 'str', *, actor: 'str' = 'user:api') -> 'DeleteSessionResult'"
+        }
+      ],
+      "route_class": "cross-tier",
+      "section": "Archive mutations",
+      "summary": "Delete a session and its archive records through the shared mutation executor."
+    },
+    {
+      "cli": {
+        "intentional_absence_authority": null,
+        "names": [
+          "read",
+          "mark"
+        ]
+      },
+      "mcp": {
+        "intentional_absence_authority": null,
+        "names": [
+          "read",
+          "get"
+        ]
+      },
+      "operation_id": "api.user-state.read",
+      "python": [
+        {
+          "async": true,
+          "binding": "Polylogue.list_tags",
+          "signature": "(self, *, origin: 'str | None' = None) -> 'dict[str, int]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_metadata",
+          "signature": "(self, session_id: 'str') -> 'dict[str, str]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_marks",
+          "signature": "(self, *, mark_type: 'str | None' = None, session_id: 'str | None' = None, target_type: 'str | None' = None, target_id: 'str | None' = None, message_id: 'str | None' = None) -> 'list[dict[str, str]]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_annotation",
+          "signature": "(self, annotation_id: 'str') -> 'dict[str, str] | None'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_annotations",
+          "signature": "(self, *, session_id: 'str | None' = None, target_type: 'str | None' = None, target_id: 'str | None' = None, message_id: 'str | None' = None) -> 'list[dict[str, str]]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_view",
+          "signature": "(self, view_id: 'str') -> 'dict[str, str] | None'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_views",
+          "signature": "(self) -> 'list[dict[str, str]]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_recall_pack",
+          "signature": "(self, pack_id: 'str') -> 'dict[str, str] | None'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_recall_packs",
+          "signature": "(self) -> 'list[dict[str, str]]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_workspace",
+          "signature": "(self, workspace_id: 'str') -> 'dict[str, str] | None'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_workspaces",
+          "signature": "(self) -> 'list[dict[str, str]]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_corrections",
+          "signature": "(self, *, session_id: 'str | None' = None, kind: 'str | None' = None) -> 'list[LearningCorrection]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_blackboard_notes",
+          "signature": "(self, *, kind: 'str | None' = None, scope_repo: 'str | None' = None, unresolved: 'bool' = False, limit: 'int' = 20) -> 'list[BlackboardNote]'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.get_setting",
+          "signature": "(self, setting_key: 'str') -> 'ArchiveUserSettingEnvelope | None'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.list_settings",
+          "signature": "(self) -> 'list[ArchiveUserSettingEnvelope]'"
+        }
+      ],
+      "route_class": "user-read",
+      "section": "Durable user state",
+      "summary": "Read tags, marks, annotations, views, recall packs, workspaces, corrections, notes, and settings from user.db."
+    },
+    {
+      "cli": {
+        "intentional_absence_authority": null,
+        "names": [
+          "mark",
+          "delete"
+        ]
+      },
+      "mcp": {
+        "intentional_absence_authority": null,
+        "names": [
+          "write"
+        ]
+      },
+      "operation_id": "api.user-state.write",
+      "python": [
+        {
+          "async": true,
+          "binding": "Polylogue.add_tag",
+          "signature": "(self, session_id: 'str', tag: 'str', *, author_ref: 'str | None' = None, author_kind: 'str | None' = None) -> 'TagMutationResult'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.remove_tag",
+          "signature": "(self, session_id: 'str', tag: 'str') -> 'TagMutationResult'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.update_metadata",
+          "signature": "(self, session_id: 'str', key: 'str', value: 'str') -> 'bool'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.set_metadata",
+          "signature": "(self, session_id: 'str', key: 'str', value: 'object') -> 'MetadataMutationResult'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.delete_metadata",
+          "signature": "(self, session_id: 'str', key: 'str') -> 'MetadataMutationResult'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.bulk_tag_sessions",
+          "signature": "(self, session_ids: 'list[str]', tags: 'list[str]', *, author_ref: 'str | None' = None, author_kind: 'str | None' = None) -> 'BulkTagMutationResult'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.add_mark",
+          "signature": "(self, session_id: 'str', mark_type: 'str', *, target_type: 'str' = 'session', target_id: 'str | None' = None, message_id: 'str | None' = None) -> 'bool'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.remove_mark",
+          "signature": "(self, session_id: 'str', mark_type: 'str', *, target_type: 'str' = 'session', target_id: 'str | None' = None, message_id: 'str | None' = None) -> 'bool'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.save_annotation",
+          "signature": "(self, annotation_id: 'str', session_id: 'str', note_text: 'str', *, target_type: 'str' = 'session', target_id: 'str | None' = None, message_id: 'str | None' = None) -> 'bool'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.delete_annotation",
+          "signature": "(self, annotation_id: 'str') -> 'bool'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.save_view",
+          "signature": "(self, view_id: 'str', name: 'str', query_json: 'str') -> 'bool'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.delete_view",
+          "signature": "(self, view_id: 'str') -> 'bool'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.create_recall_pack",
+          "signature": "(self, pack_id: 'str', label: 'str', payload_json: 'str') -> 'bool'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.delete_recall_pack",
+          "signature": "(self, pack_id: 'str') -> 'bool'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.save_workspace",
+          "signature": "(self, workspace_id: 'str', name: 'str', mode: 'str', open_targets_json: 'str', layout_json: 'str', active_target_json: 'str' = '{}') -> 'bool'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.delete_workspace",
+          "signature": "(self, workspace_id: 'str') -> 'bool'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.record_correction",
+          "signature": "(self, session_id: 'str', kind: 'str', payload: 'dict[str, str]', *, note: 'str | None' = None, author_ref: 'str | None' = None, author_kind: 'str | None' = None) -> 'LearningCorrection'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.delete_correction",
+          "signature": "(self, session_id: 'str', kind: 'str') -> 'bool'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.clear_corrections",
+          "signature": "(self, session_id: 'str') -> 'int'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.post_blackboard_note",
+          "signature": "(self, *, kind: 'str', title: 'str', content: 'str', scope_repo: 'str | None' = None, scope_session: 'str | None' = None, scope_issue: 'int | None' = None, scope_path: 'str | None' = None, related_sessions: 'tuple[str, ...]' = (), author_ref: 'str | None' = None, author_kind: 'str' = 'user', evidence_refs: 'tuple[str, ...]' = (), staleness: 'dict[str, object] | None' = None, context_policy: 'dict[str, object] | None' = None) -> 'BlackboardNote'"
+        },
+        {
+          "async": true,
+          "binding": "Polylogue.set_setting",
+          "signature": "(self, setting_key: 'str', value: 'object', *, author_ref: 'str' = 'user:local') -> 'ArchiveUserSettingEnvelope'"
+        }
+      ],
+      "route_class": "user-write",
+      "section": "Durable user state",
+      "summary": "Mutate tags, metadata, marks, annotations, views, recall packs, workspaces, corrections, notes, and settings in user.db."
+    }
+  ],
+  "schema_version": 1
+}

--- a/docs/library-api.md
+++ b/docs/library-api.md
@@ -330,6 +330,342 @@ asyncio.run(main())
 | `list_tool_usage_insights(query)` | Per-provider tool usage with explicit coverage gaps |
 | `list_archive_debt_insights(query)` | List governed archive-debt insights |
 
+<!-- BEGIN GENERATED API OPERATION PARITY -->
+
+## Generated facade operation index
+
+This reference is generated from `polylogue/api/operation_parity.py`. Each live public facade callable is bound to a stable semantic operation ID; exported data models and adapter helpers are listed as intentional exclusions in the committed [machine-readable matrix](generated/api-operation-parity.json).
+
+### Lifecycle and builders
+
+#### `api.lifecycle.construct`
+
+Construct, open, and close a facade bound to one archive runtime.
+
+Route/tier class: `lifecycle`. CLI: Intentional absence: `polylogue-s1kr`. MCP: Intentional absence: `polylogue-s1kr`.
+
+| Python callable | Signature |
+|---|---|
+| `Polylogue` | Constructed facade builder |
+| `Polylogue.__init__` | `(archive_root: 'str | Path | None' = None, db_path: 'str | Path | None' = None, *, runtime: 'ResolvedRuntimeConfig | None' = None) -> 'None'` |
+| `Polylogue.open` | `(*, config: 'Config | None' = None, runtime: 'ResolvedRuntimeConfig | None' = None, **kwargs: 'object') -> 'Polylogue'` |
+| `Polylogue.__aenter__` | `async (self) -> 'Polylogue'` |
+| `Polylogue.__aexit__` | `async (self, exc_type: 'object', exc_val: 'object', exc_tb: 'object') -> 'None'` |
+| `Polylogue.close` | `async (self) -> 'None'` |
+
+### Embedding readiness
+
+#### `api.embedding.status`
+
+Read the no-spend embedding readiness state.
+
+Route/tier class: `embedding-status`. CLI: `ops embed status`. MCP: `status`.
+
+| Python callable | Signature |
+|---|---|
+| `Polylogue.embedding_status` | `(self, *, detail: 'bool' = False) -> 'dict[str, object]'` |
+
+#### `api.embedding.preflight`
+
+Calculate a bounded no-provider-call embedding catch-up window.
+
+Route/tier class: `embedding-preflight`. CLI: `ops embed preflight`. MCP: `status`.
+
+| Python callable | Signature |
+|---|---|
+| `Polylogue.embedding_preflight` | `(self, *, rebuild: 'bool' = False, max_sessions: 'int | None' = None, max_messages: 'int | None' = None, max_cost_usd: 'float | None' = None) -> 'dict[str, object]'` |
+
+### Embedding retrieval
+
+#### `api.embedding.search`
+
+Search stored session vectors using the embeddings tier.
+
+Route/tier class: `embedding-read`. CLI: `find similar`. MCP: `query`.
+
+| Python callable | Signature |
+|---|---|
+| `Polylogue.search_similar_sessions` | `async (self, session_id: 'str', *, limit: 'int' = 10, vector_provider: 'VectorProvider | None' = None, voyage_api_key: 'str | None' = None) -> 'dict[str, object]'` |
+
+### Ingestion and derived maintenance
+
+#### `api.ingest.parse`
+
+Parse configured or explicit sources into source and index tiers.
+
+Route/tier class: `source-index-write`. CLI: `import`. MCP: `run`.
+
+| Python callable | Signature |
+|---|---|
+| `Polylogue.parse_file` | `async (self, path: 'str | Path', *, source_name: 'str | None' = None) -> 'ParseResult'` |
+| `Polylogue.parse_sources` | `async (self, sources: 'list[Source] | None' = None, *, download_assets: 'bool' = True) -> 'ParseResult'` |
+
+#### `api.index.rebuild`
+
+Rebuild or update the derived index through the mutation executor.
+
+Route/tier class: `index-write`. CLI: `ops reset --index`. MCP: `maintenance`.
+
+| Python callable | Signature |
+|---|---|
+| `Polylogue.rebuild_index` | `async (self) -> 'bool'` |
+| `Polylogue.update_index` | `async (self, session_ids: 'list[str]') -> 'bool'` |
+| `Polylogue.rebuild_insights` | `async (self, session_ids: 'Sequence[str] | None' = None, *, progress_callback: 'ProgressCallback | None' = None) -> 'SessionInsightCounts'` |
+
+### Archive reads
+
+#### `api.archive.session-read`
+
+Read sessions, summaries, messages, actions, and archive statistics from the index tier.
+
+Route/tier class: `index-read`. CLI: `find`, `read`. MCP: `query`, `read`, `get`, `status`.
+
+| Python callable | Signature |
+|---|---|
+| `Polylogue.get_session` | `async (self, session_id: 'str', *, content_projection: 'ContentProjectionSpec | None' = None) -> 'Session | None'` |
+| `Polylogue.get_sessions` | `async (self, session_ids: 'list[str]', *, content_projection: 'ContentProjectionSpec | None' = None) -> 'list[Session]'` |
+| `Polylogue.get_actions_batch` | `async (self, session_ids: 'builtins.list[str]') -> 'dict[str, tuple[Action, ...]]'` |
+| `Polylogue.list_sessions` | `async (self, origin: 'str | None' = None, limit: 'int | None' = None, content_projection: 'ContentProjectionSpec | None' = None) -> 'list[Session]'` |
+| `Polylogue.list_summaries` | `async (self, *, limit: 'int | None' = 50, offset: 'int' = 0, origin: 'str | None' = None) -> 'builtins.list[SessionSummary]'` |
+| `Polylogue.list_sessions_for_spec` | `async (self, spec: 'SessionQuerySpec', *, content_projection: 'ContentProjectionSpec | None' = None) -> 'list[Session]'` |
+| `Polylogue.search_session_hits` | `async (self, spec: 'SessionQuerySpec') -> 'builtins.list[SessionSearchHit]'` |
+| `Polylogue.search` | `async (self, query: 'str', *, limit: 'int' = 100, source: 'str | None' = None, since: 'str | None' = None) -> 'SearchResult'` |
+| `Polylogue.search_envelope` | `async (self, query: 'str', *, limit: 'int' = 50, offset: 'int' = 0, origin: 'str | None' = None, since: 'str | None' = None, until: 'str | None' = None, retrieval_lane: 'str' = 'auto', sort: 'str | None' = None, cursor: 'str | None' = None) -> 'SearchEnvelope'` |
+| `Polylogue.archive_count_sessions` | `async (self, *, origin: 'str | None' = None, excluded_origins: 'Sequence[str]' = (), tags: 'Sequence[str]' = (), excluded_tags: 'Sequence[str]' = (), repo_names: 'Sequence[str]' = (), project_refs: 'Sequence[str]' = (), has_types: 'Sequence[str]' = (), has_tool_use: 'bool' = False, has_thinking: 'bool' = False, has_paste: 'bool' = False, tool_terms: 'Sequence[str]' = (), excluded_tool_terms: 'Sequence[str]' = (), action_terms: 'Sequence[str]' = (), excluded_action_terms: 'Sequence[str]' = (), action_sequence: 'Sequence[str]' = (), action_text_terms: 'Sequence[str]' = (), referenced_paths: 'Sequence[str]' = (), cwd_prefix: 'str | None' = None, typed_only: 'bool' = False, message_type: 'str | None' = None, title: 'str | None' = None, min_messages: 'int | None' = None, max_messages: 'int | None' = None, min_words: 'int | None' = None, max_words: 'int | None' = None, since: 'str | None' = None, until: 'str | None' = None) -> 'int'` |
+| `Polylogue.archive_get_session` | `async (self, session_id: 'str') -> 'ArchiveSessionEnvelope | None'` |
+| `Polylogue.get_messages_paginated` | `async (self, session_id: 'str', *, message_role: 'MessageRoleFilter' = (), message_type: 'MessageTypeName | None' = None, material_origin: 'tuple[MaterialOrigin, ...]' = (), limit: 'int' = 50, offset: 'int' = 0, content_projection: 'ContentProjectionSpec | None' = None) -> 'tuple[list[Message], int, LineageCompleteness]'` |
+| `Polylogue.iter_messages` | `(self, session_id: 'str', *, message_roles: 'MessageRoleFilter' = (), material_origin: 'tuple[MaterialOrigin, ...]' = (), limit: 'int | None' = None) -> 'AsyncIterator[Message]'` |
+| `Polylogue.bulk_get_messages` | `async (self, session_ids: 'Sequence[str]', *, since: 'str | None' = None, until: 'str | None' = None, message_role: 'MessageRoleFilter' = (), material_origin: 'tuple[MaterialOrigin, ...]' = (), content_projection: 'ContentProjectionSpec | None' = None) -> 'dict[str, list[Message]]'` |
+| `Polylogue.query_sessions` | `async (self, *, origin: 'str | None' = None, tag: 'str | None' = None, since: 'str | None' = None, until: 'str | None' = None, sort: 'str | None' = None, limit: 'int | None' = None, offset: 'int' = 0, has_tool_use: 'bool' = False, has_thinking: 'bool' = False, has_paste: 'bool' = False, typed_only: 'bool' = False, min_messages: 'int | None' = None, max_messages: 'int | None' = None, min_words: 'int | None' = None, **kwargs: 'object') -> 'builtins.list[dict[str, object]]'` |
+| `Polylogue.count_sessions` | `async (self, *, origin: 'str | None' = None, since: 'str | None' = None, until: 'str | None' = None, **kwargs: 'object') -> 'int'` |
+| `Polylogue.get_session_summary` | `async (self, session_id: 'str') -> 'SessionSummary | None'` |
+| `Polylogue.get_session_stats` | `async (self, session_id: 'str') -> 'dict[str, int]'` |
+| `Polylogue.get_stats_by` | `async (self, group_by: 'str' = 'origin') -> 'dict[str, int]'` |
+| `Polylogue.get_index_status` | `async (self) -> 'IndexStatus'` |
+| `Polylogue.stats` | `async (self) -> 'ArchiveStats'` |
+| `Polylogue.storage_stats` | `async (self) -> 'StorageArchiveStats'` |
+| `Polylogue.facets` | `async (self, spec: 'SessionQuerySpec | None' = None, *, include_idf: 'bool' = True, include_deferred: 'bool' = True) -> 'FacetsResponse'` |
+| `Polylogue.health_check` | `async (self) -> 'ReadinessReport'` |
+| `Polylogue.filter` | `(self) -> 'SessionFilter'` |
+| `Polylogue.list_read_view_profiles` | `async (self) -> 'list[JSONDocument]'` |
+
+#### `api.archive.query-analysis`
+
+Compile, explain, diagnose, and resolve archive query and reference projections.
+
+Route/tier class: `index-read`. CLI: `find`, `read`, `analyze`. MCP: `query`, `read`, `get`, `explain`.
+
+| Python callable | Signature |
+|---|---|
+| `Polylogue.explain_query_expression` | `async (self, expression: 'str') -> 'JSONDocument'` |
+| `Polylogue.query_units` | `async (self, expression: 'str | None' = None, *, limit: 'int | None' = None, offset: 'int | None' = None, origin: 'str | None' = None, origins: 'tuple[str, ...]' = (), excluded_origins: 'tuple[str, ...]' = (), tag: 'str | None' = None, tags: 'tuple[str, ...]' = (), excluded_tags: 'tuple[str, ...]' = (), repo: 'str | None' = None, repo_names: 'tuple[str, ...]' = (), project: 'str | None' = None, project_refs: 'tuple[str, ...]' = (), has_types: 'tuple[str, ...]' = (), tool_terms: 'tuple[str, ...]' = (), excluded_tool_terms: 'tuple[str, ...]' = (), action_terms: 'tuple[str, ...]' = (), excluded_action_terms: 'tuple[str, ...]' = (), action_sequence: 'tuple[str, ...]' = (), action_text_terms: 'tuple[str, ...]' = (), referenced_paths: 'tuple[str, ...]' = (), cwd_prefix: 'str | None' = None, title: 'str | None' = None, since: 'str | None' = None, until: 'str | None' = None, has_tool_use: 'bool' = False, has_thinking: 'bool' = False, has_paste: 'bool' = False, typed_only: 'bool' = False, min_messages: 'int | None' = None, max_messages: 'int | None' = None, min_words: 'int | None' = None, max_words: 'int | None' = None, message_type: 'str | None' = None, continuation: 'str | None' = None) -> 'QueryUnitResultEnvelope'` |
+| `Polylogue.query_completions` | `async (self, kind: 'str', *, incomplete: 'str' = '', unit: 'str | None' = None, field: 'str | None' = None) -> 'JSONDocument'` |
+| `Polylogue.diagnose_query_miss` | `async (self, spec: 'SessionQuerySpec', *, full: 'bool' = False) -> 'QueryMissDiagnostics'` |
+| `Polylogue.resolve_ref` | `async (self, ref: 'str') -> 'PublicRefResolutionPayload'` |
+| `Polylogue.export_otel` | `async (self, *, source_ref: 'str', expressions: 'Sequence[str]', limit: 'int' = 50, include_message_text: 'bool' = False) -> 'OtelProjectionPayload'` |
+| `Polylogue.neighbor_candidates` | `async (self, *, session_id: 'str | None' = None, query: 'str | None' = None, origin: 'str | None' = None, limit: 'int' = 10, window_hours: 'int' = 24) -> 'list[SessionNeighborCandidate]'` |
+| `Polylogue.neighbor_candidate_payloads` | `async (self, *, session_id: 'str | None' = None, query: 'str | None' = None, origin: 'str | None' = None, limit: 'int' = 10, window_hours: 'int' = 24) -> 'list[JSONDocument]'` |
+| `Polylogue.session_correlation_payload` | `async (self, session_id: 'str', *, repo_path: 'str | None' = None, since_hours: 'int' = 2, confidence_threshold: 'float' = 0.3) -> 'JSONDocument | None'` |
+| `Polylogue.origin_usage_report` | `async (self, *, origin: 'str | None' = None, limit: 'int | None' = 25, detail: 'str' = 'full') -> 'ProviderUsageReport'` |
+| `Polylogue.session_usage_reconciliation` | `async (self, session_id: 'str') -> 'SessionUsageReconciliation'` |
+| `Polylogue.resume_brief` | `async (self, session_id: 'str', *, related_limit: 'int' = 6, repo_path: 'str | None' = None, recent_files: 'Sequence[str]' = ()) -> 'ResumeBrief | None'` |
+| `Polylogue.find_resume_candidates` | `async (self, *, repo_path: 'str', cwd: 'str | None' = None, recent_files: 'Sequence[str]' = (), limit: 'int' = 10) -> 'tuple[ResumeCandidate, ...]'` |
+
+### Source evidence reads
+
+#### `api.archive.source-evidence-read`
+
+Read raw artifacts and provider-side evidence retained in the durable source tier.
+
+Route/tier class: `source-read`. CLI: `read`, `analyze`. MCP: `read`, `explain`.
+
+| Python callable | Signature |
+|---|---|
+| `Polylogue.explain_import` | `async (self, path: 'str | Path | None' = None, *, raw_ref: 'str | None' = None, source_path: 'str | None' = None, source_name: 'str' = 'unknown', limit: 'int' = 100, redact_paths: 'bool' = True) -> 'ImportExplainPayload'` |
+| `Polylogue.get_raw_artifacts_for_session` | `async (self, session_id: 'str', *, limit: 'int' = 50, offset: 'int' = 0) -> 'tuple[list[dict[str, object]], int]'` |
+| `Polylogue.get_hook_event_summary_for_session` | `async (self, session_id: 'str') -> 'dict[str, object] | None'` |
+| `Polylogue.get_session_events` | `async (self, session_id: 'str', *, event_type: 'str | None' = None, limit: 'int | None' = None) -> 'list[dict[str, object]] | None'` |
+| `Polylogue.get_file_edits` | `async (self, session_id: 'str') -> 'list[dict[str, object]] | None'` |
+| `Polylogue.get_web_content_constructs` | `async (self, session_id: 'str', *, construct_type: 'str | None' = None) -> 'list[dict[str, object]] | None'` |
+| `Polylogue.get_agent_policies` | `async (self, session_id: 'str') -> 'list[dict[str, object]] | None'` |
+
+### Insights and topology
+
+#### `api.archive.insight-read`
+
+Read materialized archive insights, topology, and derived archive health from the index tier.
+
+Route/tier class: `index-read`. CLI: `analyze`, `read`. MCP: `query`, `get`, `status`, `explain`.
+
+| Python callable | Signature |
+|---|---|
+| `Polylogue.get_session_insight_status` | `async (self) -> 'SessionInsightStatusSnapshot'` |
+| `Polylogue.get_session_profile_insight` | `async (self, session_id: 'str', *, tier: 'str' = 'merged') -> 'SessionProfileInsight | None'` |
+| `Polylogue.get_session_profile_record` | `async (self, session_id: 'str') -> 'SessionProfileRecord | None'` |
+| `Polylogue.list_session_profile_insights` | `async (self, query: 'SessionProfileInsightQuery | None' = None) -> 'list[SessionProfileInsight]'` |
+| `Polylogue.insight_readiness_report` | `async (self, query: 'InsightReadinessQuery | None' = None) -> 'InsightReadinessReport'` |
+| `Polylogue.insight_rigor_audit` | `async (self, query: 'InsightRigorAuditQuery | None' = None) -> 'InsightRigorAuditReport'` |
+| `Polylogue.archive_debt` | `async (self, *, kinds: 'Iterable[str] | None' = None, only_actionable: 'bool' = False, limit: 'int | None' = None, exact_fts: 'bool' = False) -> 'ArchiveDebtListPayload'` |
+| `Polylogue.get_session_work_event_insights` | `async (self, session_id: 'str') -> 'list[SessionWorkEventInsight]'` |
+| `Polylogue.list_session_work_event_insights` | `async (self, query: 'SessionWorkEventInsightQuery | None' = None) -> 'list[SessionWorkEventInsight]'` |
+| `Polylogue.get_session_phase_insights` | `async (self, session_id: 'str') -> 'list[SessionPhaseInsight]'` |
+| `Polylogue.list_session_phase_insights` | `async (self, query: 'SessionPhaseInsightQuery | None' = None) -> 'list[SessionPhaseInsight]'` |
+| `Polylogue.get_thread_insight` | `async (self, thread_id: 'str') -> 'ThreadInsight | None'` |
+| `Polylogue.list_thread_insights` | `async (self, query: 'ThreadInsightQuery | None' = None) -> 'list[ThreadInsight]'` |
+| `Polylogue.list_session_tag_rollup_insights` | `async (self, query: 'SessionTagRollupQuery | None' = None) -> 'list[SessionTagRollupInsight]'` |
+| `Polylogue.list_archive_coverage_insights` | `async (self, query: 'ArchiveCoverageInsightQuery | None' = None) -> 'list[ArchiveCoverageInsight]'` |
+| `Polylogue.list_tool_usage_insights` | `async (self, query: 'ToolUsageInsightQuery | None' = None) -> 'list[ToolUsageInsight]'` |
+| `Polylogue.list_session_cost_insights` | `async (self, query: 'SessionCostInsightQuery | None' = None) -> 'list[SessionCostInsight]'` |
+| `Polylogue.get_session_latency_profile_insight` | `async (self, session_id: 'str') -> 'SessionLatencyProfileInsight | None'` |
+| `Polylogue.list_session_latency_profile_insights` | `async (self, query: 'SessionLatencyProfileInsightQuery | None' = None) -> 'list[SessionLatencyProfileInsight]'` |
+| `Polylogue.find_stuck_session_latency_profile_insights` | `async (self, query: 'SessionLatencyProfileInsightQuery | None' = None) -> 'list[SessionLatencyProfileInsight]'` |
+| `Polylogue.list_cost_rollup_insights` | `async (self, query: 'CostRollupInsightQuery | None' = None) -> 'list[CostRollupInsight]'` |
+| `Polylogue.list_usage_timeline_insights` | `async (self, query: 'UsageTimelineInsightQuery | None' = None) -> 'list[UsageTimelineInsight]'` |
+| `Polylogue.list_archive_debt_insights` | `async (self, query: 'ArchiveDebtInsightQuery | None' = None) -> 'list[ArchiveDebtInsight]'` |
+| `Polylogue.cost_outlook` | `async (self, plan_name: 'str', *, now: 'datetime | None' = None, method: 'ProjectionMethod' = <ProjectionMethod.linear: 'linear'>) -> 'CycleOutlook | None'` |
+| `Polylogue.aggregate_sessions` | `async (self, *, group_by: 'str' = 'workflow_shape', since: 'str | None' = None, until: 'str | None' = None, origin: 'str | None' = None) -> 'dict[str, object]'` |
+| `Polylogue.workflow_shape_distribution` | `async (self, *, group_by: 'str' = 'week', since: 'str | None' = None, until: 'str | None' = None, origin: 'str | None' = None) -> 'dict[str, object]'` |
+| `Polylogue.find_abandoned_sessions` | `async (self, *, since: 'str | None' = None, repo_path: 'str | None' = None, min_severity: 'str' = 'question_left', limit: 'int' = 20) -> 'dict[str, object]'` |
+| `Polylogue.tool_call_latency_distribution` | `async (self, *, since: 'str | None' = None, until: 'str | None' = None, origin: 'str | None' = None, tool_category: 'str | None' = None, limit: 'int' = 500) -> 'dict[str, object]'` |
+| `Polylogue.compare_sessions` | `async (self, session_ids: 'Sequence[str]') -> 'dict[str, object]'` |
+| `Polylogue.find_similar_sessions_by_metadata` | `async (self, session_id: 'str', *, limit: 'int' = 10, candidate_pool_limit: 'int' = 200) -> 'dict[str, object] | None'` |
+| `Polylogue.correlate_sessions` | `async (self, *, metric_x: 'str', metric_y: 'str', origin: 'str | None' = None, since: 'str | None' = None, until: 'str | None' = None) -> 'dict[str, object]'` |
+| `Polylogue.get_session_topology` | `async (self, session_id: 'str') -> 'SessionTopology | None'` |
+| `Polylogue.get_ancestors` | `async (self, session_id: 'str') -> 'list[SessionRef]'` |
+| `Polylogue.get_descendants` | `async (self, session_id: 'str') -> 'list[SessionRef]'` |
+| `Polylogue.get_siblings` | `async (self, session_id: 'str') -> 'list[SessionRef]'` |
+| `Polylogue.get_thread` | `async (self, session_id: 'str') -> 'list[SessionRef]'` |
+| `Polylogue.get_logical_session` | `async (self, session_id: 'str') -> 'LogicalSession | None'` |
+| `Polylogue.get_session_tree` | `async (self, session_id: 'str') -> 'list[Session]'` |
+| `Polylogue.postmortem_bundle` | `async (self, spec: 'SessionQuerySpec | None' = None, *, limit: 'int | None' = None) -> 'PostmortemBundle'` |
+| `Polylogue.pathology_report` | `async (self, spec: 'SessionQuerySpec | None' = None, *, limit: 'int | None' = None) -> 'PathologyReport'` |
+| `Polylogue.portfolio_bundle` | `async (self, spec: 'SessionQuerySpec | None' = None, *, limit: 'int | None' = None, top_n: 'int' = 10) -> 'PortfolioBundle'` |
+| `Polylogue.export_insight_bundle` | `async (self, request: 'InsightExportBundleRequest') -> 'InsightExportBundleResult'` |
+
+### Context and evidence
+
+#### `api.context.delivery`
+
+Compile context and record or inspect durable delivery receipts.
+
+Route/tier class: `cross-tier`. CLI: `continue`, `read`. MCP: `context`, `get`, `status`.
+
+| Python callable | Signature |
+|---|---|
+| `Polylogue.compile_context` | `async (self, spec: 'ContextSpec') -> 'ContextImage'` |
+| `Polylogue.context_image_payload` | `async (self, *, project_path: 'str | None' = None, project_repo: 'str | None' = None, since: 'str | None' = None, until: 'str | None' = None, origin: 'str | None' = None, query: 'str | None' = None, max_sessions: 'int' = 5, max_tokens: 'int | None' = None, max_messages_per_session: 'int | None' = 24, max_chars_per_message: 'int | None' = 1800, include_messages: 'bool' = True, include_assertions: 'bool' = True, redact_paths: 'bool' = True, seed_session_id: 'str | None' = None) -> 'ContextImage'` |
+| `Polylogue.context_preamble_payload` | `async (self, session_id: 'str', *, related_limit: 'int' = 5) -> 'Any'` |
+| `Polylogue.get_context_delivery` | `async (self, snapshot_ref: 'str', *, recipient_ref: 'str') -> 'ArchiveContextDeliveryEnvelope | None'` |
+| `Polylogue.list_context_deliveries` | `async (self, *, recipient_ref: 'str | None' = None, assertion_ref: 'str | None' = None, limit: 'int' = 50) -> 'list[ArchiveContextDeliveryEnvelope]'` |
+| `Polylogue.record_context_delivery` | `async (self, *, image: 'ContextImage', boundary: 'str', recipient_ref: 'str', delivered_by_ref: 'str', run_ref: 'str | None' = None, inheritance_mode: 'str' = 'explicit') -> 'ArchiveContextDeliveryEnvelope'` |
+| `Polylogue.compile_and_record_context` | `async (self, *, recipient_ref: 'str', delivered_by_ref: 'str', boundary: 'str', query: 'str | None' = None, max_sessions: 'int' = 5, max_tokens: 'int | None' = None, include_messages: 'bool' = True, include_assertions: 'bool' = True, redact_paths: 'bool' = True, seed_session_id: 'str | None' = None, run_ref: 'str | None' = None, inheritance_mode: 'str' = 'explicit') -> 'ArchiveContextDeliveryEnvelope'` |
+| `Polylogue.correlate_hermes_context_deliveries` | `async (self, hermes_session_native_id: 'str') -> 'tuple[HermesContextDeliveryCorrelation, ...]'` |
+| `Polylogue.reconcile_hermes_session_lifecycle` | `async (self, hermes_session_native_id: 'str') -> 'HermesLifecycleReconciliation | None'` |
+| `Polylogue.reconcile_codex_spawn_edges` | `async (self) -> 'CodexSpawnEdgeReconciliation | None'` |
+| `Polylogue.hermes_integration_health` | `async (self) -> 'HermesIntegrationHealth'` |
+
+### Assertions and judgments
+
+#### `api.assertion.review`
+
+Read, capture, and judge durable assertions and comparative evidence.
+
+Route/tier class: `cross-tier`. CLI: `mark`, `read`. MCP: `write`, `judge`, `read`.
+
+| Python callable | Signature |
+|---|---|
+| `Polylogue.import_annotation_batch` | `async (self, request: 'AnnotationBatchImportRequest', *, registry: 'AnnotationSchemaRegistry | None' = None) -> 'AnnotationBatchImportResult'` |
+| `Polylogue.list_assertion_claims` | `async (self, *, kinds: 'Sequence[str | AssertionKind] | None' = None, target_ref: 'str | None' = None, scope_ref: 'str | None' = None, statuses: 'Sequence[str | AssertionStatus] | None' = ('active', 'candidate'), context_inject: 'bool | None' = None, limit: 'int | None' = None) -> 'list[ArchiveAssertionEnvelope]'` |
+| `Polylogue.list_assertion_claim_payloads` | `async (self, *, kinds: 'Sequence[str | AssertionKind] | None' = None, target_ref: 'str | None' = None, scope_ref: 'str | None' = None, statuses: 'Sequence[str | AssertionStatus] | None' = ('active', 'candidate'), context_inject: 'bool | None' = None, limit: 'int | None' = None) -> 'list[AssertionClaimPayload]'` |
+| `Polylogue.list_assertion_candidates` | `async (self, *, target_ref: 'str | None' = None, kinds: 'Sequence[str | AssertionKind] | None' = None, limit: 'int | None' = None) -> 'list[AssertionClaimPayload]'` |
+| `Polylogue.list_assertion_candidate_reviews` | `async (self, *, target_ref: 'str | None' = None, kinds: 'Sequence[str | AssertionKind] | None' = None, statuses: 'Sequence[str | AssertionStatus] | None' = None, limit: 'int | None' = None) -> 'AssertionCandidateReviewListPayload'` |
+| `Polylogue.assertion_candidate_queue_health` | `async (self) -> 'AssertionCandidateQueueHealthPayload'` |
+| `Polylogue.judge_assertion_candidate` | `async (self, *, candidate_ref: 'str', decision: 'str', reason: 'str | None' = None, actor_ref: 'str' = 'user:local', inject: 'bool' = False, replacement_kind: 'str | None' = None, replacement_body_text: 'str | None' = None, replacement_value: 'object | None' = None) -> 'AssertionJudgmentResultPayload'` |
+| `Polylogue.capture_assertion_candidate` | `async (self, *, body_text: 'str', kind: 'AssertionKind', refs: 'Sequence[str]' = (), scope_refs: 'Sequence[str]' = (), cwd: 'Path | None' = None, author_ref: 'str' = 'user:local', author_kind: 'str' = 'user', idempotency_key: 'str | None' = None, ttl_seconds: 'int | None' = None) -> 'AssertionClaimPayload'` |
+| `Polylogue.judge_assertion_candidates` | `async (self, *, items: 'Sequence[Any]') -> 'AssertionBulkJudgmentPayload'` |
+| `Polylogue.record_comparative_judgment` | `async (self, judgment: 'ComparativeJudgment', *, author_kind: 'str' = 'user') -> 'ArchiveAssertionEnvelope'` |
+| `Polylogue.list_comparative_judgments` | `async (self) -> 'list[ComparativeJudgment]'` |
+| `Polylogue.join_typed_annotations` | `async (self, *, schema_id: 'str', schema_version: 'int', statuses: 'Sequence[str | AssertionStatus]', target_kind: 'str | None' = None, group_by: "Sequence[Literal['repo', 'model', 'time', 'origin']]" = (), limit: 'int' = 500, offset: 'int' = 0) -> 'AnnotationStructuralJoinResult'` |
+
+### Archive mutations
+
+#### `api.archive.session-delete`
+
+Delete a session and its archive records through the shared mutation executor.
+
+Route/tier class: `cross-tier`. CLI: `delete`. MCP: `write`.
+
+| Python callable | Signature |
+|---|---|
+| `Polylogue.delete_session` | `async (self, session_id: 'str') -> 'bool'` |
+| `Polylogue.delete_session_safe` | `async (self, session_id: 'str', *, actor: 'str' = 'user:api') -> 'DeleteSessionResult'` |
+
+### Durable user state
+
+#### `api.user-state.read`
+
+Read tags, marks, annotations, views, recall packs, workspaces, corrections, notes, and settings from user.db.
+
+Route/tier class: `user-read`. CLI: `read`, `mark`. MCP: `read`, `get`.
+
+| Python callable | Signature |
+|---|---|
+| `Polylogue.list_tags` | `async (self, *, origin: 'str | None' = None) -> 'dict[str, int]'` |
+| `Polylogue.get_metadata` | `async (self, session_id: 'str') -> 'dict[str, str]'` |
+| `Polylogue.list_marks` | `async (self, *, mark_type: 'str | None' = None, session_id: 'str | None' = None, target_type: 'str | None' = None, target_id: 'str | None' = None, message_id: 'str | None' = None) -> 'list[dict[str, str]]'` |
+| `Polylogue.get_annotation` | `async (self, annotation_id: 'str') -> 'dict[str, str] | None'` |
+| `Polylogue.list_annotations` | `async (self, *, session_id: 'str | None' = None, target_type: 'str | None' = None, target_id: 'str | None' = None, message_id: 'str | None' = None) -> 'list[dict[str, str]]'` |
+| `Polylogue.get_view` | `async (self, view_id: 'str') -> 'dict[str, str] | None'` |
+| `Polylogue.list_views` | `async (self) -> 'list[dict[str, str]]'` |
+| `Polylogue.get_recall_pack` | `async (self, pack_id: 'str') -> 'dict[str, str] | None'` |
+| `Polylogue.list_recall_packs` | `async (self) -> 'list[dict[str, str]]'` |
+| `Polylogue.get_workspace` | `async (self, workspace_id: 'str') -> 'dict[str, str] | None'` |
+| `Polylogue.list_workspaces` | `async (self) -> 'list[dict[str, str]]'` |
+| `Polylogue.list_corrections` | `async (self, *, session_id: 'str | None' = None, kind: 'str | None' = None) -> 'list[LearningCorrection]'` |
+| `Polylogue.list_blackboard_notes` | `async (self, *, kind: 'str | None' = None, scope_repo: 'str | None' = None, unresolved: 'bool' = False, limit: 'int' = 20) -> 'list[BlackboardNote]'` |
+| `Polylogue.get_setting` | `async (self, setting_key: 'str') -> 'ArchiveUserSettingEnvelope | None'` |
+| `Polylogue.list_settings` | `async (self) -> 'list[ArchiveUserSettingEnvelope]'` |
+
+#### `api.user-state.write`
+
+Mutate tags, metadata, marks, annotations, views, recall packs, workspaces, corrections, notes, and settings in user.db.
+
+Route/tier class: `user-write`. CLI: `mark`, `delete`. MCP: `write`.
+
+| Python callable | Signature |
+|---|---|
+| `Polylogue.add_tag` | `async (self, session_id: 'str', tag: 'str', *, author_ref: 'str | None' = None, author_kind: 'str | None' = None) -> 'TagMutationResult'` |
+| `Polylogue.remove_tag` | `async (self, session_id: 'str', tag: 'str') -> 'TagMutationResult'` |
+| `Polylogue.update_metadata` | `async (self, session_id: 'str', key: 'str', value: 'str') -> 'bool'` |
+| `Polylogue.set_metadata` | `async (self, session_id: 'str', key: 'str', value: 'object') -> 'MetadataMutationResult'` |
+| `Polylogue.delete_metadata` | `async (self, session_id: 'str', key: 'str') -> 'MetadataMutationResult'` |
+| `Polylogue.bulk_tag_sessions` | `async (self, session_ids: 'list[str]', tags: 'list[str]', *, author_ref: 'str | None' = None, author_kind: 'str | None' = None) -> 'BulkTagMutationResult'` |
+| `Polylogue.add_mark` | `async (self, session_id: 'str', mark_type: 'str', *, target_type: 'str' = 'session', target_id: 'str | None' = None, message_id: 'str | None' = None) -> 'bool'` |
+| `Polylogue.remove_mark` | `async (self, session_id: 'str', mark_type: 'str', *, target_type: 'str' = 'session', target_id: 'str | None' = None, message_id: 'str | None' = None) -> 'bool'` |
+| `Polylogue.save_annotation` | `async (self, annotation_id: 'str', session_id: 'str', note_text: 'str', *, target_type: 'str' = 'session', target_id: 'str | None' = None, message_id: 'str | None' = None) -> 'bool'` |
+| `Polylogue.delete_annotation` | `async (self, annotation_id: 'str') -> 'bool'` |
+| `Polylogue.save_view` | `async (self, view_id: 'str', name: 'str', query_json: 'str') -> 'bool'` |
+| `Polylogue.delete_view` | `async (self, view_id: 'str') -> 'bool'` |
+| `Polylogue.create_recall_pack` | `async (self, pack_id: 'str', label: 'str', payload_json: 'str') -> 'bool'` |
+| `Polylogue.delete_recall_pack` | `async (self, pack_id: 'str') -> 'bool'` |
+| `Polylogue.save_workspace` | `async (self, workspace_id: 'str', name: 'str', mode: 'str', open_targets_json: 'str', layout_json: 'str', active_target_json: 'str' = '{}') -> 'bool'` |
+| `Polylogue.delete_workspace` | `async (self, workspace_id: 'str') -> 'bool'` |
+| `Polylogue.record_correction` | `async (self, session_id: 'str', kind: 'str', payload: 'dict[str, str]', *, note: 'str | None' = None, author_ref: 'str | None' = None, author_kind: 'str | None' = None) -> 'LearningCorrection'` |
+| `Polylogue.delete_correction` | `async (self, session_id: 'str', kind: 'str') -> 'bool'` |
+| `Polylogue.clear_corrections` | `async (self, session_id: 'str') -> 'int'` |
+| `Polylogue.post_blackboard_note` | `async (self, *, kind: 'str', title: 'str', content: 'str', scope_repo: 'str | None' = None, scope_session: 'str | None' = None, scope_issue: 'int | None' = None, scope_path: 'str | None' = None, related_sessions: 'tuple[str, ...]' = (), author_ref: 'str | None' = None, author_kind: 'str' = 'user', evidence_refs: 'tuple[str, ...]' = (), staleness: 'dict[str, object] | None' = None, context_policy: 'dict[str, object] | None' = None) -> 'BlackboardNote'` |
+| `Polylogue.set_setting` | `async (self, setting_key: 'str', value: 'object', *, author_ref: 'str' = 'user:local') -> 'ArchiveUserSettingEnvelope'` |
+
+### Intentional exclusions
+
+| Export | Reason | Authority |
+|---|---|---|
+| `ArchiveStats` | Result data model, not an executable archive operation. | `polylogue-s1kr` |
+| `select_pending_embedding_session_window` | Public adapter helper for daemon/CLI window selection. It is intentionally not a facade operation. | `polylogue-s1kr` |
+| `Polylogue.__repr__` | Diagnostic representation protocol, not an archive operation. | `polylogue-s1kr` |
+
+<!-- END GENERATED API OPERATION PARITY -->
+
 ---
 
 **See also:** [CLI Reference](cli-reference.md) · [Data Model](data-model.md) · [Configuration](configuration.md)

--- a/polylogue/api/operation_parity.py
+++ b/polylogue/api/operation_parity.py
@@ -1,0 +1,483 @@
+"""Semantic-operation authority for the documented async Python facade.
+
+The public :class:`polylogue.api.Polylogue` facade is intentionally broader
+than any individual transport.  This declaration maps every callable on that
+facade to a stable semantic operation, or records why an exported callable is
+not a semantic operation.  Live inspection is used only to reject drift; it
+does not assign operation IDs.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Literal
+
+API_PARITY_AUTHORITY = "polylogue-s1kr"
+
+RouteClass = Literal[
+    "lifecycle",
+    "source-index-write",
+    "source-read",
+    "index-read",
+    "index-write",
+    "user-read",
+    "user-write",
+    "cross-tier",
+    "embedding-status",
+    "embedding-preflight",
+    "embedding-read",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class SurfaceBinding:
+    """A cross-surface name or an intentional, owned absence."""
+
+    names: tuple[str, ...] = ()
+    intentional_absence_authority: str | None = None
+
+    def __post_init__(self) -> None:
+        if bool(self.names) == bool(self.intentional_absence_authority):
+            raise ValueError("surface binding needs names or an absence authority, exclusively")
+
+
+@dataclass(frozen=True, slots=True)
+class ApiOperation:
+    """A semantic operation with explicit public-surface bindings."""
+
+    operation_id: str
+    section: str
+    summary: str
+    route_class: RouteClass
+    python_bindings: tuple[str, ...]
+    cli: SurfaceBinding
+    mcp: SurfaceBinding
+
+    def __post_init__(self) -> None:
+        if not self.operation_id.startswith("api."):
+            raise ValueError(f"operation ID must be stable and API-namespaced: {self.operation_id}")
+        if not self.python_bindings:
+            raise ValueError(f"{self.operation_id} must bind at least one Python callable")
+
+
+@dataclass(frozen=True, slots=True)
+class ApiExclusion:
+    """A public callable/type deliberately outside the semantic operation map."""
+
+    binding: str
+    reason: str
+    authority: str = API_PARITY_AUTHORITY
+
+
+def _absence() -> SurfaceBinding:
+    return SurfaceBinding(intentional_absence_authority=API_PARITY_AUTHORITY)
+
+
+def _surface(*names: str) -> SurfaceBinding:
+    return SurfaceBinding(names=names)
+
+
+API_OPERATIONS: tuple[ApiOperation, ...] = (
+    ApiOperation(
+        "api.lifecycle.construct",
+        "Lifecycle and builders",
+        "Construct, open, and close a facade bound to one archive runtime.",
+        "lifecycle",
+        (
+            "Polylogue",
+            "Polylogue.__init__",
+            "Polylogue.open",
+            "Polylogue.__aenter__",
+            "Polylogue.__aexit__",
+            "Polylogue.close",
+        ),
+        _absence(),
+        _absence(),
+    ),
+    ApiOperation(
+        "api.embedding.status",
+        "Embedding readiness",
+        "Read the no-spend embedding readiness state.",
+        "embedding-status",
+        ("Polylogue.embedding_status",),
+        _surface("ops embed status"),
+        _surface("status"),
+    ),
+    ApiOperation(
+        "api.embedding.preflight",
+        "Embedding readiness",
+        "Calculate a bounded no-provider-call embedding catch-up window.",
+        "embedding-preflight",
+        ("Polylogue.embedding_preflight",),
+        _surface("ops embed preflight"),
+        _surface("status"),
+    ),
+    ApiOperation(
+        "api.embedding.search",
+        "Embedding retrieval",
+        "Search stored session vectors using the embeddings tier.",
+        "embedding-read",
+        ("Polylogue.search_similar_sessions",),
+        _surface("find similar"),
+        _surface("query"),
+    ),
+    ApiOperation(
+        "api.ingest.parse",
+        "Ingestion and derived maintenance",
+        "Parse configured or explicit sources into source and index tiers.",
+        "source-index-write",
+        ("Polylogue.parse_file", "Polylogue.parse_sources"),
+        _surface("import"),
+        _surface("run"),
+    ),
+    ApiOperation(
+        "api.index.rebuild",
+        "Ingestion and derived maintenance",
+        "Rebuild or update the derived index through the mutation executor.",
+        "index-write",
+        ("Polylogue.rebuild_index", "Polylogue.update_index", "Polylogue.rebuild_insights"),
+        _surface("ops reset --index"),
+        _surface("maintenance"),
+    ),
+    ApiOperation(
+        "api.archive.session-read",
+        "Archive reads",
+        "Read sessions, summaries, messages, actions, and archive statistics from the index tier.",
+        "index-read",
+        (
+            "Polylogue.get_session",
+            "Polylogue.get_sessions",
+            "Polylogue.get_actions_batch",
+            "Polylogue.list_sessions",
+            "Polylogue.list_summaries",
+            "Polylogue.list_sessions_for_spec",
+            "Polylogue.search_session_hits",
+            "Polylogue.search",
+            "Polylogue.search_envelope",
+            "Polylogue.archive_count_sessions",
+            "Polylogue.archive_get_session",
+            "Polylogue.get_messages_paginated",
+            "Polylogue.iter_messages",
+            "Polylogue.bulk_get_messages",
+            "Polylogue.query_sessions",
+            "Polylogue.count_sessions",
+            "Polylogue.get_session_summary",
+            "Polylogue.get_session_stats",
+            "Polylogue.get_stats_by",
+            "Polylogue.get_index_status",
+            "Polylogue.stats",
+            "Polylogue.storage_stats",
+            "Polylogue.facets",
+            "Polylogue.health_check",
+            "Polylogue.filter",
+            "Polylogue.list_read_view_profiles",
+        ),
+        _surface("find", "read"),
+        _surface("query", "read", "get", "status"),
+    ),
+    ApiOperation(
+        "api.archive.query-analysis",
+        "Archive reads",
+        "Compile, explain, diagnose, and resolve archive query and reference projections.",
+        "index-read",
+        (
+            "Polylogue.explain_query_expression",
+            "Polylogue.query_units",
+            "Polylogue.query_completions",
+            "Polylogue.diagnose_query_miss",
+            "Polylogue.resolve_ref",
+            "Polylogue.export_otel",
+            "Polylogue.neighbor_candidates",
+            "Polylogue.neighbor_candidate_payloads",
+            "Polylogue.session_correlation_payload",
+            "Polylogue.origin_usage_report",
+            "Polylogue.session_usage_reconciliation",
+            "Polylogue.resume_brief",
+            "Polylogue.find_resume_candidates",
+        ),
+        _surface("find", "read", "analyze"),
+        _surface("query", "read", "get", "explain"),
+    ),
+    ApiOperation(
+        "api.archive.source-evidence-read",
+        "Source evidence reads",
+        "Read raw artifacts and provider-side evidence retained in the durable source tier.",
+        "source-read",
+        (
+            "Polylogue.explain_import",
+            "Polylogue.get_raw_artifacts_for_session",
+            "Polylogue.get_hook_event_summary_for_session",
+            "Polylogue.get_session_events",
+            "Polylogue.get_file_edits",
+            "Polylogue.get_web_content_constructs",
+            "Polylogue.get_agent_policies",
+        ),
+        _surface("read", "analyze"),
+        _surface("read", "explain"),
+    ),
+    ApiOperation(
+        "api.archive.insight-read",
+        "Insights and topology",
+        "Read materialized archive insights, topology, and derived archive health from the index tier.",
+        "index-read",
+        (
+            "Polylogue.get_session_insight_status",
+            "Polylogue.get_session_profile_insight",
+            "Polylogue.get_session_profile_record",
+            "Polylogue.list_session_profile_insights",
+            "Polylogue.insight_readiness_report",
+            "Polylogue.insight_rigor_audit",
+            "Polylogue.archive_debt",
+            "Polylogue.get_session_work_event_insights",
+            "Polylogue.list_session_work_event_insights",
+            "Polylogue.get_session_phase_insights",
+            "Polylogue.list_session_phase_insights",
+            "Polylogue.get_thread_insight",
+            "Polylogue.list_thread_insights",
+            "Polylogue.list_session_tag_rollup_insights",
+            "Polylogue.list_archive_coverage_insights",
+            "Polylogue.list_tool_usage_insights",
+            "Polylogue.list_session_cost_insights",
+            "Polylogue.get_session_latency_profile_insight",
+            "Polylogue.list_session_latency_profile_insights",
+            "Polylogue.find_stuck_session_latency_profile_insights",
+            "Polylogue.list_cost_rollup_insights",
+            "Polylogue.list_usage_timeline_insights",
+            "Polylogue.list_archive_debt_insights",
+            "Polylogue.cost_outlook",
+            "Polylogue.aggregate_sessions",
+            "Polylogue.workflow_shape_distribution",
+            "Polylogue.find_abandoned_sessions",
+            "Polylogue.tool_call_latency_distribution",
+            "Polylogue.compare_sessions",
+            "Polylogue.find_similar_sessions_by_metadata",
+            "Polylogue.correlate_sessions",
+            "Polylogue.get_session_topology",
+            "Polylogue.get_ancestors",
+            "Polylogue.get_descendants",
+            "Polylogue.get_siblings",
+            "Polylogue.get_thread",
+            "Polylogue.get_logical_session",
+            "Polylogue.get_session_tree",
+            "Polylogue.postmortem_bundle",
+            "Polylogue.pathology_report",
+            "Polylogue.portfolio_bundle",
+            "Polylogue.export_insight_bundle",
+        ),
+        _surface("analyze", "read"),
+        _surface("query", "get", "status", "explain"),
+    ),
+    ApiOperation(
+        "api.context.delivery",
+        "Context and evidence",
+        "Compile context and record or inspect durable delivery receipts.",
+        "cross-tier",
+        (
+            "Polylogue.compile_context",
+            "Polylogue.context_image_payload",
+            "Polylogue.context_preamble_payload",
+            "Polylogue.get_context_delivery",
+            "Polylogue.list_context_deliveries",
+            "Polylogue.record_context_delivery",
+            "Polylogue.compile_and_record_context",
+            "Polylogue.correlate_hermes_context_deliveries",
+            "Polylogue.reconcile_hermes_session_lifecycle",
+            "Polylogue.reconcile_codex_spawn_edges",
+            "Polylogue.hermes_integration_health",
+        ),
+        _surface("continue", "read"),
+        _surface("context", "get", "status"),
+    ),
+    ApiOperation(
+        "api.assertion.review",
+        "Assertions and judgments",
+        "Read, capture, and judge durable assertions and comparative evidence.",
+        "cross-tier",
+        (
+            "Polylogue.import_annotation_batch",
+            "Polylogue.list_assertion_claims",
+            "Polylogue.list_assertion_claim_payloads",
+            "Polylogue.list_assertion_candidates",
+            "Polylogue.list_assertion_candidate_reviews",
+            "Polylogue.assertion_candidate_queue_health",
+            "Polylogue.judge_assertion_candidate",
+            "Polylogue.capture_assertion_candidate",
+            "Polylogue.judge_assertion_candidates",
+            "Polylogue.record_comparative_judgment",
+            "Polylogue.list_comparative_judgments",
+            "Polylogue.join_typed_annotations",
+        ),
+        _surface("mark", "read"),
+        _surface("write", "judge", "read"),
+    ),
+    ApiOperation(
+        "api.archive.session-delete",
+        "Archive mutations",
+        "Delete a session and its archive records through the shared mutation executor.",
+        "cross-tier",
+        ("Polylogue.delete_session", "Polylogue.delete_session_safe"),
+        _surface("delete"),
+        _surface("write"),
+    ),
+    ApiOperation(
+        "api.user-state.read",
+        "Durable user state",
+        "Read tags, marks, annotations, views, recall packs, workspaces, corrections, notes, and settings from user.db.",
+        "user-read",
+        (
+            "Polylogue.list_tags",
+            "Polylogue.get_metadata",
+            "Polylogue.list_marks",
+            "Polylogue.get_annotation",
+            "Polylogue.list_annotations",
+            "Polylogue.get_view",
+            "Polylogue.list_views",
+            "Polylogue.get_recall_pack",
+            "Polylogue.list_recall_packs",
+            "Polylogue.get_workspace",
+            "Polylogue.list_workspaces",
+            "Polylogue.list_corrections",
+            "Polylogue.list_blackboard_notes",
+            "Polylogue.get_setting",
+            "Polylogue.list_settings",
+        ),
+        _surface("read", "mark"),
+        _surface("read", "get"),
+    ),
+    ApiOperation(
+        "api.user-state.write",
+        "Durable user state",
+        "Mutate tags, metadata, marks, annotations, views, recall packs, workspaces, corrections, notes, and settings in user.db.",
+        "user-write",
+        (
+            "Polylogue.add_tag",
+            "Polylogue.remove_tag",
+            "Polylogue.update_metadata",
+            "Polylogue.set_metadata",
+            "Polylogue.delete_metadata",
+            "Polylogue.bulk_tag_sessions",
+            "Polylogue.add_mark",
+            "Polylogue.remove_mark",
+            "Polylogue.save_annotation",
+            "Polylogue.delete_annotation",
+            "Polylogue.save_view",
+            "Polylogue.delete_view",
+            "Polylogue.create_recall_pack",
+            "Polylogue.delete_recall_pack",
+            "Polylogue.save_workspace",
+            "Polylogue.delete_workspace",
+            "Polylogue.record_correction",
+            "Polylogue.delete_correction",
+            "Polylogue.clear_corrections",
+            "Polylogue.post_blackboard_note",
+            "Polylogue.set_setting",
+        ),
+        _surface("mark", "delete"),
+        _surface("write"),
+    ),
+)
+
+API_EXCLUSIONS: tuple[ApiExclusion, ...] = (
+    ApiExclusion("ArchiveStats", "Result data model, not an executable archive operation."),
+    ApiExclusion(
+        "select_pending_embedding_session_window",
+        "Public adapter helper for daemon/CLI window selection. It is intentionally not a facade operation.",
+    ),
+    ApiExclusion("Polylogue.__repr__", "Diagnostic representation protocol, not an archive operation."),
+)
+
+
+def declared_python_bindings() -> dict[str, ApiOperation | ApiExclusion]:
+    """Return the explicit binding map and reject duplicate authority."""
+
+    bindings: dict[str, ApiOperation | ApiExclusion] = {}
+    for declaration in API_OPERATIONS:
+        for binding in declaration.python_bindings:
+            if binding in bindings:
+                raise ValueError(f"duplicate Python parity binding: {binding}")
+            bindings[binding] = declaration
+    for exclusion in API_EXCLUSIONS:
+        if exclusion.binding in bindings:
+            raise ValueError(f"binding is both operation and exclusion: {exclusion.binding}")
+        bindings[exclusion.binding] = exclusion
+    return bindings
+
+
+def _facade_callable_names() -> set[str]:
+    from polylogue.api import Polylogue
+
+    names = {"Polylogue", "Polylogue.__init__", "Polylogue.__aenter__", "Polylogue.__aexit__", "Polylogue.__repr__"}
+    for name in dir(Polylogue):
+        if name.startswith("_"):
+            continue
+        descriptor = inspect.getattr_static(Polylogue, name)
+        if isinstance(descriptor, property):
+            continue
+        if callable(getattr(Polylogue, name)):
+            names.add(f"Polylogue.{name}")
+    return names
+
+
+def live_public_callable_names() -> set[str]:
+    """Return the narrow documented facade surface, including public exports."""
+
+    from polylogue import api
+
+    names = _facade_callable_names()
+    for name in api.__all__:
+        if name == "Polylogue":
+            continue
+        if callable(getattr(api, name)):
+            names.add(name)
+    return names
+
+
+def validate_live_facade() -> None:
+    """Fail closed when declarations no longer classify the public facade."""
+
+    declared = set(declared_python_bindings())
+    live = live_public_callable_names()
+    unknown = sorted(live - declared)
+    stale = sorted(declared - live)
+    if unknown or stale:
+        details = []
+        if unknown:
+            details.append(f"unclassified live callables: {', '.join(unknown)}")
+        if stale:
+            details.append(f"declared non-callables: {', '.join(stale)}")
+        raise ValueError("API parity declaration drift: " + "; ".join(details))
+
+
+def facade_callable_records() -> tuple[tuple[str, str, bool], ...]:
+    """Return declared facade methods with current signatures and asyncness."""
+
+    from polylogue.api import Polylogue
+
+    records: list[tuple[str, str, bool]] = []
+    for binding in sorted(_facade_callable_names() - {"Polylogue", "Polylogue.__repr__"}):
+        name = binding.removeprefix("Polylogue.")
+        member = Polylogue if name == "__init__" else getattr(Polylogue, name)
+        records.append((binding, str(inspect.signature(member)), inspect.iscoroutinefunction(member)))
+    return tuple(records)
+
+
+def operations_for_section(section: str) -> Iterable[ApiOperation]:
+    return (operation for operation in API_OPERATIONS if operation.section == section)
+
+
+__all__ = [
+    "API_EXCLUSIONS",
+    "API_OPERATIONS",
+    "API_PARITY_AUTHORITY",
+    "ApiExclusion",
+    "ApiOperation",
+    "RouteClass",
+    "SurfaceBinding",
+    "declared_python_bindings",
+    "facade_callable_records",
+    "live_public_callable_names",
+    "operations_for_section",
+    "validate_live_facade",
+]

--- a/tests/unit/api/test_operation_parity.py
+++ b/tests/unit/api/test_operation_parity.py
@@ -1,0 +1,325 @@
+"""Semantic-operation parity tests for the documented Python facade."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from devtools.render_api_operation_parity import (
+    build_parity_payload,
+    render_library_api_section,
+    validate_library_api_section,
+)
+from polylogue.api import Polylogue
+from polylogue.api.operation_parity import API_OPERATIONS, ApiOperation, declared_python_bindings, validate_live_facade
+from polylogue.core.enums import BlockType, Provider, Role
+from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+ROUTE_PROOF_BINDINGS = {
+    "lifecycle": "Polylogue.open",
+    "source-index-write": "Polylogue.parse_file",
+    "source-read": "Polylogue.get_raw_artifacts_for_session",
+    "index-read": "Polylogue.stats",
+    "index-write": "Polylogue.rebuild_index",
+    "user-read": "Polylogue.list_tags",
+    "user-write": "Polylogue.add_tag",
+    "cross-tier": "Polylogue.compile_and_record_context",
+    "embedding-status": "Polylogue.embedding_status",
+    "embedding-preflight": "Polylogue.embedding_preflight",
+    "embedding-read": "Polylogue.search_similar_sessions",
+}
+
+
+def _archive(root: Path) -> Polylogue:
+    with ArchiveStore(root):
+        pass
+    return Polylogue(archive_root=root, db_path=root / "index.db")
+
+
+def _operation_for(binding: str) -> ApiOperation:
+    declaration = declared_python_bindings()[binding]
+    assert isinstance(declaration, ApiOperation)
+    return declaration
+
+
+def _assert_route(operation: ApiOperation, *, expected: str) -> None:
+    """Keep route proofs tied to declaration authority, not method spelling."""
+
+    assert operation.route_class == expected
+
+
+def test_every_live_public_callable_has_semantic_operation_or_exclusion() -> None:
+    validate_live_facade()
+    operation_ids = [operation.operation_id for operation in API_OPERATIONS]
+    assert len(operation_ids) == len(set(operation_ids))
+
+
+def test_every_declared_route_class_has_a_real_route_proof_binding() -> None:
+    assert {operation.route_class for operation in API_OPERATIONS} == set(ROUTE_PROOF_BINDINGS)
+    for route_class, binding in ROUTE_PROOF_BINDINGS.items():
+        _assert_route(_operation_for(binding), expected=route_class)
+
+
+def test_rendered_matrix_preserves_stable_operation_bindings() -> None:
+    payload = build_parity_payload()
+    assert payload["operation_count"] == len(API_OPERATIONS)
+    assert {row["operation_id"] for row in payload["operations"]} == {row.operation_id for row in API_OPERATIONS}
+    embedding = next(row for row in payload["operations"] if row["operation_id"] == "api.embedding.preflight")
+    assert embedding["python"][0]["binding"] == "Polylogue.embedding_preflight"
+    assert embedding["route_class"] == "embedding-preflight"
+
+
+def test_generated_library_api_section_is_signature_asyncness_and_section_aware() -> None:
+    section = render_library_api_section()
+    assert "#### `api.assertion.review`" in section
+    assert "`Polylogue.import_annotation_batch`" in section
+    assert "`async (self, request:" in section
+    validate_library_api_section(section)
+    with pytest.raises(ValueError, match="signatures"):
+        validate_library_api_section(section.replace("`async ", "`", 1))
+
+
+@pytest.mark.asyncio
+async def test_real_route_lifecycle_constructs_and_closes_temporary_archive(tmp_path: Path) -> None:
+    operation = _operation_for("Polylogue.open")
+    _assert_route(operation, expected="lifecycle")
+    archive = Polylogue.open(archive_root=tmp_path, db_path=tmp_path / "index.db")
+    assert archive.archive_root == tmp_path.resolve()
+    await archive.close()
+
+
+@pytest.mark.asyncio
+async def test_real_route_parse_file_writes_declared_source_and_index_tiers(tmp_path: Path) -> None:
+    operation = _operation_for("Polylogue.parse_file")
+    _assert_route(operation, expected="source-index-write")
+    archive = _archive(tmp_path)
+    payload = {
+        "sessionId": "api-parity-parse",
+        "projectHash": "api-parity",
+        "startTime": "2026-08-04T00:00:00.000Z",
+        "lastUpdated": "2026-08-04T00:01:00.000Z",
+        "kind": "chat",
+        "summary": "API parity parse",
+        "messages": [
+            {"id": "u1", "timestamp": "2026-08-04T00:00:01.000Z", "type": "user", "content": ["parity needle"]},
+            {"id": "a1", "timestamp": "2026-08-04T00:00:02.000Z", "type": "gemini", "content": "done"},
+        ],
+    }
+    source = tmp_path / "session.json"
+    source.write_text(json.dumps(payload), encoding="utf-8")
+    try:
+        result = await archive.parse_file(source, source_name=Provider.GEMINI_CLI.value)
+        assert result.changed_counts["sessions"] == 1
+        with sqlite3.connect(tmp_path / "source.db") as conn:
+            assert conn.execute("SELECT COUNT(*) FROM raw_sessions").fetchone() == (1,)
+        with sqlite3.connect(tmp_path / "index.db") as conn:
+            assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone() == (1,)
+    finally:
+        await archive.close()
+
+
+@pytest.mark.asyncio
+async def test_real_route_reads_source_evidence_from_temporary_archive(tmp_path: Path) -> None:
+    archive = _archive(tmp_path)
+    operation = _operation_for("Polylogue.get_raw_artifacts_for_session")
+    _assert_route(operation, expected="source-read")
+    source = tmp_path / "source-evidence.json"
+    source.write_text(
+        json.dumps(
+            {
+                "sessionId": "source-read",
+                "projectHash": "api-parity",
+                "startTime": "2026-08-04T00:00:00.000Z",
+                "lastUpdated": "2026-08-04T00:01:00.000Z",
+                "kind": "chat",
+                "summary": "source evidence",
+                "messages": [
+                    {"id": "m1", "timestamp": "2026-08-04T00:00:01.000Z", "type": "user", "content": ["evidence"]}
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    try:
+        await archive.parse_file(source, source_name=Provider.GEMINI_CLI.value)
+        session_id = "gemini-cli-session:source-read"
+        rows, total = await archive.get_raw_artifacts_for_session(session_id)
+        assert total == 1
+        assert rows[0]["source_path"] == str(source)
+    finally:
+        await archive.close()
+
+
+@pytest.mark.asyncio
+async def test_real_route_reads_index_state_from_temporary_archive(tmp_path: Path) -> None:
+    archive = _archive(tmp_path)
+    operation = _operation_for("Polylogue.stats")
+    _assert_route(operation, expected="index-read")
+    try:
+        with ArchiveStore(tmp_path) as store:
+            store.write_parsed(
+                ParsedSession(
+                    source_name=Provider.CODEX,
+                    provider_session_id="index-read",
+                    title="index state",
+                    messages=[
+                        ParsedMessage(
+                            provider_message_id="m1",
+                            role=Role.USER,
+                            blocks=[ParsedContentBlock(type=BlockType.TEXT, text="index")],
+                        )
+                    ],
+                )
+            )
+        assert (await archive.stats()).session_count == 1
+    finally:
+        await archive.close()
+
+
+@pytest.mark.asyncio
+async def test_real_route_rebuilds_index_through_declared_maintenance_class(tmp_path: Path) -> None:
+    archive = _archive(tmp_path)
+    operation = _operation_for("Polylogue.rebuild_index")
+    _assert_route(operation, expected="index-write")
+    try:
+        assert await archive.rebuild_index() is True
+    finally:
+        await archive.close()
+
+
+@pytest.mark.asyncio
+async def test_real_route_writes_and_reads_declared_user_tier(tmp_path: Path) -> None:
+    archive = _archive(tmp_path)
+    write_operation = _operation_for("Polylogue.add_tag")
+    read_operation = _operation_for("Polylogue.list_tags")
+    _assert_route(write_operation, expected="user-write")
+    _assert_route(read_operation, expected="user-read")
+    try:
+        with ArchiveStore(tmp_path) as store:
+            session_id = store.write_parsed(
+                ParsedSession(
+                    source_name=Provider.CODEX,
+                    provider_session_id="user-write",
+                    title="user state",
+                    messages=[
+                        ParsedMessage(
+                            provider_message_id="m1",
+                            role=Role.USER,
+                            blocks=[ParsedContentBlock(type=BlockType.TEXT, text="user")],
+                        )
+                    ],
+                )
+            )
+        assert (await archive.add_tag(session_id, "parity")).outcome == "added"
+        assert await archive.list_tags() == {"parity": 1}
+        with sqlite3.connect(tmp_path / "user.db") as conn:
+            assert conn.execute("SELECT COUNT(*) FROM assertions WHERE kind = 'tag'").fetchone() == (1,)
+    finally:
+        await archive.close()
+
+
+@pytest.mark.asyncio
+async def test_real_route_compiles_and_records_declared_cross_tier_context(tmp_path: Path) -> None:
+    archive = _archive(tmp_path)
+    operation = _operation_for("Polylogue.compile_and_record_context")
+    _assert_route(operation, expected="cross-tier")
+    try:
+        with ArchiveStore(tmp_path) as store:
+            store.write_parsed(
+                ParsedSession(
+                    source_name=Provider.CODEX,
+                    provider_session_id="cross-tier-context",
+                    title="cross-tier context",
+                    created_at="2026-08-04T00:00:00+00:00",
+                    updated_at="2026-08-04T00:01:00+00:00",
+                    messages=[
+                        ParsedMessage(
+                            provider_message_id="m1",
+                            role=Role.USER,
+                            blocks=[ParsedContentBlock(type=BlockType.TEXT, text="cross-tier archival evidence")],
+                        )
+                    ],
+                )
+            )
+        receipt = await archive.compile_and_record_context(
+            recipient_ref="agent:api-parity",
+            delivered_by_ref="user:local",
+            boundary="api-parity",
+            query="cross-tier archival",
+            max_sessions=1,
+        )
+        assert receipt.outcome == "recorded"
+        assert await archive.get_context_delivery(receipt.snapshot_ref, recipient_ref="agent:api-parity") is not None
+    finally:
+        await archive.close()
+
+
+@pytest.mark.asyncio
+async def test_real_route_embedding_status_and_preflight_are_no_spend_temporary_archive_routes(tmp_path: Path) -> None:
+    archive = _archive(tmp_path)
+    status_operation = _operation_for("Polylogue.embedding_status")
+    preflight_operation = _operation_for("Polylogue.embedding_preflight")
+    _assert_route(status_operation, expected="embedding-status")
+    _assert_route(preflight_operation, expected="embedding-preflight")
+    try:
+        status = archive.embedding_status()
+        preflight = archive.embedding_preflight(max_sessions=1)
+        assert status["status"] in {"empty", "none", "disabled", "ready", "stale", "pending"}
+        assert "pending_sessions" in preflight
+        assert (tmp_path / "embeddings.db").exists()
+        assert status["retrieval_ready"] is False
+    finally:
+        await archive.close()
+
+
+@pytest.mark.asyncio
+async def test_real_route_embedding_search_is_declared_as_embedding_read(tmp_path: Path) -> None:
+    archive = _archive(tmp_path)
+    operation = _operation_for("Polylogue.search_similar_sessions")
+    _assert_route(operation, expected="embedding-read")
+    try:
+        with pytest.raises(ValueError, match="No vector provider configured"):
+            await archive.search_similar_sessions("missing-session")
+    finally:
+        await archive.close()
+
+
+@pytest.mark.asyncio
+async def test_route_proof_rejects_a_deliberately_misrouted_method(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = _archive(tmp_path)
+    operation = _operation_for("Polylogue.add_tag")
+    _assert_route(operation, expected="user-write")
+
+    async def misrouted_add_tag(self: Polylogue, session_id: str, tag: str, **kwargs: object) -> object:
+        del tag, kwargs
+        return await self.get_metadata(session_id)
+
+    monkeypatch.setattr(Polylogue, "add_tag", misrouted_add_tag)
+    try:
+        with ArchiveStore(tmp_path) as store:
+            session_id = store.write_parsed(
+                ParsedSession(
+                    source_name=Provider.CODEX,
+                    provider_session_id="misrouted-user-write",
+                    title="misrouted user state",
+                    messages=[
+                        ParsedMessage(
+                            provider_message_id="m1",
+                            role=Role.USER,
+                            blocks=[ParsedContentBlock(type=BlockType.TEXT, text="user")],
+                        )
+                    ],
+                )
+            )
+        await archive.add_tag(session_id, "should-not-write")
+        with sqlite3.connect(tmp_path / "user.db") as conn:
+            with pytest.raises(AssertionError):
+                assert conn.execute("SELECT COUNT(*) FROM assertions WHERE kind = 'tag'").fetchone() == (1,)
+    finally:
+        await archive.close()

--- a/tests/unit/api/test_operation_parity.py
+++ b/tests/unit/api/test_operation_parity.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 
@@ -65,10 +66,11 @@ def test_every_declared_route_class_has_a_real_route_proof_binding() -> None:
 
 
 def test_rendered_matrix_preserves_stable_operation_bindings() -> None:
-    payload = build_parity_payload()
+    payload = cast(dict[str, Any], build_parity_payload())
+    operations = cast(list[dict[str, Any]], payload["operations"])
     assert payload["operation_count"] == len(API_OPERATIONS)
-    assert {row["operation_id"] for row in payload["operations"]} == {row.operation_id for row in API_OPERATIONS}
-    embedding = next(row for row in payload["operations"] if row["operation_id"] == "api.embedding.preflight")
+    assert {row["operation_id"] for row in operations} == {row.operation_id for row in API_OPERATIONS}
+    embedding = next(row for row in operations if row["operation_id"] == "api.embedding.preflight")
     assert embedding["python"][0]["binding"] == "Polylogue.embedding_preflight"
     assert embedding["route_class"] == "embedding-preflight"
 

--- a/tests/unit/devtools/test_render_api_operation_parity.py
+++ b/tests/unit/devtools/test_render_api_operation_parity.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any, cast
 
 import pytest
 
@@ -8,11 +9,14 @@ from devtools.render_api_operation_parity import build_parity_payload, render_pa
 
 
 def test_api_operation_parity_renderer_emits_stable_machine_readable_authority() -> None:
-    payload = build_parity_payload()
+    payload = cast(dict[str, Any], build_parity_payload())
+    authority = cast(dict[str, Any], payload["authority"])
+    operations = cast(list[dict[str, Any]], payload["operations"])
+    exclusions = cast(list[dict[str, Any]], payload["exclusions"])
     assert payload["schema_version"] == 1
-    assert payload["authority"]["drift_owner"] == "polylogue-s1kr"
-    assert any(row["operation_id"] == "api.lifecycle.construct" for row in payload["operations"])
-    assert any(row["binding"] == "select_pending_embedding_session_window" for row in payload["exclusions"])
+    assert authority["drift_owner"] == "polylogue-s1kr"
+    assert any(row["operation_id"] == "api.lifecycle.construct" for row in operations)
+    assert any(row["binding"] == "select_pending_embedding_session_window" for row in exclusions)
     assert json.loads(render_parity_output()) == payload
 
 

--- a/tests/unit/devtools/test_render_api_operation_parity.py
+++ b/tests/unit/devtools/test_render_api_operation_parity.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from devtools.render_api_operation_parity import build_parity_payload, render_parity_output
+
+
+def test_api_operation_parity_renderer_emits_stable_machine_readable_authority() -> None:
+    payload = build_parity_payload()
+    assert payload["schema_version"] == 1
+    assert payload["authority"]["drift_owner"] == "polylogue-s1kr"
+    assert any(row["operation_id"] == "api.lifecycle.construct" for row in payload["operations"])
+    assert any(row["binding"] == "select_pending_embedding_session_window" for row in payload["exclusions"])
+    assert json.loads(render_parity_output()) == payload
+
+
+def test_renderer_fails_closed_for_unclassified_live_facade_callable(monkeypatch: pytest.MonkeyPatch) -> None:
+    from polylogue.api import Polylogue
+    from polylogue.api.operation_parity import validate_live_facade
+
+    async def unclassified(self: Polylogue) -> None:
+        return None
+
+    monkeypatch.setattr(Polylogue, "unclassified", unclassified, raising=False)
+    with pytest.raises(ValueError, match="unclassified live callables"):
+        validate_live_facade()


### PR DESCRIPTION
## Summary

Adds a declaration-governed semantic-operation parity contract for the documented async `Polylogue` facade. The committed matrix covers 15 stable operations, 163 explicit Python bindings, and 3 intentional exclusions.

## Problem

The Python API had only a PR-body audit. New facade callables, route drift, and stale library reference signatures could land without a durable operation-level contract or generated evidence.

## Solution

- Adds `polylogue/api/operation_parity.py` as the explicit authority for operation IDs, CLI/MCP bindings, route/tier classes, and exclusions.
- Adds `devtools render api-operation-parity`, registered in `render all`, to render `docs/generated/api-operation-parity.json` and the signature- and asyncness-aware section in `docs/library-api.md`.
- Adds temporary-archive route proofs for lifecycle, source/index, source, index, user, cross-tier, and embedding routes. The misrouting proof replaces `add_tag` with an index-read route and confirms the declared user-tier effect is lost.

## Acceptance criteria

| Criterion | State | Evidence |
| --- | --- | --- |
| Generated committed operation-level CLI/MCP/Python matrix is drift-checked | Satisfied | `docs/generated/api-operation-parity.json`; `devtools render all --check` |
| Every public facade callable is an operation or explicit exclusion | Satisfied | fail-closed live-facade validator and renderer test |
| Library API reference matches live facade signatures, asyncness, and sections | Satisfied | generated `docs/library-api.md` index, including `import_annotation_batch` |
| Lifecycle and embedding preflight/status routes have real-route proof | Satisfied | temporary-archive focused API tests |
| A misrouted method fails the route-effect proof | Satisfied | `add_tag` mutation test redirects to `get_metadata` and observes no tag assertion |

Ref polylogue-s1kr

## Verification

- `devtools test tests/unit/api/test_operation_parity.py tests/unit/devtools/test_render_api_operation_parity.py` : 16 passed
- `devtools render all --check` : clean
- `devtools verify --quick` : passed through the pre-push baseline
