### PR TITLE
fix(maintenance): refuse canary rebuild in live archive

### DIFF
--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -284,10 +284,16 @@ def run_reindex_canary(
 
     if not no_promote:
         raise CanarySelectionError("reindex canary requires --no-promote")
+    from polylogue.config import resolve_archive_root
     from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
     from polylogue.storage.archive_identity import ArchiveLocation
 
     root = Path(archive_root)
+    if root.resolve() == resolve_archive_root().resolve():
+        raise CanarySelectionError(
+            "reindex canary refuses the configured live archive root; "
+            "run it against an explicitly provisioned isolated canary archive"
+        )
     current_index = Path(input_index) if input_index is not None else ArchiveLocation.resolve(root).active_index_path
     selection = select_canary_sessions(
         current_index,

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -390,6 +390,24 @@ def test_run_reindex_canary_rejects_arbitrary_sqlite_candidate(tmp_path: Path, m
         run_reindex_canary(tmp_path, input_index=current, no_promote=True)
 
 
+def test_run_reindex_canary_refuses_the_configured_live_archive_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    rebuild_called = False
+
+    def _unexpected_rebuild(*args: object, **kwargs: object) -> None:
+        nonlocal rebuild_called
+        rebuild_called = True
+        raise AssertionError("live archive canary must refuse before rebuild")
+
+    monkeypatch.setattr("polylogue.config.resolve_archive_root", lambda: tmp_path)
+    monkeypatch.setattr("polylogue.maintenance.rebuild_index.rebuild_index_from_source_sync", _unexpected_rebuild)
+
+    with pytest.raises(CanarySelectionError, match="refuses the configured live archive root"):
+        run_reindex_canary(tmp_path, no_promote=True)
+    assert not rebuild_called
+
+
 def test_durable_report_refuses_unclassified_diffs(tmp_path: Path) -> None:
     current = tmp_path / "current.db"
     candidate = tmp_path / "candidate.db"


### PR DESCRIPTION
## Summary

Fails closed before a reindex canary can create an inactive generation under the configured live archive root.

## Problem

The canary API accepted the configured archive root and delegated to the write-capable rebuild service. No canary was invoked in production.

## Solution

Compare the requested canary root with the configured archive root before selecting raws or calling rebuild, and require an explicitly provisioned isolated archive.

## Verification

- `devtools test tests/unit/maintenance/test_reindex_canary.py -k configured_live_archive_root`: 1 passed.
- `devtools verify --quick`: 23 checks passed.

Ref polylogue-0x7nh.