### PR TITLE
fix(identity): preserve id-less revision and parent contracts (#3739)

### DIFF
--- a/polylogue/archive/session_revision_membership.py
+++ b/polylogue/archive/session_revision_membership.py
@@ -7,7 +7,7 @@ from typing import Literal, TypeAlias
 
 from polylogue.core.enums import PolylogueStrEnum
 from polylogue.core.timestamps import parse_timestamp
-from polylogue.pipeline.ids import SessionRevisionProjection
+from polylogue.pipeline.ids import MessageContent, SessionRevisionProjection
 
 
 class MembershipDecision(PolylogueStrEnum):
@@ -85,6 +85,37 @@ def _identities(contents: frozenset[tuple[bytes, bytes]]) -> frozenset[bytes]:
     return frozenset(identity for identity, _content in contents)
 
 
+def _message_identities(contents: frozenset[MessageContent]) -> frozenset[bytes]:
+    return frozenset(identity for identity, _content, _multiplicity in contents)
+
+
+def _message_axis_relation(contents_a: frozenset[MessageContent], contents_b: frozenset[MessageContent]) -> _Relation:
+    """Compare message content as an unordered multiset.
+
+    Reordering remains equivalent, while a repeated id-less message is an
+    additional persisted turn rather than a duplicate that set semantics can
+    erase. A shared identity carrying different content remains a conflict.
+    """
+    counts_a = {(identity, content): multiplicity for identity, content, multiplicity in contents_a}
+    counts_b = {(identity, content): multiplicity for identity, content, multiplicity in contents_b}
+    identities_a = _message_identities(contents_a)
+    identities_b = _message_identities(contents_b)
+    for identity in identities_a & identities_b:
+        content_values_a = {content for candidate_identity, content in counts_a if candidate_identity == identity}
+        content_values_b = {content for candidate_identity, content in counts_b if candidate_identity == identity}
+        if content_values_a != content_values_b:
+            return "conflict"
+    a_richer = bool(identities_a - identities_b) or any(count > counts_b.get(key, 0) for key, count in counts_a.items())
+    b_richer = bool(identities_b - identities_a) or any(count > counts_a.get(key, 0) for key, count in counts_b.items())
+    if a_richer and b_richer:
+        return "conflict"
+    if a_richer:
+        return "a_contains_b"
+    if b_richer:
+        return "b_contains_a"
+    return "equal"
+
+
 def _content_by_identity(contents: frozenset[tuple[bytes, bytes]]) -> dict[bytes, frozenset[bytes]]:
     """Group content hashes by identity, retaining EVERY value under a colliding identity.
 
@@ -152,9 +183,7 @@ def _relation(a: SessionRevisionProjection, b: SessionRevisionProjection) -> _Re
     any single axis already is.
     """
     axes = (
-        _axis_relation(
-            _identities(a.message_contents), a.message_contents, _identities(b.message_contents), b.message_contents
-        ),
+        _message_axis_relation(a.message_contents, b.message_contents),
         _axis_relation(a.attachment_identities, a.attachment_contents, b.attachment_identities, b.attachment_contents),
         _axis_relation(
             _identities(a.event_contents), a.event_contents, _identities(b.event_contents), b.event_contents
@@ -181,7 +210,7 @@ def _frontier(projection: SessionRevisionProjection) -> tuple[int, int, int, int
     the same cohort to the same head).
     """
     return (
-        len(projection.message_contents),
+        sum(multiplicity for _identity, _content, multiplicity in projection.message_contents),
         len(projection.event_contents),
         len(projection.attachment_identities),
         len(projection.attachment_contents),

--- a/polylogue/pipeline/ids.py
+++ b/polylogue/pipeline/ids.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import unicodedata
+from collections import Counter
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, TypeAlias
@@ -29,19 +30,20 @@ if TYPE_CHECKING:
 _NULL_SENTINEL = "__POLYLOGUE_NULL__"
 _EMPTY_SENTINEL = "__POLYLOGUE_EMPTY__"
 HashScalar: TypeAlias = str | int | float | bool | None
+MessageContent: TypeAlias = tuple[bytes, bytes, int]
 
 
 @dataclass(frozen=True, slots=True)
 class SessionRevisionProjection:
     """Canonical content-only comparison value for a session revision.
 
-    One invariant governs every field below: *a conversation is a SET of
-    items keyed by content-derived identity, each carrying only
+    One invariant governs every field below: *a conversation is an unordered
+    collection of items keyed by content-derived identity, each carrying only
     content-bearing fields -- nothing else may enter the value used to
     compare two acquisitions of it* (polylogue-aggz). Concretely:
 
     - Identity is never array position. ``message_contents``,
-      ``attachment_contents``, and ``event_contents`` are ``frozenset``s, not
+      ``attachment_contents``, and ``event_contents`` are unordered, not
       ordered tuples -- a provider's export can replay an unchanged item set
       in a different array sequence across separate export requests (proven
       for Claude.ai messages and ChatGPT ``generation_lifecycle`` events:
@@ -92,7 +94,10 @@ class SessionRevisionProjection:
 
     session_hash: bytes
     message_hashes: tuple[bytes, ...]
-    message_contents: frozenset[tuple[bytes, bytes]]
+    # Each item carries its unordered multiplicity. Repeated timestamp-less
+    # id-less messages can have the same content-derived identity and content;
+    # collapsing them into a set would falsely make one and two turns equal.
+    message_contents: frozenset[MessageContent]
     attachment_identities: frozenset[bytes]
     attachment_contents: frozenset[tuple[bytes, bytes]]
     event_hashes: tuple[bytes, ...]
@@ -329,11 +334,18 @@ def attachment_identity_hash(*, message_id: JSONValue, name: JSONValue, mime_typ
     return bytes.fromhex(hash_payload({"message_id": message_id, "name": name, "mime_type": mime_type}))
 
 
-def _attachment_hash_payload(attachment: ParsedAttachment) -> dict[str, JSONValue]:
+def _attachment_hash_payload(
+    attachment: ParsedAttachment, *, message_owner_anchor: str | None = None
+) -> dict[str, JSONValue]:
     """Build attachment identity without perturbing legacy metadata-only hashes."""
+    owner_id = (
+        message_owner_anchor
+        if not attachment.message_provider_id and message_owner_anchor
+        else attachment.message_provider_id
+    )
     payload: dict[str, JSONValue] = {
         "id": _normalize_for_hash(attachment.provider_attachment_id),
-        "message_id": _normalize_for_hash(attachment.message_provider_id),
+        "message_id": _normalize_for_hash(owner_id),
         "name": _normalize_for_hash(attachment.name),
         "mime_type": _normalize_for_hash(attachment.mime_type),
         "size_bytes": _normalize_for_hash(attachment.size_bytes),
@@ -510,10 +522,27 @@ def _session_hash_components(
     caller re-deriving its own copy. Byte-identical to computing each
     payload independently -- pure sharing of an already-pure computation.
     """
+    message_comparison_ids = [_message_comparison_id(msg, idx) for idx, msg in enumerate(convo.messages, start=1)]
     messages_payload = [
-        _message_hash_payload(msg, _message_comparison_id(msg, idx)) for idx, msg in enumerate(convo.messages, start=1)
+        _message_hash_payload(message, comparison_id)
+        for message, comparison_id in zip(convo.messages, message_comparison_ids, strict=True)
     ]
-    attachments_payload = [_attachment_hash_payload(attachment) for attachment in convo.attachments]
+    owner_anchor_by_position = {
+        message.position: comparison_id
+        for message, comparison_id in zip(convo.messages, message_comparison_ids, strict=True)
+        if message.position is not None
+    }
+    attachments_payload = [
+        _attachment_hash_payload(
+            attachment,
+            message_owner_anchor=(
+                owner_anchor_by_position.get(attachment.message_position)
+                if attachment.message_position is not None
+                else None
+            ),
+        )
+        for attachment in convo.attachments
+    ]
     session_events_payload = [
         {
             "event_index": event_index,
@@ -597,14 +626,14 @@ def session_revision_projection(convo: ParsedSession) -> SessionRevisionProjecti
         attachments_payload=attachments_payload,
         session_events_payload=session_events_payload,
     )
-    message_contents: set[tuple[bytes, bytes]] = set()
+    message_content_counts: Counter[tuple[bytes, bytes]] = Counter()
     message_hashes: list[bytes] = []
     for payload in messages_payload:
         message_native_id = payload["id"]
         assert isinstance(message_native_id, str)  # built as str above, never anything else
         identity = message_identity_hash(id=message_native_id)
         content = bytes.fromhex(hash_payload(payload))
-        message_contents.add((identity, content))
+        message_content_counts[(identity, content)] += 1
         message_hashes.append(content)
     attachment_identities: set[bytes] = set()
     attachment_contents: set[tuple[bytes, bytes]] = set()
@@ -653,7 +682,9 @@ def session_revision_projection(convo: ParsedSession) -> SessionRevisionProjecti
     return SessionRevisionProjection(
         session_hash=bytes.fromhex(session_hash_hex),
         message_hashes=tuple(message_hashes),
-        message_contents=frozenset(message_contents),
+        message_contents=frozenset(
+            (identity, content, multiplicity) for (identity, content), multiplicity in message_content_counts.items()
+        ),
         attachment_identities=frozenset(attachment_identities),
         attachment_contents=frozenset(attachment_contents),
         event_hashes=tuple(event_hashes),

--- a/polylogue/sources/parsers/base_models.py
+++ b/polylogue/sources/parsers/base_models.py
@@ -145,6 +145,11 @@ class ParsedMessage(BaseModel):
     message_type: MessageType = MessageType.MESSAGE
     material_origin: MaterialOrigin = MaterialOrigin.UNKNOWN
     parent_message_provider_id: str | None = None
+    # Parser-local linkage for a parent that has no provider-issued id. The
+    # writer resolves this coordinate against this parsed batch, then stores
+    # only the resulting archive message id. It is never provider identity or
+    # persisted parser data.
+    parent_message_position: int | None = Field(default=None, exclude=True, repr=False)
     position: int | None = None
     branch_index: int = 0
     variant_index: int | None = None
@@ -192,7 +197,7 @@ class ParsedMessage(BaseModel):
     def coerce_material_origin(cls, v: object) -> MaterialOrigin:
         return MaterialOrigin.normalize(v)
 
-    @field_validator("occurred_at_ms", "position", "variant_index", "duration_ms")
+    @field_validator("occurred_at_ms", "parent_message_position", "position", "variant_index", "duration_ms")
     @classmethod
     def non_negative_optional_int(cls, value: int | None) -> int | None:
         if value is not None and value < 0:

--- a/polylogue/sources/parsers/base_support.py
+++ b/polylogue/sources/parsers/base_support.py
@@ -85,7 +85,7 @@ def synthetic_message_id(
 
 
 def fill_linear_parent_chain(messages: Sequence[ParsedMessage]) -> list[ParsedMessage]:
-    """Backfill ``parent_message_provider_id`` for a strictly linear message list.
+    """Backfill linear parent evidence for a strictly linear message list.
 
     bd polylogue-ksgg: five of nine archive origins (Codex, Hermes, Gemini
     CLI, Grok, and AI Studio Drive's non-branch path) never assert an
@@ -108,13 +108,18 @@ def fill_linear_parent_chain(messages: Sequence[ParsedMessage]) -> list[ParsedMe
     it to.
     """
     filled: list[ParsedMessage] = []
-    previous_active_id: str | None = None
+    previous_active_message: ParsedMessage | None = None
     for message in messages:
-        if message.parent_message_provider_id is None and previous_active_id is not None:
-            message = message.model_copy(update={"parent_message_provider_id": previous_active_id})
+        if message.parent_message_provider_id is None and previous_active_message is not None:
+            if previous_active_message.provider_message_id:
+                message = message.model_copy(
+                    update={"parent_message_provider_id": previous_active_message.provider_message_id}
+                )
+            elif previous_active_message.position is not None:
+                message = message.model_copy(update={"parent_message_position": previous_active_message.position})
         filled.append(message)
         if message.is_active_path is not False:
-            previous_active_id = message.provider_message_id
+            previous_active_message = message
     return filled
 
 

--- a/polylogue/sources/parsers/drive.py
+++ b/polylogue/sources/parsers/drive.py
@@ -499,11 +499,19 @@ def parse_chunked_prompt(provider: Provider | str, payload: JSONDocument, fallba
     by_position = {id(message): position for position, message in enumerate(messages)}
     temporally_sorted = sorted(messages, key=lambda message: (message.timestamp or "", by_position[id(message)]))
     filled_sorted = fill_linear_parent_chain(temporally_sorted)
-    parent_by_id = {message.provider_message_id: message.parent_message_provider_id for message in filled_sorted}
+    parent_by_position = {
+        message.position: (message.parent_message_provider_id, message.parent_message_position)
+        for message in filled_sorted
+    }
     messages = [
         message
         if message.provider_message_id in ambiguous_branch_child_ids
-        else message.model_copy(update={"parent_message_provider_id": parent_by_id.get(message.provider_message_id)})
+        else message.model_copy(
+            update={
+                "parent_message_provider_id": parent_by_position[message.position][0],
+                "parent_message_position": parent_by_position[message.position][1],
+            }
+        )
         for message in messages
     ]
     return ParsedSession(

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -3520,10 +3520,23 @@ def _write_parent_links(
         for fallback_position, message in enumerate(messages)
         if message.provider_message_id and message.provider_message_id not in duplicate_native_ids
     }
+    by_message_position = {
+        message.position: _message_id(
+            session_id,
+            message,
+            fallback_position,
+            position_offset=position_offset,
+            duplicate_native_ids=duplicate_native_ids,
+        )
+        for fallback_position, message in enumerate(messages)
+        if message.position is not None
+    }
     for fallback_position, message in enumerate(messages):
-        if not message.parent_message_provider_id:
-            continue
-        parent_message_id = by_native_id.get(message.parent_message_provider_id)
+        parent_message_id = (
+            by_native_id.get(message.parent_message_provider_id) if message.parent_message_provider_id else None
+        )
+        if parent_message_id is None and message.parent_message_position is not None:
+            parent_message_id = by_message_position.get(message.parent_message_position)
         if parent_message_id is None:
             continue
         conn.execute(

--- a/tests/unit/pipeline/test_message_identity_position_fallback.py
+++ b/tests/unit/pipeline/test_message_identity_position_fallback.py
@@ -21,6 +21,7 @@ fallback ids matched.
 from __future__ import annotations
 
 from polylogue.archive.message.roles import Role
+from polylogue.archive.session_revision_membership import MembershipRevision, classify_membership_revisions
 from polylogue.core.enums import Provider
 from polylogue.pipeline.ids import session_revision_projection
 from polylogue.sources.parsers.base import ParsedMessage, ParsedSession
@@ -81,3 +82,19 @@ def test_id_less_and_timestamp_less_message_uses_content_anchor() -> None:
     reordered = session_revision_projection(_session([bare, keyed]))
 
     assert forward.message_contents == reordered.message_contents
+
+
+def test_timestamp_less_idless_duplicates_preserve_unordered_multiplicity() -> None:
+    repeated = _id_less("assistant", "repeat", None)
+    one = session_revision_projection(_session([repeated]))
+    two = session_revision_projection(_session([repeated, repeated]))
+
+    assert sum(count for _identity, _content, count in one.message_contents) == 1
+    assert sum(count for _identity, _content, count in two.message_contents) == 2
+
+    classification = classify_membership_revisions(
+        [MembershipRevision(raw_id="one", projection=one), MembershipRevision(raw_id="two", projection=two)]
+    )
+    assert classification.accepted_raw_ids == ("one", "two")
+    assert not classification.equivalent_raw_ids
+    assert not classification.ambiguous_raw_ids

--- a/tests/unit/sources/test_parsers_codex.py
+++ b/tests/unit/sources/test_parsers_codex.py
@@ -6,16 +6,22 @@ branch tracking, git context, and edge cases.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from pathlib import Path
 from typing import Any, cast
 
 from polylogue.archive.message.types import MessageType
 from polylogue.archive.session.branch_type import BranchType
+from polylogue.archive.session_revision_membership import MembershipRevision, classify_membership_revisions
 from polylogue.core.enums import BlockType, MaterialOrigin, Role
-from polylogue.pipeline.ids import session_revision_projection
+from polylogue.pipeline.ids import session_content_hash, session_revision_projection
 from polylogue.sources.parsers.base import ParsedSession
 from polylogue.sources.parsers.codex import _tool_input_from_arguments, parse_stream
 from polylogue.sources.parsers.codex import looks_like as _looks_like_impl
 from polylogue.sources.parsers.codex import parse as _parse_impl
+from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
+from polylogue.storage.sqlite.connection import open_connection
+from tests.infra.storage_records import db_setup
 
 
 def looks_like(payload: object) -> bool:
@@ -561,6 +567,61 @@ class TestMessageParsing:
         assert result.messages[0].provider_message_id == result.messages[1].provider_message_id
         assert sum(message.is_active_leaf is True for message in result.messages) == 1
         assert result.messages[-1].is_active_leaf is True
+
+    def test_timestamp_less_duplicate_reasoning_is_membership_growth(self) -> None:
+        record = {
+            "type": "response_item",
+            "payload": {"type": "reasoning", "summary": [{"type": "summary_text", "text": "Repeat"}]},
+        }
+        one = parse([record], "codex-duplicate-membership")
+        two = parse([record, record], "codex-duplicate-membership")
+
+        classification = classify_membership_revisions(
+            [
+                MembershipRevision(raw_id="one", projection=session_revision_projection(one)),
+                MembershipRevision(raw_id="two", projection=session_revision_projection(two)),
+            ]
+        )
+
+        assert classification.accepted_raw_ids == ("one", "two")
+        assert not classification.equivalent_raw_ids
+
+    def test_idless_linear_turns_resolve_parent_coordinates_in_archive(self, workspace_env: Mapping[str, Path]) -> None:
+        result = parse(
+            [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "content": [{"type": "input_text", "text": "one"}],
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "timestamp": "2026-01-01T00:00:01Z",
+                    "content": [{"type": "output_text", "text": "two"}],
+                },
+                {
+                    "type": "message",
+                    "role": "user",
+                    "timestamp": "2026-01-01T00:00:02Z",
+                    "content": [{"type": "input_text", "text": "three"}],
+                },
+            ],
+            "codex-idless-parent-chain",
+        )
+
+        assert [message.provider_message_id for message in result.messages] == ["", "", ""]
+        assert [message.parent_message_position for message in result.messages] == [None, 0, 1]
+
+        with open_connection(db_setup(workspace_env)) as conn:
+            write_parsed_session_to_archive(conn, result, content_hash=session_content_hash(result))
+            rows = conn.execute(
+                "SELECT message_id, native_id, parent_message_id FROM messages ORDER BY position"
+            ).fetchall()
+
+        assert [row["native_id"] for row in rows] == [None, None, None]
+        assert [row["parent_message_id"] for row in rows] == [None, rows[0]["message_id"], rows[1]["message_id"]]
 
     def test_reasoning_with_only_encrypted_content_still_recorded(self) -> None:
         """No recoverable text (summary absent, content null) -- the block

--- a/tests/unit/sources/test_parsers_drive.py
+++ b/tests/unit/sources/test_parsers_drive.py
@@ -260,6 +260,65 @@ def test_parse_chunked_prompt_idless_attachment_survives_archive_write(workspace
         assert conn.execute("SELECT COUNT(*) FROM attachment_refs").fetchone()[0] == 1
 
 
+def test_parse_chunked_prompt_idless_turns_resolve_parent_coordinates_in_archive(
+    workspace_env: Mapping[str, Path],
+) -> None:
+    result = parse_chunked_prompt(
+        "gemini",
+        {
+            "id": "gemini-idless-parent-chain",
+            "chunkedPrompt": {
+                "chunks": [
+                    {"role": "user", "text": "one", "createTime": "2026-01-01T00:00:00Z"},
+                    {"role": "model", "text": "two", "createTime": "2026-01-01T00:00:01Z"},
+                    {"role": "user", "text": "three", "createTime": "2026-01-01T00:00:02Z"},
+                ]
+            },
+        },
+        "fallback",
+    )
+
+    assert [message.provider_message_id for message in result.messages] == ["", "", ""]
+    assert [message.parent_message_position for message in result.messages] == [None, 0, 1]
+
+    with open_connection(db_setup(workspace_env)) as conn:
+        write_and_hydrate(PipelineRoundtrip(result, session_content_hash(result)), conn)
+        rows = conn.execute(
+            "SELECT message_id, native_id, parent_message_id FROM messages ORDER BY position"
+        ).fetchall()
+
+    assert [row["native_id"] for row in rows] == [None, None, None]
+    assert [row["parent_message_id"] for row in rows] == [None, rows[0]["message_id"], rows[1]["message_id"]]
+
+
+def test_idless_drive_attachment_owner_changes_hash_and_revision_identity() -> None:
+    first: JSONDocument = {"role": "user", "text": "first", "createTime": "2026-01-01T00:00:00Z"}
+    second: JSONDocument = {"role": "model", "text": "second", "createTime": "2026-01-01T00:00:01Z"}
+    attachment: JSONDocument = {"id": "drive-doc", "name": "note.txt", "mimeType": "text/plain"}
+    first_owner = parse_chunked_prompt(
+        "gemini",
+        {
+            "id": "gemini-idless-attachment-owner",
+            "chunkedPrompt": {"chunks": [{**first, "driveDocument": attachment}, second]},
+        },
+        "fallback",
+    )
+    second_owner = parse_chunked_prompt(
+        "gemini",
+        {
+            "id": "gemini-idless-attachment-owner",
+            "chunkedPrompt": {"chunks": [first, {**second, "driveDocument": attachment}]},
+        },
+        "fallback",
+    )
+
+    first_projection = session_revision_projection(first_owner)
+    second_projection = session_revision_projection(second_owner)
+
+    assert session_content_hash(first_owner) != session_content_hash(second_owner)
+    assert first_projection.attachment_identities != second_projection.attachment_identities
+
+
 def test_parse_chunked_prompt_persists_run_settings_verbatim() -> None:
     """runSettings (polylogue-2qx.4 / polylogue-cgfy) must reach ``ParsedSession.run_settings``.
 


### PR DESCRIPTION
## Summary

Repairs the reopened id-less identity contract while preserving #3730’s removal of positional provider ids.

## Problem

Revision comparison erased duplicate timestamp-less synthetic messages, parser-local linear parent links vanished when an id was empty, and Drive attachment ownership could not distinguish id-less message targets.

## Solution

`SessionRevisionProjection` now records unordered message multiplicity. `ParsedMessage.parent_message_position` is transient parser-to-writer linkage, resolved to an archive parent id without persisting a provider id. Drive attachment hashes use the owning message’s stable comparison anchor when the attachment is associated through `message_position`.

## Acceptance criteria

| Criterion | Evidence |
| --- | --- |
| Repeated timestamp-less synthetic messages retain multiplicity | One-versus-two Codex reasoning records classify as ordered membership growth. |
| Id-less Codex and Drive chains retain parent links | Three chronological turns in each parser are written with two resolved archive parent links and no native ids. |
| Drive attachment ownership affects identity | Moving one stable Drive document between id-less messages changes both session content hash and attachment revision identity. |

## Verification

- `direnv exec . devtools test tests/unit/pipeline/test_message_identity_position_fallback.py tests/unit/sources/test_parsers_codex.py tests/unit/sources/test_parsers_drive.py`
  - `137 passed in 1.69s`
- `direnv exec . devtools verify --quick`
  - quick receipt `20260804T063848Z-quick-1363543-53069d7f` recorded `status: success`.

No stamp schema, unrelated provider parser, Beads state, source database, or index database was changed.