### PR TITLE
fix(storage): keep SQLite sidecars out of blob namespace

### DIFF
--- a/docs/plans/classifier-fingerprints.json
+++ b/docs/plans/classifier-fingerprints.json
@@ -315,11 +315,11 @@
       }
     },
     "polylogue/sources/parsers/hermes_state.py:looks_like_state_db_path": {
-      "fingerprint": "afbeb93cabf5d6f6e41e2bac0c9d19919e46c01b720fa190b94ae4659a1e5d0f",
+      "fingerprint": "ca8622ef35e983ab1f7553dc2a081397c2c814b38dc1341203d5e2e29876f6cf",
       "covered_by": {
         "kind": "acknowledged_safe",
-        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
-        "ref": "polylogue-gucv"
+        "reason": "Immutable blob reads preserve SQLite bytes and parsed rows while preventing sidecar creation.",
+        "ref": "polylogue-84ake"
       }
     },
     "polylogue/sources/parsers/hermes_state.py:looks_like_state_db_payload": {
@@ -331,11 +331,11 @@
       }
     },
     "polylogue/sources/parsers/hermes_verification.py:looks_like_verification_evidence_db_path": {
-      "fingerprint": "afbeb93cabf5d6f6e41e2bac0c9d19919e46c01b720fa190b94ae4659a1e5d0f",
+      "fingerprint": "ca8622ef35e983ab1f7553dc2a081397c2c814b38dc1341203d5e2e29876f6cf",
       "covered_by": {
         "kind": "acknowledged_safe",
-        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
-        "ref": "polylogue-gucv"
+        "reason": "Immutable blob reads preserve SQLite bytes and parsed rows while preventing sidecar creation.",
+        "ref": "polylogue-84ake"
       }
     },
     "polylogue/sources/parsers/hermes_verification.py:looks_like_verification_evidence_db_payload": {

--- a/docs/plans/classifier-fingerprints.json
+++ b/docs/plans/classifier-fingerprints.json
@@ -318,7 +318,7 @@
       "fingerprint": "ca8622ef35e983ab1f7553dc2a081397c2c814b38dc1341203d5e2e29876f6cf",
       "covered_by": {
         "kind": "acknowledged_safe",
-        "reason": "Immutable blob reads preserve SQLite bytes and parsed rows while preventing sidecar creation.",
+        "reason": "Immutable blob reads retain the classifier's structural table probe while preventing sidecar creation; parser-output parity is not claimed here.",
         "ref": "polylogue-84ake"
       }
     },
@@ -334,7 +334,7 @@
       "fingerprint": "ca8622ef35e983ab1f7553dc2a081397c2c814b38dc1341203d5e2e29876f6cf",
       "covered_by": {
         "kind": "acknowledged_safe",
-        "reason": "Immutable blob reads preserve SQLite bytes and parsed rows while preventing sidecar creation.",
+        "reason": "Immutable blob reads retain the classifier's structural table probe while preventing sidecar creation; parser-output parity is not claimed here.",
         "ref": "polylogue-84ake"
       }
     },

--- a/polylogue/archive/raw_payload/decode.py
+++ b/polylogue/archive/raw_payload/decode.py
@@ -330,6 +330,7 @@ def build_raw_payload_envelope(
     fallback_provider: str | Provider,
     payload_provider: str | Provider | None = None,
     jsonl_dict_only: bool = False,
+    sqlite_immutable: bool = False,
 ) -> RawPayloadEnvelope:
     """Decode raw payload and attach canonical provider/wire-format identity.
 
@@ -340,7 +341,11 @@ def build_raw_payload_envelope(
     """
     provider_for_binary = Provider.from_string(payload_provider or fallback_provider)
     if isinstance(raw_content, Path):
-        hermes_marker = _hermes_sqlite_marker_payload(raw_content, source_path=source_path)
+        hermes_marker = _hermes_sqlite_marker_payload(
+            raw_content,
+            source_path=source_path,
+            immutable=sqlite_immutable,
+        )
         if hermes_marker is not None:
             provider = Provider.HERMES
             return RawPayloadEnvelope(
@@ -392,7 +397,12 @@ def build_raw_payload_envelope(
     )
 
 
-def _hermes_sqlite_marker_payload(path: Path, *, source_path: str | Path | None) -> JSONDocument | None:
+def _hermes_sqlite_marker_payload(
+    path: Path,
+    *,
+    source_path: str | Path | None,
+    immutable: bool = False,
+) -> JSONDocument | None:
     """Route a raw Hermes SQLite blob (state.db / verification_evidence.db) to its marker payload.
 
     Binary-capable detection BEFORE any text decode, mirroring the rebuild
@@ -414,10 +424,10 @@ def _hermes_sqlite_marker_payload(path: Path, *, source_path: str | Path | None)
     from polylogue.sources.parsers import hermes_state, hermes_verification
 
     profile_root = Path(source_path).parent if source_path is not None else None
-    if hermes_state.looks_like_state_db_path(path):
-        return hermes_state.marker_payload(path, profile_root=profile_root)
-    if hermes_verification.looks_like_verification_evidence_db_path(path):
-        return hermes_verification.marker_payload(path, profile_root=profile_root)
+    if hermes_state.looks_like_state_db_path(path, immutable=immutable):
+        return hermes_state.marker_payload(path, profile_root=profile_root, immutable=immutable)
+    if hermes_verification.looks_like_verification_evidence_db_path(path, immutable=immutable):
+        return hermes_verification.marker_payload(path, profile_root=profile_root, immutable=immutable)
     return None
 
 

--- a/polylogue/pipeline/services/ingest_worker.py
+++ b/polylogue/pipeline/services/ingest_worker.py
@@ -834,6 +834,7 @@ def ingest_record(
             source_path=raw_record.source_path,
             fallback_provider=raw_record.source_name or "",
             payload_provider=stored_payload_provider,
+            sqlite_immutable=True,
         )
     except Exception as exc:
         return _record_result(

--- a/polylogue/pipeline/services/validation_runtime.py
+++ b/polylogue/pipeline/services/validation_runtime.py
@@ -50,6 +50,7 @@ def _build_validation_envelope(
         source_path=raw_record.source_path,
         fallback_provider=raw_record.source_name or "",
         payload_provider=payload_provider,
+        sqlite_immutable=True,
     )
 
 

--- a/polylogue/schemas/validation/corpus.py
+++ b/polylogue/schemas/validation/corpus.py
@@ -278,6 +278,7 @@ def verify_raw_corpus(
                     fallback_provider=raw_provider,
                     payload_provider=stored_payload_provider,
                     jsonl_dict_only=True,
+                    sqlite_immutable=True,
                 )
                 payload = envelope.payload
                 malformed_lines = envelope.malformed_jsonl_lines

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -2197,7 +2197,7 @@ class LiveBatchProcessor:
                             immutable=True,
                         )
                     elif provider is Provider.CODEX and codex_state.is_in_scope_codex_sqlite_path(
-                        blob_store.blob_path(blob_hash)
+                        blob_store.blob_path(blob_hash), immutable=True
                     ):
                         # polylogue-0jf4: Codex state dbs never become
                         # sessions of their own -- thread_state's evidence
@@ -2209,9 +2209,9 @@ class LiveBatchProcessor:
                         # snapshot admitted above is already durable
                         # evidence; no derived parse is wired in this change.
                         state_path = blob_store.blob_path(blob_hash)
-                        state_kind = codex_state.classify_codex_sqlite_path(state_path)
+                        state_kind = codex_state.classify_codex_sqlite_path(state_path, immutable=True)
                         if state_kind == "thread_state":
-                            state_snapshot = codex_state.parse_codex_state_db(state_path)
+                            state_snapshot = codex_state.parse_codex_state_db(state_path, immutable=True)
                             _write_codex_thread_state_evidence(
                                 archive,
                                 state_snapshot,

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -2179,20 +2179,22 @@ class LiveBatchProcessor:
                         # SAME parse, never a different one.
                         sessions = cached_sessions
                     elif provider is Provider.HERMES and hermes_state.looks_like_state_db_path(
-                        blob_store.blob_path(blob_hash)
+                        blob_store.blob_path(blob_hash), immutable=True
                     ):
                         sessions = hermes_state.parse_state_db(
                             blob_store.blob_path(blob_hash),
                             fallback_id=fallback_id,
                             profile_root=Path(record.source_path).parent,
+                            immutable=True,
                         )
                     elif provider is Provider.HERMES and hermes_verification.looks_like_verification_evidence_db_path(
-                        blob_store.blob_path(blob_hash)
+                        blob_store.blob_path(blob_hash), immutable=True
                     ):
                         sessions = hermes_verification.parse_verification_evidence_db(
                             blob_store.blob_path(blob_hash),
                             fallback_id=fallback_id,
                             profile_root=Path(record.source_path).parent,
+                            immutable=True,
                         )
                     elif provider is Provider.CODEX and codex_state.is_in_scope_codex_sqlite_path(
                         blob_store.blob_path(blob_hash)

--- a/polylogue/sources/parsers/codex_state.py
+++ b/polylogue/sources/parsers/codex_state.py
@@ -154,9 +154,12 @@ IN_SCOPE_KINDS: frozenset[CodexSqliteKind] = frozenset(
 )
 
 
-def _connect_readonly(path: Path, *, timeout: float = 1.0) -> sqlite3.Connection:
+def _connect_readonly(path: Path, *, timeout: float = 1.0, immutable: bool = False) -> sqlite3.Connection:
     """Open *path* read-only. Never takes a write lock against a live Codex."""
-    return sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=timeout)
+    uri = path.resolve().as_uri() + "?mode=ro"
+    if immutable:
+        uri += "&immutable=1"
+    return sqlite3.connect(uri, uri=True, timeout=timeout)
 
 
 def _table_names(conn: sqlite3.Connection) -> frozenset[str]:
@@ -164,14 +167,14 @@ def _table_names(conn: sqlite3.Connection) -> frozenset[str]:
     return frozenset(str(row[0]) for row in rows)
 
 
-def classify_codex_sqlite_path(path: Path) -> CodexSqliteKind:
+def classify_codex_sqlite_path(path: Path, *, immutable: bool = False) -> CodexSqliteKind:
     """Classify a live Codex SQLite file by its table shape.
 
     Returns ``"unknown"`` for anything unreadable or unrecognized rather than
     raising -- classification runs against a live, possibly-locked file.
     """
     try:
-        with closing(_connect_readonly(path)) as conn:
+        with closing(_connect_readonly(path, immutable=immutable)) as conn:
             tables = _table_names(conn)
     except sqlite3.Error:
         return "unknown"
@@ -181,18 +184,21 @@ def classify_codex_sqlite_path(path: Path) -> CodexSqliteKind:
     return "unknown"
 
 
-def is_in_scope_codex_sqlite_path(path: Path) -> bool:
+def is_in_scope_codex_sqlite_path(path: Path, *, immutable: bool = False) -> bool:
     """Return whether *path* is one of the databases this module acquires."""
-    return classify_codex_sqlite_path(path) in IN_SCOPE_KINDS
+    return classify_codex_sqlite_path(path, immutable=immutable) in IN_SCOPE_KINDS
 
 
-def marker_payload(path: Path, *, kind: CodexSqliteKind) -> JSONDocument:
+def marker_payload(path: Path, *, kind: CodexSqliteKind, immutable: bool = False) -> JSONDocument:
     """Return the JSON marker that routes a raw SQLite blob to this parser."""
-    return {
+    payload: JSONDocument = {
         "polylogue_artifact": CODEX_STATE_DB_MARKER,
         "state_db_path": str(path),
         "state_db_kind": kind,
     }
+    if immutable:
+        payload["sqlite_immutable"] = True
+    return payload
 
 
 def looks_like_state_db_payload(payload: JSONDocument) -> bool:
@@ -294,7 +300,7 @@ def _row_opt_int(row: sqlite3.Row, key: str) -> int | None:
     return int(value) if isinstance(value, (int, float)) else None
 
 
-def parse_codex_state_db(path: Path) -> CodexStateSnapshot:
+def parse_codex_state_db(path: Path, *, immutable: bool = False) -> CodexStateSnapshot:
     """Parse ``threads`` and ``thread_spawn_edges`` from a Codex ``state_5.sqlite`` snapshot.
 
     *path* must already be a consistent, non-live snapshot (see
@@ -303,7 +309,7 @@ def parse_codex_state_db(path: Path) -> CodexStateSnapshot:
     from the live file are responsible for snapshotting first (polylogue-0jf4
     acceptance criterion 4).
     """
-    with closing(_connect_readonly(path)) as conn:
+    with closing(_connect_readonly(path, immutable=immutable)) as conn:
         conn.row_factory = sqlite3.Row
         thread_rows = conn.execute(
             "SELECT id, title, cwd, created_at_ms, updated_at_ms, source, model, "
@@ -341,9 +347,9 @@ def parse_codex_state_db(path: Path) -> CodexStateSnapshot:
     return CodexStateSnapshot(threads=threads, spawn_edges=edges)
 
 
-def parse_codex_goals_db(path: Path) -> tuple[CodexThreadGoal, ...]:
+def parse_codex_goals_db(path: Path, *, immutable: bool = False) -> tuple[CodexThreadGoal, ...]:
     """Parse ``thread_goals`` from a Codex ``goals_1.sqlite`` snapshot."""
-    with closing(_connect_readonly(path)) as conn:
+    with closing(_connect_readonly(path, immutable=immutable)) as conn:
         conn.row_factory = sqlite3.Row
         rows = conn.execute(
             "SELECT thread_id, goal_id, objective, status, token_budget, tokens_used, "
@@ -366,12 +372,12 @@ def parse_codex_goals_db(path: Path) -> tuple[CodexThreadGoal, ...]:
     )
 
 
-def parse_codex_memories_db(path: Path) -> tuple[CodexMemoryRecord, ...]:
+def parse_codex_memories_db(path: Path, *, immutable: bool = False) -> tuple[CodexMemoryRecord, ...]:
     """Parse structural facts from a Codex ``memories_1.sqlite`` snapshot.
 
     See ``CodexMemoryRecord`` -- raw memory text is deliberately not surfaced.
     """
-    with closing(_connect_readonly(path)) as conn:
+    with closing(_connect_readonly(path, immutable=immutable)) as conn:
         conn.row_factory = sqlite3.Row
         rows = conn.execute(
             "SELECT thread_id, source_updated_at, generated_at, usage_count, "

--- a/polylogue/sources/parsers/hermes_state.py
+++ b/polylogue/sources/parsers/hermes_state.py
@@ -156,7 +156,12 @@ class HermesImportFidelity:
     caveats: tuple[str, ...]
 
 
-def marker_payload(path: Path, *, profile_root: Path | None = None) -> JSONDocument:
+def marker_payload(
+    path: Path,
+    *,
+    profile_root: Path | None = None,
+    immutable: bool = False,
+) -> JSONDocument:
     """Return the JSON marker that routes a raw SQLite blob to this parser."""
     payload: JSONDocument = {
         "polylogue_artifact": HERMES_STATE_DB_MARKER,
@@ -164,6 +169,8 @@ def marker_payload(path: Path, *, profile_root: Path | None = None) -> JSONDocum
     }
     if profile_root is not None:
         payload["profile_root"] = str(profile_root)
+    if immutable:
+        payload["sqlite_immutable"] = True
     return payload
 
 
@@ -171,10 +178,10 @@ def looks_like_state_db_payload(payload: JSONDocument) -> bool:
     return payload.get("polylogue_artifact") == HERMES_STATE_DB_MARKER and isinstance(payload.get("state_db_path"), str)
 
 
-def looks_like_state_db_path(path: Path) -> bool:
+def looks_like_state_db_path(path: Path, *, immutable: bool = False) -> bool:
     """Return true when *path* is a readable Hermes state database."""
     try:
-        with _connect_readonly(path) as conn:
+        with _connect_readonly(path, immutable=immutable) as conn:
             return _has_required_tables(conn)
     except sqlite3.Error:
         return False
@@ -186,7 +193,12 @@ def parse_state_db_payload(payload: JSONDocument, fallback_id: str) -> list[Pars
         raise ValueError("Hermes state.db marker is missing state_db_path")
     profile_value = payload.get("profile_root")
     profile_root = Path(profile_value) if isinstance(profile_value, str) and profile_value else None
-    return parse_state_db(Path(path_value), fallback_id=fallback_id, profile_root=profile_root)
+    return parse_state_db(
+        Path(path_value),
+        fallback_id=fallback_id,
+        profile_root=profile_root,
+        immutable=payload.get("sqlite_immutable") is True,
+    )
 
 
 def parse_state_db(
@@ -194,10 +206,11 @@ def parse_state_db(
     *,
     fallback_id: str | None = None,
     profile_root: Path | None = None,
+    immutable: bool = False,
 ) -> list[ParsedSession]:
     """Parse every session revision from a Hermes ``state.db`` file."""
     del fallback_id
-    with _connect_readonly(path) as conn:
+    with _connect_readonly(path, immutable=immutable) as conn:
         if not _has_required_tables(conn):
             raise ValueError(f"{path} is not a Hermes state.db file")
         session_columns = _columns(conn, "sessions")
@@ -471,8 +484,11 @@ def _fidelity_capability(
     )
 
 
-def _connect_readonly(path: Path) -> sqlite3.Connection:
-    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+def _connect_readonly(path: Path, *, immutable: bool = False) -> sqlite3.Connection:
+    uri = path.resolve().as_uri() + "?mode=ro"
+    if immutable:
+        uri += "&immutable=1"
+    conn = sqlite3.connect(uri, uri=True)
     conn.row_factory = sqlite3.Row
     return conn
 

--- a/polylogue/sources/parsers/hermes_verification.py
+++ b/polylogue/sources/parsers/hermes_verification.py
@@ -157,7 +157,12 @@ def hermes_verification_session_id_for(conversational_session_id: str) -> str:
     return observer_session_provider_id(raw_id, profile_key)
 
 
-def marker_payload(path: Path, *, profile_root: Path | None = None) -> JSONDocument:
+def marker_payload(
+    path: Path,
+    *,
+    profile_root: Path | None = None,
+    immutable: bool = False,
+) -> JSONDocument:
     """Return the JSON marker that routes a raw SQLite blob to this parser."""
     payload: JSONDocument = {
         "polylogue_artifact": HERMES_VERIFICATION_DB_MARKER,
@@ -165,6 +170,8 @@ def marker_payload(path: Path, *, profile_root: Path | None = None) -> JSONDocum
     }
     if profile_root is not None:
         payload["profile_root"] = str(profile_root)
+    if immutable:
+        payload["sqlite_immutable"] = True
     return payload
 
 
@@ -174,17 +181,20 @@ def looks_like_verification_evidence_db_payload(payload: JSONDocument) -> bool:
     )
 
 
-def looks_like_verification_evidence_db_path(path: Path) -> bool:
+def looks_like_verification_evidence_db_path(path: Path, *, immutable: bool = False) -> bool:
     """Return true when *path* is a readable Hermes verification_evidence.db."""
     try:
-        with _connect_readonly(path) as conn:
+        with _connect_readonly(path, immutable=immutable) as conn:
             return _has_required_tables(conn)
     except sqlite3.Error:
         return False
 
 
-def _connect_readonly(path: Path) -> sqlite3.Connection:
-    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+def _connect_readonly(path: Path, *, immutable: bool = False) -> sqlite3.Connection:
+    uri = path.resolve().as_uri() + "?mode=ro"
+    if immutable:
+        uri += "&immutable=1"
+    conn = sqlite3.connect(uri, uri=True)
     conn.row_factory = sqlite3.Row
     return conn
 
@@ -229,7 +239,12 @@ def parse_verification_evidence_db_payload(
     if profile_root is None:
         profile_value = payload.get("profile_root")
         profile_root = Path(profile_value) if isinstance(profile_value, str) and profile_value else None
-    return parse_verification_evidence_db(Path(path_value), fallback_id=fallback_id, profile_root=profile_root)
+    return parse_verification_evidence_db(
+        Path(path_value),
+        fallback_id=fallback_id,
+        profile_root=profile_root,
+        immutable=payload.get("sqlite_immutable") is True,
+    )
 
 
 def parse_verification_evidence_db(
@@ -237,6 +252,7 @@ def parse_verification_evidence_db(
     *,
     fallback_id: str | None = None,
     profile_root: Path | None = None,
+    immutable: bool = False,
 ) -> list[ParsedSession]:
     """Parse every verification event/state row from a Hermes verification_evidence.db file.
 
@@ -252,7 +268,7 @@ def parse_verification_evidence_db(
     unresolved.
     """
     del fallback_id
-    with _connect_readonly(path) as conn:
+    with _connect_readonly(path, immutable=immutable) as conn:
         if not _has_required_tables(conn):
             raise ValueError(f"{path} is not a Hermes verification_evidence.db file")
         schema_version = _schema_version(conn)

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -2569,15 +2569,19 @@ def _parse_one_raw(
         return []
     if provider is Provider.HERMES and looks_like_sqlite_bytes(payload):
         with _sqlite_payload_path(payload, payload_path, archive_root) as sqlite_path:
-            if hermes_state.looks_like_state_db_path(sqlite_path):
+            if hermes_state.looks_like_state_db_path(sqlite_path, immutable=True):
                 return hermes_state.parse_state_db(
                     sqlite_path,
                     fallback_id=fallback_id,
                     profile_root=Path(source_path).parent,
+                    immutable=True,
                 )
-            if hermes_verification.looks_like_verification_evidence_db_path(sqlite_path):
+            if hermes_verification.looks_like_verification_evidence_db_path(sqlite_path, immutable=True):
                 return hermes_verification.parse_verification_evidence_db(
-                    sqlite_path, fallback_id=fallback_id, profile_root=Path(source_path).parent
+                    sqlite_path,
+                    fallback_id=fallback_id,
+                    profile_root=Path(source_path).parent,
+                    immutable=True,
                 )
     return parse_payload(
         provider,

--- a/polylogue/sources/source_parsing.py
+++ b/polylogue/sources/source_parsing.py
@@ -270,6 +270,7 @@ def parse_one_source_path(
             retained_path,
             fallback_id=path.stem,
             profile_root=(original_source_path or path).parent,
+            immutable=True,
         ):
             yield (raw_data, session)
         return
@@ -303,6 +304,7 @@ def parse_one_source_path(
             retained_path,
             fallback_id=path.stem,
             profile_root=(original_source_path or path).parent,
+            immutable=True,
         ):
             yield (raw_data, session)
         return

--- a/polylogue/storage/artifacts/inspection.py
+++ b/polylogue/storage/artifacts/inspection.py
@@ -49,6 +49,8 @@ def _link_group_key(source_path: str | None) -> str | None:
 def _build_payload_envelope(
     raw_content: Path | bytes,
     record: RawSessionRecord,
+    *,
+    sqlite_immutable: bool = False,
 ) -> RawPayloadEnvelope:
     return build_raw_payload_envelope(
         raw_content,
@@ -56,6 +58,7 @@ def _build_payload_envelope(
         fallback_provider=record.source_name or "",
         payload_provider=record.payload_provider,
         jsonl_dict_only=False,
+        sqlite_immutable=sqlite_immutable,
     )
 
 
@@ -93,9 +96,12 @@ def _resolve_payload_support(
     return resolution, True
 
 
-def _hermes_state_db_schema_version(path: Path) -> int | None:
+def _hermes_state_db_schema_version(path: Path, *, immutable: bool = False) -> int | None:
     try:
-        with closing(sqlite3.connect(f"file:{path}?mode=ro", uri=True)) as conn:
+        uri = path.resolve().as_uri() + "?mode=ro"
+        if immutable:
+            uri += "&immutable=1"
+        with closing(sqlite3.connect(uri, uri=True)) as conn:
             row = conn.execute("SELECT version FROM schema_version ORDER BY rowid DESC LIMIT 1").fetchone()
     except sqlite3.Error:
         return None
@@ -118,8 +124,9 @@ def _resolve_hermes_state_db_support(
     if not isinstance(path_value, str) or not path_value:
         return (None, False)
     path = Path(path_value)
-    schema_version = _hermes_state_db_schema_version(path)
-    if schema_version is None or not looks_like_state_db_path(path):
+    immutable = payload.get("sqlite_immutable") is True
+    schema_version = _hermes_state_db_schema_version(path, immutable=immutable)
+    if schema_version is None or not looks_like_state_db_path(path, immutable=immutable):
         return (None, False)
     resolution = SchemaResolution(
         provider=Provider.HERMES.value,
@@ -150,7 +157,7 @@ def _inspect_payload_envelope(record: RawSessionRecord) -> RawPayloadEnvelope:
     # rather than the mutable source path or an in-memory prefix, ensures the
     # durable observation describes the exact acquired bytes.
     if _is_hermes_state_db_candidate(record):
-        return _build_payload_envelope(blob_path, record)
+        return _build_payload_envelope(blob_path, record, sqlite_immutable=True)
     prefix = _inspection_prefix(record)
     try:
         envelope = _build_payload_envelope(prefix, record)

--- a/tests/unit/core/test_schema_validation.py
+++ b/tests/unit/core/test_schema_validation.py
@@ -20,6 +20,7 @@ from polylogue.schemas.synthetic import SyntheticCorpus
 from polylogue.schemas.validation.corpus import verify_raw_corpus
 from polylogue.schemas.validation.requests import SchemaVerificationRequest
 from polylogue.schemas.validator import SchemaValidator, _normalize_empty_arrays, validate_provider_export
+from polylogue.storage.blob_store import BlobStore
 
 pytestmark = pytest.mark.uses_real_clock(
     "Schema validator timestamp parsing uses a real now to assert lenient ISO parsing."
@@ -767,6 +768,40 @@ def test_verify_raw_corpus_counts_missing_schema_as_skipped(db_path: Path) -> No
     assert stats.skipped_no_schema == 1
     assert stats.valid_records == 0
     assert stats.invalid_records == 0
+
+
+def test_verify_raw_corpus_keeps_retained_wal_sqlite_blob_namespace_pristine(db_path: Path, tmp_path: Path) -> None:
+    """The schema corpus inspects retained SQLite bytes, never a mutable source path."""
+    source = tmp_path / "state.db"
+    with sqlite3.connect(source) as conn:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.executescript(
+            """
+            CREATE TABLE schema_version(version INTEGER NOT NULL);
+            INSERT INTO schema_version(version) VALUES (16);
+            CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, model_config TEXT, parent_session_id TEXT, started_at REAL);
+            CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT NOT NULL, role TEXT NOT NULL, content TEXT, tool_calls TEXT, timestamp REAL NOT NULL, observed INTEGER DEFAULT 0, active INTEGER NOT NULL DEFAULT 1, compacted INTEGER NOT NULL DEFAULT 0);
+            INSERT INTO sessions(id, model_config, started_at) VALUES ('corpus-wal', '{}', 1.0);
+            INSERT INTO messages(session_id, role, content, timestamp) VALUES ('corpus-wal', 'user', 'hello', 1.0);
+            """
+        )
+        conn.commit()
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    _insert_raw_record(
+        db_path=db_path,
+        raw_id="raw-hermes-wal",
+        source_name="hermes",
+        source_path=str(source),
+        raw_content=source.read_bytes(),
+    )
+
+    report = verify_raw_corpus(
+        db_path=db_path,
+        request=SchemaVerificationRequest(providers=["hermes"], max_samples=16),
+    )
+
+    assert report.total_records == 1
+    assert BlobStore(db_path.parent / "blob").verify_all().passed
 
 
 def test_verify_raw_corpus_counts_malformed_jsonl_as_decode_error(db_path: Path) -> None:

--- a/tests/unit/maintenance/test_blob_namespace_quarantine.py
+++ b/tests/unit/maintenance/test_blob_namespace_quarantine.py
@@ -221,6 +221,37 @@ def test_apply_refuses_active_writer_and_read_only_recovery_is_idempotent(
     assert classify_blob_namespace_quarantine_recovery(receipt_parent / "recovery").outcome == "indeterminate"
 
 
+def test_root_level_interrupted_blob_is_quarantined_and_recovery_classified(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Exercise crash recovery through a real root-level ``.blob.*`` entry, never PreparedBlob cleanup."""
+    archive_root = _archive(tmp_path)
+    store = BlobStore(archive_root / "blob")
+    store.write_from_bytes(b"canonical")
+    interrupted = store.root / ".blob.crashed-before-publish"
+    interrupted.write_bytes(b"interrupted payload")
+    manifest = _verified_source_backup(archive_root, tmp_path, monkeypatch)
+    receipt_dir = tmp_path / "receipts" / "root-level-interrupted"
+    receipt_dir.parent.mkdir()
+
+    report = quarantine_blob_namespace(
+        archive_root,
+        backup_manifest=manifest,
+        receipt_dir=receipt_dir,
+        dry_run=False,
+    )
+
+    assert report.quarantine_root is not None
+    destination = report.quarantine_root / interrupted.name
+    assert not interrupted.exists()
+    assert destination.read_bytes() == b"interrupted payload"
+    assert store.verify_all().passed
+    assert classify_blob_namespace_quarantine_recovery(receipt_dir).outcome == "committed"
+
+    os.replace(destination, interrupted)
+    assert classify_blob_namespace_quarantine_recovery(receipt_dir).outcome == "rolled_back"
+
+
 def test_apply_refuses_live_daemon_busy_checkpoint_and_symlinked_receipt_parent(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/pipeline/test_binary_payload_parse_parity.py
+++ b/tests/unit/pipeline/test_binary_payload_parse_parity.py
@@ -168,7 +168,7 @@ def _profile_key(profile_dir: Path) -> str:
     return profile_key(profile_dir)
 
 
-def _write_hermes_state_db(path: Path) -> None:
+def _write_hermes_state_db(path: Path, *, wal_mode: bool = False) -> None:
     """Minimal state.db fixture covering every column ``_has_required_tables`` checks.
 
     Independent minimal copy of the shape
@@ -178,6 +178,8 @@ def _write_hermes_state_db(path: Path) -> None:
     ``_HERMES_SIGNATURE_*_COLUMNS``) are needed for this parity check.
     """
     with sqlite3.connect(path) as conn:
+        if wal_mode:
+            conn.execute("PRAGMA journal_mode=WAL")
         conn.executescript(
             """
             CREATE TABLE schema_version(version INTEGER NOT NULL);
@@ -211,6 +213,8 @@ def _write_hermes_state_db(path: Path) -> None:
             ("hermes-root", "assistant", "hi from state.db", 1_775_000_001.0),
         )
         conn.commit()
+        if wal_mode:
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
 
 
 def test_state_db_still_parses_identically_through_both_routes(blob_store: BlobStore, tmp_path: Path) -> None:
@@ -241,3 +245,28 @@ def test_state_db_still_parses_identically_through_both_routes(blob_store: BlobS
 
     assert ingest_ids == rebuild_ids
     assert "hermes-root" in ingest_ids
+
+
+def test_ingest_record_keeps_wal_sqlite_blob_namespace_pristine(blob_store: BlobStore, tmp_path: Path) -> None:
+    """The real retained-blob decode route never creates SQLite sidecars.
+
+    A WAL-mode SQLite header makes a plain ``mode=ro`` connection create
+    ``-wal`` and ``-shm`` beside the immutable blob. The live
+    ``ingest_record`` path must carry the immutable marker through both the
+    structural probe and final Hermes parser, leaving ``verify_all`` with one
+    canonical blob and no invalid namespace entries.
+    """
+    profile_dir = tmp_path / ".hermes"
+    profile_dir.mkdir(parents=True)
+    db_path = profile_dir / "state.db"
+    _write_hermes_state_db(db_path, wal_mode=True)
+    record = _record(blob_store, db_path.read_bytes(), source_path=str(db_path))
+
+    result = ingest_record(record, str(tmp_path / "archive"), "advisory", blob_root_str=str(blob_store.root))
+    verified = blob_store.verify_all()
+
+    assert result.error is None, result.error
+    assert len(result.sessions) == 1
+    assert verified.passed
+    assert verified.checked == 1
+    assert verified.failures == ()

--- a/tests/unit/pipeline/test_validation_parallelism_contracts.py
+++ b/tests/unit/pipeline/test_validation_parallelism_contracts.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import sqlite3
 from pathlib import Path
 from typing import Any
 
@@ -38,6 +39,7 @@ from polylogue.pipeline.services.validation_runtime import (
     _ValidationOutcome,
 )
 from polylogue.pipeline.stage_models import ValidateResult
+from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.runtime import RawSessionRecord
 
 # ---------------------------------------------------------------------------
@@ -71,6 +73,23 @@ def _claude_payload(title: str = "hello") -> bytes:
         ],
     }
     return core_json.dumps_bytes(body)
+
+
+def _write_wal_hermes_state_db(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.executescript(
+            """
+            CREATE TABLE schema_version(version INTEGER NOT NULL);
+            INSERT INTO schema_version(version) VALUES (16);
+            CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, model_config TEXT, parent_session_id TEXT, started_at REAL);
+            CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT NOT NULL, role TEXT NOT NULL, content TEXT, tool_calls TEXT, timestamp REAL NOT NULL, observed INTEGER DEFAULT 0, active INTEGER NOT NULL DEFAULT 1, compacted INTEGER NOT NULL DEFAULT 0);
+            INSERT INTO sessions(id, model_config, started_at) VALUES ('validation-wal', '{}', 1.0);
+            INSERT INTO messages(session_id, role, content, timestamp) VALUES ('validation-wal', 'user', 'hello', 1.0);
+            """
+        )
+        conn.commit()
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
 
 
 def _make_record(raw_id: str, *, payload: bytes) -> RawSessionRecord:
@@ -198,6 +217,34 @@ class TestValidateRecordSyncDeterminism:
         out_b = _validate_record_sync(rec_b, ValidationMode.ADVISORY, str(blob_root))
         out_a.counts_delta["validated"] = 999
         assert out_b.counts_delta.get("validated", 0) != 999
+
+    @pytest.mark.asyncio
+    async def test_evaluate_retained_wal_sqlite_keeps_blob_namespace_pristine(
+        self, blob_root: Path, tmp_path: Path
+    ) -> None:
+        """Drive validation_flow through its process worker against a real retained WAL SQLite blob."""
+        source = tmp_path / "state.db"
+        _write_wal_hermes_state_db(source)
+        store = BlobStore(blob_root)
+        blob_hash, blob_size = store.write_from_bytes(source.read_bytes())
+        record = RawSessionRecord(
+            raw_id=blob_hash,
+            blob_hash=blob_hash,
+            source_name=Provider.HERMES.value,
+            source_path=str(source),
+            payload_provider=Provider.HERMES,
+            source_index=None,
+            blob_size=blob_size,
+            acquired_at="2026-01-01T00:00:00Z",
+            file_mtime=None,
+        )
+
+        result = await evaluate_raw_artifacts(
+            repository=RecordingStore(), raw_artifacts=[record], mode=ValidationMode.ADVISORY
+        )
+
+        assert result.errors == 0
+        assert store.verify_all().passed
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/sources/test_codex_state_live_ingest.py
+++ b/tests/unit/sources/test_codex_state_live_ingest.py
@@ -36,6 +36,7 @@ from polylogue import Polylogue
 from polylogue.sources.live import WatchSource
 from polylogue.sources.live.batch import LiveBatchProcessor
 from polylogue.sources.live.cursor import CursorStore
+from polylogue.storage.blob_store import BlobStore
 
 _THREAD_ID = "66c7b83d-1b42-43a5-977c-870299c489a6"
 _CHILD_THREAD_ID = "449dd1eb-ea3d-4710-925b-7398a78fe3a7"
@@ -74,8 +75,10 @@ def _write_codex_rollout(path: Path) -> None:
     path.write_text("\n".join(json.dumps(line) for line in lines) + "\n", encoding="utf-8")
 
 
-def _write_state_5_sqlite(path: Path) -> None:
+def _write_state_5_sqlite(path: Path, *, wal_mode: bool = False) -> None:
     with sqlite3.connect(path) as conn:
+        if wal_mode:
+            conn.execute("PRAGMA journal_mode=WAL")
         conn.executescript(
             """
             CREATE TABLE threads (
@@ -106,6 +109,9 @@ def _write_state_5_sqlite(path: Path) -> None:
             "INSERT INTO thread_spawn_edges (parent_thread_id, child_thread_id, status) VALUES (?, ?, ?)",
             (_THREAD_ID, _CHILD_THREAD_ID, "closed"),
         )
+        conn.commit()
+        if wal_mode:
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
 
 
 def _make_processor(workspace_env: dict[str, Path], root_name: str, db_name: str) -> tuple[Polylogue, Path, Path]:
@@ -149,7 +155,7 @@ async def test_codex_state_ingest_leaves_session_count_unchanged(
         assert before_count == 1
 
         state_path = codex_state_root / "state_5.sqlite"
-        _write_state_5_sqlite(state_path)
+        _write_state_5_sqlite(state_path, wal_mode=True)
         state_metrics = await processor.ingest_files([state_path], emit_event=False)
         assert state_metrics.failed_file_count == 0
         # The state db produces zero NEW sessions -- its evidence attaches to
@@ -158,6 +164,7 @@ async def test_codex_state_ingest_leaves_session_count_unchanged(
 
         after_count = await archive.count_sessions()
         assert after_count == before_count == 1
+        assert BlobStore(workspace_env["archive_root"] / "blob").verify_all().passed
     finally:
         await archive.close()
 

--- a/tests/unit/storage/test_blob_store.py
+++ b/tests/unit/storage/test_blob_store.py
@@ -431,24 +431,16 @@ def test_stats_with_blobs(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_iter_namespace_classifies_interrupted_temp_file_deterministically(tmp_path: Path) -> None:
+def test_iter_all_skips_temp_files(tmp_path: Path) -> None:
     blob_store = BlobStore(tmp_path / "blobs")
-    blob_hash, _ = blob_store.write_from_bytes(b"real blob")
-    prepared = blob_store.prepare_from_bytes(b"interrupted write")
-    try:
-        entries = tuple(blob_store.iter_namespace())
-        verified = blob_store.verify_all()
+    blob_store.write_from_bytes(b"real blob")
 
-        assert [(entry.relative_path, entry.issue) for entry in entries] == [
-            (prepared.temporary_path.name, BlobNamespaceIssue.INVALID_SHARD_NAME),
-            (blob_hash[:2] + "/" + blob_hash[2:], None),
-        ]
-        assert [(failure.reason, failure.path) for failure in verified.failures] == [
-            ("invalid_namespace_entry", prepared.temporary_path.name),
-        ]
-    finally:
-        blob_store.discard_prepared(prepared)
-    assert not prepared.temporary_path.exists()
+    # Create a fake temp file (like ones during writes)
+    temp_file = blob_store.root / ".blob.temp123"
+    temp_file.write_bytes(b"temp content")
+
+    hashes = list(blob_store.iter_all())
+    assert len(hashes) == 1  # Only the real blob, not .blob.* temp
 
 
 def test_iter_all_skips_non_prefix_dirs(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_blob_store.py
+++ b/tests/unit/storage/test_blob_store.py
@@ -431,18 +431,24 @@ def test_stats_with_blobs(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_iter_all_skips_temp_files(tmp_path: Path) -> None:
+def test_iter_namespace_classifies_interrupted_temp_file_deterministically(tmp_path: Path) -> None:
     blob_store = BlobStore(tmp_path / "blobs")
-    blob_store.write_from_bytes(b"real blob")
+    blob_hash, _ = blob_store.write_from_bytes(b"real blob")
+    prepared = blob_store.prepare_from_bytes(b"interrupted write")
+    try:
+        entries = tuple(blob_store.iter_namespace())
+        verified = blob_store.verify_all()
 
-    # Create a fake temp file (like ones during writes)
-    prefix_dir = blob_store.root / "ab"
-    prefix_dir.mkdir(parents=True, exist_ok=True)
-    temp_file = prefix_dir / ".blob.temp123"
-    temp_file.write_bytes(b"temp content")
-
-    hashes = list(blob_store.iter_all())
-    assert len(hashes) == 1  # Only the real blob, not .blob.* temp
+        assert [(entry.relative_path, entry.issue) for entry in entries] == [
+            (prepared.temporary_path.name, BlobNamespaceIssue.INVALID_SHARD_NAME),
+            (blob_hash[:2] + "/" + blob_hash[2:], None),
+        ]
+        assert [(failure.reason, failure.path) for failure in verified.failures] == [
+            ("invalid_namespace_entry", prepared.temporary_path.name),
+        ]
+    finally:
+        blob_store.discard_prepared(prepared)
+    assert not prepared.temporary_path.exists()
 
 
 def test_iter_all_skips_non_prefix_dirs(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_hermes_artifact_inspection.py
+++ b/tests/unit/storage/test_hermes_artifact_inspection.py
@@ -25,8 +25,10 @@ def blob_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Blob
     reset_blob_store()
 
 
-def _write_hermes_v16(path: Path) -> None:
+def _write_hermes_v16(path: Path, *, wal_mode: bool = False) -> None:
     with sqlite3.connect(path) as conn:
+        if wal_mode:
+            conn.execute("PRAGMA journal_mode=WAL")
         conn.executescript(
             """
             CREATE TABLE schema_version (version INTEGER NOT NULL);
@@ -53,6 +55,8 @@ def _write_hermes_v16(path: Path) -> None:
             INSERT INTO messages VALUES (1, 'session-1', 'user', 'hello', 1.0, '[]', 0, 1, 0);
             """
         )
+        if wal_mode:
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
 
 
 def _write_generic_sqlite_lookalike(path: Path) -> None:
@@ -121,6 +125,27 @@ def test_retained_v16_snapshot_is_contract_backed_parseable(
     assert observation.resolved_package_version == "state-db-v16"
     assert observation.resolved_element_kind == "state_db"
     assert observation.decode_error is None
+
+
+def test_retained_wal_snapshot_marker_reopen_keeps_blob_namespace_pristine(
+    blob_store: BlobStore,
+    tmp_path: Path,
+) -> None:
+    """Inspection reopens the marker path for schema support, so both opens must be immutable."""
+    snapshot = tmp_path / "retained-wal.sqlite3"
+    _write_hermes_v16(snapshot, wal_mode=True)
+
+    observation = inspect_raw_artifact(
+        _record(
+            blob_store,
+            snapshot,
+            raw_id="hermes:profile-a:wal-revision",
+            source_path="/original/profile/state.db",
+        )
+    )
+
+    assert observation.support_status is ArtifactSupportStatus.SUPPORTED_PARSEABLE
+    assert blob_store.verify_all().passed
 
 
 def test_retained_structurally_compatible_v17_snapshot_is_parseable(


### PR DESCRIPTION
## Summary

Keeps retained SQLite blob routes immutable while leaving ordinary mutable source reads unchanged. The covered routes preserve accepted payload classification and session identity, prevent WAL sidecars in the content-addressed blob namespace, and classify root-level interrupted blob recovery.

## Problem

A real WAL-mode SQLite raw payload opened from a retained blob path without immutable mode could create `<hash>-wal` and `<hash>-shm` siblings. Those entries are outside the canonical blob namespace and make filesystem verification fail.

## Solution

Pass immutable mode through retained validation, schema-corpus, artifact-inspection marker-reopen, and Codex snapshot classification and parse routes. The marker carries immutable mode into its retained reopen. Add real WAL SQLite regressions for each route, each asserting `BlobStore.verify_all().passed`, plus a root-level `.blob.*` quarantine and recovery-classification test.

## Acceptance criteria

| Criterion | Status | Evidence |
| --- | --- | --- |
| Retained SQLite routes use immutable mode | Satisfied | Validation runtime/flow, schema corpus, artifact inspection with marker reopen, and retained Codex classification/parse opt in. |
| Ordinary mutable source reads remain unchanged | Satisfied | Parser defaults remain non-immutable; only retained blob callers pass immutable mode. |
| WAL sidecars do not pollute retained blobs | Satisfied | Real WAL SQLite route tests assert `BlobStore.verify_all().passed`. |
| Interrupted root-level blobs are recoverable | Satisfied | The quarantine test moves a real root-level `.blob.*` entry and checks committed then rolled-back recovery classification. |
| Deep message, block, or event parity | Not claimed | The classifier acknowledgement is limited to structural classification and session identity. |

## Verification

- `source .venv/bin/activate && python -m devtools test tests/unit/pipeline/test_validation_parallelism_contracts.py::TestValidateRecordSyncDeterminism::test_evaluate_retained_wal_sqlite_keeps_blob_namespace_pristine tests/unit/core/test_schema_validation.py::test_verify_raw_corpus_keeps_retained_wal_sqlite_blob_namespace_pristine tests/unit/storage/test_hermes_artifact_inspection.py::test_retained_wal_snapshot_marker_reopen_keeps_blob_namespace_pristine tests/unit/sources/test_codex_state_live_ingest.py::test_codex_state_ingest_leaves_session_count_unchanged tests/unit/maintenance/test_blob_namespace_quarantine.py::test_root_level_interrupted_blob_is_quarantined_and_recovery_classified tests/unit/pipeline/test_binary_payload_parse_parity.py::test_ingest_record_keeps_wal_sqlite_blob_namespace_pristine` passed: `6 passed in 3.23s`.
- `source .venv/bin/activate && python -m devtools verify --quick` passed all 23 static, generated-surface, policy, and schema-promotion steps.
- The testmon seed gate could not initialize in this fresh lane because the seed workflow removes its own cache provenance marker before nested checks. Focused behavior coverage passed.

Ref polylogue-84ake.