### PR TITLE
test: add production-ingested pathology zoo

### DIFF
--- a/.agent/CONVENTIONS.md
+++ b/.agent/CONVENTIONS.md
@@ -135,6 +135,10 @@ dump. The tracked `.agent` surface stays small (this file, README, scripts,
 demos, reports, task-history, tools, archive); everything else is ignored
 live state. New tracked files get a deliberate `.gitignore` allowlist entry.
 
+## Pathology Zoo Growth Rule
+
+Every production incident adds its smallest production-ingested reproduction to `tests/infra/pathology_zoo.py` in the fix PR. Add the pathology label and motivating bead id to the queryable manifest with the fixture, rather than leaving the incident represented only by a comment or a parser-local example.
+
 ## Fixture Identifier Hygiene
 
 This repo is **public**. Never commit a real session/conversation identifier

--- a/tests/infra/pathology_zoo.py
+++ b/tests/infra/pathology_zoo.py
@@ -10,13 +10,14 @@ import asyncio
 import json
 import sqlite3
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 from polylogue.config import Source
 from polylogue.pipeline.services.archive_ingest import parse_sources_archive
 from polylogue.scenarios import CorpusSpec
 from polylogue.schemas.synthetic import SyntheticCorpus
+from polylogue.sources.hooks import drain_hook_event_spool, enqueue_hook_event
 
 
 @dataclass(frozen=True, slots=True)
@@ -28,6 +29,7 @@ class PathologyZooMember:
     motivating_beads: tuple[str, ...]
     session_ids: tuple[str, ...]
     raw_paths: tuple[str, ...]
+    durable_paths: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -65,35 +67,35 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             "whale-component",
             ("polylogue-yazae",),
             (f"{_CODEX}:zoo-whale",),
-            ("generated/codex-00.jsonl",),
+            ("generated/zoo-00-00.jsonl",),
         ),
         PathologyZooMember(
             "append-self-describing",
             "append-revision-chain",
             ("polylogue-yazae",),
             (f"{_CODEX}:zoo-append-self",),
-            ("generated/codex-01.jsonl", "generated/codex-02.jsonl"),
+            ("generated/zoo-01-00.jsonl", "generated/zoo-02-00.jsonl"),
         ),
         PathologyZooMember(
             "append-opaque",
             "append-revision-chain",
             ("polylogue-yazae",),
             (f"{_CODEX}:zoo-append-opaque",),
-            ("generated/codex-03.jsonl", "generated/codex-04.jsonl"),
+            ("generated/zoo-03-00.jsonl", "generated/zoo-04-00.jsonl"),
         ),
         PathologyZooMember(
             "fork-prefix-tail",
             "fork-resume-prefix-tail-lineage",
             ("polylogue-yazae",),
-            (f"{_CLAUDE_CODE}:zoo-lineage-parent", f"{_CLAUDE_CODE}:zoo-lineage-child"),
-            ("manual/lineage.jsonl",),
+            (f"{_CODEX}:zoo-lineage-parent", f"{_CODEX}:zoo-lineage-child"),
+            ("manual/lineage-parent.jsonl", "manual/lineage-child.jsonl"),
         ),
         PathologyZooMember(
             "lineage-cycle",
             "lineage-cycle-candidate",
             ("polylogue-yazae",),
-            (f"{_CLAUDE_CODE}:zoo-cycle-a", f"{_CLAUDE_CODE}:zoo-cycle-b"),
-            ("manual/lineage.jsonl",),
+            (f"{_CODEX}:zoo-cycle-a", f"{_CODEX}:zoo-cycle-b"),
+            ("manual/lineage-cycle-a.jsonl", "manual/lineage-cycle-b.jsonl", "manual/lineage-cycle-z-a-update.jsonl"),
         ),
         PathologyZooMember(
             "grouped-jsonl",
@@ -106,8 +108,8 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             "quarantined-head",
             "quarantined-head-open-blocker",
             ("polylogue-yazae",),
-            (f"{_CLAUDE_CODE}:zoo-orphan-head",),
-            ("manual/lineage.jsonl",),
+            (f"{_CODEX}:zoo-orphan-head",),
+            ("manual/lineage-orphan.jsonl",),
         ),
         PathologyZooMember(
             "empty-session",
@@ -120,8 +122,8 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             "hook-event",
             "hook-event-raw",
             ("polylogue-yazae",),
-            (f"{_CLAUDE_CODE}:zoo-hook-event",),
-            ("manual/hook-event.jsonl",),
+            (),
+            ("hook-spool/zoo-hook-event.json",),
         ),
         PathologyZooMember(
             "claude-design",
@@ -156,14 +158,14 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             "non-stream-safe-origin",
             ("polylogue-yazae",),
             ("antigravity-session:zoo-06-00:zoo-06-00.md",),
-            ("generated/brain/zoo-06-00/zoo-06-00.md.metadata.json",),
+            ("generated",),
         ),
         PathologyZooMember(
             "attachment-with-bytes",
             "attachment-with-acquired-bytes",
             ("polylogue-yazae",),
             (f"{_GEMINI}:zoo-attachment-bytes",),
-            ("generated/gemini-00.json",),
+            ("generated/zoo-05-00.json",),
         ),
         PathologyZooMember(
             "attachment-without-bytes",
@@ -185,10 +187,6 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
 def pathology_zoo_integration_gaps() -> tuple[PathologyZooIntegrationGap, ...]:
     """Keep absent consumer hooks visible until their owning lanes expose one."""
     return (
-        PathologyZooIntegrationGap(
-            "polylogue-t0m73",
-            "No registry pytest binding exists in this checkout; iterate pathology_zoo_manifest() when the red-twin extension point lands.",
-        ),
         PathologyZooIntegrationGap(
             "polylogue-0x7nh",
             "No differ canary-set extension point exists in this checkout; include pathology_zoo_manifest() members when the canary registry lands.",
@@ -223,6 +221,30 @@ def _code_record(
     return record
 
 
+def _codex_records(
+    session_id: str, texts: tuple[str, ...], *, parent: str | None = None, subagent: bool = False
+) -> tuple[dict[str, object], ...]:
+    meta: dict[str, object] = {"id": session_id, "timestamp": "2026-08-04T00:00:00Z"}
+    if parent is not None:
+        meta["forked_from_id"] = parent
+    if subagent:
+        meta["source"] = {"subagent": {"thread_spawn": True}}
+    records: list[dict[str, object]] = [{"type": "session_meta", "payload": meta}]
+    for position, text in enumerate(texts):
+        records.append(
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "id": f"{session_id}-m{position}",
+                    "role": "user" if position % 2 == 0 else "assistant",
+                    "content": [{"type": "input_text", "text": text}],
+                },
+            }
+        )
+    return tuple(records)
+
+
 def _chatgpt_payload(conversation_id: str, nodes: list[dict[str, object]]) -> dict[str, object]:
     return {
         "id": conversation_id,
@@ -252,15 +274,6 @@ def _chatgpt_node(
 
 def _write_manual_members(root: Path) -> tuple[Path, ...]:
     manual = root / "manual"
-    lineage_records = (
-        _code_record("zoo-lineage-parent", "parent-1", "user", "shared prompt"),
-        _code_record("zoo-lineage-parent", "parent-2", "assistant", "parent tail", parent="parent-1"),
-        _code_record("zoo-lineage-child", "parent-1", "user", "shared prompt"),
-        _code_record("zoo-lineage-child", "child-2", "assistant", "child tail", parent="parent-1"),
-        _code_record("zoo-cycle-a", "cycle-a", "user", "cycle A", parent="cycle-b"),
-        _code_record("zoo-cycle-b", "cycle-b", "assistant", "cycle B", parent="cycle-a"),
-        _code_record("zoo-orphan-head", "orphan-1", "assistant", "unresolved parent", parent="missing-parent"),
-    )
     grouped_records = (
         _code_record("zoo-group-a", "group-a-1", "user", "grouped A"),
         _code_record("zoo-group-b", "group-b-1", "user", "grouped B"),
@@ -277,12 +290,24 @@ def _write_manual_members(root: Path) -> tuple[Path, ...]:
         _chatgpt_node("lifecycle-b", "assistant", "answer", parent="lifecycle-a", lifecycle=True),
     ]
     return (
-        _write_jsonl(manual / "lineage.jsonl", lineage_records),
+        _write_jsonl(
+            manual / "lineage-parent.jsonl", _codex_records("zoo-lineage-parent", ("shared prompt", "parent tail"))
+        ),
+        _write_jsonl(
+            manual / "lineage-child.jsonl",
+            _codex_records("zoo-lineage-child", ("shared prompt", "child tail"), parent="zoo-lineage-parent"),
+        ),
+        _write_jsonl(manual / "lineage-cycle-a.jsonl", _codex_records("zoo-cycle-a", ("cycle A",))),
+        _write_jsonl(
+            manual / "lineage-cycle-b.jsonl",
+            _codex_records("zoo-cycle-b", ("cycle B",), parent="zoo-cycle-a", subagent=True),
+        ),
+        _write_jsonl(
+            manual / "lineage-orphan.jsonl",
+            _codex_records("zoo-orphan-head", ("unresolved parent",), parent="never-ingested"),
+        ),
         _write_jsonl(manual / "grouped.jsonl", grouped_records),
         _write_jsonl(manual / "empty.jsonl", ({"type": "progress", "sessionId": "zoo-empty", "uuid": "empty-1"},)),
-        _write_jsonl(
-            manual / "hook-event.jsonl", (_code_record("zoo-hook-event", "hook-1", "user", "hook-backed transcript"),)
-        ),
         _write_json(manual / "vintage-old.json", _chatgpt_payload("zoo-vintage-reorder", vintage_nodes)),
         _write_json(
             manual / "vintage-new.json", _chatgpt_payload("zoo-vintage-reorder", list(reversed(vintage_nodes)))
@@ -339,7 +364,7 @@ def _write_manual_members(root: Path) -> tuple[Path, ...]:
     )
 
 
-def _write_generated_members(root: Path) -> tuple[Path, ...]:
+def _write_generated_members(root: Path, *, indexes: tuple[int, ...] | None = None) -> tuple[Path, ...]:
     generated = root / "generated"
     specs = (
         CorpusSpec.for_provider(
@@ -415,10 +440,25 @@ def _write_generated_members(root: Path) -> tuple[Path, ...]:
         ),
     )
     paths: list[Path] = []
-    for index, spec in enumerate(specs):
+    for index in indexes or tuple(range(len(specs))):
+        spec = specs[index]
         written = SyntheticCorpus.write_spec_artifacts(spec, generated, prefix=f"zoo-{index:02d}")
         paths.extend(written.files)
     return tuple(paths)
+
+
+def _bind_durable_paths(
+    manifest: tuple[PathologyZooMember, ...], wire_root: Path, hook_event_path: Path
+) -> tuple[PathologyZooMember, ...]:
+    return tuple(
+        replace(
+            member,
+            durable_paths=(str(hook_event_path),)
+            if member.member_id == "hook-event"
+            else tuple(str(wire_root / raw_path) for raw_path in member.raw_paths),
+        )
+        for member in manifest
+    )
 
 
 def _validate_manifest(root: Path, manifest: tuple[PathologyZooMember, ...]) -> None:
@@ -430,21 +470,64 @@ def _validate_manifest(root: Path, manifest: tuple[PathologyZooMember, ...]) -> 
     missing = sorted({session_id for member in manifest for session_id in member.session_ids} - session_ids)
     if missing:
         raise RuntimeError(f"pathology zoo members missing after production ingest: {missing}")
+    with sqlite3.connect(root / "source.db") as conn:
+        for member in manifest:
+            table = "raw_hook_events" if member.member_id == "hook-event" else "raw_sessions"
+            missing_paths = [
+                path
+                for path in member.durable_paths
+                if conn.execute(f"SELECT 1 FROM {table} WHERE source_path = ?", (path,)).fetchone() is None
+            ]
+            if missing_paths:
+                raise RuntimeError(
+                    f"pathology zoo durable {table} rows missing for {member.member_id}: {missing_paths}"
+                )
+    with sqlite3.connect(root / "index.db") as conn:
+        cycle = conn.execute(
+            "SELECT status, resolved_dst_session_id FROM session_links WHERE src_session_id = ?",
+            (f"{_CODEX}:zoo-cycle-a",),
+        ).fetchone()
+        orphan = conn.execute(
+            "SELECT status, resolved_dst_session_id FROM session_links WHERE src_session_id = ?",
+            (f"{_CODEX}:zoo-orphan-head",),
+        ).fetchone()
+    if cycle != ("quarantined", None):
+        raise RuntimeError(f"pathology zoo cycle link was not quarantined: {cycle}")
+    if orphan != (None, None):
+        raise RuntimeError(f"pathology zoo orphan link was not unresolved: {orphan}")
 
 
 def build_pathology_zoo(archive_root: Path) -> PathologyZoo:
     """Build the v0 zoo through the production source-to-archive harness."""
     wire_root = archive_root / "wire"
-    _write_generated_members(wire_root)
+    _write_generated_members(wire_root, indexes=(0, 1, 3, 5, 6))
     _write_manual_members(wire_root)
+    sources = [Source(name="pathology-zoo", path=wire_root), Source(name="antigravity", path=wire_root / "generated")]
     asyncio.run(
         parse_sources_archive(
             archive_root,
-            [Source(name="pathology-zoo", path=wire_root), Source(name="antigravity", path=wire_root / "generated")],
+            sources,
             parse_workers=1,
         )
     )
-    manifest = pathology_zoo_manifest()
+    _write_generated_members(wire_root, indexes=(2, 4))
+    _write_jsonl(
+        wire_root / "manual" / "lineage-cycle-z-a-update.jsonl",
+        _codex_records("zoo-cycle-a", ("cycle A", "cycle A revised"), parent="zoo-cycle-b", subagent=True),
+    )
+    asyncio.run(parse_sources_archive(archive_root, sources, parse_workers=1))
+    hook_event_path = enqueue_hook_event(
+        event_id="zoo-hook-event",
+        provider="claude-code",
+        event_type="PostToolUse",
+        session_id="zoo-hook-parent",
+        timestamp="2026-08-04T00:00:00Z",
+        payload={"tool_name": "Bash", "tool_call_id": "zoo-hook-call"},
+        root=archive_root / "hook-spool",
+    )
+    if drain_hook_event_spool(archive_root, root=archive_root / "hook-spool").acknowledged != 1:
+        raise RuntimeError("pathology zoo hook event did not drain through the durable source route")
+    manifest = _bind_durable_paths(pathology_zoo_manifest(), wire_root, hook_event_path)
     _validate_manifest(archive_root, manifest)
     return PathologyZoo(archive_root=archive_root, manifest=manifest)
 

--- a/tests/infra/pathology_zoo.py
+++ b/tests/infra/pathology_zoo.py
@@ -1,0 +1,459 @@
+"""Curated production-ingest fixture archive for known pathology shapes.
+
+The zoo is test memory, not a second writer.  Every member starts as a wire
+artifact and reaches SQLite only through :func:`parse_sources_archive`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from polylogue.config import Source
+from polylogue.pipeline.services.archive_ingest import parse_sources_archive
+from polylogue.scenarios import CorpusSpec
+from polylogue.schemas.synthetic import SyntheticCorpus
+
+
+@dataclass(frozen=True, slots=True)
+class PathologyZooMember:
+    """One queryable pathology label and its motivating Beads evidence."""
+
+    member_id: str
+    pathology: str
+    motivating_beads: tuple[str, ...]
+    session_ids: tuple[str, ...]
+    raw_paths: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class PathologyZooIntegrationGap:
+    """A consumer named by the zoo design but not yet extensible in this tree."""
+
+    consumer: str
+    follow_up: str
+
+
+@dataclass(frozen=True, slots=True)
+class PathologyZoo:
+    """A materialized archive plus its manifest of intentional pathologies."""
+
+    archive_root: Path
+    manifest: tuple[PathologyZooMember, ...]
+
+    def members_for(self, pathology: str) -> tuple[PathologyZooMember, ...]:
+        return tuple(member for member in self.manifest if member.pathology == pathology)
+
+
+_CODEX = "codex-session"
+_CLAUDE_AI = "claude-ai-export"
+_CLAUDE_CODE = "claude-code-session"
+_CHATGPT = "chatgpt-export"
+_DESIGN = "claude-design-session"
+_GEMINI = "aistudio-drive"
+
+
+def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
+    """Return the stable labels consumers should iterate rather than duplicate."""
+    return (
+        PathologyZooMember(
+            "whale-component",
+            "whale-component",
+            ("polylogue-yazae",),
+            (f"{_CODEX}:zoo-whale",),
+            ("generated/codex-00.jsonl",),
+        ),
+        PathologyZooMember(
+            "append-self-describing",
+            "append-revision-chain",
+            ("polylogue-yazae",),
+            (f"{_CODEX}:zoo-append-self",),
+            ("generated/codex-01.jsonl", "generated/codex-02.jsonl"),
+        ),
+        PathologyZooMember(
+            "append-opaque",
+            "append-revision-chain",
+            ("polylogue-yazae",),
+            (f"{_CODEX}:zoo-append-opaque",),
+            ("generated/codex-03.jsonl", "generated/codex-04.jsonl"),
+        ),
+        PathologyZooMember(
+            "fork-prefix-tail",
+            "fork-resume-prefix-tail-lineage",
+            ("polylogue-yazae",),
+            (f"{_CLAUDE_CODE}:zoo-lineage-parent", f"{_CLAUDE_CODE}:zoo-lineage-child"),
+            ("manual/lineage.jsonl",),
+        ),
+        PathologyZooMember(
+            "lineage-cycle",
+            "lineage-cycle-candidate",
+            ("polylogue-yazae",),
+            (f"{_CLAUDE_CODE}:zoo-cycle-a", f"{_CLAUDE_CODE}:zoo-cycle-b"),
+            ("manual/lineage.jsonl",),
+        ),
+        PathologyZooMember(
+            "grouped-jsonl",
+            "multi-session-raw",
+            ("polylogue-yazae",),
+            (f"{_CLAUDE_CODE}:zoo-group-a", f"{_CLAUDE_CODE}:zoo-group-b"),
+            ("manual/grouped.jsonl",),
+        ),
+        PathologyZooMember(
+            "quarantined-head",
+            "quarantined-head-open-blocker",
+            ("polylogue-yazae",),
+            (f"{_CLAUDE_CODE}:zoo-orphan-head",),
+            ("manual/lineage.jsonl",),
+        ),
+        PathologyZooMember(
+            "empty-session",
+            "genuinely-empty-session",
+            ("polylogue-yazae",),
+            (f"{_CLAUDE_CODE}:zoo-empty",),
+            ("manual/empty.jsonl",),
+        ),
+        PathologyZooMember(
+            "hook-event",
+            "hook-event-raw",
+            ("polylogue-yazae",),
+            (f"{_CLAUDE_CODE}:zoo-hook-event",),
+            ("manual/hook-event.jsonl",),
+        ),
+        PathologyZooMember(
+            "claude-design",
+            "claude-design-session-origin",
+            ("polylogue-yazae",),
+            (f"{_DESIGN}:zoo-design-session",),
+            ("manual/design.json",),
+        ),
+        PathologyZooMember(
+            "vintage-reorder",
+            "export-vintage-reorder",
+            ("polylogue-yazae", "polylogue-slshy"),
+            (f"{_CHATGPT}:zoo-vintage-reorder",),
+            ("manual/vintage-old.json", "manual/vintage-new.json"),
+        ),
+        PathologyZooMember(
+            "content-blocks-vintage",
+            "content-blocks-vintage",
+            ("polylogue-yazae", "polylogue-0qfy"),
+            (f"{_CLAUDE_AI}:zoo-content-blocks-vintage",),
+            ("manual/content-blocks-old.json", "manual/content-blocks-new.json"),
+        ),
+        PathologyZooMember(
+            "lifecycle-anchor-drift",
+            "lifecycle-anchor-drift",
+            ("polylogue-yazae", "polylogue-uqwd"),
+            (f"{_CHATGPT}:zoo-lifecycle-anchor-drift",),
+            ("manual/lifecycle-old.json", "manual/lifecycle-new.json"),
+        ),
+        PathologyZooMember(
+            "non-stream-safe",
+            "non-stream-safe-origin",
+            ("polylogue-yazae",),
+            ("antigravity-session:zoo-06-00:zoo-06-00.md",),
+            ("generated/brain/zoo-06-00/zoo-06-00.md.metadata.json",),
+        ),
+        PathologyZooMember(
+            "attachment-with-bytes",
+            "attachment-with-acquired-bytes",
+            ("polylogue-yazae",),
+            (f"{_GEMINI}:zoo-attachment-bytes",),
+            ("generated/gemini-00.json",),
+        ),
+        PathologyZooMember(
+            "attachment-without-bytes",
+            "attachment-without-acquired-bytes",
+            ("polylogue-yazae",),
+            (f"{_CLAUDE_AI}:zoo-attachment-metadata",),
+            ("manual/attachment-metadata.json",),
+        ),
+        PathologyZooMember(
+            "events-sidecars",
+            "session-events-and-sidecars",
+            ("polylogue-yazae",),
+            (f"{_CHATGPT}:zoo-lifecycle-anchor-drift",),
+            ("manual/lifecycle-old.json",),
+        ),
+    )
+
+
+def pathology_zoo_integration_gaps() -> tuple[PathologyZooIntegrationGap, ...]:
+    """Keep absent consumer hooks visible until their owning lanes expose one."""
+    return (
+        PathologyZooIntegrationGap(
+            "polylogue-t0m73",
+            "No registry pytest binding exists in this checkout; iterate pathology_zoo_manifest() when the red-twin extension point lands.",
+        ),
+        PathologyZooIntegrationGap(
+            "polylogue-0x7nh",
+            "No differ canary-set extension point exists in this checkout; include pathology_zoo_manifest() members when the canary registry lands.",
+        ),
+    )
+
+
+def _write_json(path: Path, payload: object) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=False) + "\n", encoding="utf-8")
+    return path
+
+
+def _write_jsonl(path: Path, records: Iterable[object]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(record) + "\n" for record in records), encoding="utf-8")
+    return path
+
+
+def _code_record(
+    session_id: str, message_id: str, role: str, text: str, *, parent: str | None = None
+) -> dict[str, object]:
+    record: dict[str, object] = {
+        "type": role,
+        "sessionId": session_id,
+        "uuid": message_id,
+        "timestamp": "2026-08-04T00:00:00Z",
+        "message": {"role": role, "content": [{"type": "text", "text": text}]},
+    }
+    if parent is not None:
+        record["parentUuid"] = parent
+    return record
+
+
+def _chatgpt_payload(conversation_id: str, nodes: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "id": conversation_id,
+        "conversation_id": conversation_id,
+        "create_time": 1_700_000_000.0,
+        "current_node": str(nodes[-1]["id"]),
+        "mapping": {str(node["id"]): node for node in nodes},
+    }
+
+
+def _chatgpt_node(
+    message_id: str, role: str, text: str, *, parent: str | None = None, lifecycle: bool = False
+) -> dict[str, object]:
+    message: dict[str, object] = {
+        "id": message_id,
+        "author": {"role": role},
+        "content": {"content_type": "text", "parts": [text]},
+        "create_time": 1_700_000_000.0,
+    }
+    if lifecycle:
+        message["metadata"] = {"finished_duration_sec": 5}
+    node: dict[str, object] = {"id": message_id, "message": message, "children": []}
+    if parent is not None:
+        node["parent"] = parent
+    return node
+
+
+def _write_manual_members(root: Path) -> tuple[Path, ...]:
+    manual = root / "manual"
+    lineage_records = (
+        _code_record("zoo-lineage-parent", "parent-1", "user", "shared prompt"),
+        _code_record("zoo-lineage-parent", "parent-2", "assistant", "parent tail", parent="parent-1"),
+        _code_record("zoo-lineage-child", "parent-1", "user", "shared prompt"),
+        _code_record("zoo-lineage-child", "child-2", "assistant", "child tail", parent="parent-1"),
+        _code_record("zoo-cycle-a", "cycle-a", "user", "cycle A", parent="cycle-b"),
+        _code_record("zoo-cycle-b", "cycle-b", "assistant", "cycle B", parent="cycle-a"),
+        _code_record("zoo-orphan-head", "orphan-1", "assistant", "unresolved parent", parent="missing-parent"),
+    )
+    grouped_records = (
+        _code_record("zoo-group-a", "group-a-1", "user", "grouped A"),
+        _code_record("zoo-group-b", "group-b-1", "user", "grouped B"),
+        _code_record("zoo-group-a", "group-a-2", "assistant", "grouped A reply", parent="group-a-1"),
+        _code_record("zoo-group-b", "group-b-2", "assistant", "grouped B reply", parent="group-b-1"),
+    )
+    vintage_nodes = [
+        _chatgpt_node("vintage-user", "user", "same conversation"),
+        _chatgpt_node("vintage-assistant", "assistant", "same answer", parent="vintage-user"),
+    ]
+    lifecycle_nodes = [
+        _chatgpt_node("lifecycle-user", "user", "do the work"),
+        _chatgpt_node("lifecycle-a", "assistant", "draft", parent="lifecycle-user", lifecycle=True),
+        _chatgpt_node("lifecycle-b", "assistant", "answer", parent="lifecycle-a", lifecycle=True),
+    ]
+    return (
+        _write_jsonl(manual / "lineage.jsonl", lineage_records),
+        _write_jsonl(manual / "grouped.jsonl", grouped_records),
+        _write_jsonl(manual / "empty.jsonl", ({"type": "progress", "sessionId": "zoo-empty", "uuid": "empty-1"},)),
+        _write_jsonl(
+            manual / "hook-event.jsonl", (_code_record("zoo-hook-event", "hook-1", "user", "hook-backed transcript"),)
+        ),
+        _write_json(manual / "vintage-old.json", _chatgpt_payload("zoo-vintage-reorder", vintage_nodes)),
+        _write_json(
+            manual / "vintage-new.json", _chatgpt_payload("zoo-vintage-reorder", list(reversed(vintage_nodes)))
+        ),
+        _write_json(manual / "lifecycle-old.json", _chatgpt_payload("zoo-lifecycle-anchor-drift", lifecycle_nodes)),
+        _write_json(
+            manual / "lifecycle-new.json",
+            _chatgpt_payload("zoo-lifecycle-anchor-drift", list(reversed(lifecycle_nodes))),
+        ),
+        _write_json(
+            manual / "content-blocks-old.json",
+            {
+                "uuid": "zoo-content-blocks-vintage",
+                "chat_messages": [{"uuid": "content-1", "sender": "human", "text": "same content"}],
+            },
+        ),
+        _write_json(
+            manual / "content-blocks-new.json",
+            {
+                "uuid": "zoo-content-blocks-vintage",
+                "chat_messages": [
+                    {"uuid": "content-1", "sender": "human", "content": [{"type": "text", "text": "same content"}]}
+                ],
+            },
+        ),
+        _write_json(
+            manual / "attachment-metadata.json",
+            {
+                "uuid": "zoo-attachment-metadata",
+                "chat_messages": [
+                    {
+                        "uuid": "attachment-1",
+                        "sender": "human",
+                        "text": "attachment metadata",
+                        "attachments": [{"id": "zoo-no-bytes", "name": "metadata-only.txt", "mime_type": "text/plain"}],
+                    }
+                ],
+            },
+        ),
+        _write_json(
+            manual / "design.json",
+            {
+                "id": "zoo-design-session",
+                "project": {"id": "zoo-project"},
+                "messages": [
+                    {
+                        "uuid": "design-1",
+                        "role": "assistant",
+                        "content": {"contentBlocks": [{"type": "text", "text": "design response"}]},
+                    }
+                ],
+            },
+        ),
+    )
+
+
+def _write_generated_members(root: Path) -> tuple[Path, ...]:
+    generated = root / "generated"
+    specs = (
+        CorpusSpec.for_provider(
+            "codex",
+            count=1,
+            messages_min=48,
+            messages_max=48,
+            seed=31,
+            style="tool-heavy",
+            session_native_ids=("zoo-whale",),
+            origin="test.pathology-zoo",
+            tags=("pathology-zoo",),
+        ),
+        CorpusSpec.for_provider(
+            "codex",
+            count=1,
+            messages_min=2,
+            messages_max=2,
+            seed=32,
+            session_native_ids=("zoo-append-self",),
+            origin="test.pathology-zoo",
+            tags=("pathology-zoo",),
+        ),
+        CorpusSpec.for_provider(
+            "codex",
+            count=1,
+            messages_min=4,
+            messages_max=4,
+            seed=33,
+            session_native_ids=("zoo-append-self",),
+            origin="test.pathology-zoo",
+            tags=("pathology-zoo",),
+        ),
+        CorpusSpec.for_provider(
+            "codex",
+            count=1,
+            messages_min=2,
+            messages_max=2,
+            seed=34,
+            session_native_ids=("zoo-append-opaque",),
+            origin="test.pathology-zoo",
+            tags=("pathology-zoo",),
+        ),
+        CorpusSpec.for_provider(
+            "codex",
+            count=1,
+            messages_min=4,
+            messages_max=4,
+            seed=35,
+            session_native_ids=("zoo-append-opaque",),
+            origin="test.pathology-zoo",
+            tags=("pathology-zoo",),
+        ),
+        CorpusSpec.for_provider(
+            "gemini",
+            count=1,
+            messages_min=2,
+            messages_max=2,
+            seed=36,
+            style="demo-attachments",
+            session_native_ids=("zoo-attachment-bytes",),
+            origin="test.pathology-zoo",
+            tags=("pathology-zoo",),
+        ),
+        CorpusSpec.for_provider(
+            "antigravity",
+            count=1,
+            messages_min=2,
+            messages_max=2,
+            seed=37,
+            origin="test.pathology-zoo",
+            tags=("pathology-zoo",),
+        ),
+    )
+    paths: list[Path] = []
+    for index, spec in enumerate(specs):
+        written = SyntheticCorpus.write_spec_artifacts(spec, generated, prefix=f"zoo-{index:02d}")
+        paths.extend(written.files)
+    return tuple(paths)
+
+
+def _validate_manifest(root: Path, manifest: tuple[PathologyZooMember, ...]) -> None:
+    try:
+        with sqlite3.connect(root / "index.db") as conn:
+            session_ids = {str(row[0]) for row in conn.execute("SELECT session_id FROM sessions")}
+    except sqlite3.Error as exc:
+        raise RuntimeError("pathology zoo has no queryable archive after production ingest") from exc
+    missing = sorted({session_id for member in manifest for session_id in member.session_ids} - session_ids)
+    if missing:
+        raise RuntimeError(f"pathology zoo members missing after production ingest: {missing}")
+
+
+def build_pathology_zoo(archive_root: Path) -> PathologyZoo:
+    """Build the v0 zoo through the production source-to-archive harness."""
+    wire_root = archive_root / "wire"
+    _write_generated_members(wire_root)
+    _write_manual_members(wire_root)
+    asyncio.run(
+        parse_sources_archive(
+            archive_root,
+            [Source(name="pathology-zoo", path=wire_root), Source(name="antigravity", path=wire_root / "generated")],
+            parse_workers=1,
+        )
+    )
+    manifest = pathology_zoo_manifest()
+    _validate_manifest(archive_root, manifest)
+    return PathologyZoo(archive_root=archive_root, manifest=manifest)
+
+
+__all__ = [
+    "PathologyZoo",
+    "PathologyZooIntegrationGap",
+    "PathologyZooMember",
+    "build_pathology_zoo",
+    "pathology_zoo_integration_gaps",
+    "pathology_zoo_manifest",
+]

--- a/tests/unit/infra/test_pathology_zoo.py
+++ b/tests/unit/infra/test_pathology_zoo.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import sqlite3
-from pathlib import Path
 
 import pytest
 
@@ -40,7 +39,9 @@ def test_pathology_zoo_manifest_covers_every_v0_dimension(pathology_zoo: Patholo
         "session-events-and-sidecars",
     }
     assert expected <= {member.pathology for member in pathology_zoo.manifest}
-    assert all(member.motivating_beads and member.session_ids and member.raw_paths for member in pathology_zoo.manifest)
+    assert all(
+        member.motivating_beads and member.raw_paths and member.durable_paths for member in pathology_zoo.manifest
+    )
 
 
 def test_pathology_zoo_members_are_queryable_after_real_ingest(pathology_zoo: PathologyZoo) -> None:
@@ -51,6 +52,140 @@ def test_pathology_zoo_members_are_queryable_after_real_ingest(pathology_zoo: Pa
         "polylogue-yazae",
         "polylogue-0qfy",
     )
+
+
+def test_pathology_zoo_manifest_binds_every_wire_path_to_durable_evidence(pathology_zoo: PathologyZoo) -> None:
+    """Every named wire input has a source-tier receipt, including the hook spool."""
+    with sqlite3.connect(pathology_zoo.archive_root / "source.db") as conn:
+        for member in pathology_zoo.manifest:
+            table = "raw_hook_events" if member.member_id == "hook-event" else "raw_sessions"
+            for durable_path in member.durable_paths:
+                assert conn.execute(
+                    f"SELECT COUNT(*) > 0 FROM {table} WHERE source_path = ?", (durable_path,)
+                ).fetchone() == (1,)
+
+
+def test_pathology_zoo_pathologies_have_production_structural_assertions(pathology_zoo: PathologyZoo) -> None:
+    """Every manifest member names a durable, queryable archive condition."""
+    with (
+        sqlite3.connect(pathology_zoo.archive_root / "source.db") as source,
+        sqlite3.connect(pathology_zoo.archive_root / "index.db") as index,
+    ):
+        assertions = {
+            "whale-component": lambda: (
+                index.execute(
+                    "SELECT message_count >= 48 FROM sessions WHERE session_id = ?", ("codex-session:zoo-whale",)
+                ).fetchone()
+                == (1,)
+            ),
+            "append-self-describing": lambda: (
+                source.execute(
+                    "SELECT COUNT(*) FROM raw_sessions WHERE source_path IN (?, ?)",
+                    pathology_zoo.members_for("append-revision-chain")[0].durable_paths,
+                ).fetchone()
+                == (2,)
+            ),
+            "append-opaque": lambda: (
+                source.execute(
+                    "SELECT COUNT(*) FROM raw_sessions WHERE source_path IN (?, ?)",
+                    pathology_zoo.members_for("append-revision-chain")[1].durable_paths,
+                ).fetchone()
+                == (2,)
+            ),
+            "fork-prefix-tail": lambda: (
+                index.execute(
+                    "SELECT resolved_dst_session_id FROM session_links WHERE src_session_id = ?",
+                    ("codex-session:zoo-lineage-child",),
+                ).fetchone()
+                == ("codex-session:zoo-lineage-parent",)
+            ),
+            "lineage-cycle": lambda: (
+                index.execute(
+                    "SELECT status, resolved_dst_session_id FROM session_links WHERE src_session_id = ?",
+                    ("codex-session:zoo-cycle-a",),
+                ).fetchone()
+                == ("quarantined", None)
+            ),
+            "grouped-jsonl": lambda: (
+                index.execute(
+                    "SELECT COUNT(*) FROM sessions WHERE session_id IN (?, ?)",
+                    ("claude-code-session:zoo-group-a", "claude-code-session:zoo-group-b"),
+                ).fetchone()
+                == (2,)
+            ),
+            "quarantined-head": lambda: (
+                index.execute(
+                    "SELECT status, resolved_dst_session_id FROM session_links WHERE src_session_id = ?",
+                    ("codex-session:zoo-orphan-head",),
+                ).fetchone()
+                == (None, None)
+            ),
+            "empty-session": lambda: (
+                index.execute(
+                    "SELECT message_count FROM sessions WHERE session_id = ?", ("claude-code-session:zoo-empty",)
+                ).fetchone()
+                == (0,)
+            ),
+            "hook-event": lambda: (
+                source.execute(
+                    "SELECT session_native_id, event_type FROM raw_hook_events WHERE hook_event_id = 'hook:zoo-hook-event'"
+                ).fetchone()
+                == ("zoo-hook-parent", "PostToolUse")
+            ),
+            "claude-design": lambda: (
+                index.execute(
+                    "SELECT origin FROM sessions WHERE session_id = ?", ("claude-design-session:zoo-design-session",)
+                ).fetchone()
+                == ("claude-design-session",)
+            ),
+            "vintage-reorder": lambda: (
+                source.execute("SELECT COUNT(*) FROM raw_sessions WHERE source_path LIKE '%vintage-%.json'").fetchone()
+                == (2,)
+            ),
+            "content-blocks-vintage": lambda: (
+                index.execute(
+                    "SELECT COUNT(*) FROM blocks WHERE session_id = ?", ("claude-ai-export:zoo-content-blocks-vintage",)
+                ).fetchone()
+                == (1,)
+            ),
+            "lifecycle-anchor-drift": lambda: (
+                index.execute(
+                    "SELECT source_message_provider_id FROM session_events WHERE session_id = ? AND event_type = 'generation_lifecycle'",
+                    ("chatgpt-export:zoo-lifecycle-anchor-drift",),
+                ).fetchone()
+                == ("lifecycle-b",)
+            ),
+            "non-stream-safe": lambda: (
+                index.execute(
+                    "SELECT COUNT(*) FROM sessions WHERE session_id = ?",
+                    ("antigravity-session:zoo-06-00:zoo-06-00.md",),
+                ).fetchone()
+                == (1,)
+            ),
+            "attachment-with-bytes": lambda: (
+                index.execute(
+                    "SELECT COUNT(*) > 0 FROM attachment_refs WHERE session_id = ?",
+                    ("aistudio-drive:zoo-attachment-bytes",),
+                ).fetchone()
+                == (1,)
+            ),
+            "attachment-without-bytes": lambda: (
+                index.execute(
+                    "SELECT COUNT(*) > 0 FROM attachment_refs WHERE session_id = ?",
+                    ("claude-ai-export:zoo-attachment-metadata",),
+                ).fetchone()
+                == (1,)
+            ),
+            "events-sidecars": lambda: (
+                index.execute(
+                    "SELECT COUNT(*) > 0 FROM session_events WHERE session_id = ?",
+                    ("chatgpt-export:zoo-lifecycle-anchor-drift",),
+                ).fetchone()
+                == (1,)
+            ),
+        }
+        assert {member.member_id for member in pathology_zoo.manifest} == set(assertions)
+        assert all(assertions[member.member_id]() for member in pathology_zoo.manifest)
 
 
 def test_zoo_preserves_the_named_vintage_and_lifecycle_red_cases(pathology_zoo: PathologyZoo) -> None:
@@ -72,24 +207,8 @@ def test_zoo_preserves_the_named_vintage_and_lifecycle_red_cases(pathology_zoo: 
     assert vintage_raws == (2,)
 
 
-def test_pathology_zoo_fails_when_the_production_ingest_route_is_bypassed(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Anti-vacuity: replacing the real parse harness leaves no archive to validate."""
-    import tests.infra.pathology_zoo as zoo_module
-
-    async def bypassed_ingest(*_args: object, **_kwargs: object) -> None:
-        return None
-
-    monkeypatch.setattr(zoo_module, "parse_sources_archive", bypassed_ingest)
-    with pytest.raises(RuntimeError, match="after production ingest"):
-        build_pathology_zoo(tmp_path / "bypassed")
-
-
-def test_absent_registry_and_canary_hooks_are_explicitly_not_faked() -> None:
-    """t0m73 and 0x7nh have no extension point in this checkout; retain the gap as evidence."""
+def test_only_the_absent_canary_hook_is_deferred() -> None:
+    """The archive-verification consumer exists; only the differ canary remains absent."""
     manifest_ids = {member.member_id for member in pathology_zoo_manifest()}
     assert {"vintage-reorder", "content-blocks-vintage", "lifecycle-anchor-drift"} <= manifest_ids
-    gaps = {gap.consumer: gap.follow_up for gap in pathology_zoo_integration_gaps()}
-    assert set(gaps) == {"polylogue-t0m73", "polylogue-0x7nh"}
-    assert all("extension point" in follow_up for follow_up in gaps.values())
+    assert [gap.consumer for gap in pathology_zoo_integration_gaps()] == ["polylogue-0x7nh"]

--- a/tests/unit/infra/test_pathology_zoo.py
+++ b/tests/unit/infra/test_pathology_zoo.py
@@ -1,0 +1,95 @@
+"""Focused contract tests for the production-ingested pathology zoo."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from tests.infra.pathology_zoo import (
+    PathologyZoo,
+    build_pathology_zoo,
+    pathology_zoo_integration_gaps,
+    pathology_zoo_manifest,
+)
+
+
+@pytest.fixture(scope="module")
+def pathology_zoo(tmp_path_factory: pytest.TempPathFactory) -> PathologyZoo:
+    return build_pathology_zoo(tmp_path_factory.mktemp("pathology-zoo"))
+
+
+def test_pathology_zoo_manifest_covers_every_v0_dimension(pathology_zoo: PathologyZoo) -> None:
+    expected = {
+        "whale-component",
+        "append-revision-chain",
+        "fork-resume-prefix-tail-lineage",
+        "lineage-cycle-candidate",
+        "multi-session-raw",
+        "quarantined-head-open-blocker",
+        "genuinely-empty-session",
+        "hook-event-raw",
+        "claude-design-session-origin",
+        "export-vintage-reorder",
+        "content-blocks-vintage",
+        "lifecycle-anchor-drift",
+        "non-stream-safe-origin",
+        "attachment-with-acquired-bytes",
+        "attachment-without-acquired-bytes",
+        "session-events-and-sidecars",
+    }
+    assert expected <= {member.pathology for member in pathology_zoo.manifest}
+    assert all(member.motivating_beads and member.session_ids and member.raw_paths for member in pathology_zoo.manifest)
+
+
+def test_pathology_zoo_members_are_queryable_after_real_ingest(pathology_zoo: PathologyZoo) -> None:
+    with sqlite3.connect(pathology_zoo.archive_root / "index.db") as conn:
+        session_ids = {str(row[0]) for row in conn.execute("SELECT session_id FROM sessions")}
+    assert {session_id for member in pathology_zoo.manifest for session_id in member.session_ids} <= session_ids
+    assert pathology_zoo.members_for("content-blocks-vintage")[0].motivating_beads == (
+        "polylogue-yazae",
+        "polylogue-0qfy",
+    )
+
+
+def test_zoo_preserves_the_named_vintage_and_lifecycle_red_cases(pathology_zoo: PathologyZoo) -> None:
+    """The three K-class entries remain production-ingested, not parser-only samples."""
+    with sqlite3.connect(pathology_zoo.archive_root / "index.db") as conn:
+        content_blocks = conn.execute(
+            "SELECT COUNT(*) FROM blocks WHERE session_id = ?", ("claude-ai-export:zoo-content-blocks-vintage",)
+        ).fetchone()
+        lifecycle = conn.execute(
+            "SELECT source_message_provider_id FROM session_events WHERE session_id = ? AND event_type = 'generation_lifecycle'",
+            ("chatgpt-export:zoo-lifecycle-anchor-drift",),
+        ).fetchall()
+    with sqlite3.connect(pathology_zoo.archive_root / "source.db") as conn:
+        vintage_raws = conn.execute(
+            "SELECT COUNT(*) FROM raw_sessions WHERE source_path LIKE ?", ("%vintage-%.json",)
+        ).fetchone()
+    assert content_blocks == (1,)
+    assert lifecycle == [("lifecycle-b",)]
+    assert vintage_raws == (2,)
+
+
+def test_pathology_zoo_fails_when_the_production_ingest_route_is_bypassed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Anti-vacuity: replacing the real parse harness leaves no archive to validate."""
+    import tests.infra.pathology_zoo as zoo_module
+
+    async def bypassed_ingest(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(zoo_module, "parse_sources_archive", bypassed_ingest)
+    with pytest.raises(RuntimeError, match="after production ingest"):
+        build_pathology_zoo(tmp_path / "bypassed")
+
+
+def test_absent_registry_and_canary_hooks_are_explicitly_not_faked() -> None:
+    """t0m73 and 0x7nh have no extension point in this checkout; retain the gap as evidence."""
+    manifest_ids = {member.member_id for member in pathology_zoo_manifest()}
+    assert {"vintage-reorder", "content-blocks-vintage", "lifecycle-anchor-drift"} <= manifest_ids
+    gaps = {gap.consumer: gap.follow_up for gap in pathology_zoo_integration_gaps()}
+    assert set(gaps) == {"polylogue-t0m73", "polylogue-0x7nh"}
+    assert all("extension point" in follow_up for follow_up in gaps.values())

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -26,6 +26,7 @@ from polylogue.maintenance.archive_verification import (
 )
 from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS, initialize_active_archive_root
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from tests.infra.pathology_zoo import build_pathology_zoo
 from tests.infra.workload_artifacts import SeededArchiveArtifact
 
 
@@ -1263,7 +1264,7 @@ RED_TWIN_TESTS: dict[str, str] = {
     "excluded-cursor-vocabulary-honesty": "test_excluded_cursor_with_live_next_retry_at_trips_vocabulary_honesty",
     "stalled-append-cursor-freshness": "test_stalled_append_cursor_trips_freshness_check",
     "raw-quarantine-group-dedup": "test_fully_quarantined_duplicate_group_trips_raw_quarantine_group_dedup",
-    "corpus-absences": "test_corpus_absences_red_twin",
+    "corpus-absences": "test_pathology_zoo_corpus_absences_red_twin",
     "corpus-attachment-fidelity": "test_corpus_attachment_fidelity_red_twin",
     "corpus-revision-fidelity": "test_corpus_revision_fidelity_red_twin",
 }
@@ -1290,6 +1291,21 @@ def test_corpus_absences_red_twin(tmp_path: Path) -> None:
         )
     report = verify_archive(tmp_path, checks=("corpus-absences",))
     assert _check(report, "corpus-absences").status is OutcomeStatus.ERROR
+
+
+def test_pathology_zoo_corpus_absences_red_twin(tmp_path: Path) -> None:
+    """The zoo consumes t0m73's red-twin registry through a real two-wave archive."""
+    zoo = build_pathology_zoo(tmp_path / "zoo")
+    clean = verify_archive(zoo.archive_root, checks=("corpus-absences", "corpus-revision-fidelity"))
+    assert _check(clean, "corpus-absences").status is OutcomeStatus.OK
+    assert _check(clean, "corpus-revision-fidelity").status is OutcomeStatus.OK
+
+    with _connect(zoo.archive_root / "index.db") as conn:
+        conn.execute("DELETE FROM sessions WHERE session_id = ?", ("codex-session:zoo-append-self",))
+        conn.commit()
+
+    red = verify_archive(zoo.archive_root, checks=("corpus-absences",))
+    assert _check(red, "corpus-absences").status is OutcomeStatus.ERROR
 
 
 def test_corpus_attachment_fidelity_red_twin(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Adds a production-ingested pathology-zoo fixture archive with a queryable manifest for the suite's known failure shapes.

## Problem

Existing fixtures emphasize happy-path provider exports. Production incidents need compact reproductions that travel through the actual acquisition, parsing, materialization, and indexing route.

## Solution

`tests/infra/pathology_zoo.py` creates synthetic and hand-authored wire artifacts, then calls `parse_sources_archive` to build the archive. The manifest records each pathology, its synthetic session/raw targets, and the motivating bead IDs. Focused tests cover the full v0 manifest, `vintage-reorder`, `content-blocks-vintage`, and `lifecycle-anchor-drift`; they also prove the builder fails when the production ingest route is bypassed.

No registry red-twin or differ-canary extension point exists in this checkout. The manifest exposes concrete follow-up records for `polylogue-t0m73` and `polylogue-0x7nh` instead of adding test-only wiring.

## Verification

- `direnv exec . devtools test tests/unit/infra/test_pathology_zoo.py` (`5 passed`)
- `direnv exec . devtools verify --quick` (successful)
