### PR TITLE
fix(sources): retain one id-less active leaf

### DIFF
--- a/polylogue/sources/parsers/hermes_state.py
+++ b/polylogue/sources/parsers/hermes_state.py
@@ -970,11 +970,14 @@ def _latest_message_timestamp(messages: list[ParsedMessage]) -> str | None:
 def _mark_active_leaf(messages: list[ParsedMessage]) -> list[ParsedMessage]:
     if not messages:
         return messages
-    leaf = next(
-        (message.provider_message_id for message in reversed(messages) if message.is_active_path),
+    leaf_position = next(
+        (position for position, message in reversed(list(enumerate(messages))) if message.is_active_path),
         None,
     )
-    return [message.model_copy(update={"is_active_leaf": message.provider_message_id == leaf}) for message in messages]
+    return [
+        message.model_copy(update={"is_active_leaf": position == leaf_position})
+        for position, message in enumerate(messages)
+    ]
 
 
 def _optional_text(value: object) -> str | None:

--- a/polylogue/sources/parsers/local_agent.py
+++ b/polylogue/sources/parsers/local_agent.py
@@ -18,6 +18,7 @@ from .base import (
     ParsedSessionEvent,
     fill_linear_parent_chain,
     human_authored_override,
+    mark_last_occurrence_as_active_leaf,
 )
 
 
@@ -335,13 +336,7 @@ def _parse_hermes_message(
 
 
 def _mark_active_leaf(messages: list[ParsedMessage]) -> list[ParsedMessage]:
-    if not messages:
-        return messages
-    active_leaf_message_provider_id = messages[-1].provider_message_id
-    return [
-        message.model_copy(update={"is_active_leaf": message.provider_message_id == active_leaf_message_provider_id})
-        for message in messages
-    ]
+    return mark_last_occurrence_as_active_leaf(messages)
 
 
 def _non_negative_int(value: object) -> int | None:

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -5276,10 +5276,9 @@ def _normalized_messages(messages: list[ParsedMessage]) -> list[ParsedMessage]:
     active_leaf_count = sum(1 for message in messages if message.is_active_leaf)
     if active_leaf_count == 1 or not messages:
         return messages
-    active_leaf_message_id = messages[-1].provider_message_id
     return [
-        message.model_copy(update={"is_active_leaf": message.provider_message_id == active_leaf_message_id})
-        for message in messages
+        message.model_copy(update={"is_active_leaf": position == len(messages) - 1})
+        for position, message in enumerate(messages)
     ]
 
 

--- a/tests/unit/sources/test_parsers_local_agent.py
+++ b/tests/unit/sources/test_parsers_local_agent.py
@@ -294,6 +294,43 @@ def test_gemini_cli_session_metadata_and_scratchpad_survive_as_session_events() 
     assert scratchpad_event.payload["memory_scratchpad"] == payload["memoryScratchpad"]
 
 
+@pytest.mark.parametrize(
+    ("source_name", "payload"),
+    [
+        (
+            "gemini-cli",
+            {
+                "sessionId": "idless-gemini",
+                "kind": "chat",
+                "messages": [
+                    {"type": "user", "content": ["first"]},
+                    {"type": "gemini", "content": "second"},
+                ],
+            },
+        ),
+        (
+            "hermes",
+            {
+                "session_id": "idless-hermes",
+                "platform": "linux",
+                "messages": [
+                    {"role": "user", "content": "first"},
+                    {"role": "assistant", "content": "second"},
+                ],
+            },
+        ),
+    ],
+)
+def test_local_agent_idless_messages_have_exactly_one_active_leaf(
+    source_name: str,
+    payload: JSONDocument,
+) -> None:
+    [session] = parse_payload(source_name, payload, "fallback")
+
+    assert [message.provider_message_id for message in session.messages] == ["", ""]
+    assert [message.is_active_leaf for message in session.messages] == [False, True]
+
+
 def test_hermes_session_document_parses_through_dispatch() -> None:
     payload: JSONDocument = {
         "session_id": "hermes-session-1",

--- a/tests/unit/sources/test_parsers_local_agent.py
+++ b/tests/unit/sources/test_parsers_local_agent.py
@@ -537,6 +537,23 @@ def test_hermes_state_db_parses_authoritative_sessions(tmp_path: Path) -> None:
     assert child.branch_type.value == "subagent"
 
 
+def test_hermes_state_db_duplicate_platform_ids_keep_one_active_leaf(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    _write_hermes_state_db(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "UPDATE messages SET platform_message_id = ? WHERE id IN (?, ?)",
+            ("duplicate-platform-id", 1, 4),
+        )
+
+    [root, _child] = hermes_state.parse_state_db(db_path, fallback_id="fallback")
+
+    leaves = [message for message in root.messages if message.is_active_leaf]
+    assert [message.provider_message_id for message in leaves] == ["duplicate-platform-id"]
+    assert leaves == [root.messages[4]]
+    assert root.active_leaf_message_provider_id == "duplicate-platform-id"
+
+
 def test_hermes_state_db_retains_empty_rows_and_their_state(tmp_path: Path) -> None:
     from polylogue.pipeline.ids import session_content_hash
 

--- a/tests/unit/storage/test_archive_tiers_write.py
+++ b/tests/unit/storage/test_archive_tiers_write.py
@@ -528,6 +528,47 @@ def test_archive_tiers_writer_does_not_collapse_duplicate_message_native_ids(tmp
     assert session_row["active_leaf_message_id"] == f"{session_id}:1.0"
 
 
+def test_archive_tiers_writer_normalizes_duplicate_idless_active_leaves_by_position(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "index.db")
+    try:
+        session = ParsedSession(
+            source_name=Provider.GEMINI_CLI,
+            provider_session_id="gemini-idless-leaves",
+            title="Id-less leaves",
+            messages=[
+                ParsedMessage(
+                    provider_message_id="",
+                    role=Role.USER,
+                    text="first",
+                    position=0,
+                    is_active_leaf=True,
+                    blocks=[ParsedContentBlock(type=BlockType.TEXT, text="first")],
+                ),
+                ParsedMessage(
+                    provider_message_id="",
+                    role=Role.ASSISTANT,
+                    text="second",
+                    position=1,
+                    is_active_leaf=True,
+                    blocks=[ParsedContentBlock(type=BlockType.TEXT, text="second")],
+                ),
+            ],
+        )
+
+        session_id = write_parsed_session_to_archive(conn, session)
+
+        leaf_positions = [
+            row[0]
+            for row in conn.execute(
+                "SELECT position FROM messages WHERE session_id = ? AND is_active_leaf = 1 ORDER BY position",
+                (session_id,),
+            )
+        ]
+        assert leaf_positions == [1]
+    finally:
+        conn.close()
+
+
 def test_archive_tiers_writer_replaces_lone_surrogates_before_sqlite(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "index.db")
     session = ParsedSession(


### PR DESCRIPTION
## Summary

PR #3730 already landed the positional-identity repair. This replacement closes the remaining id-less and duplicate-native-ID active-leaf gaps found during independent review.

## Problem

Gemini CLI and Hermes JSON parsers preserved missing native IDs as empty strings, but selected the active leaf by provider-ID equality. Hermes state.db applied the same pattern to duplicate real platform IDs. Each case could emit more than one active leaf, while SQLite defensive normalization also used equality.

## Solution

Use position to select the final leaf in the local-agent parsers, the Hermes state.db parser, and SQLite defensive normalization. Native IDs remain unchanged. The regressions exercise Gemini CLI, Hermes JSON, Hermes SQLite, and persisted SQLite rows.

## Acceptance criteria

- Reorder-stable id-less comparison identity and the Drive parser-to-SQLite attachment route are landed in #3730 and pass the focused matrix.
- Native IDs remain preserved on native-ID routes.
- Duplicate and id-less IDs now yield one active leaf in parser output and persisted rows.

## Verification

- `direnv exec . devtools test <22 focused identity, parser, Drive, and SQLite nodes>`: 25 passed.
- `direnv exec . devtools test tests/unit/sources/test_parsers_local_agent.py -k ...`: 4 passed, including duplicate Hermes platform IDs.
- `direnv exec . devtools verify --quick`: success, including mypy and `lab policy position-derived-identity`.
- `git diff --check origin/master...HEAD`: clean.

## Adversarial review

Independent review initially returned BLOCK for Gemini CLI and Hermes JSON id-less equality-based leaf selection plus SQLite normalization. A final cold review found the matching Hermes state.db duplicate-platform-ID path. Both findings are fixed by position-based selection and parser-to-SQLite regressions.

**Adversarial review verdict: APPROVE.**

Supersedes #3712. The original PR and its branch were not mutated.

Ref polylogue-slshy.