### PR TITLE
fix(rebuild): gate candidates on corpus fidelity

### DIFF
--- a/polylogue/maintenance/archive_verification.py
+++ b/polylogue/maintenance/archive_verification.py
@@ -235,6 +235,7 @@ class ArchiveVerificationReport(OutcomeReport):
 
 
 ArchiveVerificationCheckFn = Callable[[Path, int], ArchiveVerificationCheck]
+ArchiveVerificationCandidateCheckFn = Callable[[Path, Path, int], ArchiveVerificationCheck]
 
 
 @dataclass(frozen=True)
@@ -249,6 +250,9 @@ class ArchiveVerificationCheckSpec:
     #: check added without a class tag is a construction-time TypeError, not a
     #: silent "" that would slip past classification).
     check_class: ArchiveVerificationCheckClass
+    #: Optional candidate-index execution path for checks that combine the
+    #: durable archive root with an inactive generation before promotion.
+    candidate_run: ArchiveVerificationCandidateCheckFn | None = None
 
 
 def _tier_path(archive_root: Path, tier: ArchiveTier) -> Path:
@@ -1448,8 +1452,13 @@ def _gib_str(byte_count: int) -> str:
 
 
 def _check_corpus_absences(archive_root: Path, sample_limit: int) -> ArchiveVerificationCheck:
+    return _check_corpus_absences_at_index_path(archive_root, _resolve_index_path(archive_root), sample_limit)
+
+
+def _check_corpus_absences_at_index_path(
+    archive_root: Path, index_path: Path, sample_limit: int
+) -> ArchiveVerificationCheck:
     source_path = _tier_path(archive_root, ArchiveTier.SOURCE)
-    index_path = _resolve_index_path(archive_root)
     if not source_path.exists() or not index_path.exists():
         return _skip_check("corpus-absences", "source.db or index.db not present")
     try:
@@ -1483,7 +1492,14 @@ def _check_corpus_absences(archive_root: Path, sample_limit: int) -> ArchiveVeri
 
 
 def _check_corpus_attachment_fidelity(archive_root: Path, _sample_limit: int) -> ArchiveVerificationCheck:
-    index_path = _resolve_index_path(archive_root)
+    return _check_corpus_attachment_fidelity_at_index_path(
+        archive_root, _resolve_index_path(archive_root), _sample_limit
+    )
+
+
+def _check_corpus_attachment_fidelity_at_index_path(
+    _archive_root: Path, index_path: Path, _sample_limit: int
+) -> ArchiveVerificationCheck:
     if not index_path.exists():
         return _skip_check("corpus-attachment-fidelity", "index.db not present")
     try:
@@ -1515,8 +1531,13 @@ def _check_corpus_attachment_fidelity(archive_root: Path, _sample_limit: int) ->
 
 
 def _check_corpus_revision_fidelity(archive_root: Path, sample_limit: int) -> ArchiveVerificationCheck:
+    return _check_corpus_revision_fidelity_at_index_path(archive_root, _resolve_index_path(archive_root), sample_limit)
+
+
+def _check_corpus_revision_fidelity_at_index_path(
+    archive_root: Path, index_path: Path, sample_limit: int
+) -> ArchiveVerificationCheck:
     source_path = _tier_path(archive_root, ArchiveTier.SOURCE)
-    index_path = _resolve_index_path(archive_root)
     if not source_path.exists() or not index_path.exists():
         return _skip_check("corpus-revision-fidelity", "source.db or index.db not present")
     try:
@@ -2049,18 +2070,21 @@ ARCHIVE_VERIFICATION_CHECKS: tuple[ArchiveVerificationCheckSpec, ...] = (
         "Every source-backed logical corpus document is represented by an indexed session (polylogue-f1vg).",
         _check_corpus_absences,
         ArchiveVerificationCheckClass.STATE_INVARIANT,
+        _check_corpus_absences_at_index_path,
     ),
     ArchiveVerificationCheckSpec(
         "corpus-attachment-fidelity",
         "Every attachment reference is acquired or explicitly typed unavailable, bucketed by origin and upload origin (polylogue-f1vg).",
         _check_corpus_attachment_fidelity,
         ArchiveVerificationCheckClass.FIDELITY,
+        _check_corpus_attachment_fidelity_at_index_path,
     ),
     ArchiveVerificationCheckSpec(
         "corpus-revision-fidelity",
         "Indexed comparable evidence is not smaller than the best recorded source revision (polylogue-f1vg).",
         _check_corpus_revision_fidelity,
         ArchiveVerificationCheckClass.FIDELITY,
+        _check_corpus_revision_fidelity_at_index_path,
     ),
 )
 
@@ -2118,6 +2142,7 @@ def verify_archive(
     *,
     checks: Sequence[str] | None = None,
     sample_limit: int = DEFAULT_SAMPLE_LIMIT,
+    index_path_override: Path | None = None,
 ) -> ArchiveVerificationReport:
     """Run every selected archive-coherence check and return the aggregate report.
 
@@ -2127,15 +2152,26 @@ def verify_archive(
     outcome rather than aborting the remaining checks. ``checks=None`` (the
     default) runs the full registry in :data:`ARCHIVE_VERIFICATION_CHECKS`
     order; a name not in the registry raises :class:`ValueError` immediately.
+    ``index_path_override`` runs only checks with a candidate runner against
+    that inactive generation's real index while retaining durable tiers from
+    ``archive_root``.
     """
     specs = _select_check_specs(checks)
+    if index_path_override is not None:
+        unsupported = [spec.name for spec in specs if spec.candidate_run is None]
+        if unsupported:
+            raise ValueError("candidate index verification is unsupported for check(s): " + ", ".join(unsupported))
     # Typed at the OutcomeCheck base so this list assigns cleanly into
     # ArchiveVerificationReport.checks (inherited, invariant list[OutcomeCheck])
     # without a redundant narrower field redeclaration on the report dataclass.
     results: list[OutcomeCheck] = []
     for spec in specs:
         try:
-            result = spec.run(archive_root, sample_limit)
+            result = (
+                spec.candidate_run(archive_root, index_path_override, sample_limit)
+                if index_path_override is not None and spec.candidate_run is not None
+                else spec.run(archive_root, sample_limit)
+            )
         except Exception as exc:  # defense-in-depth: see module/function docstring
             logger.exception("archive verification check %s raised", spec.name)
             result = _error_check(spec.name, f"check raised {type(exc).__name__}: {exc}")

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -641,7 +641,11 @@ async def _rebuild_index_from_source_owned(
     request: RebuildIndexRequest, *, root: Path, owned: OwnedArchiveLocation
 ) -> RebuildIndexReceipt:
     """Ownership-proven body of :func:`rebuild_index_from_source`."""
-    from polylogue.maintenance.archive_verification import REINDEX_ACCEPTANCE_CHECKS, verify_archive
+    from polylogue.maintenance.archive_verification import (
+        CORPUS_FIDELITY_CHECKS,
+        REINDEX_ACCEPTANCE_CHECKS,
+        verify_archive,
+    )
     from polylogue.maintenance.replay import rebuild_index_from_source as replay_source
     from polylogue.sources.revision_backfill import RebuildDeadlineExceededError
     from polylogue.storage.archive_readiness import archive_readiness_status
@@ -1064,14 +1068,24 @@ async def _rebuild_index_from_source_owned(
                     elapsed_s=round(elapsed_s, 3),
                 )
             terminal_started_at = time.perf_counter()
-            # polylogue-t0m73: the reindex acceptance gate -- every
+            # polylogue-t0m73: the index-only reindex acceptance gate -- every
             # ground-truth check whose universe is satisfiable from a
             # generation directory's index.db alone (source.db/user.db/
             # embeddings.db live once at the archive root, not per
             # generation, so cross-tier checks are excluded; see
             # REINDEX_ACCEPTANCE_CHECKS' docstring). This subsumed the older
             # fts-parity-only gate.
-            acceptance_report = verify_archive(generation_root, checks=list(REINDEX_ACCEPTANCE_CHECKS))
+            acceptance_reports = (
+                verify_archive(generation_root, checks=REINDEX_ACCEPTANCE_CHECKS),
+                # polylogue-f1vg: an inactive generation has only index.db, so
+                # corpus fidelity combines that candidate with the durable
+                # source tier at the archive root before promotion.
+                verify_archive(
+                    root,
+                    checks=CORPUS_FIDELITY_CHECKS,
+                    index_path_override=Path(generation.index_path),
+                ),
+            )
             terminal_timings_s["terminal.reindex_acceptance"] = time.perf_counter() - terminal_started_at
             logger.info(
                 "rebuild_terminal_stage_complete",
@@ -1079,10 +1093,11 @@ async def _rebuild_index_from_source_owned(
                 stage="reindex_acceptance",
                 elapsed_s=round(terminal_timings_s["terminal.reindex_acceptance"], 3),
             )
-            if acceptance_report.blocking:
+            if any(report.blocking for report in acceptance_reports):
                 failing = "; ".join(
                     f"{check.name}: {check.summary}"
-                    for check in acceptance_report.checks
+                    for report in acceptance_reports
+                    for check in report.checks
                     if check.status.value == "error" and getattr(check, "waived_bead_id", None) is None
                 )
                 raise RuntimeError(

--- a/tests/unit/devtools/test_corpus_fidelity.py
+++ b/tests/unit/devtools/test_corpus_fidelity.py
@@ -2,17 +2,15 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
+import sqlite3
 from pathlib import Path
 
 import pytest
 
 from devtools import corpus_fidelity
-from polylogue.maintenance.archive_verification import (
-    CORPUS_FIDELITY_CHECKS,
-    verify_archive,
-)
-from tests.infra.workload_artifacts import SeededArchiveArtifact
+from tests.infra.workload_artifacts import SeededArchiveArtifact, clone_seeded_archive
 
 
 def test_command_runs_registered_gate_against_real_seeded_archive(
@@ -30,34 +28,79 @@ def test_command_runs_registered_gate_against_real_seeded_archive(
     assert "clear" in output
 
 
-def test_command_binds_exact_registry_selection_and_json_contract(
+def _clone(artifact: SeededArchiveArtifact, destination: Path) -> Path:
+    return clone_seeded_archive(artifact, destination).root
+
+
+@pytest.mark.parametrize(
+    ("violation", "expected_check"),
+    (
+        ("absent", "corpus-absences"),
+        ("attachment", "corpus-attachment-fidelity"),
+        ("revision", "corpus-revision-fidelity"),
+    ),
+)
+def test_command_blocks_real_seeded_archive_fidelity_violations(
+    corpus_fidelity_archive: SeededArchiveArtifact,
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
+    violation: str,
+    expected_check: str,
 ) -> None:
-    captured: dict[str, object] = {}
+    """The command drives the production registry over a writable clone of
+    the real seeded SQLite archive. Removing its ``verify_archive`` call or
+    any selected checker leaves the corresponding archive mutation green.
+    """
+    root = _clone(corpus_fidelity_archive, tmp_path / violation)
+    with sqlite3.connect(root / "index.db") as index:
+        session_row = index.execute("SELECT session_id FROM sessions ORDER BY session_id LIMIT 1").fetchone()
+        message_row = index.execute(
+            "SELECT message_id FROM messages WHERE session_id = ? ORDER BY position LIMIT 1",
+            session_row,
+        ).fetchone()
+        assert session_row is not None
+        assert message_row is not None
+        session_id = str(session_row[0])
+        if violation == "attachment":
+            index.execute(
+                "INSERT INTO attachments(attachment_id, acquisition_status) VALUES ('fixture-unfetched', 'unfetched')"
+            )
+            index.execute(
+                "INSERT INTO attachment_refs(attachment_id, session_id, message_id, position, upload_origin) "
+                "VALUES ('fixture-unfetched', ?, ?, 99, 'drive')",
+                (session_id, message_row[0]),
+            )
+    if violation in {"absent", "revision"}:
+        origin, native_id = session_id.split(":", 1)
+        raw_id = f"fixture-{violation}"
+        provider_session_id = native_id if violation == "revision" else "absent"
+        with sqlite3.connect(root / "source.db") as source:
+            source.execute(
+                "INSERT INTO raw_sessions(raw_id, origin, native_id, source_path, blob_hash, blob_size, "
+                "acquired_at_ms, logical_source_key) VALUES (?, ?, ?, ?, ?, 10, 100, ?)",
+                (
+                    raw_id,
+                    origin,
+                    provider_session_id,
+                    f"/fixture/{raw_id}",
+                    hashlib.sha256(raw_id.encode()).digest(),
+                    f"fixture:{provider_session_id}",
+                ),
+            )
+            source.execute(
+                "INSERT INTO raw_session_memberships(raw_id, logical_source_key, provider_session_id, "
+                "source_revision, normalized_content_hash, message_count) VALUES (?, ?, ?, 'fixture-revision', ?, ?)",
+                (
+                    raw_id,
+                    f"fixture:{provider_session_id}",
+                    provider_session_id,
+                    b"f" * 32,
+                    100_000 if violation == "revision" else 4,
+                ),
+            )
 
-    def fake_verify_archive(
-        archive_root: Path,
-        *,
-        checks: tuple[str, ...],
-        sample_limit: int,
-    ) -> object:
-        captured["archive_root"] = archive_root
-        captured["checks"] = checks
-        captured["sample_limit"] = sample_limit
-        return verify_archive(tmp_path / "missing", checks=checks, sample_limit=sample_limit)
-
-    monkeypatch.setattr(corpus_fidelity, "verify_archive", fake_verify_archive)
-    exit_code = corpus_fidelity.main(["--archive-root", str(tmp_path / "requested"), "--sample-limit", "3", "--json"])
-
+    exit_code = corpus_fidelity.main(["--archive-root", str(root), "--json"])
     assert exit_code == 1
-    assert captured == {
-        "archive_root": tmp_path / "requested",
-        "checks": CORPUS_FIDELITY_CHECKS,
-        "sample_limit": 3,
-    }
     payload = json.loads(capsys.readouterr().out)
     assert payload["blocking"] is True
-    assert [check["name"] for check in payload["checks"]] == list(CORPUS_FIDELITY_CHECKS)
-    assert all(check["status"] == "skip" for check in payload["checks"])
+    assert {check["name"]: check["status"] for check in payload["checks"]}[expected_check] == "error"

--- a/tests/unit/maintenance/test_rebuild_index_phase_timing.py
+++ b/tests/unit/maintenance/test_rebuild_index_phase_timing.py
@@ -95,6 +95,26 @@ def test_replayed_receipt_carries_selection_phase_timing(tmp_path: Path, monkeyp
         assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 2
 
 
+def test_partial_rebuild_cannot_complete_when_candidate_omits_source_document(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``rebuild_index_from_source_sync`` must reject the real candidate
+    generation when its selected raw subset omits a source-backed document.
+    Partial requests are independently forbidden from promotion, so this
+    uses their allowed ``promote=False`` route. Removing the candidate-index
+    corpus report lets that real route report a completed rebuild instead.
+    """
+    root = tmp_path / "archive"
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
+    raw_ids = _seed_distinct_codex_sessions(root, 2)
+
+    with pytest.raises(RuntimeError, match="reindex acceptance gate failed.*corpus-absences"):
+        rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, raw_ids=(raw_ids[0],), promote=False))
+
+    with sqlite3.connect(root / "index.db") as conn:
+        assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 0
+
+
 def test_deferred_pass_cost_carries_selection_phase_timing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A resumable pass that defers on its pass deadline still records the
     selection-phase cost -- the same key as the final "replayed" receipt,


### PR DESCRIPTION
## Summary

Require corpus-fidelity validation for every completed inactive index candidate, using durable source evidence together with the candidate’s own index before promotion.

## Problem

The existing reindex acceptance gate inspected only a candidate generation directory, which contains index.db but not source.db. The corpus absence, attachment, and revision checks therefore existed only as a separately invokable devtools command and could not block a candidate that lacked source-backed evidence.

## Solution

Add candidate-aware runners to the existing archive-verification registry for the three corpus checks. The rebuild path now runs the existing index-only acceptance selection and the existing corpus-fidelity selection against the durable archive root plus the inactive generation index. Replace the devtools command binding mock with mutations of writable clones of the real seeded SQLite archive, and add a real partial-rebuild route that must fail corpus acceptance before completion.

Ref polylogue-f1vg

## Verification

- `source .venv/bin/activate && devtools test tests/unit/devtools/test_corpus_fidelity.py tests/unit/maintenance/test_rebuild_index_phase_timing.py` → `7 passed in 1.46s`.
- `source .venv/bin/activate && devtools render devtools-reference --check` → `sync OK: docs/devtools.md`.
- `source .venv/bin/activate && devtools verify --all` → format, lint, mypy, generated-surface, layering, schema, manifest, CI-command, docs, and policy checks passed; the broad pytest phase is baseline-red in unrelated provider/watcher/property areas. Its first watcher failure passed on exact rerun: `devtools test tests/unit/sources/test_live_watcher.py::test_end_to_end_hidden_root_file_creation_triggers_ingest` → `1 passed in 1.51s`.
- Pre-push hook through `nix develop --command git push -u origin feature/fix/corpus-fidelity-gate` passed its quick format, lint, mypy, and generated-surface baseline.