### PR TITLE
feat(reindex): stamp parser semantics in candidate generations

### DIFF
--- a/docs/examples/demo-tour/command-output/01-claim-versus-receipt.txt
+++ b/docs/examples/demo-tour/command-output/01-claim-versus-receipt.txt
@@ -29,7 +29,7 @@ source material:
   blob_sha256: 9fd0dbdb080058070935924534a903cc63a8dcba571f6b2734f92a96576b59d7
 
 completion-claim experiment:
-  sample manifest: a3769731d70cbfc50b9a267b3f8b1290ad56b34dad1c6cff5a3ca63f0e09174f
+  sample manifest: 76641b92f998b7cf8bca20d9c5d401c934da8b9adfbdb760588f5a191d402fce
   denominator: 2
 unsupported by structural evidence: 0 (0.0%)
 neutral prior outcome: 0 (0.0%)

--- a/docs/examples/demo-tour/transcript.txt
+++ b/docs/examples/demo-tour/transcript.txt
@@ -38,7 +38,7 @@ source material:
   blob_sha256: 9fd0dbdb080058070935924534a903cc63a8dcba571f6b2734f92a96576b59d7
 
 completion-claim experiment:
-  sample manifest: a3769731d70cbfc50b9a267b3f8b1290ad56b34dad1c6cff5a3ca63f0e09174f
+  sample manifest: 76641b92f998b7cf8bca20d9c5d401c934da8b9adfbdb760588f5a191d402fce
   denominator: 2
 unsupported by structural evidence: 0 (0.0%)
 neutral prior outcome: 0 (0.0%)

--- a/polylogue/maintenance/archive_verification.py
+++ b/polylogue/maintenance/archive_verification.py
@@ -49,6 +49,7 @@ from polylogue.maintenance.corpus_fidelity import (
     audit_attachment_fidelity,
     audit_revision_fidelity,
 )
+from polylogue.sources.origin_specs import lowering_fingerprint, parser_fingerprint_for_origin
 from polylogue.storage.blob_gc import BLOB_REF_LIVENESS_JOIN
 from polylogue.storage.introspection import table_exists
 from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS
@@ -1210,6 +1211,165 @@ def _check_message_count_projection(archive_root: Path, sample_limit: int) -> Ar
 
 
 # ---------------------------------------------------------------------------
+# Check: parser/lowering semantic stamp coverage (polylogue-xselt)
+# ---------------------------------------------------------------------------
+
+
+def _check_session_fingerprint_stamps(archive_root: Path, sample_limit: int) -> ArchiveVerificationCheck:
+    """Require every candidate session to carry current, unmixed semantic stamps.
+
+    ``sessions`` is the ground-truth candidate universe. The check compares
+    each row to the current source-derived stamp rather than accepting a
+    merely well-formed historical value, so a parser/lowering semantic change
+    cannot promote a stale reindex candidate.
+    """
+    index_path = _resolve_index_path(archive_root)
+    if not index_path.exists():
+        return _skip_check("session-fingerprint-stamps", "index.db not present")
+    try:
+        conn = _open_ro(index_path)
+    except sqlite3.Error as exc:
+        return _error_check("session-fingerprint-stamps", f"could not open index.db: {exc}", exc=exc)
+
+    try:
+        required_columns = {"parser_fingerprint", "lowering_fingerprint"}
+        columns = {str(row[1]) for row in conn.execute("PRAGMA table_info(sessions)")}
+        missing_columns = sorted(required_columns - columns)
+        if missing_columns:
+            return _error_check(
+                "session-fingerprint-stamps",
+                f"sessions is missing fingerprint column(s): {', '.join(missing_columns)}",
+            )
+
+        total = int(conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0])
+        invalid_sql = "{column} IS NULL OR length({column}) != 64 OR {column} GLOB '*[^0-9a-f]*'"
+        invalid_parser_count = int(
+            conn.execute(
+                f"SELECT COUNT(*) FROM sessions WHERE {invalid_sql.format(column='parser_fingerprint')}"
+            ).fetchone()[0]
+        )
+        invalid_lowering_count = int(
+            conn.execute(
+                f"SELECT COUNT(*) FROM sessions WHERE {invalid_sql.format(column='lowering_fingerprint')}"
+            ).fetchone()[0]
+        )
+        parser_rows = [
+            (str(row[0]), str(row[1]), int(row[2]))
+            for row in conn.execute(
+                """
+                SELECT origin, parser_fingerprint, COUNT(*)
+                FROM sessions
+                WHERE parser_fingerprint IS NOT NULL
+                  AND length(parser_fingerprint) = 64
+                  AND parser_fingerprint NOT GLOB '*[^0-9a-f]*'
+                GROUP BY origin, parser_fingerprint
+                ORDER BY origin, parser_fingerprint
+                """
+            )
+        ]
+        lowering_rows = [
+            (str(row[0]), int(row[1]))
+            for row in conn.execute(
+                """
+                SELECT lowering_fingerprint, COUNT(*)
+                FROM sessions
+                WHERE lowering_fingerprint IS NOT NULL
+                  AND length(lowering_fingerprint) = 64
+                  AND lowering_fingerprint NOT GLOB '*[^0-9a-f]*'
+                GROUP BY lowering_fingerprint
+                ORDER BY lowering_fingerprint
+                """
+            )
+        ]
+        session_stamp_rows = [
+            (str(row[0]), row[1], row[2])
+            for row in conn.execute("SELECT origin, parser_fingerprint, lowering_fingerprint FROM sessions")
+        ]
+        invalid_sample = [
+            str(row[0])
+            for row in conn.execute(
+                f"""
+                SELECT session_id FROM sessions
+                WHERE {invalid_sql.format(column="parser_fingerprint")}
+                   OR {invalid_sql.format(column="lowering_fingerprint")}
+                ORDER BY session_id
+                LIMIT ?
+                """,
+                (sample_limit,),
+            )
+        ]
+    except sqlite3.Error as exc:
+        return _error_check("session-fingerprint-stamps", f"could not read index.db: {exc}", exc=exc)
+    finally:
+        conn.close()
+
+    expected_parser_by_origin: dict[str, str] = {}
+    parser_values_by_origin: dict[str, dict[str, int]] = {}
+    for origin, fingerprint, count in parser_rows:
+        parser_values_by_origin.setdefault(origin, {})[fingerprint] = count
+    parser_stale_by_origin: dict[str, int] = {}
+    parser_mixed_by_origin: dict[str, int] = {}
+    for origin, values in parser_values_by_origin.items():
+        try:
+            expected = parser_fingerprint_for_origin(origin)
+        except ValueError:
+            parser_stale_by_origin[origin] = sum(values.values())
+            continue
+        expected_parser_by_origin[origin] = expected
+        stale_count = sum(count for fingerprint, count in values.items() if fingerprint != expected)
+        if stale_count:
+            parser_stale_by_origin[origin] = stale_count
+        if len(values) != 1:
+            parser_mixed_by_origin[origin] = len(values)
+
+    expected_lowering = lowering_fingerprint()
+    lowering_stale_count = sum(count for fingerprint, count in lowering_rows if fingerprint != expected_lowering)
+    lowering_distinct_count = len(lowering_rows)
+    fully_current_count = sum(
+        expected_parser_by_origin.get(origin) is not None
+        and parser_fingerprint == expected_parser_by_origin[origin]
+        and lowering_stamp == expected_lowering
+        for origin, parser_fingerprint, lowering_stamp in session_stamp_rows
+    )
+    problems: list[str] = []
+    if invalid_parser_count:
+        problems.append(f"missing/invalid parser stamps={invalid_parser_count:,}")
+    if invalid_lowering_count:
+        problems.append(f"missing/invalid lowering stamps={invalid_lowering_count:,}")
+    if parser_stale_by_origin:
+        problems.append(f"stale parser stamps={parser_stale_by_origin}")
+    if lowering_stale_count:
+        problems.append(f"stale lowering stamps={lowering_stale_count:,}")
+    if parser_mixed_by_origin:
+        problems.append(f"mixed parser stamps={parser_mixed_by_origin}")
+    if total and lowering_distinct_count != 1:
+        problems.append(f"mixed lowering stamps={lowering_distinct_count}")
+
+    return ArchiveVerificationCheck(
+        name="session-fingerprint-stamps",
+        status=OutcomeStatus.ERROR if problems else OutcomeStatus.OK,
+        summary=("; ".join(problems) if problems else f"{total:,} session(s) carry current semantic stamps"),
+        count=len(problems),
+        details=[f"invalid:{session_id}" for session_id in invalid_sample],
+        evidence={
+            "session_count": total,
+            "fully_current_session_count": fully_current_count,
+            "invalid_parser_stamp_count": invalid_parser_count,
+            "invalid_lowering_stamp_count": invalid_lowering_count,
+            "expected_parser_by_origin": expected_parser_by_origin,
+            "parser_values_by_origin": parser_values_by_origin,
+            "parser_stale_by_origin": parser_stale_by_origin,
+            "parser_mixed_by_origin": parser_mixed_by_origin,
+            "expected_lowering_fingerprint": expected_lowering,
+            "lowering_values": dict(lowering_rows),
+            "lowering_stale_count": lowering_stale_count,
+            "lowering_distinct_count": lowering_distinct_count,
+            "invalid_sample": invalid_sample,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
 # Check 6: planner stats presence (polylogue-l3tk class)
 # ---------------------------------------------------------------------------
 
@@ -2020,6 +2180,12 @@ ARCHIVE_VERIFICATION_CHECKS: tuple[ArchiveVerificationCheckSpec, ...] = (
         ArchiveVerificationCheckClass.CONSERVATION,
     ),
     ArchiveVerificationCheckSpec(
+        "session-fingerprint-stamps",
+        "Every indexed session carries current, unmixed parser and lowering semantic stamps (polylogue-xselt).",
+        _check_session_fingerprint_stamps,
+        ArchiveVerificationCheckClass.STATE_INVARIANT,
+    ),
+    ArchiveVerificationCheckSpec(
         "planner-stats",
         "sqlite_stat1 covers blocks/messages/action_pairs (polylogue-l3tk class, warn-level).",
         _check_planner_stats,
@@ -2118,6 +2284,7 @@ REINDEX_ACCEPTANCE_CHECKS: tuple[str, ...] = (
     "enum-superset-check",
     "session-lineage-acyclic",
     "message-count-projection",
+    "session-fingerprint-stamps",
     "planner-stats",
 )
 

--- a/polylogue/sources/origin_specs.py
+++ b/polylogue/sources/origin_specs.py
@@ -18,13 +18,16 @@ compatibility-only.
 
 from __future__ import annotations
 
+import ast
 import gzip
+import hashlib
 import json
 import re
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, replace
+from functools import lru_cache
 from pathlib import Path
-from typing import Literal
+from typing import Literal, cast
 
 from polylogue.core.enums import Origin, Provider
 from polylogue.declarations import (
@@ -41,6 +44,137 @@ from polylogue.declarations import (
 OriginLifecycle = Literal["executable", "reserved", "unsupported", "compatibility-only"]
 OriginCompletenessMaturity = Literal["accepted", "proposed", "reserved", "unsupported"]
 ArtifactParsePolicy = Literal["session", "fact", "raw-only"]
+
+_SOURCE_ROOT = Path(__file__).resolve().parents[2]
+_LOWERING_FINGERPRINT_PATHS: tuple[str, ...] = (
+    "polylogue/sources/dispatch.py",
+    "polylogue/pipeline/ids.py",
+    "polylogue/storage/sqlite/archive_tiers/write.py",
+    "polylogue/archive/session_revision_membership.py",
+)
+
+
+def _without_leading_docstring(body: list[ast.stmt]) -> list[ast.stmt]:
+    if (
+        body
+        and isinstance(body[0], ast.Expr)
+        and isinstance(body[0].value, ast.Constant)
+        and isinstance(body[0].value.value, str)
+    ):
+        return body[1:]
+    return body
+
+
+class _DocstringStripper(ast.NodeTransformer):
+    """Apply the classifier-fingerprint AST convention to whole modules."""
+
+    def visit_Module(self, node: ast.Module) -> ast.Module:
+        node = cast(ast.Module, self.generic_visit(node))
+        node.body = _without_leading_docstring(node.body)
+        return node
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> ast.ClassDef:
+        node = cast(ast.ClassDef, self.generic_visit(node))
+        node.body = _without_leading_docstring(node.body)
+        return node
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.FunctionDef:
+        node = cast(ast.FunctionDef, self.generic_visit(node))
+        node.body = _without_leading_docstring(node.body)
+        return node
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> ast.AsyncFunctionDef:
+        node = cast(ast.AsyncFunctionDef, self.generic_visit(node))
+        node.body = _without_leading_docstring(node.body)
+        return node
+
+
+def _source_path(path: str) -> Path:
+    candidate = Path(path)
+    return (candidate if candidate.is_absolute() else _SOURCE_ROOT / candidate).resolve()
+
+
+def _source_signature(path: Path) -> tuple[str, int, int]:
+    stat = path.stat()
+    return str(path), stat.st_mtime_ns, stat.st_size
+
+
+def _fingerprint_path_label(path: Path) -> str:
+    """Describe repository sources without binding a stamp to one checkout."""
+    try:
+        return path.relative_to(_SOURCE_ROOT).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _module_path(base: Path) -> Path | None:
+    module_file = base.with_suffix(".py")
+    if module_file.is_file():
+        return module_file.resolve()
+    package_init = base / "__init__.py"
+    return package_init.resolve() if package_init.is_file() else None
+
+
+@lru_cache(maxsize=512)
+def _local_import_paths(signature: tuple[str, int, int]) -> tuple[str, ...]:
+    """Return local Python dependencies of one parser-semantic source file."""
+    path = Path(signature[0])
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    found: set[Path] = set()
+    for node in ast.walk(tree):
+        candidate: Path | None = None
+        if isinstance(node, ast.ImportFrom):
+            if node.level:
+                base = path.parent
+                for _ in range(node.level - 1):
+                    base = base.parent
+                candidate = _module_path(base / Path(*(node.module or "").split(".")))
+            elif node.module and node.module.startswith("polylogue."):
+                candidate = _module_path(_SOURCE_ROOT / Path(*node.module.split(".")))
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.startswith("polylogue."):
+                    resolved = _module_path(_SOURCE_ROOT / Path(*alias.name.split(".")))
+                    if resolved is not None:
+                        found.add(resolved)
+        if candidate is not None:
+            found.add(candidate)
+    return tuple(sorted(str(item) for item in found))
+
+
+def _semantic_source_paths(paths: tuple[str, ...]) -> tuple[Path, ...]:
+    pending = [_source_path(path) for path in paths]
+    found: set[Path] = set()
+    while pending:
+        path = pending.pop()
+        if path in found:
+            continue
+        found.add(path)
+        for dependency in _local_import_paths(_source_signature(path)):
+            pending.append(Path(dependency))
+    return tuple(sorted(found))
+
+
+@lru_cache(maxsize=128)
+def _fingerprint_sources_cached(signatures: tuple[tuple[str, int, int], ...], namespace: str) -> str:
+    fragments: list[dict[str, str]] = []
+    for path_string, _mtime_ns, _size in signatures:
+        tree = ast.parse(Path(path_string).read_text(encoding="utf-8"))
+        normalized = _DocstringStripper().visit(tree)
+        fragments.append(
+            {
+                "path": _fingerprint_path_label(Path(path_string)),
+                "ast": ast.dump(normalized, annotate_fields=True, include_attributes=False),
+            }
+        )
+    payload = {"namespace": namespace, "sources": fragments}
+    return hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
+
+
+def _fingerprint_sources(paths: tuple[str, ...], *, namespace: str) -> str:
+    source_paths = _semantic_source_paths(paths)
+    signatures = tuple(_source_signature(path) for path in source_paths)
+    return _fingerprint_sources_cached(signatures, namespace)
 
 
 @dataclass(frozen=True, slots=True)
@@ -256,6 +390,15 @@ class OriginSpec:
     #: ``get_assembly_spec`` registry by :func:`validate_assembly_spec_parity`
     #: rather than replacing that registry with a second one.
     assembly_spec_path: str | None = None
+
+    def parser_fingerprint(self) -> str:
+        """Return the origin-scoped fingerprint of parser output semantics."""
+        return _fingerprint_sources(self.parser_paths, namespace=f"parser:{self.origin.value}")
+
+
+def lowering_fingerprint() -> str:
+    """Return the shared lowering, identity, revision, and lineage fingerprint."""
+    return _fingerprint_sources(_LOWERING_FINGERPRINT_PATHS, namespace="lowering")
 
 
 @dataclass(frozen=True, slots=True)
@@ -1305,12 +1448,19 @@ for _spec in (
 ):
     ORIGIN_SPEC_REGISTRY.register(_with_completeness_modes(_spec))
 ORIGIN_SPECS = ORIGIN_SPEC_REGISTRY.specs()
+_ORIGIN_SPECS_BY_ORIGIN = {spec.origin: spec for spec in ORIGIN_SPECS}
 
 
 def origin_specs() -> tuple[OriginSpec, ...]:
     """Return the stable public-origin admission projection."""
 
     return ORIGIN_SPECS
+
+
+def parser_fingerprint_for_origin(origin: Origin | str) -> str:
+    """Return the current parser fingerprint for one normalized archive origin."""
+    normalized = Origin.from_string(origin)
+    return _ORIGIN_SPECS_BY_ORIGIN[normalized].parser_fingerprint()
 
 
 def validate_dispatch_precedence(provider_order: tuple[Provider, ...]) -> tuple[OriginSpecDiagnostic, ...]:
@@ -1441,6 +1591,8 @@ __all__ = [
     "artifact_suffixes_for_provider",
     "schema_observed_leaf_values",
     "undeclared_schema_values",
+    "lowering_fingerprint",
+    "parser_fingerprint_for_origin",
     "validate_assembly_spec_parity",
     "validate_dispatch_precedence",
     "validate_stream_parser_parity",

--- a/polylogue/sources/origin_specs.py
+++ b/polylogue/sources/origin_specs.py
@@ -94,6 +94,12 @@ def _source_path(path: str) -> Path:
     return (candidate if candidate.is_absolute() else _SOURCE_ROOT / candidate).resolve()
 
 
+def _source_file_from_reference(reference: str) -> str:
+    """Return the file portion of a declared ``path:Symbol`` reference."""
+    path, separator, _symbol = reference.partition(":")
+    return path if separator else reference
+
+
 def _source_signature(path: Path) -> tuple[str, int, int]:
     stat = path.stat()
     return str(path), stat.st_mtime_ns, stat.st_size
@@ -393,7 +399,15 @@ class OriginSpec:
 
     def parser_fingerprint(self) -> str:
         """Return the origin-scoped fingerprint of parser output semantics."""
-        return _fingerprint_sources(self.parser_paths, namespace=f"parser:{self.origin.value}")
+        declared_paths = list(self.parser_paths)
+        declared_paths.extend(self.assembly_paths)
+        if self.stream_parser_path is not None:
+            declared_paths.append(self.stream_parser_path)
+        if self.assembly_spec_path is not None:
+            declared_paths.append(self.assembly_spec_path)
+        declared_paths.extend(rule.parser_path for rule in self.artifact_rules if rule.parser_path is not None)
+        source_paths = tuple(dict.fromkeys(_source_file_from_reference(path) for path in declared_paths))
+        return _fingerprint_sources(source_paths, namespace=f"parser:{self.origin.value}")
 
 
 def lowering_fingerprint() -> str:

--- a/polylogue/storage/sqlite/archive_tiers/index.py
+++ b/polylogue/storage/sqlite/archive_tiers/index.py
@@ -433,7 +433,10 @@ from polylogue.storage.sqlite.delegation_facts import delegation_facts_insert_sq
 # `blocks_command_trigram` remains because `devtools/affordance_usage.py`'s
 # `_cli_action_rows` is a real consumer with a documented archive-scale
 # speedup. See the v63 declaration in lifecycle.py.
-INDEX_SCHEMA_VERSION = 63
+# polylogue-xselt: v64 adds parser/lowering semantic stamps consumed by the
+# reindex acceptance gate. They remain nullable only so pre-bootstrap index
+# generations can be opened long enough to undergo the semantic replay.
+INDEX_SCHEMA_VERSION = 64
 
 # polylogue-v6i3: shared WHEN-clause fragment gating the blocks_command_trigram
 # trigger BODIES on the same dedicated bulk-build guard row messages_fts's
@@ -541,6 +544,10 @@ CREATE TABLE IF NOT EXISTS sessions (
     parent_session_id       TEXT REFERENCES sessions(session_id) ON DELETE SET NULL,
     root_session_id         TEXT REFERENCES sessions(session_id) ON DELETE SET NULL,
     raw_id                  TEXT,
+    -- Written by the parsed-session chokepoint in the same transaction as
+    -- this row. Pre-v64 generations are intentionally nullable until replay.
+    parser_fingerprint      TEXT,
+    lowering_fingerprint    TEXT,
     branch_type             TEXT CHECK ({nullable_check("branch_type", BranchType)}),
     active_leaf_message_id  TEXT,
     title                   TEXT,

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -34,6 +34,7 @@ from polylogue.core.json import JSONValue
 from polylogue.core.sources import origin_from_provider
 from polylogue.core.timestamps import parse_timestamp
 from polylogue.logging import get_logger
+from polylogue.sources.origin_specs import lowering_fingerprint, parser_fingerprint_for_origin
 from polylogue.sources.parsers.base import (
     ParsedAttachment,
     ParsedContentBlock,
@@ -384,6 +385,8 @@ def write_parsed_session_to_archive(
     origin = origin_from_provider(session.source_name)
     native_id = _stored_session_native_id(session.provider_session_id)
     session_id = archive_session_id(origin.value, native_id)
+    parser_semantic_fingerprint = parser_fingerprint_for_origin(origin)
+    lowering_semantic_fingerprint = lowering_fingerprint()
     # This session's own rows are about to be rewritten; drop any stale memoized
     # own-signatures so the batch cache never serves pre-write rows for it.
     if signature_cache is not None:
@@ -550,7 +553,8 @@ def write_parsed_session_to_archive(
             conn.execute(
                 """
                 INSERT INTO sessions (
-                    native_id, origin, raw_id, branch_type, active_leaf_message_id,
+                    native_id, origin, raw_id, parser_fingerprint, lowering_fingerprint,
+                    branch_type, active_leaf_message_id,
                     title, session_kind, title_source, title_ref, title_confidence,
                     display_name, run_settings_json, pending_drafts_json,
                     git_branch, git_repository_url, commit_hash,
@@ -560,9 +564,11 @@ def write_parsed_session_to_archive(
                     assistant_message_count, system_message_count,
                     tool_message_count, user_word_count, authored_user_word_count, assistant_word_count,
                     content_hash, created_at_ms, updated_at_ms
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(origin, native_id) DO UPDATE SET
                     raw_id = excluded.raw_id,
+                    parser_fingerprint = excluded.parser_fingerprint,
+                    lowering_fingerprint = excluded.lowering_fingerprint,
                     branch_type = excluded.branch_type,
                     active_leaf_message_id = excluded.active_leaf_message_id,
                     title = COALESCE(excluded.title, sessions.title),
@@ -633,6 +639,8 @@ def write_parsed_session_to_archive(
                     native_id,
                     origin.value,
                     raw_id,
+                    parser_semantic_fingerprint,
+                    lowering_semantic_fingerprint,
                     _enum_value(session.branch_type),
                     active_leaf_message_id,
                     _sqlite_text(session.title),

--- a/polylogue/storage/sqlite/lifecycle.py
+++ b/polylogue/storage/sqlite/lifecycle.py
@@ -858,6 +858,13 @@ INDEX_DELTA_DECLARATIONS: tuple[IndexDeltaDeclaration, ...] = (
             ),
         ),
     ),
+    IndexDeltaDeclaration(
+        version=64,
+        # The new session stamps are derived from parser/lowering semantics.
+        # Existing rows require raw replay for trustworthy values, so nullable
+        # DDL cannot take the clone-safe fast-forward route.
+        classes=(DerivedDeltaClass.SEMANTIC_REPARSE,),
+    ),
 )
 
 

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -24,6 +24,7 @@ from polylogue.maintenance.archive_verification import (
     ArchiveVerificationWaiver,
     verify_archive,
 )
+from polylogue.sources.origin_specs import lowering_fingerprint, parser_fingerprint_for_origin
 from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS, initialize_active_archive_root
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from tests.infra.workload_artifacts import SeededArchiveArtifact
@@ -60,10 +61,11 @@ def _seed_coherent_archive(root: Path) -> None:
     try:
         index_conn.execute(
             """
-            INSERT INTO sessions(native_id, origin, raw_id, content_hash, message_count)
-            VALUES ('session', 'codex-session', 'raw-1', ?, 1)
+            INSERT INTO sessions(
+                native_id, origin, raw_id, parser_fingerprint, lowering_fingerprint, content_hash, message_count
+            ) VALUES ('session', 'codex-session', 'raw-1', ?, ?, ?, 1)
             """,
-            (b"s" * 32,),
+            (parser_fingerprint_for_origin("codex-session"), lowering_fingerprint(), b"s" * 32),
         )
         index_conn.execute(
             """
@@ -738,6 +740,70 @@ def test_message_count_projection_passes_on_coherent_archive(tmp_path: Path) -> 
     assert check.evidence["drifted_session_count"] == 0
 
 
+def test_reindex_acceptance_rejects_missing_semantic_stamp_coverage(tmp_path: Path) -> None:
+    """A candidate cannot promote when a session has no parser stamp."""
+    _seed_coherent_archive(tmp_path)
+    with _connect(tmp_path / "index.db") as conn:
+        conn.execute("UPDATE sessions SET parser_fingerprint = NULL")
+
+    report = verify_archive(tmp_path, checks=REINDEX_ACCEPTANCE_CHECKS)
+
+    check = _check(report, "session-fingerprint-stamps")
+    assert report.blocking
+    assert check.status is OutcomeStatus.ERROR
+    assert check.evidence["invalid_parser_stamp_count"] == 1
+    assert check.evidence["fully_current_session_count"] == 0
+
+
+def test_reindex_acceptance_rejects_missing_semantic_stamp_column(tmp_path: Path) -> None:
+    """A pre-bootstrap candidate cannot bypass coverage by lacking the column."""
+    _seed_coherent_archive(tmp_path)
+    with _connect(tmp_path / "index.db") as conn:
+        conn.execute("ALTER TABLE sessions DROP COLUMN parser_fingerprint")
+
+    report = verify_archive(tmp_path, checks=REINDEX_ACCEPTANCE_CHECKS)
+
+    check = _check(report, "session-fingerprint-stamps")
+    assert report.blocking
+    assert check.status is OutcomeStatus.ERROR
+    assert "missing fingerprint column(s): parser_fingerprint" in check.summary
+
+
+def test_reindex_acceptance_rejects_stale_semantic_stamps(tmp_path: Path) -> None:
+    """A well-formed historic stamp must fail the current-source comparison."""
+    _seed_coherent_archive(tmp_path)
+    with _connect(tmp_path / "index.db") as conn:
+        conn.execute("UPDATE sessions SET parser_fingerprint = ?", ("0" * 64,))
+
+    report = verify_archive(tmp_path, checks=REINDEX_ACCEPTANCE_CHECKS)
+
+    check = _check(report, "session-fingerprint-stamps")
+    assert report.blocking
+    assert check.status is OutcomeStatus.ERROR
+    assert check.evidence["parser_stale_by_origin"] == {"codex-session": 1}
+
+
+def test_reindex_acceptance_rejects_mixed_semantic_stamps(tmp_path: Path) -> None:
+    """A partly replayed candidate cannot hide a second parser/lowering vintage."""
+    _seed_coherent_archive(tmp_path)
+    with _connect(tmp_path / "index.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO sessions(native_id, origin, parser_fingerprint, lowering_fingerprint, content_hash, message_count)
+            VALUES ('other', 'codex-session', ?, ?, ?, 0)
+            """,
+            ("1" * 64, "2" * 64, b"o" * 32),
+        )
+
+    report = verify_archive(tmp_path, checks=REINDEX_ACCEPTANCE_CHECKS)
+
+    check = _check(report, "session-fingerprint-stamps")
+    assert report.blocking
+    assert check.status is OutcomeStatus.ERROR
+    assert check.evidence["parser_mixed_by_origin"] == {"codex-session": 2}
+    assert check.evidence["lowering_distinct_count"] == 2
+
+
 def test_missing_enum_value_trips_enum_superset_check(tmp_path: Path) -> None:
     """RED TWIN (I2): a live CHECK list frozen at an older, narrower Origin
     vocabulary is exactly the drift class this check exists to catch -- an
@@ -1241,10 +1307,10 @@ def test_reindex_acceptance_subset_is_satisfiable_from_index_only_root(tmp_path:
         initialize_archive_tier(conn, ArchiveTier.INDEX)
         conn.execute(
             """
-            INSERT INTO sessions(native_id, origin, content_hash, message_count)
-            VALUES ('session', 'codex-session', ?, 0)
+            INSERT INTO sessions(native_id, origin, parser_fingerprint, lowering_fingerprint, content_hash, message_count)
+            VALUES ('session', 'codex-session', ?, ?, ?, 0)
             """,
-            (b"s" * 32,),
+            (parser_fingerprint_for_origin("codex-session"), lowering_fingerprint(), b"s" * 32),
         )
         conn.commit()
         conn.execute("ANALYZE blocks")
@@ -1284,6 +1350,7 @@ RED_TWIN_TESTS: dict[str, str] = {
     "embeddings-refs-liveness": "test_orphaned_embedding_ref_trips_embeddings_refs_liveness",
     "session-lineage-acyclic": "test_parent_session_id_cycle_trips_session_lineage_acyclic",
     "message-count-projection": "test_drifted_message_count_trips_message_count_projection",
+    "session-fingerprint-stamps": "test_reindex_acceptance_rejects_missing_semantic_stamp_coverage",
     "planner-stats": "test_missing_sqlite_stat1_is_warning_not_error",
     "convergence-freshness": "test_stalled_backlog_trips_convergence_freshness",
     "user-tier-refs": "test_dangling_assertion_target_trips_user_tier_refs",

--- a/tests/unit/maintenance/test_rebuild_index_candidate_promotion.py
+++ b/tests/unit/maintenance/test_rebuild_index_candidate_promotion.py
@@ -1,0 +1,89 @@
+"""Real candidate-promotion proof for semantic stamp acceptance."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Callable
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+import polylogue.storage.sqlite.archive_tiers.revision_governance as revision_governance
+from polylogue.core.enums import Provider
+from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
+from polylogue.storage.index_generation import IndexGenerationStore
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+
+def _codex_session(native_id: str, text: str) -> bytes:
+    rows = [
+        {"type": "session_meta", "payload": {"id": native_id, "timestamp": "2026-08-05T10:00:00Z"}},
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "id": f"{native_id}-m0",
+                "role": "user",
+                "content": [{"type": "input_text", "text": text}],
+            },
+        },
+    ]
+    return b"".join(json.dumps(row, sort_keys=True).encode() + b"\n" for row in rows)
+
+
+def _seed_raw(root: Path, native_id: str, text: str) -> None:
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=_codex_session(native_id, text),
+            source_path=f"stamp-regression/{native_id}.jsonl",
+            acquired_at_ms=1,
+        )
+
+
+def _active_snapshot(root: Path) -> tuple[tuple[object, ...], ...]:
+    with sqlite3.connect(root / "index.db") as conn:
+        return (
+            tuple(conn.execute("SELECT session_id, content_hash FROM sessions ORDER BY session_id")),
+            tuple(conn.execute("SELECT message_id, text FROM blocks ORDER BY block_id")),
+        )
+
+
+def test_stamp_corruption_blocks_real_candidate_promotion_without_touching_active(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The production rebuild route rejects an unstamped candidate before swap."""
+    root = tmp_path / "archive"
+    initialize_active_archive_root(root)
+    _seed_raw(root, "active-session", "active generation remains exact")
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
+
+    initial = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+    assert initial.status == "replayed"
+
+    store = IndexGenerationStore.for_archive_root(root)
+    active_before = store.active_pointer.resolve(strict=True)
+    snapshot_before = _active_snapshot(root)
+
+    _seed_raw(root, "candidate-session", "candidate must never become active")
+    original_writer = cast(Callable[..., str], revision_governance.__dict__["write_parsed_session_to_archive"])
+    corruption_calls = 0
+
+    def bypass_stamps(conn: sqlite3.Connection, *args: object, **kwargs: object) -> str:
+        nonlocal corruption_calls
+        result = original_writer(conn, *args, **kwargs)
+        conn.execute("UPDATE sessions SET parser_fingerprint = NULL, lowering_fingerprint = NULL")
+        corruption_calls += 1
+        return result
+
+    monkeypatch.setattr(revision_governance, "write_parsed_session_to_archive", bypass_stamps)
+
+    with pytest.raises(RuntimeError, match="reindex acceptance gate failed.*session-fingerprint-stamps"):
+        rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+
+    assert corruption_calls > 0
+    assert store.active_pointer.resolve(strict=True) == active_before
+    assert _active_snapshot(root) == snapshot_before

--- a/tests/unit/sources/test_origin_specs.py
+++ b/tests/unit/sources/test_origin_specs.py
@@ -91,6 +91,34 @@ def test_parser_fingerprint_changes_when_a_normalizing_parser_helper_changes(tmp
     assert before != after
 
 
+def test_parser_fingerprint_changes_when_a_declared_assembly_helper_changes(tmp_path: Path) -> None:
+    """Assembly enrichment is part of the origin's normalized output contract."""
+    spec = next(spec for spec in ORIGIN_SPECS if spec.origin is Origin.AISTUDIO_DRIVE)
+    parser_source = tmp_path / "parser.py"
+    assembly_source = tmp_path / "assembly.py"
+    helper_source = tmp_path / "support.py"
+    parser_source.write_text("def parse(payload):\n    return payload\n", encoding="utf-8")
+    assembly_source.write_text(
+        "from .support import enrich\n\n"
+        "class AssemblySpec:\n"
+        "    def enrich_session(self, session):\n"
+        "        return enrich(session)\n",
+        encoding="utf-8",
+    )
+    helper_source.write_text("def enrich(value):\n    return value.strip()\n", encoding="utf-8")
+    synthetic = replace(
+        spec,
+        parser_paths=(str(parser_source),),
+        assembly_spec_path=f"{assembly_source}:AssemblySpec",
+    )
+
+    before = synthetic.parser_fingerprint()
+    helper_source.write_text("def enrich(value):\n    return value.strip().casefold()\n", encoding="utf-8")
+    after = synthetic.parser_fingerprint()
+
+    assert before != after
+
+
 def test_production_fingerprints_are_stable_across_a_fresh_interpreter() -> None:
     current_parser = parser_fingerprint_for_origin(Origin.CODEX_SESSION)
     command = (

--- a/tests/unit/sources/test_origin_specs.py
+++ b/tests/unit/sources/test_origin_specs.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from dataclasses import replace
+from pathlib import Path
 
 import pytest
 
@@ -17,6 +20,8 @@ from polylogue.sources.origin_specs import (
     OriginSpecRegistry,
     artifact_suffixes_for_provider,
     check_dropped_value_vocabularies,
+    lowering_fingerprint,
+    parser_fingerprint_for_origin,
     schema_observed_leaf_values,
     undeclared_schema_values,
     validate_assembly_spec_parity,
@@ -60,6 +65,43 @@ def test_origin_specs_cover_the_public_enum_and_admission_lifecycles() -> None:
     assert by_origin[Origin.UNKNOWN_EXPORT].lifecycle == "compatibility-only"
     assert by_origin[Origin.AISTUDIO_DRIVE].provider_wires == (Provider.GEMINI, Provider.DRIVE)
     assert ORIGIN_SPEC_REGISTRY.diagnostics() == ()
+
+
+def test_parser_fingerprint_changes_when_a_normalizing_parser_helper_changes(tmp_path: Path) -> None:
+    """Parser helper behavior is part of the persisted normalized-output contract.
+
+    Mutation proof: changing the helper from stripping to case-folding changes
+    the parser fingerprint, so a candidate stamped before that semantic change
+    cannot satisfy the current-fingerprint comparison.
+    """
+    spec = next(spec for spec in ORIGIN_SPECS if spec.origin is Origin.CODEX_SESSION)
+    parser_source = tmp_path / "parser.py"
+    helper_source = tmp_path / "support.py"
+    parser_source.write_text(
+        "from .support import normalize\n\ndef parse(payload):\n    return {'title': normalize(payload['title'])}\n",
+        encoding="utf-8",
+    )
+    helper_source.write_text("def normalize(value):\n    return value.strip()\n", encoding="utf-8")
+    synthetic = replace(spec, parser_paths=(str(parser_source),))
+
+    before = synthetic.parser_fingerprint()
+    helper_source.write_text("def normalize(value):\n    return value.casefold()\n", encoding="utf-8")
+    after = synthetic.parser_fingerprint()
+
+    assert before != after
+
+
+def test_production_fingerprints_are_stable_across_a_fresh_interpreter() -> None:
+    current_parser = parser_fingerprint_for_origin(Origin.CODEX_SESSION)
+    command = (
+        "from polylogue.core.enums import Origin; "
+        "from polylogue.sources.origin_specs import parser_fingerprint_for_origin; "
+        "print(parser_fingerprint_for_origin(Origin.CODEX_SESSION))"
+    )
+    restarted = subprocess.check_output([sys.executable, "-c", command], text=True, cwd=Path.cwd()).strip()
+
+    assert restarted == current_parser
+    assert len(lowering_fingerprint()) == 64
 
 
 def test_origin_specs_are_parity_checked_against_current_dispatch_order() -> None:

--- a/tests/unit/storage/test_archive_tiers_write.py
+++ b/tests/unit/storage/test_archive_tiers_write.py
@@ -18,6 +18,7 @@ from polylogue.core.enums import (
     TitleSource,
     WebConstructType,
 )
+from polylogue.sources.origin_specs import lowering_fingerprint, parser_fingerprint_for_origin
 from polylogue.sources.parsers.base import (
     ParsedAttachment,
     ParsedContentBlock,
@@ -4841,5 +4842,42 @@ def test_repo_edges_write_repo_for_discovered_git_root(tmp_path: Path) -> None:
         ).fetchone()
         assert session_repo_row is not None
         assert session_repo_row["root_path"] == str(repo_root)
+    finally:
+        conn.close()
+
+
+def test_real_writer_persists_current_semantic_fingerprints_on_replay(tmp_path: Path) -> None:
+    """The ordinary parsed-session write path stamps both initial and replay writes."""
+    conn = _connect(tmp_path / "index.db")
+    try:
+        session = ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id="fingerprint-session",
+            messages=[
+                ParsedMessage(
+                    provider_message_id="m1",
+                    role=Role.USER,
+                    text="fingerprint stamp proof",
+                    material_origin=MaterialOrigin.HUMAN_AUTHORED,
+                )
+            ],
+        )
+
+        session_id = write_parsed_session_to_archive(conn, session, raw_id="raw-first")
+        first = conn.execute(
+            "SELECT parser_fingerprint, lowering_fingerprint FROM sessions WHERE session_id = ?", (session_id,)
+        ).fetchone()
+        assert first is not None
+        assert tuple(first) == (
+            parser_fingerprint_for_origin("codex-session"),
+            lowering_fingerprint(),
+        )
+
+        write_parsed_session_to_archive(conn, session, raw_id="raw-replay", force_replace=True)
+        replay = conn.execute(
+            "SELECT parser_fingerprint, lowering_fingerprint, raw_id FROM sessions WHERE session_id = ?", (session_id,)
+        ).fetchone()
+        assert replay is not None
+        assert tuple(replay) == (*tuple(first), "raw-replay")
     finally:
         conn.close()

--- a/tests/unit/storage/test_index_fast_forward_lifecycle.py
+++ b/tests/unit/storage/test_index_fast_forward_lifecycle.py
@@ -89,6 +89,13 @@ def test_v61_pricing_column_drop_is_a_clone_safe_constraint_copy_forward() -> No
     assert declaration.operations[0].objects == (("table", "session_model_usage"),)
 
 
+def test_v64_fingerprint_stamp_delta_requires_semantic_reparse() -> None:
+    declaration = next(d for d in lifecycle.INDEX_DELTA_DECLARATIONS if d.version == 64)
+
+    assert declaration.classes == (DerivedDeltaClass.SEMANTIC_REPARSE,)
+    assert lifecycle.index_fast_forward_plan(63, 64) is None
+
+
 def test_current_index_schema_has_a_complete_delta_declaration() -> None:
     """Exercise the exact declaration report consumed by the schema policy lint."""
     report = index_delta_declaration_report(INDEX_SCHEMA_VERSION)


### PR DESCRIPTION
## Summary

Persist parser and lowering semantic fingerprints on indexed sessions, and reject a reindex candidate unless every session has the one current stamp set.

## Problem

Before this change, the reindex acceptance list did not include a fingerprint check and the session schema had no stamp columns. A real temporary SQLite candidate therefore reported `acceptance_blocking=False` with no parser or lowering stamp coverage. Historic 64-hex values would also have been accepted because nothing compared them with current parser semantics.

## Solution

Add nullable v64 index columns and declare the change `SEMANTIC_REPARSE`. Source-derived fingerprints follow each origin parser's local imports and the shared lowering, identity, revision, and lineage implementation. The existing parsed-session writer persists both values on initial writes and force-replace replay. The existing reindex acceptance path now rejects absent columns, invalid or missing values, stale values, and mixed values before promotion.

The demo-tour manifest evidence was refreshed because its deterministic cohort value had drifted in the current base. Its evidence counts and output shape are unchanged.

Ref polylogue-xselt.

## Acceptance criteria

| Criterion | Result |
| --- | --- |
| Parser semantics change the parser stamp | Satisfied by a helper behavior mutation test. |
| Real replay writer persists stamps | Satisfied for initial and `force_replace` writes against temporary SQLite. |
| Promotion gate requires complete current coverage | Satisfied for missing column, missing value, stale value, and mixed stamp mutations. |
| Schema treats existing rows as semantic replay work | Satisfied by v64 lifecycle test. |

## Verification

- `source .venv/bin/activate && devtools test tests/unit/sources/test_origin_specs.py::test_parser_fingerprint_changes_when_a_normalizing_parser_helper_changes tests/unit/sources/test_origin_specs.py::test_production_fingerprints_are_stable_across_a_fresh_interpreter tests/unit/storage/test_archive_tiers_write.py::test_real_writer_persists_current_semantic_fingerprints_on_replay tests/unit/storage/test_index_fast_forward_lifecycle.py::test_v64_fingerprint_stamp_delta_requires_semantic_reparse tests/unit/maintenance/test_archive_verification.py::test_reindex_acceptance_rejects_missing_semantic_stamp_coverage tests/unit/maintenance/test_archive_verification.py::test_reindex_acceptance_rejects_stale_semantic_stamps tests/unit/maintenance/test_archive_verification.py::test_reindex_acceptance_rejects_mixed_semantic_stamps` produced `7 passed`.
- `source .venv/bin/activate && devtools test tests/unit/maintenance/test_archive_verification.py::test_reindex_acceptance_rejects_missing_semantic_stamp_coverage tests/unit/maintenance/test_archive_verification.py::test_reindex_acceptance_rejects_missing_semantic_stamp_column tests/unit/maintenance/test_archive_verification.py::test_reindex_acceptance_rejects_stale_semantic_stamps tests/unit/maintenance/test_archive_verification.py::test_reindex_acceptance_rejects_mixed_semantic_stamps` produced `4 passed`.
- `source .venv/bin/activate && devtools verify --quick` completed with every listed step successful.