### PR TITLE
fix(insights): preserve temporal provenance on public reads (#3731)

### DIFF
--- a/polylogue/insights/archive.py
+++ b/polylogue/insights/archive.py
@@ -177,7 +177,10 @@ class ArchiveDebtInsightQuery(PaginatedInsightQuery):
 
 class _InsightRecordWithProvenance(Protocol):
     materializer_version: int
-    materialized_at: str
+
+    @property
+    def materialized_at(self) -> str | None: ...
+
     source_updated_at: str | None
     source_sort_key: float | None
     input_high_water_mark: str | None
@@ -625,7 +628,7 @@ def records_provenance(
         for row in row_list
         if getattr(row, materialized_at_attr, None)
     ]
-    materialized_at = max(materialized_at_values).isoformat() if materialized_at_values else "1970-01-01T00:00:00+00:00"
+    materialized_at = max(materialized_at_values).isoformat() if materialized_at_values else None
     source_updated_at_values = [
         _parse_iso_timestamp(str(getattr(row, source_updated_at_attr)))
         for row in row_list

--- a/polylogue/insights/archive_models.py
+++ b/polylogue/insights/archive_models.py
@@ -38,7 +38,10 @@ class ArchiveInsightModel(BaseModel):
 
 class ArchiveInsightProvenance(ArchiveInsightModel):
     materializer_version: int
-    materialized_at: str
+    # Materialization is freshness metadata. A legacy row without its shared
+    # materialization marker must remain absent, rather than acquiring a
+    # synthetic epoch timestamp that callers could mistake for event time.
+    materialized_at: str | None = None
     source_updated_at: str | None = None
     source_sort_key: float | None = None
     input_high_water_mark: str | None = None

--- a/polylogue/insights/timeline_renderer.py
+++ b/polylogue/insights/timeline_renderer.py
@@ -72,7 +72,7 @@ class TimelineEntry:
     duration_ms: int
     fidelity: FidelityTag
     timing_provenance: str
-    confidence: float = 0.0
+    confidence: float | None = None
     tools_used: tuple[str, ...] = ()
     file_paths: tuple[str, ...] = ()
     word_count: int = 0
@@ -152,7 +152,7 @@ def _phase_entry(insight: SessionPhaseInsight, *, phase_kind: str = "phase") -> 
         duration_ms=evidence.duration_ms,
         fidelity=fidelity_for(evidence.timing_provenance),
         timing_provenance=evidence.timing_provenance,
-        confidence=inference.confidence if inference is not None else 0.0,
+        confidence=inference.confidence if inference is not None else None,
         word_count=evidence.word_count,
     )
 

--- a/polylogue/insights/transforms.py
+++ b/polylogue/insights/transforms.py
@@ -112,11 +112,11 @@ def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _session_transform_timestamp(session: Session) -> str:
+def _session_transform_timestamp(session: Session) -> str | None:
     message_timestamps = [message.timestamp for message in session.messages if message.timestamp is not None]
     timestamp = session.updated_at or session.created_at or (max(message_timestamps) if message_timestamps else None)
     if timestamp is None:
-        return "1970-01-01T00:00:00+00:00"
+        return None
     return timestamp.astimezone(timezone.utc).isoformat()
 
 
@@ -178,7 +178,7 @@ class TransformMetadata(ArchiveInsightModel):
     transform_version: int
     input_session_id: str
     source_origin: str
-    computed_at: str = Field(default_factory=_utc_now_iso)
+    computed_at: str | None = Field(default_factory=_utc_now_iso)
     input_message_count: int = 0
 
 
@@ -868,7 +868,10 @@ def build_successor_context_bundle(digest: SessionDigest) -> SuccessorContextBun
         title=digest.title or digest.session_id,
         source_origin=digest.transform.source_origin,
         message_count=digest.size_metrics.message_count,
-        generated_at=digest.transform.computed_at,
+        # The context bundle's generation time is freshness metadata. It is
+        # deliberately independent of a session whose source event time is
+        # unknown, which remains null on TransformMetadata.
+        generated_at=digest.transform.computed_at or _utc_now_iso(),
         selection_strategy="single_session_session_digest_v0",
         scope=SuccessorContextScope(
             seed_refs=(f"session:{digest.session_id}",),

--- a/polylogue/storage/insights/session/records.py
+++ b/polylogue/storage/insights/session/records.py
@@ -24,7 +24,7 @@ class SessionProfileRecord(BaseModel):
     session_id: SessionId
     logical_session_id: SessionId
     materializer_version: int = SESSION_INSIGHT_MATERIALIZER_VERSION
-    materialized_at: str
+    materialized_at: str | None = None
     source_updated_at: str | None = None
     source_sort_key: float | None = None
     input_high_water_mark: str | None = None
@@ -99,7 +99,6 @@ class SessionProfileRecord(BaseModel):
         "session_id",
         "logical_session_id",
         "source_name",
-        "materialized_at",
         "search_text",
         "evidence_search_text",
         "inference_search_text",

--- a/polylogue/storage/insights/timeline/records.py
+++ b/polylogue/storage/insights/timeline/records.py
@@ -23,7 +23,7 @@ class SessionWorkEventRecord(BaseModel):
     event_id: str
     session_id: SessionId
     materializer_version: int = SESSION_INSIGHT_MATERIALIZER_VERSION
-    materialized_at: str
+    materialized_at: str | None = None
     source_updated_at: str | None = None
     source_sort_key: float | None = None
     input_high_water_mark: str | None = None
@@ -51,7 +51,6 @@ class SessionWorkEventRecord(BaseModel):
     @field_validator(
         "event_id",
         "session_id",
-        "materialized_at",
         "source_name",
         "heuristic_label",
         "summary",
@@ -69,7 +68,7 @@ class SessionPhaseRecord(BaseModel):
     phase_id: str
     session_id: SessionId
     materializer_version: int = SESSION_INSIGHT_MATERIALIZER_VERSION
-    materialized_at: str
+    materialized_at: str | None = None
     source_updated_at: str | None = None
     source_sort_key: float | None = None
     input_high_water_mark: str | None = None
@@ -97,7 +96,6 @@ class SessionPhaseRecord(BaseModel):
     @field_validator(
         "phase_id",
         "session_id",
-        "materialized_at",
         "source_name",
         "kind",
         "search_text",

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -4356,11 +4356,14 @@ class ArchiveStore:
                 ),
                 provenance=ArchiveInsightProvenance(
                     materializer_version=1,
-                    materialized_at=_iso_from_ms(row["source_sort_key_ms"]) or "1970-01-01T00:00:00Z",
+                    materialized_at=None,
                     source_updated_at=_iso_from_ms(row["source_sort_key_ms"]),
                     source_sort_key=(
                         float(row["source_sort_key_ms"]) / 1000.0 if row["source_sort_key_ms"] is not None else None
                     ),
+                    input_high_water_mark=_iso_from_ms(row["source_sort_key_ms"]),
+                    input_high_water_mark_source="sort_key" if row["source_sort_key_ms"] is not None else None,
+                    time_confidence="estimated" if row["source_sort_key_ms"] is not None else "unknown",
                 ),
             )
             for row in rows
@@ -5032,11 +5035,14 @@ class ArchiveStore:
                 ),
                 provenance=ArchiveInsightProvenance(
                     materializer_version=1,
-                    materialized_at=_iso_from_ms(row["source_sort_key_ms"]) or "1970-01-01T00:00:00Z",
+                    materialized_at=None,
                     source_updated_at=_iso_from_ms(row["source_sort_key_ms"]),
                     source_sort_key=(
                         float(row["source_sort_key_ms"]) / 1000.0 if row["source_sort_key_ms"] is not None else None
                     ),
+                    input_high_water_mark=_iso_from_ms(row["source_sort_key_ms"]),
+                    input_high_water_mark_source="sort_key" if row["source_sort_key_ms"] is not None else None,
+                    time_confidence="estimated" if row["source_sort_key_ms"] is not None else "unknown",
                 ),
             )
             for row in rows
@@ -9092,38 +9098,61 @@ def _read_archive_materialization(
     conn: sqlite3.Connection,
     insight_type: str,
     session_id: str,
-) -> ArchiveInsightMaterialization:
+) -> ArchiveInsightMaterialization | None:
     try:
         return read_insight_materialization(conn, insight_type, session_id)
     except KeyError:
-        return ArchiveInsightMaterialization(
-            insight_type=insight_type,
-            session_id=session_id,
+        return None
+
+
+def _archive_provenance(
+    materialization: ArchiveInsightMaterialization | None,
+    *,
+    input_high_water_mark: str | None = None,
+    input_high_water_mark_source: str | None = None,
+) -> ArchiveInsightProvenance:
+    if materialization is None:
+        return ArchiveInsightProvenance(
             materializer_version=1,
-            materialized_at_ms=0,
-            source_updated_at_ms=None,
-            source_sort_key_ms=None,
-            input_high_water_mark_ms=None,
-            input_row_count=0,
+            materialized_at=None,
+            input_high_water_mark=input_high_water_mark,
+            input_high_water_mark_source=input_high_water_mark_source,
+            time_confidence=time_confidence_for_source(input_high_water_mark_source),
         )
-
-
-def _archive_provenance(materialization: ArchiveInsightMaterialization) -> ArchiveInsightProvenance:
+    resolved_hwm = (
+        input_high_water_mark
+        if input_high_water_mark is not None
+        else _iso_from_ms(materialization.input_high_water_mark_ms)
+    )
+    resolved_source = (
+        input_high_water_mark_source
+        if input_high_water_mark_source is not None
+        else materialization.input_high_water_mark_source
+    )
     return ArchiveInsightProvenance(
         materializer_version=materialization.materializer_version,
-        materialized_at=_iso_from_ms(materialization.materialized_at_ms) or "1970-01-01T00:00:00Z",
+        materialized_at=_iso_from_ms(materialization.materialized_at_ms),
         source_updated_at=_iso_from_ms(materialization.source_updated_at_ms),
         source_sort_key=(
             materialization.source_sort_key_ms / 1000.0 if materialization.source_sort_key_ms is not None else None
         ),
-        input_high_water_mark=_iso_from_ms(materialization.input_high_water_mark_ms),
-        input_high_water_mark_source=materialization.input_high_water_mark_source,
-        time_confidence=time_confidence_for_source(materialization.input_high_water_mark_source),
+        input_high_water_mark=resolved_hwm,
+        input_high_water_mark_source=resolved_source,
+        time_confidence=time_confidence_for_source(resolved_source),
     )
 
 
-def _archive_inference_provenance(materialization: ArchiveInsightMaterialization) -> ArchiveInferenceProvenance:
-    base = _archive_provenance(materialization)
+def _archive_inference_provenance(
+    materialization: ArchiveInsightMaterialization | None,
+    *,
+    input_high_water_mark: str | None = None,
+    input_high_water_mark_source: str | None = None,
+) -> ArchiveInferenceProvenance:
+    base = _archive_provenance(
+        materialization,
+        input_high_water_mark=input_high_water_mark,
+        input_high_water_mark_source=input_high_water_mark_source,
+    )
     return ArchiveInferenceProvenance(
         materializer_version=base.materializer_version,
         materialized_at=base.materialized_at,
@@ -9132,12 +9161,14 @@ def _archive_inference_provenance(materialization: ArchiveInsightMaterialization
         input_high_water_mark=base.input_high_water_mark,
         input_high_water_mark_source=base.input_high_water_mark_source,
         time_confidence=base.time_confidence,
-        inference_version=materialization.materializer_version,
+        inference_version=base.materializer_version,
         inference_family="archive",
     )
 
 
-def _archive_enrichment_provenance(materialization: ArchiveInsightMaterialization) -> ArchiveEnrichmentProvenance:
+def _archive_enrichment_provenance(
+    materialization: ArchiveInsightMaterialization | None,
+) -> ArchiveEnrichmentProvenance:
     base = _archive_provenance(materialization)
     return ArchiveEnrichmentProvenance(
         materializer_version=base.materializer_version,
@@ -9147,7 +9178,7 @@ def _archive_enrichment_provenance(materialization: ArchiveInsightMaterializatio
         input_high_water_mark=base.input_high_water_mark,
         input_high_water_mark_source=base.input_high_water_mark_source,
         time_confidence=base.time_confidence,
-        enrichment_version=materialization.materializer_version,
+        enrichment_version=base.materializer_version,
         enrichment_family="archive",
     )
 
@@ -9156,7 +9187,7 @@ def _work_event_insight_from_archive_row(
     event: ArchiveSessionWorkEvent,
     *,
     origin: str,
-    materialization: ArchiveInsightMaterialization,
+    materialization: ArchiveInsightMaterialization | None,
 ) -> SessionWorkEventInsight:
     evidence_payload = {
         **event.evidence,
@@ -9180,8 +9211,16 @@ def _work_event_insight_from_archive_row(
         session_id=event.session_id,
         origin=origin,
         event_index=event.position,
-        provenance=_archive_provenance(materialization),
-        inference_provenance=_archive_inference_provenance(materialization),
+        provenance=_archive_provenance(
+            materialization,
+            input_high_water_mark=event.input_high_water_mark,
+            input_high_water_mark_source=event.input_high_water_mark_source,
+        ),
+        inference_provenance=_archive_inference_provenance(
+            materialization,
+            input_high_water_mark=event.input_high_water_mark,
+            input_high_water_mark_source=event.input_high_water_mark_source,
+        ),
         evidence=WorkEventEvidencePayload.model_validate(evidence_payload),
         inference=WorkEventInferencePayload.model_validate(inference_payload),
     )
@@ -9191,7 +9230,7 @@ def _phase_insight_from_archive_row(
     phase: ArchiveSessionPhase,
     *,
     origin: str,
-    materialization: ArchiveInsightMaterialization,
+    materialization: ArchiveInsightMaterialization | None,
 ) -> SessionPhaseInsight:
     evidence_payload = {
         **phase.evidence,
@@ -9207,7 +9246,11 @@ def _phase_insight_from_archive_row(
         session_id=phase.session_id,
         origin=origin,
         phase_index=phase.position,
-        provenance=_archive_provenance(materialization),
+        provenance=_archive_provenance(
+            materialization,
+            input_high_water_mark=phase.input_high_water_mark,
+            input_high_water_mark_source=phase.input_high_water_mark_source,
+        ),
         evidence=SessionPhaseEvidencePayload.model_validate(evidence_payload),
     )
 
@@ -9216,7 +9259,7 @@ def _phase_insight_from_archive_row(
 class _SessionProfileComponents:
     """Extracted session-profile payloads shared by the insight and record builders."""
 
-    materialization: ArchiveInsightMaterialization
+    materialization: ArchiveInsightMaterialization | None
     evidence: SessionEvidencePayload
     inference: SessionInferencePayload
     enrichment: SessionEnrichmentPayload | None
@@ -9322,7 +9365,7 @@ def _session_profile_components_from_archive_row(
                     terminal_state=inference.terminal_state,
                     terminal_state_confidence=inference.terminal_state_confidence,
                     terminal_state_evidence=dict(evidence.terminal_state_evidence),
-                    as_of=_iso_from_ms(materialization.source_updated_at_ms),
+                    as_of=_iso_from_ms(materialization.source_updated_at_ms) if materialization is not None else None,
                 )
             }
         )
@@ -9392,22 +9435,28 @@ def _session_profile_record_from_archive_row(
     source_name = str(row["origin"])
     title = str(row["title"]) if row["title"] is not None else None
     workflow_shape = str(row["workflow_shape"] or "unknown")
-    materialized_at = _iso_from_ms(materialization.materialized_at_ms) or "1970-01-01T00:00:00Z"
+    materialized_at = _iso_from_ms(materialization.materialized_at_ms) if materialization is not None else None
     # search_text* are FTS-only and not consumed by hydrate_session_profile;
     # synthesize a stable non-empty string so the record validates.
     search_text = title or workflow_shape or session_id
     return SessionProfileRecord(
         session_id=SessionId(session_id),
         logical_session_id=SessionId(logical_session_id),
-        materializer_version=materialization.materializer_version,
+        materializer_version=materialization.materializer_version if materialization is not None else 1,
         materialized_at=materialized_at,
-        source_updated_at=_iso_from_ms(materialization.source_updated_at_ms),
+        source_updated_at=_iso_from_ms(materialization.source_updated_at_ms) if materialization is not None else None,
         source_sort_key=(
-            materialization.source_sort_key_ms / 1000.0 if materialization.source_sort_key_ms is not None else None
+            materialization.source_sort_key_ms / 1000.0
+            if materialization is not None and materialization.source_sort_key_ms is not None
+            else None
         ),
-        input_high_water_mark=_iso_from_ms(materialization.input_high_water_mark_ms),
-        input_high_water_mark_source=materialization.input_high_water_mark_source,
-        input_row_count=materialization.input_row_count,
+        input_high_water_mark=(
+            _iso_from_ms(materialization.input_high_water_mark_ms) if materialization is not None else None
+        ),
+        input_high_water_mark_source=(
+            materialization.input_high_water_mark_source if materialization is not None else None
+        ),
+        input_row_count=materialization.input_row_count if materialization is not None else 0,
         source_name=source_name,
         title=title,
         first_message_at=evidence.first_message_at,

--- a/polylogue/storage/sqlite/queries/session_insight_timeline_reads.py
+++ b/polylogue/storage/sqlite/queries/session_insight_timeline_reads.py
@@ -26,8 +26,7 @@ _WORK_EVENT_SELECT = f"""
     swe.event_id,
     swe.session_id,
     COALESCE(im.materializer_version, 1) AS materializer_version,
-    COALESCE(strftime({_ISO_MS}, im.materialized_at_ms / 1000.0, 'unixepoch'), '1970-01-01T00:00:00.000Z')
-        AS materialized_at,
+    strftime({_ISO_MS}, im.materialized_at_ms / 1000.0, 'unixepoch') AS materialized_at,
     strftime({_ISO_MS}, im.source_updated_at_ms / 1000.0, 'unixepoch') AS source_updated_at,
     im.source_sort_key_ms / 1000.0 AS source_sort_key,
     swe.input_high_water_mark,
@@ -58,8 +57,7 @@ _PHASE_SELECT = f"""
     sph.phase_id,
     sph.session_id,
     COALESCE(im.materializer_version, 1) AS materializer_version,
-    COALESCE(strftime({_ISO_MS}, im.materialized_at_ms / 1000.0, 'unixepoch'), '1970-01-01T00:00:00.000Z')
-        AS materialized_at,
+    strftime({_ISO_MS}, im.materialized_at_ms / 1000.0, 'unixepoch') AS materialized_at,
     strftime({_ISO_MS}, im.source_updated_at_ms / 1000.0, 'unixepoch') AS source_updated_at,
     im.source_sort_key_ms / 1000.0 AS source_sort_key,
     sph.input_high_water_mark,
@@ -206,15 +204,12 @@ async def list_work_events(
         params.append(escape_fts5_query(query.query))
         order_by = (
             "ORDER BY bm25(session_work_events_fts), "
-            "COALESCE(swe.started_at_ms, swe.ended_at_ms, im.source_sort_key_ms, im.materialized_at_ms) DESC, swe.position"
+            "COALESCE(swe.started_at_ms, swe.ended_at_ms, im.source_sort_key_ms) DESC, swe.position"
         )
     else:
         from_clause = _WORK_EVENT_FROM
         where = []
-        order_by = (
-            "ORDER BY COALESCE(swe.started_at_ms, swe.ended_at_ms, im.source_sort_key_ms, im.materialized_at_ms) DESC, "
-            "swe.position"
-        )
+        order_by = "ORDER BY COALESCE(swe.started_at_ms, swe.ended_at_ms, im.source_sort_key_ms) DESC, swe.position"
 
     if query.session_id:
         where.append("swe.session_id = ?")
@@ -227,12 +222,12 @@ async def list_work_events(
         params.append(query.heuristic_label)
     if query.since:
         where.append(
-            "strftime('%Y-%m-%dT%H:%M:%fZ', COALESCE(swe.ended_at_ms, swe.started_at_ms, im.source_sort_key_ms, im.materialized_at_ms) / 1000.0, 'unixepoch') >= ?"
+            "strftime('%Y-%m-%dT%H:%M:%fZ', COALESCE(swe.ended_at_ms, swe.started_at_ms, im.source_sort_key_ms) / 1000.0, 'unixepoch') >= ?"
         )
         params.append(query.since)
     if query.until:
         where.append(
-            "strftime('%Y-%m-%dT%H:%M:%fZ', COALESCE(swe.started_at_ms, swe.ended_at_ms, im.source_sort_key_ms, im.materialized_at_ms) / 1000.0, 'unixepoch') <= ?"
+            "strftime('%Y-%m-%dT%H:%M:%fZ', COALESCE(swe.started_at_ms, swe.ended_at_ms, im.source_sort_key_ms) / 1000.0, 'unixepoch') <= ?"
         )
         params.append(query.until)
     if query.session_date_since:
@@ -275,12 +270,12 @@ async def list_session_phases(
         params.append(query.kind)
     if query.since:
         where.append(
-            "strftime('%Y-%m-%dT%H:%M:%fZ', COALESCE(sph.ended_at_ms, sph.started_at_ms, im.source_sort_key_ms, im.materialized_at_ms) / 1000.0, 'unixepoch') >= ?"
+            "strftime('%Y-%m-%dT%H:%M:%fZ', COALESCE(sph.ended_at_ms, sph.started_at_ms, im.source_sort_key_ms) / 1000.0, 'unixepoch') >= ?"
         )
         params.append(query.since)
     if query.until:
         where.append(
-            "strftime('%Y-%m-%dT%H:%M:%fZ', COALESCE(sph.started_at_ms, sph.ended_at_ms, im.source_sort_key_ms, im.materialized_at_ms) / 1000.0, 'unixepoch') <= ?"
+            "strftime('%Y-%m-%dT%H:%M:%fZ', COALESCE(sph.started_at_ms, sph.ended_at_ms, im.source_sort_key_ms) / 1000.0, 'unixepoch') <= ?"
         )
         params.append(query.until)
     if query.session_date_since:
@@ -297,7 +292,7 @@ async def list_session_phases(
     sql = f"SELECT {_PHASE_SELECT} {_PHASE_FROM}"
     if where:
         sql += " WHERE " + " AND ".join(where)
-    sql += " ORDER BY COALESCE(sph.started_at_ms, sph.ended_at_ms, im.source_sort_key_ms, im.materialized_at_ms) DESC, sph.position"
+    sql += " ORDER BY COALESCE(sph.started_at_ms, sph.ended_at_ms, im.source_sort_key_ms) DESC, sph.position"
     if query.limit is not None:
         sql += " LIMIT ? OFFSET ?"
         params.extend([query.limit, query.offset])

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -5337,6 +5337,55 @@ async def test_archive_tiers_api_session_profiles_read_index_tier(tmp_path: Path
         await archive.close()
 
 
+async def test_archive_tiers_api_hydrates_unknown_temporal_provenance_without_marker(tmp_path: Path) -> None:
+    """The public async facade preserves row-level temporal provenance."""
+
+    archive = _archive(tmp_path)
+    session = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="api-temporal-provenance",
+        messages=[
+            ParsedMessage(
+                provider_message_id="m1",
+                role=Role.USER,
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text="timeless API event")],
+            )
+        ],
+    )
+    try:
+        with ArchiveStore(archive.config.archive_root) as archive_db:
+            session_id = archive_db.write_parsed(session)
+        with sqlite3.connect(tmp_path / "index.db") as conn:
+            conn.execute(
+                """
+                INSERT INTO session_work_events (
+                    session_id, position, work_event_type, summary,
+                    input_high_water_mark, input_high_water_mark_source
+                ) VALUES (?, 0, 'implementation', 'timeless API event', ?, 'provider_ts')
+                """,
+                (session_id, "2026-08-04T09:30:00Z"),
+            )
+            conn.execute(
+                """
+                INSERT INTO session_phases (
+                    session_id, position, input_high_water_mark, input_high_water_mark_source
+                ) VALUES (?, 0, ?, 'provider_ts')
+                """,
+                (session_id, "2026-08-04T09:30:00Z"),
+            )
+            conn.commit()
+
+        work_event = (await archive.get_session_work_event_insights(session_id))[0]
+        phase = (await archive.get_session_phase_insights(session_id))[0]
+
+        for insight in (work_event, phase):
+            assert insight.provenance.materialized_at is None
+            assert insight.provenance.input_high_water_mark_source == "provider_ts"
+            assert insight.provenance.time_confidence == "recorded"
+    finally:
+        await archive.close()
+
+
 async def test_archive_tiers_api_session_insight_status_reads_index_tier(tmp_path: Path) -> None:
     """Session insight status projects readiness."""
     import sqlite3

--- a/tests/unit/cli/test_insights.py
+++ b/tests/unit/cli/test_insights.py
@@ -13,8 +13,14 @@ from click.testing import CliRunner, Result
 
 from polylogue.cli.click_app import cli
 from polylogue.cli.commands.insights import _make_callback
-from polylogue.insights.archive import ArchiveCoverageInsight
-from polylogue.insights.archive_models import ARCHIVE_INSIGHT_CONTRACT_VERSION
+from polylogue.insights.archive import ArchiveCoverageInsight, SessionWorkEventInsight
+from polylogue.insights.archive_models import (
+    ARCHIVE_INSIGHT_CONTRACT_VERSION,
+    ArchiveInferenceProvenance,
+    ArchiveInsightProvenance,
+    WorkEventEvidencePayload,
+    WorkEventInferencePayload,
+)
 from polylogue.insights.registry import get_insight_type, insight_items_payload
 from polylogue.storage.insights.session.rebuild import rebuild_archive_session_insights
 from polylogue.storage.insights.session.runtime import SessionInsightCounts, SessionInsightStatusSnapshot
@@ -95,6 +101,44 @@ def test_insight_items_payload_can_render_cli_and_mcp_keys() -> None:
     assert json_object_list(cli_payload["archive_coverage"])[0]["insight_kind"] == "archive_coverage"
     assert mcp_payload["total"] == 1
     assert json_object_list(mcp_payload["items"])[0]["origin"] == "claude-code-session"
+
+    temporal = SessionWorkEventInsight(
+        event_id="temporal-event",
+        session_id="codex-session:temporal",
+        origin="codex-session",
+        event_index=0,
+        provenance=ArchiveInsightProvenance(
+            materializer_version=1,
+            materialized_at=None,
+            input_high_water_mark="2026-08-04T09:30:00Z",
+            input_high_water_mark_source="provider_ts",
+            time_confidence="recorded",
+        ),
+        inference_provenance=ArchiveInferenceProvenance(
+            materializer_version=1,
+            materialized_at=None,
+            input_high_water_mark="2026-08-04T09:30:00Z",
+            input_high_water_mark_source="provider_ts",
+            time_confidence="recorded",
+            inference_version=1,
+            inference_family="archive",
+        ),
+        evidence=WorkEventEvidencePayload(start_index=0, end_index=0),
+        inference=WorkEventInferencePayload(
+            heuristic_label="implementation",
+            summary="timeless event",
+            confidence=0.5,
+        ),
+    )
+    temporal_mcp_payload = insight_items_payload(
+        [temporal],
+        get_insight_type("session_work_events"),
+        item_key="items",
+    )
+    temporal_provenance = json_object(json_object_list(temporal_mcp_payload["items"])[0]["provenance"])
+    assert temporal_provenance["materialized_at"] is None
+    assert temporal_provenance["input_high_water_mark_source"] == "provider_ts"
+    assert temporal_provenance["time_confidence"] == "recorded"
 
 
 def _seed_products(cli_workspace: CliWorkspace) -> None:
@@ -799,6 +843,41 @@ def test_insights_profile_date_filters_and_phases_json(cli_workspace: CliWorkspa
     assert json_int(profile_payload["total"]) == 2
     assert json_int(phase_payload["total"]) >= 1
     assert json_object_list(phase_payload["session_phases"])[0]["insight_kind"] == "session_phase"
+
+
+def test_insights_work_events_json_preserves_archive_temporal_provenance_without_marker(
+    cli_workspace: CliWorkspace,
+) -> None:
+    """CLI serialization uses the ArchiveStore provenance, not an epoch fallback."""
+
+    db_path = cli_workspace["db_path"]
+    session_token = "temporal-provenance"
+    session_id = native_session_id_for("codex", session_token)
+    SessionBuilder(db_path, session_token).provider("codex").add_message("u1", role="user", text="timeless").save()
+    with open_index_db(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO session_work_events (
+                session_id, position, work_event_type, summary,
+                input_high_water_mark, input_high_water_mark_source
+            ) VALUES (?, 0, 'implementation', 'timeless event', ?, 'provider_ts')
+            """,
+            (session_id, "2026-08-04T09:30:00Z"),
+        )
+        conn.commit()
+
+    result = CliRunner().invoke(
+        cli,
+        ["analyze", "insights", "work-events", "--session-id", session_id, "--format", "json"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    row = json_object_list(extract_json_result(result.output)["session_work_events"])[0]
+    provenance = json_object(row["provenance"])
+    assert provenance["materialized_at"] is None
+    assert provenance["input_high_water_mark_source"] == "provider_ts"
+    assert provenance["time_confidence"] == "recorded"
 
 
 def test_session_insight_rebuild_pages_full_rebuild(cli_workspace: CliWorkspace) -> None:

--- a/tests/unit/insights/test_timeline_renderer.py
+++ b/tests/unit/insights/test_timeline_renderer.py
@@ -287,6 +287,18 @@ class TestJsonContract:
         # Payload is JSON-serializable as-is
         json.dumps(payload)
 
+    def test_phase_without_inference_emits_unknown_confidence(self) -> None:
+        phase = _phase()
+        phase = phase.model_copy(update={"inference": None, "inference_provenance": None})
+
+        payload = build_session_timeline("conv-json", [], [phase]).to_dict()
+
+        entries = payload["entries"]
+        assert isinstance(entries, list)
+        entry = entries[0]
+        assert isinstance(entry, dict)
+        assert entry["confidence"] is None
+
 
 class TestSessionTimelineDataclass:
     def test_frozen(self) -> None:

--- a/tests/unit/insights/test_transforms.py
+++ b/tests/unit/insights/test_transforms.py
@@ -714,6 +714,14 @@ def test_successor_context_marks_missing_evidence_explicitly() -> None:
     assert "- [missing-evidence] events: No structured tool or test outcome events were extracted." in rendered
 
 
+def test_session_digest_keeps_absent_source_time_unknown() -> None:
+    """A storage-free public transform must not fabricate an epoch instant."""
+
+    digest = compile_session_digest(_sparse_session())
+
+    assert digest.transform.computed_at is None
+
+
 def test_successor_context_does_not_promote_random_hex_to_commit_ref() -> None:
     session = Session(
         id=SessionId("codex-session:hex-output"),

--- a/tests/unit/storage/test_fts_escape_in_insights.py
+++ b/tests/unit/storage/test_fts_escape_in_insights.py
@@ -204,3 +204,41 @@ async def test_list_work_events_escaped_query_matches_literal_phrase() -> None:
         assert len(result_hit) == 1
     finally:
         await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_timeline_read_keeps_missing_materialization_unknown_and_orders_by_event_time() -> None:
+    """Read SQL must not turn freshness metadata into event-time ordering."""
+
+    conn = await _make_work_events_db()
+    try:
+        await conn.executescript(
+            """
+            INSERT INTO sessions (session_id, origin) VALUES ('c2', 'claude-code-session');
+            INSERT INTO insight_materialization (
+                insight_type, session_id, materializer_version, materialized_at_ms, input_row_count
+            ) VALUES ('work_events', 'c2', 5, 1893456000000, 1);
+            INSERT INTO session_work_events (
+                session_id, position, work_event_type, summary, search_text
+            ) VALUES ('c2', 0, 'edit', 'timeless but freshly materialized', 'timeless');
+            """
+        )
+        await conn.commit()
+
+        rows = await list_work_events(conn, SessionTimelineListQuery(limit=5))
+
+        # c2 has the later materialization timestamp but no event/source time;
+        # c1's recorded timestamp must still order before it.
+        assert [row.session_id for row in rows] == ["c1", "c2"]
+        timeless = next(row for row in rows if row.session_id == "c2")
+        assert timeless.materialized_at == "2030-01-01T00:00:00.000Z"
+        assert timeless.start_time is None
+        assert timeless.end_time is None
+        assert timeless.canonical_session_date is None
+
+        await conn.execute("DELETE FROM insight_materialization WHERE session_id = 'c2'")
+        await conn.commit()
+        without_marker = (await list_work_events(conn, SessionTimelineListQuery(session_id="c2", limit=5)))[0]
+        assert without_marker.materialized_at is None
+    finally:
+        await conn.close()

--- a/tests/unit/storage/test_work_event_phase_time_window.py
+++ b/tests/unit/storage/test_work_event_phase_time_window.py
@@ -64,6 +64,52 @@ def test_phase_since_until_window_includes_timeless_phase(tmp_path: Path) -> Non
     assert {row.session_id for row in until_rows} == {session_id}
 
 
+def test_archive_store_hydrates_unknown_time_without_epoch_or_marker_fallback(tmp_path: Path) -> None:
+    """A missing materialization marker is not event-time evidence.
+
+    This exercises the ArchiveStore path used by the public async API and CLI.
+    Restoring either the synthetic epoch materialization record or dropping the
+    row-level stored source tag makes the assertions below fail.
+    """
+
+    with ArchiveStore(tmp_path / "archive") as facade:
+        conn = facade._conn
+        session_id = _insert_timeless_session(conn, native_id="unknown-time")
+        conn.execute(
+            """
+            INSERT INTO session_work_events (
+                session_id, position, work_event_type, summary,
+                input_high_water_mark, input_high_water_mark_source
+            ) VALUES (?, 0, 'implementation', 'timeless event', ?, 'provider_ts')
+            """,
+            (session_id, "2026-08-04T09:30:00Z"),
+        )
+        conn.execute(
+            """
+            INSERT INTO session_phases (
+                session_id, position, input_high_water_mark, input_high_water_mark_source
+            ) VALUES (?, 0, ?, 'provider_ts')
+            """,
+            (session_id, "2026-08-04T09:30:00Z"),
+        )
+        conn.commit()
+
+        work_event = facade.get_session_work_event_insights(session_id)[0]
+        phase = facade.get_session_phase_insights(session_id)[0]
+
+    for insight in (work_event, phase):
+        assert insight.provenance.materialized_at is None
+        assert insight.provenance.input_high_water_mark == "2026-08-04T09:30:00Z"
+        assert insight.provenance.input_high_water_mark_source == "provider_ts"
+        assert insight.provenance.time_confidence == "recorded"
+    assert work_event.evidence.start_time is None
+    assert work_event.evidence.end_time is None
+    assert work_event.evidence.canonical_session_date is None
+    assert phase.evidence.start_time is None
+    assert phase.evidence.end_time is None
+    assert phase.evidence.canonical_session_date is None
+
+
 def test_work_event_since_until_window_still_excludes_out_of_range_timestamped_event(tmp_path: Path) -> None:
     """Sanity check the fix does not disturb ordinary since/until exclusion."""
     with ArchiveStore(tmp_path / "archive") as facade:


### PR DESCRIPTION
## Summary

Preserve unknown temporal facts through public insight hydration. Materialization remains freshness metadata and cannot become event time, ordering input, or an epoch sentinel.

## Problem

Timeline SQL and ArchiveStore hydration fabricated epoch values when a materialization marker was absent. Timeline ordering and window filters could use materialization time after all event timestamps were null. The public timeline renderer also emitted `0.0` for a phase without inference.

## Solution

Archive insight provenance and timeline records now represent an absent materialization timestamp as `null`. ArchiveStore forwards stored row-level temporal source tags even without a shared materialization record. Timeline reads use only event or source-sort timestamps for filtering and ordering. Aggregate hydration labels a sort-key value as estimated rather than materialized. Session transforms retain an absent event timestamp as `null`, while successor-context generation uses a separate freshness timestamp. Phase timeline entries use `null` confidence when no inference exists.

## Bead acceptance evidence

- `polylogue-cuxz.1`: ArchiveStore, async API, CLI, and the shared MCP payload serializer retain `input_high_water_mark_source` and `time_confidence`; missing markers remain `null`, never recorded by default. The focused tests fail if source-tag forwarding or epoch fallback returns.
- `polylogue-cuxz.3`: Covers the temporal and profile/phase portion of the no-sentinel and authority-preservation criteria. Other fact families and visual work remain in the existing Bead scope.
- `polylogue-896y`: Repairs the concrete public semantic defect without changing the broader clock-read audit, rebuild, convergence, or reindex mechanics.

## Verification

- `devtools test tests/unit/storage/test_work_event_phase_time_window.py::test_archive_store_hydrates_unknown_time_without_epoch_or_marker_fallback tests/unit/storage/test_fts_escape_in_insights.py::test_timeline_read_keeps_missing_materialization_unknown_and_orders_by_event_time tests/unit/api/test_facade_contracts.py::test_archive_tiers_api_hydrates_unknown_temporal_provenance_without_marker tests/unit/cli/test_insights.py::test_insight_items_payload_can_render_cli_and_mcp_keys tests/unit/cli/test_insights.py::test_insights_work_events_json_preserves_archive_temporal_provenance_without_marker tests/unit/insights/test_timeline_renderer.py::TestJsonContract::test_phase_without_inference_emits_unknown_confidence tests/unit/insights/test_transforms.py::test_session_digest_keeps_absent_source_time_unknown`
  - `7 passed in 2.01s`
- `devtools verify --quick`
  - pre-push baseline passed format, lint, mypy, generated rendering, layering, schema roundtrip, and policy checks.