### PR TITLE
docs: retire empty identity acknowledgement registry

### DIFF
--- a/devtools/verify_position_derived_identity.py
+++ b/devtools/verify_position_derived_identity.py
@@ -14,15 +14,13 @@ make ``attachment_identity_hash`` (``polylogue/pipeline/ids.py``) stop
 reading either the real or synthetic attachment id at all for comparison
 purposes.
 
-polylogue-gysk3 found the identical hazard still live one level up:
+polylogue-gysk3 found the identical hazard one level up:
 ``message_identity_hash`` (``polylogue/pipeline/ids.py``) hashes a message's
 ``id`` directly, and that id IS ``provider_message_id`` -- multiple parsers
 construct it as ``f"msg-{index}"`` or similar whenever the raw record
-carries no native id of its own. Fixing every existing instance is a
-separate, higher-risk follow-on (polylogue-gysk3); this lint (ds4b4 item 3)
-is the preventive half -- it stops a *new* occurrence of the same shape from
-being added silently, in a parser or anywhere else, without requiring every
-already-known instance to be ripped out first.
+carries no native id of its own. The production repair removed every known
+instance. This lint (ds4b4 item 3) prevents the same shape returning in a
+parser or shared parser helper.
 
 What this lint checks
 ----------------------
@@ -35,12 +33,11 @@ the value expression is an f-string, ``str.format()`` call, or ``+``
 concatenation that references a variable named like a loop index/position
 (``index``, ``idx``, ``i``, ``pos``, ``position`` -- ``ENUMERATE_VAR_NAMES``).
 
-Every currently-known instance is recorded in the acknowledgment manifest
-(``docs/plans/position-derived-identity-acks.json``), each referencing
-polylogue-gysk3 (the tracked follow-up to actually fix them). A *new*
-occurrence with no manifest entry fails the gate -- it must either avoid
-positional identity, or be explicitly acknowledged (naming a tracked
-follow-up bead/issue) via ``--ack``.
+No current finding needs an acknowledgement. The optional acknowledgement
+manifest (``docs/plans/position-derived-identity-acks.json``) is absent while
+the audit is clean and is created only by ``--ack`` for a newly discovered,
+temporarily accepted finding with a tracked follow-up. An unacknowledged
+occurrence fails the gate; a stale acknowledgement fails it too.
 
 Scope and false-positive discipline
 ------------------------------------

--- a/docs/plans/position-derived-identity-acks.json
+++ b/docs/plans/position-derived-identity-acks.json
@@ -1,3 +1,0 @@
-{
-  "acknowledged": {}
-}


### PR DESCRIPTION
## Summary

Retires the empty position-derived identity acknowledgement registry now that the substantive repair is present on `master` in #3739. This PR deliberately contains only the residual cleanup and its verifier-documentation alignment.

## Problem

The registry has contained no acknowledged exceptions since #3730. Keeping an empty exception carrier and documentation that describes it as standing implies a live positional-identity waiver after the parser audit and #3739 repair eliminated every covered case.

## Solution

`docs/plans/position-derived-identity-acks.json` is deleted. The verifier documentation now describes the acknowledgement manifest as optional and created only by `--ack` for a future temporarily accepted finding. The audit found no position-derived `provider_message_id` assignment. Claude’s `__idless:<original_index>` value is parser-local only, while every Class-B synthetic parsed message routes through `synthetic_message_id()` with a content-derived seed. Class-A fallbacks remain empty.

| Requirement | Evidence |
| --- | --- |
| Reorder-stable id-less re-export | #3739 parser and revision tests enter real parser and projection paths. |
| Duplicate id-less multiplicity | `SessionRevisionProjection` records multiplicity and membership classification accepts one then two identical records. |
| Codex and Drive parent persistence | Parser-local `parent_message_position` reaches `write_parsed_session_to_archive`; SQLite rows retain parent links with `native_id IS NULL`. |
| Drive attachment ownership | The attachment hash uses its id-less owner comparison anchor, so moving an attachment changes session and attachment revision identities. |
| Retire acknowledgement file | Empty registry deleted after the current parser audit. |

## Verification

- Historical #3730 production-path reproduction: one duplicate record yielded `one_message_contents=1`, `two_message_contents=1`, and `equivalent_raw_ids=('two',)`. This is the pre-fix defect.
- `POLYLOGUE_PYTEST_WORKERS=1 devtools test tests/unit/pipeline/test_message_identity_position_fallback.py tests/unit/sources/test_parsers_codex.py tests/unit/sources/test_parsers_drive.py tests/unit/storage/test_archive_tiers_write.py -k 'idless or id_less or identity or parent or attachment'`: `36 passed in 8.78s`.
- `devtools lab policy position-derived-identity`: `unacknowledged position-derived identity constructions: 0`, `stale manifest entries: 0`.
- `POLYLOGUE_PYTEST_WORKERS=1 devtools verify --quick`: success in the final pre-push baseline, including `lab policy position-derived-identity`.

## Anti-vacuity

- Reorder coverage enters actual parsers and `session_revision_projection`; restoring position-derived fallback changes the compared identities.
- Duplicate coverage enters `classify_membership_revisions`; replacing the counted projection with a set recreates the historical equivalent result.
- Parent coverage parses id-less Codex and Drive payloads, writes a temporary SQLite archive, and reads persisted `parent_message_id` values.
- Attachment coverage parses Drive payloads then compares the real session and attachment hash projections after ownership moves.

## Adversarial review notes

- Iteration 1: no real gaps. One borderline found the verifier docstring still described the deleted JSON as a standing manifest. Commit `534ffbfce` makes it explicit that the missing file means an empty acknowledgement set and `--ack` creates one only if required.

## Scope

No stamp code changed, and this PR does not claim `polylogue-xselt` is unblocked. `polylogue-uqwd` remains unresolved and is outside this file-retirement cleanup.

Ref polylogue-slshy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified audit guidance for position-derived message identities.
  * Documented that clean audits no longer produce an acknowledgement manifest.
* **Chores**
  * Removed the obsolete, empty acknowledgement plan file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->