### PR TITLE
fix(reindex): gate fast-forward candidates on corpus fidelity

### DIFF
--- a/devtools/index_v37_fast_forward.py
+++ b/devtools/index_v37_fast_forward.py
@@ -24,6 +24,7 @@ from typing import cast
 
 from devtools.clone_support import reflink_clone
 from polylogue.config import Config
+from polylogue.maintenance.archive_verification import CORPUS_FIDELITY_CHECKS, verify_archive
 from polylogue.maintenance.offline_guard import running_daemon_pid
 from polylogue.storage.index_generation import IndexGenerationStore, RebuildLease, source_revision_snapshot
 from polylogue.storage.sqlite.archive_tiers.index import INDEX_DDL
@@ -299,6 +300,20 @@ def _require_daemon_stopped(archive_root: Path) -> None:
         raise IndexV37FastForwardError(f"polylogued PID {pid} is still running")
 
 
+def _require_candidate_corpus_fidelity(archive_root: Path, candidate_index: Path) -> None:
+    """Require the managed-rebuild corpus gate before this candidate activates."""
+    report = verify_archive(
+        archive_root,
+        checks=CORPUS_FIDELITY_CHECKS,
+        index_path_override=candidate_index,
+    )
+    if report.blocking:
+        failing = "; ".join(
+            f"{check.name}: {check.summary}" for check in report.checks if check.status.value == "error"
+        )
+        raise IndexV37FastForwardError(f"candidate corpus fidelity gate failed: {failing}")
+
+
 def _checkpoint_stopped_database(path: Path, *, label: str = "active index") -> None:
     """Consolidate a stopped writer's committed WAL before clone evidence."""
     resolved = path.resolve(strict=True)
@@ -508,6 +523,7 @@ def activate_forward(*, receipt_path: Path) -> dict[str, object]:
             raise IndexV37FastForwardError("canonical v37 schema changed since clone preparation")
         if _proven_clone_identity(clone) != receipt.get("clone_identity"):
             raise IndexV37FastForwardError("prepared clone bytes changed before activation")
+        _require_candidate_corpus_fidelity(archive_root, clone)
         if status == "prepared":
             receipt.update({"status": "activating", "activation_started_at_ms": _now_ms()})
             _write_receipt(receipt_path, receipt)

--- a/tests/unit/devtools/test_index_v37_fast_forward.py
+++ b/tests/unit/devtools/test_index_v37_fast_forward.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sqlite3
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -51,6 +52,10 @@ def _archive(tmp_path: Path) -> tuple[Path, int]:
         conn.execute(
             "INSERT INTO sessions(native_id, origin, content_hash) VALUES ('session', 'chatgpt-export', ?)",
             (b"s" * 32,),
+        )
+        conn.execute(
+            "INSERT INTO messages(session_id, native_id, position, role, content_hash) VALUES (?, 'message', 0, 'user', ?)",
+            ("chatgpt-export:session", b"m" * 32),
         )
         conn.commit()
     (storage / "index.db").symlink_to(active)
@@ -281,6 +286,79 @@ def test_activate_refuses_in_place_clone_mutation_with_preserved_stat_identity(
     assert clone.stat().st_size == before.st_size
     assert clone.stat().st_mtime_ns == before.st_mtime_ns
     assert IndexGenerationStore.for_archive_root(root).active_pointer.resolve().parent.name == f"v{ffw_version}"
+
+
+def _add_unfetched_candidate_attachment(candidate_index: Path) -> None:
+    with sqlite3.connect(candidate_index) as conn:
+        session_row = conn.execute("SELECT session_id FROM sessions LIMIT 1").fetchone()
+        assert session_row is not None
+        message_row = conn.execute(
+            "SELECT message_id FROM messages WHERE session_id = ? LIMIT 1", (session_row[0],)
+        ).fetchone()
+        assert message_row is not None
+        conn.execute(
+            "INSERT INTO attachments(attachment_id, acquisition_status) VALUES ('candidate-unfetched', 'unfetched')"
+        )
+        conn.execute(
+            "INSERT INTO attachment_refs(attachment_id, session_id, message_id, position, upload_origin) "
+            "VALUES ('candidate-unfetched', ?, ?, 99, 'drive')",
+            (session_row[0], message_row[0]),
+        )
+
+
+def _refresh_receipt_clone_identity(receipt_path: Path, clone: Path) -> None:
+    receipt = forward._load_receipt(receipt_path)
+    receipt["clone_identity"] = forward._proven_clone_identity(clone)
+    forward._write_receipt(receipt_path, receipt)
+
+
+def test_activate_refuses_corpus_invalid_inactive_candidate_before_pointer_swap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _patch_lifecycle_for_v36_upgrade: None
+) -> None:
+    root, ffw_version = _archive(tmp_path)
+    receipt = tmp_path / "receipt.json"
+    monkeypatch.setattr(forward, "running_daemon_pid", lambda _config: None)
+    prepared = prepare_forward(archive_root=root, receipt_path=receipt)
+    generation = prepared["generation"]
+    assert isinstance(generation, dict)
+    clone = Path(str(generation["index_path"]))
+    _add_unfetched_candidate_attachment(clone)
+    _refresh_receipt_clone_identity(receipt, clone)
+
+    with pytest.raises(
+        IndexV37FastForwardError, match="candidate corpus fidelity gate failed.*corpus-attachment-fidelity"
+    ):
+        activate_forward(receipt_path=receipt)
+
+    assert IndexGenerationStore.for_archive_root(root).active_pointer.resolve().parent.name == f"v{ffw_version}"
+
+
+def test_activate_recovery_refuses_corpus_invalid_inactive_candidate_before_pointer_swap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _patch_lifecycle_for_v36_upgrade: None
+) -> None:
+    root, ffw_version = _archive(tmp_path)
+    receipt = tmp_path / "receipt.json"
+    monkeypatch.setattr(forward, "running_daemon_pid", lambda _config: None)
+    prepared = prepare_forward(archive_root=root, receipt_path=receipt)
+    generation_payload = prepared["generation"]
+    assert isinstance(generation_payload, dict)
+    clone = Path(str(generation_payload["index_path"]))
+    _add_unfetched_candidate_attachment(clone)
+    _refresh_receipt_clone_identity(receipt, clone)
+    activating = forward._load_receipt(receipt)
+    activating["status"] = "activating"
+    forward._write_receipt(receipt, activating)
+    store = IndexGenerationStore.for_archive_root(root)
+    generation = store.load(str(generation_payload["generation_id"]))
+    store._write(replace(generation, state="promoting"))
+
+    with pytest.raises(
+        IndexV37FastForwardError, match="candidate corpus fidelity gate failed.*corpus-attachment-fidelity"
+    ):
+        activate_forward(receipt_path=receipt)
+
+    assert store.active_pointer.resolve().parent.name == f"v{ffw_version}"
+    assert store.load(generation.generation_id).state == "inactive"
 
 
 def test_activate_recovers_after_pointer_swap_before_final_receipt(

--- a/tests/unit/maintenance/test_corpus_fidelity.py
+++ b/tests/unit/maintenance/test_corpus_fidelity.py
@@ -297,18 +297,19 @@ def test_candidate_index_corpus_gate_reads_durable_source_and_inactive_index(
 ) -> None:
     """Each candidate runner reads the real inactive index, not active state.
 
-    This mutates a separate candidate ``index.db`` plus the durable source
-    clone where the check needs source evidence. Removing a candidate runner,
-    or accidentally routing it through the active index, leaves the matching
-    mutation green instead of reporting the selected gate as blocking.
+    Each case leaves default verification of the active index clear. The
+    revision case adds matching durable source evidence before reducing only
+    the candidate, so removing a candidate runner, or accidentally routing
+    it through the active index, leaves the selected candidate gate green.
     """
     root = _clone(corpus_fidelity_archive, tmp_path / violation)
     candidate_index = tmp_path / f"{violation}-candidate-index.db"
     shutil.copy2(root / "index.db", candidate_index)
     session_id = _first_session_id(root)
 
-    if violation == "attachment":
-        with _connect(candidate_index) as conn:
+    assert not verify_archive(root, checks=(expected_check,)).blocking
+    with _connect(candidate_index) as conn:
+        if violation == "attachment":
             message_row = conn.execute(
                 "SELECT message_id FROM messages WHERE session_id = ? LIMIT 1", (session_id,)
             ).fetchone()
@@ -321,36 +322,40 @@ def test_candidate_index_corpus_gate_reads_durable_source_and_inactive_index(
                 "VALUES ('candidate-unfetched', ?, ?, 99, 'drive')",
                 (session_id, message_row[0]),
             )
-    else:
-        origin, native_id = session_id.split(":", 1)
-        raw_id = f"candidate-{violation}"
-        provider_session_id = native_id if violation == "revision" else "candidate-absent"
-        with _connect(root / "source.db") as conn:
-            _insert_raw(
-                conn,
-                raw_id=raw_id,
-                origin=origin,
-                native_id=provider_session_id,
-                logical_source_key=f"fixture:{provider_session_id}",
-            )
-            conn.execute(
-                """
-                INSERT INTO raw_session_memberships(
-                    raw_id, logical_source_key, provider_session_id, source_revision,
-                    normalized_content_hash, message_count
-                ) VALUES (?, ?, ?, 'candidate-revision', ?, ?)
-                """,
-                (
-                    raw_id,
-                    f"fixture:{provider_session_id}",
-                    provider_session_id,
-                    b"c" * 32,
-                    100_000 if violation == "revision" else 4,
-                ),
-            )
+        elif violation == "absent":
+            conn.execute("DELETE FROM sessions WHERE session_id = ?", (session_id,))
+        else:
+            origin, native_id = session_id.split(":", 1)
+            message_row = conn.execute(
+                "SELECT message_id FROM messages WHERE session_id = ? ORDER BY position LIMIT 1", (session_id,)
+            ).fetchone()
+            assert message_row is not None
+            with _connect(root / "source.db") as source:
+                _insert_raw(
+                    source,
+                    raw_id="candidate-revision-source",
+                    origin=origin,
+                    native_id=native_id,
+                    logical_source_key=f"fixture:{native_id}",
+                )
+                message_count = conn.execute(
+                    "SELECT COUNT(*) FROM messages WHERE session_id = ?", (session_id,)
+                ).fetchone()[0]
+                source.execute(
+                    """
+                    INSERT INTO raw_session_memberships(
+                        raw_id, logical_source_key, provider_session_id, source_revision,
+                        normalized_content_hash, message_count
+                    ) VALUES ('candidate-revision-source', ?, ?, 'candidate-revision', ?, ?)
+                    """,
+                    (f"fixture:{native_id}", native_id, b"c" * 32, message_count),
+                )
+            conn.execute("DELETE FROM messages WHERE session_id = ? AND message_id != ?", (session_id, message_row[0]))
+            conn.execute("DELETE FROM session_events WHERE session_id = ?", (session_id,))
 
     report = verify_archive(root, checks=(expected_check,), index_path_override=candidate_index)
 
+    assert not verify_archive(root, checks=(expected_check,)).blocking
     assert report.blocking
     assert len(report.checks) == 1
     check = report.checks[0]


### PR DESCRIPTION
## Summary

Require the v37 fast-forward promotion path to run the existing candidate corpus-fidelity gate before activation.

## Problem

The fast-forward tool verified clone identity and schema shape but did not run the corpus checks that managed rebuild uses before promoting an inactive candidate. The activating-receipt recovery path could reach the same promotion route.

## Solution

Reuse `CORPUS_FIDELITY_CHECKS` and `verify_archive` with the durable archive root plus the explicit inactive candidate index. Real SQLite regressions cover normal promotion refusal, activating-recovery refusal, and candidate-only absence, attachment, and revision drift while default active verification stays clear.

## Verification

- `source .venv/bin/activate && devtools test tests/unit/devtools/test_index_v37_fast_forward.py tests/unit/maintenance/test_corpus_fidelity.py` -> `24 passed in 4.15s`.
- `source .venv/bin/activate && devtools verify --quick` -> exit 0, all 23 checks passed.
- Pre-push reran `devtools verify --quick` -> exit 0.

Ref polylogue-dlfcx.