### PR TITLE
fix(rebuild): gate candidates on corpus fidelity

### DIFF
--- a/tests/unit/maintenance/test_corpus_fidelity.py
+++ b/tests/unit/maintenance/test_corpus_fidelity.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import hashlib
+import shutil
 import sqlite3
 from pathlib import Path
+
+import pytest
 
 from polylogue.core.outcomes import OutcomeStatus
 from polylogue.maintenance.archive_verification import (
@@ -276,6 +279,83 @@ def test_revision_gate_catches_smaller_index_than_best_recorded_revision(
     assert check.evidence["unexplained_shortfall"] == 1
     assert check.evidence["worst"][0]["session_id"] == session_id
     assert check.evidence["worst"][0]["best_recorded_messages"] == 100000
+
+
+@pytest.mark.parametrize(
+    ("violation", "expected_check"),
+    (
+        ("absent", "corpus-absences"),
+        ("attachment", "corpus-attachment-fidelity"),
+        ("revision", "corpus-revision-fidelity"),
+    ),
+)
+def test_candidate_index_corpus_gate_reads_durable_source_and_inactive_index(
+    corpus_fidelity_archive: SeededArchiveArtifact,
+    tmp_path: Path,
+    violation: str,
+    expected_check: str,
+) -> None:
+    """Each candidate runner reads the real inactive index, not active state.
+
+    This mutates a separate candidate ``index.db`` plus the durable source
+    clone where the check needs source evidence. Removing a candidate runner,
+    or accidentally routing it through the active index, leaves the matching
+    mutation green instead of reporting the selected gate as blocking.
+    """
+    root = _clone(corpus_fidelity_archive, tmp_path / violation)
+    candidate_index = tmp_path / f"{violation}-candidate-index.db"
+    shutil.copy2(root / "index.db", candidate_index)
+    session_id = _first_session_id(root)
+
+    if violation == "attachment":
+        with _connect(candidate_index) as conn:
+            message_row = conn.execute(
+                "SELECT message_id FROM messages WHERE session_id = ? LIMIT 1", (session_id,)
+            ).fetchone()
+            assert message_row is not None
+            conn.execute(
+                "INSERT INTO attachments(attachment_id, acquisition_status) VALUES ('candidate-unfetched', 'unfetched')"
+            )
+            conn.execute(
+                "INSERT INTO attachment_refs(attachment_id, session_id, message_id, position, upload_origin) "
+                "VALUES ('candidate-unfetched', ?, ?, 99, 'drive')",
+                (session_id, message_row[0]),
+            )
+    else:
+        origin, native_id = session_id.split(":", 1)
+        raw_id = f"candidate-{violation}"
+        provider_session_id = native_id if violation == "revision" else "candidate-absent"
+        with _connect(root / "source.db") as conn:
+            _insert_raw(
+                conn,
+                raw_id=raw_id,
+                origin=origin,
+                native_id=provider_session_id,
+                logical_source_key=f"fixture:{provider_session_id}",
+            )
+            conn.execute(
+                """
+                INSERT INTO raw_session_memberships(
+                    raw_id, logical_source_key, provider_session_id, source_revision,
+                    normalized_content_hash, message_count
+                ) VALUES (?, ?, ?, 'candidate-revision', ?, ?)
+                """,
+                (
+                    raw_id,
+                    f"fixture:{provider_session_id}",
+                    provider_session_id,
+                    b"c" * 32,
+                    100_000 if violation == "revision" else 4,
+                ),
+            )
+
+    report = verify_archive(root, checks=(expected_check,), index_path_override=candidate_index)
+
+    assert report.blocking
+    assert len(report.checks) == 1
+    check = report.checks[0]
+    assert isinstance(check, ArchiveVerificationCheck)
+    assert check.status is OutcomeStatus.ERROR
 
 
 def test_revision_gate_explains_event_reclassification_without_hiding_shortfall(

--- a/tests/unit/maintenance/test_rebuild_index_phase_timing.py
+++ b/tests/unit/maintenance/test_rebuild_index_phase_timing.py
@@ -36,6 +36,7 @@ from pathlib import Path
 
 import pytest
 
+import polylogue.maintenance.rebuild_index as rebuild_index
 from polylogue.core.enums import Provider
 from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -110,6 +111,84 @@ def test_partial_rebuild_cannot_complete_when_candidate_omits_source_document(
 
     with pytest.raises(RuntimeError, match="reindex acceptance gate failed.*corpus-absences"):
         rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, raw_ids=(raw_ids[0],), promote=False))
+
+    with sqlite3.connect(root / "index.db") as conn:
+        assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 0
+
+
+@pytest.mark.parametrize(
+    ("violation", "expected_check"),
+    (
+        ("attachment", "corpus-attachment-fidelity"),
+        ("revision", "corpus-revision-fidelity"),
+    ),
+)
+def test_rebuild_corpus_gate_blocks_mutated_inactive_candidate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    violation: str,
+    expected_check: str,
+) -> None:
+    """The real rebuild acceptance stage rejects each corrupted candidate.
+
+    The hook wraps the production bulk-derived-state step, after replay has
+    built the actual inactive index and immediately before the production
+    acceptance stage. It never replaces ``verify_archive``: attachment
+    corruption is written to the inactive SQLite index, while revision
+    corruption adds durable source evidence the already-built candidate lacks.
+    Removing the corpus acceptance report lets this full rebuild complete.
+    """
+    root = tmp_path / "archive"
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
+    _seed_distinct_codex_sessions(root, 1)
+    original_repopulate = rebuild_index._repopulate_bulk_build_derived_state
+
+    def corrupt_candidate_before_acceptance(index_path: Path) -> dict[str, float]:
+        timings_s = original_repopulate(index_path)
+        with sqlite3.connect(index_path) as candidate:
+            session_row = candidate.execute("SELECT session_id FROM sessions LIMIT 1").fetchone()
+            assert session_row is not None
+            session_id = str(session_row[0])
+            if violation == "attachment":
+                message_row = candidate.execute(
+                    "SELECT message_id FROM messages WHERE session_id = ? LIMIT 1", (session_id,)
+                ).fetchone()
+                assert message_row is not None
+                candidate.execute(
+                    "INSERT INTO attachments(attachment_id, acquisition_status) VALUES ('rebuild-unfetched', 'unfetched')"
+                )
+                candidate.execute(
+                    "INSERT INTO attachment_refs(attachment_id, session_id, message_id, position, upload_origin) "
+                    "VALUES ('rebuild-unfetched', ?, ?, 99, 'drive')",
+                    (session_id, message_row[0]),
+                )
+        if violation == "revision":
+            origin, native_id = session_id.split(":", 1)
+            with sqlite3.connect(root / "source.db") as source:
+                source.execute(
+                    """
+                    INSERT INTO raw_sessions(
+                        raw_id, origin, native_id, source_path, blob_hash, blob_size,
+                        acquired_at_ms, logical_source_key
+                    ) VALUES ('rebuild-best-revision', ?, ?, '/fixture/rebuild-best-revision', ?, 10, 100, ?)
+                    """,
+                    (origin, native_id, b"r" * 32, f"fixture:{native_id}"),
+                )
+                source.execute(
+                    """
+                    INSERT INTO raw_session_memberships(
+                        raw_id, logical_source_key, provider_session_id, source_revision,
+                        normalized_content_hash, message_count
+                    ) VALUES ('rebuild-best-revision', ?, ?, 'rebuild-best', ?, 100000)
+                    """,
+                    (f"fixture:{native_id}", native_id, b"r" * 32),
+                )
+        return timings_s
+
+    monkeypatch.setattr(rebuild_index, "_repopulate_bulk_build_derived_state", corrupt_candidate_before_acceptance)
+
+    with pytest.raises(RuntimeError, match=f"reindex acceptance gate failed.*{expected_check}"):
+        rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=False))
 
     with sqlite3.connect(root / "index.db") as conn:
         assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 0


### PR DESCRIPTION
## Summary

Require corpus-fidelity validation for every completed inactive index candidate, using durable source evidence together with the candidate index before completion or promotion.

## Problem

The reindex acceptance gate inspected only an inactive generation directory, which contains index.db but not source.db. Corpus absence, attachment, and revision fidelity were separately invokable but could not block a candidate against durable source evidence.

## Solution

Add candidate-aware runners to the existing archive-verification registry for all three corpus checks. The rebuild path runs the existing index-only acceptance selection and corpus-fidelity selection against the durable archive root plus the inactive candidate index. Direct tests mutate cloned real seeded SQLite archives, including each candidate runner, and real rebuild-route tests mutate candidate evidence immediately before the production acceptance stage.

Ref polylogue-f1vg

## Verification

- `source .venv/bin/activate && devtools test tests/unit/maintenance/test_rebuild_index_phase_timing.py tests/unit/maintenance/test_corpus_fidelity.py tests/unit/devtools/test_corpus_fidelity.py` -> `20 passed in 10.54s` after rebase.
- Pre-push `source .venv/bin/activate && nix develop --command git push --force-with-lease origin feature/fix/corpus-fidelity-gate:feature/fix/corpus-fidelity-gate` -> quick verification succeeded with exit code 0.
- Earlier `source .venv/bin/activate && devtools verify --all` completed static and policy checks, but broad pytest was baseline-red in unrelated provider, watcher, and property areas. The first watcher failure passed on exact rerun: `devtools test tests/unit/sources/test_live_watcher.py::test_end_to_end_hidden_root_file_creation_triggers_ingest` -> `1 passed in 1.51s`.

## Adversarial review notes

- Iteration 1: found that attachment and revision candidate runners lacked inactive-index coverage. Fixed in `c6dec71ac`.
- Iteration 2: found that attachment and revision were not exercised through rebuild completion. Fixed in `0ee3e26f9`.
- Iteration 3: no legitimate gaps found across the stated acceptance criteria.