### PR TITLE
feat(verification): add schema-inference gate receipt

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -349,6 +349,22 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
+        "verify schema-inference-gate",
+        "verification",
+        "Run the read-only schema-inference prerequisite and persist a PASS/FAIL receipt.",
+        "devtools.schema_inference_gate",
+        use_when=(
+            "Run before schema inference or the 818fy rebuild. Supply a receipt from a separate full blob-hash "
+            "verification run; this command never invents hash evidence or mutates the archive."
+        ),
+        examples=(
+            "devtools verify schema-inference-gate --archive-root /path/to/archive "
+            "--blob-hash-receipt /path/to/blob-hash.json --receipt /path/to/gate.json",
+            "devtools verify schema-inference-gate --archive-root /path/to/archive "
+            "--blob-hash-receipt /path/to/blob-hash.json --receipt /path/to/gate.json --json",
+        ),
+    ),
+    CommandSpec(
         "release readiness",
         "release",
         "Validate the externally-presentable release gate definition.",

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -354,14 +354,14 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         "Run the read-only schema-inference prerequisite and persist a PASS/FAIL receipt.",
         "devtools.schema_inference_gate",
         use_when=(
-            "Run before schema inference or the 818fy rebuild. Supply a receipt from a separate full blob-hash "
-            "verification run; this command never invents hash evidence or mutates the archive."
+            "Run before schema inference or the 818fy rebuild. Declare every external source root represented in "
+            "source.db; the command scans those roots and runs BlobStore's full verifier without mutating the archive."
         ),
         examples=(
             "devtools verify schema-inference-gate --archive-root /path/to/archive "
-            "--blob-hash-receipt /path/to/blob-hash.json --receipt /path/to/gate.json",
+            "--ground-truth-root codex-session=/path/to/codex --receipt /path/to/schema-inference-gate-receipt.json",
             "devtools verify schema-inference-gate --archive-root /path/to/archive "
-            "--blob-hash-receipt /path/to/blob-hash.json --receipt /path/to/gate.json --json",
+            "--ground-truth-root codex-session=/path/to/codex --receipt /path/to/schema-inference-gate-receipt.json --json",
         ),
     ),
     CommandSpec(

--- a/devtools/schema_inference_gate.py
+++ b/devtools/schema_inference_gate.py
@@ -1,0 +1,49 @@
+"""Run the schema-inference prerequisite and persist its go/no-go receipt."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import TextIO
+
+from polylogue.maintenance.schema_inference_gate import run_schema_inference_gate
+
+
+def main(argv: list[str] | None = None, *, stdout: TextIO | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--archive-root", type=Path, required=True, help="Archive root to inspect read-only.")
+    parser.add_argument(
+        "--blob-hash-receipt",
+        type=Path,
+        required=True,
+        help="Required receipt from a separate full blob-hash verification run.",
+    )
+    parser.add_argument("--receipt", type=Path, required=True, help="Destination for the durable gate receipt.")
+    parser.add_argument("--sample-limit", type=int, default=10, help="Maximum evidence rows per failure class.")
+    parser.add_argument("--json", action="store_true", help="Emit the durable receipt as JSON.")
+    args = parser.parse_args(argv)
+    output = stdout if stdout is not None else sys.stdout
+    result = run_schema_inference_gate(
+        args.archive_root,
+        blob_hash_receipt=args.blob_hash_receipt,
+        receipt_path=args.receipt,
+        sample_limit=args.sample_limit,
+    )
+    if args.json:
+        json.dump(result.payload, output, indent=2, sort_keys=True)
+        print(file=output)
+    else:
+        print(f"Schema-inference gate: {result.payload['archive_root']}", file=output)
+        print(f"  receipt: {args.receipt}", file=output)
+        print(f"  verdict: {result.payload['verdict']}", file=output)
+        reasons = result.payload.get("pass_fail_reasons", [])
+        if isinstance(reasons, list):
+            for reason in reasons:
+                print(f"  reason: {reason}", file=output)
+    return 0 if result.passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/devtools/schema_inference_gate.py
+++ b/devtools/schema_inference_gate.py
@@ -15,20 +15,32 @@ def main(argv: list[str] | None = None, *, stdout: TextIO | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--archive-root", type=Path, required=True, help="Archive root to inspect read-only.")
     parser.add_argument(
-        "--blob-hash-receipt",
+        "--ground-truth-root",
+        action="append",
+        default=[],
+        metavar="ORIGIN=PATH",
+        help="External source root to scan and reconcile for an origin; repeat for each origin in source.db.",
+    )
+    parser.add_argument(
+        "--receipt",
         type=Path,
         required=True,
-        help="Required receipt from a separate full blob-hash verification run.",
+        help="External destination named schema-inference-gate-receipt.json.",
     )
-    parser.add_argument("--receipt", type=Path, required=True, help="Destination for the durable gate receipt.")
     parser.add_argument("--sample-limit", type=int, default=10, help="Maximum evidence rows per failure class.")
     parser.add_argument("--json", action="store_true", help="Emit the durable receipt as JSON.")
     args = parser.parse_args(argv)
+    ground_truth_roots: dict[str, list[Path]] = {}
+    for raw in args.ground_truth_root:
+        origin, separator, path = raw.partition("=")
+        if not separator or not origin or not path:
+            parser.error("--ground-truth-root must be ORIGIN=PATH")
+        ground_truth_roots.setdefault(origin, []).append(Path(path))
     output = stdout if stdout is not None else sys.stdout
     result = run_schema_inference_gate(
         args.archive_root,
-        blob_hash_receipt=args.blob_hash_receipt,
         receipt_path=args.receipt,
+        ground_truth_roots=ground_truth_roots,
         sample_limit=args.sample_limit,
     )
     if args.json:

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -196,6 +196,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools verify manifests` | Verify internal consistency across all docs/plans/*.yaml manifest files. |
 | `devtools verify public-claims` | Verify generated public-claim views, preset parity, sanitized refs, coverage markers, and retired copy. |
 | `devtools verify pytest-timeout-overrides` | Verify explicit pytest timeout overrides are positive, bounded, and justified. |
+| `devtools verify schema-inference-gate` | Run the read-only schema-inference prerequisite and persist a PASS/FAIL receipt. |
 | `devtools verify test-infra-currency` | Verify tests/infra/ helpers reference only tables that exist in the current SCHEMA_VERSION. |
 
 ### Benchmarking

--- a/polylogue/maintenance/corpus_fidelity.py
+++ b/polylogue/maintenance/corpus_fidelity.py
@@ -76,9 +76,13 @@ def audit_absences(
                 unattributable_sample.append(str(raw_id))
 
     absent: collections.Counter[tuple[str, str]] = collections.Counter()
+    documents_known_by_origin: collections.Counter[str] = collections.Counter()
+    documents_present_by_origin: collections.Counter[str] = collections.Counter()
     samples: dict[str, list[str]] = collections.defaultdict(list)
     for (origin, provider_session_id), decisions in by_document.items():
+        documents_known_by_origin[origin] += 1
         if f"{origin}:{provider_session_id}" in present_ids:
+            documents_present_by_origin[origin] += 1
             continue
         if decisions == {"<byte-revision>"}:
             cause = "byte-revision-governed"
@@ -95,6 +99,8 @@ def audit_absences(
     return {
         "documents_known": len(by_document),
         "documents_present": len(by_document) - sum(absent.values()),
+        "documents_known_by_origin": dict(sorted(documents_known_by_origin.items())),
+        "documents_present_by_origin": dict(sorted(documents_present_by_origin.items())),
         "absent_total": sum(absent.values()),
         "raws_without_attributable_identity": unattributable,
         "membershipless_non_session_artifacts_excluded": non_session_artifacts,

--- a/polylogue/maintenance/schema_inference_gate.py
+++ b/polylogue/maintenance/schema_inference_gate.py
@@ -9,12 +9,13 @@ receipt path.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import platform
 import sqlite3
 import sys
 from collections import Counter
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -22,6 +23,7 @@ from typing import Any, cast
 
 from polylogue.maintenance.archive_verification import CORPUS_FIDELITY_CHECKS, verify_archive
 from polylogue.storage.archive_identity import ArchiveIdentity, ArchiveLocation
+from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.introspection import table_exists
 from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
@@ -29,48 +31,32 @@ from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 from polylogue.version import POLYLOGUE_VERSION
 
 RECEIPT_SCHEMA = "polylogue.schema-inference-gate.v1"
-BLOB_HASH_RECEIPT_SCHEMA = "polylogue.blob-hash-verification.v1"
-GATE_VERSION = "1"
+GATE_VERSION = "2"
 DEFAULT_SAMPLE_LIMIT = 10
+RECEIPT_FILENAME = "schema-inference-gate-receipt.json"
 
 _ALLOWED_RESIDUAL_EXPLANATIONS = frozenset(
     {"materialized", "superseded-duplicate", "legitimately-excluded-non-conversation"}
 )
 _CAUSE_EXPLANATIONS = {"byte-revision-governed": "superseded-duplicate"}
 
-# These are declared inputs for the existing corpus reconciliation. The gate
-# records them in every receipt so a later run cannot be mistaken for a run
-# against a different acquisition corpus. Hooks and browser capture are the
-# explicit no-external-ground-truth exceptions from r9xsj.
+# Hooks and browser capture are the explicit no-external-ground-truth
+# exceptions from r9xsj. Every other origin present in source.db must receive
+# a caller-declared, readable external root and is reconciled by content hash.
 GROUND_TRUTH_INPUTS: dict[str, dict[str, object]] = {
     "codex-session": {
-        "paths": [
-            "~/.codex/sessions",
-            "~/.codex/state_5.sqlite",
-            "~/.codex/goals_1.sqlite",
-            "~/.codex/memories_1.sqlite",
-        ],
         "exempt": False,
     },
     "claude-code-session": {
-        "paths": ["~/.claude/projects", "source.db:raw_artifacts", "source.db:history_sidecars"],
         "exempt": False,
     },
-    "chatgpt-export": {"paths": ["/realm/data/exports/chatlog"], "exempt": False},
-    "claude-ai-export": {"paths": ["/realm/data/exports/chatlog"], "exempt": False},
-    "aistudio-drive": {"paths": ["/realm/data/exports/chatlog"], "exempt": False},
-    "grok-export": {"paths": ["/realm/data/exports/chatlog"], "exempt": False},
-    "hermes-session": {
-        "paths": [
-            "~/.hermes/sessions",
-            "~/.hermes/state.db",
-            "~/.hermes/verification_evidence.db",
-            "~/.hermes/observability",
-        ],
-        "exempt": False,
-    },
-    "antigravity-session": {"paths": ["~/.gemini/antigravity/brain"], "exempt": False},
-    "gemini-cli-session": {"paths": ["~/.gemini/tmp"], "exempt": False},
+    "chatgpt-export": {"exempt": False},
+    "claude-ai-export": {"exempt": False},
+    "aistudio-drive": {"exempt": False},
+    "grok-export": {"exempt": False},
+    "hermes-session": {"exempt": False},
+    "antigravity-session": {"exempt": False},
+    "gemini-cli-session": {"exempt": False},
     "hooks": {
         "paths": ["source.db:raw_hook_events"],
         "exempt": True,
@@ -152,18 +138,19 @@ def _source_counts(conn: sqlite3.Connection) -> dict[str, dict[str, int]]:
     }
 
 
+def _referenced_blob_hashes(conn: sqlite3.Connection) -> set[str]:
+    """Return the durable source-tier blob universe as canonical hashes."""
+
+    sql = "SELECT blob_hash FROM raw_sessions"
+    if table_exists(conn, "blob_refs"):
+        sql += " UNION SELECT blob_hash FROM blob_refs"
+    return {bytes(row[0]).hex() for row in conn.execute(sql) if row[0] is not None}
+
+
 def _source_blob_denominators(conn: sqlite3.Connection) -> dict[str, int]:
     """Return the source-tier hash universe an independent blob scan must cover."""
 
-    if table_exists(conn, "blob_refs"):
-        distinct_hashes = int(
-            conn.execute(
-                "SELECT COUNT(*) FROM (SELECT blob_hash FROM raw_sessions UNION SELECT blob_hash FROM blob_refs)"
-            ).fetchone()[0]
-        )
-    else:
-        distinct_hashes = int(conn.execute("SELECT COUNT(DISTINCT blob_hash) FROM raw_sessions").fetchone()[0])
-    return {"distinct_referenced_blob_hashes": distinct_hashes}
+    return {"distinct_referenced_blob_hashes": len(_referenced_blob_hashes(conn))}
 
 
 def _duplicate_gate(
@@ -252,7 +239,46 @@ def _duplicate_gate(
                 continue
 
             if str(row["census_status"] or "") == "non_session":
-                resolved_by_rule["legitimately-excluded-non-conversation"] += 1
+                exclusion = source.execute(
+                    """
+                    SELECT blob_hash, blob_size, indexed_twin_raw_id,
+                           indexed_twin_session_id, parser_fingerprint
+                    FROM raw_non_session_duplicate_exclusion_receipts
+                    WHERE raw_id = ?
+                    """,
+                    (raw_id,),
+                ).fetchone()
+                if exclusion is not None:
+                    exclusion_hash = bytes(exclusion[0]).hex()
+                    exclusion_twin_ok = source.execute(
+                        """
+                        SELECT 1
+                        FROM raw_sessions twin
+                        JOIN idx_tier.sessions twin_session ON twin_session.raw_id = twin.raw_id
+                        WHERE twin.raw_id = ? AND twin_session.session_id = ?
+                          AND twin.blob_hash = ? AND twin.blob_size = ?
+                        """,
+                        (
+                            str(exclusion[2]),
+                            str(exclusion[3]),
+                            bytes.fromhex(str(row["blob_hash"])),
+                            int(row["blob_size"]),
+                        ),
+                    ).fetchone()
+                    if (
+                        exclusion_hash == str(row["blob_hash"]).lower()
+                        and int(exclusion[1]) == int(row["blob_size"])
+                        and bool(str(exclusion[4]).strip())
+                        and exclusion_twin_ok
+                    ):
+                        resolved_by_rule["legitimately-excluded-non-conversation"] += 1
+                        continue
+                invalid_receipts.append(
+                    {
+                        "raw_id": raw_id,
+                        "reason": "non-session exclusion lacks a content-bound receipt to an indexed twin",
+                    }
+                )
                 continue
             unresolved.append(
                 {
@@ -402,82 +428,173 @@ def _tier_schema_identity(archive_root: Path, location: ArchiveLocation) -> dict
     return {"archive": ArchiveIdentity.resolve_location(location).as_dict(), "tiers": tiers}
 
 
-def _required_string(mapping: Mapping[str, object], key: str) -> str:
-    value = mapping.get(key)
-    if not isinstance(value, str) or not value.strip():
-        raise SchemaInferenceGateError(f"blob hash receipt field {key!r} must be a non-empty string")
-    return value
+def _resolve_receipt_path(receipt_path: Path, *, archive_root: Path) -> Path:
+    """Accept only the dedicated receipt filename outside the archive file set."""
 
-
-def _validate_blob_hash_receipt(
-    path: Path,
-    *,
-    archive_root: Path,
-    source_version: int | None,
-    expected_referenced_hashes: int,
-) -> dict[str, object]:
-    result: dict[str, object] = {"path": str(path), "schema": BLOB_HASH_RECEIPT_SCHEMA, "passed": False}
+    target = receipt_path.expanduser().resolve()
+    root = archive_root.resolve()
+    if target.name != RECEIPT_FILENAME:
+        raise SchemaInferenceGateError(f"receipt filename must be {RECEIPT_FILENAME!r}")
     try:
-        document = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        result["reason"] = f"could not read full blob-hash receipt: {exc}"
-        return result
-    if not isinstance(document, dict):
-        result["reason"] = "full blob-hash receipt root must be an object"
-        return result
-    result["input"] = document
+        target.relative_to(root)
+    except ValueError:
+        return target
+    raise SchemaInferenceGateError("receipt path must be outside the archive root")
+
+
+def _snapshot_blob_root(blob_root: Path) -> dict[str, object]:
+    """Fingerprint the canonical namespace before and after full verification."""
+
+    entries: list[dict[str, object]] = []
+    for entry in BlobStore(blob_root).iter_namespace():
+        item: dict[str, object] = {
+            "path": entry.relative_path,
+            "kind": entry.kind.value,
+            "hash": entry.hash_hex,
+            "issue": entry.issue.value if entry.issue is not None else None,
+        }
+        try:
+            stat = entry.path.stat()
+            item["size"] = stat.st_size
+            item["inode"] = stat.st_ino
+            item["mtime_ns"] = stat.st_mtime_ns
+        except OSError as exc:
+            item["stat_error"] = str(exc)
+        entries.append(item)
+    encoded = json.dumps(entries, sort_keys=True, separators=(",", ":")).encode()
+    return {
+        "path": str(blob_root),
+        "entry_count": len(entries),
+        "canonical_blob_count": sum(1 for entry in entries if entry["kind"] == "blob"),
+        "digest": hashlib.sha256(encoded).hexdigest(),
+    }
+
+
+def _full_blob_hash_evidence(archive_root: Path, *, referenced_hashes: set[str]) -> dict[str, object]:
+    """Run the production BlobStore full verification route and bind its snapshot."""
+
+    blob_root = archive_root / "blob"
+    before = _snapshot_blob_root(blob_root)
+    verification = BlobStore(blob_root).verify_all(max_failures=100)
+    after = _snapshot_blob_root(blob_root)
+    canonical_hashes = set(BlobStore(blob_root).iter_all())
+    missing_references = sorted(referenced_hashes - canonical_hashes)
     errors: list[str] = []
-    if document.get("schema") != BLOB_HASH_RECEIPT_SCHEMA:
-        errors.append(f"schema must be {BLOB_HASH_RECEIPT_SCHEMA!r}")
-    if document.get("archive_root") != str(archive_root.absolute()):
-        errors.append("archive_root does not match the requested archive")
-    if document.get("source_schema_version") != source_version:
-        errors.append("source_schema_version does not match source.db")
-    if document.get("mode") != "full":
-        errors.append("mode must be 'full'")
-    if document.get("verdict") != "PASS":
-        errors.append("verdict must be PASS")
-    if document.get("findings") not in ([], None):
-        errors.append("findings must be empty")
-    try:
-        tool_version = _required_string(document, "tool_version")
-        result["tool_version"] = tool_version
-    except SchemaInferenceGateError as exc:
-        errors.append(str(exc))
-    input_paths = document.get("input_paths")
-    if not isinstance(input_paths, dict) or not input_paths:
-        errors.append("input_paths must be a non-empty object")
-    else:
-        result["input_paths"] = input_paths
-    counts = document.get("counts")
-    if not isinstance(counts, dict):
-        errors.append("counts must be an object")
-    else:
-        for name in ("scanned_blobs", "total_blobs_seen", "scanned_references", "total_references_seen"):
-            value = counts.get(name)
-            if not isinstance(value, int) or value < 0:
-                errors.append(f"counts.{name} must be a non-negative integer")
-        if all(isinstance(counts.get(name), int) for name in ("scanned_blobs", "total_blobs_seen")) and counts.get(
-            "scanned_blobs"
-        ) != counts.get("total_blobs_seen"):
-            errors.append("full scan must scan every blob seen")
-        if all(
-            isinstance(counts.get(name), int) for name in ("scanned_references", "total_references_seen")
-        ) and counts.get("scanned_references") != counts.get("total_references_seen"):
-            errors.append("full scan must scan every reference seen")
-        total_references = counts.get("total_references_seen")
-        total_blobs = counts.get("total_blobs_seen")
-        if isinstance(total_references, int) and total_references != expected_referenced_hashes:
-            errors.append(
-                "total_references_seen does not match the source-tier distinct referenced blob-hash denominator"
-            )
-        if isinstance(total_blobs, int) and total_blobs < expected_referenced_hashes:
-            errors.append("total_blobs_seen is smaller than the source-tier distinct referenced blob-hash denominator")
-    result["errors"] = errors
-    result["passed"] = not errors
-    if errors:
-        result["reason"] = "; ".join(errors)
-    return result
+    if before["digest"] != after["digest"]:
+        errors.append("blob-root snapshot changed during full verification")
+    if verification.failures:
+        errors.append("BlobStore.verify_all reported integrity failures")
+    if verification.truncated:
+        errors.append("BlobStore.verify_all truncated before a complete result")
+    if missing_references:
+        errors.append("referenced source blobs are absent from the verified blob root")
+    return {
+        "passed": not errors,
+        "verifier": {
+            "identity": "polylogue.storage.blob_store.BlobStore.verify_all",
+            "polylogue_version": POLYLOGUE_VERSION,
+        },
+        "before_snapshot": before,
+        "after_snapshot": after,
+        "counts": {
+            "scanned_blobs": verification.checked,
+            "scanned_bytes": verification.checked_bytes,
+            "referenced_hashes": len(referenced_hashes),
+            "missing_referenced_hashes": len(missing_references),
+        },
+        "failures": [
+            {"hash": failure.hash, "reason": failure.reason, "detail": failure.detail, "path": failure.path}
+            for failure in verification.failures
+        ],
+        "missing_references": _sample(missing_references, DEFAULT_SAMPLE_LIMIT),
+        "errors": errors,
+        "reason": "; ".join(errors) if errors else None,
+    }
+
+
+def _iter_ground_truth_files(root: Path) -> Iterable[Path]:
+    if root.is_file():
+        yield root
+        return
+    for path in sorted(root.rglob("*")):
+        if path.is_file():
+            yield path
+
+
+def _file_hash(path: Path) -> tuple[str, int]:
+    hasher = hashlib.sha256()
+    size = 0
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            hasher.update(chunk)
+            size += len(chunk)
+    return hasher.hexdigest(), size
+
+
+def _ground_truth_evidence(
+    archive_root: Path,
+    *,
+    source_counts: Mapping[str, Mapping[str, int]],
+    roots: Mapping[str, Sequence[Path]] | None,
+) -> dict[str, object]:
+    """Compare source raw blobs with the files actually present under declared roots."""
+
+    root_map = roots or {}
+    source_path = archive_root / ARCHIVE_TIER_SPECS[ArchiveTier.SOURCE].filename
+    evidence: dict[str, object] = {}
+    errors: list[str] = []
+    with open_readonly_connection(source_path) as source:
+        for origin in sorted(source_counts):
+            declared = GROUND_TRUTH_INPUTS.get(origin, {"exempt": False})
+            if bool(declared.get("exempt")):
+                evidence[origin] = {"exempt": True, "reason": declared.get("reason")}
+                continue
+            declared_roots = tuple(Path(path).expanduser().resolve() for path in root_map.get(origin, ()))
+            unavailable = [str(path) for path in declared_roots if not path.exists()]
+            if not declared_roots or unavailable:
+                errors.append(f"ground truth for {origin} is unavailable or undeclared")
+                evidence[origin] = {
+                    "exempt": False,
+                    "declared_roots": [str(path) for path in declared_roots],
+                    "unavailable_roots": unavailable,
+                    "passed": False,
+                }
+                continue
+            files = [path for root in declared_roots for path in _iter_ground_truth_files(root)]
+            hashes: set[str] = set()
+            bytes_total = 0
+            try:
+                for path in files:
+                    digest, size = _file_hash(path)
+                    hashes.add(digest)
+                    bytes_total += size
+            except OSError as exc:
+                errors.append(f"ground truth for {origin} could not be fully scanned: {exc}")
+                evidence[origin] = {
+                    "exempt": False,
+                    "declared_roots": [str(path) for path in declared_roots],
+                    "passed": False,
+                }
+                continue
+            source_hashes = {
+                bytes(row[0]).hex()
+                for row in source.execute("SELECT DISTINCT blob_hash FROM raw_sessions WHERE origin = ?", (origin,))
+            }
+            missing = sorted(source_hashes - hashes)
+            if missing:
+                errors.append(f"ground truth for {origin} does not verify every source raw blob")
+            evidence[origin] = {
+                "exempt": False,
+                "declared_roots": [str(path) for path in declared_roots],
+                "external_files": len(files),
+                "external_bytes": bytes_total,
+                "external_hashes": len(hashes),
+                "source_blob_hashes": len(source_hashes),
+                "unverified_source_blob_hashes": len(missing),
+                "unverified_samples": _sample(missing, DEFAULT_SAMPLE_LIMIT),
+                "passed": not missing,
+            }
+    return {"passed": not errors, "origins": evidence, "reasons": errors}
 
 
 def _fidelity_evidence(report: object) -> dict[str, object]:
@@ -630,8 +747,8 @@ def _write_json(path: Path, payload: dict[str, object]) -> None:
 def run_schema_inference_gate(
     archive_root: Path,
     *,
-    blob_hash_receipt: Path,
     receipt_path: Path,
+    ground_truth_roots: Mapping[str, Sequence[Path]] | None = None,
     sample_limit: int = DEFAULT_SAMPLE_LIMIT,
 ) -> SchemaInferenceGateResult:
     """Run and persist the schema-inference prerequisite receipt."""
@@ -639,6 +756,7 @@ def run_schema_inference_gate(
     if sample_limit <= 0:
         raise SchemaInferenceGateError("sample_limit must be positive")
     root = Path(archive_root).absolute()
+    safe_receipt_path = _resolve_receipt_path(Path(receipt_path), archive_root=root)
     try:
         location = ArchiveLocation.resolve(root)
         index_path = location.active_index_path
@@ -648,27 +766,40 @@ def run_schema_inference_gate(
         index_path = root / "index.db"
 
     source_entry = _as_dict(_as_dict(schema_identity.get("tiers")).get("source"))
-    source_version = source_entry.get("actual_user_version")
-    source_schema_version = int(source_version) if isinstance(source_version, int) else None
     source_schema_ok = bool(source_entry.get("matches_expected"))
 
     try:
         source_gates = _run_source_gates(root, index_path=index_path, sample_limit=sample_limit)
     except (OSError, sqlite3.Error) as exc:
         source_gates = _failed_source_gates(f"source-tier read failed: {exc}")
+    blob_denominators = _as_dict(source_gates.get("blob_denominators"))
     try:
         corpus_report = verify_archive(root, checks=CORPUS_FIDELITY_CHECKS, sample_limit=sample_limit)
         fidelity = _fidelity_evidence(corpus_report)
     except Exception as exc:
         fidelity = {"report": {}, "typed_residuals": [], "passed": False, "reasons": [f"corpus audit raised: {exc}"]}
-    blob_denominators = _as_dict(source_gates.get("blob_denominators"))
-    expected_referenced_hashes = _int_or_zero(blob_denominators.get("distinct_referenced_blob_hashes"))
-    hash_receipt = _validate_blob_hash_receipt(
-        Path(blob_hash_receipt),
-        archive_root=root,
-        source_version=source_schema_version,
-        expected_referenced_hashes=expected_referenced_hashes,
-    )
+    try:
+        with open_readonly_connection(root / "source.db") as source:
+            referenced_hashes = _referenced_blob_hashes(source)
+        full_blob_hash_verification = _full_blob_hash_evidence(root, referenced_hashes=referenced_hashes)
+    except (OSError, sqlite3.Error) as exc:
+        full_blob_hash_verification = {
+            "passed": False,
+            "errors": [f"full BlobStore verification could not read source evidence: {exc}"],
+            "reason": f"full BlobStore verification could not read source evidence: {exc}",
+        }
+    try:
+        ground_truth = _ground_truth_evidence(
+            root,
+            source_counts=cast(Mapping[str, Mapping[str, int]], source_gates.get("source_counts", {})),
+            roots=ground_truth_roots,
+        )
+    except (OSError, sqlite3.Error) as exc:
+        ground_truth = {
+            "passed": False,
+            "origins": {},
+            "reasons": [f"ground truth reconciliation could not read source evidence: {exc}"],
+        }
 
     gate_results = _as_dict(source_gates.get("gates"))
     duplicate_gate = source_gates.get("duplicate_gate", {})
@@ -684,8 +815,12 @@ def run_schema_inference_gate(
         fidelity_reasons = fidelity.get("reasons", [])
         if isinstance(fidelity_reasons, list):
             reasons.extend(str(reason) for reason in fidelity_reasons)
-    if not bool(hash_receipt.get("passed")):
-        reasons.append(str(hash_receipt.get("reason") or "full blob-hash verification receipt is not a PASS"))
+    if not bool(full_blob_hash_verification.get("passed")):
+        reasons.append(str(full_blob_hash_verification.get("reason") or "full BlobStore verification is not a PASS"))
+    if not bool(ground_truth.get("passed")):
+        ground_truth_reasons = ground_truth.get("reasons", [])
+        if isinstance(ground_truth_reasons, list):
+            reasons.extend(str(reason) for reason in ground_truth_reasons)
 
     payload: dict[str, object] = {
         "schema": RECEIPT_SCHEMA,
@@ -699,15 +834,15 @@ def run_schema_inference_gate(
         "source_denominators": source_gates.get("source_counts", {}),
         "blob_denominators": blob_denominators,
         "ground_truth_denominators": fidelity.get("denominators", {}),
-        "ground_truth_inputs": GROUND_TRUTH_INPUTS,
+        "ground_truth_inputs": ground_truth,
         "exemptions": {name: value for name, value in GROUND_TRUTH_INPUTS.items() if bool(value.get("exempt"))},
         "corpus_fidelity": fidelity,
-        "full_blob_hash_verification": hash_receipt,
+        "full_blob_hash_verification": full_blob_hash_verification,
         "input_paths": {
             "archive_root": str(root),
             "source_db": str(root / "source.db"),
             "active_index_db": str(index_path),
-            "blob_hash_receipt": str(Path(blob_hash_receipt).absolute()),
+            "receipt": str(safe_receipt_path),
         },
         "tool_versions": {
             "polylogue": POLYLOGUE_VERSION,
@@ -718,14 +853,14 @@ def run_schema_inference_gate(
         },
         "pass_fail_reasons": reasons,
     }
-    _write_json(Path(receipt_path), payload)
+    _write_json(safe_receipt_path, payload)
     return SchemaInferenceGateResult(payload)
 
 
 __all__ = [
-    "BLOB_HASH_RECEIPT_SCHEMA",
     "DEFAULT_SAMPLE_LIMIT",
     "GROUND_TRUTH_INPUTS",
+    "RECEIPT_FILENAME",
     "RECEIPT_SCHEMA",
     "SchemaInferenceGateError",
     "SchemaInferenceGateResult",

--- a/polylogue/maintenance/schema_inference_gate.py
+++ b/polylogue/maintenance/schema_inference_gate.py
@@ -1,0 +1,733 @@
+"""Read-only go/no-go receipt for the schema-inference prerequisite.
+
+This gate composes the existing corpus-fidelity registry with the four
+source-tier hard gates named by polylogue-r9xsj. It never runs a repair or
+cleanup actuator. SQLite inputs are opened through the repository's
+read-only connection helper; the only write is the caller-selected JSON
+receipt path.
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+import sqlite3
+import sys
+from collections import Counter
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, cast
+
+from polylogue.maintenance.archive_verification import CORPUS_FIDELITY_CHECKS, verify_archive
+from polylogue.storage.archive_identity import ArchiveIdentity, ArchiveLocation
+from polylogue.storage.introspection import table_exists
+from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.connection_profile import open_readonly_connection
+from polylogue.version import POLYLOGUE_VERSION
+
+RECEIPT_SCHEMA = "polylogue.schema-inference-gate.v1"
+BLOB_HASH_RECEIPT_SCHEMA = "polylogue.blob-hash-verification.v1"
+GATE_VERSION = "1"
+DEFAULT_SAMPLE_LIMIT = 10
+
+_ALLOWED_RESIDUAL_EXPLANATIONS = frozenset(
+    {"materialized", "superseded-duplicate", "legitimately-excluded-non-conversation"}
+)
+_CAUSE_EXPLANATIONS = {"byte-revision-governed": "superseded-duplicate"}
+
+# These are declared inputs for the existing corpus reconciliation. The gate
+# records them in every receipt so a later run cannot be mistaken for a run
+# against a different acquisition corpus. Hooks and browser capture are the
+# explicit no-external-ground-truth exceptions from r9xsj.
+GROUND_TRUTH_INPUTS: dict[str, dict[str, object]] = {
+    "codex-session": {
+        "paths": [
+            "~/.codex/sessions",
+            "~/.codex/state_5.sqlite",
+            "~/.codex/goals_1.sqlite",
+            "~/.codex/memories_1.sqlite",
+        ],
+        "exempt": False,
+    },
+    "claude-code-session": {
+        "paths": ["~/.claude/projects", "source.db:raw_artifacts", "source.db:history_sidecars"],
+        "exempt": False,
+    },
+    "chatgpt-export": {"paths": ["/realm/data/exports/chatlog"], "exempt": False},
+    "claude-ai-export": {"paths": ["/realm/data/exports/chatlog"], "exempt": False},
+    "aistudio-drive": {"paths": ["/realm/data/exports/chatlog"], "exempt": False},
+    "grok-export": {"paths": ["/realm/data/exports/chatlog"], "exempt": False},
+    "hermes-session": {
+        "paths": [
+            "~/.hermes/sessions",
+            "~/.hermes/state.db",
+            "~/.hermes/verification_evidence.db",
+            "~/.hermes/observability",
+        ],
+        "exempt": False,
+    },
+    "antigravity-session": {"paths": ["~/.gemini/antigravity/brain"], "exempt": False},
+    "gemini-cli-session": {"paths": ["~/.gemini/tmp"], "exempt": False},
+    "hooks": {
+        "paths": ["source.db:raw_hook_events"],
+        "exempt": True,
+        "reason": "hooks are the live origin and have no external filesystem ground truth",
+    },
+    "browser-capture": {
+        "paths": ["source.db:raw_sessions"],
+        "exempt": True,
+        "reason": "browser capture is the origin and has no re-scannable external export",
+    },
+}
+
+_HARD_GATE_SQL: dict[str, str] = {
+    "zero-surviving-quarantine": "SELECT COUNT(*) FROM raw_sessions WHERE revision_authority = 'quarantined'",
+    "zero-quarantine-without-logical-source-key": (
+        "SELECT COUNT(*) FROM raw_sessions WHERE revision_authority = 'quarantined' AND logical_source_key IS NULL"
+    ),
+    "zero-unresolved-raw-authority-blockers": (
+        "SELECT COUNT(*) FROM raw_authority_blockers WHERE resolved_at_ms IS NULL"
+    ),
+}
+
+
+class SchemaInferenceGateError(ValueError):
+    """The gate input or receipt shape is invalid."""
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaInferenceGateResult:
+    """The durable receipt payload and its process exit verdict."""
+
+    payload: dict[str, object]
+
+    @property
+    def passed(self) -> bool:
+        return self.payload.get("verdict") == "PASS"
+
+
+def _sample(values: list[str], limit: int) -> list[str]:
+    return values[:limit]
+
+
+def _query_count(
+    conn: sqlite3.Connection,
+    *,
+    gate_id: str,
+    sql: str,
+    sample_sql: str,
+    sample_limit: int,
+) -> dict[str, object]:
+    count = int(conn.execute(sql).fetchone()[0])
+    samples = [str(row[0]) for row in conn.execute(sample_sql, (sample_limit,))]
+    return {
+        "gate": gate_id,
+        "sql": sql,
+        "count": count,
+        "samples": samples,
+        "passed": count == 0,
+        "reason": None if count == 0 else f"{count} row(s) matched the required zero-result query",
+    }
+
+
+def _source_counts(conn: sqlite3.Connection) -> dict[str, dict[str, int]]:
+    rows = conn.execute(
+        """
+        SELECT origin, COUNT(*), COUNT(DISTINCT blob_hash), COALESCE(SUM(blob_size), 0)
+        FROM raw_sessions
+        GROUP BY origin
+        ORDER BY origin
+        """
+    ).fetchall()
+    return {
+        str(origin): {
+            "raw_rows": int(raw_rows),
+            "distinct_blobs": int(distinct_blobs),
+            "bytes": int(bytes_total),
+        }
+        for origin, raw_rows, distinct_blobs, bytes_total in rows
+    }
+
+
+def _source_blob_denominators(conn: sqlite3.Connection) -> dict[str, int]:
+    """Return the source-tier hash universe an independent blob scan must cover."""
+
+    if table_exists(conn, "blob_refs"):
+        distinct_hashes = int(
+            conn.execute(
+                "SELECT COUNT(*) FROM (SELECT blob_hash FROM raw_sessions UNION SELECT blob_hash FROM blob_refs)"
+            ).fetchone()[0]
+        )
+    else:
+        distinct_hashes = int(conn.execute("SELECT COUNT(DISTINCT blob_hash) FROM raw_sessions").fetchone()[0])
+    return {"distinct_referenced_blob_hashes": distinct_hashes}
+
+
+def _duplicate_gate(
+    source: sqlite3.Connection,
+    *,
+    index_path: Path,
+    sample_limit: int,
+) -> dict[str, object]:
+    """Classify every duplicate of an indexed twin under explicit rules."""
+
+    sql = (
+        "raw_sessions rows sharing blob_hash with an indexed twin, excluding "
+        "materialized rows, valid supersession receipts, and typed "
+        "non-session census rows"
+    )
+    source.row_factory = sqlite3.Row
+    try:
+        source.execute("ATTACH DATABASE ? AS idx_tier", (f"file:{index_path}?mode=ro",))
+        has_receipts = table_exists(source, "raw_byte_duplicate_supersession_receipts")
+        has_census = table_exists(source, "raw_membership_census")
+        census_status = (
+            "(SELECT c.status FROM raw_membership_census c WHERE c.raw_id = r.raw_id)" if has_census else "NULL"
+        )
+        rows = source.execute(
+            f"""
+            SELECT r.raw_id, hex(r.blob_hash) AS blob_hash, r.blob_size,
+                   {census_status} AS census_status,
+                   EXISTS(SELECT 1 FROM idx_tier.sessions own WHERE own.raw_id = r.raw_id) AS own_indexed
+            FROM raw_sessions r
+            WHERE EXISTS (
+                SELECT 1
+                FROM raw_sessions twin
+                JOIN idx_tier.sessions twin_session ON twin_session.raw_id = twin.raw_id
+                WHERE twin.blob_hash = r.blob_hash AND twin.raw_id != r.raw_id
+            )
+            ORDER BY r.raw_id
+            """
+        ).fetchall()
+
+        unresolved: list[dict[str, object]] = []
+        invalid_receipts: list[dict[str, object]] = []
+        resolved_by_rule: Counter[str] = Counter()
+        for row in rows:
+            raw_id = str(row["raw_id"])
+            if bool(row["own_indexed"]):
+                resolved_by_rule["materialized"] += 1
+                continue
+
+            receipt = None
+            if has_receipts:
+                receipt = source.execute(
+                    "SELECT blob_hash, duplicate_of_raw_id, duplicate_of_session_id, blob_size "
+                    "FROM raw_byte_duplicate_supersession_receipts WHERE raw_id = ?",
+                    (raw_id,),
+                ).fetchone()
+            if receipt is not None:
+                receipt_hash = bytes(receipt[0]).hex()
+                twin_ok = source.execute(
+                    """
+                    SELECT 1
+                    FROM raw_sessions twin
+                    JOIN idx_tier.sessions twin_session ON twin_session.raw_id = twin.raw_id
+                    WHERE twin.raw_id = ? AND twin_session.session_id = ?
+                      AND twin.blob_hash = ? AND twin.blob_size = ?
+                    """,
+                    (
+                        str(receipt[1]),
+                        str(receipt[2]),
+                        bytes.fromhex(str(row["blob_hash"])),
+                        int(row["blob_size"]),
+                    ),
+                ).fetchone()
+                if (
+                    receipt_hash == str(row["blob_hash"]).lower()
+                    and int(receipt[3]) == int(row["blob_size"])
+                    and twin_ok
+                ):
+                    resolved_by_rule["superseded-duplicate"] += 1
+                    continue
+                invalid_receipts.append(
+                    {
+                        "raw_id": raw_id,
+                        "reason": "supersession receipt does not match raw hash/size and indexed twin",
+                    }
+                )
+                continue
+
+            if str(row["census_status"] or "") == "non_session":
+                resolved_by_rule["legitimately-excluded-non-conversation"] += 1
+                continue
+            unresolved.append(
+                {
+                    "raw_id": raw_id,
+                    "blob_hash": str(row["blob_hash"]).lower(),
+                    "blob_size": int(row["blob_size"]),
+                    "reason": "no materialization, valid supersession receipt, or typed exclusion",
+                }
+            )
+    finally:
+        source.row_factory = None
+
+    failure_count = len(unresolved) + len(invalid_receipts)
+    return {
+        "gate": "zero-unexplained-byte-duplicates",
+        "rule": sql,
+        "receipt_table_present": has_receipts,
+        "candidate_count": len(rows),
+        "resolved_by_rule": dict(sorted(resolved_by_rule.items())),
+        "unresolved_count": len(unresolved),
+        "unresolved": unresolved[:sample_limit],
+        "invalid_receipt_count": len(invalid_receipts),
+        "invalid_receipts": invalid_receipts[:sample_limit],
+        "count": failure_count,
+        "passed": failure_count == 0,
+        "reason": None
+        if failure_count == 0
+        else f"{failure_count} duplicate disposition(s) are unexplained or invalid",
+    }
+
+
+def _run_source_gates(archive_root: Path, *, index_path: Path, sample_limit: int) -> dict[str, object]:
+    source_path = archive_root / ARCHIVE_TIER_SPECS[ArchiveTier.SOURCE].filename
+    if not source_path.exists() or not index_path.exists():
+        return {
+            "gates": {
+                gate: {
+                    "gate": gate,
+                    "sql": sql,
+                    "count": 1,
+                    "samples": [],
+                    "passed": False,
+                    "reason": "required source.db or active index.db is missing",
+                }
+                for gate, sql in _HARD_GATE_SQL.items()
+            },
+            "duplicate_gate": {
+                "gate": "zero-unexplained-byte-duplicates",
+                "count": 1,
+                "passed": False,
+                "reason": "required source.db or active index.db is missing",
+            },
+            "source_counts": {},
+            "blob_denominators": {"distinct_referenced_blob_hashes": 0},
+        }
+
+    with open_readonly_connection(source_path) as source:
+        source.row_factory = sqlite3.Row
+        gates = {
+            "zero-surviving-quarantine": _query_count(
+                source,
+                gate_id="zero-surviving-quarantine",
+                sql=_HARD_GATE_SQL["zero-surviving-quarantine"],
+                sample_sql="SELECT raw_id FROM raw_sessions WHERE revision_authority = 'quarantined' ORDER BY raw_id LIMIT ?",
+                sample_limit=sample_limit,
+            ),
+            "zero-quarantine-without-logical-source-key": _query_count(
+                source,
+                gate_id="zero-quarantine-without-logical-source-key",
+                sql=_HARD_GATE_SQL["zero-quarantine-without-logical-source-key"],
+                sample_sql="SELECT raw_id FROM raw_sessions WHERE revision_authority = 'quarantined' AND logical_source_key IS NULL ORDER BY raw_id LIMIT ?",
+                sample_limit=sample_limit,
+            ),
+        }
+        if table_exists(source, "raw_authority_blockers"):
+            gates["zero-unresolved-raw-authority-blockers"] = _query_count(
+                source,
+                gate_id="zero-unresolved-raw-authority-blockers",
+                sql=_HARD_GATE_SQL["zero-unresolved-raw-authority-blockers"],
+                sample_sql="SELECT blocker_id FROM raw_authority_blockers WHERE resolved_at_ms IS NULL ORDER BY blocker_id LIMIT ?",
+                sample_limit=sample_limit,
+            )
+        else:
+            gates["zero-unresolved-raw-authority-blockers"] = {
+                "gate": "zero-unresolved-raw-authority-blockers",
+                "sql": _HARD_GATE_SQL["zero-unresolved-raw-authority-blockers"],
+                "count": 1,
+                "samples": [],
+                "passed": False,
+                "reason": "required raw_authority_blockers table is missing",
+            }
+        source_counts = _source_counts(source)
+        blob_denominators = _source_blob_denominators(source)
+        duplicate_gate = _duplicate_gate(source, index_path=index_path, sample_limit=sample_limit)
+    return {
+        "gates": gates,
+        "duplicate_gate": duplicate_gate,
+        "source_counts": source_counts,
+        "blob_denominators": blob_denominators,
+    }
+
+
+def _failed_source_gates(reason: str) -> dict[str, object]:
+    gates = {
+        gate: {
+            "gate": gate,
+            "sql": sql,
+            "count": 1,
+            "samples": [],
+            "passed": False,
+            "reason": reason,
+        }
+        for gate, sql in _HARD_GATE_SQL.items()
+    }
+    return {
+        "gates": gates,
+        "duplicate_gate": {
+            "gate": "zero-unexplained-byte-duplicates",
+            "count": 1,
+            "passed": False,
+            "reason": reason,
+        },
+        "source_counts": {},
+        "blob_denominators": {"distinct_referenced_blob_hashes": 0},
+    }
+
+
+def _tier_schema_identity(archive_root: Path, location: ArchiveLocation) -> dict[str, object]:
+    tiers: dict[str, object] = {}
+    for tier, spec in ARCHIVE_TIER_SPECS.items():
+        path = location.active_index_path if tier is ArchiveTier.INDEX else archive_root / spec.filename
+        entry: dict[str, object] = {
+            "path": str(path),
+            "expected_user_version": spec.version,
+            "durability": spec.durability,
+            "exists": path.exists(),
+            "actual_user_version": None,
+        }
+        if path.exists():
+            try:
+                with open_readonly_connection(path) as conn:
+                    entry["actual_user_version"] = int(conn.execute("PRAGMA user_version").fetchone()[0])
+            except sqlite3.Error as exc:
+                entry["error"] = str(exc)
+        entry["matches_expected"] = entry["actual_user_version"] == spec.version
+        tiers[tier.value] = entry
+    return {"archive": ArchiveIdentity.resolve_location(location).as_dict(), "tiers": tiers}
+
+
+def _required_string(mapping: Mapping[str, object], key: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise SchemaInferenceGateError(f"blob hash receipt field {key!r} must be a non-empty string")
+    return value
+
+
+def _validate_blob_hash_receipt(
+    path: Path,
+    *,
+    archive_root: Path,
+    source_version: int | None,
+    expected_referenced_hashes: int,
+) -> dict[str, object]:
+    result: dict[str, object] = {"path": str(path), "schema": BLOB_HASH_RECEIPT_SCHEMA, "passed": False}
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        result["reason"] = f"could not read full blob-hash receipt: {exc}"
+        return result
+    if not isinstance(document, dict):
+        result["reason"] = "full blob-hash receipt root must be an object"
+        return result
+    result["input"] = document
+    errors: list[str] = []
+    if document.get("schema") != BLOB_HASH_RECEIPT_SCHEMA:
+        errors.append(f"schema must be {BLOB_HASH_RECEIPT_SCHEMA!r}")
+    if document.get("archive_root") != str(archive_root.absolute()):
+        errors.append("archive_root does not match the requested archive")
+    if document.get("source_schema_version") != source_version:
+        errors.append("source_schema_version does not match source.db")
+    if document.get("mode") != "full":
+        errors.append("mode must be 'full'")
+    if document.get("verdict") != "PASS":
+        errors.append("verdict must be PASS")
+    if document.get("findings") not in ([], None):
+        errors.append("findings must be empty")
+    try:
+        tool_version = _required_string(document, "tool_version")
+        result["tool_version"] = tool_version
+    except SchemaInferenceGateError as exc:
+        errors.append(str(exc))
+    input_paths = document.get("input_paths")
+    if not isinstance(input_paths, dict) or not input_paths:
+        errors.append("input_paths must be a non-empty object")
+    else:
+        result["input_paths"] = input_paths
+    counts = document.get("counts")
+    if not isinstance(counts, dict):
+        errors.append("counts must be an object")
+    else:
+        for name in ("scanned_blobs", "total_blobs_seen", "scanned_references", "total_references_seen"):
+            value = counts.get(name)
+            if not isinstance(value, int) or value < 0:
+                errors.append(f"counts.{name} must be a non-negative integer")
+        if all(isinstance(counts.get(name), int) for name in ("scanned_blobs", "total_blobs_seen")) and counts.get(
+            "scanned_blobs"
+        ) != counts.get("total_blobs_seen"):
+            errors.append("full scan must scan every blob seen")
+        if all(
+            isinstance(counts.get(name), int) for name in ("scanned_references", "total_references_seen")
+        ) and counts.get("scanned_references") != counts.get("total_references_seen"):
+            errors.append("full scan must scan every reference seen")
+        total_references = counts.get("total_references_seen")
+        total_blobs = counts.get("total_blobs_seen")
+        if isinstance(total_references, int) and total_references != expected_referenced_hashes:
+            errors.append(
+                "total_references_seen does not match the source-tier distinct referenced blob-hash denominator"
+            )
+        if isinstance(total_blobs, int) and total_blobs < expected_referenced_hashes:
+            errors.append("total_blobs_seen is smaller than the source-tier distinct referenced blob-hash denominator")
+    result["errors"] = errors
+    result["passed"] = not errors
+    if errors:
+        result["reason"] = "; ".join(errors)
+    return result
+
+
+def _fidelity_evidence(report: object) -> dict[str, object]:
+    report_to_json = cast(Any, report).to_json
+    payload = dict(report_to_json())
+    checks = payload.get("checks")
+    if not isinstance(checks, list):
+        return {"report": payload, "passed": False, "reasons": ["corpus report has no checks list"]}
+    by_name: dict[str, dict[str, object]] = {
+        str(check.get("name")): check for check in checks if isinstance(check, dict)
+    }
+    reasons: list[str] = []
+    typed_residuals: list[dict[str, object]] = []
+
+    required_checks = set(CORPUS_FIDELITY_CHECKS)
+    missing_checks = sorted(required_checks - by_name.keys())
+    if missing_checks:
+        reasons.append(f"corpus fidelity checks missing from report: {', '.join(missing_checks)}")
+    for name in CORPUS_FIDELITY_CHECKS:
+        check = by_name.get(name)
+        if check is None:
+            continue
+        status = check.get("status")
+        if status not in {"ok", "error"}:
+            reasons.append(f"corpus fidelity check {name} did not run successfully: status={status!r}")
+
+    def required_count(evidence: dict[str, object], key: str, label: str) -> int:
+        value = evidence.get(key)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            reasons.append(f"corpus fidelity evidence {label}.{key} is missing or invalid")
+            return 0
+        return value
+
+    def nonnegative_mapping(value: object, label: str) -> dict[str, int]:
+        if not isinstance(value, dict):
+            reasons.append(f"corpus fidelity evidence {label} is missing or invalid")
+            return {}
+        normalized: dict[str, int] = {}
+        for key, raw_value in value.items():
+            if not isinstance(raw_value, int) or isinstance(raw_value, bool) or raw_value < 0:
+                reasons.append(f"corpus fidelity evidence {label}.{key} is not a non-negative integer")
+            else:
+                normalized[str(key)] = raw_value
+        return normalized
+
+    absence = by_name.get("corpus-absences", {})
+    absence_evidence = _as_dict(absence.get("evidence"))
+    absent_total = required_count(absence_evidence, "absent_total", "corpus-absences")
+    absent_by_origin = absence_evidence.get("absent_by_origin_cause")
+    if not isinstance(absent_by_origin, dict):
+        reasons.append("corpus fidelity evidence corpus-absences.absent_by_origin_cause is missing or invalid")
+        absent_by_origin = {}
+    per_origin_total = 0
+    for bucket, raw_count in absent_by_origin.items():
+        if not isinstance(raw_count, int) or isinstance(raw_count, bool) or raw_count < 0:
+            reasons.append(f"corpus fidelity evidence corpus-absences.{bucket} is not a non-negative integer")
+            continue
+        count = raw_count
+        per_origin_total += count
+        if count == 0:
+            continue
+        origin, _, cause = str(bucket).partition("/")
+        explanation = _CAUSE_EXPLANATIONS.get(cause)
+        if explanation not in _ALLOWED_RESIDUAL_EXPLANATIONS:
+            reasons.append(f"untyped corpus residual {bucket}={count}; bare quarantine is never accepted")
+        else:
+            typed_residuals.append({"origin": origin, "cause": cause, "count": count, "explanation": explanation})
+    if per_origin_total != absent_total:
+        reasons.append(f"absence aggregate {absent_total} disagrees with per-origin residual total {per_origin_total}")
+    unattributable = required_count(absence_evidence, "raws_without_attributable_identity", "corpus-absences")
+    if unattributable:
+        reasons.append("corpus residual contains raw rows without attributable identity")
+    known_by_origin = nonnegative_mapping(
+        absence_evidence.get("documents_known_by_origin"), "corpus-absences.documents_known_by_origin"
+    )
+    present_by_origin = nonnegative_mapping(
+        absence_evidence.get("documents_present_by_origin"), "corpus-absences.documents_present_by_origin"
+    )
+    documents_known = required_count(absence_evidence, "documents_known", "corpus-absences")
+    documents_present = required_count(absence_evidence, "documents_present", "corpus-absences")
+    if sum(known_by_origin.values()) != documents_known:
+        reasons.append("corpus known-document aggregate disagrees with per-origin denominators")
+    if sum(present_by_origin.values()) != documents_present:
+        reasons.append("corpus present-document aggregate disagrees with per-origin denominators")
+    if documents_present > documents_known or documents_present + absent_total != documents_known:
+        reasons.append("corpus known/present/absent document denominators are inconsistent")
+    for origin in sorted(set(known_by_origin) | set(present_by_origin)):
+        if present_by_origin.get(origin, 0) > known_by_origin.get(origin, 0):
+            reasons.append(f"corpus present denominator exceeds known denominator for {origin}")
+    if absence.get("status") == "error" and not absent_total and not unattributable:
+        reasons.append("corpus-absences reported error without a residual explanation")
+
+    revision = by_name.get("corpus-revision-fidelity", {})
+    revision_evidence = _as_dict(revision.get("evidence"))
+    unexplained_shortfall = required_count(revision_evidence, "unexplained_shortfall", "corpus-revision-fidelity")
+    unexplained_by_origin = revision_evidence.get("unexplained_by_origin")
+    worst = revision_evidence.get("worst")
+    unexplained_by_origin = nonnegative_mapping(unexplained_by_origin, "corpus-revision-fidelity.unexplained_by_origin")
+    if not isinstance(worst, list):
+        reasons.append("corpus fidelity evidence corpus-revision-fidelity.worst is missing or invalid")
+        worst = []
+    if unexplained_shortfall != sum(_int_or_zero(value) for value in unexplained_by_origin.values()):
+        reasons.append("revision aggregate disagrees with per-origin residual total")
+    if unexplained_shortfall or unexplained_by_origin or worst:
+        reasons.append("corpus revision fidelity has an untyped residual")
+    if revision.get("status") == "error" and not unexplained_shortfall and not unexplained_by_origin and not worst:
+        reasons.append("corpus-revision-fidelity reported error without a residual explanation")
+
+    attachment = by_name.get("corpus-attachment-fidelity", {})
+    attachment_evidence = _as_dict(attachment.get("evidence"))
+    refs_unfetched = required_count(attachment_evidence, "refs_unfetched", "corpus-attachment-fidelity")
+    if refs_unfetched:
+        reasons.append("corpus attachment fidelity has unfetched references")
+    if attachment.get("status") == "error" and not refs_unfetched:
+        reasons.append("corpus-attachment-fidelity reported error without a residual explanation")
+
+    skipped = [name for name, check in by_name.items() if check.get("status") == "skip"]
+    if skipped:
+        reasons.append(f"corpus fidelity checks skipped: {', '.join(sorted(skipped))}")
+    return {
+        "report": payload,
+        "typed_residuals": typed_residuals,
+        "passed": not reasons,
+        "reasons": reasons,
+        "denominators": {
+            "documents_known": documents_known,
+            "documents_present": documents_present,
+            "documents_known_by_origin": known_by_origin,
+            "documents_present_by_origin": present_by_origin,
+            "revision_origins": sorted(str(key) for key in _as_dict(revision_evidence.get("explained_by_origin"))),
+        },
+    }
+
+
+def _as_dict(value: object) -> dict[str, object]:
+    return cast(dict[str, object], value) if isinstance(value, dict) else {}
+
+
+def _int_or_zero(value: object) -> int:
+    return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def run_schema_inference_gate(
+    archive_root: Path,
+    *,
+    blob_hash_receipt: Path,
+    receipt_path: Path,
+    sample_limit: int = DEFAULT_SAMPLE_LIMIT,
+) -> SchemaInferenceGateResult:
+    """Run and persist the schema-inference prerequisite receipt."""
+
+    if sample_limit <= 0:
+        raise SchemaInferenceGateError("sample_limit must be positive")
+    root = Path(archive_root).absolute()
+    try:
+        location = ArchiveLocation.resolve(root)
+        index_path = location.active_index_path
+        schema_identity = _tier_schema_identity(root, location)
+    except (OSError, ValueError, RuntimeError) as exc:
+        schema_identity = {"error": str(exc), "tiers": {}}
+        index_path = root / "index.db"
+
+    source_entry = _as_dict(_as_dict(schema_identity.get("tiers")).get("source"))
+    source_version = source_entry.get("actual_user_version")
+    source_schema_version = int(source_version) if isinstance(source_version, int) else None
+    source_schema_ok = bool(source_entry.get("matches_expected"))
+
+    try:
+        source_gates = _run_source_gates(root, index_path=index_path, sample_limit=sample_limit)
+    except (OSError, sqlite3.Error) as exc:
+        source_gates = _failed_source_gates(f"source-tier read failed: {exc}")
+    try:
+        corpus_report = verify_archive(root, checks=CORPUS_FIDELITY_CHECKS, sample_limit=sample_limit)
+        fidelity = _fidelity_evidence(corpus_report)
+    except Exception as exc:
+        fidelity = {"report": {}, "typed_residuals": [], "passed": False, "reasons": [f"corpus audit raised: {exc}"]}
+    blob_denominators = _as_dict(source_gates.get("blob_denominators"))
+    expected_referenced_hashes = _int_or_zero(blob_denominators.get("distinct_referenced_blob_hashes"))
+    hash_receipt = _validate_blob_hash_receipt(
+        Path(blob_hash_receipt),
+        archive_root=root,
+        source_version=source_schema_version,
+        expected_referenced_hashes=expected_referenced_hashes,
+    )
+
+    gate_results = _as_dict(source_gates.get("gates"))
+    duplicate_gate = source_gates.get("duplicate_gate", {})
+    if isinstance(duplicate_gate, dict):
+        gate_results["zero-unexplained-byte-duplicates"] = duplicate_gate
+    passed_hard_gates = all(bool(_as_dict(result).get("passed")) for result in gate_results.values())
+    reasons = [
+        str(_as_dict(result).get("reason")) for result in gate_results.values() if _as_dict(result).get("reason")
+    ]
+    if not source_schema_ok:
+        reasons.append("source.db schema identity is missing or does not match the packaged schema")
+    if not bool(fidelity.get("passed")):
+        fidelity_reasons = fidelity.get("reasons", [])
+        if isinstance(fidelity_reasons, list):
+            reasons.extend(str(reason) for reason in fidelity_reasons)
+    if not bool(hash_receipt.get("passed")):
+        reasons.append(str(hash_receipt.get("reason") or "full blob-hash verification receipt is not a PASS"))
+
+    payload: dict[str, object] = {
+        "schema": RECEIPT_SCHEMA,
+        "gate_version": GATE_VERSION,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "verdict": "PASS" if not reasons and passed_hard_gates else "FAIL",
+        "archive_root": str(root),
+        "schema_identity": schema_identity,
+        "source_schema_identity": source_entry,
+        "query_results": gate_results,
+        "source_denominators": source_gates.get("source_counts", {}),
+        "blob_denominators": blob_denominators,
+        "ground_truth_denominators": fidelity.get("denominators", {}),
+        "ground_truth_inputs": GROUND_TRUTH_INPUTS,
+        "exemptions": {name: value for name, value in GROUND_TRUTH_INPUTS.items() if bool(value.get("exempt"))},
+        "corpus_fidelity": fidelity,
+        "full_blob_hash_verification": hash_receipt,
+        "input_paths": {
+            "archive_root": str(root),
+            "source_db": str(root / "source.db"),
+            "active_index_db": str(index_path),
+            "blob_hash_receipt": str(Path(blob_hash_receipt).absolute()),
+        },
+        "tool_versions": {
+            "polylogue": POLYLOGUE_VERSION,
+            "gate": GATE_VERSION,
+            "python": platform.python_version(),
+            "executable": sys.executable,
+            "corpus_audit": "polylogue.maintenance.corpus_fidelity via archive verification registry",
+        },
+        "pass_fail_reasons": reasons,
+    }
+    _write_json(Path(receipt_path), payload)
+    return SchemaInferenceGateResult(payload)
+
+
+__all__ = [
+    "BLOB_HASH_RECEIPT_SCHEMA",
+    "DEFAULT_SAMPLE_LIMIT",
+    "GROUND_TRUTH_INPUTS",
+    "RECEIPT_SCHEMA",
+    "SchemaInferenceGateError",
+    "SchemaInferenceGateResult",
+    "run_schema_inference_gate",
+]

--- a/polylogue/storage/sqlite/archive_tiers/source.py
+++ b/polylogue/storage/sqlite/archive_tiers/source.py
@@ -21,7 +21,7 @@ from polylogue.core.enums import (
 from polylogue.storage.sqlite.archive_tiers.common import check, literal_check, nullable_check
 from polylogue.storage.sqlite.archive_tiers.types import ProvenRevisionAuthority
 
-SOURCE_SCHEMA_VERSION = 26
+SOURCE_SCHEMA_VERSION = 27
 
 SOURCE_DDL = f"""
 CREATE TABLE IF NOT EXISTS raw_sessions (
@@ -264,6 +264,24 @@ ON raw_byte_duplicate_supersession_receipts(promoted_at_ms);
 
 CREATE INDEX IF NOT EXISTS idx_raw_byte_duplicate_supersession_receipts_duplicate_of
 ON raw_byte_duplicate_supersession_receipts(duplicate_of_raw_id);
+
+-- v27 (polylogue-r9xsj): a non-session classification alone is not a
+-- duplicate disposition. This immutable receipt binds an excluded raw blob to
+-- the indexed twin whose bytes make the exclusion safe.
+CREATE TABLE IF NOT EXISTS raw_non_session_duplicate_exclusion_receipts (
+    raw_id                     TEXT PRIMARY KEY REFERENCES raw_sessions(raw_id) ON DELETE CASCADE,
+    blob_hash                  BLOB NOT NULL CHECK(length(blob_hash) = 32),
+    blob_size                  INTEGER NOT NULL CHECK(blob_size >= 0),
+    indexed_twin_raw_id        TEXT NOT NULL,
+    indexed_twin_session_id    TEXT NOT NULL,
+    parser_fingerprint         TEXT NOT NULL,
+    excluded_at_ms             INTEGER NOT NULL CHECK(excluded_at_ms >= 0),
+    tool_version               TEXT NOT NULL,
+    detail                     TEXT NOT NULL DEFAULT ''
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_raw_non_session_duplicate_exclusion_receipts_twin
+ON raw_non_session_duplicate_exclusion_receipts(indexed_twin_raw_id);
 
 -- v25 (polylogue-zm4w8): one immutable receipt per raw_sessions row marked a
 -- proven duplicate within a fully-quarantined (source_path, blob_hash) group

--- a/polylogue/storage/sqlite/migrations/source/027_raw_non_session_duplicate_exclusion_receipts.sql
+++ b/polylogue/storage/sqlite/migrations/source/027_raw_non_session_duplicate_exclusion_receipts.sql
@@ -1,0 +1,17 @@
+-- polylogue-r9xsj: evidence for a duplicate excluded as non-conversation must
+-- bind its source blob to the indexed twin. raw_membership_census.status alone
+-- records a parser classification, not a durable duplicate disposition.
+CREATE TABLE IF NOT EXISTS raw_non_session_duplicate_exclusion_receipts (
+    raw_id                     TEXT PRIMARY KEY REFERENCES raw_sessions(raw_id) ON DELETE CASCADE,
+    blob_hash                  BLOB NOT NULL CHECK(length(blob_hash) = 32),
+    blob_size                  INTEGER NOT NULL CHECK(blob_size >= 0),
+    indexed_twin_raw_id        TEXT NOT NULL,
+    indexed_twin_session_id    TEXT NOT NULL,
+    parser_fingerprint         TEXT NOT NULL,
+    excluded_at_ms             INTEGER NOT NULL CHECK(excluded_at_ms >= 0),
+    tool_version               TEXT NOT NULL,
+    detail                     TEXT NOT NULL DEFAULT ''
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_raw_non_session_duplicate_exclusion_receipts_twin
+ON raw_non_session_duplicate_exclusion_receipts(indexed_twin_raw_id);

--- a/tests/unit/devtools/test_schema_inference_gate.py
+++ b/tests/unit/devtools/test_schema_inference_gate.py
@@ -6,22 +6,21 @@ import json
 from pathlib import Path
 
 from devtools import schema_inference_gate
-from tests.unit.maintenance.test_schema_inference_gate import _seed_archive, _write_hash_receipt
+from polylogue.maintenance.schema_inference_gate import RECEIPT_FILENAME
+from tests.unit.maintenance.test_schema_inference_gate import _seed_archive
 
 
 def test_devtools_command_requires_caller_root_and_persists_receipt(tmp_path: Path) -> None:
     root = tmp_path / "archive"
-    _seed_archive(root)
-    blob_receipt = tmp_path / "blob.json"
-    _write_hash_receipt(root, blob_receipt)
-    output = tmp_path / "gate.json"
+    ground_truth = _seed_archive(root)
+    output = tmp_path / RECEIPT_FILENAME
 
     exit_code = schema_inference_gate.main(
         [
             "--archive-root",
             str(root),
-            "--blob-hash-receipt",
-            str(blob_receipt),
+            "--ground-truth-root",
+            f"codex-session={ground_truth}",
             "--receipt",
             str(output),
             "--json",

--- a/tests/unit/devtools/test_schema_inference_gate.py
+++ b/tests/unit/devtools/test_schema_inference_gate.py
@@ -1,0 +1,34 @@
+"""CLI adapter tests for the schema-inference gate receipt."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from devtools import schema_inference_gate
+from tests.unit.maintenance.test_schema_inference_gate import _seed_archive, _write_hash_receipt
+
+
+def test_devtools_command_requires_caller_root_and_persists_receipt(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _seed_archive(root)
+    blob_receipt = tmp_path / "blob.json"
+    _write_hash_receipt(root, blob_receipt)
+    output = tmp_path / "gate.json"
+
+    exit_code = schema_inference_gate.main(
+        [
+            "--archive-root",
+            str(root),
+            "--blob-hash-receipt",
+            str(blob_receipt),
+            "--receipt",
+            str(output),
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["verdict"] == "PASS"
+    assert payload["input_paths"]["archive_root"] == str(root.absolute())

--- a/tests/unit/maintenance/test_schema_inference_gate.py
+++ b/tests/unit/maintenance/test_schema_inference_gate.py
@@ -1,9 +1,8 @@
-"""Acceptance and anti-vacuity tests for the schema-inference gate."""
+"""Production-route regression tests for the schema-inference gate."""
 
 from __future__ import annotations
 
 import hashlib
-import json
 import sqlite3
 from pathlib import Path
 from typing import Any, cast
@@ -12,24 +11,34 @@ import pytest
 
 import polylogue.maintenance.schema_inference_gate as gate
 from polylogue.maintenance.schema_inference_gate import (
-    BLOB_HASH_RECEIPT_SCHEMA,
+    RECEIPT_FILENAME,
+    SchemaInferenceGateError,
     run_schema_inference_gate,
 )
+from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
 
 
-def _seed_archive(root: Path) -> None:
+def _seed_archive(root: Path) -> Path:
+    """Create one source raw whose actual external file and blob agree."""
+
     initialize_active_archive_root(root)
+    ground_truth = root.parent / f"{root.name}-codex-ground-truth"
+    ground_truth.mkdir()
+    payload = b"actual external codex raw"
+    source_file = ground_truth / "session.jsonl"
+    source_file.write_bytes(payload)
+    blob_hash, blob_size = BlobStore(root / "blob").write_from_bytes(payload)
     with sqlite3.connect(root / "source.db") as conn:
         conn.execute(
             """
             INSERT INTO raw_sessions(
                 raw_id, origin, native_id, source_path, blob_hash, blob_size,
                 acquired_at_ms, logical_source_key, revision_authority
-            ) VALUES ('raw-1', 'codex-session', 'session', '/fixture/session.jsonl', ?, 10, 100,
+            ) VALUES ('raw-1', 'codex-session', 'session', ?, ?, ?, 100,
                       'codex:session', 'byte_proven')
             """,
-            (b"a" * 32,),
+            (str(source_file), bytes.fromhex(blob_hash), blob_size),
         )
         conn.execute(
             """
@@ -64,71 +73,135 @@ def _seed_archive(root: Path) -> None:
         conn.execute("ANALYZE blocks")
         conn.execute("ANALYZE messages")
         conn.execute("ANALYZE action_pairs")
+    return ground_truth
 
 
-def _write_hash_receipt(root: Path, path: Path, *, mode: str = "full", verdict: str = "PASS") -> None:
-    with sqlite3.connect(root / "source.db") as conn:
-        source_version = int(conn.execute("PRAGMA user_version").fetchone()[0])
-        source_count = int(conn.execute("SELECT COUNT(DISTINCT blob_hash) FROM raw_sessions").fetchone()[0])
-    path.write_text(
-        json.dumps(
-            {
-                "schema": BLOB_HASH_RECEIPT_SCHEMA,
-                "archive_root": str(root.absolute()),
-                "source_schema_version": source_version,
-                "mode": mode,
-                "verdict": verdict,
-                "tool_version": "fixture-hash-verifier/1",
-                "input_paths": {"source_db": str(root / "source.db"), "blob_root": str(root / "blob")},
-                "counts": {
-                    "scanned_blobs": source_count,
-                    "total_blobs_seen": source_count,
-                    "scanned_references": source_count,
-                    "total_references_seen": source_count,
-                },
-                "findings": [],
-            }
-        ),
-        encoding="utf-8",
-    )
-
-
-def _run(root: Path, tmp_path: Path, *, hash_receipt: Path | None = None) -> dict[str, Any]:
-    hash_path = hash_receipt or tmp_path / "blob-hash.json"
-    if hash_receipt is None:
-        _write_hash_receipt(root, hash_path)
+def _run(root: Path, tmp_path: Path, *, ground_truth: Path | None = None) -> dict[str, Any]:
+    external_root = ground_truth or root.parent / f"{root.name}-codex-ground-truth"
     result = run_schema_inference_gate(
         root,
-        blob_hash_receipt=hash_path,
-        receipt_path=tmp_path / "schema-inference-gate.json",
+        receipt_path=tmp_path / RECEIPT_FILENAME,
+        ground_truth_roots={"codex-session": (external_root,)},
     )
     return cast(dict[str, Any], result.payload)
 
 
-def test_clean_archive_writes_pass_receipt_and_does_not_mutate_sqlite(tmp_path: Path) -> None:
+def test_clean_archive_runs_actual_blobstore_verifier_and_external_reconciliation(tmp_path: Path) -> None:
     root = tmp_path / "archive"
-    _seed_archive(root)
-    hash_receipt = tmp_path / "blob-hash.json"
-    _write_hash_receipt(root, hash_receipt)
+    ground_truth = _seed_archive(root)
     before = {name: hashlib.sha256((root / name).read_bytes()).hexdigest() for name in ("source.db", "index.db")}
 
-    payload = _run(root, tmp_path, hash_receipt=hash_receipt)
+    payload = _run(root, tmp_path, ground_truth=ground_truth)
 
     assert payload["verdict"] == "PASS"
-    assert payload["schema"] == "polylogue.schema-inference-gate.v1"
-    assert (
-        payload["source_schema_identity"]["actual_user_version"]
-        == payload["source_schema_identity"]["expected_user_version"]
-    )
-    assert payload["ground_truth_inputs"]["hooks"]["exempt"] is True
-    assert payload["ground_truth_inputs"]["browser-capture"]["exempt"] is True
-    assert payload["ground_truth_denominators"]["documents_known_by_origin"] == {"codex-session": 1}
-    assert payload["ground_truth_denominators"]["documents_present_by_origin"] == {"codex-session": 1}
-    assert payload["full_blob_hash_verification"]["passed"] is True
-    assert payload["tool_versions"]["polylogue"]
+    assert payload["ground_truth_inputs"]["origins"]["codex-session"]["external_files"] == 1
+    assert payload["ground_truth_inputs"]["origins"]["codex-session"]["unverified_source_blob_hashes"] == 0
+    full = payload["full_blob_hash_verification"]
+    assert full["passed"] is True
+    assert full["verifier"]["identity"] == "polylogue.storage.blob_store.BlobStore.verify_all"
+    assert full["before_snapshot"]["digest"] == full["after_snapshot"]["digest"]
     assert {
         name: hashlib.sha256((root / name).read_bytes()).hexdigest() for name in ("source.db", "index.db")
     } == before
+
+
+def test_receipt_target_can_never_replace_a_live_tier(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    ground_truth = _seed_archive(root)
+    source_before = hashlib.sha256((root / "source.db").read_bytes()).hexdigest()
+
+    with pytest.raises(SchemaInferenceGateError, match="receipt filename"):
+        run_schema_inference_gate(
+            root,
+            receipt_path=root / "source.db",
+            ground_truth_roots={"codex-session": (ground_truth,)},
+        )
+    with pytest.raises(SchemaInferenceGateError, match="outside the archive root"):
+        run_schema_inference_gate(
+            root,
+            receipt_path=root / RECEIPT_FILENAME,
+            ground_truth_roots={"codex-session": (ground_truth,)},
+        )
+
+    assert hashlib.sha256((root / "source.db").read_bytes()).hexdigest() == source_before
+
+
+def test_unavailable_or_unverified_external_ground_truth_is_a_hard_failure(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _seed_archive(root)
+
+    unavailable = _run(root, tmp_path, ground_truth=tmp_path / "missing-root")
+    assert unavailable["verdict"] == "FAIL"
+    assert any("unavailable or undeclared" in reason for reason in unavailable["pass_fail_reasons"])
+
+    wrong_root = tmp_path / "wrong-root"
+    wrong_root.mkdir()
+    (wrong_root / "session.jsonl").write_bytes(b"wrong bytes")
+    unverified = _run(root, tmp_path, ground_truth=wrong_root)
+    assert unverified["verdict"] == "FAIL"
+    assert unverified["ground_truth_inputs"]["origins"]["codex-session"]["unverified_source_blob_hashes"] == 1
+
+
+def test_full_blob_hash_evidence_is_not_a_caller_claim(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    ground_truth = _seed_archive(root)
+    with sqlite3.connect(root / "source.db") as conn:
+        blob_hash = bytes(conn.execute("SELECT blob_hash FROM raw_sessions WHERE raw_id = 'raw-1'").fetchone()[0]).hex()
+    BlobStore(root / "blob").blob_path(blob_hash).write_bytes(b"corrupted")
+
+    payload = _run(root, tmp_path, ground_truth=ground_truth)
+
+    assert payload["verdict"] == "FAIL"
+    full = payload["full_blob_hash_verification"]
+    assert full["passed"] is False
+    assert full["verifier"]["identity"] == "polylogue.storage.blob_store.BlobStore.verify_all"
+    assert any(finding["reason"] == "hash_mismatch" for finding in full["failures"])
+
+
+def test_non_session_duplicate_requires_durable_content_bound_twin_receipt(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    ground_truth = _seed_archive(root)
+    with sqlite3.connect(root / "source.db") as conn:
+        blob_hash, blob_size = conn.execute(
+            "SELECT blob_hash, blob_size FROM raw_sessions WHERE raw_id = 'raw-1'"
+        ).fetchone()
+        conn.execute(
+            """
+            INSERT INTO raw_sessions(raw_id, origin, native_id, source_path, blob_hash, blob_size,
+                                     acquired_at_ms, logical_source_key, revision_authority)
+            VALUES ('raw-excluded', 'codex-session', 'excluded', ?, ?, ?, 101,
+                    'codex:excluded', 'byte_proven')
+            """,
+            (str(ground_truth / "session.jsonl"), blob_hash, blob_size),
+        )
+        conn.execute(
+            """
+            INSERT INTO raw_membership_census(raw_id, parser_fingerprint, status, member_count, censused_at_ms, detail)
+            VALUES ('raw-excluded', 'fixture/1', 'non_session', 0, 101, 'fixture')
+            """
+        )
+
+    bare_status = _run(root, tmp_path, ground_truth=ground_truth)
+    assert bare_status["verdict"] == "FAIL"
+    duplicate = bare_status["query_results"]["zero-unexplained-byte-duplicates"]
+    assert duplicate["invalid_receipt_count"] == 1
+
+    with sqlite3.connect(root / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_non_session_duplicate_exclusion_receipts(
+                raw_id, blob_hash, blob_size, indexed_twin_raw_id, indexed_twin_session_id,
+                parser_fingerprint, excluded_at_ms, tool_version
+            ) VALUES ('raw-excluded', ?, ?, 'raw-1', 'codex-session:session', 'fixture/1', 101, 'fixture/1')
+            """,
+            (blob_hash, blob_size),
+        )
+
+    receipted = _run(root, tmp_path, ground_truth=ground_truth)
+    assert receipted["verdict"] == "PASS"
+    assert receipted["query_results"]["zero-unexplained-byte-duplicates"]["resolved_by_rule"] == {
+        "legitimately-excluded-non-conversation": 1
+    }
 
 
 @pytest.mark.parametrize(
@@ -137,94 +210,47 @@ def test_clean_archive_writes_pass_receipt_and_does_not_mutate_sqlite(tmp_path: 
         ("quarantine", {"zero-surviving-quarantine"}),
         ("orphan-quarantine", {"zero-surviving-quarantine", "zero-quarantine-without-logical-source-key"}),
         ("blocker", {"zero-unresolved-raw-authority-blockers"}),
-        ("duplicate", {"zero-unexplained-byte-duplicates"}),
     ),
 )
-def test_each_source_hard_gate_has_a_red_twin(
+def test_each_source_hard_gate_has_a_real_sqlite_red_twin(
     tmp_path: Path,
     mutation: str,
     expected_gates: set[str],
 ) -> None:
     root = tmp_path / mutation
-    _seed_archive(root)
+    ground_truth = _seed_archive(root)
     with sqlite3.connect(root / "source.db") as conn:
         if mutation == "quarantine":
             conn.execute(
-                "INSERT INTO raw_sessions(raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms, logical_source_key, revision_authority) "
-                "VALUES ('raw-quarantine', 'codex-session', 'q', '/q', ?, 1, 101, 'codex:q', 'quarantined')",
-                (b"q" * 32,),
+                "INSERT INTO raw_sessions(raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms, logical_source_key, revision_authority) VALUES ('raw-quarantine', 'codex-session', 'q', ?, ?, 1, 101, 'codex:q', 'quarantined')",
+                (str(ground_truth / "session.jsonl"), b"q" * 32),
             )
         elif mutation == "orphan-quarantine":
             conn.execute(
-                "INSERT INTO raw_sessions(raw_id, origin, source_path, blob_hash, blob_size, acquired_at_ms, revision_authority) "
-                "VALUES ('raw-orphan-quarantine', 'codex-session', '/q', ?, 1, 101, 'quarantined')",
-                (b"o" * 32,),
-            )
-        elif mutation == "blocker":
-            conn.execute(
-                "INSERT INTO raw_authority_blockers(blocker_id, plan_id, census_id, reason, expected_json, observed_json, created_at_ms) "
-                "VALUES ('blocker-1', 'missing-plan', 'missing-census', 'fixture', '{}', '{}', 101)"
+                "INSERT INTO raw_sessions(raw_id, origin, source_path, blob_hash, blob_size, acquired_at_ms, revision_authority) VALUES ('raw-orphan', 'codex-session', ?, ?, 1, 101, 'quarantined')",
+                (str(ground_truth / "session.jsonl"), b"o" * 32),
             )
         else:
             conn.execute(
-                "INSERT INTO raw_sessions(raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms, logical_source_key, revision_authority) "
-                "VALUES ('raw-duplicate', 'codex-session', 'duplicate', '/duplicate', ?, 10, 101, 'codex:duplicate', 'byte_proven')",
-                (b"a" * 32,),
+                "INSERT INTO raw_authority_blockers(blocker_id, plan_id, census_id, reason, expected_json, observed_json, created_at_ms) VALUES ('blocker-1', 'missing-plan', 'missing-census', 'fixture', '{}', '{}', 101)"
             )
 
-    payload = _run(root, tmp_path)
-    results = payload["query_results"]
+    payload = _run(root, tmp_path, ground_truth=ground_truth)
     assert payload["verdict"] == "FAIL"
+    results = payload["query_results"]
     assert {name for name in expected_gates if not results[name]["passed"]} == expected_gates
-    for name in expected_gates:
-        assert results[name]["count"] > 0
 
 
-def test_valid_supersession_receipt_and_typed_exclusion_are_explicit_duplicate_rules(tmp_path: Path) -> None:
-    root = tmp_path / "resolved-duplicates"
-    _seed_archive(root)
-    with sqlite3.connect(root / "source.db") as conn:
-        conn.execute(
-            "INSERT INTO raw_sessions(raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms, logical_source_key, revision_authority) "
-            "VALUES ('raw-receipted', 'codex-session', 'duplicate', '/duplicate', ?, 10, 101, 'codex:duplicate', 'byte_proven')",
-            (b"a" * 32,),
-        )
-        conn.execute(
-            "INSERT INTO raw_byte_duplicate_supersession_receipts(raw_id, blob_hash, blob_size, duplicate_of_raw_id, duplicate_of_session_id, previous_revision_authority, promoted_at_ms, tool_version, backup_manifest_path) "
-            "VALUES ('raw-receipted', ?, 10, 'raw-1', 'codex-session:session', 'byte_proven', 101, 'fixture/1', '/fixture/backup.json')",
-            (b"a" * 32,),
-        )
-        conn.execute(
-            "INSERT INTO raw_sessions(raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms, logical_source_key, revision_authority) "
-            "VALUES ('raw-excluded', 'codex-session', 'excluded', '/excluded', ?, 10, 102, 'codex:excluded', 'byte_proven')",
-            (b"a" * 32,),
-        )
-        conn.execute(
-            "INSERT INTO raw_membership_census(raw_id, parser_fingerprint, status, member_count, censused_at_ms, detail) "
-            "VALUES ('raw-excluded', 'fixture/1', 'non_session', 0, 102, 'non-conversation fixture')"
-        )
-
-    payload = _run(root, tmp_path)
-
-    assert payload["verdict"] == "PASS"
-    duplicate = payload["query_results"]["zero-unexplained-byte-duplicates"]
-    assert duplicate["resolved_by_rule"] == {
-        "legitimately-excluded-non-conversation": 1,
-        "superseded-duplicate": 1,
-    }
-
-
-def test_untyped_fidelity_residual_fails_even_when_existing_aggregate_is_false_green(
+def test_untyped_fidelity_residual_fails_even_when_aggregate_looks_green(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     root = tmp_path / "false-favorable"
-    _seed_archive(root)
+    ground_truth = _seed_archive(root)
 
-    class _Report:
+    class Report:
         def to_json(self) -> dict[str, object]:
             return {
-                "archive_root": str(root),
                 "checks": [
                     {
                         "name": "corpus-absences",
@@ -245,90 +271,10 @@ def test_untyped_fidelity_residual_fails_even_when_existing_aggregate_is_false_g
                         "status": "ok",
                         "evidence": {"unexplained_shortfall": 0, "unexplained_by_origin": {}, "worst": []},
                     },
-                ],
+                ]
             }
 
-    monkeypatch.setattr(gate, "verify_archive", lambda *args, **kwargs: _Report())
-    payload = _run(root, tmp_path)
-
+    monkeypatch.setattr(gate, "verify_archive", lambda *args, **kwargs: Report())
+    payload = _run(root, tmp_path, ground_truth=ground_truth)
     assert payload["verdict"] == "FAIL"
-    assert any("aggregate" in reason or "untyped corpus residual" in reason for reason in payload["pass_fail_reasons"])
-
-
-def test_missing_or_partial_hash_receipt_can_never_become_a_pass(tmp_path: Path) -> None:
-    root = tmp_path / "hash-required"
-    _seed_archive(root)
-    missing = run_schema_inference_gate(
-        root,
-        blob_hash_receipt=tmp_path / "missing.json",
-        receipt_path=tmp_path / "missing-gate.json",
-    )
-    assert missing.payload["verdict"] == "FAIL"
-    missing_hash = missing.payload["full_blob_hash_verification"]
-    assert isinstance(missing_hash, dict)
-    assert missing_hash["passed"] is False
-
-    partial = tmp_path / "partial.json"
-    _write_hash_receipt(root, partial, mode="sample", verdict="PASS")
-    sampled = run_schema_inference_gate(
-        root,
-        blob_hash_receipt=partial,
-        receipt_path=tmp_path / "partial-gate.json",
-    )
-    assert sampled.payload["verdict"] == "FAIL"
-    sampled_hash = sampled.payload["full_blob_hash_verification"]
-    assert isinstance(sampled_hash, dict)
-    assert "mode must be 'full'" in sampled_hash["reason"]
-
-    uncovered = tmp_path / "uncovered.json"
-    _write_hash_receipt(root, uncovered)
-    uncovered_payload = json.loads(uncovered.read_text(encoding="utf-8"))
-    uncovered_payload["counts"] = {
-        "scanned_blobs": 0,
-        "total_blobs_seen": 0,
-        "scanned_references": 0,
-        "total_references_seen": 0,
-    }
-    uncovered.write_text(json.dumps(uncovered_payload), encoding="utf-8")
-    uncovered_result = run_schema_inference_gate(
-        root,
-        blob_hash_receipt=uncovered,
-        receipt_path=tmp_path / "uncovered-gate.json",
-    )
-    assert uncovered_result.payload["verdict"] == "FAIL"
-    uncovered_hash = uncovered_result.payload["full_blob_hash_verification"]
-    assert isinstance(uncovered_hash, dict)
-    assert "does not match the source-tier" in uncovered_hash["reason"]
-
-
-def test_unresolved_duplicate_with_invalid_receipt_is_not_hidden_by_receipt_presence(tmp_path: Path) -> None:
-    root = tmp_path / "invalid-duplicate-receipt"
-    _seed_archive(root)
-    with sqlite3.connect(root / "source.db") as conn:
-        conn.execute(
-            "INSERT INTO raw_sessions(raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms, logical_source_key, revision_authority) "
-            "VALUES ('raw-invalid-receipt', 'codex-session', 'duplicate', '/duplicate', ?, 10, 101, 'codex:duplicate', 'byte_proven')",
-            (b"a" * 32,),
-        )
-        conn.execute(
-            "INSERT INTO raw_sessions(raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms, logical_source_key, revision_authority) "
-            "VALUES ('raw-unrelated', 'codex-session', 'unrelated', '/unrelated', ?, 10, 101, 'codex:unrelated', 'byte_proven')",
-            (b"b" * 32,),
-        )
-        conn.execute(
-            "INSERT INTO raw_byte_duplicate_supersession_receipts(raw_id, blob_hash, blob_size, duplicate_of_raw_id, duplicate_of_session_id, previous_revision_authority, promoted_at_ms, tool_version, backup_manifest_path) "
-            "VALUES ('raw-invalid-receipt', ?, 10, 'raw-unrelated', 'codex-session:unrelated', 'byte_proven', 101, 'fixture/1', '/fixture/backup.json')",
-            (b"a" * 32,),
-        )
-    with sqlite3.connect(root / "index.db") as conn:
-        conn.execute(
-            "INSERT INTO sessions(native_id, origin, raw_id, content_hash, message_count) "
-            "VALUES ('unrelated', 'codex-session', 'raw-unrelated', ?, 1)",
-            (b"u" * 32,),
-        )
-
-    payload = _run(root, tmp_path)
-
-    assert payload["verdict"] == "FAIL"
-    duplicate = payload["query_results"]["zero-unexplained-byte-duplicates"]
-    assert duplicate["invalid_receipt_count"] == 1
+    assert any("untyped corpus residual" in reason for reason in payload["pass_fail_reasons"])

--- a/tests/unit/maintenance/test_schema_inference_gate.py
+++ b/tests/unit/maintenance/test_schema_inference_gate.py
@@ -1,0 +1,334 @@
+"""Acceptance and anti-vacuity tests for the schema-inference gate."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+import polylogue.maintenance.schema_inference_gate as gate
+from polylogue.maintenance.schema_inference_gate import (
+    BLOB_HASH_RECEIPT_SCHEMA,
+    run_schema_inference_gate,
+)
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+
+def _seed_archive(root: Path) -> None:
+    initialize_active_archive_root(root)
+    with sqlite3.connect(root / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_sessions(
+                raw_id, origin, native_id, source_path, blob_hash, blob_size,
+                acquired_at_ms, logical_source_key, revision_authority
+            ) VALUES ('raw-1', 'codex-session', 'session', '/fixture/session.jsonl', ?, 10, 100,
+                      'codex:session', 'byte_proven')
+            """,
+            (b"a" * 32,),
+        )
+        conn.execute(
+            """
+            INSERT INTO raw_session_memberships(
+                raw_id, logical_source_key, provider_session_id, source_revision,
+                normalized_content_hash, message_count, decision, decided_at_ms
+            ) VALUES ('raw-1', 'codex:session', 'session', 'rev-1', ?, 1, 'applied', 100)
+            """,
+            (b"m" * 32,),
+        )
+    with sqlite3.connect(root / "index.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO sessions(native_id, origin, raw_id, content_hash, message_count)
+            VALUES ('session', 'codex-session', 'raw-1', ?, 1)
+            """,
+            (b"s" * 32,),
+        )
+        conn.execute(
+            """
+            INSERT INTO messages(session_id, position, role, material_origin, content_hash)
+            VALUES ('codex-session:session', 0, 'user', 'human_authored', ?)
+            """,
+            (b"n" * 32,),
+        )
+        conn.execute(
+            """
+            INSERT INTO blocks(message_id, session_id, position, block_type, text)
+            VALUES ('codex-session:session:0.0', 'codex-session:session', 0, 'text', 'hello')
+            """
+        )
+        conn.execute("ANALYZE blocks")
+        conn.execute("ANALYZE messages")
+        conn.execute("ANALYZE action_pairs")
+
+
+def _write_hash_receipt(root: Path, path: Path, *, mode: str = "full", verdict: str = "PASS") -> None:
+    with sqlite3.connect(root / "source.db") as conn:
+        source_version = int(conn.execute("PRAGMA user_version").fetchone()[0])
+        source_count = int(conn.execute("SELECT COUNT(DISTINCT blob_hash) FROM raw_sessions").fetchone()[0])
+    path.write_text(
+        json.dumps(
+            {
+                "schema": BLOB_HASH_RECEIPT_SCHEMA,
+                "archive_root": str(root.absolute()),
+                "source_schema_version": source_version,
+                "mode": mode,
+                "verdict": verdict,
+                "tool_version": "fixture-hash-verifier/1",
+                "input_paths": {"source_db": str(root / "source.db"), "blob_root": str(root / "blob")},
+                "counts": {
+                    "scanned_blobs": source_count,
+                    "total_blobs_seen": source_count,
+                    "scanned_references": source_count,
+                    "total_references_seen": source_count,
+                },
+                "findings": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _run(root: Path, tmp_path: Path, *, hash_receipt: Path | None = None) -> dict[str, Any]:
+    hash_path = hash_receipt or tmp_path / "blob-hash.json"
+    if hash_receipt is None:
+        _write_hash_receipt(root, hash_path)
+    result = run_schema_inference_gate(
+        root,
+        blob_hash_receipt=hash_path,
+        receipt_path=tmp_path / "schema-inference-gate.json",
+    )
+    return cast(dict[str, Any], result.payload)
+
+
+def test_clean_archive_writes_pass_receipt_and_does_not_mutate_sqlite(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _seed_archive(root)
+    hash_receipt = tmp_path / "blob-hash.json"
+    _write_hash_receipt(root, hash_receipt)
+    before = {name: hashlib.sha256((root / name).read_bytes()).hexdigest() for name in ("source.db", "index.db")}
+
+    payload = _run(root, tmp_path, hash_receipt=hash_receipt)
+
+    assert payload["verdict"] == "PASS"
+    assert payload["schema"] == "polylogue.schema-inference-gate.v1"
+    assert (
+        payload["source_schema_identity"]["actual_user_version"]
+        == payload["source_schema_identity"]["expected_user_version"]
+    )
+    assert payload["ground_truth_inputs"]["hooks"]["exempt"] is True
+    assert payload["ground_truth_inputs"]["browser-capture"]["exempt"] is True
+    assert payload["ground_truth_denominators"]["documents_known_by_origin"] == {"codex-session": 1}
+    assert payload["ground_truth_denominators"]["documents_present_by_origin"] == {"codex-session": 1}
+    assert payload["full_blob_hash_verification"]["passed"] is True
+    assert payload["tool_versions"]["polylogue"]
+    assert {
+        name: hashlib.sha256((root / name).read_bytes()).hexdigest() for name in ("source.db", "index.db")
+    } == before
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected_gates"),
+    (
+        ("quarantine", {"zero-surviving-quarantine"}),
+        ("orphan-quarantine", {"zero-surviving-quarantine", "zero-quarantine-without-logical-source-key"}),
+        ("blocker", {"zero-unresolved-raw-authority-blockers"}),
+        ("duplicate", {"zero-unexplained-byte-duplicates"}),
+    ),
+)
+def test_each_source_hard_gate_has_a_red_twin(
+    tmp_path: Path,
+    mutation: str,
+    expected_gates: set[str],
+) -> None:
+    root = tmp_path / mutation
+    _seed_archive(root)
+    with sqlite3.connect(root / "source.db") as conn:
+        if mutation == "quarantine":
+            conn.execute(
+                "INSERT INTO raw_sessions(raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms, logical_source_key, revision_authority) "
+                "VALUES ('raw-quarantine', 'codex-session', 'q', '/q', ?, 1, 101, 'codex:q', 'quarantined')",
+                (b"q" * 32,),
+            )
+        elif mutation == "orphan-quarantine":
+            conn.execute(
+                "INSERT INTO raw_sessions(raw_id, origin, source_path, blob_hash, blob_size, acquired_at_ms, revision_authority) "
+                "VALUES ('raw-orphan-quarantine', 'codex-session', '/q', ?, 1, 101, 'quarantined')",
+                (b"o" * 32,),
+            )
+        elif mutation == "blocker":
+            conn.execute(
+                "INSERT INTO raw_authority_blockers(blocker_id, plan_id, census_id, reason, expected_json, observed_json, created_at_ms) "
+                "VALUES ('blocker-1', 'missing-plan', 'missing-census', 'fixture', '{}', '{}', 101)"
+            )
+        else:
+            conn.execute(
+                "INSERT INTO raw_sessions(raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms, logical_source_key, revision_authority) "
+                "VALUES ('raw-duplicate', 'codex-session', 'duplicate', '/duplicate', ?, 10, 101, 'codex:duplicate', 'byte_proven')",
+                (b"a" * 32,),
+            )
+
+    payload = _run(root, tmp_path)
+    results = payload["query_results"]
+    assert payload["verdict"] == "FAIL"
+    assert {name for name in expected_gates if not results[name]["passed"]} == expected_gates
+    for name in expected_gates:
+        assert results[name]["count"] > 0
+
+
+def test_valid_supersession_receipt_and_typed_exclusion_are_explicit_duplicate_rules(tmp_path: Path) -> None:
+    root = tmp_path / "resolved-duplicates"
+    _seed_archive(root)
+    with sqlite3.connect(root / "source.db") as conn:
+        conn.execute(
+            "INSERT INTO raw_sessions(raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms, logical_source_key, revision_authority) "
+            "VALUES ('raw-receipted', 'codex-session', 'duplicate', '/duplicate', ?, 10, 101, 'codex:duplicate', 'byte_proven')",
+            (b"a" * 32,),
+        )
+        conn.execute(
+            "INSERT INTO raw_byte_duplicate_supersession_receipts(raw_id, blob_hash, blob_size, duplicate_of_raw_id, duplicate_of_session_id, previous_revision_authority, promoted_at_ms, tool_version, backup_manifest_path) "
+            "VALUES ('raw-receipted', ?, 10, 'raw-1', 'codex-session:session', 'byte_proven', 101, 'fixture/1', '/fixture/backup.json')",
+            (b"a" * 32,),
+        )
+        conn.execute(
+            "INSERT INTO raw_sessions(raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms, logical_source_key, revision_authority) "
+            "VALUES ('raw-excluded', 'codex-session', 'excluded', '/excluded', ?, 10, 102, 'codex:excluded', 'byte_proven')",
+            (b"a" * 32,),
+        )
+        conn.execute(
+            "INSERT INTO raw_membership_census(raw_id, parser_fingerprint, status, member_count, censused_at_ms, detail) "
+            "VALUES ('raw-excluded', 'fixture/1', 'non_session', 0, 102, 'non-conversation fixture')"
+        )
+
+    payload = _run(root, tmp_path)
+
+    assert payload["verdict"] == "PASS"
+    duplicate = payload["query_results"]["zero-unexplained-byte-duplicates"]
+    assert duplicate["resolved_by_rule"] == {
+        "legitimately-excluded-non-conversation": 1,
+        "superseded-duplicate": 1,
+    }
+
+
+def test_untyped_fidelity_residual_fails_even_when_existing_aggregate_is_false_green(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "false-favorable"
+    _seed_archive(root)
+
+    class _Report:
+        def to_json(self) -> dict[str, object]:
+            return {
+                "archive_root": str(root),
+                "checks": [
+                    {
+                        "name": "corpus-absences",
+                        "status": "ok",
+                        "evidence": {
+                            "absent_total": 0,
+                            "documents_known": 1,
+                            "documents_present": 1,
+                            "documents_known_by_origin": {"codex-session": 1},
+                            "documents_present_by_origin": {"codex-session": 1},
+                            "absent_by_origin_cause": {"codex-session/settled-yet-absent": 1},
+                            "raws_without_attributable_identity": 0,
+                        },
+                    },
+                    {"name": "corpus-attachment-fidelity", "status": "ok", "evidence": {"refs_unfetched": 0}},
+                    {
+                        "name": "corpus-revision-fidelity",
+                        "status": "ok",
+                        "evidence": {"unexplained_shortfall": 0, "unexplained_by_origin": {}, "worst": []},
+                    },
+                ],
+            }
+
+    monkeypatch.setattr(gate, "verify_archive", lambda *args, **kwargs: _Report())
+    payload = _run(root, tmp_path)
+
+    assert payload["verdict"] == "FAIL"
+    assert any("aggregate" in reason or "untyped corpus residual" in reason for reason in payload["pass_fail_reasons"])
+
+
+def test_missing_or_partial_hash_receipt_can_never_become_a_pass(tmp_path: Path) -> None:
+    root = tmp_path / "hash-required"
+    _seed_archive(root)
+    missing = run_schema_inference_gate(
+        root,
+        blob_hash_receipt=tmp_path / "missing.json",
+        receipt_path=tmp_path / "missing-gate.json",
+    )
+    assert missing.payload["verdict"] == "FAIL"
+    missing_hash = missing.payload["full_blob_hash_verification"]
+    assert isinstance(missing_hash, dict)
+    assert missing_hash["passed"] is False
+
+    partial = tmp_path / "partial.json"
+    _write_hash_receipt(root, partial, mode="sample", verdict="PASS")
+    sampled = run_schema_inference_gate(
+        root,
+        blob_hash_receipt=partial,
+        receipt_path=tmp_path / "partial-gate.json",
+    )
+    assert sampled.payload["verdict"] == "FAIL"
+    sampled_hash = sampled.payload["full_blob_hash_verification"]
+    assert isinstance(sampled_hash, dict)
+    assert "mode must be 'full'" in sampled_hash["reason"]
+
+    uncovered = tmp_path / "uncovered.json"
+    _write_hash_receipt(root, uncovered)
+    uncovered_payload = json.loads(uncovered.read_text(encoding="utf-8"))
+    uncovered_payload["counts"] = {
+        "scanned_blobs": 0,
+        "total_blobs_seen": 0,
+        "scanned_references": 0,
+        "total_references_seen": 0,
+    }
+    uncovered.write_text(json.dumps(uncovered_payload), encoding="utf-8")
+    uncovered_result = run_schema_inference_gate(
+        root,
+        blob_hash_receipt=uncovered,
+        receipt_path=tmp_path / "uncovered-gate.json",
+    )
+    assert uncovered_result.payload["verdict"] == "FAIL"
+    uncovered_hash = uncovered_result.payload["full_blob_hash_verification"]
+    assert isinstance(uncovered_hash, dict)
+    assert "does not match the source-tier" in uncovered_hash["reason"]
+
+
+def test_unresolved_duplicate_with_invalid_receipt_is_not_hidden_by_receipt_presence(tmp_path: Path) -> None:
+    root = tmp_path / "invalid-duplicate-receipt"
+    _seed_archive(root)
+    with sqlite3.connect(root / "source.db") as conn:
+        conn.execute(
+            "INSERT INTO raw_sessions(raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms, logical_source_key, revision_authority) "
+            "VALUES ('raw-invalid-receipt', 'codex-session', 'duplicate', '/duplicate', ?, 10, 101, 'codex:duplicate', 'byte_proven')",
+            (b"a" * 32,),
+        )
+        conn.execute(
+            "INSERT INTO raw_sessions(raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms, logical_source_key, revision_authority) "
+            "VALUES ('raw-unrelated', 'codex-session', 'unrelated', '/unrelated', ?, 10, 101, 'codex:unrelated', 'byte_proven')",
+            (b"b" * 32,),
+        )
+        conn.execute(
+            "INSERT INTO raw_byte_duplicate_supersession_receipts(raw_id, blob_hash, blob_size, duplicate_of_raw_id, duplicate_of_session_id, previous_revision_authority, promoted_at_ms, tool_version, backup_manifest_path) "
+            "VALUES ('raw-invalid-receipt', ?, 10, 'raw-unrelated', 'codex-session:unrelated', 'byte_proven', 101, 'fixture/1', '/fixture/backup.json')",
+            (b"a" * 32,),
+        )
+    with sqlite3.connect(root / "index.db") as conn:
+        conn.execute(
+            "INSERT INTO sessions(native_id, origin, raw_id, content_hash, message_count) "
+            "VALUES ('unrelated', 'codex-session', 'raw-unrelated', ?, 1)",
+            (b"u" * 32,),
+        )
+
+    payload = _run(root, tmp_path)
+
+    assert payload["verdict"] == "FAIL"
+    duplicate = payload["query_results"]["zero-unexplained-byte-duplicates"]
+    assert duplicate["invalid_receipt_count"] == 1


### PR DESCRIPTION
## Summary

Hardens the schema-inference go/no-go receipt so it derives all required evidence itself without writing into the archive.

## Problem

The prior receipt could overwrite an archive file, trusted a caller-authored full-hash JSON, reported source/index consistency as ground truth, and treated a bare non-session census row as a duplicate disposition.

## Solution

- Receipt output is restricted to `schema-inference-gate-receipt.json` outside the archive root.
- The gate invokes `BlobStore.verify_all` directly and records verifier identity plus before/after blob-root snapshots.
- Every non-exempt origin present in source.db must declare readable external roots; the gate hashes them and rejects absent source blobs.
- Source migration 027 adds immutable non-session duplicate-exclusion receipts that bind the excluded raw blob to an indexed twin.

## Acceptance criteria

| Criterion | Status | Evidence |
| --- | --- | --- |
| No unsafe receipt target | Satisfied | Real SQLite red twin proves source.db and archive-local targets are rejected. |
| External ground truth is inspected | Satisfied | Real root scan hashes declared files and rejects unavailable or mismatched roots. |
| Full blob evidence is independent | Satisfied | Production `BlobStore.verify_all` route with stable snapshot assertion and corruption red twin. |
| Duplicate exclusions are durable and content-bound | Satisfied | Migration 027 plus red twin for a bare `non_session` census row. |

## Verification

- `devtools test tests/unit/maintenance/test_schema_inference_gate.py tests/unit/devtools/test_schema_inference_gate.py`: `10 passed in 1.40s`.
- `devtools verify --quick`: all 23 static/generated/layering steps passed.
- `devtools lab policy schema-versioning`: `Schema evolution policy intact.`

The full testmon seed was not run because the verifier creates an unmarked testmon cache and its checkout guard then rejects its own seed subprocess. This is recorded as residual verification uncertainty.

## Adversarial review notes

Iteration 1 could not start: the requested Luna/high local reviewer was rate-limited before analysis. No claim of an independent clean review is made.

Ref polylogue-r9xsj