### PR TITLE
fix(storage): expose unpaired action result state

### DIFF
--- a/devtools/docs_surface.py
+++ b/devtools/docs_surface.py
@@ -432,6 +432,12 @@ DOCS_REFERENCE_ENTRIES: tuple[DocsEntry, ...] = (
     _entry(
         "Race Window Audit", "audits/2026-07-09-race-window-audit.md", "Race-window investigation record.", "archive"
     ),
+    _entry(
+        "Unpaired Tool Results Classification",
+        "audits/2026-08-04-unpaired-tool-results.md",
+        "Classification of unpaired tool-call evidence and action result states.",
+        "archive",
+    ),
     _entry("Audit Record Index", "audits/README.md", "Index of dated investigation records.", "archive"),
     _entry(
         "1498 Cascade Retrospective",

--- a/docs/README.md
+++ b/docs/README.md
@@ -134,6 +134,7 @@ Start with **Guides** for a task, **Reference** for a surface contract, and **Ar
 | [Daemon Loop Lock-Starvation Map](audits/2026-07-09-daemon-loop-lock-starvation-map.md) | Lock-starvation investigation record. |
 | [Hash Boundary Census](audits/2026-07-09-hash-boundary-census.md) | Hash-boundary investigation record. |
 | [Race Window Audit](audits/2026-07-09-race-window-audit.md) | Race-window investigation record. |
+| [Unpaired Tool Results Classification](audits/2026-08-04-unpaired-tool-results.md) | Classification of unpaired tool-call evidence and action result states. |
 | [Audit Record Index](audits/README.md) | Index of dated investigation records. |
 | [1498 Cascade Retrospective](retro/2026-05-24-1498-cascade.md) | Historical cascade incident retrospective. |
 | [Retrospective Index](retro/README.md) | Index of historical incident retrospectives. |

--- a/docs/audits/2026-08-04-unpaired-tool-results.md
+++ b/docs/audits/2026-08-04-unpaired-tool-results.md
@@ -1,0 +1,37 @@
+# Unpaired Tool Results Classification
+
+## Scope and method
+
+This audit classifies the corrected 2026-08-03 baseline of 49,886 unpaired, identity-bearing tool calls. The old 26,188 figure compared total block counts and therefore could not establish per-call pairing. The corrected query pairs within `(session_id, tool_id, transcript rank)` and counts a tool use only when its correlation id is non-empty and the corresponding result rank is absent.
+
+The audit intentionally excludes 2,096 tool uses with no usable correlation id. They cannot be paired by identity and are separately represented by the same `no_result` action state. They are not part of the corrected 49,886 baseline.
+
+## Classification
+
+| Origin | Cause | Calls | Classification |
+| --- | --- | ---: | --- |
+| `codex-session` | Identity-bearing invocation has no emitted result record. Spot checks show a command followed by a later user intervention, so an interior position is not evidence that a result existed. | 33,994 | Honest no-result evidence, including interrupted or superseded work. |
+| `chatgpt-export` | Recipient-addressed provider invocation has no child/result record. A representative `dalle.text2im` call is the only tool block in its exported turn. | 15,423 | Honest provider no-result evidence. |
+| `claude-code-session` | Invocation ends without a result event, commonly `ExitPlanMode` awaiting an operator decision. | 466 | Honest pending or interrupted evidence. |
+| `claude-ai-export` | Sparse provider invocation without a result record. Observed examples include terminal `Gmail:create_label` and `create_file` calls. | 3 | Honest provider no-result evidence. |
+| **Total** |  | **49,886** | **No parser pairing defect was established.** |
+
+## Pairing-defect decision
+
+No category is reclassified as a parser defect. The Corpus Lens note already ruled out tail truncation as the dominant explanation for Codex and ChatGPT. Live, read-only samples strengthen the more precise conclusion: a result row is sometimes absent because the transcript records interruption, operator disposition, or provider-side omission. Reconstructing a result from later prose, a neighboring event, or a guessed positional match would fabricate evidence and risk false pairings.
+
+The resulting action read model names the expected state `no_result`. It is distinct from `outcome_unknown`, which requires an existing paired `tool_result` row whose structured `is_error` and `exit_code` signals are both absent. The index change is view-only, so it does not mutate source data, blobs, or existing materialized action rows.
+
+## Evidence
+
+Read-only live archive checks used `index.db` in SQLite `mode=ro&immutable=1`:
+
+```sql
+SELECT COUNT(*)
+FROM action_pairs
+WHERE tool_result_block_id IS NULL
+  AND tool_id IS NOT NULL
+  AND tool_id != '';
+```
+
+The 2026-08-03 baseline returned 49,886. Origin counts were produced from the same predicate, grouped by the session origin. Current archive growth is deliberately not substituted for this historical baseline.

--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -10,3 +10,4 @@ and [Developer Tools](../devtools.md) references for present-tense behavior.
 - [Daemon loop lock-starvation map](2026-07-09-daemon-loop-lock-starvation-map.md)
 - [Hash boundary census](2026-07-09-hash-boundary-census.md)
 - [Race window audit](2026-07-09-race-window-audit.md)
+- [Unpaired tool results classification](2026-08-04-unpaired-tool-results.md)

--- a/docs/examples/demo-tour/command-output/01-claim-versus-receipt.txt
+++ b/docs/examples/demo-tour/command-output/01-claim-versus-receipt.txt
@@ -29,7 +29,7 @@ source material:
   blob_sha256: 9fd0dbdb080058070935924534a903cc63a8dcba571f6b2734f92a96576b59d7
 
 completion-claim experiment:
-  sample manifest: a3769731d70cbfc50b9a267b3f8b1290ad56b34dad1c6cff5a3ca63f0e09174f
+  sample manifest: 76641b92f998b7cf8bca20d9c5d401c934da8b9adfbdb760588f5a191d402fce
   denominator: 2
 unsupported by structural evidence: 0 (0.0%)
 neutral prior outcome: 0 (0.0%)

--- a/docs/examples/demo-tour/transcript.txt
+++ b/docs/examples/demo-tour/transcript.txt
@@ -38,7 +38,7 @@ source material:
   blob_sha256: 9fd0dbdb080058070935924534a903cc63a8dcba571f6b2734f92a96576b59d7
 
 completion-claim experiment:
-  sample manifest: a3769731d70cbfc50b9a267b3f8b1290ad56b34dad1c6cff5a3ca63f0e09174f
+  sample manifest: 76641b92f998b7cf8bca20d9c5d401c934da8b9adfbdb760588f5a191d402fce
   denominator: 2
 unsupported by structural evidence: 0 (0.0%)
 neutral prior outcome: 0 (0.0%)

--- a/polylogue/core/enums.py
+++ b/polylogue/core/enums.py
@@ -429,6 +429,19 @@ class ToolResultUnknownReason(PolylogueStrEnum):
     NOT_READ = "not_read"
 
 
+class ActionResultState(PolylogueStrEnum):
+    """Presence and structural-outcome state of one ``actions`` row.
+
+    ``NO_RESULT`` means no ``tool_result`` block was paired to the invocation.
+    It must remain distinct from ``OUTCOME_UNKNOWN``, where a result block
+    exists but provider structure did not report a pass/fail outcome.
+    """
+
+    NO_RESULT = "no_result"
+    OUTCOME_UNKNOWN = "outcome_unknown"
+    OUTCOME_REPORTED = "outcome_reported"
+
+
 class SessionRefKind(PolylogueStrEnum):
     """Closed vocabulary for ``session_refs.kind`` (tracker-agnostic).
 
@@ -750,6 +763,7 @@ class RawAuthorityVerdict(PolylogueStrEnum):
 
 
 __all__ = [
+    "ActionResultState",
     "AssertionKind",
     "AssertionStatus",
     "AssertionVisibility",

--- a/polylogue/storage/sqlite/action_relation.py
+++ b/polylogue/storage/sqlite/action_relation.py
@@ -81,7 +81,12 @@ SELECT
     ranked_results.output_text,
     ranked_results.is_error,
     ranked_results.exit_code,
-    ranked_results.tool_result_block_id
+    ranked_results.tool_result_block_id,
+    CASE
+        WHEN ranked_results.tool_result_block_id IS NULL THEN 'no_result'
+        WHEN ranked_results.is_error IS NULL AND ranked_results.exit_code IS NULL THEN 'outcome_unknown'
+        ELSE 'outcome_reported'
+    END AS result_state
 FROM ranked_uses
 LEFT JOIN ranked_results
     ON ranked_results.session_id = ranked_uses.session_id
@@ -102,7 +107,8 @@ SELECT
     NULL AS output_text,
     NULL AS is_error,
     NULL AS exit_code,
-    NULL AS tool_result_block_id
+    NULL AS tool_result_block_id,
+    'no_result' AS result_state
 FROM blocks u{session_index_hint}
 WHERE u.block_type = 'tool_use' AND (u.tool_id IS NULL OR u.tool_id = ''){null_id_bound}
 """.strip()

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -63,7 +63,7 @@ from polylogue.archive.semantic.subscription_pricing import compute_credit_cost
 from polylogue.archive.session_revision_membership import MembershipClassification
 from polylogue.archive.stats import ArchiveStats
 from polylogue.core.dates import parse_date
-from polylogue.core.enums import Origin, Provider
+from polylogue.core.enums import ActionResultState, Origin, Provider
 from polylogue.core.json import JSONValue, require_json_value
 from polylogue.core.refs import delegation_edge_object_id
 from polylogue.core.sources import origin_from_provider
@@ -461,26 +461,42 @@ class ArchiveActionQueryRow:
     output_text: str | None
     is_error: int | None
     exit_code: int | None
+    result_state: ActionResultState
     followup_class: str | None
     followup_message_ref: str | None
 
 
 def _archive_action_query_row(row: sqlite3.Row) -> ArchiveActionQueryRow:
+    tool_result_block_id = str(row["tool_result_block_id"]) if row["tool_result_block_id"] is not None else None
+    is_error = int(row["is_error"]) if row["is_error"] is not None else None
+    exit_code = int(row["exit_code"]) if row["exit_code"] is not None else None
+    result_state = (
+        ActionResultState(str(row["result_state"]))
+        if "result_state" in row
+        else (
+            ActionResultState.NO_RESULT
+            if tool_result_block_id is None
+            else ActionResultState.OUTCOME_UNKNOWN
+            if is_error is None and exit_code is None
+            else ActionResultState.OUTCOME_REPORTED
+        )
+    )
     return ArchiveActionQueryRow(
         session_id=str(row["session_id"]),
         message_id=str(row["message_id"]),
         origin=str(row["origin"]),
         title=str(row["title"]) if row["title"] is not None else None,
         tool_use_block_id=str(row["tool_use_block_id"]),
-        tool_result_block_id=str(row["tool_result_block_id"]) if row["tool_result_block_id"] is not None else None,
+        tool_result_block_id=tool_result_block_id,
         tool_name=str(row["tool_name"]) if row["tool_name"] is not None else None,
         semantic_type=str(row["semantic_type"]) if row["semantic_type"] is not None else None,
         tool_command=str(row["tool_command"]) if row["tool_command"] is not None else None,
         tool_path=str(row["tool_path"]) if row["tool_path"] is not None else None,
         occurred_at_ms=int(row["occurred_at_ms"]) if row["occurred_at_ms"] is not None else None,
         output_text=str(row["output_text"]) if row["output_text"] is not None else None,
-        is_error=int(row["is_error"]) if row["is_error"] is not None else None,
-        exit_code=int(row["exit_code"]) if row["exit_code"] is not None else None,
+        is_error=is_error,
+        exit_code=exit_code,
+        result_state=result_state,
         followup_class=str(row["followup_class"]) if row["followup_class"] is not None else None,
         followup_message_ref=str(row["followup_message_ref"]) if row["followup_message_ref"] is not None else None,
     )
@@ -1315,6 +1331,7 @@ _ARCHIVE_ACTION_QUERY_COLUMNS: tuple[tuple[str, str], ...] = (
     ("output_text", "a.output_text"),
     ("is_error", "a.is_error"),
     ("exit_code", "a.exit_code"),
+    ("result_state", "a.result_state"),
     ("followup_class", "a.followup_class"),
     ("followup_message_ref", "a.followup_message_ref"),
 )

--- a/polylogue/storage/sqlite/archive_tiers/index.py
+++ b/polylogue/storage/sqlite/archive_tiers/index.py
@@ -426,6 +426,10 @@ from polylogue.storage.sqlite.delegation_facts import delegation_facts_insert_sq
 #    source`, `daemon/http.py` status payloads), not confined to
 #    repair/status internals. price_catalogs metadata is out of scope here
 #    (table-level finding, tracked separately by polylogue-resk).
+# polylogue-cuxz.5: v64 adds the actions view-only ``result_state`` projection.
+# It is computed entirely from already-materialized ``action_pairs`` outcome
+# columns, so a fast-forward only replaces the view. No raw session needs
+# reparsing and no persisted value changes.
 # polylogue-eizc: v63 drops `threads_fts`, a maintained FTS surface with real
 # triggers and rebuild/repair/freshness machinery but no application-layer
 # consumers. Its only MATCH reader had zero production callers; the live
@@ -433,7 +437,7 @@ from polylogue.storage.sqlite.delegation_facts import delegation_facts_insert_sq
 # `blocks_command_trigram` remains because `devtools/affordance_usage.py`'s
 # `_cli_action_rows` is a real consumer with a documented archive-scale
 # speedup. See the v63 declaration in lifecycle.py.
-INDEX_SCHEMA_VERSION = 63
+INDEX_SCHEMA_VERSION = 64
 
 # polylogue-v6i3: shared WHEN-clause fragment gating the blocks_command_trigram
 # trigger BODIES on the same dedicated bulk-build guard row messages_fts's
@@ -1018,7 +1022,12 @@ CREATE VIEW IF NOT EXISTS actions AS
 SELECT
     ap.session_id, ap.message_id, ap.tool_use_block_id, ap.tool_name, ap.semantic_type,
     ap.tool_command, ap.tool_path, tu.tool_input AS tool_input, tr.text AS output_text,
-    ap.is_error, ap.exit_code, ap.tool_result_block_id
+    ap.is_error, ap.exit_code, ap.tool_result_block_id,
+    CASE
+        WHEN ap.tool_result_block_id IS NULL THEN 'no_result'
+        WHEN ap.is_error IS NULL AND ap.exit_code IS NULL THEN 'outcome_unknown'
+        ELSE 'outcome_reported'
+    END AS result_state
 FROM action_pairs ap
 JOIN blocks tu ON tu.block_id = ap.tool_use_block_id
 LEFT JOIN blocks tr ON tr.block_id = ap.tool_result_block_id;

--- a/polylogue/storage/sqlite/lifecycle.py
+++ b/polylogue/storage/sqlite/lifecycle.py
@@ -858,6 +858,21 @@ INDEX_DELTA_DECLARATIONS: tuple[IndexDeltaDeclaration, ...] = (
             ),
         ),
     ),
+    IndexDeltaDeclaration(
+        version=64,
+        # polylogue-cuxz.5: `actions.result_state` is a CASE projection over
+        # existing action_pairs columns. Replacing this derived view exposes
+        # no-result separately from an existing result with unknown outcome;
+        # it neither changes parser semantics nor materialized values.
+        classes=(DerivedDeltaClass.VIEW_ONLY,),
+        operations=(
+            FastForwardOperation(
+                name="v64-actions-result-state",
+                kind=FastForwardOperationKind.REPLACE_VIEW,
+                objects=(("view", "actions"),),
+            ),
+        ),
+    ),
 )
 
 

--- a/tests/unit/storage/test_archive_tiers_archive.py
+++ b/tests/unit/storage/test_archive_tiers_archive.py
@@ -10,7 +10,7 @@ from polylogue.archive.ingest_flags import DOM_FALLBACK_INGEST_FLAG, NATIVE_BROW
 from polylogue.archive.message.roles import Role
 from polylogue.archive.message.types import MessageType
 from polylogue.archive.query.expression import parse_unit_source_expression
-from polylogue.core.enums import BlockType, Origin, Provider
+from polylogue.core.enums import ActionResultState, BlockType, Origin, Provider
 from polylogue.scenarios.workload import (
     BudgetVerdict,
     WorkloadPhaseObservation,
@@ -172,6 +172,56 @@ def test_archive_tiers_archive_facade_queries_session_actions_by_session_index(t
     assert [(row.session_id, row.is_error, row.exit_code) for row in failed_rows] == [(session_id, 1, 2)]
     assert [(row.group_key, row.count) for row in error_counts] == [("1", 1)]
     assert [(row.group_key, row.count) for row in exit_counts] == [("2", 1)]
+
+
+def test_archive_facade_exposes_distinct_action_result_absence_states(tmp_path: Path) -> None:
+    """The repository route preserves the actions view's result-state split.
+
+    One result row is structurally unknown while the other call has no paired
+    row. If repository hydration drops result_state or derives both from the
+    nullable outcome columns, this real writer -> actions view -> repository
+    route cannot return the two distinct enum values.
+    """
+    session = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="codex-action-result-states",
+        messages=[
+            ParsedMessage(
+                provider_message_id="m1",
+                role=Role.ASSISTANT,
+                blocks=[
+                    ParsedContentBlock(
+                        type=BlockType.TOOL_USE,
+                        tool_name="Bash",
+                        tool_id="tool-unknown",
+                        tool_input={"command": "unknown"},
+                    ),
+                    ParsedContentBlock(
+                        type=BlockType.TOOL_RESULT,
+                        tool_id="tool-unknown",
+                        text="provider did not report outcome",
+                    ),
+                    ParsedContentBlock(
+                        type=BlockType.TOOL_USE,
+                        tool_name="Bash",
+                        tool_id="tool-absent",
+                        tool_input={"command": "absent"},
+                    ),
+                ],
+            )
+        ],
+    )
+    root = tmp_path / "archive"
+    with ArchiveStore(root) as facade:
+        session_id = facade.write_parsed(session)
+
+    with ArchiveStore.open_existing(root) as facade:
+        rows = facade.query_session_actions([session_id], limit=10)
+
+    assert [(row.tool_command, row.result_state, row.tool_result_block_id is None) for row in rows] == [
+        ("unknown", ActionResultState.OUTCOME_UNKNOWN, False),
+        ("absent", ActionResultState.NO_RESULT, True),
+    ]
 
 
 def test_exact_session_action_count_bounds_pairing_before_global_ranking(

--- a/tests/unit/storage/test_archive_tiers_ddl.py
+++ b/tests/unit/storage/test_archive_tiers_ddl.py
@@ -511,14 +511,74 @@ def test_actions_view_never_cross_pairs_empty_string_tool_id(tmp_path: Path) -> 
     )
 
     actions = conn.execute(
-        "SELECT tool_command, output_text FROM actions WHERE session_id = ? ORDER BY tool_command",
+        "SELECT tool_command, output_text, result_state FROM actions WHERE session_id = ? ORDER BY tool_command",
         (session_id,),
     ).fetchall()
     # Both uses still surface (unpaired) -- none cross-paired with the
     # unrelated empty-string tool_result.
     assert [dict(row) for row in actions] == [
-        {"tool_command": "unlinked-1", "output_text": None},
-        {"tool_command": "unlinked-2", "output_text": None},
+        {"tool_command": "unlinked-1", "output_text": None, "result_state": "no_result"},
+        {"tool_command": "unlinked-2", "output_text": None, "result_state": "no_result"},
+    ]
+
+
+def test_actions_view_distinguishes_absent_result_from_unknown_outcome(tmp_path: Path) -> None:
+    """The production view must not collapse an absent result into unknown.
+
+    The paired result fixture deliberately carries no is_error/exit_code
+    signal. Changing the view's no-result branch to outcome_unknown makes the
+    two selected states equal and fails this regression guard.
+    """
+    conn = _connect(tmp_path / "index.db")
+    _apply_tier(conn, ArchiveTier.INDEX)
+    conn.execute(
+        """
+        INSERT INTO sessions (native_id, origin, title, content_hash, created_at_ms, updated_at_ms)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        ("result-state-session", "codex-session", "Result states", _HASH, 1_767_225_600_000, 1_767_225_601_000),
+    )
+    session_id = conn.execute(
+        "SELECT session_id FROM sessions WHERE native_id = ?", ("result-state-session",)
+    ).fetchone()["session_id"]
+    conn.execute(
+        """
+        INSERT INTO messages (session_id, native_id, position, role, message_type, content_hash, occurred_at_ms)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (session_id, "message", 0, "assistant", "message", _HASH, 1_767_225_600_000),
+    )
+    message_id = conn.execute("SELECT message_id FROM messages WHERE session_id = ?", (session_id,)).fetchone()[
+        "message_id"
+    ]
+    for position, tool_id, command in ((0, "unknown", "unknown-outcome"), (1, "absent", "no-result")):
+        conn.execute(
+            """
+            INSERT INTO blocks (message_id, session_id, position, block_type, tool_name, tool_id, tool_input)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (message_id, session_id, position, "tool_use", "shell", tool_id, f'{{"command": "{command}"}}'),
+        )
+    conn.execute(
+        """
+        INSERT INTO blocks (message_id, session_id, position, block_type, text, tool_id)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (message_id, session_id, 2, "tool_result", "provider omitted outcome", "unknown"),
+    )
+
+    actions = conn.execute(
+        "SELECT tool_command, tool_result_block_id, result_state FROM actions WHERE session_id = ? ORDER BY tool_command",
+        (session_id,),
+    ).fetchall()
+
+    assert [dict(row) for row in actions] == [
+        {"tool_command": "no-result", "tool_result_block_id": None, "result_state": "no_result"},
+        {
+            "tool_command": "unknown-outcome",
+            "tool_result_block_id": f"{message_id}:2",
+            "result_state": "outcome_unknown",
+        },
     ]
 
 


### PR DESCRIPTION
## Summary

Classifies the corrected 49,886 identity-bearing unpaired tool calls and adds a typed action-result state that preserves absent results separately from existing results with an unreported outcome.

## Problem

The actions read model represented both a missing `tool_result` row and a paired row with null outcome signals through the same nullable fields. Readers could not count or reason about unpaired calls without conflating those two evidence states.

## Solution

Adds `ActionResultState` with `no_result`, `outcome_unknown`, and `outcome_reported`; projects it from the canonical actions view and its session-bounded relation; and carries it through `ArchiveActionQueryRow`. Index schema v64 is a `VIEW_ONLY` fast-forward that replaces the derived view and does not reparse raw data or mutate source/blob tiers. The audit records 33,994 Codex, 15,423 ChatGPT, 466 Claude Code, and 3 Claude export identity-bearing no-result calls. No parser pairing defect was established, so the remainder is preserved as named evidence rather than reconstructed heuristically.

## Verification

- `./.venv/bin/python -m devtools test tests/unit/storage/test_archive_tiers_ddl.py::test_actions_view_distinguishes_absent_result_from_unknown_outcome tests/unit/storage/test_archive_tiers_ddl.py::test_actions_view_never_cross_pairs_empty_string_tool_id tests/unit/storage/test_archive_tiers_archive.py::test_archive_facade_exposes_distinct_action_result_absence_states` returned `3 passed`.
- Pre-push `devtools verify --quick` passed: format, lint, mypy, render, layering, schema roundtrip, policy checks, and demo-tour freshness.
- A fresh-worktree `devtools verify --seed-testmon --skip-slow` could not seed because the guard rejects the seed command's own unmarked `.cache/testmon/seed-attempt.json`; no guard was bypassed.

Ref polylogue-cuxz.5.
