### PR TITLE
fix(devtools): bound Beads state-report tree rendering

### DIFF
--- a/devtools/beads_state_report.py
+++ b/devtools/beads_state_report.py
@@ -89,6 +89,7 @@ RECONCILIATION_WINDOW = 1200
 STALE_CLAIM_DAYS = 7  # in_progress untouched this long = zombie claim
 AGED_URGENT_DAYS = 14  # open P0/P1 older than this = urgency not being consumed
 VELOCITY_WINDOW_DAYS = 14  # trailing window vs the window before it
+TREE_MAX_DEPTH = 2  # structure view renders two parent-child levels
 
 SUBSYSTEMS: dict[str, tuple[str, ...]] = {
     # canonical subsystem -> area:* label suffixes folded into it
@@ -1290,17 +1291,63 @@ def cluster_svg(facts: Facts, nodes: Sequence[str]) -> str:
     return "".join(parts)
 
 
-def tree_html(facts: Facts, root: str, depth: int = 0) -> str:
-    kids = sorted(facts.children.get(root, []))
-    if not kids or depth > 1:
+def tree_html(
+    facts: Facts,
+    root: str,
+    depth: int = 0,
+    _path: frozenset[str] | None = None,
+    _seen_edges: set[tuple[str, str]] | None = None,
+) -> str:
+    """Render a bounded parent-child tree from an untrusted export.
+
+    The export can contain repeated edges or a cycle.  Keep the normal
+    two-level view, but make each render visit an edge at most once and never
+    recurse into an ancestor.  Suppressed malformed edges remain visible as a
+    compact diagnostic with both endpoint ids.
+    """
+    if depth >= TREE_MAX_DEPTH:
         return ""
+
+    path = frozenset() if _path is None else _path
+    if root in path:
+        return ""
+    path = path | {root}
+    seen_edges = set() if _seen_edges is None else _seen_edges
+    kids = sorted(facts.children.get(root, []))
+    if not kids:
+        return ""
+
     items = []
+    duplicate_counts: Counter[str] = Counter()
+    cyclic_children: set[str] = set()
     for kid in kids:
+        edge = (root, kid)
+        if edge in seen_edges:
+            duplicate_counts[kid] += 1
+            continue
+        seen_edges.add(edge)
         if kid not in facts.issues:
             continue
-        sub = tree_html(facts, kid, depth + 1)
+        if kid in path:
+            cyclic_children.add(kid)
+            continue
+        sub = tree_html(facts, kid, depth + 1, path, seen_edges)
         title = esc(str(facts.issues[kid]["title"])[:78])
         items.append(f'<li>{chip(facts, kid)} <span class="meta">{title}</span>{sub}</li>')
+
+    for kid, count in sorted(duplicate_counts.items()):
+        items.append(
+            f'<li class="tree-diagnostic"><span class="meta">'
+            f"suppressed {count:,} duplicate parent-child edge(s): "
+            f"<code>{esc(root)} &rarr; {esc(kid)}</code></span></li>"
+        )
+    for kid in sorted(cyclic_children):
+        items.append(
+            f'<li class="tree-diagnostic"><span class="meta">'
+            f"suppressed cyclic parent-child edge: "
+            f"<code>{esc(root)} &rarr; {esc(kid)}</code></span></li>"
+        )
+
     return f'<ul class="tree">{"".join(items)}</ul>'
 
 

--- a/tests/unit/devtools/test_beads_state_report.py
+++ b/tests/unit/devtools/test_beads_state_report.py
@@ -17,6 +17,7 @@ from devtools.beads_state_report import (
     compute_insights,
     json_payload,
     render,
+    tree_html,
 )
 
 NOW = dt.datetime(2026, 8, 1, 12, 0, tzinfo=dt.UTC)
@@ -212,6 +213,55 @@ class TestParallelFrontier:
 # render invariants
 # ---------------------------------------------------------------------------
 class TestRender:
+    def test_tree_renderer_preserves_normal_hierarchy(self) -> None:
+        facts = _facts(
+            [
+                _bead("root", itype="epic", deps=[]),
+                _bead("child", deps=[_dep("child", "root", "parent-child")]),
+                _bead("grandchild", deps=[_dep("grandchild", "child", "parent-child")]),
+            ]
+        )
+
+        output = tree_html(facts, "root")
+
+        assert output.index('class="bi">child</span>') < output.index('class="bi">grandchild</span>')
+        assert output.count('class="tree-diagnostic"') == 0
+
+    def test_tree_renderer_suppresses_parent_child_cycle(self) -> None:
+        facts = _facts(
+            [
+                _bead("parent", itype="epic", deps=[_dep("parent", "child", "parent-child")]),
+                _bead("child", deps=[_dep("child", "parent", "parent-child")]),
+            ]
+        )
+
+        output = tree_html(facts, "parent")
+
+        assert output.count('class="bi">child</span>') == 1
+        assert output.count('class="bi">parent</span>') == 0
+        assert "suppressed cyclic parent-child edge" in output
+        assert "child &rarr; parent" in output
+
+    def test_tree_renderer_bounds_duplicate_edge_output(self) -> None:
+        duplicate_count = 20_000
+        facts = _facts(
+            [
+                _bead(
+                    "parent",
+                    itype="epic",
+                    deps=[_dep("child", "parent", "parent-child")] * duplicate_count,
+                ),
+                _bead("child"),
+            ]
+        )
+
+        output = tree_html(facts, "parent")
+
+        assert len(output) < 100_000
+        assert output.count('class="bi">child</span>') == 1
+        assert f"suppressed {duplicate_count - 1:,} duplicate parent-child edge(s)" in output
+        assert "parent &rarr; child" in output
+
     def test_verification_verdicts_and_health_queues_survive(self, tmp_path: Any) -> None:
         beads = [
             _bead("verified", notes="VERIFICATION (sweep-3): STALE because superseded"),


### PR DESCRIPTION
## Summary

Bounds the generated Polylogue Beads state-report tree when its report input contains repeated parent-child links or a cycle.

## Problem

The state-report renderer recursively followed its in-memory parent-child map without a path or edge guard. Corrupt or hostile report input could therefore produce excessive HTML or recurse forever.

This is a defensive hardening change for Polylogue's generated HTML report only. It does not repair the `bd list --all` CLI renderer. That production Beads CLI defect is being handled in a separate upstream checkout and PR.

## Solution

`devtools/beads_state_report.py` now suppresses a repeated parent-child edge or a branch that revisits an ancestor, and renders one compact diagnostic in its place. The report keeps the existing output for ordinary acyclic hierarchies.

## Verification

`devtools test tests/unit/devtools/test_beads_state_report.py`

Passed: `15 passed`.

`devtools verify --quick`

Passed: `23 checks passed`.
