### PR TITLE
fix(maintenance): gate reindex on blob-ref liveness

### DIFF
--- a/devtools/docs_surface.py
+++ b/devtools/docs_surface.py
@@ -432,6 +432,12 @@ DOCS_REFERENCE_ENTRIES: tuple[DocsEntry, ...] = (
     _entry(
         "Race Window Audit", "audits/2026-07-09-race-window-audit.md", "Race-window investigation record.", "archive"
     ),
+    _entry(
+        "Blob-Reference Liveness Closure Audit",
+        "audits/2026-08-04-blob-ref-liveness-closure.md",
+        "I3 live evidence, source-tier reconciliation safeguards, and the direct-reindex gate.",
+        "archive",
+    ),
     _entry("Audit Record Index", "audits/README.md", "Index of dated investigation records.", "archive"),
     _entry(
         "1498 Cascade Retrospective",

--- a/docs/README.md
+++ b/docs/README.md
@@ -134,6 +134,7 @@ Start with **Guides** for a task, **Reference** for a surface contract, and **Ar
 | [Daemon Loop Lock-Starvation Map](audits/2026-07-09-daemon-loop-lock-starvation-map.md) | Lock-starvation investigation record. |
 | [Hash Boundary Census](audits/2026-07-09-hash-boundary-census.md) | Hash-boundary investigation record. |
 | [Race Window Audit](audits/2026-07-09-race-window-audit.md) | Race-window investigation record. |
+| [Blob-Reference Liveness Closure Audit](audits/2026-08-04-blob-ref-liveness-closure.md) | I3 live evidence, source-tier reconciliation safeguards, and the direct-reindex gate. |
 | [Audit Record Index](audits/README.md) | Index of dated investigation records. |
 | [1498 Cascade Retrospective](retro/2026-05-24-1498-cascade.md) | Historical cascade incident retrospective. |
 | [Retrospective Index](retro/README.md) | Index of historical incident retrospectives. |

--- a/docs/audits/2026-08-04-blob-ref-liveness-closure.md
+++ b/docs/audits/2026-08-04-blob-ref-liveness-closure.md
@@ -1,0 +1,51 @@
+# Blob-reference liveness closure audit
+
+Date: 2026-08-04
+
+Scope: `polylogue-0v4tn` and merged PR #3705.
+
+## Decision
+
+PR #3705 delivered the guarded source-tier reconciliation actuator, but it did not itself apply that actuator to the live archive. The live archive is still red for I3, so this change makes I3 a direct rebuild preflight gate. It does not claim that the live bookkeeping repair is complete.
+
+## Acceptance matrix
+
+| Requirement | Evidence | Status |
+| --- | --- | --- |
+| Set-based `raw_payload` referent check | `BLOB_REF_LIVENESS_JOIN` maps `raw_payload` to `raw_sessions.raw_id`; the classifier uses a `LEFT JOIN` per mapped ref type. | Satisfied |
+| Set-based attachment referent check | `attachment` maps to the parent `raw_sessions.raw_id`, not retired index-tier attachment identity. The archive verifier now imports the same canonical mapping. | Satisfied |
+| Read-only default | `blob-reference-liveness` calls the reconciler without `--apply`, which opens `source.db` with `mode=ro`. | Satisfied |
+| Offline, fresh verified backup, and transaction safety for apply | Apply rejects a running daemon, checkpoints and validates the source backup before and inside `BEGIN IMMEDIATE`, fsyncs a prepared receipt, checks the exact delete count, runs `quick_check`, and commits or rolls back as one transaction. | Satisfied |
+| Receipt and blob safety | The receipt records the exact candidate digest before mutation and terminal state after it. The only actuator mutation is `DELETE FROM blob_refs`; it contains no blob-store unlink or file deletion. | Satisfied |
+| Direct reindex gate | `rebuild_index_from_source` now runs `blob-refs-liveness` against the actual archive root before it acquires a rebuild lease or creates generation state. | Satisfied |
+| Predicate anti-vacuity | The classifier fixture has a live and orphan ref for every mapped type and asserts the exact orphan matrix. Inverting the `LEFT JOIN ... IS NULL` predicate reports the four live rows instead and fails the assertion. | Satisfied |
+
+## Live I3 evidence
+
+Read-only command, run against `/realm/db/polylogue/source.db`:
+
+```sql
+SELECT 'raw_payload' AS ref_type, COUNT(*) AS orphaned
+FROM blob_refs AS b
+LEFT JOIN raw_sessions AS r ON r.raw_id = b.ref_id
+WHERE b.ref_type = 'raw_payload' AND r.raw_id IS NULL
+UNION ALL
+SELECT 'attachment' AS ref_type, COUNT(*) AS orphaned
+FROM blob_refs AS b
+LEFT JOIN raw_sessions AS r ON r.raw_id = b.ref_id
+WHERE b.ref_type = 'attachment' AND r.raw_id IS NULL
+ORDER BY ref_type;
+```
+
+Result:
+
+```text
+attachment|0
+raw_payload|73427
+```
+
+No live apply, source backup creation, blob deletion, namespace quarantine, GC run, or raw-authority operation occurred. A future offline operator pass must use `polylogue ops maintenance blob-reference-liveness --apply` with a fresh verified source backup and a new receipt path. The preflight gate will continue to reject direct reindexing until I3 reports zero unwaived orphan refs.
+
+## Adversarial review
+
+One independent read-only review found that the original apply test mocked the offline guard. This change adds a regression test that simulates a live daemon and proves refusal occurs before receipt creation or `blob_refs` mutation. Source tracing then found and repaired the verifier's stale attachment referent mapping and the missing direct-reindex preflight.

--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -10,3 +10,4 @@ and [Developer Tools](../devtools.md) references for present-tense behavior.
 - [Daemon loop lock-starvation map](2026-07-09-daemon-loop-lock-starvation-map.md)
 - [Hash boundary census](2026-07-09-hash-boundary-census.md)
 - [Race window audit](2026-07-09-race-window-audit.md)
+- [Blob-reference liveness closure audit](2026-08-04-blob-ref-liveness-closure.md)

--- a/polylogue/maintenance/archive_verification.py
+++ b/polylogue/maintenance/archive_verification.py
@@ -49,6 +49,7 @@ from polylogue.maintenance.corpus_fidelity import (
     audit_attachment_fidelity,
     audit_revision_fidelity,
 )
+from polylogue.storage.blob_gc import BLOB_REF_LIVENESS_JOIN
 from polylogue.storage.introspection import table_exists
 from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
@@ -888,9 +889,7 @@ def _check_enum_superset(archive_root: Path, _sample_limit: int) -> ArchiveVerif
 #: intends), so a ref_type this check doesn't recognize is itself a gap the
 #: check surfaces via `_error_check`, not a silent skip.
 _BLOB_REF_REFERENT_TABLES: dict[str, tuple[str, str]] = {
-    "raw_payload": ("raw_sessions", "raw_id"),
-    "attachment": ("raw_artifacts", "artifact_id"),
-    "sidecar": ("history_sidecars", "sidecar_id"),
+    ref_type: (referent_table, referent_column) for ref_type, referent_table, referent_column in BLOB_REF_LIVENESS_JOIN
 }
 
 

--- a/polylogue/maintenance/blob_ref_liveness_reconciliation.py
+++ b/polylogue/maintenance/blob_ref_liveness_reconciliation.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from polylogue.config import Config
-from polylogue.maintenance.offline_guard import offline_maintenance_block_reason
+from polylogue.maintenance.offline_guard import running_daemon_pid
 from polylogue.paths import render_root
 from polylogue.storage.blob_ref_liveness import (
     BlobRefLivenessClassification,
@@ -52,6 +52,18 @@ class BlobRefLivenessReconciliationReport:
 
 def _offline_config(archive_root: Path) -> Config:
     return Config(archive_root=archive_root, render_root=render_root(), sources=[])
+
+
+def _offline_apply_block_reason(archive_root: Path) -> str | None:
+    """Refuse this offline-only repair whenever its archive daemon is live."""
+
+    daemon_pid = running_daemon_pid(_offline_config(archive_root))
+    if daemon_pid is None:
+        return None
+    return (
+        f"Refusing offline blob-ref liveness reconciliation while polylogued PID {daemon_pid} is running. "
+        "Stop polylogued before applying this repair."
+    )
 
 
 def _checkpoint_source_db(conn: sqlite3.Connection) -> None:
@@ -256,7 +268,7 @@ def reconcile_blob_ref_liveness(
         raise BlobRefLivenessReconciliationError(
             f"recovered existing prepared receipt as {outcome}: {receipt_path}; choose a fresh receipt path before retrying"
         )
-    if reason := offline_maintenance_block_reason(_offline_config(archive_root), active=True, dry_run=False):
+    if reason := _offline_apply_block_reason(archive_root):
         raise BlobRefLivenessReconciliationError(reason)
 
     conn = sqlite3.connect(source_db)

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -623,6 +623,16 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
     )
     if reason := offline_maintenance_block_reason(active_config, active=True, dry_run=False):
         raise RuntimeError(reason)
+    from polylogue.maintenance.archive_verification import verify_archive
+
+    source_liveness = verify_archive(root, checks=("blob-refs-liveness",))
+    if source_liveness.blocking:
+        failing = "; ".join(
+            f"{check.name}: {check.summary}"
+            for check in source_liveness.checks
+            if check.status.value == "error" and getattr(check, "waived_bead_id", None) is None
+        )
+        raise RuntimeError(f"reindex source preflight gate failed: {failing}")
 
     # This is deliberately outside archive-location acquisition and
     # generation-store construction.  Those steps can create/rewrite archive

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -595,7 +595,34 @@ def test_blob_refs_liveness_passes_on_coherent_archive(tmp_path: Path) -> None:
 
     check = _check(report, "blob-refs-liveness")
     assert check.status is OutcomeStatus.OK
-    assert check.evidence["orphans_by_ref_type"] == {"raw_payload": 0, "attachment": 0, "sidecar": 0}
+    assert check.evidence["orphans_by_ref_type"] == {
+        "attachment": 0,
+        "hook_payload": 0,
+        "raw_payload": 0,
+        "sidecar": 0,
+    }
+
+
+def test_attachment_blob_ref_joins_its_parent_raw_session(tmp_path: Path) -> None:
+    _seed_coherent_archive(tmp_path)
+    conn = _connect(tmp_path / "source.db")
+    try:
+        conn.execute(
+            """
+            INSERT INTO blob_refs(blob_hash, ref_id, ref_type, size_bytes, acquired_at_ms)
+            VALUES (?, 'raw-1', 'attachment', 10, 100)
+            """,
+            (b"a" * 32,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    report = verify_archive(tmp_path, checks=("blob-refs-liveness",))
+
+    check = _check(report, "blob-refs-liveness")
+    assert check.status is OutcomeStatus.OK
+    assert check.evidence["orphans_by_ref_type"]["attachment"] == 0
 
 
 def test_orphaned_embedding_ref_trips_embeddings_refs_liveness(tmp_path: Path) -> None:

--- a/tests/unit/maintenance/test_rebuild_index_ownership.py
+++ b/tests/unit/maintenance/test_rebuild_index_ownership.py
@@ -11,6 +11,7 @@ holding the general archive-location ownership lock.
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -50,6 +51,24 @@ def test_rebuild_refuses_when_archive_location_already_owned(tmp_path: Path) -> 
     # Releasing the concurrent holder's ownership lets the rebuild proceed.
     receipt = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root))
     assert receipt.status == "empty-source"
+
+
+def test_rebuild_source_preflight_rejects_orphaned_blob_refs_before_generation_creation(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _init_empty_source(root)
+    with sqlite3.connect(root / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO blob_refs(blob_hash, ref_id, ref_type, size_bytes, acquired_at_ms)
+            VALUES (?, 'raw-that-does-not-exist', 'raw_payload', 10, 100)
+            """,
+            (b"o" * 32,),
+        )
+
+    with pytest.raises(RuntimeError, match="reindex source preflight gate failed: blob-refs-liveness"):
+        rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root))
+
+    assert not (root / ".index-generations").exists()
 
 
 def test_rebuild_releases_ownership_lock_after_completion(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_blob_gc_ref_type_liveness.py
+++ b/tests/unit/storage/test_blob_gc_ref_type_liveness.py
@@ -187,8 +187,8 @@ def test_interrupted_hook_rekey_blocks_liveness_deletion_and_preserves_blob(
         lambda *args, **kwargs: args[0],
     )
     monkeypatch.setattr(
-        "polylogue.maintenance.blob_ref_liveness_reconciliation.offline_maintenance_block_reason",
-        lambda *args, **kwargs: None,
+        "polylogue.maintenance.blob_ref_liveness_reconciliation.running_daemon_pid",
+        lambda _config: None,
     )
     with pytest.raises(BlobRefLivenessReconciliationError, match="rekeyable_hook_payloads=1"):
         reconcile_blob_ref_liveness(

--- a/tests/unit/storage/test_blob_ref_liveness.py
+++ b/tests/unit/storage/test_blob_ref_liveness.py
@@ -139,6 +139,29 @@ def test_apply_requires_backup_and_receipt_before_mutation(tmp_path: Path) -> No
         assert conn.execute("SELECT COUNT(*) FROM blob_refs").fetchone() == (8,)
 
 
+def test_apply_refuses_a_running_daemon_before_receipt_or_blob_ref_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive_root = _source_archive(tmp_path)
+    receipt = tmp_path / "receipts" / "liveness.jsonl"
+    monkeypatch.setattr(
+        "polylogue.maintenance.blob_ref_liveness_reconciliation.running_daemon_pid",
+        lambda _config: 1234,
+    )
+
+    with pytest.raises(BlobRefLivenessReconciliationError, match="while polylogued PID 1234 is running"):
+        reconcile_blob_ref_liveness(
+            archive_root,
+            backup_manifest=tmp_path / "backup.json",
+            receipt_path=receipt,
+            dry_run=False,
+        )
+
+    assert not receipt.exists()
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        assert conn.execute("SELECT COUNT(*) FROM blob_refs").fetchone() == (8,)
+
+
 def test_restart_recovers_prepared_receipt_after_committed_delete(tmp_path: Path) -> None:
     archive_root = _source_archive(tmp_path)
     receipt = tmp_path / "receipts" / "interrupted.jsonl"
@@ -232,8 +255,8 @@ def test_apply_deletes_only_join_proven_orphans_and_persists_receipt(
         fake_validate,
     )
     monkeypatch.setattr(
-        "polylogue.maintenance.blob_ref_liveness_reconciliation.offline_maintenance_block_reason",
-        lambda *args, **kwargs: None,
+        "polylogue.maintenance.blob_ref_liveness_reconciliation.running_daemon_pid",
+        lambda _config: None,
     )
 
     report = reconcile_blob_ref_liveness(
@@ -286,8 +309,8 @@ def test_unknown_ref_type_blocks_apply_fail_closed(tmp_path: Path, monkeypatch: 
         lambda *args, **kwargs: args[0],
     )
     monkeypatch.setattr(
-        "polylogue.maintenance.blob_ref_liveness_reconciliation.offline_maintenance_block_reason",
-        lambda *args, **kwargs: None,
+        "polylogue.maintenance.blob_ref_liveness_reconciliation.running_daemon_pid",
+        lambda _config: None,
     )
     with pytest.raises(BlobRefLivenessReconciliationError, match="cannot be proven"):
         reconcile_blob_ref_liveness(


### PR DESCRIPTION
## Summary

Make source-tier blob-reference liveness a direct rebuild preflight gate, align attachment verification with the canonical parent raw-session referent, and record the live I3 closure boundary.

## Problem

PR #3705 added the guarded reconciliation actuator, but the archive verifier still treated attachment refs as pointing to the obsolete `raw_artifacts` table. The direct reindex route did not run I3 before creating rebuild lifecycle state. A fresh read-only I3 census found `attachment=0` and `raw_payload=73,427`, so an honest blob-pristine or reindex-ready claim is not possible.

## Solution

`archive_verification` now derives every referent mapping from the source-tier canonical liveness tuple. The rebuild entrypoint verifies `blob-refs-liveness` at the archive root before acquiring the rebuild lease or creating a generation. The liveness actuator now refuses any running `polylogued` before validating a backup, creating a receipt, or deleting a `blob_refs` row. The audit documents the result and the required future operator action.

| Requirement | Status |
| --- | --- |
| Parent raw-session attachment referent | Satisfied by the shared canonical mapping and a real source-table regression test. |
| Direct reindex gate | Satisfied before generation lifecycle creation. |
| Offline source-tier apply | Satisfied by an explicit live-daemon refusal test. |
| Live cleanup | Intentionally not performed. The remaining 73,427 raw-payload refs keep the gate red. |

No blob namespace quarantine, generic GC algorithm, raw-authority behavior, source backup, or production archive data changed.

## Verification

- `direnv exec . devtools test tests/unit/storage/test_blob_ref_liveness.py tests/unit/storage/test_blob_gc_ref_type_liveness.py tests/unit/cli/test_blob_ref_liveness_cli.py tests/unit/maintenance/test_archive_verification.py tests/unit/maintenance/test_rebuild_index_ownership.py` produced `97 passed`.
- `direnv exec . mypy` produced `Success: no issues found in 2591 source files`.
- `direnv exec . ruff check ...` produced `All checks passed!`.
- `direnv exec . devtools render all --check` reported every generated surface `sync OK`.
- Read-only live I3 SQL against `/realm/db/polylogue/source.db` returned `attachment|0` and `raw_payload|73427`.

## Adversarial review notes

One completed independent read-only review found that apply tests mocked the offline guard. This PR adds the concrete daemon refusal test. Follow-up source tracing found the stale attachment referent mapping and missing rebuild preflight, both covered by real source-table and public rebuild-entrypoint tests.

Ref polylogue-0v4tn
