### PR TITLE
feat(maintenance): add reindex canary gate

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -393,6 +393,17 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         featured=True,
     ),
     CommandSpec(
+        "reindex-canary",
+        "verification",
+        "Run the product's representative inactive-generation reindex canary.",
+        "devtools.reindex_canary",
+        use_when="Exercise the bounded semantic reindex canary before paying for a full rebuild.",
+        examples=(
+            "devtools reindex-canary --input /path/to/index.db --sample 100 --report /path/to/canary.json --no-promote",
+            "devtools reindex-canary --pathology-session-id codex-session:whale --report /path/to/canary.json --no-promote",
+        ),
+    ),
+    CommandSpec(
         "verify coverage",
         "verification",
         "Run pytest with the repository coverage floor from pyproject.toml.",

--- a/devtools/reindex_canary.py
+++ b/devtools/reindex_canary.py
@@ -1,0 +1,28 @@
+"""Developer-tool adapter for the product reindex canary command."""
+
+from __future__ import annotations
+
+import sys
+
+from devtools.cli_boundary import invoke_polylogue_cli
+from polylogue.scenarios import polylogue_execution
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Delegate to the real product CLI without reimplementing rebuild logic."""
+
+    forwarded = list(argv or ())
+    if "--json" in forwarded:
+        forwarded.remove("--json")
+        if "--output-format" not in forwarded:
+            forwarded.extend(("--output-format", "json"))
+    result = invoke_polylogue_cli(
+        polylogue_execution("ops", "maintenance", "reindex-canary", *forwarded),
+    )
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+    return result.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -180,6 +180,7 @@ These are the commands worth remembering during normal repo work:
 
 | Command | Description |
 | --- | --- |
+| `devtools reindex-canary` | Run the product's representative inactive-generation reindex canary. |
 | `devtools test` | Run a focused pytest selection through the managed harness. |
 | `devtools verify` | Run the local verification baseline before pushing or creating a PR. |
 | `devtools verify agent-integration` | Verify manual compilation, parser examples, continuation, native delivery, packaging, and live cutover signatures. |

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -288,6 +288,19 @@ polylogue ops maintenance blob-reference-prune-orphans \
   --quarantine-file /tmp/quarantine.jsonl --output-format json
 ```
 
+### `polylogue ops maintenance reindex-canary` — inactive-generation semantic diff
+
+Read-only with respect to the active index. Before a full reindex, this command selects a bounded representative set of sessions, rebuilds those raws into an inactive generation, and diffs the resulting sessions, messages, blocks, links, and derived rows against the active generation. It requires `--no-promote`, writes a durable report, and refuses a report with unclassified differences. Treat every difference as either an expected effect of a named repair or a newly discovered defect. It is a preflight gate, not a replacement for the full managed rebuild.
+
+```bash
+polylogue ops maintenance reindex-canary \
+  --input /realm/db/polylogue/index.db \
+  --sample 100 \
+  --report /realm/tmp/polylogue-reindex-canary.json \
+  --no-promote \
+  --output-format json
+```
+
 ### `polylogue ops maintenance verify-archive` — coherence gate
 
 Read-only. Runs a fixed registry of independent checks over the whole

--- a/docs/plans/docs-coverage-baseline.yaml
+++ b/docs/plans/docs-coverage-baseline.yaml
@@ -48,8 +48,6 @@ gaps:
       reason: "pre-existing gap at gate introduction (polylogue-3tl.9); needs a doc entry, not baseline growth"
     - name: 'ops maintenance attachment-acquisition-debt'
       reason: "pre-existing gap at gate introduction (polylogue-3tl.9); needs a doc entry, not baseline growth"
-    - name: 'ops maintenance backup-plan'
-      reason: "pre-existing gap at gate introduction (polylogue-3tl.9); needs a doc entry, not baseline growth"
     - name: 'ops maintenance blob-gc'
       reason: "pre-existing gap at gate introduction (polylogue-3tl.9); needs a doc entry, not baseline growth"
     - name: 'ops maintenance blob-reference-recovery-plan'

--- a/docs/plans/docs-coverage-baseline.yaml
+++ b/docs/plans/docs-coverage-baseline.yaml
@@ -52,11 +52,7 @@ gaps:
       reason: "pre-existing gap at gate introduction (polylogue-3tl.9); needs a doc entry, not baseline growth"
     - name: 'ops maintenance blob-gc'
       reason: "pre-existing gap at gate introduction (polylogue-3tl.9); needs a doc entry, not baseline growth"
-    - name: 'ops maintenance blob-reference-prune-orphans'
-      reason: "pre-existing gap at gate introduction (polylogue-3tl.9); needs a doc entry, not baseline growth"
     - name: 'ops maintenance blob-reference-recovery-plan'
-      reason: "pre-existing gap at gate introduction (polylogue-3tl.9); needs a doc entry, not baseline growth"
-    - name: 'ops maintenance blob-reference-replace-from-source'
       reason: "pre-existing gap at gate introduction (polylogue-3tl.9); needs a doc entry, not baseline growth"
     - name: 'ops maintenance browser-canonical-authority-conflicts'
       reason: "pre-existing gap at gate introduction (polylogue-3tl.9); missed in the initial baseline sweep, not a new surface"

--- a/polylogue/cli/commands/maintenance/__init__.py
+++ b/polylogue/cli/commands/maintenance/__init__.py
@@ -66,6 +66,12 @@ _COMMANDS: tuple[tuple[str, str, str, str], ...] = (
         "Report consolidated raw-replay rebuild status (lease/generation/cursor/delta/recovery). Read-only.",
     ),
     (
+        "reindex-canary",
+        "_reindex_canary",
+        "reindex_canary_command",
+        "Replay a representative inactive canary and persist its reviewed diff report.",
+    ),
+    (
         "raw-authority-frontier",
         "_raw_identity",
         "raw_authority_frontier_command",

--- a/polylogue/cli/commands/maintenance/_reindex_canary.py
+++ b/polylogue/cli/commands/maintenance/_reindex_canary.py
@@ -1,0 +1,110 @@
+"""Run a bounded semantic reindex canary through the existing rebuild service."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+
+from polylogue.paths import archive_root
+
+
+@click.command("reindex-canary")
+@click.option(
+    "--input-index",
+    "--input",
+    "input_index",
+    type=click.Path(path_type=Path, exists=True, dir_okay=False, readable=True),
+    default=None,
+    help="Explicit active index.db to compare and select from. Defaults to the configured active index.",
+)
+@click.option(
+    "--sessions-per-origin",
+    "--sample",
+    "sessions_per_origin",
+    type=int,
+    default=100,
+    show_default=True,
+    help="Newest replayable sessions selected automatically for each origin.",
+)
+@click.option(
+    "--pathology-session-id",
+    multiple=True,
+    help="Explicit pathology session_id to include. May be supplied multiple times.",
+)
+@click.option(
+    "--sample-session-id",
+    multiple=True,
+    help="Explicit sample session_id to include. May be supplied multiple times.",
+)
+@click.option(
+    "--report",
+    "report_path",
+    type=click.Path(path_type=Path, dir_okay=False),
+    required=True,
+    help="Destination for the reviewed canary report.",
+)
+@click.option("--output-format", type=click.Choice(["plain", "json"]), default="plain", show_default=True)
+@click.option(
+    "--no-promote",
+    is_flag=True,
+    help="Required safety gate: leave the rebuilt candidate inactive for comparison.",
+)
+def reindex_canary_command(
+    input_index: Path | None,
+    sessions_per_origin: int,
+    pathology_session_id: tuple[str, ...],
+    sample_session_id: tuple[str, ...],
+    report_path: Path,
+    output_format: str,
+    no_promote: bool,
+) -> None:
+    """Replay representative raw inputs into an inactive generation and compare it."""
+
+    if not no_promote:
+        raise click.UsageError("reindex-canary requires --no-promote")
+    if sessions_per_origin <= 0:
+        raise click.BadParameter("sample size must be positive", param_hint="--sessions-per-origin")
+
+    from polylogue.maintenance.reindex_canary import (
+        CanaryRunResult,
+        UnclassifiedCanaryDiffError,
+        run_reindex_canary,
+        write_canary_report,
+    )
+
+    result: CanaryRunResult | None = None
+    try:
+        result = run_reindex_canary(
+            archive_root(),
+            input_index=input_index,
+            sessions_per_origin=sessions_per_origin,
+            pathology_session_ids=pathology_session_id,
+            sample_session_ids=sample_session_id,
+            no_promote=no_promote,
+        )
+        durable = write_canary_report(
+            report_path,
+            selection=result.selection,
+            comparison=result.comparison,
+            reviews=(),
+        )
+    except UnclassifiedCanaryDiffError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if result is None:
+        raise click.ClickException("reindex canary produced no run result")
+    payload = durable.to_dict()
+    if output_format == "json":
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    click.echo(f"Selected:     {len(result.selection.selected_raw_ids):,} raw row(s)")
+    click.echo(f"Compared:     {len(result.comparison.differences):,} difference(s)")
+    click.echo(f"Classified:   {durable.unclassified_count == 0}")
+    click.echo(f"Report:       {report_path}")
+
+
+__all__ = ["reindex_canary_command"]

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -70,7 +70,9 @@ class ExpectedDifference:
             return False
         if self.operations and operation not in self.operations:
             return False
-        return not self.columns or bool(set(self.columns).intersection(changed_columns))
+        if not self.columns:
+            return True
+        return bool(changed_columns) and set(changed_columns).issubset(self.columns)
 
 
 @dataclass(frozen=True, slots=True)
@@ -108,6 +110,7 @@ class CanaryDiffReport:
     session_ids: tuple[str, ...]
     compared_tables: tuple[str, ...]
     missing_tables: tuple[str, ...]
+    missing_columns: tuple[tuple[str, tuple[str, ...]], ...]
     differences: tuple[RowDifference, ...]
 
     @property
@@ -135,6 +138,7 @@ class CanaryDiffReport:
             "session_ids": list(self.session_ids),
             "compared_tables": list(self.compared_tables),
             "missing_tables": list(self.missing_tables),
+            "missing_columns": [{"table": table, "columns": list(columns)} for table, columns in self.missing_columns],
             "summary": {
                 "difference_count": len(self.differences),
                 "expected_count": self.expected_count,
@@ -520,8 +524,60 @@ def compare_reindex_generations(
         candidate_tables = _read_model_tables(candidate)
         compared_tables = tuple(sorted(current_tables.intersection(candidate_tables)))
         missing_tables = tuple(sorted(current_tables.symmetric_difference(candidate_tables)))
+        schema_differences: list[RowDifference] = []
+        missing_columns: list[tuple[str, tuple[str, ...]]] = []
+        for table in missing_tables:
+            current_present = table in current_tables
+            current_columns = _table_columns(current, table) if current_present else ()
+            candidate_columns = _table_columns(candidate, table) if table in candidate_tables else ()
+            operation = DifferenceOperation.REMOVED if current_present else DifferenceOperation.ADDED
+            changed_columns = tuple(sorted(set(current_columns).union(candidate_columns)))
+            before = {"table": table, "columns": list(current_columns)} if current_present else None
+            after = {"table": table, "columns": list(candidate_columns)} if table in candidate_tables else None
+            schema_differences.append(
+                _build_difference(
+                    table=table,
+                    operation=operation,
+                    identity=(("__schema__", "table"),),
+                    before=before,
+                    after=after,
+                    changed_columns=changed_columns,
+                    expected=reviewed,
+                )
+            )
+        for table in compared_tables:
+            current_column_set = set(_table_columns(current, table))
+            candidate_column_set = set(_table_columns(candidate, table))
+            only_current = current_column_set - candidate_column_set
+            only_candidate = candidate_column_set - current_column_set
+            if only_current or only_candidate:
+                missing_columns.append((table, tuple(sorted(only_current.union(only_candidate)))))
+            for column in sorted(only_current):
+                schema_differences.append(
+                    _build_difference(
+                        table=table,
+                        operation=DifferenceOperation.REMOVED,
+                        identity=(("__schema__", "column"), ("name", column)),
+                        before={"table": table, "column": column},
+                        after=None,
+                        changed_columns=(column,),
+                        expected=reviewed,
+                    )
+                )
+            for column in sorted(only_candidate):
+                schema_differences.append(
+                    _build_difference(
+                        table=table,
+                        operation=DifferenceOperation.ADDED,
+                        identity=(("__schema__", "column"), ("name", column)),
+                        before=None,
+                        after={"table": table, "column": column},
+                        changed_columns=(column,),
+                        expected=reviewed,
+                    )
+                )
         selected_sessions = _selected_session_ids(current, candidate, session_ids)
-        differences: list[RowDifference] = []
+        differences = schema_differences
         for table in compared_tables:
             differences.extend(
                 _compare_table(
@@ -539,6 +595,7 @@ def compare_reindex_generations(
         session_ids=selected_sessions,
         compared_tables=compared_tables,
         missing_tables=missing_tables,
+        missing_columns=tuple(missing_columns),
         differences=tuple(differences),
     )
 
@@ -637,33 +694,50 @@ def _compare_table(
         else:
             operation = DifferenceOperation.CHANGED
             changed_columns = tuple(column for column in columns if before.get(column) != after.get(column))
-        matching = next(
-            (
-                item
-                for item in expected
-                if item.matches(table=table, operation=operation, changed_columns=changed_columns)
-            ),
-            None,
-        )
         differences.append(
-            RowDifference(
+            _build_difference(
                 table=table,
                 operation=operation,
                 identity=tuple((column, key[index]) for index, column in enumerate(primary_key)),
                 before=before,
                 after=after,
                 changed_columns=changed_columns,
-                classification=(
-                    DifferenceClassification.EXPECTED if matching is not None else DifferenceClassification.UNEXPECTED
-                ),
-                rationale=(
-                    f"{matching.bead_ref}: {matching.rationale}"
-                    if matching is not None
-                    else "no reviewed bead or delta declaration matched this difference"
-                ),
+                expected=expected,
             )
         )
     return differences
+
+
+def _build_difference(
+    *,
+    table: str,
+    operation: DifferenceOperation,
+    identity: tuple[tuple[str, object], ...],
+    before: dict[str, object] | None,
+    after: dict[str, object] | None,
+    changed_columns: tuple[str, ...],
+    expected: tuple[ExpectedDifference, ...],
+) -> RowDifference:
+    matching = next(
+        (item for item in expected if item.matches(table=table, operation=operation, changed_columns=changed_columns)),
+        None,
+    )
+    return RowDifference(
+        table=table,
+        operation=operation,
+        identity=identity,
+        before=before,
+        after=after,
+        changed_columns=changed_columns,
+        classification=DifferenceClassification.EXPECTED
+        if matching is not None
+        else DifferenceClassification.UNEXPECTED,
+        rationale=(
+            f"{matching.bead_ref}: {matching.rationale}"
+            if matching is not None
+            else "no reviewed bead or delta declaration matched this difference"
+        ),
+    )
 
 
 def _table_rows(

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -10,13 +10,14 @@ repair, or otherwise mutate a generation.
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 from collections import Counter
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import StrEnum
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 
 class DifferenceOperation(StrEnum):
@@ -32,6 +33,14 @@ class DifferenceClassification(StrEnum):
 
     EXPECTED = "expected"
     UNEXPECTED = "unexpected"
+
+
+class CanarySelectionError(ValueError):
+    """The requested representative canary cannot be built from this index."""
+
+
+class UnclassifiedCanaryDiffError(ValueError):
+    """A durable report was requested without one review per diff row."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -135,6 +144,257 @@ class CanaryDiffReport:
             },
             "differences": [item.to_dict() for item in self.differences],
         }
+
+
+@dataclass(frozen=True, slots=True)
+class CanarySelection:
+    """Deterministic, read-only input selection for one canary rebuild."""
+
+    index_path: Path
+    sessions_per_origin: int
+    selected_session_ids: tuple[str, ...]
+    selected_raw_ids: tuple[str, ...]
+    sampled_session_ids: tuple[str, ...]
+    pathology_session_ids: tuple[str, ...]
+    sample_session_ids: tuple[str, ...]
+    origin_counts: tuple[tuple[str, int], ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "index_path": str(self.index_path),
+            "sessions_per_origin": self.sessions_per_origin,
+            "selected_session_ids": list(self.selected_session_ids),
+            "selected_raw_ids": list(self.selected_raw_ids),
+            "sampled_session_ids": list(self.sampled_session_ids),
+            "pathology_session_ids": list(self.pathology_session_ids),
+            "sample_session_ids": list(self.sample_session_ids),
+            "origin_counts": dict(self.origin_counts),
+        }
+
+
+def select_canary_sessions(
+    index_path: Path,
+    *,
+    sessions_per_origin: int = 100,
+    pathology_session_ids: Iterable[str] = (),
+    sample_session_ids: Iterable[str] = (),
+) -> CanarySelection:
+    """Select a representative raw-id set from a real active index.
+
+    The automatic portion takes the newest deterministic ``N`` sessions for
+    every origin. Explicit pathology and sample sessions are always included,
+    even when they fall outside that sample. Every explicit id must resolve to
+    an indexed session with a non-null ``raw_id`` because the existing rebuild
+    route accepts raw ids, not summaries or synthetic session descriptions.
+    """
+
+    if sessions_per_origin <= 0:
+        raise CanarySelectionError("sessions_per_origin must be positive")
+    path = Path(index_path)
+    pathology = tuple(dict.fromkeys(str(value) for value in pathology_session_ids))
+    explicit_samples = tuple(dict.fromkeys(str(value) for value in sample_session_ids))
+    explicit = set(pathology).union(explicit_samples)
+    with _open_read_only(path) as connection:
+        rows = connection.execute(
+            """
+            SELECT session_id, origin, raw_id, sort_key_ms
+            FROM sessions
+            ORDER BY origin, (sort_key_ms IS NULL), sort_key_ms DESC, session_id
+            """
+        ).fetchall()
+
+    records: dict[str, tuple[str, str | None]] = {
+        str(row["session_id"]): (
+            str(row["origin"]),
+            str(row["raw_id"]) if row["raw_id"] is not None else None,
+        )
+        for row in rows
+    }
+    missing = sorted(explicit.difference(records))
+    if missing:
+        raise CanarySelectionError(f"explicit canary session(s) are not indexed: {', '.join(missing)}")
+    without_raw = sorted(session_id for session_id in explicit if records[session_id][1] is None)
+    if without_raw:
+        raise CanarySelectionError(
+            "explicit canary session(s) have no raw_id and cannot be replayed: " + ", ".join(without_raw)
+        )
+
+    sampled: list[str] = []
+    origin_seen: dict[str, int] = {}
+    for row in rows:
+        if row["raw_id"] is None:
+            continue
+        origin = str(row["origin"])
+        if origin_seen.get(origin, 0) >= sessions_per_origin:
+            continue
+        session_id = str(row["session_id"])
+        sampled.append(session_id)
+        origin_seen[origin] = origin_seen.get(origin, 0) + 1
+
+    selected = set(sampled).union(explicit)
+    selected_session_ids = tuple(sorted(selected))
+    selected_raw_ids = tuple(
+        sorted(raw_id for session_id in selected if (raw_id := records[session_id][1]) is not None)
+    )
+    origin_counts = Counter(records[session_id][0] for session_id in selected)
+    return CanarySelection(
+        index_path=path,
+        sessions_per_origin=sessions_per_origin,
+        selected_session_ids=selected_session_ids,
+        selected_raw_ids=selected_raw_ids,
+        sampled_session_ids=tuple(sorted(sampled)),
+        pathology_session_ids=tuple(sorted(pathology)),
+        sample_session_ids=tuple(sorted(explicit_samples)),
+        origin_counts=tuple(sorted(origin_counts.items())),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class CanaryDifferenceReview:
+    """An explicit operator classification for one diff row."""
+
+    table: str
+    operation: DifferenceOperation
+    identity: tuple[tuple[str, object], ...]
+    classification: DifferenceClassification
+    reference: str
+    rationale: str
+
+    @classmethod
+    def for_difference(
+        cls,
+        difference: RowDifference,
+        *,
+        classification: DifferenceClassification,
+        reference: str,
+        rationale: str,
+    ) -> CanaryDifferenceReview:
+        return cls(
+            table=difference.table,
+            operation=difference.operation,
+            identity=difference.identity,
+            classification=classification,
+            reference=reference,
+            rationale=rationale,
+        )
+
+    @property
+    def key(self) -> tuple[str, DifferenceOperation, tuple[tuple[str, object], ...]]:
+        return self.table, self.operation, self.identity
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "table": self.table,
+            "operation": self.operation.value,
+            "identity": dict(self.identity),
+            "classification": self.classification.value,
+            "reference": self.reference,
+            "rationale": self.rationale,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class DurableCanaryReport:
+    """The reviewed, persisted canary changelog."""
+
+    selection: CanarySelection
+    comparison: CanaryDiffReport
+    reviews: tuple[CanaryDifferenceReview, ...]
+
+    @property
+    def unclassified_count(self) -> int:
+        return self.comparison.unclassified_count
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": 1,
+            "selection": self.selection.to_dict(),
+            "comparison": self.comparison.to_dict(),
+            "reviews": [review.to_dict() for review in self.reviews],
+        }
+
+
+def write_canary_report(
+    output_path: Path,
+    *,
+    selection: CanarySelection,
+    comparison: CanaryDiffReport,
+    reviews: Iterable[CanaryDifferenceReview],
+) -> DurableCanaryReport:
+    """Persist a reviewed report, refusing any incomplete classification.
+
+    Reviews must cover exactly the comparator's row identities. This prevents
+    a report from becoming a durable green-light artifact while a diff was
+    silently omitted from review. The write is atomic and touches only the
+    requested report path, never either SQLite generation.
+    """
+
+    review_list = tuple(reviews)
+    review_by_key: dict[tuple[str, DifferenceOperation, tuple[tuple[str, object], ...]], CanaryDifferenceReview] = {}
+    duplicate_keys: list[object] = []
+    for review in review_list:
+        if not review.reference.strip() or not review.rationale.strip():
+            raise UnclassifiedCanaryDiffError("every canary review needs a non-empty reference and rationale")
+        if review.key in review_by_key:
+            duplicate_keys.append(review.key)
+        review_by_key[review.key] = review
+    difference_keys = {
+        (
+            difference.table,
+            difference.operation,
+            difference.identity,
+        )
+        for difference in comparison.differences
+    }
+    missing_keys = difference_keys.difference(review_by_key)
+    extra_keys = set(review_by_key).difference(difference_keys)
+    if duplicate_keys or missing_keys or extra_keys:
+        detail = [
+            f"duplicate={len(duplicate_keys)}",
+            f"missing={len(missing_keys)}",
+            f"extra={len(extra_keys)}",
+        ]
+        raise UnclassifiedCanaryDiffError("canary report classification is incomplete (" + ", ".join(detail) + ")")
+
+    reviewed_differences = tuple(
+        replace(
+            difference,
+            classification=review_by_key[(difference.table, difference.operation, difference.identity)].classification,
+            rationale=(
+                f"{review_by_key[(difference.table, difference.operation, difference.identity)].reference}: "
+                f"{review_by_key[(difference.table, difference.operation, difference.identity)].rationale}"
+            ),
+        )
+        for difference in comparison.differences
+    )
+    reviewed_comparison = replace(comparison, differences=reviewed_differences)
+    durable = DurableCanaryReport(selection=selection, comparison=reviewed_comparison, reviews=review_list)
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    payload = json.dumps(durable.to_dict(), ensure_ascii=False, indent=2, sort_keys=True)
+    with temporary.open("w", encoding="utf-8") as stream:
+        stream.write(payload)
+        stream.write("\n")
+        stream.flush()
+        os.fsync(stream.fileno())
+    os.replace(temporary, path)
+    return durable
+
+
+def load_canary_report(path: Path) -> dict[str, object]:
+    """Read a durable report and reject any persisted unclassified summary."""
+
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise UnclassifiedCanaryDiffError("canary report root must be an object")
+    comparison = payload.get("comparison")
+    if not isinstance(comparison, dict):
+        raise UnclassifiedCanaryDiffError("canary report has no comparison object")
+    summary = comparison.get("summary")
+    if not isinstance(summary, dict) or summary.get("unclassified_count"):
+        raise UnclassifiedCanaryDiffError("canary report contains unclassified differences")
+    return cast(dict[str, object], payload)
 
 
 # These are SQLite implementation details rather than semantic read models.
@@ -387,10 +647,18 @@ def _quote_identifier(value: str) -> str:
 
 
 __all__ = [
+    "CanaryDifferenceReview",
     "CanaryDiffReport",
+    "CanarySelection",
+    "CanarySelectionError",
+    "DurableCanaryReport",
     "DifferenceClassification",
     "DifferenceOperation",
     "ExpectedDifference",
     "RowDifference",
+    "UnclassifiedCanaryDiffError",
     "compare_reindex_generations",
+    "load_canary_report",
+    "select_canary_sessions",
+    "write_canary_report",
 ]

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -172,6 +172,22 @@ class CanarySelection:
         }
 
 
+@dataclass(frozen=True, slots=True)
+class CanaryRunResult:
+    """Evidence from one bounded inactive-generation canary run."""
+
+    selection: CanarySelection
+    comparison: CanaryDiffReport
+    rebuild_receipt: dict[str, object]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "selection": self.selection.to_dict(),
+            "comparison": self.comparison.to_dict(),
+            "rebuild_receipt": self.rebuild_receipt,
+        }
+
+
 def select_canary_sessions(
     index_path: Path,
     *,
@@ -246,6 +262,52 @@ def select_canary_sessions(
         pathology_session_ids=tuple(sorted(pathology)),
         sample_session_ids=tuple(sorted(explicit_samples)),
         origin_counts=tuple(sorted(origin_counts.items())),
+    )
+
+
+def run_reindex_canary(
+    archive_root: Path,
+    *,
+    input_index: Path | None = None,
+    sessions_per_origin: int = 100,
+    pathology_session_ids: Iterable[str] = (),
+    sample_session_ids: Iterable[str] = (),
+    no_promote: bool,
+) -> CanaryRunResult:
+    """Replay a selected canary through the existing inactive rebuild route."""
+
+    if not no_promote:
+        raise CanarySelectionError("reindex canary requires --no-promote")
+    from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
+    from polylogue.storage.archive_identity import ArchiveLocation
+
+    root = Path(archive_root)
+    current_index = Path(input_index) if input_index is not None else ArchiveLocation.resolve(root).active_index_path
+    selection = select_canary_sessions(
+        current_index,
+        sessions_per_origin=sessions_per_origin,
+        pathology_session_ids=pathology_session_ids,
+        sample_session_ids=sample_session_ids,
+    )
+    receipt = rebuild_index_from_source_sync(
+        RebuildIndexRequest(
+            archive_root=root,
+            raw_ids=selection.selected_raw_ids,
+            promote=False,
+        )
+    )
+    candidate_value = receipt.generation.get("index_path")
+    if not isinstance(candidate_value, str):
+        raise CanarySelectionError("rebuild receipt did not identify an inactive candidate index")
+    comparison = compare_reindex_generations(
+        current_index,
+        Path(candidate_value),
+        session_ids=selection.selected_session_ids,
+    )
+    return CanaryRunResult(
+        selection=selection,
+        comparison=comparison,
+        rebuild_receipt=receipt.to_dict(),
     )
 
 
@@ -649,6 +711,7 @@ def _quote_identifier(value: str) -> str:
 __all__ = [
     "CanaryDifferenceReview",
     "CanaryDiffReport",
+    "CanaryRunResult",
     "CanarySelection",
     "CanarySelectionError",
     "DurableCanaryReport",
@@ -659,6 +722,7 @@ __all__ = [
     "UnclassifiedCanaryDiffError",
     "compare_reindex_generations",
     "load_canary_report",
+    "run_reindex_canary",
     "select_canary_sessions",
     "write_canary_report",
 ]

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -12,8 +12,10 @@ from __future__ import annotations
 import json
 import os
 import sqlite3
+import tempfile
 from collections import Counter
 from collections.abc import Iterable
+from contextlib import suppress
 from dataclasses import dataclass, replace
 from enum import StrEnum
 from pathlib import Path
@@ -495,19 +497,35 @@ def write_canary_report(
     durable = DurableCanaryReport(selection=selection, comparison=reviewed_comparison, reviews=review_list)
     path = Path(output_path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_name(f".{path.name}.tmp")
     payload = json.dumps(durable.to_dict(), ensure_ascii=False, indent=2, sort_keys=True)
-    with temporary.open("w", encoding="utf-8") as stream:
-        stream.write(payload)
-        stream.write("\n")
-        stream.flush()
-        os.fsync(stream.fileno())
-    os.replace(temporary, path)
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as stream:
+            temporary = Path(stream.name)
+            stream.write(payload)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        temporary = None
+        _fsync_directory(path.parent)
+    except BaseException:
+        if temporary is not None:
+            with suppress(OSError):
+                temporary.unlink()
+        raise
     return durable
 
 
 def load_canary_report(path: Path) -> dict[str, object]:
-    """Read a durable report and reject any persisted unclassified summary."""
+    """Read and structurally revalidate a durable report's review coverage."""
 
     payload = json.loads(Path(path).read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
@@ -516,9 +534,127 @@ def load_canary_report(path: Path) -> dict[str, object]:
     if not isinstance(comparison, dict):
         raise UnclassifiedCanaryDiffError("canary report has no comparison object")
     summary = comparison.get("summary")
-    if not isinstance(summary, dict) or summary.get("unclassified_count"):
-        raise UnclassifiedCanaryDiffError("canary report contains unclassified differences")
+    if not isinstance(summary, dict):
+        raise UnclassifiedCanaryDiffError("canary report has no comparison summary object")
+    raw_differences = comparison.get("differences")
+    if not isinstance(raw_differences, list):
+        raise UnclassifiedCanaryDiffError("canary report has no differences list")
+    differences = tuple(_difference_from_dict(item) for item in raw_differences)
+    raw_reviews = payload.get("reviews")
+    if not isinstance(raw_reviews, list):
+        raise UnclassifiedCanaryDiffError("canary report has no reviews list")
+    reviews = tuple(_review_from_dict(item) for item in raw_reviews)
+    difference_keys = tuple(_difference_key(difference) for difference in differences)
+    review_keys = tuple(review.key for review in reviews)
+    if len(set(difference_keys)) != len(difference_keys) or len(set(review_keys)) != len(review_keys):
+        raise UnclassifiedCanaryDiffError("canary report contains duplicate difference or review identities")
+    difference_by_key = dict(zip(difference_keys, differences, strict=True))
+    review_by_key = dict(zip(review_keys, reviews, strict=True))
+    missing_keys = set(difference_by_key).difference(review_by_key)
+    extra_keys = set(review_by_key).difference(difference_by_key)
+    if missing_keys or extra_keys:
+        raise UnclassifiedCanaryDiffError(
+            f"canary report review coverage is incomplete (missing={len(missing_keys)}, extra={len(extra_keys)})"
+        )
+    for key, difference in difference_by_key.items():
+        review = review_by_key[key]
+        if review.classification is not difference.classification:
+            raise UnclassifiedCanaryDiffError("canary report review classification disagrees with its difference")
+    comparison["summary"] = _summary_for_differences(differences)
     return cast(dict[str, object], payload)
+
+
+def _difference_key(difference: RowDifference) -> tuple[str, DifferenceOperation, tuple[tuple[str, object], ...]]:
+    return difference.table, difference.operation, difference.identity
+
+
+def _difference_from_dict(value: object) -> RowDifference:
+    if not isinstance(value, dict):
+        raise UnclassifiedCanaryDiffError("canary report difference must be an object")
+    identity = value.get("identity")
+    changed_columns = value.get("changed_columns")
+    if (
+        not isinstance(identity, dict)
+        or not isinstance(changed_columns, list)
+        or not all(isinstance(column, str) for column in changed_columns)
+    ):
+        raise UnclassifiedCanaryDiffError("canary report difference has invalid identity or changed columns")
+    before = value.get("before")
+    after = value.get("after")
+    if before is not None and not isinstance(before, dict):
+        raise UnclassifiedCanaryDiffError("canary report difference has invalid before row")
+    if after is not None and not isinstance(after, dict):
+        raise UnclassifiedCanaryDiffError("canary report difference has invalid after row")
+    table = value.get("table")
+    rationale = value.get("rationale")
+    if not isinstance(table, str) or not isinstance(rationale, str):
+        raise UnclassifiedCanaryDiffError("canary report difference has invalid table or rationale")
+    try:
+        operation = DifferenceOperation(value["operation"])
+        classification = DifferenceClassification(value["classification"])
+    except (KeyError, ValueError) as exc:
+        raise UnclassifiedCanaryDiffError("canary report difference has invalid operation or classification") from exc
+    return RowDifference(
+        table=table,
+        operation=operation,
+        identity=tuple((str(key), item) for key, item in identity.items()),
+        before=cast(dict[str, object] | None, before),
+        after=cast(dict[str, object] | None, after),
+        changed_columns=tuple(cast(list[str], changed_columns)),
+        classification=classification,
+        rationale=rationale,
+    )
+
+
+def _review_from_dict(value: object) -> CanaryDifferenceReview:
+    if not isinstance(value, dict):
+        raise UnclassifiedCanaryDiffError("canary report review must be an object")
+    identity = value.get("identity")
+    table = value.get("table")
+    reference = value.get("reference")
+    rationale = value.get("rationale")
+    if (
+        not isinstance(identity, dict)
+        or not isinstance(table, str)
+        or not isinstance(reference, str)
+        or not isinstance(rationale, str)
+        or not reference.strip()
+        or not rationale.strip()
+    ):
+        raise UnclassifiedCanaryDiffError("every canary review needs a valid reference and rationale")
+    try:
+        operation = DifferenceOperation(value["operation"])
+        classification = DifferenceClassification(value["classification"])
+    except (KeyError, ValueError) as exc:
+        raise UnclassifiedCanaryDiffError("canary report review has invalid operation or classification") from exc
+    return CanaryDifferenceReview(
+        table=table,
+        operation=operation,
+        identity=tuple((str(key), item) for key, item in identity.items()),
+        classification=classification,
+        reference=reference,
+        rationale=rationale,
+    )
+
+
+def _summary_for_differences(differences: tuple[RowDifference, ...]) -> dict[str, object]:
+    expected_count = sum(item.classification is DifferenceClassification.EXPECTED for item in differences)
+    unexpected_count = sum(item.classification is DifferenceClassification.UNEXPECTED for item in differences)
+    return {
+        "difference_count": len(differences),
+        "expected_count": expected_count,
+        "unexpected_count": unexpected_count,
+        "unclassified_count": 0,
+        "counts_by_table": dict(sorted(Counter(item.table for item in differences).items())),
+    }
+
+
+def _fsync_directory(directory: Path) -> None:
+    descriptor = os.open(str(directory), os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
 
 
 # These are SQLite implementation details rather than semantic read models.

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -354,6 +354,7 @@ def _validate_canary_candidate(
         isinstance(value, str) and value for value in (generation_id, owner_id, source_snapshot, candidate_value)
     ):
         raise CanarySelectionError("rebuild receipt did not identify a complete inactive candidate generation")
+    assert isinstance(candidate_value, str)
 
     location = ArchiveLocation.resolve(archive_root)
     anchor = location.active_pointer or location.configured_tier("index").configured_path
@@ -726,8 +727,12 @@ def compare_reindex_generations(
             candidate_columns = _table_columns(candidate, table) if table in candidate_tables else ()
             operation = DifferenceOperation.REMOVED if current_present else DifferenceOperation.ADDED
             changed_columns = tuple(sorted(set(current_columns).union(candidate_columns)))
-            before = {"table": table, "columns": list(current_columns)} if current_present else None
-            after = {"table": table, "columns": list(candidate_columns)} if table in candidate_tables else None
+            before: dict[str, object] | None = (
+                {"table": table, "columns": list(current_columns)} if current_present else None
+            )
+            after: dict[str, object] | None = (
+                {"table": table, "columns": list(candidate_columns)} if table in candidate_tables else None
+            )
             schema_differences.append(
                 _build_difference(
                     table=table,

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -300,12 +300,15 @@ def run_reindex_canary(
             promote=False,
         )
     )
-    candidate_value = receipt.generation.get("index_path")
-    if not isinstance(candidate_value, str):
-        raise CanarySelectionError("rebuild receipt did not identify an inactive candidate index")
+    candidate_path = _validate_canary_candidate(
+        root,
+        current_index=current_index,
+        selection=selection,
+        receipt=receipt,
+    )
     comparison = compare_reindex_generations(
         current_index,
-        Path(candidate_value),
+        candidate_path,
         session_ids=selection.selected_session_ids,
     )
     return CanaryRunResult(
@@ -313,6 +316,61 @@ def run_reindex_canary(
         comparison=comparison,
         rebuild_receipt=receipt.to_dict(),
     )
+
+
+def _validate_canary_candidate(
+    archive_root: Path,
+    *,
+    current_index: Path,
+    selection: CanarySelection,
+    receipt: object,
+) -> Path:
+    """Prove the compared index is this run's own inactive generation."""
+    from polylogue.storage.archive_identity import ArchiveLocation
+
+    root = archive_root.resolve()
+    receipt_root = getattr(receipt, "archive_root", None)
+    if not isinstance(receipt_root, str) or Path(receipt_root).resolve() != root:
+        raise CanarySelectionError("rebuild receipt belongs to a different archive root")
+    if getattr(receipt, "status", None) != "replayed" or getattr(receipt, "materialized", None) is not True:
+        raise CanarySelectionError("rebuild receipt is not a completed materialized replay")
+    if getattr(receipt, "selected_raw_count", None) != len(selection.selected_raw_ids):
+        raise CanarySelectionError("rebuild receipt selected a different raw-id set than the canary")
+
+    generation = getattr(receipt, "generation", None)
+    if not isinstance(generation, dict):
+        raise CanarySelectionError("rebuild receipt did not identify an inactive candidate generation")
+    if generation.get("archive_root") != str(root):
+        raise CanarySelectionError("candidate generation belongs to a different archive root")
+    if generation.get("state") != "inactive":
+        raise CanarySelectionError("reindex canary candidate must remain an inactive generation")
+    generation_id = generation.get("generation_id")
+    owner_id = generation.get("owner_id")
+    source_snapshot = generation.get("source_snapshot")
+    candidate_value = generation.get("index_path")
+    if not all(
+        isinstance(value, str) and value for value in (generation_id, owner_id, source_snapshot, candidate_value)
+    ):
+        raise CanarySelectionError("rebuild receipt did not identify a complete inactive candidate generation")
+
+    location = ArchiveLocation.resolve(archive_root)
+    anchor = location.active_pointer or location.configured_tier("index").configured_path
+    expected_generation_root = anchor.parent / ".index-generations"
+    candidate_path = Path(candidate_value)
+    try:
+        candidate_resolved = candidate_path.resolve(strict=True)
+        current_resolved = Path(current_index).resolve(strict=True)
+    except OSError as exc:
+        raise CanarySelectionError("rebuild receipt candidate index is not readable") from exc
+    if candidate_resolved == current_resolved:
+        raise CanarySelectionError("rebuild receipt candidate index is the active index")
+    if (
+        candidate_resolved.name != "index.db"
+        or candidate_resolved.parent.name != generation_id
+        or candidate_resolved.parent.parent != expected_generation_root.resolve()
+    ):
+        raise CanarySelectionError("rebuild receipt candidate is outside this archive's generation root")
+    return candidate_path
 
 
 @dataclass(frozen=True, slots=True)

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -1,0 +1,396 @@
+"""Read-only semantic comparison for an inactive reindex canary.
+
+The rebuild service owns creation of an inactive generation.  This module owns
+the other half of the canary contract: compare the real SQLite read models in
+that generation with the active index and account for every row difference.
+It deliberately opens both inputs read-only and never knows how to promote,
+repair, or otherwise mutate a generation.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections import Counter
+from collections.abc import Iterable
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+
+class DifferenceOperation(StrEnum):
+    """The row-level change observed between the active and candidate indexes."""
+
+    ADDED = "added"
+    REMOVED = "removed"
+    CHANGED = "changed"
+
+
+class DifferenceClassification(StrEnum):
+    """How the canary changelog accounts for a semantic difference."""
+
+    EXPECTED = "expected"
+    UNEXPECTED = "unexpected"
+
+
+@dataclass(frozen=True, slots=True)
+class ExpectedDifference:
+    """A reviewed change signature that is allowed in a canary report.
+
+    Matching is intentionally structural.  A bead or delta declaration names
+    the affected table and may narrow the signature to an operation and/or a
+    changed column.  Unmatched differences are ``UNEXPECTED`` by default, so
+    the report cannot contain an unclassified bucket.
+    """
+
+    table: str
+    bead_ref: str
+    rationale: str
+    operations: tuple[DifferenceOperation, ...] = ()
+    columns: tuple[str, ...] = ()
+
+    def matches(
+        self,
+        *,
+        table: str,
+        operation: DifferenceOperation,
+        changed_columns: tuple[str, ...],
+    ) -> bool:
+        if self.table != table:
+            return False
+        if self.operations and operation not in self.operations:
+            return False
+        return not self.columns or bool(set(self.columns).intersection(changed_columns))
+
+
+@dataclass(frozen=True, slots=True)
+class RowDifference:
+    """One canonical row-level difference in the canary changelog."""
+
+    table: str
+    operation: DifferenceOperation
+    identity: tuple[tuple[str, object], ...]
+    before: dict[str, object] | None
+    after: dict[str, object] | None
+    changed_columns: tuple[str, ...]
+    classification: DifferenceClassification
+    rationale: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "table": self.table,
+            "operation": self.operation.value,
+            "identity": dict(self.identity),
+            "before": self.before,
+            "after": self.after,
+            "changed_columns": list(self.changed_columns),
+            "classification": self.classification.value,
+            "rationale": self.rationale,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CanaryDiffReport:
+    """Complete, JSON-ready account of a read-model comparison."""
+
+    current_index: Path
+    candidate_index: Path
+    session_ids: tuple[str, ...]
+    compared_tables: tuple[str, ...]
+    missing_tables: tuple[str, ...]
+    differences: tuple[RowDifference, ...]
+
+    @property
+    def expected_count(self) -> int:
+        return sum(item.classification is DifferenceClassification.EXPECTED for item in self.differences)
+
+    @property
+    def unexpected_count(self) -> int:
+        return sum(item.classification is DifferenceClassification.UNEXPECTED for item in self.differences)
+
+    @property
+    def unclassified_count(self) -> int:
+        """The explicit zero-bucket contract for the canary changelog."""
+
+        return 0
+
+    @property
+    def counts_by_table(self) -> dict[str, int]:
+        return dict(sorted(Counter(item.table for item in self.differences).items()))
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "current_index": str(self.current_index),
+            "candidate_index": str(self.candidate_index),
+            "session_ids": list(self.session_ids),
+            "compared_tables": list(self.compared_tables),
+            "missing_tables": list(self.missing_tables),
+            "summary": {
+                "difference_count": len(self.differences),
+                "expected_count": self.expected_count,
+                "unexpected_count": self.unexpected_count,
+                "unclassified_count": self.unclassified_count,
+                "counts_by_table": self.counts_by_table,
+            },
+            "differences": [item.to_dict() for item in self.differences],
+        }
+
+
+# These are SQLite implementation details rather than semantic read models.
+# FTS backing tables are virtual-table internals and generation metadata is not
+# part of the session read model.  Aggregate rollups without a session key
+# cannot be attributed to a partial canary and are therefore intentionally
+# outside this comparator's scope.
+_EXCLUDED_TABLES = frozenset(
+    {
+        "delegation_refresh_scope",
+        "derived_refresh_guard",
+        "agent_meta_sidecar_purge_receipts",
+        "session_tag_rollups",
+    }
+)
+_CORE_TABLES = ("sessions", "messages", "blocks", "session_links")
+_SESSION_SCOPE_COLUMNS = (
+    "session_id",
+    "src_session_id",
+    "parent_session_id",
+    "child_session_id",
+)
+_VOLATILE_COLUMNS = frozenset(
+    {
+        "generation_id",
+        "generation_owner_id",
+        "materialized_at",
+        "materialized_at_ms",
+        "materialized_at_utc",
+        "refreshed_at_ms",
+    }
+)
+
+
+def compare_reindex_generations(
+    current_index: Path,
+    candidate_index: Path,
+    *,
+    session_ids: Iterable[str] = (),
+    expected: Iterable[ExpectedDifference] = (),
+) -> CanaryDiffReport:
+    """Compare real generation read models without mutating either database.
+
+    ``current_index`` is the active generation and ``candidate_index`` is the
+    inactive generation produced by the existing rebuild service.  When no
+    session selection is supplied, the union of session ids in both databases
+    is compared.  A partial selection is useful for the N-per-origin canary
+    and still reports additions/removals inside that selection.
+    """
+
+    current_path = Path(current_index)
+    candidate_path = Path(candidate_index)
+    if not current_path.exists():
+        raise FileNotFoundError(f"current index does not exist: {current_path}")
+    if not candidate_path.exists():
+        raise FileNotFoundError(f"candidate index does not exist: {candidate_path}")
+
+    reviewed = tuple(expected)
+    with _open_read_only(current_path) as current, _open_read_only(candidate_path) as candidate:
+        current_tables = _read_model_tables(current)
+        candidate_tables = _read_model_tables(candidate)
+        compared_tables = tuple(sorted(current_tables.intersection(candidate_tables)))
+        missing_tables = tuple(sorted(current_tables.symmetric_difference(candidate_tables)))
+        selected_sessions = _selected_session_ids(current, candidate, session_ids)
+        differences: list[RowDifference] = []
+        for table in compared_tables:
+            differences.extend(
+                _compare_table(
+                    table,
+                    current,
+                    candidate,
+                    session_ids=selected_sessions,
+                    expected=reviewed,
+                )
+            )
+
+    return CanaryDiffReport(
+        current_index=current_path,
+        candidate_index=candidate_path,
+        session_ids=selected_sessions,
+        compared_tables=compared_tables,
+        missing_tables=missing_tables,
+        differences=tuple(differences),
+    )
+
+
+def _open_read_only(path: Path) -> sqlite3.Connection:
+    uri = f"file:{path.resolve(strict=True)}?mode=ro"
+    connection = sqlite3.connect(uri, uri=True)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA query_only = ON")
+    return connection
+
+
+def _read_model_tables(connection: sqlite3.Connection) -> set[str]:
+    rows = connection.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
+    ).fetchall()
+    result: set[str] = set()
+    for row in rows:
+        table = str(row[0])
+        if table in _EXCLUDED_TABLES or table.startswith("messages_fts") or table.startswith("blocks_command_trigram"):
+            continue
+        columns = _table_columns(connection, table)
+        if table in _CORE_TABLES or any(column in columns for column in _SESSION_SCOPE_COLUMNS):
+            result.add(table)
+    return result
+
+
+def _table_columns(connection: sqlite3.Connection, table: str) -> tuple[str, ...]:
+    quoted = _quote_identifier(table)
+    rows = connection.execute(f"PRAGMA table_xinfo({quoted})").fetchall()
+    # hidden=1/2 are virtual-table shadow columns. Generated columns (3) are
+    # real semantic ids and remain in the comparison.
+    return tuple(str(row[1]) for row in rows if int(row[6]) not in (1, 2))
+
+
+def _table_primary_key(connection: sqlite3.Connection, table: str, columns: tuple[str, ...]) -> tuple[str, ...]:
+    rows = connection.execute(f"PRAGMA table_xinfo({_quote_identifier(table)})").fetchall()
+    primary_key = [(int(row[5]), str(row[1])) for row in rows if int(row[5]) > 0 and int(row[6]) not in (1, 2)]
+    if primary_key:
+        return tuple(name for _position, name in sorted(primary_key))
+    for preferred in ("session_id", "message_id", "block_id", "event_id", "policy_id"):
+        if preferred in columns:
+            return (preferred,)
+    return columns
+
+
+def _selected_session_ids(
+    current: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    requested: Iterable[str],
+) -> tuple[str, ...]:
+    explicit = tuple(dict.fromkeys(str(value) for value in requested))
+    if explicit:
+        return tuple(sorted(explicit))
+    values: set[str] = set()
+    for connection in (current, candidate):
+        if "sessions" not in _read_model_tables(connection):
+            continue
+        rows = connection.execute("SELECT session_id FROM sessions ORDER BY session_id").fetchall()
+        values.update(str(row[0]) for row in rows)
+    return tuple(sorted(values))
+
+
+def _compare_table(
+    table: str,
+    current: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    *,
+    session_ids: tuple[str, ...],
+    expected: tuple[ExpectedDifference, ...],
+) -> list[RowDifference]:
+    current_columns = _table_columns(current, table)
+    candidate_columns = _table_columns(candidate, table)
+    columns = tuple(column for column in current_columns if column in candidate_columns)
+    if not columns:
+        return []
+    scope_columns = tuple(column for column in _SESSION_SCOPE_COLUMNS if column in columns)
+    if not scope_columns:
+        return []
+    current_rows = _table_rows(current, table, columns, scope_columns, session_ids)
+    candidate_rows = _table_rows(candidate, table, columns, scope_columns, session_ids)
+    keys = sorted(set(current_rows).union(candidate_rows), key=repr)
+    primary_key = _table_primary_key(current, table, columns)
+    differences: list[RowDifference] = []
+    for key in keys:
+        before = current_rows.get(key)
+        after = candidate_rows.get(key)
+        if before == after:
+            continue
+        if before is None:
+            operation = DifferenceOperation.ADDED
+            changed_columns = tuple(after) if after is not None else ()
+        elif after is None:
+            operation = DifferenceOperation.REMOVED
+            changed_columns = tuple(before)
+        else:
+            operation = DifferenceOperation.CHANGED
+            changed_columns = tuple(column for column in columns if before.get(column) != after.get(column))
+        matching = next(
+            (
+                item
+                for item in expected
+                if item.matches(table=table, operation=operation, changed_columns=changed_columns)
+            ),
+            None,
+        )
+        differences.append(
+            RowDifference(
+                table=table,
+                operation=operation,
+                identity=tuple((column, key[index]) for index, column in enumerate(primary_key)),
+                before=before,
+                after=after,
+                changed_columns=changed_columns,
+                classification=(
+                    DifferenceClassification.EXPECTED if matching is not None else DifferenceClassification.UNEXPECTED
+                ),
+                rationale=(
+                    f"{matching.bead_ref}: {matching.rationale}"
+                    if matching is not None
+                    else "no reviewed bead or delta declaration matched this difference"
+                ),
+            )
+        )
+    return differences
+
+
+def _table_rows(
+    connection: sqlite3.Connection,
+    table: str,
+    columns: tuple[str, ...],
+    scope_columns: tuple[str, ...],
+    session_ids: tuple[str, ...],
+) -> dict[tuple[object, ...], dict[str, object]]:
+    selected_columns = tuple(column for column in columns if column not in _VOLATILE_COLUMNS)
+    quoted_columns = ", ".join(_quote_identifier(column) for column in columns)
+    query = f"SELECT {quoted_columns} FROM {_quote_identifier(table)}"
+    parameters: tuple[str, ...] = ()
+    if session_ids:
+        placeholders = ", ".join("?" for _ in session_ids)
+        query += " WHERE " + " OR ".join(f"{_quote_identifier(column)} IN ({placeholders})" for column in scope_columns)
+        parameters = session_ids * len(scope_columns)
+    query += " ORDER BY rowid" if table not in {"sessions", "messages", "blocks", "session_links"} else ""
+    result: dict[tuple[object, ...], dict[str, object]] = {}
+    primary_key = _table_primary_key(connection, table, columns)
+    for row in connection.execute(query, parameters):
+        normalized = {column: _normalize_value(column, row[column]) for column in selected_columns}
+        key = tuple(_normalize_value(column, row[column]) for column in primary_key)
+        result[key] = normalized
+    return result
+
+
+def _normalize_value(column: str, value: Any) -> object:
+    if value is None:
+        return None
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return bytes(value).hex()
+    if isinstance(value, str) and column.endswith("_json"):
+        try:
+            return json.dumps(json.loads(value), ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        except (TypeError, ValueError):
+            return value
+    return value
+
+
+def _quote_identifier(value: str) -> str:
+    return '"' + value.replace('"', '""') + '"'
+
+
+__all__ = [
+    "CanaryDiffReport",
+    "DifferenceClassification",
+    "DifferenceOperation",
+    "ExpectedDifference",
+    "RowDifference",
+    "compare_reindex_generations",
+]

--- a/tests/unit/cli/test_reindex_canary_cli.py
+++ b/tests/unit/cli/test_reindex_canary_cli.py
@@ -161,14 +161,26 @@ def test_reindex_canary_cli_refuses_to_write_unclassified_report(tmp_path: Path,
 
 def test_shared_canary_runner_uses_existing_inactive_rebuild_route(tmp_path: Path, monkeypatch) -> None:
     current_index = tmp_path / "current.db"
-    candidate_index = tmp_path / "candidate.db"
+    candidate_index = tmp_path / ".index-generations" / "gen-test" / "index.db"
     current_index.touch()
+    candidate_index.parent.mkdir(parents=True)
     candidate_index.touch()
     selection = _run_result(current_index).selection
     captured: dict[str, object] = {}
 
     class Receipt:
-        generation = {"index_path": str(candidate_index)}
+        archive_root = str(tmp_path.resolve())
+        selected_raw_count = len(selection.selected_raw_ids)
+        status = "replayed"
+        materialized = True
+        generation = {
+            "generation_id": "gen-test",
+            "owner_id": "owner",
+            "archive_root": str(tmp_path.resolve()),
+            "index_path": str(candidate_index),
+            "state": "inactive",
+            "source_snapshot": "snapshot",
+        }
 
         def to_dict(self) -> dict[str, object]:
             return {"generation": self.generation}
@@ -206,4 +218,4 @@ def test_shared_canary_runner_uses_existing_inactive_rebuild_route(tmp_path: Pat
     assert request.raw_ids == selection.selected_raw_ids  # type: ignore[attr-defined]
     assert request.promote is False  # type: ignore[attr-defined]
     assert captured["compare"] == (current_index, candidate_index, selection.selected_session_ids)
-    assert result.rebuild_receipt == {"generation": {"index_path": str(candidate_index)}}
+    assert result.rebuild_receipt == {"generation": Receipt.generation}

--- a/tests/unit/cli/test_reindex_canary_cli.py
+++ b/tests/unit/cli/test_reindex_canary_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 from polylogue.cli.click_app import cli
@@ -63,7 +64,7 @@ def test_reindex_canary_cli_requires_no_promote(tmp_path: Path) -> None:
 
 def test_reindex_canary_cli_routes_selection_and_report_without_rebuild_duplication(
     tmp_path: Path,
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     index_path = tmp_path / "index.db"
     index_path.touch()
@@ -129,7 +130,9 @@ def test_reindex_canary_cli_routes_selection_and_report_without_rebuild_duplicat
     assert json.loads(result.stdout)["selection"]["selected_raw_ids"] == ["raw-sample"]
 
 
-def test_reindex_canary_cli_refuses_to_write_unclassified_report(tmp_path: Path, monkeypatch) -> None:
+def test_reindex_canary_cli_refuses_to_write_unclassified_report(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     index_path = tmp_path / "index.db"
     index_path.touch()
     run_result = _run_result(index_path, differences=(object(),))
@@ -159,7 +162,9 @@ def test_reindex_canary_cli_refuses_to_write_unclassified_report(tmp_path: Path,
     assert "classification is incomplete" in result.output
 
 
-def test_shared_canary_runner_uses_existing_inactive_rebuild_route(tmp_path: Path, monkeypatch) -> None:
+def test_shared_canary_runner_uses_existing_inactive_rebuild_route(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     current_index = tmp_path / "current.db"
     candidate_index = tmp_path / ".index-generations" / "gen-test" / "index.db"
     current_index.touch()

--- a/tests/unit/cli/test_reindex_canary_cli.py
+++ b/tests/unit/cli/test_reindex_canary_cli.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from polylogue.cli.click_app import cli
+from polylogue.cli.commands.maintenance import _reindex_canary as command_module
+from polylogue.maintenance.reindex_canary import (
+    CanaryDiffReport,
+    CanaryRunResult,
+    CanarySelection,
+    DurableCanaryReport,
+    UnclassifiedCanaryDiffError,
+    run_reindex_canary,
+)
+
+
+def _run_result(index_path: Path, *, differences: tuple[object, ...] = ()) -> CanaryRunResult:
+    selection = CanarySelection(
+        index_path=index_path,
+        sessions_per_origin=2,
+        selected_session_ids=("codex-session:sample",),
+        selected_raw_ids=("raw-sample",),
+        sampled_session_ids=("codex-session:sample",),
+        pathology_session_ids=("codex-session:pathology",),
+        sample_session_ids=("codex-session:sample",),
+        origin_counts=(("codex-session", 1),),
+    )
+    comparison = CanaryDiffReport(
+        current_index=index_path,
+        candidate_index=index_path.with_name("candidate.db"),
+        session_ids=selection.selected_session_ids,
+        compared_tables=("sessions",),
+        missing_tables=(),
+        differences=differences,  # type: ignore[arg-type]
+    )
+    return CanaryRunResult(selection=selection, comparison=comparison, rebuild_receipt={"status": "replayed"})
+
+
+def test_reindex_canary_cli_requires_no_promote(tmp_path: Path) -> None:
+    index_path = tmp_path / "index.db"
+    index_path.touch()
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--input",
+            str(index_path),
+            "--report",
+            str(tmp_path / "canary.json"),
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "requires --no-promote" in result.output
+
+
+def test_reindex_canary_cli_routes_selection_and_report_without_rebuild_duplication(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    index_path = tmp_path / "index.db"
+    index_path.touch()
+    report_path = tmp_path / "reports" / "canary.json"
+    run_result = _run_result(index_path)
+    captured: dict[str, object] = {}
+
+    def fake_run(*args: object, **kwargs: object) -> CanaryRunResult:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return run_result
+
+    def fake_write(path: Path, **kwargs: object) -> DurableCanaryReport:
+        captured["report_path"] = path
+        captured["report_kwargs"] = kwargs
+        return DurableCanaryReport(
+            selection=run_result.selection,
+            comparison=run_result.comparison,
+            reviews=(),
+        )
+
+    monkeypatch.setattr(command_module, "archive_root", lambda: tmp_path)
+    monkeypatch.setattr("polylogue.maintenance.reindex_canary.run_reindex_canary", fake_run)
+    monkeypatch.setattr("polylogue.maintenance.reindex_canary.write_canary_report", fake_write)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--input",
+            str(index_path),
+            "--sample",
+            "2",
+            "--pathology-session-id",
+            "codex-session:pathology",
+            "--sample-session-id",
+            "codex-session:sample",
+            "--report",
+            str(report_path),
+            "--no-promote",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert captured["args"] == (tmp_path,)
+    assert captured["kwargs"] == {
+        "input_index": index_path,
+        "sessions_per_origin": 2,
+        "pathology_session_ids": ("codex-session:pathology",),
+        "sample_session_ids": ("codex-session:sample",),
+        "no_promote": True,
+    }
+    assert captured["report_path"] == report_path
+    report_kwargs = captured["report_kwargs"]
+    assert isinstance(report_kwargs, dict)
+    assert report_kwargs["reviews"] == ()
+    assert json.loads(result.stdout)["selection"]["selected_raw_ids"] == ["raw-sample"]
+
+
+def test_reindex_canary_cli_refuses_to_write_unclassified_report(tmp_path: Path, monkeypatch) -> None:
+    index_path = tmp_path / "index.db"
+    index_path.touch()
+    run_result = _run_result(index_path, differences=(object(),))
+    monkeypatch.setattr(command_module, "archive_root", lambda: tmp_path)
+    monkeypatch.setattr("polylogue.maintenance.reindex_canary.run_reindex_canary", lambda *args, **kwargs: run_result)
+    monkeypatch.setattr(
+        "polylogue.maintenance.reindex_canary.write_canary_report",
+        lambda *args, **kwargs: (_ for _ in ()).throw(UnclassifiedCanaryDiffError("classification is incomplete")),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--input",
+            str(index_path),
+            "--report",
+            str(tmp_path / "canary.json"),
+            "--no-promote",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "classification is incomplete" in result.output
+
+
+def test_shared_canary_runner_uses_existing_inactive_rebuild_route(tmp_path: Path, monkeypatch) -> None:
+    current_index = tmp_path / "current.db"
+    candidate_index = tmp_path / "candidate.db"
+    current_index.touch()
+    candidate_index.touch()
+    selection = _run_result(current_index).selection
+    captured: dict[str, object] = {}
+
+    class Receipt:
+        generation = {"index_path": str(candidate_index)}
+
+        def to_dict(self) -> dict[str, object]:
+            return {"generation": self.generation}
+
+    def fake_rebuild(request: object) -> Receipt:
+        captured["request"] = request
+        return Receipt()
+
+    def fake_compare(current: Path, candidate: Path, *, session_ids: tuple[str, ...]) -> CanaryDiffReport:
+        captured["compare"] = (current, candidate, session_ids)
+        return CanaryDiffReport(
+            current_index=current,
+            candidate_index=candidate,
+            session_ids=session_ids,
+            compared_tables=("sessions",),
+            missing_tables=(),
+            differences=(),
+        )
+
+    monkeypatch.setattr(
+        "polylogue.maintenance.reindex_canary.select_canary_sessions", lambda *args, **kwargs: selection
+    )
+    monkeypatch.setattr("polylogue.maintenance.rebuild_index.rebuild_index_from_source_sync", fake_rebuild)
+    monkeypatch.setattr("polylogue.maintenance.reindex_canary.compare_reindex_generations", fake_compare)
+
+    result = run_reindex_canary(
+        tmp_path,
+        input_index=current_index,
+        sessions_per_origin=2,
+        no_promote=True,
+    )
+
+    request = captured["request"]
+    assert request.raw_ids == selection.selected_raw_ids  # type: ignore[attr-defined]
+    assert request.promote is False  # type: ignore[attr-defined]
+    assert captured["compare"] == (current_index, candidate_index, selection.selected_session_ids)
+    assert result.rebuild_receipt == {"generation": {"index_path": str(candidate_index)}}

--- a/tests/unit/cli/test_reindex_canary_cli.py
+++ b/tests/unit/cli/test_reindex_canary_cli.py
@@ -34,6 +34,7 @@ def _run_result(index_path: Path, *, differences: tuple[object, ...] = ()) -> Ca
         session_ids=selection.selected_session_ids,
         compared_tables=("sessions",),
         missing_tables=(),
+        missing_columns=(),
         differences=differences,  # type: ignore[arg-type]
     )
     return CanaryRunResult(selection=selection, comparison=comparison, rebuild_receipt={"status": "replayed"})
@@ -184,6 +185,7 @@ def test_shared_canary_runner_uses_existing_inactive_rebuild_route(tmp_path: Pat
             session_ids=session_ids,
             compared_tables=("sessions",),
             missing_tables=(),
+            missing_columns=(),
             differences=(),
         )
 

--- a/tests/unit/devtools/test_reindex_canary.py
+++ b/tests/unit/devtools/test_reindex_canary.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+import pytest
+
 import devtools.reindex_canary as reindex_canary
 from polylogue.scenarios import ExecutionSpec
 
 
-def test_devtools_reindex_canary_delegates_to_product_cli(monkeypatch, capsys) -> None:
+def test_devtools_reindex_canary_delegates_to_product_cli(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
     captured: dict[str, object] = {}
 
-    def fake_invoke(execution: ExecutionSpec):
+    def fake_invoke(execution: ExecutionSpec) -> object:
         captured["execution"] = execution
 
         class Result:

--- a/tests/unit/devtools/test_reindex_canary.py
+++ b/tests/unit/devtools/test_reindex_canary.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import devtools.reindex_canary as reindex_canary
+from polylogue.scenarios import ExecutionSpec
+
+
+def test_devtools_reindex_canary_delegates_to_product_cli(monkeypatch, capsys) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_invoke(execution: ExecutionSpec):
+        captured["execution"] = execution
+
+        class Result:
+            exit_code = 0
+            stdout = "canary output\n"
+            stderr = ""
+
+        return Result()
+
+    monkeypatch.setattr(reindex_canary, "invoke_polylogue_cli", fake_invoke)
+
+    assert reindex_canary.main(["--report", "/tmp/canary.json", "--no-promote", "--json"]) == 0
+    execution = captured["execution"]
+    assert isinstance(execution, ExecutionSpec)
+    assert execution.command == (
+        "polylogue",
+        "--plain",
+        "ops",
+        "maintenance",
+        "reindex-canary",
+        "--report",
+        "/tmp/canary.json",
+        "--no-promote",
+        "--output-format",
+        "json",
+    )
+    assert capsys.readouterr().out == "canary output\n"

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -9,13 +9,14 @@ green, while the real blocks read model must report the changed row.
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
+import tempfile
 from pathlib import Path
 from typing import Any
 
 import pytest
 
-import polylogue.maintenance.reindex_canary as reindex_canary
 from polylogue.maintenance.reindex_canary import (
     CanaryDifferenceReview,
     CanaryDiffReport,
@@ -311,7 +312,9 @@ def test_selector_refuses_unknown_or_non_replayable_explicit_sessions(tmp_path: 
         select_canary_sessions(index, pathology_session_ids=("codex-session:alpha",))
 
 
-def test_run_reindex_canary_compares_its_own_inactive_generation(tmp_path: Path, monkeypatch) -> None:
+def test_run_reindex_canary_compares_its_own_inactive_generation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     current = tmp_path / "current.db"
     current.touch()
     generation_id = "gen-canary"
@@ -344,13 +347,12 @@ def test_run_reindex_canary_compares_its_own_inactive_generation(tmp_path: Path,
         "polylogue.maintenance.reindex_canary.select_canary_sessions", lambda *args, **kwargs: selection
     )
     monkeypatch.setattr("polylogue.maintenance.rebuild_index.rebuild_index_from_source_sync", lambda request: Receipt())
-    monkeypatch.setattr(
-        "polylogue.maintenance.reindex_canary.compare_reindex_generations",
-        lambda current_path, candidate_path, *, session_ids: (
-            captured.update({"paths": (current_path, candidate_path), "session_ids": session_ids})
-            or _empty_comparison(current_path, candidate_path, session_ids)
-        ),
-    )
+
+    def fake_compare(current_path: Path, candidate_path: Path, *, session_ids: tuple[str, ...]) -> CanaryDiffReport:
+        captured.update({"paths": (current_path, candidate_path), "session_ids": session_ids})
+        return _empty_comparison(current_path, candidate_path, session_ids)
+
+    monkeypatch.setattr("polylogue.maintenance.reindex_canary.compare_reindex_generations", fake_compare)
 
     result = run_reindex_canary(root, input_index=current, no_promote=True)
 
@@ -358,7 +360,7 @@ def test_run_reindex_canary_compares_its_own_inactive_generation(tmp_path: Path,
     assert captured["paths"] == (current, candidate)
 
 
-def test_run_reindex_canary_rejects_arbitrary_sqlite_candidate(tmp_path: Path, monkeypatch) -> None:
+def test_run_reindex_canary_rejects_arbitrary_sqlite_candidate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     current = tmp_path / "current.db"
     current.touch()
     arbitrary = tmp_path / "arbitrary.db"
@@ -499,7 +501,9 @@ def test_loading_canary_report_recomputes_tampered_summary(tmp_path: Path) -> No
 
     loaded = load_canary_report(report_path)
 
-    summary = loaded["comparison"]["summary"]
+    comparison_payload = loaded["comparison"]
+    assert isinstance(comparison_payload, dict)
+    summary = comparison_payload["summary"]
     assert isinstance(summary, dict)
     assert summary["difference_count"] == len(reviews)
     assert summary["unexpected_count"] == len(reviews)
@@ -522,7 +526,7 @@ def test_canary_report_uses_unique_temporary_names(tmp_path: Path, monkeypatch: 
         )
         for difference in comparison.differences
     )
-    original = reindex_canary.tempfile.NamedTemporaryFile
+    original = tempfile.NamedTemporaryFile
     names: list[str] = []
 
     def recording_named_temporary_file(*args: Any, **kwargs: Any) -> Any:
@@ -530,7 +534,7 @@ def test_canary_report_uses_unique_temporary_names(tmp_path: Path, monkeypatch: 
         names.append(stream.name)
         return stream
 
-    monkeypatch.setattr(reindex_canary.tempfile, "NamedTemporaryFile", recording_named_temporary_file)
+    monkeypatch.setattr(tempfile, "NamedTemporaryFile", recording_named_temporary_file)
     write_canary_report(report_path, selection=selection, comparison=comparison, reviews=reviews)
     write_canary_report(report_path, selection=selection, comparison=comparison, reviews=reviews)
 
@@ -562,7 +566,7 @@ def test_canary_report_cleans_temporary_file_when_replace_fails(
     def fail_replace(source: object, destination: object) -> None:
         raise OSError("replace failed")
 
-    monkeypatch.setattr(reindex_canary.os, "replace", fail_replace)
+    monkeypatch.setattr(os, "replace", fail_replace)
     with pytest.raises(OSError, match="replace failed"):
         write_canary_report(report_path, selection=selection, comparison=comparison, reviews=reviews)
 

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -1,0 +1,162 @@
+"""Focused real-generation tests for the reindex canary differ.
+
+The production dependency is ``compare_reindex_generations`` reading two
+canonical ``index.db`` files.  The anti-vacuity mutation for the core test is
+changing the candidate block text: a synthetic summary comparator would stay
+green, while the real blocks read model must report the changed row.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from polylogue.maintenance.reindex_canary import (
+    DifferenceClassification,
+    DifferenceOperation,
+    ExpectedDifference,
+    compare_reindex_generations,
+)
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+
+def _seed_index(
+    path: Path,
+    *,
+    sessions: tuple[str, ...] = ("alpha",),
+    block_text: str = "stable transcript",
+    profile_materialized_at: str = "first-run",
+    profile_message_count: int = 1,
+) -> None:
+    initialize_archive_database(path, ArchiveTier.INDEX)
+    with sqlite3.connect(path) as connection:
+        for native_id in sessions:
+            session_id = f"codex-session:{native_id}"
+            connection.execute(
+                """
+                INSERT INTO sessions(native_id, origin, content_hash, message_count)
+                VALUES (?, 'codex-session', ?, 1)
+                """,
+                (native_id, native_id.encode().ljust(32, b"-")),
+            )
+            connection.execute(
+                """
+                INSERT INTO messages(session_id, position, role, material_origin, content_hash)
+                VALUES (?, 0, 'user', 'human_authored', ?)
+                """,
+                (session_id, native_id.encode().ljust(32, b"m")),
+            )
+            connection.execute(
+                """
+                INSERT INTO blocks(message_id, session_id, position, block_type, text)
+                VALUES (?, ?, 0, 'text', ?)
+                """,
+                (f"{session_id}:0.0", session_id, block_text),
+            )
+            connection.execute(
+                """
+                INSERT INTO session_profiles(session_id, materialized_at, message_count, tags_json)
+                VALUES (?, ?, ?, ?)
+                """,
+                (session_id, profile_materialized_at, profile_message_count, '{"b":2,"a":1}'),
+            )
+        connection.commit()
+
+
+def test_equal_real_generations_ignore_only_materialization_metadata(tmp_path: Path) -> None:
+    current = tmp_path / "current.db"
+    candidate = tmp_path / "candidate.db"
+    _seed_index(current, profile_materialized_at="current-build")
+    _seed_index(candidate, profile_materialized_at="candidate-build")
+
+    report = compare_reindex_generations(current, candidate)
+
+    assert report.differences == ()
+    assert report.unclassified_count == 0
+    assert {"sessions", "messages", "blocks", "session_profiles"}.issubset(report.compared_tables)
+
+
+def test_differ_reports_real_core_and_derived_row_changes(tmp_path: Path) -> None:
+    current = tmp_path / "current.db"
+    candidate = tmp_path / "candidate.db"
+    _seed_index(current, sessions=("alpha", "removed"))
+    _seed_index(
+        candidate,
+        sessions=("alpha", "added"),
+        block_text="changed transcript",
+        profile_message_count=2,
+    )
+
+    report = compare_reindex_generations(current, candidate)
+
+    assert report.unexpected_count > 0
+    assert report.unclassified_count == 0
+    operations = {(item.table, item.operation) for item in report.differences}
+    assert ("blocks", DifferenceOperation.CHANGED) in operations
+    assert ("blocks", DifferenceOperation.ADDED) in operations
+    assert ("blocks", DifferenceOperation.REMOVED) in operations
+    assert any(
+        item.table == "session_profiles"
+        and item.operation is DifferenceOperation.CHANGED
+        and "message_count" in item.changed_columns
+        for item in report.differences
+    )
+    assert all(item.classification is DifferenceClassification.UNEXPECTED for item in report.differences)
+
+
+def test_expected_difference_is_structurally_accounted_for(tmp_path: Path) -> None:
+    current = tmp_path / "current.db"
+    candidate = tmp_path / "candidate.db"
+    _seed_index(current)
+    _seed_index(candidate, profile_message_count=2)
+
+    report = compare_reindex_generations(
+        current,
+        candidate,
+        expected=(
+            ExpectedDifference(
+                table="session_profiles",
+                columns=("message_count",),
+                bead_ref="polylogue-example",
+                rationale="the reviewed materializer change updates this aggregate",
+            ),
+        ),
+    )
+
+    profile_changes = [item for item in report.differences if item.table == "session_profiles"]
+    assert profile_changes
+    assert all(item.classification is DifferenceClassification.EXPECTED for item in profile_changes)
+    assert all("polylogue-example" in item.rationale for item in profile_changes)
+    assert report.expected_count == len(profile_changes)
+
+
+def test_selected_sessions_bound_the_canary_to_a_real_subset(tmp_path: Path) -> None:
+    current = tmp_path / "current.db"
+    candidate = tmp_path / "candidate.db"
+    _seed_index(current, sessions=("kept", "outside"))
+    _seed_index(candidate, sessions=("kept", "outside"))
+    with sqlite3.connect(candidate) as connection:
+        connection.execute(
+            "UPDATE blocks SET text = 'outside changed' WHERE session_id = ?",
+            ("codex-session:outside",),
+        )
+        connection.commit()
+
+    report = compare_reindex_generations(current, candidate, session_ids=("codex-session:kept",))
+
+    assert report.session_ids == ("codex-session:kept",)
+    assert report.differences == ()
+
+
+def test_canary_comparison_is_read_only(tmp_path: Path) -> None:
+    current = tmp_path / "current.db"
+    candidate = tmp_path / "candidate.db"
+    _seed_index(current)
+    _seed_index(candidate)
+    before = current.stat().st_ino, current.stat().st_size, candidate.stat().st_ino, candidate.stat().st_size
+
+    compare_reindex_generations(current, candidate)
+
+    after = current.stat().st_ino, current.stat().st_size, candidate.stat().st_ino, candidate.stat().st_size
+    assert after == before

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -116,6 +116,28 @@ def test_differ_reports_real_core_and_derived_row_changes(tmp_path: Path) -> Non
     assert all(item.classification is DifferenceClassification.UNEXPECTED for item in report.differences)
 
 
+def test_missing_tables_and_columns_are_explicit_unexpected_differences(tmp_path: Path) -> None:
+    current = tmp_path / "current.db"
+    candidate = tmp_path / "candidate.db"
+    _seed_index(current)
+    _seed_index(candidate)
+    with sqlite3.connect(candidate) as connection:
+        connection.execute("ALTER TABLE session_profiles DROP COLUMN tags_json")
+        connection.execute("DROP TABLE blocks")
+        connection.commit()
+
+    report = compare_reindex_generations(current, candidate)
+
+    assert report.missing_tables == ("blocks",)
+    assert report.missing_columns == (("session_profiles", ("tags_json",)),)
+    schema_differences = [item for item in report.differences if item.identity[0][0] == "__schema__"]
+    assert {(item.table, item.operation) for item in schema_differences} == {
+        ("blocks", DifferenceOperation.REMOVED),
+        ("session_profiles", DifferenceOperation.REMOVED),
+    }
+    assert report.unexpected_count == len(report.differences)
+
+
 def test_expected_difference_is_structurally_accounted_for(tmp_path: Path) -> None:
     current = tmp_path / "current.db"
     candidate = tmp_path / "candidate.db"
@@ -140,6 +162,34 @@ def test_expected_difference_is_structurally_accounted_for(tmp_path: Path) -> No
     assert all(item.classification is DifferenceClassification.EXPECTED for item in profile_changes)
     assert all("polylogue-example" in item.rationale for item in profile_changes)
     assert report.expected_count == len(profile_changes)
+
+
+def test_expected_difference_cannot_hide_extra_changed_columns(tmp_path: Path) -> None:
+    current = tmp_path / "current.db"
+    candidate = tmp_path / "candidate.db"
+    _seed_index(current)
+    _seed_index(candidate, profile_message_count=2)
+    with sqlite3.connect(candidate) as connection:
+        connection.execute("UPDATE session_profiles SET tags_json = ?", ('{"extra":true}',))
+        connection.commit()
+
+    report = compare_reindex_generations(
+        current,
+        candidate,
+        expected=(
+            ExpectedDifference(
+                table="session_profiles",
+                columns=("message_count",),
+                bead_ref="polylogue-example",
+                rationale="the reviewed materializer change updates this aggregate",
+            ),
+        ),
+    )
+
+    profile_changes = [item for item in report.differences if item.table == "session_profiles"]
+    assert len(profile_changes) == 1
+    assert profile_changes[0].changed_columns == ("tags_json", "message_count")
+    assert profile_changes[0].classification is DifferenceClassification.UNEXPECTED
 
 
 def test_selected_sessions_bound_the_canary_to_a_real_subset(tmp_path: Path) -> None:

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -8,11 +8,14 @@ green, while the real blocks read model must report the changed row.
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from pathlib import Path
+from typing import Any
 
 import pytest
 
+import polylogue.maintenance.reindex_canary as reindex_canary
 from polylogue.maintenance.reindex_canary import (
     CanaryDifferenceReview,
     CanaryDiffReport,
@@ -429,3 +432,139 @@ def test_durable_report_persists_explicit_review_for_every_diff(tmp_path: Path) 
     assert isinstance(summary, dict)
     assert summary["unclassified_count"] == 0
     assert summary["unexpected_count"] == len(reviews)
+
+
+def test_loading_canary_report_rechecks_exact_review_coverage(tmp_path: Path) -> None:
+    current = tmp_path / "current.db"
+    candidate = tmp_path / "candidate.db"
+    report_path = tmp_path / "reports" / "canary.json"
+    _seed_index(current)
+    _seed_index(candidate, block_text="changed transcript")
+    comparison = compare_reindex_generations(current, candidate)
+    selection = select_canary_sessions(current, sessions_per_origin=1)
+    reviews = tuple(
+        CanaryDifferenceReview.for_difference(
+            difference,
+            classification=DifferenceClassification.UNEXPECTED,
+            reference="polylogue-follow-up",
+            rationale="the canary has no reviewed expected delta for this row",
+        )
+        for difference in comparison.differences
+    )
+    write_canary_report(report_path, selection=selection, comparison=comparison, reviews=reviews)
+
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    payload["reviews"] = payload["reviews"][:-1]
+    payload["comparison"]["summary"] = {
+        "difference_count": 0,
+        "expected_count": 0,
+        "unexpected_count": 0,
+        "unclassified_count": 0,
+        "counts_by_table": {},
+    }
+    report_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(UnclassifiedCanaryDiffError, match="review coverage is incomplete"):
+        load_canary_report(report_path)
+
+
+def test_loading_canary_report_recomputes_tampered_summary(tmp_path: Path) -> None:
+    current = tmp_path / "current.db"
+    candidate = tmp_path / "candidate.db"
+    report_path = tmp_path / "reports" / "canary.json"
+    _seed_index(current)
+    _seed_index(candidate, block_text="changed transcript")
+    comparison = compare_reindex_generations(current, candidate)
+    selection = select_canary_sessions(current, sessions_per_origin=1)
+    reviews = tuple(
+        CanaryDifferenceReview.for_difference(
+            difference,
+            classification=DifferenceClassification.UNEXPECTED,
+            reference="polylogue-follow-up",
+            rationale="the canary has no reviewed expected delta for this row",
+        )
+        for difference in comparison.differences
+    )
+    write_canary_report(report_path, selection=selection, comparison=comparison, reviews=reviews)
+
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    payload["comparison"]["summary"] = {
+        "difference_count": 0,
+        "expected_count": 0,
+        "unexpected_count": 0,
+        "unclassified_count": 0,
+        "counts_by_table": {},
+    }
+    report_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = load_canary_report(report_path)
+
+    summary = loaded["comparison"]["summary"]
+    assert isinstance(summary, dict)
+    assert summary["difference_count"] == len(reviews)
+    assert summary["unexpected_count"] == len(reviews)
+
+
+def test_canary_report_uses_unique_temporary_names(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    current = tmp_path / "current.db"
+    candidate = tmp_path / "candidate.db"
+    report_path = tmp_path / "reports" / "canary.json"
+    _seed_index(current)
+    _seed_index(candidate, block_text="changed transcript")
+    comparison = compare_reindex_generations(current, candidate)
+    selection = select_canary_sessions(current, sessions_per_origin=1)
+    reviews = tuple(
+        CanaryDifferenceReview.for_difference(
+            difference,
+            classification=DifferenceClassification.UNEXPECTED,
+            reference="polylogue-follow-up",
+            rationale="the canary has no reviewed expected delta for this row",
+        )
+        for difference in comparison.differences
+    )
+    original = reindex_canary.tempfile.NamedTemporaryFile
+    names: list[str] = []
+
+    def recording_named_temporary_file(*args: Any, **kwargs: Any) -> Any:
+        stream = original(*args, **kwargs)
+        names.append(stream.name)
+        return stream
+
+    monkeypatch.setattr(reindex_canary.tempfile, "NamedTemporaryFile", recording_named_temporary_file)
+    write_canary_report(report_path, selection=selection, comparison=comparison, reviews=reviews)
+    write_canary_report(report_path, selection=selection, comparison=comparison, reviews=reviews)
+
+    assert len(names) == 2
+    assert len(set(names)) == 2
+    assert list(report_path.parent.glob(f".{report_path.name}.*.tmp")) == []
+
+
+def test_canary_report_cleans_temporary_file_when_replace_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    current = tmp_path / "current.db"
+    candidate = tmp_path / "candidate.db"
+    report_path = tmp_path / "reports" / "canary.json"
+    _seed_index(current)
+    _seed_index(candidate, block_text="changed transcript")
+    comparison = compare_reindex_generations(current, candidate)
+    selection = select_canary_sessions(current, sessions_per_origin=1)
+    reviews = tuple(
+        CanaryDifferenceReview.for_difference(
+            difference,
+            classification=DifferenceClassification.UNEXPECTED,
+            reference="polylogue-follow-up",
+            rationale="the canary has no reviewed expected delta for this row",
+        )
+        for difference in comparison.differences
+    )
+
+    def fail_replace(source: object, destination: object) -> None:
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(reindex_canary.os, "replace", fail_replace)
+    with pytest.raises(OSError, match="replace failed"):
+        write_canary_report(report_path, selection=selection, comparison=comparison, reviews=reviews)
+
+    assert not report_path.exists()
+    assert list(report_path.parent.glob(f".{report_path.name}.*.tmp")) == []

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -15,6 +15,8 @@ import pytest
 
 from polylogue.maintenance.reindex_canary import (
     CanaryDifferenceReview,
+    CanaryDiffReport,
+    CanarySelection,
     CanarySelectionError,
     DifferenceClassification,
     DifferenceOperation,
@@ -22,6 +24,7 @@ from polylogue.maintenance.reindex_canary import (
     UnclassifiedCanaryDiffError,
     compare_reindex_generations,
     load_canary_report,
+    run_reindex_canary,
     select_canary_sessions,
     write_canary_report,
 )
@@ -73,6 +76,31 @@ def _seed_index(
                 (session_id, profile_materialized_at, profile_message_count, '{"b":2,"a":1}'),
             )
         connection.commit()
+
+
+def _empty_selection(index_path: Path) -> CanarySelection:
+    return CanarySelection(
+        index_path=index_path,
+        sessions_per_origin=1,
+        selected_session_ids=(),
+        selected_raw_ids=(),
+        sampled_session_ids=(),
+        pathology_session_ids=(),
+        sample_session_ids=(),
+        origin_counts=(),
+    )
+
+
+def _empty_comparison(current: Path, candidate: Path, session_ids: tuple[str, ...]) -> CanaryDiffReport:
+    return CanaryDiffReport(
+        current_index=current,
+        candidate_index=candidate,
+        session_ids=session_ids,
+        compared_tables=(),
+        missing_tables=(),
+        missing_columns=(),
+        differences=(),
+    )
 
 
 def test_equal_real_generations_ignore_only_materialization_metadata(tmp_path: Path) -> None:
@@ -278,6 +306,83 @@ def test_selector_refuses_unknown_or_non_replayable_explicit_sessions(tmp_path: 
         connection.commit()
     with pytest.raises(CanarySelectionError, match="no raw_id"):
         select_canary_sessions(index, pathology_session_ids=("codex-session:alpha",))
+
+
+def test_run_reindex_canary_compares_its_own_inactive_generation(tmp_path: Path, monkeypatch) -> None:
+    current = tmp_path / "current.db"
+    current.touch()
+    generation_id = "gen-canary"
+    candidate = tmp_path / ".index-generations" / generation_id / "index.db"
+    candidate.parent.mkdir(parents=True)
+    candidate.touch()
+    root = tmp_path
+    selection = _empty_selection(current)
+
+    class Receipt:
+        archive_root = str(root.resolve())
+        selected_raw_count = len(selection.selected_raw_ids)
+        status = "replayed"
+        materialized = True
+        generation = {
+            "generation_id": generation_id,
+            "owner_id": "owner",
+            "archive_root": str(root.resolve()),
+            "index_path": str(candidate),
+            "state": "inactive",
+            "source_snapshot": "snapshot",
+        }
+
+        def to_dict(self) -> dict[str, object]:
+            return {"generation": self.generation}
+
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        "polylogue.maintenance.reindex_canary.select_canary_sessions", lambda *args, **kwargs: selection
+    )
+    monkeypatch.setattr("polylogue.maintenance.rebuild_index.rebuild_index_from_source_sync", lambda request: Receipt())
+    monkeypatch.setattr(
+        "polylogue.maintenance.reindex_canary.compare_reindex_generations",
+        lambda current_path, candidate_path, *, session_ids: (
+            captured.update({"paths": (current_path, candidate_path), "session_ids": session_ids})
+            or _empty_comparison(current_path, candidate_path, session_ids)
+        ),
+    )
+
+    result = run_reindex_canary(root, input_index=current, no_promote=True)
+
+    assert result.comparison.candidate_index == candidate
+    assert captured["paths"] == (current, candidate)
+
+
+def test_run_reindex_canary_rejects_arbitrary_sqlite_candidate(tmp_path: Path, monkeypatch) -> None:
+    current = tmp_path / "current.db"
+    current.touch()
+    arbitrary = tmp_path / "arbitrary.db"
+    arbitrary.touch()
+    selection = _empty_selection(current)
+
+    class Receipt:
+        archive_root = str(tmp_path.resolve())
+        selected_raw_count = 0
+        status = "replayed"
+        materialized = True
+        generation = {
+            "generation_id": "gen-canary",
+            "owner_id": "owner",
+            "archive_root": str(tmp_path.resolve()),
+            "index_path": str(arbitrary),
+            "state": "inactive",
+            "source_snapshot": "snapshot",
+        }
+
+    monkeypatch.setattr(
+        "polylogue.maintenance.reindex_canary.select_canary_sessions", lambda *args, **kwargs: selection
+    )
+    monkeypatch.setattr("polylogue.maintenance.rebuild_index.rebuild_index_from_source_sync", lambda request: Receipt())
+
+    with pytest.raises(CanarySelectionError, match="outside this archive's generation root"):
+        run_reindex_canary(tmp_path, input_index=current, no_promote=True)
 
 
 def test_durable_report_refuses_unclassified_diffs(tmp_path: Path) -> None:

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -11,11 +11,19 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
+import pytest
+
 from polylogue.maintenance.reindex_canary import (
+    CanaryDifferenceReview,
+    CanarySelectionError,
     DifferenceClassification,
     DifferenceOperation,
     ExpectedDifference,
+    UnclassifiedCanaryDiffError,
     compare_reindex_generations,
+    load_canary_report,
+    select_canary_sessions,
+    write_canary_report,
 )
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
@@ -28,17 +36,20 @@ def _seed_index(
     block_text: str = "stable transcript",
     profile_materialized_at: str = "first-run",
     profile_message_count: int = 1,
+    origins: tuple[str, ...] | None = None,
 ) -> None:
     initialize_archive_database(path, ArchiveTier.INDEX)
     with sqlite3.connect(path) as connection:
-        for native_id in sessions:
-            session_id = f"codex-session:{native_id}"
+        session_origins = origins or ("codex-session",) * len(sessions)
+        assert len(session_origins) == len(sessions)
+        for native_id, origin in zip(sessions, session_origins, strict=True):
+            session_id = f"{origin}:{native_id}"
             connection.execute(
                 """
-                INSERT INTO sessions(native_id, origin, content_hash, message_count)
-                VALUES (?, 'codex-session', ?, 1)
+                INSERT INTO sessions(native_id, origin, raw_id, content_hash, message_count)
+                VALUES (?, ?, ?, ?, 1)
                 """,
-                (native_id, native_id.encode().ljust(32, b"-")),
+                (native_id, origin, f"raw-{native_id}", native_id.encode().ljust(32, b"-")),
             )
             connection.execute(
                 """
@@ -160,3 +171,106 @@ def test_canary_comparison_is_read_only(tmp_path: Path) -> None:
 
     after = current.stat().st_ino, current.stat().st_size, candidate.stat().st_ino, candidate.stat().st_size
     assert after == before
+
+
+def test_selector_samples_each_origin_and_keeps_explicit_inputs(tmp_path: Path) -> None:
+    index = tmp_path / "index.db"
+    _seed_index(
+        index,
+        sessions=("codex-a", "codex-pathology", "chat-a", "chat-sample", "claude-a", "claude-pathology"),
+        origins=(
+            "codex-session",
+            "codex-session",
+            "chatgpt-export",
+            "chatgpt-export",
+            "claude-ai-export",
+            "claude-ai-export",
+        ),
+    )
+
+    selection = select_canary_sessions(
+        index,
+        sessions_per_origin=1,
+        pathology_session_ids=("codex-session:codex-pathology", "claude-ai-export:claude-pathology"),
+        sample_session_ids=("chatgpt-export:chat-sample",),
+    )
+
+    assert selection.origin_counts == (
+        ("chatgpt-export", 2),
+        ("claude-ai-export", 2),
+        ("codex-session", 2),
+    )
+    assert selection.selected_session_ids == (
+        "chatgpt-export:chat-a",
+        "chatgpt-export:chat-sample",
+        "claude-ai-export:claude-a",
+        "claude-ai-export:claude-pathology",
+        "codex-session:codex-a",
+        "codex-session:codex-pathology",
+    )
+    assert selection.selected_raw_ids == (
+        "raw-chat-a",
+        "raw-chat-sample",
+        "raw-claude-a",
+        "raw-claude-pathology",
+        "raw-codex-a",
+        "raw-codex-pathology",
+    )
+
+
+def test_selector_refuses_unknown_or_non_replayable_explicit_sessions(tmp_path: Path) -> None:
+    index = tmp_path / "index.db"
+    _seed_index(index)
+    with pytest.raises(CanarySelectionError, match="not indexed"):
+        select_canary_sessions(index, pathology_session_ids=("codex-session:missing",))
+    with sqlite3.connect(index) as connection:
+        connection.execute("UPDATE sessions SET raw_id = NULL")
+        connection.commit()
+    with pytest.raises(CanarySelectionError, match="no raw_id"):
+        select_canary_sessions(index, pathology_session_ids=("codex-session:alpha",))
+
+
+def test_durable_report_refuses_unclassified_diffs(tmp_path: Path) -> None:
+    current = tmp_path / "current.db"
+    candidate = tmp_path / "candidate.db"
+    report_path = tmp_path / "reports" / "canary.json"
+    _seed_index(current)
+    _seed_index(candidate, block_text="changed transcript")
+    comparison = compare_reindex_generations(current, candidate)
+    selection = select_canary_sessions(current, sessions_per_origin=1)
+
+    with pytest.raises(UnclassifiedCanaryDiffError, match="classification is incomplete"):
+        write_canary_report(report_path, selection=selection, comparison=comparison, reviews=())
+    assert not report_path.exists()
+
+
+def test_durable_report_persists_explicit_review_for_every_diff(tmp_path: Path) -> None:
+    current = tmp_path / "current.db"
+    candidate = tmp_path / "candidate.db"
+    report_path = tmp_path / "reports" / "canary.json"
+    _seed_index(current)
+    _seed_index(candidate, block_text="changed transcript")
+    comparison = compare_reindex_generations(current, candidate)
+    selection = select_canary_sessions(current, sessions_per_origin=1)
+    reviews = tuple(
+        CanaryDifferenceReview.for_difference(
+            difference,
+            classification=DifferenceClassification.UNEXPECTED,
+            reference="polylogue-follow-up",
+            rationale="the canary has no reviewed expected delta for this row",
+        )
+        for difference in comparison.differences
+    )
+
+    durable = write_canary_report(report_path, selection=selection, comparison=comparison, reviews=reviews)
+    loaded = load_canary_report(report_path)
+
+    assert durable.unclassified_count == 0
+    assert report_path.exists()
+    assert loaded["schema_version"] == 1
+    comparison_payload = loaded["comparison"]
+    assert isinstance(comparison_payload, dict)
+    summary = comparison_payload["summary"]
+    assert isinstance(summary, dict)
+    assert summary["unclassified_count"] == 0
+    assert summary["unexpected_count"] == len(reviews)


### PR DESCRIPTION
## Summary

Adds the stamp-free reindex canary that rebuilds representative raw material into an inactive generation and requires a reviewed semantic diff before a full rebuild.

## Problem

A schema-valid rebuild can change parsed archive semantics while ordinary structural verification stays green. The earlier branch also contained parser-fingerprint stamps that remain blocked on the id-less identity repair.

## Solution

Adds bounded origin-aware selection, inactive-generation rebuild receipt validation, schema-asymmetry detection, strict expected-column classification, durable atomic reports, a product CLI and devtools entrypoint, and a maintenance runbook. This branch deliberately excludes the fingerprint-stamp commit.

## Verification

- 22 focused canary route tests passed on the implementation branch.
- Strict mypy and Ruff passed for the canary implementation and tests.
- Current rebased branch: devtools verify docs-coverage and devtools render all --check passed.
- Pre-push quick-gate receipt: 0125d005.

Ref polylogue-0x7nh.