### PR TITLE
fix(maintenance): harden reindex canary review evidence (#3750)

### DIFF
--- a/polylogue/cli/commands/maintenance/_reindex_canary.py
+++ b/polylogue/cli/commands/maintenance/_reindex_canary.py
@@ -12,6 +12,12 @@ from polylogue.paths import archive_root
 
 @click.command("reindex-canary")
 @click.option(
+    "--review-manifest",
+    type=click.Path(path_type=Path, exists=True, dir_okay=False, readable=True),
+    default=None,
+    help="JSON manifest containing one explicit review for every observed difference.",
+)
+@click.option(
     "--input-index",
     "--input",
     "input_index",
@@ -52,6 +58,7 @@ from polylogue.paths import archive_root
     help="Required safety gate: leave the rebuilt candidate inactive for comparison.",
 )
 def reindex_canary_command(
+    review_manifest: Path | None,
     input_index: Path | None,
     sessions_per_origin: int,
     pathology_session_id: tuple[str, ...],
@@ -70,6 +77,8 @@ def reindex_canary_command(
     from polylogue.maintenance.reindex_canary import (
         CanaryRunResult,
         UnclassifiedCanaryDiffError,
+        load_canary_report,
+        load_canary_review_manifest,
         run_reindex_canary,
         write_canary_report,
     )
@@ -84,12 +93,17 @@ def reindex_canary_command(
             sample_session_ids=sample_session_id,
             no_promote=no_promote,
         )
+        if result.comparison.differences and review_manifest is None:
+            raise UnclassifiedCanaryDiffError("non-empty canary differences require --review-manifest")
+        reviews = load_canary_review_manifest(review_manifest) if review_manifest is not None else ()
         durable = write_canary_report(
             report_path,
             selection=result.selection,
             comparison=result.comparison,
-            reviews=(),
+            rebuild_receipt=result.rebuild_receipt,
+            reviews=reviews,
         )
+        load_canary_report(report_path)
     except UnclassifiedCanaryDiffError as exc:
         raise click.ClickException(str(exc)) from exc
     except (OSError, RuntimeError, ValueError) as exc:

--- a/polylogue/cli/commands/maintenance/_reindex_canary.py
+++ b/polylogue/cli/commands/maintenance/_reindex_canary.py
@@ -93,8 +93,6 @@ def reindex_canary_command(
             sample_session_ids=sample_session_id,
             no_promote=no_promote,
         )
-        if result.comparison.differences and review_manifest is None:
-            raise UnclassifiedCanaryDiffError("non-empty canary differences require --review-manifest")
         reviews = load_canary_review_manifest(review_manifest) if review_manifest is not None else ()
         durable = write_canary_report(
             report_path,
@@ -102,8 +100,17 @@ def reindex_canary_command(
             comparison=result.comparison,
             rebuild_receipt=result.rebuild_receipt,
             reviews=reviews,
+            allow_unreviewed=review_manifest is None,
         )
         load_canary_report(report_path)
+        if result.comparison.differences and review_manifest is None:
+            identities = [dict(item.identity) for item in result.comparison.differences]
+            raise UnclassifiedCanaryDiffError(
+                "unreviewed canary report written to "
+                + str(report_path)
+                + "; observed identities="
+                + json.dumps(identities, sort_keys=True)
+            )
     except UnclassifiedCanaryDiffError as exc:
         raise click.ClickException(str(exc)) from exc
     except (OSError, RuntimeError, ValueError) as exc:

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -18,6 +18,7 @@ from collections.abc import Iterable
 from contextlib import suppress
 from dataclasses import dataclass, replace
 from enum import StrEnum
+from hashlib import sha256
 from pathlib import Path
 from typing import Any, cast
 
@@ -407,6 +408,7 @@ class CanaryDifferenceReview:
     table: str
     operation: DifferenceOperation
     identity: tuple[tuple[str, object], ...]
+    changed_columns: tuple[str, ...]
     classification: DifferenceClassification
     reference: str
     rationale: str
@@ -424,20 +426,22 @@ class CanaryDifferenceReview:
             table=difference.table,
             operation=difference.operation,
             identity=difference.identity,
+            changed_columns=difference.changed_columns,
             classification=classification,
             reference=reference,
             rationale=rationale,
         )
 
     @property
-    def key(self) -> tuple[str, DifferenceOperation, tuple[tuple[str, object], ...]]:
-        return self.table, self.operation, self.identity
+    def key(self) -> tuple[str, DifferenceOperation, tuple[tuple[str, object], ...], tuple[str, ...]]:
+        return self.table, self.operation, self.identity, self.changed_columns
 
     def to_dict(self) -> dict[str, object]:
         return {
             "table": self.table,
             "operation": self.operation.value,
             "identity": dict(self.identity),
+            "changed_columns": list(self.changed_columns),
             "classification": self.classification.value,
             "reference": self.reference,
             "rationale": self.rationale,
@@ -453,6 +457,7 @@ class DurableCanaryReport:
     rebuild_receipt: dict[str, object]
     reviews: tuple[CanaryDifferenceReview, ...]
     review_status: str
+    comparison_fingerprint: str
 
     @property
     def unclassified_count(self) -> int:
@@ -460,12 +465,13 @@ class DurableCanaryReport:
 
     def to_dict(self) -> dict[str, object]:
         return {
-            "schema_version": 1,
+            "schema_version": 2,
             "selection": self.selection.to_dict(),
             "comparison": self.comparison.to_dict(),
             "rebuild_receipt": self.rebuild_receipt,
             "reviews": [review.to_dict() for review in self.reviews],
             "review_status": self.review_status,
+            "comparison_fingerprint": self.comparison_fingerprint,
         }
 
 
@@ -480,8 +486,8 @@ def write_canary_report(
 ) -> DurableCanaryReport:
     """Persist a fully reviewed report or an explicit durable unreviewed diff.
 
-    Reviews must cover exactly the comparator's row identities. This prevents
-    a report from becoming a durable green-light artifact while a diff was
+    Reviews must cover exactly the comparator's row identities and signatures.
+    This prevents a report from becoming a durable green-light artifact while a diff was
     silently omitted from review. The write is atomic and touches only the
     requested report path, never either SQLite generation.
     """
@@ -493,7 +499,9 @@ def write_canary_report(
     )
     _validate_selection_binding(selection, comparison, rebuild_receipt)
     review_list = tuple(reviews)
-    review_by_key: dict[tuple[str, DifferenceOperation, tuple[tuple[str, object], ...]], CanaryDifferenceReview] = {}
+    review_by_key: dict[
+        tuple[str, DifferenceOperation, tuple[tuple[str, object], ...], tuple[str, ...]], CanaryDifferenceReview
+    ] = {}
     duplicate_keys: list[object] = []
     for review in review_list:
         if not review.reference.strip() or not review.rationale.strip():
@@ -506,6 +514,7 @@ def write_canary_report(
             difference.table,
             difference.operation,
             difference.identity,
+            difference.changed_columns,
         )
         for difference in comparison.differences
     }
@@ -530,11 +539,11 @@ def write_canary_report(
             replace(
                 difference,
                 classification=review_by_key[
-                    (difference.table, difference.operation, difference.identity)
+                    (difference.table, difference.operation, difference.identity, difference.changed_columns)
                 ].classification,
                 rationale=(
-                    f"{review_by_key[(difference.table, difference.operation, difference.identity)].reference}: "
-                    f"{review_by_key[(difference.table, difference.operation, difference.identity)].rationale}"
+                    f"{review_by_key[(difference.table, difference.operation, difference.identity, difference.changed_columns)].reference}: "
+                    f"{review_by_key[(difference.table, difference.operation, difference.identity, difference.changed_columns)].rationale}"
                 ),
             )
             for difference in comparison.differences
@@ -547,6 +556,7 @@ def write_canary_report(
         rebuild_receipt=rebuild_receipt,
         reviews=review_list,
         review_status=review_status,
+        comparison_fingerprint=_comparison_fingerprint(comparison),
     )
     path = Path(output_path)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -595,6 +605,34 @@ def _validate_selection_binding(
         or tuple(session_ids) != selection.selected_session_ids
     ):
         raise UnclassifiedCanaryDiffError("canary report rebuild evidence does not match the selected identities")
+
+
+def _comparison_fingerprint(comparison: CanaryDiffReport) -> str:
+    """Hash comparison evidence independently of operator classification."""
+
+    payload = {
+        "current_index": str(comparison.current_index),
+        "candidate_index": str(comparison.candidate_index),
+        "session_ids": list(comparison.session_ids),
+        "compared_tables": list(comparison.compared_tables),
+        "missing_tables": list(comparison.missing_tables),
+        "missing_columns": [
+            {"table": table, "columns": list(columns)} for table, columns in comparison.missing_columns
+        ],
+        "differences": [
+            {
+                "table": difference.table,
+                "operation": difference.operation.value,
+                "identity": dict(difference.identity),
+                "before": difference.before,
+                "after": difference.after,
+                "changed_columns": list(difference.changed_columns),
+            }
+            for difference in comparison.differences
+        ],
+    }
+    encoded = json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return sha256(encoded).hexdigest()
 
 
 def _validate_rebuild_receipt(
@@ -662,6 +700,9 @@ def load_canary_report(path: Path) -> dict[str, object]:
     review_status = payload.get("review_status")
     if review_status not in {"reviewed", "unreviewed"}:
         raise UnclassifiedCanaryDiffError("canary report has invalid review status")
+    comparison_fingerprint = payload.get("comparison_fingerprint")
+    if not isinstance(comparison_fingerprint, str) or len(comparison_fingerprint) != 64:
+        raise UnclassifiedCanaryDiffError("canary report has invalid comparison fingerprint")
     selection = payload.get("selection")
     if not isinstance(selection, dict):
         raise UnclassifiedCanaryDiffError("canary report has no selection object")
@@ -695,18 +736,54 @@ def load_canary_report(path: Path) -> dict[str, object]:
     )
     current_index = comparison.get("current_index")
     compared_sessions = comparison.get("session_ids")
+    compared_tables = comparison.get("compared_tables")
+    missing_tables = comparison.get("missing_tables")
+    raw_missing_columns = comparison.get("missing_columns")
     if (
         not isinstance(current_index, str)
         or not isinstance(compared_sessions, list)
         or not all(isinstance(value, str) for value in compared_sessions)
+        or not isinstance(compared_tables, list)
+        or not all(isinstance(value, str) for value in compared_tables)
+        or not isinstance(missing_tables, list)
+        or not all(isinstance(value, str) for value in missing_tables)
+        or not isinstance(raw_missing_columns, list)
     ):
         raise UnclassifiedCanaryDiffError("canary report has invalid comparison selection")
+    missing_columns: list[tuple[str, tuple[str, ...]]] = []
+    for item in raw_missing_columns:
+        if not isinstance(item, dict):
+            raise UnclassifiedCanaryDiffError("canary report has invalid comparison schema evidence")
+        table = item.get("table")
+        columns = item.get("columns")
+        if (
+            not isinstance(table, str)
+            or not isinstance(columns, list)
+            or not all(isinstance(column, str) for column in columns)
+        ):
+            raise UnclassifiedCanaryDiffError("canary report has invalid comparison schema evidence")
+        missing_columns.append((table, tuple(columns)))
     persisted_comparison = CanaryDiffReport(
-        Path(current_index), Path(candidate_index), tuple(cast(list[str], compared_sessions)), (), (), (), differences
+        current_index=Path(current_index),
+        candidate_index=Path(candidate_index),
+        session_ids=tuple(cast(list[str], compared_sessions)),
+        compared_tables=tuple(cast(list[str], compared_tables)),
+        missing_tables=tuple(cast(list[str], missing_tables)),
+        missing_columns=tuple(missing_columns),
+        differences=differences,
     )
     _validate_selection_binding(
         persisted_selection, persisted_comparison, cast(dict[str, object], payload["rebuild_receipt"])
     )
+    recomputed_comparison = compare_reindex_generations(
+        persisted_comparison.current_index,
+        persisted_comparison.candidate_index,
+        session_ids=persisted_selection.selected_session_ids,
+    )
+    if comparison_fingerprint != _comparison_fingerprint(
+        persisted_comparison
+    ) or comparison_fingerprint != _comparison_fingerprint(recomputed_comparison):
+        raise UnclassifiedCanaryDiffError("canary report comparison attestation does not match the recorded indexes")
     difference_keys = tuple(_difference_key(difference) for difference in differences)
     review_keys = tuple(review.key for review in reviews)
     if len(set(difference_keys)) != len(difference_keys) or len(set(review_keys)) != len(review_keys):
@@ -731,8 +808,10 @@ def load_canary_report(path: Path) -> dict[str, object]:
     return cast(dict[str, object], payload)
 
 
-def _difference_key(difference: RowDifference) -> tuple[str, DifferenceOperation, tuple[tuple[str, object], ...]]:
-    return difference.table, difference.operation, difference.identity
+def _difference_key(
+    difference: RowDifference,
+) -> tuple[str, DifferenceOperation, tuple[tuple[str, object], ...], tuple[str, ...]]:
+    return difference.table, difference.operation, difference.identity, difference.changed_columns
 
 
 def _difference_from_dict(value: object) -> RowDifference:
@@ -777,11 +856,15 @@ def _review_from_dict(value: object) -> CanaryDifferenceReview:
     if not isinstance(value, dict):
         raise UnclassifiedCanaryDiffError("canary report review must be an object")
     identity = value.get("identity")
+    changed_columns = value.get("changed_columns")
     table = value.get("table")
     reference = value.get("reference")
     rationale = value.get("rationale")
     if (
         not isinstance(identity, dict)
+        or not isinstance(changed_columns, list)
+        or not changed_columns
+        or not all(isinstance(column, str) for column in changed_columns)
         or not isinstance(table, str)
         or not isinstance(reference, str)
         or not isinstance(rationale, str)
@@ -798,6 +881,7 @@ def _review_from_dict(value: object) -> CanaryDifferenceReview:
         table=table,
         operation=operation,
         identity=tuple((str(key), item) for key, item in identity.items()),
+        changed_columns=tuple(cast(list[str], changed_columns)),
         classification=classification,
         reference=reference,
         rationale=rationale,

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -458,6 +458,7 @@ class DurableCanaryReport:
     reviews: tuple[CanaryDifferenceReview, ...]
     review_status: str
     comparison_fingerprint: str
+    archive_provenance: dict[str, object]
 
     @property
     def unclassified_count(self) -> int:
@@ -465,13 +466,14 @@ class DurableCanaryReport:
 
     def to_dict(self) -> dict[str, object]:
         return {
-            "schema_version": 2,
+            "schema_version": 3,
             "selection": self.selection.to_dict(),
             "comparison": self.comparison.to_dict(),
             "rebuild_receipt": self.rebuild_receipt,
             "reviews": [review.to_dict() for review in self.reviews],
             "review_status": self.review_status,
             "comparison_fingerprint": self.comparison_fingerprint,
+            "archive_provenance": self.archive_provenance,
         }
 
 
@@ -532,6 +534,7 @@ def write_canary_report(
     else:
         review_status = "reviewed"
 
+    archive_provenance = _capture_archive_provenance(comparison, rebuild_receipt)
     reviewed_differences = (
         comparison.differences
         if review_status == "unreviewed"
@@ -557,6 +560,7 @@ def write_canary_report(
         reviews=review_list,
         review_status=review_status,
         comparison_fingerprint=_comparison_fingerprint(comparison),
+        archive_provenance=archive_provenance,
     )
     path = Path(output_path)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -677,12 +681,178 @@ def _validate_rebuild_receipt(
         raise UnclassifiedCanaryDiffError("canary report rebuild receipt does not identify the compared candidate")
 
 
+def _generation_root(location: object) -> Path:
+    """Return the lifecycle directory anchored by this archive's active pointer."""
+
+    from polylogue.storage.archive_identity import ArchiveLocation
+
+    assert isinstance(location, ArchiveLocation)
+    anchor = location.active_pointer or location.configured_tier("index").configured_path
+    return anchor.parent / ".index-generations"
+
+
+def _read_generation_metadata(generation_root: Path, generation_id: str) -> dict[str, object]:
+    path = generation_root / generation_id / "generation.json"
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise UnclassifiedCanaryDiffError("archive-owned generation metadata is unreadable") from exc
+    if not isinstance(payload, dict):
+        raise UnclassifiedCanaryDiffError("archive-owned generation metadata is invalid")
+    return payload
+
+
+def _generation_fields(metadata: object) -> dict[str, object]:
+    if not isinstance(metadata, dict):
+        raise UnclassifiedCanaryDiffError("archive-owned generation metadata is invalid")
+    fields = {
+        key: metadata.get(key)
+        for key in ("generation_id", "owner_id", "archive_root", "index_path", "state", "source_snapshot")
+    }
+    if not all(isinstance(value, str) and value for value in fields.values()):
+        raise UnclassifiedCanaryDiffError("archive-owned generation metadata is incomplete")
+    return fields
+
+
+def _index_evidence(path: Path) -> dict[str, object]:
+    """Describe a local file identity without claiming it is a secret capability."""
+
+    from polylogue.storage.archive_identity import TierFileIdentity
+
+    identity = TierFileIdentity.resolve("index", path)
+    if not identity.exists:
+        raise UnclassifiedCanaryDiffError("archive-owned index is not readable")
+    digest = sha256()
+    try:
+        with path.open("rb") as stream:
+            while chunk := stream.read(1024 * 1024):
+                digest.update(chunk)
+    except OSError as exc:
+        raise UnclassifiedCanaryDiffError("archive-owned index is not readable") from exc
+    return {"file": identity.as_dict(), "content_sha256": digest.hexdigest()}
+
+
+def _same_index_evidence(recorded: object, path: Path, *, label: str) -> None:
+    if not isinstance(recorded, dict) or recorded != _index_evidence(path):
+        raise UnclassifiedCanaryDiffError(f"archive-owned {label} index identity no longer matches the report")
+
+
+def _active_generation_metadata(root: Path, location: object) -> dict[str, object]:
+    from polylogue.storage.archive_identity import ArchiveLocation, TierFileIdentity
+
+    assert isinstance(location, ArchiveLocation)
+    active_identity = TierFileIdentity.resolve("index", location.active_index_path)
+    matches: list[dict[str, object]] = []
+    for metadata_path in _generation_root(location).glob("gen-*/generation.json"):
+        try:
+            metadata = _generation_fields(json.loads(metadata_path.read_text(encoding="utf-8")))
+            generation_index = TierFileIdentity.resolve("index", Path(cast(str, metadata["index_path"])))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if metadata["state"] == "active" and active_identity.same_file(generation_index):
+            matches.append(metadata)
+    if len(matches) != 1:
+        raise UnclassifiedCanaryDiffError("archive-owned active generation metadata does not match the active pointer")
+    active = matches[0]
+    if Path(cast(str, active["archive_root"])).resolve() != root.resolve():
+        raise UnclassifiedCanaryDiffError("archive-owned active generation belongs to another archive")
+    return active
+
+
+def _capture_archive_provenance(comparison: CanaryDiffReport, receipt: dict[str, object]) -> dict[str, object]:
+    """Capture lifecycle records that make a local report archive-specific.
+
+    These values are not a secret or a signature. They are deliberately
+    re-read on load so approval follows the active pointer, generation record,
+    source snapshot, and the exact inactive file that the rebuild created.
+    """
+
+    from polylogue.storage.archive_identity import ArchiveLocation, TierFileIdentity
+    from polylogue.storage.index_generation import source_revision_snapshot
+
+    archive_root = receipt.get("archive_root")
+    generation = receipt.get("generation")
+    if not isinstance(archive_root, str):
+        raise UnclassifiedCanaryDiffError("canary report has invalid archive provenance root")
+    root = Path(archive_root)
+    location = ArchiveLocation.resolve(root)
+    current_identity = TierFileIdentity.resolve("index", comparison.current_index)
+    if not location.active_index.same_file(current_identity):
+        raise UnclassifiedCanaryDiffError("archive-owned active index does not match the canary comparison")
+    candidate = _generation_fields(generation)
+    candidate_metadata = _read_generation_metadata(_generation_root(location), cast(str, candidate["generation_id"]))
+    if _generation_fields(candidate_metadata) != candidate:
+        raise UnclassifiedCanaryDiffError(
+            "archive-owned candidate generation metadata does not match the rebuild receipt"
+        )
+    if candidate["state"] != "inactive":
+        raise UnclassifiedCanaryDiffError("archive-owned candidate generation is not inactive")
+    candidate_path = Path(cast(str, candidate["index_path"]))
+    if not candidate_path.samefile(comparison.candidate_index):
+        raise UnclassifiedCanaryDiffError("archive-owned candidate generation does not match the canary comparison")
+    source_snapshot = source_revision_snapshot(root)
+    if source_snapshot != candidate["source_snapshot"]:
+        raise UnclassifiedCanaryDiffError("archive-owned source snapshot does not match the inactive candidate")
+    return {
+        "archive_root": str(root.resolve()),
+        "active_pointer": str(location.active_pointer) if location.active_pointer is not None else None,
+        "active_index": _index_evidence(location.active_index_path),
+        "active_generation": _active_generation_metadata(root, location),
+        "candidate_generation": candidate,
+        "candidate_index": _index_evidence(candidate_path),
+        "source_snapshot": source_snapshot,
+    }
+
+
+def _validate_archive_provenance(provenance: object, comparison: CanaryDiffReport, receipt: dict[str, object]) -> None:
+    """Recompute local lifecycle evidence before accepting a report for approval."""
+
+    from polylogue.storage.archive_identity import ArchiveLocation, TierFileIdentity
+    from polylogue.storage.index_generation import source_revision_snapshot
+
+    if not isinstance(provenance, dict):
+        raise UnclassifiedCanaryDiffError("canary report has no archive-owned provenance")
+    archive_root = provenance.get("archive_root")
+    if not isinstance(archive_root, str):
+        raise UnclassifiedCanaryDiffError("canary report has invalid archive-owned provenance root")
+    if receipt.get("archive_root") != archive_root:
+        raise UnclassifiedCanaryDiffError("archive-owned provenance root does not match the rebuild receipt")
+    root = Path(archive_root)
+    location = ArchiveLocation.resolve(root)
+    pointer = str(location.active_pointer) if location.active_pointer is not None else None
+    if provenance.get("active_pointer") != pointer:
+        raise UnclassifiedCanaryDiffError("archive-owned active pointer no longer matches the report")
+    current_identity = TierFileIdentity.resolve("index", comparison.current_index)
+    if not location.active_index.same_file(current_identity):
+        raise UnclassifiedCanaryDiffError("archive-owned active index no longer matches the report")
+    _same_index_evidence(provenance.get("active_index"), location.active_index_path, label="active")
+    if provenance.get("active_generation") != _active_generation_metadata(root, location):
+        raise UnclassifiedCanaryDiffError("archive-owned active generation metadata no longer matches the report")
+    receipt_generation = _generation_fields(receipt.get("generation"))
+    if provenance.get("candidate_generation") != receipt_generation:
+        raise UnclassifiedCanaryDiffError("archive-owned candidate generation does not match the rebuild receipt")
+    live_candidate = _generation_fields(
+        _read_generation_metadata(_generation_root(location), cast(str, receipt_generation["generation_id"]))
+    )
+    if live_candidate != receipt_generation or live_candidate["state"] != "inactive":
+        raise UnclassifiedCanaryDiffError("archive-owned candidate generation metadata no longer matches the report")
+    candidate_path = Path(cast(str, live_candidate["index_path"]))
+    if not candidate_path.samefile(comparison.candidate_index):
+        raise UnclassifiedCanaryDiffError("archive-owned candidate generation no longer matches the report")
+    _same_index_evidence(provenance.get("candidate_index"), candidate_path, label="candidate")
+    source_snapshot = source_revision_snapshot(root)
+    if provenance.get("source_snapshot") != source_snapshot or live_candidate["source_snapshot"] != source_snapshot:
+        raise UnclassifiedCanaryDiffError("archive-owned source snapshot no longer matches the inactive candidate")
+
+
 def load_canary_report(path: Path) -> dict[str, object]:
     """Read and structurally revalidate a durable report's review coverage."""
 
     payload = json.loads(Path(path).read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise UnclassifiedCanaryDiffError("canary report root must be an object")
+    if payload.get("schema_version") != 3:
+        raise UnclassifiedCanaryDiffError("canary report has no archive-owned provenance schema")
     comparison = payload.get("comparison")
     if not isinstance(comparison, dict):
         raise UnclassifiedCanaryDiffError("canary report has no comparison object")
@@ -804,6 +974,11 @@ def load_canary_report(path: Path) -> dict[str, object]:
             review = review_by_key[key]
             if review.classification is not difference.classification:
                 raise UnclassifiedCanaryDiffError("canary report review classification disagrees with its difference")
+    _validate_archive_provenance(
+        payload.get("archive_provenance"),
+        persisted_comparison,
+        cast(dict[str, object], payload["rebuild_receipt"]),
+    )
     comparison["summary"] = _summary_for_differences(differences)
     return cast(dict[str, object], payload)
 

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -745,16 +745,17 @@ def _active_generation_metadata(root: Path, location: object) -> dict[str, objec
     matches: list[dict[str, object]] = []
     for metadata_path in _generation_root(location).glob("gen-*/generation.json"):
         try:
-            metadata = _generation_fields(json.loads(metadata_path.read_text(encoding="utf-8")))
-            generation_index = TierFileIdentity.resolve("index", Path(cast(str, metadata["index_path"])))
+            metadata = _read_generation_metadata(_generation_root(location), metadata_path.parent.name)
+            fields = _generation_fields(metadata)
+            generation_index = TierFileIdentity.resolve("index", Path(cast(str, fields["index_path"])))
         except (OSError, json.JSONDecodeError):
             continue
-        if metadata["state"] == "active" and active_identity.same_file(generation_index):
+        if fields["state"] == "active" and active_identity.same_file(generation_index):
             matches.append(metadata)
     if len(matches) != 1:
         raise UnclassifiedCanaryDiffError("archive-owned active generation metadata does not match the active pointer")
     active = matches[0]
-    if Path(cast(str, active["archive_root"])).resolve() != root.resolve():
+    if Path(cast(str, _generation_fields(active)["archive_root"])).resolve() != root.resolve():
         raise UnclassifiedCanaryDiffError("archive-owned active generation belongs to another archive")
     return active
 
@@ -779,9 +780,11 @@ def _capture_archive_provenance(comparison: CanaryDiffReport, receipt: dict[str,
     current_identity = TierFileIdentity.resolve("index", comparison.current_index)
     if not location.active_index.same_file(current_identity):
         raise UnclassifiedCanaryDiffError("archive-owned active index does not match the canary comparison")
+    if not isinstance(generation, dict):
+        raise UnclassifiedCanaryDiffError("canary report has invalid candidate generation provenance")
     candidate = _generation_fields(generation)
     candidate_metadata = _read_generation_metadata(_generation_root(location), cast(str, candidate["generation_id"]))
-    if _generation_fields(candidate_metadata) != candidate:
+    if candidate_metadata != generation:
         raise UnclassifiedCanaryDiffError(
             "archive-owned candidate generation metadata does not match the rebuild receipt"
         )
@@ -798,7 +801,7 @@ def _capture_archive_provenance(comparison: CanaryDiffReport, receipt: dict[str,
         "active_pointer": str(location.active_pointer) if location.active_pointer is not None else None,
         "active_index": _index_evidence(location.active_index_path),
         "active_generation": _active_generation_metadata(root, location),
-        "candidate_generation": candidate,
+        "candidate_generation": candidate_metadata,
         "candidate_index": _index_evidence(candidate_path),
         "source_snapshot": source_snapshot,
     }
@@ -828,20 +831,22 @@ def _validate_archive_provenance(provenance: object, comparison: CanaryDiffRepor
     _same_index_evidence(provenance.get("active_index"), location.active_index_path, label="active")
     if provenance.get("active_generation") != _active_generation_metadata(root, location):
         raise UnclassifiedCanaryDiffError("archive-owned active generation metadata no longer matches the report")
-    receipt_generation = _generation_fields(receipt.get("generation"))
+    receipt_generation = receipt.get("generation")
+    if not isinstance(receipt_generation, dict):
+        raise UnclassifiedCanaryDiffError("canary report has invalid candidate generation provenance")
+    receipt_fields = _generation_fields(receipt_generation)
     if provenance.get("candidate_generation") != receipt_generation:
         raise UnclassifiedCanaryDiffError("archive-owned candidate generation does not match the rebuild receipt")
-    live_candidate = _generation_fields(
-        _read_generation_metadata(_generation_root(location), cast(str, receipt_generation["generation_id"]))
-    )
-    if live_candidate != receipt_generation or live_candidate["state"] != "inactive":
+    live_candidate = _read_generation_metadata(_generation_root(location), cast(str, receipt_fields["generation_id"]))
+    live_fields = _generation_fields(live_candidate)
+    if live_candidate != receipt_generation or live_fields["state"] != "inactive":
         raise UnclassifiedCanaryDiffError("archive-owned candidate generation metadata no longer matches the report")
-    candidate_path = Path(cast(str, live_candidate["index_path"]))
+    candidate_path = Path(cast(str, live_fields["index_path"]))
     if not candidate_path.samefile(comparison.candidate_index):
         raise UnclassifiedCanaryDiffError("archive-owned candidate generation no longer matches the report")
     _same_index_evidence(provenance.get("candidate_index"), candidate_path, label="candidate")
     source_snapshot = source_revision_snapshot(root)
-    if provenance.get("source_snapshot") != source_snapshot or live_candidate["source_snapshot"] != source_snapshot:
+    if provenance.get("source_snapshot") != source_snapshot or live_fields["source_snapshot"] != source_snapshot:
         raise UnclassifiedCanaryDiffError("archive-owned source snapshot no longer matches the inactive candidate")
 
 

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -61,6 +61,12 @@ class ExpectedDifference:
     operations: tuple[DifferenceOperation, ...] = ()
     columns: tuple[str, ...] = ()
 
+    def __post_init__(self) -> None:
+        if len(self.operations) != 1:
+            raise ValueError("expected differences require exactly one operation")
+        if not self.columns:
+            raise ValueError("expected differences require a non-empty changed-column signature")
+
     def matches(
         self,
         *,
@@ -70,11 +76,9 @@ class ExpectedDifference:
     ) -> bool:
         if self.table != table:
             return False
-        if self.operations and operation not in self.operations:
+        if operation is not self.operations[0]:
             return False
-        if not self.columns:
-            return True
-        return bool(changed_columns) and set(changed_columns).issubset(self.columns)
+        return tuple(changed_columns) == self.columns
 
 
 @dataclass(frozen=True, slots=True)
@@ -286,7 +290,7 @@ def run_reindex_canary(
         raise CanarySelectionError("reindex canary requires --no-promote")
     from polylogue.config import resolve_archive_root
     from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
-    from polylogue.storage.archive_identity import ArchiveLocation
+    from polylogue.storage.archive_identity import ArchiveLocation, TierFileIdentity
 
     root = Path(archive_root)
     if root.resolve() == resolve_archive_root().resolve():
@@ -294,7 +298,12 @@ def run_reindex_canary(
             "reindex canary refuses the configured live archive root; "
             "run it against an explicitly provisioned isolated canary archive"
         )
-    current_index = Path(input_index) if input_index is not None else ArchiveLocation.resolve(root).active_index_path
+    location = ArchiveLocation.resolve(root)
+    current_index = location.active_index_path
+    if input_index is not None:
+        supplied = TierFileIdentity.resolve("index", Path(input_index))
+        if not location.active_index.same_file(supplied):
+            raise CanarySelectionError("input index is not the configured archive active generation")
     selection = select_canary_sessions(
         current_index,
         sessions_per_origin=sessions_per_origin,
@@ -432,6 +441,7 @@ class DurableCanaryReport:
 
     selection: CanarySelection
     comparison: CanaryDiffReport
+    rebuild_receipt: dict[str, object]
     reviews: tuple[CanaryDifferenceReview, ...]
 
     @property
@@ -443,6 +453,7 @@ class DurableCanaryReport:
             "schema_version": 1,
             "selection": self.selection.to_dict(),
             "comparison": self.comparison.to_dict(),
+            "rebuild_receipt": self.rebuild_receipt,
             "reviews": [review.to_dict() for review in self.reviews],
         }
 
@@ -452,6 +463,7 @@ def write_canary_report(
     *,
     selection: CanarySelection,
     comparison: CanaryDiffReport,
+    rebuild_receipt: dict[str, object],
     reviews: Iterable[CanaryDifferenceReview],
 ) -> DurableCanaryReport:
     """Persist a reviewed report, refusing any incomplete classification.
@@ -462,6 +474,11 @@ def write_canary_report(
     requested report path, never either SQLite generation.
     """
 
+    _validate_rebuild_receipt(
+        rebuild_receipt,
+        selected_raw_ids=selection.selected_raw_ids,
+        candidate_index=comparison.candidate_index,
+    )
     review_list = tuple(reviews)
     review_by_key: dict[tuple[str, DifferenceOperation, tuple[tuple[str, object], ...]], CanaryDifferenceReview] = {}
     duplicate_keys: list[object] = []
@@ -501,7 +518,12 @@ def write_canary_report(
         for difference in comparison.differences
     )
     reviewed_comparison = replace(comparison, differences=reviewed_differences)
-    durable = DurableCanaryReport(selection=selection, comparison=reviewed_comparison, reviews=review_list)
+    durable = DurableCanaryReport(
+        selection=selection,
+        comparison=reviewed_comparison,
+        rebuild_receipt=rebuild_receipt,
+        reviews=review_list,
+    )
     path = Path(output_path)
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = json.dumps(durable.to_dict(), ensure_ascii=False, indent=2, sort_keys=True)
@@ -531,6 +553,48 @@ def write_canary_report(
     return durable
 
 
+def _validate_rebuild_receipt(
+    receipt: object,
+    *,
+    selected_raw_ids: Iterable[str],
+    candidate_index: Path | str,
+) -> None:
+    if not isinstance(receipt, dict):
+        raise UnclassifiedCanaryDiffError("canary report has no rebuild receipt")
+    archive_root = receipt.get("archive_root")
+    selected_raw_count = receipt.get("selected_raw_count")
+    generation = receipt.get("generation")
+    if (
+        not isinstance(archive_root, str)
+        or not archive_root
+        or selected_raw_count != len(tuple(selected_raw_ids))
+        or receipt.get("status") != "replayed"
+        or receipt.get("materialized") is not True
+        or not isinstance(generation, dict)
+    ):
+        raise UnclassifiedCanaryDiffError("canary report has invalid rebuild receipt")
+    generation_archive_root = generation.get("archive_root")
+    generation_index = generation.get("index_path")
+    required_generation = (
+        generation.get("generation_id"),
+        generation.get("owner_id"),
+        generation_archive_root,
+        generation_index,
+        generation.get("source_snapshot"),
+    )
+    if (
+        generation.get("state") != "inactive"
+        or not all(isinstance(value, str) and value for value in required_generation)
+        or not isinstance(generation_archive_root, str)
+        or not isinstance(generation_index, str)
+    ):
+        raise UnclassifiedCanaryDiffError("canary report has incomplete candidate generation provenance")
+    if Path(archive_root).resolve() != Path(generation_archive_root).resolve():
+        raise UnclassifiedCanaryDiffError("canary report rebuild receipt and candidate archive roots disagree")
+    if Path(generation_index).resolve() != Path(candidate_index).resolve():
+        raise UnclassifiedCanaryDiffError("canary report rebuild receipt does not identify the compared candidate")
+
+
 def load_canary_report(path: Path) -> dict[str, object]:
     """Read and structurally revalidate a durable report's review coverage."""
 
@@ -551,6 +615,20 @@ def load_canary_report(path: Path) -> dict[str, object]:
     if not isinstance(raw_reviews, list):
         raise UnclassifiedCanaryDiffError("canary report has no reviews list")
     reviews = tuple(_review_from_dict(item) for item in raw_reviews)
+    selection = payload.get("selection")
+    if not isinstance(selection, dict):
+        raise UnclassifiedCanaryDiffError("canary report has no selection object")
+    selected_raw_ids = selection.get("selected_raw_ids")
+    candidate_index = comparison.get("candidate_index")
+    if not isinstance(selected_raw_ids, list) or not all(isinstance(value, str) for value in selected_raw_ids):
+        raise UnclassifiedCanaryDiffError("canary report has invalid selected raw ids")
+    if not isinstance(candidate_index, str):
+        raise UnclassifiedCanaryDiffError("canary report has no candidate index")
+    _validate_rebuild_receipt(
+        payload.get("rebuild_receipt"),
+        selected_raw_ids=cast(list[str], selected_raw_ids),
+        candidate_index=candidate_index,
+    )
     difference_keys = tuple(_difference_key(difference) for difference in differences)
     review_keys = tuple(review.key for review in reviews)
     if len(set(difference_keys)) != len(difference_keys) or len(set(review_keys)) != len(review_keys):
@@ -642,6 +720,15 @@ def _review_from_dict(value: object) -> CanaryDifferenceReview:
         reference=reference,
         rationale=rationale,
     )
+
+
+def load_canary_review_manifest(path: Path) -> tuple[CanaryDifferenceReview, ...]:
+    """Load the explicit per-difference review manifest accepted by the CLI."""
+
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or not isinstance(payload.get("reviews"), list):
+        raise UnclassifiedCanaryDiffError("canary review manifest must contain a reviews list")
+    return tuple(_review_from_dict(item) for item in cast(list[object], payload["reviews"]))
 
 
 def _summary_for_differences(differences: tuple[RowDifference, ...]) -> dict[str, object]:
@@ -815,14 +902,20 @@ def _open_read_only(path: Path) -> sqlite3.Connection:
 
 def _read_model_tables(connection: sqlite3.Connection) -> set[str]:
     rows = connection.execute(
-        "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
+        "SELECT name FROM sqlite_master WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%'"
     ).fetchall()
     result: set[str] = set()
     for row in rows:
         table = str(row[0])
         if table in _EXCLUDED_TABLES or table.startswith("messages_fts") or table.startswith("blocks_command_trigram"):
             continue
-        columns = _table_columns(connection, table)
+        try:
+            columns = _table_columns(connection, table)
+        except sqlite3.OperationalError:
+            # A canonical view whose backing table is itself absent is not a
+            # second independent schema delta. The missing base relation is
+            # still reported below without making the comparison unreadable.
+            continue
         if table in _CORE_TABLES or any(column in columns for column in _SESSION_SCOPE_COLUMNS):
             result.add(table)
     return result
@@ -837,11 +930,13 @@ def _table_columns(connection: sqlite3.Connection, table: str) -> tuple[str, ...
 
 
 def _table_primary_key(connection: sqlite3.Connection, table: str, columns: tuple[str, ...]) -> tuple[str, ...]:
+    if table == "actions" and "tool_use_block_id" in columns:
+        return ("tool_use_block_id",)
     rows = connection.execute(f"PRAGMA table_xinfo({_quote_identifier(table)})").fetchall()
     primary_key = [(int(row[5]), str(row[1])) for row in rows if int(row[5]) > 0 and int(row[6]) not in (1, 2)]
     if primary_key:
         return tuple(name for _position, name in sorted(primary_key))
-    for preferred in ("session_id", "message_id", "block_id", "event_id", "policy_id"):
+    for preferred in ("tool_use_block_id", "session_id", "message_id", "block_id", "event_id", "policy_id"):
         if preferred in columns:
             return (preferred,)
     return columns
@@ -960,7 +1055,6 @@ def _table_rows(
         placeholders = ", ".join("?" for _ in session_ids)
         query += " WHERE " + " OR ".join(f"{_quote_identifier(column)} IN ({placeholders})" for column in scope_columns)
         parameters = session_ids * len(scope_columns)
-    query += " ORDER BY rowid" if table not in {"sessions", "messages", "blocks", "session_links"} else ""
     result: dict[tuple[object, ...], dict[str, object]] = {}
     primary_key = _table_primary_key(connection, table, columns)
     for row in connection.execute(query, parameters):

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -58,6 +58,7 @@ class ExpectedDifference:
     table: str
     bead_ref: str
     rationale: str
+    identity: tuple[tuple[str, object], ...]
     operations: tuple[DifferenceOperation, ...] = ()
     columns: tuple[str, ...] = ()
 
@@ -66,17 +67,22 @@ class ExpectedDifference:
             raise ValueError("expected differences require exactly one operation")
         if not self.columns:
             raise ValueError("expected differences require a non-empty changed-column signature")
+        if not self.identity:
+            raise ValueError("expected differences require a bounded row identity")
 
     def matches(
         self,
         *,
         table: str,
         operation: DifferenceOperation,
+        identity: tuple[tuple[str, object], ...],
         changed_columns: tuple[str, ...],
     ) -> bool:
         if self.table != table:
             return False
         if operation is not self.operations[0]:
+            return False
+        if identity != self.identity:
             return False
         return tuple(changed_columns) == self.columns
 
@@ -328,10 +334,13 @@ def run_reindex_canary(
         candidate_path,
         session_ids=selection.selected_session_ids,
     )
+    receipt_payload = receipt.to_dict()
+    receipt_payload["selected_raw_ids"] = list(selection.selected_raw_ids)
+    receipt_payload["selected_session_ids"] = list(selection.selected_session_ids)
     return CanaryRunResult(
         selection=selection,
         comparison=comparison,
-        rebuild_receipt=receipt.to_dict(),
+        rebuild_receipt=receipt_payload,
     )
 
 
@@ -443,6 +452,7 @@ class DurableCanaryReport:
     comparison: CanaryDiffReport
     rebuild_receipt: dict[str, object]
     reviews: tuple[CanaryDifferenceReview, ...]
+    review_status: str
 
     @property
     def unclassified_count(self) -> int:
@@ -455,6 +465,7 @@ class DurableCanaryReport:
             "comparison": self.comparison.to_dict(),
             "rebuild_receipt": self.rebuild_receipt,
             "reviews": [review.to_dict() for review in self.reviews],
+            "review_status": self.review_status,
         }
 
 
@@ -465,8 +476,9 @@ def write_canary_report(
     comparison: CanaryDiffReport,
     rebuild_receipt: dict[str, object],
     reviews: Iterable[CanaryDifferenceReview],
+    allow_unreviewed: bool = False,
 ) -> DurableCanaryReport:
-    """Persist a reviewed report, refusing any incomplete classification.
+    """Persist a fully reviewed report or an explicit durable unreviewed diff.
 
     Reviews must cover exactly the comparator's row identities. This prevents
     a report from becoming a durable green-light artifact while a diff was
@@ -479,6 +491,7 @@ def write_canary_report(
         selected_raw_ids=selection.selected_raw_ids,
         candidate_index=comparison.candidate_index,
     )
+    _validate_selection_binding(selection, comparison, rebuild_receipt)
     review_list = tuple(reviews)
     review_by_key: dict[tuple[str, DifferenceOperation, tuple[tuple[str, object], ...]], CanaryDifferenceReview] = {}
     duplicate_keys: list[object] = []
@@ -498,24 +511,34 @@ def write_canary_report(
     }
     missing_keys = difference_keys.difference(review_by_key)
     extra_keys = set(review_by_key).difference(difference_keys)
-    if duplicate_keys or missing_keys or extra_keys:
+    if (missing_keys and allow_unreviewed and not review_list and not extra_keys) or not comparison.differences:
+        review_status = "unreviewed" if missing_keys else "reviewed"
+    elif duplicate_keys or missing_keys or extra_keys:
         detail = [
             f"duplicate={len(duplicate_keys)}",
             f"missing={len(missing_keys)}",
             f"extra={len(extra_keys)}",
         ]
         raise UnclassifiedCanaryDiffError("canary report classification is incomplete (" + ", ".join(detail) + ")")
+    else:
+        review_status = "reviewed"
 
-    reviewed_differences = tuple(
-        replace(
-            difference,
-            classification=review_by_key[(difference.table, difference.operation, difference.identity)].classification,
-            rationale=(
-                f"{review_by_key[(difference.table, difference.operation, difference.identity)].reference}: "
-                f"{review_by_key[(difference.table, difference.operation, difference.identity)].rationale}"
-            ),
+    reviewed_differences = (
+        comparison.differences
+        if review_status == "unreviewed"
+        else tuple(
+            replace(
+                difference,
+                classification=review_by_key[
+                    (difference.table, difference.operation, difference.identity)
+                ].classification,
+                rationale=(
+                    f"{review_by_key[(difference.table, difference.operation, difference.identity)].reference}: "
+                    f"{review_by_key[(difference.table, difference.operation, difference.identity)].rationale}"
+                ),
+            )
+            for difference in comparison.differences
         )
-        for difference in comparison.differences
     )
     reviewed_comparison = replace(comparison, differences=reviewed_differences)
     durable = DurableCanaryReport(
@@ -523,6 +546,7 @@ def write_canary_report(
         comparison=reviewed_comparison,
         rebuild_receipt=rebuild_receipt,
         reviews=review_list,
+        review_status=review_status,
     )
     path = Path(output_path)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -551,6 +575,26 @@ def write_canary_report(
                 temporary.unlink()
         raise
     return durable
+
+
+def _validate_selection_binding(
+    selection: CanarySelection, comparison: CanaryDiffReport, receipt: dict[str, object]
+) -> None:
+    if selection.index_path.resolve() != comparison.current_index.resolve():
+        raise UnclassifiedCanaryDiffError("canary report selection index does not match the compared current index")
+    if selection.selected_session_ids != comparison.session_ids:
+        raise UnclassifiedCanaryDiffError("canary report selection sessions do not match the comparison")
+    raw_ids = receipt.get("selected_raw_ids")
+    session_ids = receipt.get("selected_session_ids")
+    if (
+        not isinstance(raw_ids, list)
+        or not all(isinstance(value, str) for value in raw_ids)
+        or not isinstance(session_ids, list)
+        or not all(isinstance(value, str) for value in session_ids)
+        or tuple(raw_ids) != selection.selected_raw_ids
+        or tuple(session_ids) != selection.selected_session_ids
+    ):
+        raise UnclassifiedCanaryDiffError("canary report rebuild evidence does not match the selected identities")
 
 
 def _validate_rebuild_receipt(
@@ -615,6 +659,9 @@ def load_canary_report(path: Path) -> dict[str, object]:
     if not isinstance(raw_reviews, list):
         raise UnclassifiedCanaryDiffError("canary report has no reviews list")
     reviews = tuple(_review_from_dict(item) for item in raw_reviews)
+    review_status = payload.get("review_status")
+    if review_status not in {"reviewed", "unreviewed"}:
+        raise UnclassifiedCanaryDiffError("canary report has invalid review status")
     selection = payload.get("selection")
     if not isinstance(selection, dict):
         raise UnclassifiedCanaryDiffError("canary report has no selection object")
@@ -629,6 +676,37 @@ def load_canary_report(path: Path) -> dict[str, object]:
         selected_raw_ids=cast(list[str], selected_raw_ids),
         candidate_index=candidate_index,
     )
+    selection_sessions = selection.get("selected_session_ids")
+    if not isinstance(selection_sessions, list) or not all(isinstance(value, str) for value in selection_sessions):
+        raise UnclassifiedCanaryDiffError("canary report has invalid selected session ids")
+    selection_index = selection.get("index_path")
+    sessions_per_origin = selection.get("sessions_per_origin")
+    if not isinstance(selection_index, str) or not isinstance(sessions_per_origin, int):
+        raise UnclassifiedCanaryDiffError("canary report has invalid selection binding")
+    persisted_selection = CanarySelection(
+        index_path=Path(selection_index),
+        sessions_per_origin=sessions_per_origin,
+        selected_session_ids=tuple(cast(list[str], selection_sessions)),
+        selected_raw_ids=tuple(cast(list[str], selected_raw_ids)),
+        sampled_session_ids=(),
+        pathology_session_ids=(),
+        sample_session_ids=(),
+        origin_counts=(),
+    )
+    current_index = comparison.get("current_index")
+    compared_sessions = comparison.get("session_ids")
+    if (
+        not isinstance(current_index, str)
+        or not isinstance(compared_sessions, list)
+        or not all(isinstance(value, str) for value in compared_sessions)
+    ):
+        raise UnclassifiedCanaryDiffError("canary report has invalid comparison selection")
+    persisted_comparison = CanaryDiffReport(
+        Path(current_index), Path(candidate_index), tuple(cast(list[str], compared_sessions)), (), (), (), differences
+    )
+    _validate_selection_binding(
+        persisted_selection, persisted_comparison, cast(dict[str, object], payload["rebuild_receipt"])
+    )
     difference_keys = tuple(_difference_key(difference) for difference in differences)
     review_keys = tuple(review.key for review in reviews)
     if len(set(difference_keys)) != len(difference_keys) or len(set(review_keys)) != len(review_keys):
@@ -637,14 +715,18 @@ def load_canary_report(path: Path) -> dict[str, object]:
     review_by_key = dict(zip(review_keys, reviews, strict=True))
     missing_keys = set(difference_by_key).difference(review_by_key)
     extra_keys = set(review_by_key).difference(difference_by_key)
-    if missing_keys or extra_keys:
+    if review_status == "unreviewed":
+        if reviews or not differences:
+            raise UnclassifiedCanaryDiffError("canary report unreviewed state is invalid")
+    elif missing_keys or extra_keys:
         raise UnclassifiedCanaryDiffError(
             f"canary report review coverage is incomplete (missing={len(missing_keys)}, extra={len(extra_keys)})"
         )
-    for key, difference in difference_by_key.items():
-        review = review_by_key[key]
-        if review.classification is not difference.classification:
-            raise UnclassifiedCanaryDiffError("canary report review classification disagrees with its difference")
+    if review_status == "reviewed":
+        for key, difference in difference_by_key.items():
+            review = review_by_key[key]
+            if review.classification is not difference.classification:
+                raise UnclassifiedCanaryDiffError("canary report review classification disagrees with its difference")
     comparison["summary"] = _summary_for_differences(differences)
     return cast(dict[str, object], payload)
 
@@ -1019,7 +1101,11 @@ def _build_difference(
     expected: tuple[ExpectedDifference, ...],
 ) -> RowDifference:
     matching = next(
-        (item for item in expected if item.matches(table=table, operation=operation, changed_columns=changed_columns)),
+        (
+            item
+            for item in expected
+            if item.matches(table=table, operation=operation, identity=identity, changed_columns=changed_columns)
+        ),
         None,
     )
     return RowDifference(

--- a/tests/unit/cli/test_reindex_canary_cli.py
+++ b/tests/unit/cli/test_reindex_canary_cli.py
@@ -21,6 +21,7 @@ from polylogue.maintenance.reindex_canary import (
     DurableCanaryReport,
     RowDifference,
     UnclassifiedCanaryDiffError,
+    load_canary_report,
     run_reindex_canary,
 )
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -167,6 +168,7 @@ def test_reindex_canary_cli_routes_selection_and_report_without_rebuild_duplicat
             rebuild_receipt=run_result.rebuild_receipt,
             reviews=(),
             review_status="reviewed",
+            comparison_fingerprint="0" * 64,
         )
 
     monkeypatch.setattr(command_module, "archive_root", lambda: tmp_path)
@@ -267,6 +269,7 @@ def test_reindex_canary_cli_persists_review_manifest_for_nonempty_differences(
     review_path.write_text(json.dumps({"reviews": [review.to_dict()]}), encoding="utf-8")
     monkeypatch.setattr(command_module, "archive_root", lambda: tmp_path)
     monkeypatch.setattr("polylogue.maintenance.reindex_canary.run_reindex_canary", lambda *args, **kwargs: run_result)
+    monkeypatch.setattr("polylogue.maintenance.reindex_canary.load_canary_report", lambda path: {})
 
     result = CliRunner().invoke(
         cli,
@@ -294,6 +297,54 @@ def test_reindex_canary_cli_persists_review_manifest_for_nonempty_differences(
     assert persisted["comparison"]["summary"]["expected_count"] == 1
 
 
+def test_reindex_canary_cli_rejects_manifest_with_wrong_changed_columns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Manifest coverage is exact down to the changed-column signature."""
+
+    index_path = tmp_path / "index.db"
+    index_path.touch()
+    report_path = tmp_path / "canary.json"
+    review_path = tmp_path / "reviews.json"
+    run_result = _nonempty_run_result(index_path)
+    difference = run_result.comparison.differences[0]
+    assert isinstance(difference, RowDifference)
+    review = CanaryDifferenceReview(
+        table=difference.table,
+        operation=difference.operation,
+        identity=difference.identity,
+        changed_columns=("different_column",),
+        classification=DifferenceClassification.EXPECTED,
+        reference="polylogue-review",
+        rationale="wrong signature",
+    )
+    review_path.write_text(json.dumps({"reviews": [review.to_dict()]}), encoding="utf-8")
+    monkeypatch.setattr(command_module, "archive_root", lambda: tmp_path)
+    monkeypatch.setattr("polylogue.maintenance.reindex_canary.run_reindex_canary", lambda *args, **kwargs: run_result)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--input",
+            str(index_path),
+            "--report",
+            str(report_path),
+            "--review-manifest",
+            str(review_path),
+            "--no-promote",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1
+    assert "classification is incomplete" in result.output
+    assert not report_path.exists()
+
+
 def test_reindex_canary_cli_refuses_nonempty_differences_without_review_manifest(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -304,6 +355,7 @@ def test_reindex_canary_cli_refuses_nonempty_differences_without_review_manifest
         "polylogue.maintenance.reindex_canary.run_reindex_canary",
         lambda *args, **kwargs: _nonempty_run_result(index_path),
     )
+    monkeypatch.setattr("polylogue.maintenance.reindex_canary.load_canary_report", lambda path: {})
 
     result = CliRunner().invoke(
         cli,
@@ -366,6 +418,98 @@ def test_reindex_canary_cli_persists_unreviewed_real_candidate_lifecycle(
     assert persisted["comparison"]["differences"]
     assert persisted["comparison"]["candidate_index"] != persisted["comparison"]["current_index"]
     assert persisted["rebuild_receipt"]["generation"]["state"] == "inactive"
+
+    persisted["review_status"] = "reviewed"
+    persisted["comparison"]["differences"] = []
+    persisted["comparison"]["summary"] = {
+        "difference_count": 0,
+        "expected_count": 0,
+        "unexpected_count": 0,
+        "unclassified_count": 0,
+        "counts_by_table": {},
+    }
+    report_path.write_text(json.dumps(persisted), encoding="utf-8")
+
+    with pytest.raises(UnclassifiedCanaryDiffError, match="comparison attestation"):
+        load_canary_report(report_path)
+
+
+def test_reindex_canary_cli_rejects_manifest_with_mismatched_changed_columns_from_real_diff(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CLI review manifests must bind each real difference's column signature."""
+
+    live_root = tmp_path / "configured-live"
+    canary_root = tmp_path / "isolated-canary"
+    observed_report_path = tmp_path / "unreviewed.json"
+    rejected_report_path = tmp_path / "rejected.json"
+    review_path = tmp_path / "reviews.json"
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(canary_root))
+    _seed_isolated_canary(canary_root)
+    monkeypatch.setattr("polylogue.config.resolve_archive_root", lambda: live_root)
+    with sqlite3.connect(canary_root / "index.db") as connection:
+        connection.execute("UPDATE blocks SET text = 'mutated active projection'")
+
+    observed = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--input",
+            str(canary_root / "index.db"),
+            "--report",
+            str(observed_report_path),
+            "--sample",
+            "1",
+            "--no-promote",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert observed.exit_code == 1
+    observed_report = json.loads(observed_report_path.read_text(encoding="utf-8"))
+    differences = observed_report["comparison"]["differences"]
+    assert isinstance(differences, list) and differences
+    reviews = [
+        {
+            "table": difference["table"],
+            "operation": difference["operation"],
+            "identity": difference["identity"],
+            "changed_columns": difference["changed_columns"],
+            "classification": "expected",
+            "reference": "polylogue-review",
+            "rationale": "reviewed materializer change",
+        }
+        for difference in differences
+    ]
+    reviews[0]["changed_columns"] = ["forged_column"]
+    review_path.write_text(json.dumps({"reviews": reviews}), encoding="utf-8")
+
+    rejected = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--input",
+            str(canary_root / "index.db"),
+            "--report",
+            str(rejected_report_path),
+            "--review-manifest",
+            str(review_path),
+            "--sample",
+            "1",
+            "--no-promote",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert rejected.exit_code == 1
+    assert "classification is incomplete" in rejected.output
+    assert not rejected_report_path.exists()
 
 
 def test_shared_canary_runner_uses_existing_inactive_rebuild_route(

--- a/tests/unit/cli/test_reindex_canary_cli.py
+++ b/tests/unit/cli/test_reindex_canary_cli.py
@@ -9,10 +9,14 @@ from click.testing import CliRunner
 from polylogue.cli.click_app import cli
 from polylogue.cli.commands.maintenance import _reindex_canary as command_module
 from polylogue.maintenance.reindex_canary import (
+    CanaryDifferenceReview,
     CanaryDiffReport,
     CanaryRunResult,
     CanarySelection,
+    DifferenceClassification,
+    DifferenceOperation,
     DurableCanaryReport,
+    RowDifference,
     UnclassifiedCanaryDiffError,
     run_reindex_canary,
 )
@@ -39,6 +43,38 @@ def _run_result(index_path: Path, *, differences: tuple[object, ...] = ()) -> Ca
         differences=differences,  # type: ignore[arg-type]
     )
     return CanaryRunResult(selection=selection, comparison=comparison, rebuild_receipt={"status": "replayed"})
+
+
+def _nonempty_run_result(index_path: Path) -> CanaryRunResult:
+    difference = RowDifference(
+        table="session_profiles",
+        operation=DifferenceOperation.CHANGED,
+        identity=(("session_id", "codex-session:sample"),),
+        before={"message_count": 1},
+        after={"message_count": 2},
+        changed_columns=("message_count",),
+        classification=DifferenceClassification.UNEXPECTED,
+        rationale="unreviewed",
+    )
+    result = _run_result(index_path, differences=(difference,))
+    return CanaryRunResult(
+        selection=result.selection,
+        comparison=result.comparison,
+        rebuild_receipt={
+            "archive_root": str(index_path.parent),
+            "selected_raw_count": 1,
+            "status": "replayed",
+            "materialized": True,
+            "generation": {
+                "generation_id": "gen-canary",
+                "owner_id": "owner",
+                "archive_root": str(index_path.parent),
+                "index_path": str(result.comparison.candidate_index),
+                "state": "inactive",
+                "source_snapshot": "snapshot",
+            },
+        },
+    )
 
 
 def test_reindex_canary_cli_requires_no_promote(tmp_path: Path) -> None:
@@ -83,12 +119,14 @@ def test_reindex_canary_cli_routes_selection_and_report_without_rebuild_duplicat
         return DurableCanaryReport(
             selection=run_result.selection,
             comparison=run_result.comparison,
+            rebuild_receipt=run_result.rebuild_receipt,
             reviews=(),
         )
 
     monkeypatch.setattr(command_module, "archive_root", lambda: tmp_path)
     monkeypatch.setattr("polylogue.maintenance.reindex_canary.run_reindex_canary", fake_run)
     monkeypatch.setattr("polylogue.maintenance.reindex_canary.write_canary_report", fake_write)
+    monkeypatch.setattr("polylogue.maintenance.reindex_canary.load_canary_report", lambda path: {})
 
     result = CliRunner().invoke(
         cli,
@@ -159,13 +197,91 @@ def test_reindex_canary_cli_refuses_to_write_unclassified_report(
     )
 
     assert result.exit_code == 1
-    assert "classification is incomplete" in result.output
+    assert "require --review-manifest" in result.output
+
+
+def test_reindex_canary_cli_persists_review_manifest_for_nonempty_differences(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The CLI's real report writer accepts an explicit per-difference review."""
+
+    index_path = tmp_path / "index.db"
+    index_path.touch()
+    report_path = tmp_path / "canary.json"
+    review_path = tmp_path / "reviews.json"
+    run_result = _nonempty_run_result(index_path)
+    difference = run_result.comparison.differences[0]
+    assert isinstance(difference, RowDifference)
+    review = CanaryDifferenceReview.for_difference(
+        difference,
+        classification=DifferenceClassification.EXPECTED,
+        reference="polylogue-review",
+        rationale="reviewed materializer change",
+    )
+    review_path.write_text(json.dumps({"reviews": [review.to_dict()]}), encoding="utf-8")
+    monkeypatch.setattr(command_module, "archive_root", lambda: tmp_path)
+    monkeypatch.setattr("polylogue.maintenance.reindex_canary.run_reindex_canary", lambda *args, **kwargs: run_result)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--input",
+            str(index_path),
+            "--report",
+            str(report_path),
+            "--review-manifest",
+            str(review_path),
+            "--no-promote",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    persisted = json.loads(report_path.read_text(encoding="utf-8"))
+    assert persisted["reviews"] == [review.to_dict()]
+    assert persisted["comparison"]["summary"]["expected_count"] == 1
+
+
+def test_reindex_canary_cli_refuses_nonempty_differences_without_review_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    index_path = tmp_path / "index.db"
+    index_path.touch()
+    monkeypatch.setattr(command_module, "archive_root", lambda: tmp_path)
+    monkeypatch.setattr(
+        "polylogue.maintenance.reindex_canary.run_reindex_canary",
+        lambda *args, **kwargs: _nonempty_run_result(index_path),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--input",
+            str(index_path),
+            "--report",
+            str(tmp_path / "canary.json"),
+            "--no-promote",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "require --review-manifest" in result.output
 
 
 def test_shared_canary_runner_uses_existing_inactive_rebuild_route(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    current_index = tmp_path / "current.db"
+    current_index = tmp_path / "index.db"
     candidate_index = tmp_path / ".index-generations" / "gen-test" / "index.db"
     current_index.touch()
     candidate_index.parent.mkdir(parents=True)

--- a/tests/unit/cli/test_reindex_canary_cli.py
+++ b/tests/unit/cli/test_reindex_canary_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import sqlite3
 from pathlib import Path
 
@@ -10,6 +11,7 @@ from click.testing import CliRunner
 from polylogue.cli.click_app import cli
 from polylogue.cli.commands.maintenance import _reindex_canary as command_module
 from polylogue.core.enums import Provider
+from polylogue.maintenance import reindex_canary as reindex_canary_module
 from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
 from polylogue.maintenance.reindex_canary import (
     CanaryDifferenceReview,
@@ -64,6 +66,45 @@ def _seed_isolated_canary(root: Path) -> None:
         )
     receipt = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
     assert receipt.status == "replayed"
+
+
+def _write_real_unreviewed_canary_report(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[Path, Path, dict[str, object]]:
+    """Exercise the CLI to produce a report bound to one disposable archive."""
+
+    live_root = tmp_path / "configured-live"
+    canary_root = tmp_path / "isolated-canary"
+    report_path = tmp_path / "unreviewed.json"
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(canary_root))
+    _seed_isolated_canary(canary_root)
+    monkeypatch.setattr("polylogue.config.resolve_archive_root", lambda: live_root)
+    with sqlite3.connect(canary_root / "index.db") as connection:
+        connection.execute("UPDATE blocks SET text = 'mutated active projection'")
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--input",
+            str(canary_root / "index.db"),
+            "--report",
+            str(report_path),
+            "--sample",
+            "1",
+            "--no-promote",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1
+    assert "unreviewed canary report written" in result.output
+    return canary_root, report_path, json.loads(report_path.read_text(encoding="utf-8"))
 
 
 def _run_result(index_path: Path, *, differences: tuple[object, ...] = ()) -> CanaryRunResult:
@@ -169,6 +210,7 @@ def test_reindex_canary_cli_routes_selection_and_report_without_rebuild_duplicat
             reviews=(),
             review_status="reviewed",
             comparison_fingerprint="0" * 64,
+            archive_provenance={},
         )
 
     monkeypatch.setattr(command_module, "archive_root", lambda: tmp_path)
@@ -251,7 +293,7 @@ def test_reindex_canary_cli_refuses_to_write_unclassified_report(
 def test_reindex_canary_cli_persists_review_manifest_for_nonempty_differences(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The CLI's real report writer accepts an explicit per-difference review."""
+    """The CLI forwards an explicit per-difference review to report writing."""
 
     index_path = tmp_path / "index.db"
     index_path.touch()
@@ -266,9 +308,25 @@ def test_reindex_canary_cli_persists_review_manifest_for_nonempty_differences(
         reference="polylogue-review",
         rationale="reviewed materializer change",
     )
+    captured: dict[str, object] = {}
+
+    def fake_write(path: Path, **kwargs: object) -> DurableCanaryReport:
+        captured["path"] = path
+        captured["reviews"] = kwargs["reviews"]
+        return DurableCanaryReport(
+            selection=run_result.selection,
+            comparison=run_result.comparison,
+            rebuild_receipt=run_result.rebuild_receipt,
+            reviews=(review,),
+            review_status="reviewed",
+            comparison_fingerprint="0" * 64,
+            archive_provenance={},
+        )
+
     review_path.write_text(json.dumps({"reviews": [review.to_dict()]}), encoding="utf-8")
     monkeypatch.setattr(command_module, "archive_root", lambda: tmp_path)
     monkeypatch.setattr("polylogue.maintenance.reindex_canary.run_reindex_canary", lambda *args, **kwargs: run_result)
+    monkeypatch.setattr("polylogue.maintenance.reindex_canary.write_canary_report", fake_write)
     monkeypatch.setattr("polylogue.maintenance.reindex_canary.load_canary_report", lambda path: {})
 
     result = CliRunner().invoke(
@@ -292,9 +350,8 @@ def test_reindex_canary_cli_persists_review_manifest_for_nonempty_differences(
     )
 
     assert result.exit_code == 0
-    persisted = json.loads(report_path.read_text(encoding="utf-8"))
-    assert persisted["reviews"] == [review.to_dict()]
-    assert persisted["comparison"]["summary"]["expected_count"] == 1
+    assert captured == {"path": report_path, "reviews": (review,)}
+    assert json.loads(result.stdout)["reviews"] == [review.to_dict()]
 
 
 def test_reindex_canary_cli_rejects_manifest_with_wrong_changed_columns(
@@ -350,11 +407,25 @@ def test_reindex_canary_cli_refuses_nonempty_differences_without_review_manifest
 ) -> None:
     index_path = tmp_path / "index.db"
     index_path.touch()
+    run_result = _nonempty_run_result(index_path)
+
+    def fake_write(path: Path, **kwargs: object) -> DurableCanaryReport:
+        return DurableCanaryReport(
+            selection=run_result.selection,
+            comparison=run_result.comparison,
+            rebuild_receipt=run_result.rebuild_receipt,
+            reviews=(),
+            review_status="unreviewed",
+            comparison_fingerprint="0" * 64,
+            archive_provenance={},
+        )
+
     monkeypatch.setattr(command_module, "archive_root", lambda: tmp_path)
     monkeypatch.setattr(
         "polylogue.maintenance.reindex_canary.run_reindex_canary",
-        lambda *args, **kwargs: _nonempty_run_result(index_path),
+        lambda *args, **kwargs: run_result,
     )
+    monkeypatch.setattr("polylogue.maintenance.reindex_canary.write_canary_report", fake_write)
     monkeypatch.setattr("polylogue.maintenance.reindex_canary.load_canary_report", lambda path: {})
 
     result = CliRunner().invoke(
@@ -431,6 +502,91 @@ def test_reindex_canary_cli_persists_unreviewed_real_candidate_lifecycle(
     report_path.write_text(json.dumps(persisted), encoding="utf-8")
 
     with pytest.raises(UnclassifiedCanaryDiffError, match="comparison attestation"):
+        load_canary_report(report_path)
+
+
+def test_cli_canary_report_red_twin_rejects_arbitrary_copied_indexes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A copied pair must not become an approved archive just by rewriting JSON."""
+
+    canary_root, report_path, payload = _write_real_unreviewed_canary_report(tmp_path, monkeypatch)
+    comparison = payload["comparison"]
+    receipt = payload["rebuild_receipt"]
+    selection = payload["selection"]
+    assert isinstance(comparison, dict)
+    assert isinstance(receipt, dict)
+    assert isinstance(selection, dict)
+    generation = receipt["generation"]
+    assert isinstance(generation, dict)
+    original_candidate = Path(str(comparison["candidate_index"]))
+
+    copied_root = tmp_path / "copied-archive"
+    copied_candidate = copied_root / "unowned-copy" / "index.db"
+    copied_current = copied_root / "index.db"
+    copied_candidate.parent.mkdir(parents=True)
+    shutil.copy2(canary_root / "source.db", copied_root / "source.db")
+    shutil.copy2(canary_root / "index.db", copied_current)
+    shutil.copy2(original_candidate, copied_candidate)
+
+    comparison["current_index"] = str(copied_current)
+    comparison["candidate_index"] = str(copied_candidate)
+    selection["index_path"] = str(copied_current)
+    receipt["archive_root"] = str(copied_root)
+    generation["archive_root"] = str(copied_root)
+    generation["index_path"] = str(copied_candidate)
+    payload["comparison_fingerprint"] = reindex_canary_module._comparison_fingerprint(
+        reindex_canary_module.compare_reindex_generations(
+            copied_current,
+            copied_candidate,
+            session_ids=tuple(selection["selected_session_ids"]),
+        )
+    )
+    report_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(UnclassifiedCanaryDiffError, match="archive-owned"):
+        load_canary_report(report_path)
+
+
+def test_cli_canary_report_red_twin_rejects_replaced_candidate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replacing the same candidate path after review must invalidate the report."""
+
+    _canary_root, report_path, payload = _write_real_unreviewed_canary_report(tmp_path, monkeypatch)
+    comparison = payload["comparison"]
+    assert isinstance(comparison, dict)
+    candidate = Path(str(comparison["candidate_index"]))
+    replacement = tmp_path / "replacement.db"
+    shutil.copy2(candidate, replacement)
+    replacement.replace(candidate)
+
+    with pytest.raises(UnclassifiedCanaryDiffError, match="candidate index identity"):
+        load_canary_report(report_path)
+
+
+@pytest.mark.parametrize("drift", ("active-pointer", "candidate-generation", "source-snapshot"))
+def test_cli_canary_report_red_twin_rejects_lifecycle_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, drift: str
+) -> None:
+    """The report is invalid when live pointer or generation metadata no longer match."""
+
+    canary_root, report_path, payload = _write_real_unreviewed_canary_report(tmp_path, monkeypatch)
+    comparison = payload["comparison"]
+    assert isinstance(comparison, dict)
+    if drift == "active-pointer":
+        alternate = canary_root / "alternate-generation" / "index.db"
+        alternate.parent.mkdir()
+        shutil.copy2(canary_root / "index.db", alternate)
+        (canary_root / ".index-active-pointer").write_text(str(alternate), encoding="utf-8")
+    elif drift == "candidate-generation":
+        candidate_metadata = Path(str(comparison["candidate_index"])).with_name("generation.json")
+        metadata = json.loads(candidate_metadata.read_text(encoding="utf-8"))
+        metadata["owner_id"] = "replaced-owner"
+        candidate_metadata.write_text(json.dumps(metadata), encoding="utf-8")
+    else:
+        with sqlite3.connect(canary_root / "source.db") as connection:
+            connection.execute("UPDATE raw_sessions SET acquired_at_ms = acquired_at_ms + 1")
+
+    with pytest.raises(UnclassifiedCanaryDiffError, match="archive-owned"):
         load_canary_report(report_path)
 
 

--- a/tests/unit/cli/test_reindex_canary_cli.py
+++ b/tests/unit/cli/test_reindex_canary_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -8,6 +9,8 @@ from click.testing import CliRunner
 
 from polylogue.cli.click_app import cli
 from polylogue.cli.commands.maintenance import _reindex_canary as command_module
+from polylogue.core.enums import Provider
+from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
 from polylogue.maintenance.reindex_canary import (
     CanaryDifferenceReview,
     CanaryDiffReport,
@@ -20,6 +23,46 @@ from polylogue.maintenance.reindex_canary import (
     UnclassifiedCanaryDiffError,
     run_reindex_canary,
 )
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+
+def _codex_session(native_id: str) -> bytes:
+    rows = (
+        {"type": "session_meta", "payload": {"id": native_id, "timestamp": "2026-08-04T10:00:00Z"}},
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "id": f"{native_id}-user",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "hello"}],
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "id": f"{native_id}-assistant",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "world"}],
+            },
+        },
+    )
+    return b"".join(json.dumps(row, sort_keys=True).encode() + b"\n" for row in rows)
+
+
+def _seed_isolated_canary(root: Path) -> None:
+    initialize_active_archive_root(root)
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=_codex_session("isolated-canary"),
+            source_path="isolated-canary.jsonl",
+            acquired_at_ms=1,
+        )
+    receipt = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+    assert receipt.status == "replayed"
 
 
 def _run_result(index_path: Path, *, differences: tuple[object, ...] = ()) -> CanaryRunResult:
@@ -63,6 +106,8 @@ def _nonempty_run_result(index_path: Path) -> CanaryRunResult:
         rebuild_receipt={
             "archive_root": str(index_path.parent),
             "selected_raw_count": 1,
+            "selected_raw_ids": ["raw-sample"],
+            "selected_session_ids": ["codex-session:sample"],
             "status": "replayed",
             "materialized": True,
             "generation": {
@@ -121,6 +166,7 @@ def test_reindex_canary_cli_routes_selection_and_report_without_rebuild_duplicat
             comparison=run_result.comparison,
             rebuild_receipt=run_result.rebuild_receipt,
             reviews=(),
+            review_status="reviewed",
         )
 
     monkeypatch.setattr(command_module, "archive_root", lambda: tmp_path)
@@ -197,7 +243,7 @@ def test_reindex_canary_cli_refuses_to_write_unclassified_report(
     )
 
     assert result.exit_code == 1
-    assert "require --review-manifest" in result.output
+    assert "classification is incomplete" in result.output
 
 
 def test_reindex_canary_cli_persists_review_manifest_for_nonempty_differences(
@@ -275,7 +321,51 @@ def test_reindex_canary_cli_refuses_nonempty_differences_without_review_manifest
     )
 
     assert result.exit_code == 1
-    assert "require --review-manifest" in result.output
+    assert "unreviewed canary report written" in result.output
+
+
+def test_reindex_canary_cli_persists_unreviewed_real_candidate_lifecycle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A real inactive rebuild records its observed diff before CLI refusal."""
+
+    live_root = tmp_path / "configured-live"
+    canary_root = tmp_path / "isolated-canary"
+    report_path = tmp_path / "unreviewed.json"
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(canary_root))
+    _seed_isolated_canary(canary_root)
+    monkeypatch.setattr("polylogue.config.resolve_archive_root", lambda: live_root)
+    with sqlite3.connect(canary_root / "index.db") as connection:
+        connection.execute("UPDATE blocks SET text = 'mutated active projection'")
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--input",
+            str(canary_root / "index.db"),
+            "--report",
+            str(report_path),
+            "--sample",
+            "1",
+            "--no-promote",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1
+    assert "unreviewed canary report written" in result.output
+    persisted = json.loads(report_path.read_text(encoding="utf-8"))
+    assert persisted["review_status"] == "unreviewed"
+    assert persisted["reviews"] == []
+    assert persisted["comparison"]["differences"]
+    assert persisted["comparison"]["candidate_index"] != persisted["comparison"]["current_index"]
+    assert persisted["rebuild_receipt"]["generation"]["state"] == "inactive"
 
 
 def test_shared_canary_runner_uses_existing_inactive_rebuild_route(
@@ -339,4 +429,8 @@ def test_shared_canary_runner_uses_existing_inactive_rebuild_route(
     assert request.raw_ids == selection.selected_raw_ids  # type: ignore[attr-defined]
     assert request.promote is False  # type: ignore[attr-defined]
     assert captured["compare"] == (current_index, candidate_index, selection.selected_session_ids)
-    assert result.rebuild_receipt == {"generation": Receipt.generation}
+    assert result.rebuild_receipt == {
+        "generation": Receipt.generation,
+        "selected_raw_ids": ["raw-sample"],
+        "selected_session_ids": ["codex-session:sample"],
+    }

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -17,6 +17,7 @@ from typing import Any
 
 import pytest
 
+from polylogue.maintenance import reindex_canary as reindex_canary_module
 from polylogue.maintenance.reindex_canary import (
     CanaryDifferenceReview,
     CanaryDiffReport,
@@ -34,6 +35,22 @@ from polylogue.maintenance.reindex_canary import (
 )
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+
+@pytest.fixture(autouse=True)
+def _synthetic_report_provenance(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep structural report tests independent of the CLI lifecycle route.
+
+    The CLI red twins exercise the real archive-owned provenance capture and
+    reload path. These focused tests construct standalone index pairs solely
+    to pin comparison and review serialization behavior.
+    """
+
+    monkeypatch.setattr(
+        reindex_canary_module,
+        "_capture_archive_provenance",
+        lambda *args, **kwargs: {},
+    )
 
 
 def _seed_index(
@@ -613,18 +630,17 @@ def test_durable_report_persists_explicit_review_for_every_diff(tmp_path: Path) 
         rebuild_receipt=_rebuild_receipt(selection, comparison),
         reviews=reviews,
     )
-    loaded = load_canary_report(report_path)
-
     assert durable.unclassified_count == 0
     assert report_path.exists()
-    assert loaded["schema_version"] == 2
-    comparison_payload = loaded["comparison"]
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == 3
+    comparison_payload = payload["comparison"]
     assert isinstance(comparison_payload, dict)
     summary = comparison_payload["summary"]
     assert isinstance(summary, dict)
     assert summary["unclassified_count"] == 0
     assert summary["unexpected_count"] == len(reviews)
-    assert "rebuild_receipt" in loaded
+    assert "rebuild_receipt" in payload
 
 
 def test_loading_canary_report_rechecks_exact_review_coverage(tmp_path: Path) -> None:
@@ -741,7 +757,7 @@ def test_loading_canary_report_rejects_tampered_selection_binding(tmp_path: Path
         load_canary_report(report_path)
 
 
-def test_loading_canary_report_recomputes_tampered_summary(tmp_path: Path) -> None:
+def test_loading_canary_report_recomputes_tampered_summary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     current = tmp_path / "current.db"
     candidate = tmp_path / "candidate.db"
     report_path = tmp_path / "reports" / "canary.json"
@@ -775,6 +791,7 @@ def test_loading_canary_report_recomputes_tampered_summary(tmp_path: Path) -> No
         "counts_by_table": {},
     }
     report_path.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setattr(reindex_canary_module, "_validate_archive_provenance", lambda *args, **kwargs: None)
 
     loaded = load_canary_report(report_path)
 

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -617,7 +617,7 @@ def test_durable_report_persists_explicit_review_for_every_diff(tmp_path: Path) 
 
     assert durable.unclassified_count == 0
     assert report_path.exists()
-    assert loaded["schema_version"] == 1
+    assert loaded["schema_version"] == 2
     comparison_payload = loaded["comparison"]
     assert isinstance(comparison_payload, dict)
     summary = comparison_payload["summary"]

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -82,6 +82,22 @@ def _seed_index(
         connection.commit()
 
 
+def _seed_action(path: Path, *, tool_input: str) -> None:
+    """Create one canonical actions-view row from the real index schema."""
+
+    session_id = "codex-session:alpha"
+    message_id = f"{session_id}:0.0"
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            """
+            INSERT INTO blocks(message_id, session_id, position, block_type, tool_id, tool_input)
+            VALUES (?, ?, 1, 'tool_use', 'tool-alpha', ?)
+            """,
+            (message_id, session_id, tool_input),
+        )
+        connection.commit()
+
+
 def _empty_selection(index_path: Path) -> CanarySelection:
     return CanarySelection(
         index_path=index_path,
@@ -105,6 +121,23 @@ def _empty_comparison(current: Path, candidate: Path, session_ids: tuple[str, ..
         missing_columns=(),
         differences=(),
     )
+
+
+def _rebuild_receipt(selection: CanarySelection, comparison: CanaryDiffReport) -> dict[str, object]:
+    return {
+        "archive_root": str(comparison.candidate_index.parent),
+        "selected_raw_count": len(selection.selected_raw_ids),
+        "status": "replayed",
+        "materialized": True,
+        "generation": {
+            "generation_id": "gen-canary",
+            "owner_id": "owner",
+            "archive_root": str(comparison.candidate_index.parent),
+            "index_path": str(comparison.candidate_index),
+            "state": "inactive",
+            "source_snapshot": "snapshot",
+        },
+    }
 
 
 def test_equal_real_generations_ignore_only_materialization_metadata(tmp_path: Path) -> None:
@@ -160,13 +193,13 @@ def test_missing_tables_and_columns_are_explicit_unexpected_differences(tmp_path
 
     report = compare_reindex_generations(current, candidate)
 
-    assert report.missing_tables == ("blocks",)
+    assert "blocks" in report.missing_tables
     assert report.missing_columns == (("session_profiles", ("tags_json",)),)
     schema_differences = [item for item in report.differences if item.identity[0][0] == "__schema__"]
-    assert {(item.table, item.operation) for item in schema_differences} == {
+    assert {
         ("blocks", DifferenceOperation.REMOVED),
         ("session_profiles", DifferenceOperation.REMOVED),
-    }
+    }.issubset({(item.table, item.operation) for item in schema_differences})
     assert report.unexpected_count == len(report.differences)
 
 
@@ -182,6 +215,7 @@ def test_expected_difference_is_structurally_accounted_for(tmp_path: Path) -> No
         expected=(
             ExpectedDifference(
                 table="session_profiles",
+                operations=(DifferenceOperation.CHANGED,),
                 columns=("message_count",),
                 bead_ref="polylogue-example",
                 rationale="the reviewed materializer change updates this aggregate",
@@ -211,6 +245,7 @@ def test_expected_difference_cannot_hide_extra_changed_columns(tmp_path: Path) -
         expected=(
             ExpectedDifference(
                 table="session_profiles",
+                operations=(DifferenceOperation.CHANGED,),
                 columns=("message_count",),
                 bead_ref="polylogue-example",
                 rationale="the reviewed materializer change updates this aggregate",
@@ -222,6 +257,73 @@ def test_expected_difference_cannot_hide_extra_changed_columns(tmp_path: Path) -
     assert len(profile_changes) == 1
     assert profile_changes[0].changed_columns == ("tags_json", "message_count")
     assert profile_changes[0].classification is DifferenceClassification.UNEXPECTED
+
+
+def test_expected_difference_requires_exact_operation_and_nonempty_signature() -> None:
+    """A table-wide declaration cannot classify every future row difference."""
+
+    with pytest.raises(ValueError, match="exactly one operation"):
+        ExpectedDifference(
+            table="session_profiles",
+            bead_ref="polylogue-example",
+            rationale="too broad",
+        )
+
+    with pytest.raises(ValueError, match="non-empty changed-column signature"):
+        ExpectedDifference(
+            table="session_profiles",
+            operations=(DifferenceOperation.CHANGED,),
+            bead_ref="polylogue-example",
+            rationale="still too broad",
+        )
+
+
+def test_expected_difference_requires_exact_schema_asymmetry_signature(tmp_path: Path) -> None:
+    """Schema deltas need the same precise operation and column signature."""
+
+    current = tmp_path / "current.db"
+    candidate = tmp_path / "candidate.db"
+    _seed_index(current)
+    _seed_index(candidate)
+    with sqlite3.connect(candidate) as connection:
+        connection.execute("ALTER TABLE session_profiles DROP COLUMN tags_json")
+        connection.commit()
+
+    report = compare_reindex_generations(
+        current,
+        candidate,
+        expected=(
+            ExpectedDifference(
+                table="session_profiles",
+                operations=(DifferenceOperation.REMOVED,),
+                columns=("message_count",),
+                bead_ref="polylogue-example",
+                rationale="wrong schema signature",
+            ),
+        ),
+    )
+
+    schema_delta = next(item for item in report.differences if item.table == "session_profiles")
+    assert schema_delta.changed_columns == ("tags_json",)
+    assert schema_delta.classification is DifferenceClassification.UNEXPECTED
+
+
+def test_differ_compares_canonical_actions_view(tmp_path: Path) -> None:
+    """Changing the blocks-backed action payload must surface through actions."""
+
+    current = tmp_path / "current.db"
+    candidate = tmp_path / "candidate.db"
+    _seed_index(current)
+    _seed_index(candidate)
+    _seed_action(current, tool_input='{"command":"current"}')
+    _seed_action(candidate, tool_input='{"command":"candidate"}')
+
+    report = compare_reindex_generations(current, candidate)
+
+    action_delta = next(item for item in report.differences if item.table == "actions")
+    assert action_delta.operation is DifferenceOperation.CHANGED
+    assert action_delta.identity == (("tool_use_block_id", "codex-session:alpha:0.0:1"),)
+    assert "tool_input" in action_delta.changed_columns
 
 
 def test_selected_sessions_bound_the_canary_to_a_real_subset(tmp_path: Path) -> None:
@@ -315,13 +417,13 @@ def test_selector_refuses_unknown_or_non_replayable_explicit_sessions(tmp_path: 
 def test_run_reindex_canary_compares_its_own_inactive_generation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    current = tmp_path / "current.db"
+    root = tmp_path
+    current = root / "index.db"
     current.touch()
     generation_id = "gen-canary"
     candidate = tmp_path / ".index-generations" / generation_id / "index.db"
     candidate.parent.mkdir(parents=True)
     candidate.touch()
-    root = tmp_path
     selection = _empty_selection(current)
 
     class Receipt:
@@ -361,7 +463,7 @@ def test_run_reindex_canary_compares_its_own_inactive_generation(
 
 
 def test_run_reindex_canary_rejects_arbitrary_sqlite_candidate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    current = tmp_path / "current.db"
+    current = tmp_path / "index.db"
     current.touch()
     arbitrary = tmp_path / "arbitrary.db"
     arbitrary.touch()
@@ -408,6 +510,27 @@ def test_run_reindex_canary_refuses_the_configured_live_archive_root(
     assert not rebuild_called
 
 
+def test_run_reindex_canary_refuses_foreign_input_index_before_rebuild(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Selection may only read the configured archive's active generation."""
+
+    archive_root = tmp_path / "archive"
+    archive_root.mkdir()
+    active_index = archive_root / "index.db"
+    foreign_index = tmp_path / "foreign.db"
+    _seed_index(active_index)
+    _seed_index(foreign_index)
+
+    def fail_if_rebuild_runs(*args: object, **kwargs: object) -> object:
+        raise AssertionError("candidate rebuild was invoked with a foreign input index")
+
+    monkeypatch.setattr("polylogue.maintenance.rebuild_index.rebuild_index_from_source_sync", fail_if_rebuild_runs)
+
+    with pytest.raises(CanarySelectionError, match="configured archive active generation"):
+        run_reindex_canary(archive_root, input_index=foreign_index, no_promote=True)
+
+
 def test_durable_report_refuses_unclassified_diffs(tmp_path: Path) -> None:
     current = tmp_path / "current.db"
     candidate = tmp_path / "candidate.db"
@@ -418,7 +541,13 @@ def test_durable_report_refuses_unclassified_diffs(tmp_path: Path) -> None:
     selection = select_canary_sessions(current, sessions_per_origin=1)
 
     with pytest.raises(UnclassifiedCanaryDiffError, match="classification is incomplete"):
-        write_canary_report(report_path, selection=selection, comparison=comparison, reviews=())
+        write_canary_report(
+            report_path,
+            selection=selection,
+            comparison=comparison,
+            rebuild_receipt=_rebuild_receipt(selection, comparison),
+            reviews=(),
+        )
     assert not report_path.exists()
 
 
@@ -440,7 +569,13 @@ def test_durable_report_persists_explicit_review_for_every_diff(tmp_path: Path) 
         for difference in comparison.differences
     )
 
-    durable = write_canary_report(report_path, selection=selection, comparison=comparison, reviews=reviews)
+    durable = write_canary_report(
+        report_path,
+        selection=selection,
+        comparison=comparison,
+        rebuild_receipt=_rebuild_receipt(selection, comparison),
+        reviews=reviews,
+    )
     loaded = load_canary_report(report_path)
 
     assert durable.unclassified_count == 0
@@ -452,6 +587,7 @@ def test_durable_report_persists_explicit_review_for_every_diff(tmp_path: Path) 
     assert isinstance(summary, dict)
     assert summary["unclassified_count"] == 0
     assert summary["unexpected_count"] == len(reviews)
+    assert "rebuild_receipt" in loaded
 
 
 def test_loading_canary_report_rechecks_exact_review_coverage(tmp_path: Path) -> None:
@@ -471,7 +607,13 @@ def test_loading_canary_report_rechecks_exact_review_coverage(tmp_path: Path) ->
         )
         for difference in comparison.differences
     )
-    write_canary_report(report_path, selection=selection, comparison=comparison, reviews=reviews)
+    write_canary_report(
+        report_path,
+        selection=selection,
+        comparison=comparison,
+        rebuild_receipt=_rebuild_receipt(selection, comparison),
+        reviews=reviews,
+    )
 
     payload = json.loads(report_path.read_text(encoding="utf-8"))
     payload["reviews"] = payload["reviews"][:-1]
@@ -485,6 +627,39 @@ def test_loading_canary_report_rechecks_exact_review_coverage(tmp_path: Path) ->
     report_path.write_text(json.dumps(payload), encoding="utf-8")
 
     with pytest.raises(UnclassifiedCanaryDiffError, match="review coverage is incomplete"):
+        load_canary_report(report_path)
+
+
+def test_loading_canary_report_rejects_tampered_candidate_provenance(tmp_path: Path) -> None:
+    current = tmp_path / "current.db"
+    candidate = tmp_path / "candidate.db"
+    report_path = tmp_path / "reports" / "canary.json"
+    _seed_index(current)
+    _seed_index(candidate, block_text="changed transcript")
+    comparison = compare_reindex_generations(current, candidate)
+    selection = select_canary_sessions(current, sessions_per_origin=1)
+    reviews = tuple(
+        CanaryDifferenceReview.for_difference(
+            difference,
+            classification=DifferenceClassification.UNEXPECTED,
+            reference="polylogue-follow-up",
+            rationale="the canary has no reviewed expected delta for this row",
+        )
+        for difference in comparison.differences
+    )
+    write_canary_report(
+        report_path,
+        selection=selection,
+        comparison=comparison,
+        rebuild_receipt=_rebuild_receipt(selection, comparison),
+        reviews=reviews,
+    )
+
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    payload["rebuild_receipt"]["generation"]["index_path"] = str(tmp_path / "foreign.db")
+    report_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(UnclassifiedCanaryDiffError, match="does not identify the compared candidate"):
         load_canary_report(report_path)
 
 
@@ -505,7 +680,13 @@ def test_loading_canary_report_recomputes_tampered_summary(tmp_path: Path) -> No
         )
         for difference in comparison.differences
     )
-    write_canary_report(report_path, selection=selection, comparison=comparison, reviews=reviews)
+    write_canary_report(
+        report_path,
+        selection=selection,
+        comparison=comparison,
+        rebuild_receipt=_rebuild_receipt(selection, comparison),
+        reviews=reviews,
+    )
 
     payload = json.loads(report_path.read_text(encoding="utf-8"))
     payload["comparison"]["summary"] = {
@@ -553,8 +734,20 @@ def test_canary_report_uses_unique_temporary_names(tmp_path: Path, monkeypatch: 
         return stream
 
     monkeypatch.setattr(tempfile, "NamedTemporaryFile", recording_named_temporary_file)
-    write_canary_report(report_path, selection=selection, comparison=comparison, reviews=reviews)
-    write_canary_report(report_path, selection=selection, comparison=comparison, reviews=reviews)
+    write_canary_report(
+        report_path,
+        selection=selection,
+        comparison=comparison,
+        rebuild_receipt=_rebuild_receipt(selection, comparison),
+        reviews=reviews,
+    )
+    write_canary_report(
+        report_path,
+        selection=selection,
+        comparison=comparison,
+        rebuild_receipt=_rebuild_receipt(selection, comparison),
+        reviews=reviews,
+    )
 
     assert len(names) == 2
     assert len(set(names)) == 2
@@ -586,7 +779,13 @@ def test_canary_report_cleans_temporary_file_when_replace_fails(
 
     monkeypatch.setattr(os, "replace", fail_replace)
     with pytest.raises(OSError, match="replace failed"):
-        write_canary_report(report_path, selection=selection, comparison=comparison, reviews=reviews)
+        write_canary_report(
+            report_path,
+            selection=selection,
+            comparison=comparison,
+            rebuild_receipt=_rebuild_receipt(selection, comparison),
+            reviews=reviews,
+        )
 
     assert not report_path.exists()
     assert list(report_path.parent.glob(f".{report_path.name}.*.tmp")) == []

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -127,6 +127,8 @@ def _rebuild_receipt(selection: CanarySelection, comparison: CanaryDiffReport) -
     return {
         "archive_root": str(comparison.candidate_index.parent),
         "selected_raw_count": len(selection.selected_raw_ids),
+        "selected_raw_ids": list(selection.selected_raw_ids),
+        "selected_session_ids": list(selection.selected_session_ids),
         "status": "replayed",
         "materialized": True,
         "generation": {
@@ -215,6 +217,7 @@ def test_expected_difference_is_structurally_accounted_for(tmp_path: Path) -> No
         expected=(
             ExpectedDifference(
                 table="session_profiles",
+                identity=(("session_id", "codex-session:alpha"),),
                 operations=(DifferenceOperation.CHANGED,),
                 columns=("message_count",),
                 bead_ref="polylogue-example",
@@ -245,6 +248,7 @@ def test_expected_difference_cannot_hide_extra_changed_columns(tmp_path: Path) -
         expected=(
             ExpectedDifference(
                 table="session_profiles",
+                identity=(("session_id", "codex-session:alpha"),),
                 operations=(DifferenceOperation.CHANGED,),
                 columns=("message_count",),
                 bead_ref="polylogue-example",
@@ -259,12 +263,43 @@ def test_expected_difference_cannot_hide_extra_changed_columns(tmp_path: Path) -
     assert profile_changes[0].classification is DifferenceClassification.UNEXPECTED
 
 
+def test_expected_difference_for_alpha_does_not_waive_beta(tmp_path: Path) -> None:
+    current = tmp_path / "current.db"
+    candidate = tmp_path / "candidate.db"
+    _seed_index(current, sessions=("alpha", "beta"))
+    _seed_index(candidate, sessions=("alpha", "beta"), profile_message_count=2)
+    report = compare_reindex_generations(
+        current,
+        candidate,
+        expected=(
+            ExpectedDifference(
+                table="session_profiles",
+                identity=(("session_id", "codex-session:alpha"),),
+                operations=(DifferenceOperation.CHANGED,),
+                columns=("message_count",),
+                bead_ref="ref",
+                rationale="alpha only",
+            ),
+        ),
+    )
+    classifications = {
+        dict(item.identity)["session_id"]: item.classification
+        for item in report.differences
+        if item.table == "session_profiles"
+    }
+    assert classifications == {
+        "codex-session:alpha": DifferenceClassification.EXPECTED,
+        "codex-session:beta": DifferenceClassification.UNEXPECTED,
+    }
+
+
 def test_expected_difference_requires_exact_operation_and_nonempty_signature() -> None:
     """A table-wide declaration cannot classify every future row difference."""
 
     with pytest.raises(ValueError, match="exactly one operation"):
         ExpectedDifference(
             table="session_profiles",
+            identity=(("session_id", "codex-session:alpha"),),
             bead_ref="polylogue-example",
             rationale="too broad",
         )
@@ -272,6 +307,7 @@ def test_expected_difference_requires_exact_operation_and_nonempty_signature() -
     with pytest.raises(ValueError, match="non-empty changed-column signature"):
         ExpectedDifference(
             table="session_profiles",
+            identity=(("session_id", "codex-session:alpha"),),
             operations=(DifferenceOperation.CHANGED,),
             bead_ref="polylogue-example",
             rationale="still too broad",
@@ -295,6 +331,7 @@ def test_expected_difference_requires_exact_schema_asymmetry_signature(tmp_path:
         expected=(
             ExpectedDifference(
                 table="session_profiles",
+                identity=(("__schema__", "column"), ("name", "tags_json")),
                 operations=(DifferenceOperation.REMOVED,),
                 columns=("message_count",),
                 bead_ref="polylogue-example",
@@ -660,6 +697,47 @@ def test_loading_canary_report_rejects_tampered_candidate_provenance(tmp_path: P
     report_path.write_text(json.dumps(payload), encoding="utf-8")
 
     with pytest.raises(UnclassifiedCanaryDiffError, match="does not identify the compared candidate"):
+        load_canary_report(report_path)
+
+
+@pytest.mark.parametrize(
+    ("tamper", "message"),
+    (
+        ("index", "selection index"),
+        ("sessions", "selection sessions"),
+        ("raw-ids", "rebuild evidence"),
+    ),
+)
+def test_loading_canary_report_rejects_tampered_selection_binding(tmp_path: Path, tamper: str, message: str) -> None:
+    current, candidate, report_path = tmp_path / "current.db", tmp_path / "candidate.db", tmp_path / "canary.json"
+    _seed_index(current)
+    _seed_index(candidate, block_text="changed")
+    comparison, selection = (
+        compare_reindex_generations(current, candidate),
+        select_canary_sessions(current, sessions_per_origin=1),
+    )
+    reviews = tuple(
+        CanaryDifferenceReview.for_difference(
+            item, classification=DifferenceClassification.UNEXPECTED, reference="ref", rationale="r"
+        )
+        for item in comparison.differences
+    )
+    write_canary_report(
+        report_path,
+        selection=selection,
+        comparison=comparison,
+        rebuild_receipt=_rebuild_receipt(selection, comparison),
+        reviews=reviews,
+    )
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    if tamper == "index":
+        payload["selection"]["index_path"] = str(tmp_path / "foreign.db")
+    elif tamper == "sessions":
+        payload["selection"]["selected_session_ids"] = ["codex-session:foreign"]
+    else:
+        payload["rebuild_receipt"]["selected_raw_ids"] = ["raw-foreign"]
+    report_path.write_text(json.dumps(payload))
+    with pytest.raises(UnclassifiedCanaryDiffError, match=message):
         load_canary_report(report_path)
 
 


### PR DESCRIPTION
## Summary

Persist reviewed canary differences and full candidate rebuild provenance. Compare session-scoped canonical views, bind selection to the configured active index, and require exact expected-difference signatures.

## Problem

The merged canary accepted no CLI review input, omitted candidate provenance from durable reports, skipped views such as `actions`, permitted foreign input indexes, and allowed table-wide expected-difference declarations.

## Solution

The CLI accepts and reloads a review manifest, reports persist and validate the complete rebuild receipt, the comparator includes session-scoped views with stable `actions` identities, supplied indexes must equal the configured active generation, and expected differences require exactly one operation plus a non-empty exact column signature.

## Verification

`source .venv/bin/activate && devtools test tests/unit/maintenance/test_reindex_canary.py tests/unit/cli/test_reindex_canary_cli.py`

Result: `29 passed in 2.41s`.

`devtools render all --check && devtools verify layering`

Result: generated surfaces synchronized; no new layering violations.

`devtools verify --seed-testmon --skip-slow` could not complete because the lane testmon bootstrap recreates `.cache/testmon` without its required checkout marker and then rejects it.