### PR TITLE
test(infra): compose pathologies with raw ingestion order

### DIFF
--- a/tests/infra/pathology_composer.py
+++ b/tests/infra/pathology_composer.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any
 
 from polylogue.archive.models import Session
@@ -55,6 +55,71 @@ class ComposedPathology:
     sessions: tuple[Session, ...] = ()
     raw_payloads: tuple[object, ...] = ()
     metadata: Mapping[str, object] = field(default_factory=dict)
+    components: tuple[ComposedPathology, ...] = ()
+    raw_ingestion_order: tuple[int, ...] | None = None
+
+    def __post_init__(self) -> None:
+        """Normalize and validate the raw sequence a harness will ingest."""
+        order = self.raw_ingestion_order
+        if order is None:
+            order = tuple(range(len(self.raw_payloads)))
+            object.__setattr__(self, "raw_ingestion_order", order)
+
+        expected = tuple(range(len(self.raw_payloads)))
+        if len(order) != len(expected) or not all(type(index) is int for index in order) or set(order) != set(expected):
+            raise ValueError("raw_ingestion_order must be a permutation of raw_payloads indexes")
+
+    @property
+    def raw_payloads_in_ingestion_order(self) -> tuple[object, ...]:
+        """Return raw payloads in the deterministic order a harness should ingest."""
+        assert self.raw_ingestion_order is not None
+        return tuple(self.raw_payloads[index] for index in self.raw_ingestion_order)
+
+    def with_raw_ingestion_order(self, raw_ingestion_order: Sequence[int]) -> ComposedPathology:
+        """Return this arrangement with a different deterministic raw ingest order."""
+        return replace(self, raw_ingestion_order=tuple(raw_ingestion_order))
+
+    def compose(
+        self,
+        *pathologies: ComposedPathology,
+        name: str | None = None,
+        raw_ingestion_order: Sequence[int] | None = None,
+    ) -> ComposedPathology:
+        """Nest this arrangement with others without introducing a corpus DSL."""
+        return compose_pathologies(
+            self,
+            *pathologies,
+            name=name,
+            raw_ingestion_order=raw_ingestion_order,
+        )
+
+
+def compose_pathologies(
+    *pathologies: ComposedPathology,
+    name: str | None = None,
+    raw_ingestion_order: Sequence[int] | None = None,
+) -> ComposedPathology:
+    """Combine existing arrangements and optionally permute their raw ingestion.
+
+    The result retains each direct component for inspection while exposing its
+    sessions and raw payloads as one flat corpus. ``raw_ingestion_order`` is a
+    permutation over that flat raw-payload sequence, so a metamorphic test can
+    feed the same artifacts through the real ingestion path under many orders.
+    """
+    if not pathologies:
+        raise ValueError("compose_pathologies requires at least one pathology")
+
+    component_names = tuple(pathology.name for pathology in pathologies)
+    return ComposedPathology(
+        name=name if name is not None else "+".join(component_names),
+        pathology="+".join(pathology.pathology for pathology in pathologies),
+        motivated_by="; ".join(pathology.motivated_by for pathology in pathologies),
+        description=f"Composition of archive pathologies: {', '.join(component_names)}.",
+        sessions=tuple(session for pathology in pathologies for session in pathology.sessions),
+        raw_payloads=tuple(payload for pathology in pathologies for payload in pathology.raw_payloads),
+        components=pathologies,
+        raw_ingestion_order=None if raw_ingestion_order is None else tuple(raw_ingestion_order),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -454,6 +519,7 @@ def extract_new_shape_turns(payload: JSONRecord) -> list[tuple[str, str]]:
 
 __all__ = [
     "ComposedPathology",
+    "compose_pathologies",
     "compose_append_revision_chain",
     "compose_fork_prefix_tail_lineage",
     "compose_multi_session_bundle",

--- a/tests/infra/test_pathology_composer.py
+++ b/tests/infra/test_pathology_composer.py
@@ -1,9 +1,8 @@
 """Tests proving each pathology composer's claimed structural property.
 
-These are pure structural assertions on the returned ``ComposedPathology``
-(no archive/database writes) -- see the module docstring in
-``pathology_composer.py`` for why a live write is not required to prove the
-claimed shape.
+These are structural assertions on returned ``ComposedPathology`` values. The
+composer is the test-infrastructure route that supplies ordered raw payloads
+to future production-ingestion metamorphic tests.
 """
 
 from __future__ import annotations
@@ -17,6 +16,7 @@ from tests.infra.pathology_composer import (
     compose_append_revision_chain,
     compose_fork_prefix_tail_lineage,
     compose_multi_session_bundle,
+    compose_pathologies,
     compose_quarantined_head_arrangement,
     compose_vintage_variant_pair,
     compose_whale_scale_component,
@@ -220,6 +220,38 @@ def test_vintage_variant_pair_extracted_content_is_equal_despite_shape_differenc
     new_turns = extract_new_shape_turns(new_shape)
 
     assert old_turns == new_turns == list(turns)
+
+
+# ---------------------------------------------------------------------------
+# Composition and ingestion order
+# ---------------------------------------------------------------------------
+
+
+def test_composition_nests_existing_pathologies_and_orders_flat_raw_payloads() -> None:
+    bundle = compose_multi_session_bundle([{"record": 1}, {"record": 2}], session_count=2)
+    variants = compose_vintage_variant_pair()
+    nested = compose_pathologies(bundle, variants, name="raw-shapes")
+    composed = compose_append_revision_chain(session_id="nested-append", revision_count=2).compose(
+        nested,
+        raw_ingestion_order=(2, 0, 1),
+    )
+
+    assert composed.components == (compose_append_revision_chain(session_id="nested-append", revision_count=2), nested)
+    assert nested.components == (bundle, variants)
+    assert composed.raw_ingestion_order == (2, 0, 1)
+    assert composed.raw_payloads_in_ingestion_order == (
+        variants.raw_payloads[1],
+        bundle.raw_payloads[0],
+        variants.raw_payloads[0],
+    )
+
+
+@pytest.mark.parametrize("order", [(0, 0), (0,), (0, 2), ("0", 1)])
+def test_raw_ingestion_order_must_be_a_complete_index_permutation(order: tuple[object, ...]) -> None:
+    pathology = compose_vintage_variant_pair()
+
+    with pytest.raises(ValueError, match="permutation"):
+        pathology.with_raw_ingestion_order(order)  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add a small immutable composition layer for archive pathology fixtures.

## Problem

Existing pathology composers produced isolated outputs. The reindex metamorphic suite could neither nest those outputs nor deterministically vary the order in which their raw payloads arrive.

## Solution

`ComposedPathology` now retains direct components, flattens their sessions and raw payloads for existing consumers, and validates an optional raw-payload permutation. `compose_pathologies(...)` and the instance `compose(...)` method support nesting without a DSL. `raw_payloads_in_ingestion_order` is the ordered value a future rrxe4 production-ingestion loop consumes.

## Acceptance criteria

| Criterion | Result |
| --- | --- |
| Existing pathologies can compose and nest | Satisfied by `compose_pathologies(...)`, `ComposedPathology.compose(...)`, and nested-composition coverage. |
| Raw ingestion order is deterministic and parameterized | Satisfied by validated `raw_ingestion_order` and `raw_payloads_in_ingestion_order`. |
| Avoid a speculative general DSL | Satisfied. The change is a single immutable data composition operation. |

Ref polylogue-un60n.

## Verification

`source .venv/bin/activate && devtools test tests/infra/test_pathology_composer.py`

`31 passed in 1.00s`

`source .venv/bin/activate && devtools verify --quick`

Completed with exit code 0 across formatting, Ruff, mypy, render, layering, manifests, and policy checks. The default affected-test verification was not run because this lane has no seeded testmon graph; it refused before running tests.

## Anti-vacuity

The regression exercises the actual `ComposedPathology` composition and raw-ingestion-sequence API that rrxe4 will pass into its production ingestion loop. It does not reimplement ordering in the test. Before this change, importing `compose_pathologies` raised `ImportError`; removing the flattening or permutation application makes the asserted raw sequence fail, while removing validation makes the invalid-permutation cases fail.