### PR TITLE
test(devtools): align identity acknowledgement contract (#3760)

### DIFF
--- a/tests/unit/devtools/test_verify_position_derived_identity.py
+++ b/tests/unit/devtools/test_verify_position_derived_identity.py
@@ -83,10 +83,10 @@ def build_a_second(records):
     }
 
 
-def test_real_parsers_directory_findings_are_all_acknowledged(capsys: pytest.CaptureFixture[str]) -> None:
-    """Every currently-known instance (polylogue-gysk3's tracked follow-up)
-    must be recorded in the committed manifest -- this is the regression
-    test that a NEW, unacknowledged occurrence would fail."""
+def test_real_parsers_directory_is_clean_without_acknowledgements(capsys: pytest.CaptureFixture[str]) -> None:
+    """A clean parser audit has no manifest; new findings must fail or use
+    a temporary ``--ack`` entry with a tracked follow-up."""
+    assert not lint.MANIFEST_PATH.exists()
     assert lint.main(["--json"]) == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["ok"] is True


### PR DESCRIPTION
## Summary

Aligns the real-parser position-derived-identity test with the clean-state contract introduced by #3756.

## Problem

The verifier treats a missing acknowledgement manifest as clean and reserves `--ack` for a newly discovered, temporarily accepted finding with a tracked follow-up. The test still stated the older contract that every known finding must be recorded in a committed manifest.

## Solution

`tests/unit/devtools/test_verify_position_derived_identity.py` now names the clean audit state, asserts that the acknowledgement manifest is absent, and continues through `lint.main(["--json"])`. The existing nonzero path for an unacknowledged production finding remains covered.

## Verification

- `POLYLOGUE_PYTEST_WORKERS=1 devtools test tests/unit/devtools/test_verify_position_derived_identity.py`: `9 passed in 4.64s`.
- `devtools lab policy position-derived-identity`: `unacknowledged position-derived identity constructions: 0`; `stale manifest entries (finding no longer exists): 0`.
- Pre-push `devtools verify --quick`: exit `0` in `189.21s`, including format, lint, mypy, generated-surface, and policy checks.

Ref #3756.
