### PR TITLE
fix(devtools): verify lanes through their own venv (#3753)

### DIFF
--- a/devtools/lane_init.py
+++ b/devtools/lane_init.py
@@ -177,18 +177,23 @@ def _guard_check(worktree: Path) -> str | None:
     if not python.exists():
         return f"no venv python at {python}"
     result = _run(
-        [str(python), "-P", "-c", "import polylogue; print(polylogue.__file__)"],
+        [
+            str(python),
+            "-P",
+            "-c",
+            (
+                "from pathlib import Path; "
+                "from devtools.checkout_guard import assert_polylogue_matches_checkout; "
+                "fingerprint = assert_polylogue_matches_checkout("
+                "Path.cwd(), context='devtools workspace lane-init'); "
+                "print(fingerprint.polylogue_import_path)"
+            ),
+        ],
         cwd=worktree,
         env=_lane_env(worktree),
     )
     if result.returncode != 0:
-        return f"lane venv cannot import polylogue: {result.stderr.strip()[-400:]}"
-    resolved = result.stdout.strip()
-    if not resolved.startswith(str(worktree) + os.sep):
-        return (
-            f"guard violation: lane venv resolves polylogue to {resolved!r}, "
-            f"outside the lane worktree -- the shared-venv hijack this command exists to prevent"
-        )
+        return f"lane checkout guard failed: {result.stderr.strip()[-800:]}"
     return None
 
 
@@ -203,24 +208,6 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"lane-init: {error}", file=sys.stderr)
         return 1
 
-    verify = _run(
-        [
-            sys.executable,
-            "-m",
-            "devtools",
-            "workspace",
-            "verify-worktree",
-            str(worktree),
-            "--expect-branch",
-            args.branch,
-        ],
-        cwd=root,
-    )
-    if verify.returncode != 0:
-        sys.stderr.write(verify.stdout + verify.stderr)
-        print("lane-init: verify-worktree failed", file=sys.stderr)
-        return 1
-
     if not args.no_venv:
         error = _provision_venv(worktree)
         if error:
@@ -230,6 +217,26 @@ def main(argv: Sequence[str] | None = None) -> int:
         if error:
             print(f"lane-init: {error}", file=sys.stderr)
             return 1
+
+    verify_python = worktree / ".venv" / "bin" / "python" if not args.no_venv else Path(sys.executable)
+    verify = _run(
+        [
+            str(verify_python),
+            "-m",
+            "devtools",
+            "workspace",
+            "verify-worktree",
+            str(worktree),
+            "--expect-branch",
+            args.branch,
+        ],
+        cwd=worktree if not args.no_venv else root,
+        env=_lane_env(worktree) if not args.no_venv else None,
+    )
+    if verify.returncode != 0:
+        sys.stderr.write(verify.stdout + verify.stderr)
+        print("lane-init: verify-worktree failed", file=sys.stderr)
+        return 1
 
     base_sha = _run(["git", "-C", str(worktree), "rev-parse", "--short=9", "HEAD"]).stdout.strip()
     workers = recommended_workers(args.expected_lanes)

--- a/tests/unit/devtools/test_lane_init.py
+++ b/tests/unit/devtools/test_lane_init.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 import sys
 from collections.abc import Sequence
 from pathlib import Path
@@ -137,58 +139,95 @@ def test_provision_venv_ignores_inherited_uv_project(tmp_path: Path, monkeypatch
     assert lane_init._provision_venv(lane) is None
 
 
-def test_main_verifies_a_new_lane_with_its_own_environment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """The production command must leave a main-checkout shell before verifying.
+def test_main_provisions_and_verifies_a_real_lane_from_a_poisoned_coordinator(tmp_path: Path) -> None:
+    """Run the full lane-init process boundary against a real linked worktree.
 
-    Mutation proof: restoring the former ``sys.executable``/coordinator-cwd
-    verification route makes the simulated checkout guard return 125 before
-    lane-init can report the lane as ready.
+    The coordinator copy deliberately makes its verify-worktree module fail.
+    The outer process also names that coordinator in every Python and uv
+    routing variable. A successful run therefore proves that lane-init creates
+    the linked worktree, provisions its venv, runs the shared checkout guard,
+    invokes verify-worktree through the lane interpreter, and appends its
+    ledger without using coordinator code or environment state.
+
+    Mutation proof: restoring the former coordinator interpreter/environment
+    route executes the coordinator canary and makes lane-init fail. Removing
+    either Python or uv environment scrubbing causes the lane guard to resolve
+    the coordinator package and return the asserted exit 125 below.
     """
     coordinator = tmp_path / "main"
     lane = tmp_path / "lane"
-    coordinator.mkdir()
-    lane.mkdir()
-    lane_python = lane / ".venv" / "bin" / "python"
-    lane_python.parent.mkdir(parents=True)
-    lane_python.touch()
+    project_root = Path(__file__).resolve().parents[3]
+    subprocess.run(
+        ["git", "clone", "--shared", str(project_root), str(coordinator)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
     coordinator_python = coordinator / ".venv" / "bin" / "python"
+    coordinator_python.parent.mkdir(parents=True)
+    coordinator_python.symlink_to(Path(sys.executable))
+    (coordinator / "devtools" / "verify_worktree.py").write_text(
+        "raise SystemExit('coordinator verify-worktree must not run')\n",
+        encoding="utf-8",
+    )
 
-    monkeypatch.setattr(lane_init, "repo_root", lambda: coordinator)
-    monkeypatch.setattr(lane_init, "_ensure_worktree", lambda *_: None)
-    monkeypatch.setattr(sys, "executable", str(coordinator_python))
-    monkeypatch.setenv("VIRTUAL_ENV", str(coordinator / ".venv"))
-    monkeypatch.setenv("PYTHONPATH", str(coordinator))
-    monkeypatch.setattr(lane_init, "coordinator_root", lambda root: root)
-    monkeypatch.setattr(lane_init, "append_ledger", lambda root, record: root / lane_init.LEDGER_RELPATH)
+    poisoned_env = os.environ | {
+        "VIRTUAL_ENV": str(coordinator / ".venv"),
+        "PYTHONPATH": str(coordinator),
+        "UV_PROJECT": str(coordinator),
+        "UV_WORKING_DIR": str(coordinator),
+    }
+    driver = "from devtools.lane_init import main; import sys; raise SystemExit(main(sys.argv[1:]))"
+    result = subprocess.run(
+        [
+            str(coordinator_python),
+            "-c",
+            driver,
+            str(lane),
+            "--branch",
+            "feature/test/real-lane",
+            "--base",
+            "HEAD",
+        ],
+        cwd=coordinator,
+        env=poisoned_env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "lane ready:" in result.stdout
+    assert "coordinator verify-worktree must not run" not in result.stderr
+    assert (lane / ".git").is_file()
+    lane_python = lane / ".venv" / "bin" / "python"
+    assert lane_python.is_file()
 
-    events: list[str] = []
+    ledger = coordinator / lane_init.LEDGER_RELPATH
+    record = json.loads(ledger.read_text(encoding="utf-8").splitlines()[-1])
+    assert record["worktree"] == str(lane)
+    assert record["branch"] == "feature/test/real-lane"
+    assert record["venv"] is True
 
-    def provision(worktree: Path) -> None:
-        assert worktree == lane
-        events.append("provision")
-        return None
-
-    def guard(worktree: Path) -> None:
-        assert worktree == lane
-        events.append("guard")
-        return None
-
-    def run(cmd: Sequence[str], *, cwd: Path | None = None, env: dict[str, str] | None = None) -> CompletedProcess[str]:
-        if "verify-worktree" in cmd:
-            events.append("verify")
-            if cmd[0] != str(lane_python) or cwd != lane or env is None:
-                return CompletedProcess(cmd, 125, "", "guard: coordinator editable import\n")
-            assert "VIRTUAL_ENV" not in env
-            assert "PYTHONPATH" not in env
-            assert env["UV_PROJECT_ENVIRONMENT"] == str(lane / ".venv")
-            return CompletedProcess(cmd, 0, "", "")
-        if cmd[:4] == ["git", "-C", str(lane), "rev-parse"]:
-            return CompletedProcess(cmd, 0, "abcdef123\n", "")
-        raise AssertionError(f"unexpected command: {cmd}")
-
-    monkeypatch.setattr(lane_init, "_provision_venv", provision)
-    monkeypatch.setattr(lane_init, "_guard_check", guard)
-    monkeypatch.setattr(lane_init, "_run", run)
-
-    assert lane_init.main([str(lane), "--branch", "feature/test/lane-env"]) == 0
-    assert events == ["provision", "guard", "verify"]
+    foreign_guard = subprocess.run(
+        [
+            str(lane_python),
+            "-P",
+            "-c",
+            (
+                "from pathlib import Path\n"
+                "import sys\n"
+                "from devtools.checkout_guard import CheckoutImportMismatchError, assert_polylogue_matches_checkout\n"
+                "try:\n"
+                "    assert_polylogue_matches_checkout(Path.cwd(), context='poisoned lane')\n"
+                "except CheckoutImportMismatchError as exc:\n"
+                "    print(exc, file=sys.stderr)\n"
+                "    raise SystemExit(125)\n"
+            ),
+        ],
+        cwd=lane,
+        env=poisoned_env,
+        capture_output=True,
+        text=True,
+    )
+    assert foreign_guard.returncode == 125
+    assert "resolved OUTSIDE this checkout" in foreign_guard.stderr
+    assert "give this checkout its own venv" in foreign_guard.stderr

--- a/tests/unit/devtools/test_lane_init.py
+++ b/tests/unit/devtools/test_lane_init.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from collections.abc import Sequence
 from pathlib import Path
 from subprocess import CompletedProcess
@@ -59,15 +60,20 @@ def test_lane_record_shape_and_ledger_append(tmp_path: Path) -> None:
     assert len(lines) == 2 and lines[0]["branch"] == "feature/x"
 
 
-def test_guard_check_flags_escaped_resolution(tmp_path: Path) -> None:
+def test_guard_check_rejects_a_true_foreign_environment(tmp_path: Path) -> None:
     lane = tmp_path / "lane"
     python = lane / ".venv" / "bin" / "python"
     python.parent.mkdir(parents=True)
-    # a fake "python" that reports a module path OUTSIDE the worktree
-    python.write_text("#!/bin/sh\necho /somewhere/else/polylogue/__init__.py\n")
+    python.write_text(
+        "#!/bin/sh\n"
+        "echo 'devtools workspace lane-init: import resolved outside lane: /foreign/polylogue/__init__.py' >&2\n"
+        "exit 125\n"
+    )
     python.chmod(0o755)
     error = lane_init._guard_check(lane)
-    assert error is not None and "guard violation" in error
+    assert error is not None
+    assert "lane checkout guard failed" in error
+    assert "/foreign/polylogue/__init__.py" in error
 
 
 def test_guard_check_runs_lane_interpreter_from_lane_root(tmp_path: Path) -> None:
@@ -119,9 +125,7 @@ def test_provision_venv_forces_the_lane_environment(tmp_path: Path, monkeypatch:
     assert env["UV_PROJECT_ENVIRONMENT"] == str(lane / ".venv")
 
 
-def test_provision_venv_ignores_inherited_uv_project_and_guard_uses_lane(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_provision_venv_ignores_inherited_uv_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A coordinator's UV_PROJECT must not install its editable source in a lane venv."""
     coordinator = tmp_path / "coordinator"
     lane = tmp_path / "lane"
@@ -131,4 +135,60 @@ def test_provision_venv_ignores_inherited_uv_project_and_guard_uses_lane(
     monkeypatch.setenv("UV_WORKING_DIR", str(coordinator))
 
     assert lane_init._provision_venv(lane) is None
-    assert lane_init._guard_check(lane) is None
+
+
+def test_main_verifies_a_new_lane_with_its_own_environment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The production command must leave a main-checkout shell before verifying.
+
+    Mutation proof: restoring the former ``sys.executable``/coordinator-cwd
+    verification route makes the simulated checkout guard return 125 before
+    lane-init can report the lane as ready.
+    """
+    coordinator = tmp_path / "main"
+    lane = tmp_path / "lane"
+    coordinator.mkdir()
+    lane.mkdir()
+    lane_python = lane / ".venv" / "bin" / "python"
+    lane_python.parent.mkdir(parents=True)
+    lane_python.touch()
+    coordinator_python = coordinator / ".venv" / "bin" / "python"
+
+    monkeypatch.setattr(lane_init, "repo_root", lambda: coordinator)
+    monkeypatch.setattr(lane_init, "_ensure_worktree", lambda *_: None)
+    monkeypatch.setattr(sys, "executable", str(coordinator_python))
+    monkeypatch.setenv("VIRTUAL_ENV", str(coordinator / ".venv"))
+    monkeypatch.setenv("PYTHONPATH", str(coordinator))
+    monkeypatch.setattr(lane_init, "coordinator_root", lambda root: root)
+    monkeypatch.setattr(lane_init, "append_ledger", lambda root, record: root / lane_init.LEDGER_RELPATH)
+
+    events: list[str] = []
+
+    def provision(worktree: Path) -> None:
+        assert worktree == lane
+        events.append("provision")
+        return None
+
+    def guard(worktree: Path) -> None:
+        assert worktree == lane
+        events.append("guard")
+        return None
+
+    def run(cmd: Sequence[str], *, cwd: Path | None = None, env: dict[str, str] | None = None) -> CompletedProcess[str]:
+        if "verify-worktree" in cmd:
+            events.append("verify")
+            if cmd[0] != str(lane_python) or cwd != lane or env is None:
+                return CompletedProcess(cmd, 125, "", "guard: coordinator editable import\n")
+            assert "VIRTUAL_ENV" not in env
+            assert "PYTHONPATH" not in env
+            assert env["UV_PROJECT_ENVIRONMENT"] == str(lane / ".venv")
+            return CompletedProcess(cmd, 0, "", "")
+        if cmd[:4] == ["git", "-C", str(lane), "rev-parse"]:
+            return CompletedProcess(cmd, 0, "abcdef123\n", "")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(lane_init, "_provision_venv", provision)
+    monkeypatch.setattr(lane_init, "_guard_check", guard)
+    monkeypatch.setattr(lane_init, "_run", run)
+
+    assert lane_init.main([str(lane), "--branch", "feature/test/lane-env"]) == 0
+    assert events == ["provision", "guard", "verify"]


### PR DESCRIPTION
## Summary

Route newly provisioned lane validation through the lane virtual environment before reporting the worktree ready, with a real linked-worktree regression.

## Problem

`lane-init` created a worktree but invoked `verify-worktree` with the coordinator interpreter and environment. A coordinator editable installation could therefore make the command fail its own checkout guard before the new lane environment was used. The original regression replaced every production collaborator and did not prove the real route.

## Solution

Provision the lane venv first, execute the shared checkout guard through its interpreter with inherited Python routing removed, then invoke `verify-worktree` from the lane with that same environment. The regression creates a temporary coordinator clone and a real linked worktree, leaves lane-init collaborators unpatched, poisons `VIRTUAL_ENV`, `PYTHONPATH`, `UV_PROJECT`, and `UV_WORKING_DIR`, and plants a coordinator `verify-worktree` canary. It succeeds only when the lane environment is used. A second process deliberately imports the coordinator package from the lane and requires the real guard to exit 125 with remediation.

## Acceptance criteria

| Bead criterion | Evidence |
| --- | --- |
| Clean linked lane passes preflight | Unpatched lane-init creates a real temporary linked worktree, provisions its venv, runs the guard, verifies the worktree, and writes its ledger. |
| Foreign environment fails with remediation evidence | A lane interpreter with a coordinator `PYTHONPATH` executes `assert_polylogue_matches_checkout`, returns 125, and prints its own-venv remediation. |
| Main interpreter against lane code is caught before tests | The coordinator canary would run if verification remained on the coordinator route; the successful test proves the lane interpreter is selected. |
| Verify evidence carries environment fingerprint | Existing focused checkout-guard coverage remains exercised. |
| Production preflight is exercised | No lane-init collaborator is patched in the real route. |

Ref polylogue-wple

## Verification

- `.venv/bin/python -m devtools test tests/unit/devtools/test_lane_init.py` produced `7 passed in 5.55s`.
- `.venv/bin/python -m devtools verify --quick` completed successfully.
- The push hook reran the quick baseline successfully in the lane environment.