### PR TITLE
fix(operations): resolve OperationSpec code references

### DIFF
--- a/polylogue/operations/specs.py
+++ b/polylogue/operations/specs.py
@@ -817,8 +817,8 @@ RUNTIME_OPERATION_SPECS: tuple[OperationSpec, ...] = (
         path_targets=("assertion-candidate-capture-loop",),
         code_refs=(
             "polylogue.api.archive.PolylogueArchiveMixin.capture_assertion_candidate",
-            "polylogue.cli.commands.note.capture_note_command",
-            "polylogue.mcp.server_cutover._dispatch_write (operation=capture_assertion_candidate)",
+            "polylogue.cli.commands.note.note_command",
+            "polylogue.mcp.server_cutover._dispatch_write",
             "polylogue.operations.mutation_actuators.CaptureAssertionCandidateActuator",
         ),
         surfaces=("facade", "cli", "mcp"),
@@ -862,7 +862,7 @@ RUNTIME_OPERATION_SPECS: tuple[OperationSpec, ...] = (
         path_targets=("message-fts-readiness-loop",),
         code_refs=(
             "polylogue.api.ingest.PolylogueIngestMixin.rebuild_index",
-            "polylogue.mcp.server_cutover._dispatch_maintenance (operation=rebuild_index)",
+            "polylogue.mcp.server_cutover._dispatch_maintenance",
             "polylogue.operations.mutation_actuators.IndexRebuildActuator",
         ),
         surfaces=("facade", "mcp"),
@@ -885,7 +885,7 @@ RUNTIME_OPERATION_SPECS: tuple[OperationSpec, ...] = (
         path_targets=("message-fts-readiness-loop",),
         code_refs=(
             "polylogue.api.archive.PolylogueArchiveMixin.update_index",
-            "polylogue.mcp.server_cutover._dispatch_maintenance (operation=update_index)",
+            "polylogue.mcp.server_cutover._dispatch_maintenance",
             "polylogue.operations.mutation_actuators.IndexRebuildActuator",
         ),
         surfaces=("facade", "mcp"),
@@ -908,7 +908,7 @@ RUNTIME_OPERATION_SPECS: tuple[OperationSpec, ...] = (
         path_targets=("session-insight-repair-loop",),
         code_refs=(
             "polylogue.api.archive.PolylogueArchiveMixin.rebuild_insights",
-            "polylogue.mcp.server_cutover._dispatch_maintenance (operation=rebuild_insights)",
+            "polylogue.mcp.server_cutover._dispatch_maintenance",
             "polylogue.operations.mutation_actuators.InsightsRebuildActuator",
         ),
         surfaces=("facade", "mcp"),

--- a/tests/unit/verification/test_code_refs_resolve.py
+++ b/tests/unit/verification/test_code_refs_resolve.py
@@ -41,6 +41,8 @@ from polylogue.operations.specs import (
     RUNTIME_OPERATION_SPECS,
 )
 
+_DOTTED_SYMBOL_RE = re.compile(r"^[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)+$")
+
 
 class _NestedFunctionRef:
     """Marker sentinel: an attr resolved via the nested-def source-scan fallback."""
@@ -94,9 +96,9 @@ def _resolve_code_ref(ref: str) -> object:
     ``Class`` then ``method`` via getattr), falling back to shorter prefixes.
     """
 
+    if not _DOTTED_SYMBOL_RE.fullmatch(ref):
+        raise ValueError(f"code_ref must be an unannotated dotted symbol: {ref!r}")
     parts = ref.split(".")
-    if len(parts) < 2:
-        raise ValueError(f"code_ref has no dotted module component: {ref!r}")
 
     try:
         return importlib.import_module(ref)
@@ -167,3 +169,17 @@ def test_code_ref_resolves_to_a_real_symbol(owner: str, ref: str) -> None:
         _resolve_code_ref(ref)
     except (ImportError, AttributeError, ValueError) as exc:
         pytest.fail(f"{owner} declares unresolvable code_ref {ref!r}: {exc}")
+
+
+def test_code_ref_rejects_missing_symbol() -> None:
+    """The shared resolver rejects a stale symbol instead of importing only its module."""
+
+    with pytest.raises(AttributeError, match="missing_symbol"):
+        _resolve_code_ref("polylogue.operations.specs.missing_symbol")
+
+
+def test_code_ref_rejects_annotated_prose() -> None:
+    """Operation identity belongs to the owning spec, never an annotated code_ref."""
+
+    with pytest.raises(ValueError, match="unannotated dotted symbol"):
+        _resolve_code_ref("polylogue.mcp.server_cutover._dispatch_write (operation=write)")


### PR DESCRIPTION
## Summary

Repair five stale operation-catalog code references and make the focused resolver reject annotated prose before import resolution.

## Problem

The capture-note entry named a removed command, while four dispatcher references appended operation annotations to what should be importable dotted symbols. Those stale strings made the catalog attribution unverifiable.

## Solution

`polylogue/operations/specs.py` now names `note_command`, `_dispatch_write`, and `_dispatch_maintenance` directly. The owning `OperationSpec` continues to hold each operation identity. The resolver test enforces dotted-symbol syntax before resolving every declared catalog reference and includes negative coverage for missing symbols and annotated prose.

## Verification

- `direnv exec . devtools test tests/unit/verification/test_code_refs_resolve.py` produced `277 passed in 3.98s`.
- `direnv exec . devtools verify --quick` completed with exit code `0`.

## Anti-vacuity

The test parametrizes every declared catalog reference through the real resolver. It fails for `polylogue.operations.specs.missing_symbol` and for an annotated dispatcher reference, so removing a target symbol or reintroducing parenthetical operation prose fails the gate.

Ref polylogue-t46.9.