### PR TITLE
feat(storage): enforce durable migration change trains

### DIFF
--- a/devtools/verify_schema_upgrade_lane.py
+++ b/devtools/verify_schema_upgrade_lane.py
@@ -64,12 +64,22 @@ import sys
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
+from typing import cast
 
 from devtools import repo_root as _get_root
 from polylogue.storage.sqlite.archive_tiers.index import INDEX_SCHEMA_VERSION
 from polylogue.storage.sqlite.archive_tiers.index_convergence import (
     INDEX_BENIGN_DDL_REGISTRY,
     BenignDDLEntry,
+)
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.durable_change_train import (
+    DurableMigrationClaim,
+    durable_change_train_policy_report,
+    durable_migration_claim_for_sql,
+)
+from polylogue.storage.sqlite.durable_change_train import (
+    durable_migration_collision_report as _durable_migration_collision_report,
 )
 from polylogue.storage.sqlite.lifecycle import IndexDeltaDeclarationReport, index_delta_declaration_report
 
@@ -199,16 +209,64 @@ def _invalid_migration_paths() -> list[Path]:
     return invalid
 
 
+def _durable_migration_claims_on_disk() -> tuple[DurableMigrationClaim, ...]:
+    """Build the shared migration-slot claims from checked-in SQL resources."""
+    claims: list[DurableMigrationClaim] = []
+    for tier_name in sorted(ALLOWED_MIGRATION_TIERS):
+        tier = ArchiveTier(tier_name)
+        tier_dir = MIGRATIONS_DIR / tier_name
+        if not tier_dir.exists():
+            continue
+        for path in sorted(tier_dir.glob("*.sql")):
+            if re.fullmatch(r"\d{3,}_[a-z0-9_]+\.sql", path.name) is None:
+                continue
+            claims.append(
+                durable_migration_claim_for_sql(
+                    tier,
+                    path.relative_to(ROOT),
+                    path.read_text(encoding="utf-8"),
+                    owner_ref=str(path.relative_to(ROOT)),
+                )
+            )
+    return tuple(claims)
+
+
+def durable_migration_collision_report(
+    claims: Iterable[DurableMigrationClaim],
+) -> dict[str, object]:
+    """Expose the shared slot report to schema-policy callers and tests."""
+    return _durable_migration_collision_report(claims)
+
+
 def _format_report(
     *,
     helpers: list[HelperHit],
     invalid_migrations: list[Path],
     delta_report: IndexDeltaDeclarationReport,
     benign_ddl_violations: list[BenignDDLViolation],
+    durable_change_train_reports: dict[str, dict[str, object]] | None = None,
+    durable_migration_collisions: dict[str, object] | None = None,
 ) -> str:
+    durable_change_train_reports = durable_change_train_reports or {}
+    durable_violations = [
+        violation
+        for report in durable_change_train_reports.values()
+        for violation in cast(tuple[object, ...], report.get("violations", ()))
+        if isinstance(violation, str)
+    ]
+    durable_reservations = [
+        reservation
+        for report in durable_change_train_reports.values()
+        for reservation in cast(tuple[object, ...], report.get("reservations", ()))
+    ]
+    durable_migration_collisions = durable_migration_collisions or {}
+    collision_entries = cast(tuple[object, ...], durable_migration_collisions.get("collisions", ()))
     lines = [
         f"derived-tier upgrade helpers found: {len(helpers)}",
         f"invalid durable migration resources found: {len(invalid_migrations)}",
+        f"durable change-train reservations found: {len(durable_reservations)}",
+        f"durable change-train violations found: {len(durable_violations)}",
+        f"durable migration slot collisions found: {len(collision_entries)}",
         f"undeclared index schema deltas found: {len(delta_report['missing_versions'])}",
         f"invalid index benign-DDL registry entries found: {len(benign_ddl_violations)}",
     ]
@@ -245,7 +303,26 @@ def _format_report(
             "data-non-transforming CREATE TABLE IF NOT EXISTS / CREATE INDEX IF NOT EXISTS / "
             "DROP TABLE IF EXISTS statements."
         )
-    if not helpers and not invalid_migrations and bool(delta_report["ok"]) and not benign_ddl_violations:
+    if durable_reservations:
+        lines.append("")
+        lines.append("Durable change-train reservations:")
+        lines.extend(f"  {reservation}" for reservation in durable_reservations)
+    if durable_violations:
+        lines.append("")
+        lines.append("Durable change-train violations:")
+        lines.extend(f"  {violation}" for violation in durable_violations)
+    if collision_entries:
+        lines.append("")
+        lines.append("Durable migration slot collisions:")
+        lines.extend(f"  {collision}" for collision in collision_entries)
+    if (
+        not helpers
+        and not invalid_migrations
+        and bool(delta_report["ok"])
+        and not benign_ddl_violations
+        and not durable_violations
+        and not collision_entries
+    ):
         lines.append("")
         lines.append("Schema evolution policy intact.")
     return "\n".join(lines)
@@ -261,10 +338,21 @@ def main(argv: list[str] | None = None) -> int:
 
     helpers = _collect_upgrade_helpers()
     invalid_migrations = _invalid_migration_paths()
+    durable_change_train_reports = {
+        tier.value: durable_change_train_policy_report(tier) for tier in (ArchiveTier.SOURCE, ArchiveTier.USER)
+    }
+    durable_migration_collisions = durable_migration_collision_report(_durable_migration_claims_on_disk())
     delta_report = index_delta_declaration_report(INDEX_SCHEMA_VERSION)
     benign_ddl_violations = _invalid_benign_ddl_entries()
 
-    ok = not helpers and not invalid_migrations and bool(delta_report["ok"]) and not benign_ddl_violations
+    ok = (
+        not helpers
+        and not invalid_migrations
+        and bool(delta_report["ok"])
+        and not benign_ddl_violations
+        and all(bool(report.get("ok")) for report in durable_change_train_reports.values())
+        and bool(durable_migration_collisions["ok"])
+    )
 
     if args.json:
         payload = {
@@ -272,6 +360,8 @@ def main(argv: list[str] | None = None) -> int:
                 {"name": hit.name, "path": str(hit.path.relative_to(ROOT)), "line": hit.lineno} for hit in helpers
             ],
             "invalid_migration_resources": [str(path.relative_to(ROOT)) for path in invalid_migrations],
+            "durable_change_trains": durable_change_train_reports,
+            "durable_migration_collisions": durable_migration_collisions,
             "index_delta_declarations": delta_report,
             "invalid_benign_ddl_entries": [
                 {"name": violation.entry_name, "reason": violation.reason} for violation in benign_ddl_violations
@@ -286,6 +376,8 @@ def main(argv: list[str] | None = None) -> int:
                 invalid_migrations=invalid_migrations,
                 delta_report=delta_report,
                 benign_ddl_violations=benign_ddl_violations,
+                durable_change_train_reports=durable_change_train_reports,
+                durable_migration_collisions=durable_migration_collisions,
             )
         )
 

--- a/devtools/verify_schema_upgrade_lane.py
+++ b/devtools/verify_schema_upgrade_lane.py
@@ -104,6 +104,9 @@ _HELPER_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^ensure_schema_upgrades_v\d+$"),
 )
 
+_DURABLE_MIGRATION_SQL_RE = re.compile(r"^\d{3,}_[a-z0-9_]+\.sql$")
+_DURABLE_MIGRATION_SIDECAR_RE = re.compile(r"^\d{3,}\.train\.json$")
+
 
 @dataclass(frozen=True, slots=True)
 class HelperHit:
@@ -203,7 +206,10 @@ def _invalid_migration_paths() -> list[Path]:
         if (
             len(rel.parts) != 2
             or rel.parts[0] not in ALLOWED_MIGRATION_TIERS
-            or not re.match(r"^\d{3,}_[a-z0-9_]+\.sql$", rel.parts[1])
+            or not (
+                _DURABLE_MIGRATION_SQL_RE.fullmatch(rel.parts[1])
+                or _DURABLE_MIGRATION_SIDECAR_RE.fullmatch(rel.parts[1])
+            )
         ):
             invalid.append(path)
     return invalid

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -110,6 +110,17 @@ Polylogue has two schema-evolution regimes, keyed by tier durability.
   `CREATE TABLE`, `CREATE INDEX`, `ADD COLUMN`, and bounded backfills.
   Destructive durable-tier changes require a copy-forward design and explicit
   operator consent.
+- **Durable change trains** make that migration window machine-readable.
+  Every source migration above v26 and every user migration above v10 must
+  ship beside the SQL resource as `migrations/{source,user}/NNN.train.json`.
+  The frozen manifest binds the tier, shipped and target versions, slot,
+  exact SQL filename and SHA-256, owner, schema/runtime riders, behavior
+  proofs, ordering, row-count exceptions, restart convergence proof, and
+  drop policy. Package-resource discovery rejects missing, malformed,
+  stale, noncontiguous, hash-mismatched, or orphaned sidecars before SQL
+  runs. The lifecycle is declare, admit, reserve, authorize, apply, prove,
+  and release. It uses the existing migration transaction and verified backup
+  receipt, with no train state database and no second migration engine.
 - **Derived tiers** (`index.db`, `embeddings.db`) do not have in-place migration
   chains. They are rebuildable products over durable source/user evidence:
   schema mismatches are handled by rebuilding or blue-green replacing the

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -24,16 +24,19 @@ polylogue ops maintenance migrate-tier source \
   --output-format json
 ```
 
-The command refuses before opening SQLite when a live daemon pidfile is found.
-The migration runner then validates the package sidecar, revalidates the
-backup against the current database, and performs the numbered SQL step in
-the existing transaction. It verifies row and schema parity, SQLite
-integrity, foreign keys, and canonical DDL parity before commit. A failed
-transaction is rolled back and may be retried after the cause is repaired.
+The command acquires the daemon startup exclusion and archive ownership before
+opening SQLite. It refuses when a live daemon or another archive writer holds
+either authority. The migration runner then validates the package sidecar,
+revalidates the backup against the current database, and performs the numbered
+SQL step in the existing transaction. It verifies row and schema parity,
+SQLite integrity, foreign keys, and canonical DDL parity before commit. A
+failed transaction is rolled back and may be retried after the cause is
+repaired.
 
-After restart, inspect daemon health and the train proof in the JSON output.
-The train is not complete until the daemon has reopened the migrated tier and
-the recorded runtime consumers converge successfully.
+The JSON output reports the migration receipt and stopped-daemon authority.
+Restart health and runtime-consumer convergence are the final lifecycle proof
+and are recorded by the durable train lifecycle API, not inferred from this
+command's migration result alone.
 
 For the conceptual model behind derived insights and the FTS / blob
 substrate, see [architecture.md](architecture.md) and

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -752,6 +752,14 @@ systemctl --user start polylogued.service
 polylogue ops doctor
 ```
 
+The daemon and `migrate-tier` command share the stable
+`<archive-root>/.archive-ownership.lock` archive lease. `daemon.pid` is process
+metadata only and is never reclaimed by unlinking it as a lock. A crash during
+the train apply phase leaves a checksummed manifest under
+`.maintenance-state/durable-change-trains/`; the next daemon startup acquires
+the same archive lease, reconciles the interrupted version, and persists the
+recovery evidence before opening normal archive components.
+
 Never hand-edit a tier or use a plain manifest as migration authority. A
 durable migration requires a successful scratch-restore receipt authenticated
 by the exact live tier's local key; public hashes and an in-memory "Verification: OK" are

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -6,6 +6,35 @@ This guide is for operators choosing between
 daemon will catch up." It also collects runbook recipes for the most
 common operational incidents.
 
+## Applying a durable schema change train
+
+Durable schema changes are an offline release operation. Before applying a
+`source.db` or `user.db` migration above its adoption floor, confirm that the
+release contains the matching `migrations/{source,user}/NNN.train.json`
+sidecar. The sidecar reserves the exact slot and SQL hash and records the
+runtime and restart evidence needed for the change.
+
+Stop `polylogued`, create a fresh verified backup with the normal
+`backup_archive(..., verify=True)` route, then invoke the existing maintenance
+command with that manifest:
+
+```bash
+polylogue ops maintenance migrate-tier source \
+  --backup-manifest /path/to/verified-source-backup/manifest.json \
+  --output-format json
+```
+
+The command refuses before opening SQLite when a live daemon pidfile is found.
+The migration runner then validates the package sidecar, revalidates the
+backup against the current database, and performs the numbered SQL step in
+the existing transaction. It verifies row and schema parity, SQLite
+integrity, foreign keys, and canonical DDL parity before commit. A failed
+transaction is rolled back and may be retried after the cause is repaired.
+
+After restart, inspect daemon health and the train proof in the JSON output.
+The train is not complete until the daemon has reopened the migrated tier and
+the recorded runtime consumers converge successfully.
+
 For the conceptual model behind derived insights and the FTS / blob
 substrate, see [architecture.md](architecture.md) and
 [internals.md](internals.md). For daemon ownership of the inline

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -21,7 +21,7 @@ over the `CREATE TABLE` statement.
 
 | Tier file | Tier | Version constant |
 |-----------|------|------------------|
-| `source.py` | `source.db` | `SOURCE_SCHEMA_VERSION = 18` |
+| `source.py` | `source.db` | `SOURCE_SCHEMA_VERSION = 26` |
 | `index.py` | `index.db` | `INDEX_SCHEMA_VERSION = 53` |
 | `embeddings.py` | `embeddings.db` | `EMBEDDINGS_SCHEMA_VERSION = 4` |
 | `user.py` | `user.db` | `USER_SCHEMA_VERSION = 10` |
@@ -29,6 +29,28 @@ over the `CREATE TABLE` statement.
 
 There is no single global "schema version" number. Each tier is versioned and
 bootstrapped independently.
+
+### Durable migration change trains
+
+`source.db` and `user.db` migrations above the adoption floors source v26 and
+user v10 require a deterministic package sidecar beside the SQL resource:
+`migrations/{source,user}/NNN.train.json`. The sidecar is a frozen manifest,
+not a second migration store. It binds the tier, shipped and target versions,
+slot, exact SQL filename and SHA-256, owner/reference, schema objects, runtime
+consumers, behavior proofs, dependency order, row-count exceptions, restart
+proof, and drop policy. The existing migration runner discovers these package
+resources before opening the migration transaction and rejects missing,
+malformed, stale, noncontiguous, hash-mismatched, or unproven trains.
+
+Slot paths are part of the merge contract. Two branches reserving the same
+`<tier>/<NNN>.train.json` path produce a Git add/add conflict that must be
+resolved by renumbering or combining the train, rather than silently choosing
+one migration. Schema policy JSON reports every reservation and violation.
+
+Applying a train still uses the existing stopped-daemon gate, verified backup
+receipt, SQLite transaction, integrity and foreign-key checks, canonical DDL
+parity checks, and restart convergence proof. No train state table and no
+parallel migration engine are created.
 
 The runtime table inventory per tier is also enumerated in
 `polylogue/cli/commands/status.py` (`_ARCHIVE_TIER_TABLES`), which `polylogue

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -49,7 +49,10 @@ one migration. Schema policy JSON reports every reservation and violation.
 
 Applying a train still uses the existing stopped-daemon gate, verified backup
 receipt, SQLite transaction, integrity and foreign-key checks, canonical DDL
-parity checks, and restart convergence proof. No train state table and no
+parity checks, and restart convergence proof. The maintenance route persists
+each lifecycle transition under `<archive-root>/.maintenance-state/durable-change-trains/`.
+Daemon startup reconciles a backup-authorized manifest left by a crash before
+schema probing and retains the recovery evidence. No train state table and no
 parallel migration engine are created.
 
 The runtime table inventory per tier is also enumerated in

--- a/polylogue/cli/commands/maintenance/_migrate_tier.py
+++ b/polylogue/cli/commands/maintenance/_migrate_tier.py
@@ -16,6 +16,7 @@ required-gate budget as every sibling command).
 from __future__ import annotations
 
 import contextlib
+import fcntl
 import json
 import os
 import sqlite3
@@ -46,6 +47,24 @@ def _require_stopped_daemon(root: Path) -> str:
     return "proof:daemon-stopped"
 
 
+def _acquire_offline_writer_authority(root: Path) -> tuple[int, str]:
+    """Hold the daemon startup exclusion for the complete offline operation."""
+    pidfile = root / "daemon.pid"
+    descriptor = os.open(pidfile, os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as exc:
+        os.close(descriptor)
+        raise MigrationError(f"durable migration requires exclusive daemon startup authority: {pidfile}") from exc
+    try:
+        _require_stopped_daemon(root)
+    except Exception:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+        raise
+    return descriptor, "proof:daemon-stopped-and-startup-excluded"
+
+
 @click.command("migrate-tier")
 @click.argument("tier", type=click.Choice(tuple(sorted(tier.value for tier in DURABLE_MIGRATION_TIERS))))
 @click.option(
@@ -62,15 +81,19 @@ def migrate_tier_command(tier: str, backup_manifest: Path | None, output_format:
     blue-green replace those from source evidence instead.
     """
     from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS
-    from polylogue.storage.sqlite.migration_runner import migrate_archive_tier
+    from polylogue.storage.sqlite.migration_runner import hold_durable_migration_writer, migrate_archive_tier
 
     archive_tier = ArchiveTier(tier)
     spec = ARCHIVE_TIER_SPECS[archive_tier]
     path = archive_root() / spec.filename
     stopped_daemon_evidence_ref: str | None = None
+    daemon_authority_fd: int | None = None
     try:
-        stopped_daemon_evidence_ref = _require_stopped_daemon(path.parent)
-        with contextlib.closing(sqlite3.connect(path)) as conn:
+        daemon_authority_fd, stopped_daemon_evidence_ref = _acquire_offline_writer_authority(path.parent)
+        with (
+            hold_durable_migration_writer(path.parent, owner_id=f"migrate-tier:{os.getpid()}"),
+            contextlib.closing(sqlite3.connect(path)) as conn,
+        ):
             result = migrate_archive_tier(conn, archive_tier, backup_manifest=backup_manifest)
     except (sqlite3.Error, MigrationError) as exc:
         if output_format == "json":
@@ -91,6 +114,10 @@ def migrate_tier_command(tier: str, backup_manifest: Path | None, output_format:
         else:
             click.echo(f"Migration blocked for {tier}: {exc}", err=True)
         raise SystemExit(1) from exc
+    finally:
+        if daemon_authority_fd is not None:
+            fcntl.flock(daemon_authority_fd, fcntl.LOCK_UN)
+            os.close(daemon_authority_fd)
 
     payload = {
         "ok": True,

--- a/polylogue/cli/commands/maintenance/_migrate_tier.py
+++ b/polylogue/cli/commands/maintenance/_migrate_tier.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import os
 import sqlite3
 from pathlib import Path
 
@@ -25,6 +26,24 @@ import click
 from polylogue.paths import archive_root
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.migration_runner import DURABLE_MIGRATION_TIERS, MigrationError
+
+
+def _daemon_pidfile_is_live(pidfile: Path) -> bool:
+    """Return whether the archive pidfile names a live polylogued process."""
+    try:
+        pid = int(pidfile.read_text(encoding="utf-8").strip())
+        os.kill(pid, 0)
+        return b"polylogued" in Path(f"/proc/{pid}/cmdline").read_bytes()
+    except (OSError, ValueError):
+        return False
+
+
+def _require_stopped_daemon(root: Path) -> str:
+    """Refuse before opening SQLite when the daemon still owns the archive."""
+    pidfile = root / "daemon.pid"
+    if _daemon_pidfile_is_live(pidfile):
+        raise MigrationError(f"durable migration requires the daemon to be stopped; live pidfile: {pidfile}")
+    return "proof:daemon-stopped"
 
 
 @click.command("migrate-tier")
@@ -48,7 +67,9 @@ def migrate_tier_command(tier: str, backup_manifest: Path | None, output_format:
     archive_tier = ArchiveTier(tier)
     spec = ARCHIVE_TIER_SPECS[archive_tier]
     path = archive_root() / spec.filename
+    stopped_daemon_evidence_ref: str | None = None
     try:
+        stopped_daemon_evidence_ref = _require_stopped_daemon(path.parent)
         with contextlib.closing(sqlite3.connect(path)) as conn:
             result = migrate_archive_tier(conn, archive_tier, backup_manifest=backup_manifest)
     except (sqlite3.Error, MigrationError) as exc:
@@ -60,6 +81,7 @@ def migrate_tier_command(tier: str, backup_manifest: Path | None, output_format:
                         "tier": tier,
                         "path": str(path),
                         "backup_manifest": str(backup_manifest) if backup_manifest is not None else None,
+                        "stopped_daemon_evidence_ref": stopped_daemon_evidence_ref,
                         "error": str(exc),
                     },
                     indent=2,
@@ -75,6 +97,7 @@ def migrate_tier_command(tier: str, backup_manifest: Path | None, output_format:
         "tier": tier,
         "path": str(path),
         "backup_manifest": str(backup_manifest) if backup_manifest is not None else None,
+        "stopped_daemon_evidence_ref": stopped_daemon_evidence_ref,
         "backup_receipt": str(result.backup_receipt) if result.backup_receipt is not None else None,
         "from_version": result.from_version,
         "to_version": result.to_version,

--- a/polylogue/cli/commands/maintenance/_migrate_tier.py
+++ b/polylogue/cli/commands/maintenance/_migrate_tier.py
@@ -15,8 +15,6 @@ required-gate budget as every sibling command).
 
 from __future__ import annotations
 
-import contextlib
-import fcntl
 import json
 import os
 import sqlite3
@@ -24,6 +22,11 @@ from pathlib import Path
 
 import click
 
+from polylogue.operations.durable_change_train import (
+    ArchiveOwnershipError,
+    acquire_durable_archive_ownership,
+    execute_durable_change_train,
+)
 from polylogue.paths import archive_root
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.migration_runner import DURABLE_MIGRATION_TIERS, MigrationError
@@ -47,24 +50,6 @@ def _require_stopped_daemon(root: Path) -> str:
     return "proof:daemon-stopped"
 
 
-def _acquire_offline_writer_authority(root: Path) -> tuple[int, str]:
-    """Hold the daemon startup exclusion for the complete offline operation."""
-    pidfile = root / "daemon.pid"
-    descriptor = os.open(pidfile, os.O_RDWR | os.O_CREAT, 0o644)
-    try:
-        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except OSError as exc:
-        os.close(descriptor)
-        raise MigrationError(f"durable migration requires exclusive daemon startup authority: {pidfile}") from exc
-    try:
-        _require_stopped_daemon(root)
-    except Exception:
-        fcntl.flock(descriptor, fcntl.LOCK_UN)
-        os.close(descriptor)
-        raise
-    return descriptor, "proof:daemon-stopped-and-startup-excluded"
-
-
 @click.command("migrate-tier")
 @click.argument("tier", type=click.Choice(tuple(sorted(tier.value for tier in DURABLE_MIGRATION_TIERS))))
 @click.option(
@@ -81,21 +66,23 @@ def migrate_tier_command(tier: str, backup_manifest: Path | None, output_format:
     blue-green replace those from source evidence instead.
     """
     from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS
-    from polylogue.storage.sqlite.migration_runner import hold_durable_migration_writer, migrate_archive_tier
 
     archive_tier = ArchiveTier(tier)
     spec = ARCHIVE_TIER_SPECS[archive_tier]
     path = archive_root() / spec.filename
     stopped_daemon_evidence_ref: str | None = None
-    daemon_authority_fd: int | None = None
     try:
-        daemon_authority_fd, stopped_daemon_evidence_ref = _acquire_offline_writer_authority(path.parent)
-        with (
-            hold_durable_migration_writer(path.parent, owner_id=f"migrate-tier:{os.getpid()}"),
-            contextlib.closing(sqlite3.connect(path)) as conn,
-        ):
-            result = migrate_archive_tier(conn, archive_tier, backup_manifest=backup_manifest)
-    except (sqlite3.Error, MigrationError) as exc:
+        with acquire_durable_archive_ownership(path.parent, owner_id=f"migrate-tier:{os.getpid()}") as archive_owner:
+            stopped_daemon_evidence_ref = _require_stopped_daemon(path.parent)
+            execution = execute_durable_change_train(
+                path.parent,
+                archive_tier,
+                backup_manifest=backup_manifest,
+                daemon_stopped_evidence_ref=stopped_daemon_evidence_ref,
+                single_writer_evidence_ref="proof:archive-ownership-lock",
+                release_archive_ownership=archive_owner.release,
+            )
+    except (sqlite3.Error, MigrationError, ArchiveOwnershipError) as exc:
         if output_format == "json":
             click.echo(
                 json.dumps(
@@ -114,26 +101,30 @@ def migrate_tier_command(tier: str, backup_manifest: Path | None, output_format:
         else:
             click.echo(f"Migration blocked for {tier}: {exc}", err=True)
         raise SystemExit(1) from exc
-    finally:
-        if daemon_authority_fd is not None:
-            fcntl.flock(daemon_authority_fd, fcntl.LOCK_UN)
-            os.close(daemon_authority_fd)
 
+    result = execution.migration_result
     payload = {
         "ok": True,
         "tier": tier,
         "path": str(path),
         "backup_manifest": str(backup_manifest) if backup_manifest is not None else None,
         "stopped_daemon_evidence_ref": stopped_daemon_evidence_ref,
-        "backup_receipt": str(result.backup_receipt) if result.backup_receipt is not None else None,
-        "from_version": result.from_version,
-        "to_version": result.to_version,
-        "applied_versions": list(result.applied_versions),
+        "train_manifest": str(execution.manifest_path) if execution.manifest_path is not None else None,
+        "train_state": execution.train.state.value if execution.train is not None else None,
+        "backup_receipt": str(result.backup_receipt)
+        if result is not None and result.backup_receipt is not None
+        else None,
+        "from_version": result.from_version if result is not None else None,
+        "to_version": result.to_version if result is not None else None,
+        "applied_versions": list(result.applied_versions) if result is not None else [],
     }
     if output_format == "json":
         click.echo(json.dumps(payload, indent=2, sort_keys=True))
         return
 
+    if result is None:
+        click.echo(f"No pending durable migration for {tier}.")
+        return
     applied = ", ".join(str(version) for version in result.applied_versions) or "none"
     click.echo(
         f"Migrated {tier}: {result.from_version} -> {result.to_version} "

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -2144,10 +2144,35 @@ async def run_daemon_services(
 
     log_mapped_bytes_budget_check(logger, check_mapped_bytes_budget_against_cgroup_limit())
 
+    # One stable archive ownership lock is shared with offline maintenance.
+    # The pidfile below remains process metadata only and is never the
+    # authority used to exclude a concurrent migration or startup.
+    from polylogue.operations.durable_change_train import (
+        acquire_durable_archive_ownership,
+        reconcile_durable_change_trains_on_startup,
+    )
+
+    archive_owner = acquire_durable_archive_ownership(archive_root_path, owner_id=f"daemon:{os.getpid()}")
+    try:
+        recovered_train_paths = reconcile_durable_change_trains_on_startup(archive_root_path)
+        if recovered_train_paths:
+            logger.warning(
+                "daemon: reconciled %d interrupted durable change train(s) during startup: %s",
+                len(recovered_train_paths),
+                ", ".join(str(path) for path in recovered_train_paths),
+            )
+    except BaseException:
+        archive_owner.release()
+        raise
+
     # Schema preflight runs FIRST, before any DB-touching startup task. A
     # mismatched runtime/db combination must not even open the DB for FTS or
     # heartbeat queries — that is the IO cost #1003 is meant to avoid.
-    schema_alert = _check_schema_version_fast()
+    try:
+        schema_alert = _check_schema_version_fast()
+    except BaseException:
+        archive_owner.release()
+        raise
     # polylogue-gbs02: "watcher_blocked" here means "the derived tier (or
     # worse) is stale, so materialize/index-writing maintenance loops must
     # stay parked" -- unchanged from before, still gates the loops/converger/
@@ -2215,13 +2240,16 @@ async def run_daemon_services(
 
     # Prevent concurrent daemon instances: verify existing pidfile, then
     # acquire an advisory flock.
-    if pidfile.exists():
-        if _verify_pidfile(pidfile):
+    try:
+        if pidfile.exists() and _verify_pidfile(pidfile):
             old_pid = pidfile.read_text().strip()
             raise RuntimeError(f"Daemon already running (PID {old_pid}). Stop it first or remove {pidfile}")
-        pidfile.unlink(missing_ok=True)
-
-    pidfile_fd = _acquire_pidfile(pidfile)
+        # A stale pidfile is overwritten in place after the stable archive
+        # lock is held. It is never unlinked as a lock-reclamation strategy.
+        pidfile_fd = _acquire_pidfile(pidfile)
+    except BaseException:
+        archive_owner.release()
+        raise
     # Only register the pidfile for atexit cleanup AFTER lock acquisition.
     # Setting _pidfile_path before _acquire_pidfile() means a failed lock
     # attempt by an ephemeral instance would still atexit-unlink the live
@@ -2244,31 +2272,45 @@ async def run_daemon_services(
                 await write_coordinator.run_sync("daemon.lifecycle.stop", lifecycle.stop, exit_kind="error")
         writer_drained = await write_coordinator.shutdown(timeout=5.0)
         _release_pidfile_after_writer_drain(pidfile_fd, writer_drained=writer_drained)
+        if writer_drained:
+            archive_owner.release()
         _daemon_lifecycle = None
         raise
 
-    # Ensure all configured source roots exist so health checks don't flag
-    # never-yet-used sources (e.g. hooks sidecar dir) as missing.
-    for src in sources:
-        src.root.mkdir(parents=True, exist_ok=True)
+    try:
+        # Ensure all configured source roots exist so health checks don't flag
+        # never-yet-used sources (e.g. hooks sidecar dir) as missing.
+        for src in sources:
+            src.root.mkdir(parents=True, exist_ok=True)
 
-    if lifecycle_events_enabled:
-        await _emit_daemon_lifecycle_event(
-            "startup",
-            archive_root_path=archive_root_path,
-            status="starting",
-            payload={
-                "api_enabled": enable_api,
-                "api_host": api_host,
-                "api_port": api_port,
-                "browser_capture_enabled": enable_browser_capture,
-                "browser_capture_host": browser_capture_host,
-                "browser_capture_port": browser_capture_port,
-                "watch_enabled": enable_watch,
-                "source_catchup_enabled": enable_source_catchup,
-                "source_roots": [str(src.root) for src in sources],
-            },
-        )
+        if lifecycle_events_enabled:
+            await _emit_daemon_lifecycle_event(
+                "startup",
+                archive_root_path=archive_root_path,
+                status="starting",
+                payload={
+                    "api_enabled": enable_api,
+                    "api_host": api_host,
+                    "api_port": api_port,
+                    "browser_capture_enabled": enable_browser_capture,
+                    "browser_capture_host": browser_capture_host,
+                    "browser_capture_port": browser_capture_port,
+                    "watch_enabled": enable_watch,
+                    "source_catchup_enabled": enable_source_catchup,
+                    "source_roots": [str(src.root) for src in sources],
+                },
+            )
+    except BaseException:
+        lifecycle = _daemon_lifecycle
+        if lifecycle is not None:
+            with contextlib.suppress(Exception):
+                await write_coordinator.run_sync("daemon.lifecycle.stop", lifecycle.stop, exit_kind="error")
+        writer_drained = await write_coordinator.shutdown(timeout=5.0)
+        _release_pidfile_after_writer_drain(pidfile_fd, writer_drained=writer_drained)
+        if writer_drained:
+            archive_owner.release()
+        _daemon_lifecycle = None
+        raise
 
     # Periodic maintenance tasks. If schema preflight blocks the watcher, do
     # not start any background loop that opens the archive: a mismatched
@@ -2311,6 +2353,7 @@ async def run_daemon_services(
     cleanup_task: asyncio.Task[object] | None = None
     cleanup_cancel_requests = 0
     termination: BaseException | None = None
+    writer_drained = False
     try:
         if enable_browser_capture:
             resolved_browser_capture_auth_token = resolve_receiver_auth_token(
@@ -2629,6 +2672,8 @@ async def run_daemon_services(
                 for _ in range(cleanup_cancel_requests):
                     cleanup_task.cancel()
             restore_signal_handlers(previous_signal_handlers)
+            if writer_drained:
+                archive_owner.release()
             _daemon_lifecycle = None
 
     logger.info("daemon stopped")

--- a/polylogue/operations/durable_change_train.py
+++ b/polylogue/operations/durable_change_train.py
@@ -1,0 +1,60 @@
+"""Product-layer adapters for durable schema-change train operations."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+from polylogue.storage.archive_identity import ArchiveLocation, ArchiveOwnershipError, OwnedArchiveLocation
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.durable_change_train import (
+    DurableChangeTrainExecution,
+)
+from polylogue.storage.sqlite.durable_change_train import (
+    execute_durable_change_train as _execute_durable_change_train,
+)
+from polylogue.storage.sqlite.durable_change_train import (
+    reconcile_durable_change_train_startup as _reconcile_durable_change_train_startup,
+)
+from polylogue.storage.sqlite.migration_runner import DurableRuntimeConsumerResult
+
+
+def acquire_durable_archive_ownership(root: Path, *, owner_id: str) -> OwnedArchiveLocation:
+    """Acquire the stable archive lease shared by daemon and maintenance."""
+    location = ArchiveLocation.resolve(root)
+    return OwnedArchiveLocation.acquire(location, owner_id=owner_id)
+
+
+def execute_durable_change_train(
+    archive_root: Path,
+    tier: ArchiveTier,
+    *,
+    backup_manifest: Path | None,
+    daemon_stopped_evidence_ref: str,
+    single_writer_evidence_ref: str,
+    runtime_consumer_results: tuple[DurableRuntimeConsumerResult, ...] | None = None,
+    release_archive_ownership: Callable[[], None],
+) -> DurableChangeTrainExecution:
+    """Run one durable migration through the storage authority contract."""
+    return _execute_durable_change_train(
+        archive_root,
+        tier,
+        backup_manifest=backup_manifest,
+        daemon_stopped_evidence_ref=daemon_stopped_evidence_ref,
+        single_writer_evidence_ref=single_writer_evidence_ref,
+        runtime_consumer_results=runtime_consumer_results,
+        release_archive_ownership=release_archive_ownership,
+    )
+
+
+def reconcile_durable_change_trains_on_startup(root: Path) -> tuple[Path, ...]:
+    """Run bootstrap train recovery before daemon surfaces open the archive."""
+    return _reconcile_durable_change_train_startup(root)
+
+
+__all__ = [
+    "acquire_durable_archive_ownership",
+    "ArchiveOwnershipError",
+    "execute_durable_change_train",
+    "reconcile_durable_change_trains_on_startup",
+]

--- a/polylogue/storage/archive_identity.py
+++ b/polylogue/storage/archive_identity.py
@@ -7,6 +7,7 @@ import logging
 import os
 import socket
 import sys
+import threading
 import time
 import uuid
 from dataclasses import dataclass
@@ -17,6 +18,9 @@ from typing import Literal
 from polylogue.version import VERSION_INFO
 
 logger = logging.getLogger(__name__)
+
+_LOCAL_ARCHIVE_OWNERS_LOCK = threading.RLock()
+_LOCAL_ARCHIVE_OWNERS: dict[Path, tuple[int, int, str]] = {}
 
 ArchiveTierName = Literal["source", "index", "embeddings", "user", "ops", "audit"]
 TIER_FILENAMES: tuple[tuple[ArchiveTierName, str], ...] = (
@@ -339,7 +343,13 @@ class OwnedArchiveLocation:
         self._fd: int | None = None
 
     @classmethod
-    def acquire(cls, location: ArchiveLocation, *, owner_id: str | None = None) -> OwnedArchiveLocation:
+    def acquire(
+        cls,
+        location: ArchiveLocation,
+        *,
+        owner_id: str | None = None,
+        allow_reentrant: bool = False,
+    ) -> OwnedArchiveLocation:
         """Claim exclusive ownership of ``location`` for a maintenance/campaign writer.
 
         Raises :class:`ArchiveOwnershipError` immediately -- before any
@@ -350,14 +360,31 @@ class OwnedArchiveLocation:
         """
         owner = owner_id or f"pid={os.getpid()} host={socket.gethostname()} token={uuid.uuid4().hex}"
         instance = cls(location)
-        instance._fd = _acquire_ownership_lock_fd(instance.lock_path, owner=owner)
-        instance.owner_id = owner
+        with _LOCAL_ARCHIVE_OWNERS_LOCK:
+            existing = _LOCAL_ARCHIVE_OWNERS.get(instance.lock_path)
+            if existing is None or not allow_reentrant:
+                fd = _acquire_ownership_lock_fd(instance.lock_path, owner=owner)
+                _LOCAL_ARCHIVE_OWNERS[instance.lock_path] = (fd, 1, owner)
+                instance.owner_id = owner
+            else:
+                fd, references, existing_owner = existing
+                _LOCAL_ARCHIVE_OWNERS[instance.lock_path] = (fd, references + 1, existing_owner)
+                instance.owner_id = existing_owner
+            instance._fd = fd
         return instance
 
     def release(self) -> None:
         if self._fd is not None:
-            fcntl.flock(self._fd, fcntl.LOCK_UN)
-            os.close(self._fd)
+            with _LOCAL_ARCHIVE_OWNERS_LOCK:
+                existing = _LOCAL_ARCHIVE_OWNERS.get(self.lock_path)
+                if existing is not None and existing[0] == self._fd:
+                    fd, references, owner = existing
+                    if references <= 1:
+                        _LOCAL_ARCHIVE_OWNERS.pop(self.lock_path, None)
+                        fcntl.flock(fd, fcntl.LOCK_UN)
+                        os.close(fd)
+                    else:
+                        _LOCAL_ARCHIVE_OWNERS[self.lock_path] = (fd, references - 1, owner)
             self._fd = None
 
     def __enter__(self) -> OwnedArchiveLocation:

--- a/polylogue/storage/sqlite/archive_tiers/bootstrap.py
+++ b/polylogue/storage/sqlite/archive_tiers/bootstrap.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
@@ -286,8 +287,23 @@ def initialize_archive_database(path: Path, tier: ArchiveTier) -> None:
 
 def initialize_active_archive_root(root: Path) -> None:
     """Create or initialize every tier database in an archive root."""
-    for spec in ARCHIVE_TIER_SPECS.values():
-        initialize_archive_database(root / spec.filename, spec.tier)
+    from polylogue.storage.archive_identity import ArchiveLocation, OwnedArchiveLocation
+
+    with OwnedArchiveLocation.acquire(
+        ArchiveLocation.resolve(root),
+        owner_id=f"bootstrap:{os.getpid()}",
+        allow_reentrant=True,
+    ):
+        reconcile_durable_change_trains_on_startup(root)
+        for spec in ARCHIVE_TIER_SPECS.values():
+            initialize_archive_database(root / spec.filename, spec.tier)
+
+
+def reconcile_durable_change_trains_on_startup(root: Path) -> tuple[Path, ...]:
+    """Reconcile persisted durable trains without executing migration SQL."""
+    from polylogue.storage.sqlite.durable_change_train import reconcile_durable_change_train_startup
+
+    return reconcile_durable_change_train_startup(root)
 
 
 __all__ = [
@@ -297,5 +313,6 @@ __all__ = [
     "initialize_active_archive_root",
     "initialize_archive_database",
     "initialize_archive_tier",
+    "reconcile_durable_change_trains_on_startup",
     "archive_tier_spec",
 ]

--- a/polylogue/storage/sqlite/archive_tiers/bootstrap.py
+++ b/polylogue/storage/sqlite/archive_tiers/bootstrap.py
@@ -10,7 +10,7 @@ from typing import Literal
 from polylogue.storage.sqlite.archive_tiers import ARCHIVE_DDL_BY_TIER, ARCHIVE_VERSION_BY_TIER
 from polylogue.storage.sqlite.archive_tiers.index_convergence import apply_index_benign_ddl_convergence
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
-from polylogue.storage.sqlite.migration_runner import DURABLE_MIGRATION_TIERS, migrate_archive_tier
+from polylogue.storage.sqlite.migration_runner import DURABLE_MIGRATION_TIERS
 from polylogue.storage.sqlite.sqlite_vec_extension import try_load_sqlite_vec
 
 DurabilityClass = Literal["irreplaceable", "rebuildable", "expensive_rebuild", "human", "disposable"]
@@ -219,9 +219,7 @@ def _ensure_ops_cursor_lag_sample_columns(conn: sqlite3.Connection) -> None:
     )
 
 
-def initialize_archive_database(
-    path: Path, tier: ArchiveTier, *, migration_backup_manifest: Path | None = None
-) -> None:
+def initialize_archive_database(path: Path, tier: ArchiveTier) -> None:
     """Create or initialize one archive tier database file."""
     path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(path)
@@ -246,14 +244,6 @@ def initialize_archive_database(
                 # archive converges without touching INDEX_SCHEMA_VERSION.
                 apply_index_benign_ddl_convergence(conn)
                 conn.commit()
-            return
-        if (
-            current_version != 0
-            and current_version < expected_version
-            and tier in DURABLE_MIGRATION_TIERS
-            and migration_backup_manifest is not None
-        ):
-            migrate_archive_tier(conn, tier, backup_manifest=migration_backup_manifest)
             return
         if current_version != 0:
             if current_version < expected_version and tier in DURABLE_MIGRATION_TIERS:

--- a/polylogue/storage/sqlite/archive_tiers/bootstrap.py
+++ b/polylogue/storage/sqlite/archive_tiers/bootstrap.py
@@ -220,10 +220,19 @@ def _ensure_ops_cursor_lag_sample_columns(conn: sqlite3.Connection) -> None:
     )
 
 
-def initialize_archive_database(path: Path, tier: ArchiveTier) -> None:
+def initialize_archive_database(path: Path, tier: ArchiveTier, *, allow_create: bool = True) -> None:
     """Create or initialize one archive tier database file."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(path)
+    if allow_create:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(path)
+    else:
+        try:
+            metadata = path.lstat()
+        except FileNotFoundError as exc:
+            raise RuntimeError(f"durable tier is missing; refusing runtime initialization: {path}") from exc
+        if path.is_symlink() or not path.is_file() or metadata.st_nlink != 1:
+            raise RuntimeError(f"durable tier is not a safe existing file; refusing runtime initialization: {path}")
+        conn = sqlite3.connect(f"{path.resolve(strict=True).as_uri()}?mode=rw", uri=True)
     try:
         current_version = int(conn.execute("PRAGMA user_version").fetchone()[0])
         expected_version = archive_tier_spec(tier).version

--- a/polylogue/storage/sqlite/durable_change_train.py
+++ b/polylogue/storage/sqlite/durable_change_train.py
@@ -1,0 +1,291 @@
+"""Durable source/user migration change-train authority."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+from importlib import resources
+from pathlib import Path
+from typing import Final
+
+from polylogue.storage.sqlite import migration_runner as _migration_runner
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.migration_runner import (
+    DURABLE_CHANGE_TRAIN_FORMAT,
+    DurableChangeTrain,
+    DurableChangeTrainApplyError,
+    DurableChangeTrainError,
+    DurableChangeTrainRecoveryError,
+    DurableChangeTrainState,
+    DurableMigrationClaim,
+    _validate_riders,
+    add_durable_change_train_rider,
+    admit_durable_change_train,
+    apply_durable_change_train,
+    authorize_durable_change_train_backup,
+    declare_durable_change_train,
+    durable_change_train_from_payload,
+    durable_change_train_to_payload,
+    durable_migration_claim_for_sql,
+    durable_migration_claims,
+    durable_migration_collision_report,
+    find_durable_migration_collisions,
+    load_durable_change_train_manifest,
+    prove_durable_change_train,
+    reconcile_interrupted_durable_change_train,
+    record_durable_writer_release,
+    recover_durable_change_train,
+    release_durable_change_train,
+    reserve_durable_change_train,
+    validate_durable_change_train_manifest,
+    write_durable_change_train_manifest,
+)
+
+DURABLE_MIGRATION_ADOPTION_FLOORS: Final[dict[ArchiveTier, int]] = {
+    ArchiveTier.SOURCE: 26,
+    ArchiveTier.USER: 10,
+}
+_SIDECAR_NAME_RE = re.compile(r"^(?P<slot>\d{3,})\.train\.json$")
+_MIGRATION_NAME_RE = re.compile(r"^(?P<slot>\d{3,})_[a-z0-9_]+\.sql$")
+_DROP_SQL_RE = re.compile(r"(?is)\bDROP\s+(?:TABLE|INDEX|TRIGGER|VIEW)\b")
+
+
+@dataclass(frozen=True, slots=True)
+class DurableMigrationSidecar:
+    """A deterministic package resource binding one SQL slot to its train."""
+
+    tier: ArchiveTier
+    slot: int
+    resource_name: str
+    train: DurableChangeTrain
+
+
+def durable_migration_sidecar_name(slot: int) -> str:
+    """Return the only accepted Git path for a numbered train sidecar."""
+    if slot < 1:
+        raise DurableChangeTrainError(f"durable migration sidecar slot must be positive: {slot}")
+    return f"{slot:03d}.train.json"
+
+
+def _migration_package(tier: ArchiveTier) -> str:
+    return f"polylogue.storage.sqlite.migrations.{tier.value}"
+
+
+def _sidecar_slot(name: str) -> int | None:
+    match = _SIDECAR_NAME_RE.fullmatch(name)
+    return int(match.group("slot")) if match is not None else None
+
+
+def _load_sidecar_resource(tier: ArchiveTier, resource_name: str) -> DurableMigrationSidecar:
+    try:
+        resource = resources.files(_migration_package(tier)).joinpath(resource_name)
+        raw = json.loads(resource.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise DurableChangeTrainError(
+            f"missing durable migration train sidecar for {tier.value}: {resource_name}"
+        ) from exc
+    except (json.JSONDecodeError, OSError, UnicodeError) as exc:
+        raise DurableChangeTrainError(
+            f"malformed durable migration train sidecar for {tier.value}: {resource_name}"
+        ) from exc
+    if not isinstance(raw, dict):
+        raise DurableChangeTrainError(f"durable migration train sidecar must be an object: {resource_name}")
+    train = durable_change_train_from_payload(raw)
+    slot = _sidecar_slot(resource_name)
+    if slot is None:
+        raise DurableChangeTrainError(f"invalid durable migration train sidecar name: {resource_name}")
+    return DurableMigrationSidecar(tier=tier, slot=slot, resource_name=resource_name, train=train)
+
+
+def _validate_sidecar_binding(
+    sidecar: DurableMigrationSidecar,
+    *,
+    migration_name: str,
+    sql: str,
+) -> None:
+    train = sidecar.train
+    expected_claim = durable_migration_claim_for_sql(
+        sidecar.tier,
+        migration_name,
+        sql,
+        owner_ref=train.migration.owner_ref,
+    )
+    if train.state is not DurableChangeTrainState.DECLARED:
+        raise DurableChangeTrainError(f"durable migration sidecar must begin declared: {sidecar.resource_name}")
+    if train.tier is not sidecar.tier or train.current_version != sidecar.slot - 1:
+        raise DurableChangeTrainError(
+            f"durable migration sidecar version is stale or mismatched: {sidecar.resource_name}"
+        )
+    if train.target_version != sidecar.slot or train.slot != sidecar.slot:
+        raise DurableChangeTrainError(f"durable migration sidecar target/slot mismatch: {sidecar.resource_name}")
+    if Path(train.migration.path).name != migration_name:
+        raise DurableChangeTrainError(f"durable migration sidecar SQL filename mismatch: {sidecar.resource_name}")
+    if train.migration.sql_sha256 != expected_claim.sql_sha256:
+        raise DurableChangeTrainError(f"durable migration sidecar SQL SHA-256 mismatch: {sidecar.resource_name}")
+    if train.migration.requires_backup != expected_claim.requires_backup:
+        raise DurableChangeTrainError(f"durable migration sidecar backup policy mismatch: {sidecar.resource_name}")
+    _validate_riders(train)
+    if train.migration.requires_backup and not train.backup_plan_ref:
+        raise DurableChangeTrainError(
+            f"backup-required durable migration sidecar lacks a backup plan: {sidecar.resource_name}"
+        )
+    if _DROP_SQL_RE.search(sql) is not None and not train.drop_constraints:
+        raise DurableChangeTrainError(f"durable migration sidecar forbids an unapproved drop: {sidecar.resource_name}")
+
+
+def validate_durable_migration_sidecars(
+    tier: ArchiveTier,
+    migrations: Sequence[tuple[str, str]],
+) -> tuple[DurableMigrationSidecar, ...]:
+    """Require and validate every post-floor SQL slot's checked-in sidecar.
+
+    Discovery uses ``importlib.resources`` so the policy follows the package
+    resources consumed by production, including installed wheels. Extra,
+    malformed, stale, or orphaned sidecars are rejected as well.
+    """
+    if tier not in DURABLE_MIGRATION_ADOPTION_FLOORS:
+        return ()
+    by_slot: dict[int, tuple[str, str]] = {}
+    for name, sql in migrations:
+        match = _MIGRATION_NAME_RE.fullmatch(name)
+        if match is None:
+            continue
+        slot = int(match.group("slot"))
+        if slot in by_slot:
+            raise DurableChangeTrainError(f"duplicate durable migration slot: {tier.value}/{slot:03d}")
+        by_slot[slot] = (name, sql)
+    floor = DURABLE_MIGRATION_ADOPTION_FLOORS[tier]
+    try:
+        package = resources.files(_migration_package(tier))
+        sidecar_names = {item.name for item in package.iterdir() if item.name.endswith(".train.json")}
+    except (ModuleNotFoundError, FileNotFoundError) as exc:
+        if any(slot > floor for slot in by_slot):
+            raise DurableChangeTrainError(f"cannot discover durable migration train sidecars for {tier.value}") from exc
+        return ()
+    observed: list[DurableMigrationSidecar] = []
+    for name in sorted(sidecar_names):
+        sidecar_slot = _sidecar_slot(name)
+        if sidecar_slot is None:
+            raise DurableChangeTrainError(f"invalid durable migration train sidecar name: {name}")
+        if sidecar_slot <= floor:
+            raise DurableChangeTrainError(
+                f"durable migration train sidecar is below adoption floor: {tier.value}/{name}"
+            )
+        if sidecar_slot not in by_slot:
+            raise DurableChangeTrainError(
+                f"durable migration train sidecar has no matching SQL resource: {tier.value}/{name}"
+            )
+        sidecar = _load_sidecar_resource(tier, name)
+        _validate_sidecar_binding(
+            sidecar,
+            migration_name=by_slot[sidecar_slot][0],
+            sql=by_slot[sidecar_slot][1],
+        )
+        observed.append(sidecar)
+    for slot, (name, sql) in sorted(by_slot.items()):
+        if slot <= floor:
+            continue
+        expected_name = durable_migration_sidecar_name(slot)
+        if expected_name not in sidecar_names:
+            raise DurableChangeTrainError(f"missing durable migration train sidecar: {tier.value}/{expected_name}")
+        sidecar = _load_sidecar_resource(tier, expected_name)
+        _validate_sidecar_binding(sidecar, migration_name=name, sql=sql)
+        if sidecar.slot != slot:
+            raise DurableChangeTrainError(f"durable migration train sidecar slot mismatch: {expected_name}")
+    expected_slots = tuple(range(floor + 1, max(by_slot, default=floor) + 1))
+    observed_slots = tuple(sorted(slot for slot in by_slot if slot > floor))
+    if observed_slots != expected_slots:
+        raise DurableChangeTrainError(
+            f"durable migration train sidecars are noncontiguous for {tier.value}: "
+            f"expected {expected_slots}, found {observed_slots}"
+        )
+    return tuple(observed)
+
+
+def durable_change_train_policy_report(tier: ArchiveTier) -> dict[str, object]:
+    """Emit reservations and every discovered violation for schema policy JSON."""
+    reservations: list[dict[str, object]] = []
+    violations: list[str] = []
+    try:
+        package = resources.files(_migration_package(tier))
+        migrations = tuple(
+            (item.name, item.read_text(encoding="utf-8"))
+            for item in package.iterdir()
+            if _MIGRATION_NAME_RE.fullmatch(item.name) is not None
+        )
+        sidecars = validate_durable_migration_sidecars(tier, migrations)
+        for sidecar in sidecars:
+            reservation = sidecar.train.reservation
+            if reservation is not None:
+                reservations.append(
+                    {
+                        "tier": tier.value,
+                        "slot": sidecar.slot,
+                        "resource": sidecar.resource_name,
+                        "reservation": {
+                            "reservation_id": reservation.reservation_id,
+                            "owner_ref": reservation.owner_ref,
+                            "archive_root": reservation.archive_root,
+                            "tier_path": reservation.tier_path,
+                            "active": reservation.active,
+                        },
+                    }
+                )
+    except (DurableChangeTrainError, ModuleNotFoundError, FileNotFoundError, OSError) as exc:
+        violations.append(str(exc))
+    return {
+        "tier": tier.value,
+        "adoption_floor": DURABLE_MIGRATION_ADOPTION_FLOORS.get(tier),
+        "reservations": reservations,
+        "violations": violations,
+        "ok": not violations,
+    }
+
+
+DurableChangeTrainManifest = DurableChangeTrain
+
+
+def __getattr__(name: str) -> object:
+    """Keep the authority import path compatible with the runner API."""
+    try:
+        return getattr(_migration_runner, name)
+    except AttributeError as exc:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
+
+
+__all__ = [
+    "DURABLE_CHANGE_TRAIN_FORMAT",
+    "DURABLE_MIGRATION_ADOPTION_FLOORS",
+    "DurableChangeTrainManifest",
+    "DurableMigrationSidecar",
+    "durable_migration_sidecar_name",
+    "validate_durable_migration_sidecars",
+    "durable_change_train_policy_report",
+    "DurableChangeTrain",
+    "DurableChangeTrainState",
+    "DurableChangeTrainError",
+    "DurableChangeTrainApplyError",
+    "DurableChangeTrainRecoveryError",
+    "DurableMigrationClaim",
+    "durable_migration_claim_for_sql",
+    "durable_migration_claims",
+    "durable_migration_collision_report",
+    "find_durable_migration_collisions",
+    "add_durable_change_train_rider",
+    "durable_change_train_to_payload",
+    "validate_durable_change_train_manifest",
+    "declare_durable_change_train",
+    "admit_durable_change_train",
+    "reserve_durable_change_train",
+    "authorize_durable_change_train_backup",
+    "apply_durable_change_train",
+    "recover_durable_change_train",
+    "reconcile_interrupted_durable_change_train",
+    "record_durable_writer_release",
+    "prove_durable_change_train",
+    "release_durable_change_train",
+    "write_durable_change_train_manifest",
+    "load_durable_change_train_manifest",
+]

--- a/polylogue/storage/sqlite/durable_change_train.py
+++ b/polylogue/storage/sqlite/durable_change_train.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import importlib
+import inspect
 import json
+import os
 import re
-from collections.abc import Sequence
+import sqlite3
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from importlib import resources
 from pathlib import Path
-from typing import Final
+from typing import Final, cast
 
 from polylogue.storage.sqlite import migration_runner as _migration_runner
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
@@ -19,7 +23,10 @@ from polylogue.storage.sqlite.migration_runner import (
     DurableChangeTrainError,
     DurableChangeTrainRecoveryError,
     DurableChangeTrainState,
+    DurableFreshDDLParityProof,
     DurableMigrationClaim,
+    DurableRuntimeConsumerResult,
+    MigrationResult,
     _validate_riders,
     add_durable_change_train_rider,
     admit_durable_change_train,
@@ -34,6 +41,7 @@ from polylogue.storage.sqlite.migration_runner import (
     find_durable_migration_collisions,
     load_durable_change_train_manifest,
     prove_durable_change_train,
+    prove_durable_fresh_ddl_parity,
     reconcile_interrupted_durable_change_train,
     record_durable_writer_release,
     recover_durable_change_train,
@@ -60,6 +68,15 @@ class DurableMigrationSidecar:
     slot: int
     resource_name: str
     train: DurableChangeTrain
+
+
+@dataclass(frozen=True, slots=True)
+class DurableChangeTrainExecution:
+    """Result of one production durable change-train execution."""
+
+    train: DurableChangeTrain | None
+    manifest_path: Path | None
+    migration_result: MigrationResult | None
 
 
 def durable_migration_sidecar_name(slot: int) -> str:
@@ -244,6 +261,356 @@ def durable_change_train_policy_report(tier: ArchiveTier) -> dict[str, object]:
     }
 
 
+def durable_change_train_manifest_path(archive_root: Path, tier: ArchiveTier, slot: int) -> Path:
+    """Return the stable persisted authority path for one archive train."""
+    if tier not in DURABLE_MIGRATION_ADOPTION_FLOORS:
+        raise DurableChangeTrainError(f"{tier.value} has no durable change-train authority")
+    if slot <= DURABLE_MIGRATION_ADOPTION_FLOORS[tier]:
+        raise DurableChangeTrainError(f"durable train slot is below the adoption floor: {tier.value}/{slot}")
+    return archive_root / ".maintenance-state" / "durable-change-trains" / f"{tier.value}-{slot:03d}.json"
+
+
+def durable_migration_sidecar_for_slot(tier: ArchiveTier, slot: int) -> DurableMigrationSidecar | None:
+    """Load the package sidecar for the next numbered production migration."""
+    if tier not in DURABLE_MIGRATION_ADOPTION_FLOORS:
+        return None
+    steps = _migration_runner._load_migrations(tier)
+    step = next((item for item in steps if item.version == slot), None)
+    if step is None:
+        return None
+    sidecars = validate_durable_migration_sidecars(tier, tuple((item.name, item.sql) for item in steps))
+    return next((item for item in sidecars if item.slot == slot), None)
+
+
+def _persist_train_transition(path: Path, train: DurableChangeTrain, *, expected_revision: int) -> DurableChangeTrain:
+    write_durable_change_train_manifest(path, train, expected_revision=expected_revision)
+    return load_durable_change_train_manifest(path)
+
+
+def _fresh_ddl_parity_for_train(
+    train: DurableChangeTrain,
+    *,
+    migrated_connection: sqlite3.Connection | None = None,
+) -> DurableFreshDDLParityProof:
+    """Compare a live result, or two canonical creates, against bootstrap DDL."""
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+
+    if migrated_connection is None:
+        with sqlite3.connect(":memory:") as migrated, sqlite3.connect(":memory:") as fresh:
+            initialize_archive_tier(migrated, train.tier)
+            initialize_archive_tier(fresh, train.tier)
+            return prove_durable_fresh_ddl_parity(
+                train.tier,
+                train.target_version,
+                migrated_connection=migrated,
+                fresh_connection=fresh,
+                evidence_ref=f"proof:canonical-bootstrap:{train.tier.value}:v{train.target_version}",
+            )
+    with sqlite3.connect(":memory:") as fresh:
+        initialize_archive_tier(fresh, train.tier)
+        return prove_durable_fresh_ddl_parity(
+            train.tier,
+            train.target_version,
+            migrated_connection=migrated_connection,
+            fresh_connection=fresh,
+            evidence_ref=f"proof:recovered-bootstrap:{train.tier.value}:v{train.target_version}",
+        )
+
+
+def _runtime_consumer_results(
+    train: DurableChangeTrain,
+    archive_root: Path,
+) -> tuple[DurableRuntimeConsumerResult, ...]:
+    """Invoke each declared production probe before recording behavior proof."""
+    results: list[DurableRuntimeConsumerResult] = []
+    for rider in train.riders:
+        for consumer in rider.runtime_consumers:
+            reference = consumer.production_ref
+            module_ref, separator, symbol_ref = reference.partition(":")
+            if not separator or not symbol_ref:
+                raise DurableChangeTrainError(f"runtime consumer reference is not importable: {reference}")
+            module_name = module_ref.removesuffix(".py").replace("/", ".")
+            try:
+                value: object = importlib.import_module(module_name)
+                for component in symbol_ref.split("."):
+                    value = getattr(value, component)
+            except (ImportError, AttributeError) as exc:
+                raise DurableChangeTrainError(
+                    f"runtime consumer {consumer.consumer_id} cannot resolve production reference {reference}"
+                ) from exc
+            if not callable(value):
+                raise DurableChangeTrainError(f"runtime consumer {consumer.consumer_id} is not callable: {reference}")
+            try:
+                if reference.endswith(":initialize_archive_database"):
+                    value(archive_root / f"{train.tier.value}.db", train.tier)
+                elif reference.endswith(":initialize_archive_tier"):
+                    with sqlite3.connect(":memory:") as probe:
+                        value(probe, train.tier)
+                elif not any(
+                    parameter.default is inspect.Parameter.empty
+                    and parameter.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+                    for parameter in inspect.signature(value).parameters.values()
+                ):
+                    value()
+                else:
+                    raise DurableChangeTrainError(
+                        f"runtime consumer {consumer.consumer_id} has no durable probe adapter: {reference}"
+                    )
+            except DurableChangeTrainError:
+                raise
+            except Exception as exc:
+                raise DurableChangeTrainError(
+                    f"runtime consumer {consumer.consumer_id} probe failed: {reference}: {exc}"
+                ) from exc
+            results.append(
+                DurableRuntimeConsumerResult(
+                    consumer_id=consumer.consumer_id,
+                    behavior_proof_ref=consumer.behavior_proof_ref,
+                    passed=True,
+                    detail=f"resolved {reference}",
+                )
+            )
+    return tuple(results)
+
+
+def _prove_and_release_persisted_train(
+    archive_root: Path,
+    manifest_path: Path,
+    train: DurableChangeTrain,
+    *,
+    runtime_consumer_results: Sequence[DurableRuntimeConsumerResult] | None = None,
+) -> DurableChangeTrain:
+    """Finish a persisted applied/proven train after an interrupted process."""
+    tier_path = archive_root / f"{train.tier.value}.db"
+    if train.state is DurableChangeTrainState.APPLIED:
+        if train.reservation is not None and train.reservation.active:
+            previous_revision = train.revision
+            train = record_durable_writer_release(
+                train,
+                evidence_ref=f"proof:startup-writer-release:{train.train_id}",
+            )
+            train = _persist_train_transition(manifest_path, train, expected_revision=previous_revision)
+        from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+
+        initialize_archive_database(tier_path, train.tier)
+        with sqlite3.connect(tier_path) as restarted:
+            actual_parity = _fresh_ddl_parity_for_train(train, migrated_connection=restarted)
+            runtime_results = (
+                tuple(runtime_consumer_results)
+                if runtime_consumer_results is not None
+                else _runtime_consumer_results(train, archive_root)
+            )
+            restart = _migration_runner.capture_durable_restart_convergence(
+                restarted,
+                train,
+                runtime_consumers=runtime_results,
+                evidence_ref=f"proof:startup-restart:{train.train_id}",
+            )
+        previous_revision = train.revision
+        train = prove_durable_change_train(
+            train,
+            fresh_ddl_parity=actual_parity,
+            runtime_consumers=runtime_results,
+            restart_convergence=restart,
+            proof_refs=(f"proof:startup-recovery:{train.train_id}",),
+        )
+        train = _persist_train_transition(manifest_path, train, expected_revision=previous_revision)
+    if train.state is DurableChangeTrainState.PROVEN:
+        previous_revision = train.revision
+        train = release_durable_change_train(
+            train,
+            evidence_ref=f"proof:startup-train-release:{train.train_id}",
+        )
+        train = _persist_train_transition(manifest_path, train, expected_revision=previous_revision)
+    return train
+
+
+def execute_durable_change_train(
+    archive_root: Path,
+    tier: ArchiveTier,
+    *,
+    backup_manifest: Path | None,
+    daemon_stopped_evidence_ref: str,
+    single_writer_evidence_ref: str,
+    runtime_consumer_results: Sequence[DurableRuntimeConsumerResult] | None = None,
+    release_archive_ownership: Callable[[], None],
+) -> DurableChangeTrainExecution:
+    """Execute the real maintenance route through every persisted train state."""
+    reconcile_durable_change_train_startup(archive_root)
+    tier_path = archive_root / f"{tier.value}.db"
+    with sqlite3.connect(tier_path) as probe:
+        current_version = int(probe.execute("PRAGMA user_version").fetchone()[0] or 0)
+    runtime_target_version = cast(dict[ArchiveTier, int], vars(_migration_runner)["ARCHIVE_VERSION_BY_TIER"])[tier]
+    if current_version > runtime_target_version:
+        raise DurableChangeTrainError(
+            f"{tier.value} tier version {current_version} is newer than runtime target {runtime_target_version}"
+        )
+    if current_version < runtime_target_version:
+        # Validate the complete route before any historical step can commit.
+        # This prevents an old archive from being advanced to the adoption
+        # floor when a later SQL/sidecar slot is missing.
+        migration_steps = _migration_runner._load_migrations(tier)
+        validate_durable_migration_sidecars(
+            tier,
+            tuple((step.name, step.sql) for step in migration_steps),
+        )
+        with sqlite3.connect(":memory:") as preflight:
+            _migration_runner._pending_migration_steps(
+                preflight,
+                tier,
+                current_version=current_version,
+                target_version=runtime_target_version,
+            )
+    legacy_result: MigrationResult | None = None
+    floor = DURABLE_MIGRATION_ADOPTION_FLOORS.get(tier)
+    if floor is not None and current_version < floor:
+        with sqlite3.connect(tier_path) as conn:
+            legacy_result = _migration_runner.migrate_archive_tier(
+                conn,
+                tier,
+                backup_manifest=backup_manifest,
+                target_version=floor,
+            )
+        current_version = legacy_result.to_version
+    sidecar = durable_migration_sidecar_for_slot(tier, current_version + 1)
+    if sidecar is None:
+        if current_version != runtime_target_version:
+            raise DurableChangeTrainError(
+                f"durable migration chain for {tier.value} stops at v{current_version}; "
+                f"runtime requires v{runtime_target_version} and the next train sidecar is missing"
+            )
+        return DurableChangeTrainExecution(train=None, manifest_path=None, migration_result=legacy_result)
+
+    manifest_path = durable_change_train_manifest_path(archive_root, tier, sidecar.slot)
+    if manifest_path.exists():
+        train = load_durable_change_train_manifest(manifest_path)
+        if train.train_id != sidecar.train.train_id or train.migration != sidecar.train.migration:
+            raise DurableChangeTrainError(f"persisted durable train does not match package sidecar: {manifest_path}")
+    else:
+        train = _persist_train_transition(manifest_path, sidecar.train, expected_revision=-1)
+
+    if train.state is DurableChangeTrainState.RELEASED:
+        return DurableChangeTrainExecution(train=train, manifest_path=manifest_path, migration_result=None)
+
+    if train.state is DurableChangeTrainState.DECLARED:
+        previous_revision = train.revision
+        train = admit_durable_change_train(
+            train,
+            observed_current_version=current_version,
+            fresh_ddl_parity=_fresh_ddl_parity_for_train(train),
+            admission_evidence_ref=f"proof:maintenance-admission:{train.train_id}",
+            migration_claims=(sidecar.train.migration,),
+            canonical_target_version=cast(dict[ArchiveTier, int], vars(_migration_runner)["ARCHIVE_VERSION_BY_TIER"])[
+                tier
+            ],
+        )
+        train = _persist_train_transition(manifest_path, train, expected_revision=previous_revision)
+    if train.state is DurableChangeTrainState.ADMITTED:
+        previous_revision = train.revision
+        train = reserve_durable_change_train(
+            train,
+            reservation_id=f"maintenance:{train.train_id}",
+            reservation_owner_ref=train.owner_ref,
+            archive_root=archive_root,
+            tier_path=tier_path,
+            daemon_stopped_evidence_ref=daemon_stopped_evidence_ref,
+            single_writer_evidence_ref=single_writer_evidence_ref,
+        )
+        train = _persist_train_transition(manifest_path, train, expected_revision=previous_revision)
+    if train.state is DurableChangeTrainState.RESERVED:
+        previous_revision = train.revision
+        with sqlite3.connect(tier_path) as conn:
+            train = authorize_durable_change_train_backup(
+                conn,
+                train,
+                backup_manifest=backup_manifest,
+                evidence_ref=f"proof:maintenance-backup:{train.train_id}",
+            )
+        train = _persist_train_transition(manifest_path, train, expected_revision=previous_revision)
+    if train.state is DurableChangeTrainState.BACKUP_AUTHORIZED:
+        previous_revision = train.revision
+        try:
+            with sqlite3.connect(tier_path) as conn:
+                train = apply_durable_change_train(conn, train)
+        except DurableChangeTrainApplyError as exc:
+            _persist_train_transition(manifest_path, exc.failed_train, expected_revision=previous_revision)
+            raise
+        train = _persist_train_transition(manifest_path, train, expected_revision=previous_revision)
+    if train.state is not DurableChangeTrainState.APPLIED:
+        raise DurableChangeTrainError(f"maintenance train did not reach applied state: {train.state.value}")
+
+    migration_result = train.apply_evidence.migration_result if train.apply_evidence is not None else None
+    if legacy_result is not None and migration_result is not None:
+        migration_result = MigrationResult(
+            tier=tier,
+            from_version=legacy_result.from_version,
+            to_version=migration_result.to_version,
+            applied_versions=legacy_result.applied_versions + migration_result.applied_versions,
+            backup_receipt=migration_result.backup_receipt or legacy_result.backup_receipt,
+        )
+    previous_revision = train.revision
+    train = record_durable_writer_release(
+        train,
+        evidence_ref=f"proof:maintenance-writer-release:{train.train_id}",
+    )
+    train = _persist_train_transition(manifest_path, train, expected_revision=previous_revision)
+
+    # Keep the stable archive lease through restart and runtime proof so a
+    # daemon cannot reconcile the same APPLIED manifest concurrently.
+    train = _prove_and_release_persisted_train(
+        archive_root,
+        manifest_path,
+        train,
+        runtime_consumer_results=runtime_consumer_results,
+    )
+    release_archive_ownership()
+    return DurableChangeTrainExecution(train=train, manifest_path=manifest_path, migration_result=migration_result)
+
+
+def reconcile_durable_change_train_startup(archive_root: Path) -> tuple[Path, ...]:
+    """Reconcile backup-authorized trains left by a crashed maintenance process."""
+    from polylogue.storage.archive_identity import ArchiveLocation, OwnedArchiveLocation
+
+    with OwnedArchiveLocation.acquire(
+        ArchiveLocation.resolve(archive_root),
+        owner_id=f"durable-train-recovery:{os.getpid()}",
+        allow_reentrant=True,
+    ):
+        return _reconcile_durable_change_train_startup_locked(archive_root)
+
+
+def _reconcile_durable_change_train_startup_locked(archive_root: Path) -> tuple[Path, ...]:
+    """Reconcile persisted trains while the caller holds archive ownership."""
+    manifest_root = archive_root / ".maintenance-state" / "durable-change-trains"
+    if not manifest_root.is_dir():
+        return ()
+    reconciled: list[Path] = []
+    for manifest_path in sorted(manifest_root.glob("*.json")):
+        train = load_durable_change_train_manifest(manifest_path)
+        if train.state is DurableChangeTrainState.BACKUP_AUTHORIZED:
+            tier_path = archive_root / f"{train.tier.value}.db"
+            try:
+                with sqlite3.connect(tier_path) as conn:
+                    recovered = reconcile_interrupted_durable_change_train(
+                        conn,
+                        train,
+                        interruption_evidence_ref=f"proof:startup-recovery:{train.train_id}",
+                        writer_release_evidence_ref=f"proof:startup-writer-release:{train.train_id}",
+                    )
+            except DurableChangeTrainRecoveryError as exc:
+                _persist_train_transition(manifest_path, exc.failed_train, expected_revision=train.revision)
+                raise
+            train = _persist_train_transition(manifest_path, recovered, expected_revision=train.revision)
+        if train.state not in {
+            DurableChangeTrainState.APPLIED,
+            DurableChangeTrainState.PROVEN,
+        }:
+            continue
+        _prove_and_release_persisted_train(archive_root, manifest_path, train)
+        reconciled.append(manifest_path)
+    return tuple(reconciled)
+
+
 DurableChangeTrainManifest = DurableChangeTrain
 
 
@@ -260,9 +627,14 @@ __all__ = [
     "DURABLE_MIGRATION_ADOPTION_FLOORS",
     "DurableChangeTrainManifest",
     "DurableMigrationSidecar",
+    "DurableChangeTrainExecution",
     "durable_migration_sidecar_name",
     "validate_durable_migration_sidecars",
     "durable_change_train_policy_report",
+    "durable_change_train_manifest_path",
+    "durable_migration_sidecar_for_slot",
+    "execute_durable_change_train",
+    "reconcile_durable_change_train_startup",
     "DurableChangeTrain",
     "DurableChangeTrainState",
     "DurableChangeTrainError",

--- a/polylogue/storage/sqlite/durable_change_train.py
+++ b/polylogue/storage/sqlite/durable_change_train.py
@@ -27,11 +27,13 @@ from polylogue.storage.sqlite.migration_runner import (
     DurableMigrationClaim,
     DurableRuntimeConsumerResult,
     MigrationResult,
+    _assert_durable_database_continuity,
     _validate_riders,
     add_durable_change_train_rider,
     admit_durable_change_train,
     apply_durable_change_train,
     authorize_durable_change_train_backup,
+    capture_durable_database_evidence,
     declare_durable_change_train,
     durable_change_train_from_payload,
     durable_change_train_to_payload,
@@ -342,7 +344,7 @@ def _runtime_consumer_results(
                 raise DurableChangeTrainError(f"runtime consumer {consumer.consumer_id} is not callable: {reference}")
             try:
                 if reference.endswith(":initialize_archive_database"):
-                    value(archive_root / f"{train.tier.value}.db", train.tier)
+                    value(archive_root / f"{train.tier.value}.db", train.tier, allow_create=False)
                 elif reference.endswith(":initialize_archive_tier"):
                     with sqlite3.connect(":memory:") as probe:
                         value(probe, train.tier)
@@ -373,6 +375,42 @@ def _runtime_consumer_results(
     return tuple(results)
 
 
+def _open_existing_tier(tier_path: Path) -> sqlite3.Connection:
+    """Open an existing durable tier without allowing SQLite to create it."""
+    try:
+        metadata = tier_path.lstat()
+    except FileNotFoundError as exc:
+        raise DurableChangeTrainError(
+            "durable tier is missing; refusing startup initialization/release until restored"
+        ) from exc
+    if tier_path.is_symlink() or not tier_path.is_file() or metadata.st_nlink != 1:
+        raise DurableChangeTrainError(
+            "durable tier was replaced by an unsafe file; refusing startup initialization/release"
+        )
+    try:
+        return sqlite3.connect(f"{tier_path.resolve(strict=True).as_uri()}?mode=rw", uri=True)
+    except (OSError, sqlite3.Error) as exc:
+        raise DurableChangeTrainError("durable tier could not be opened without initialization") from exc
+
+
+def _verify_persisted_live_tier_continuity(conn: sqlite3.Connection, train: DurableChangeTrain) -> None:
+    """Prove the exact reopened connection still names the persisted durable tier."""
+    if train.apply_evidence is None:
+        raise DurableChangeTrainError(f"{train.state.value} train lacks post-apply continuity evidence")
+    actual = capture_durable_database_evidence(conn, train.tier)
+    expected = train.apply_evidence.post
+    if actual.user_version != train.target_version:
+        raise DurableChangeTrainError(
+            f"{train.tier.value} durable tier continuity proof failed; refusing startup initialization/release"
+        )
+    try:
+        _assert_durable_database_continuity(actual, expected, label=train.tier.value)
+    except DurableChangeTrainError as exc:
+        raise DurableChangeTrainError(
+            f"{train.tier.value} durable tier continuity proof failed; refusing startup initialization/release"
+        ) from exc
+
+
 def _prove_and_release_persisted_train(
     archive_root: Path,
     manifest_path: Path,
@@ -383,45 +421,49 @@ def _prove_and_release_persisted_train(
     """Finish a persisted applied/proven train after an interrupted process."""
     tier_path = archive_root / f"{train.tier.value}.db"
     if train.state is DurableChangeTrainState.APPLIED:
-        if train.reservation is not None and train.reservation.active:
-            previous_revision = train.revision
-            train = record_durable_writer_release(
-                train,
-                evidence_ref=f"proof:startup-writer-release:{train.train_id}",
-            )
-            train = _persist_train_transition(manifest_path, train, expected_revision=previous_revision)
-        from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
-
-        initialize_archive_database(tier_path, train.tier)
-        with sqlite3.connect(tier_path) as restarted:
-            actual_parity = _fresh_ddl_parity_for_train(train, migrated_connection=restarted)
+        live = _open_existing_tier(tier_path)
+        try:
+            _verify_persisted_live_tier_continuity(live, train)
+            if train.reservation is not None and train.reservation.active:
+                previous_revision = train.revision
+                train = record_durable_writer_release(
+                    train,
+                    evidence_ref=f"proof:startup-writer-release:{train.train_id}",
+                )
+                train = _persist_train_transition(manifest_path, train, expected_revision=previous_revision)
+            actual_parity = _fresh_ddl_parity_for_train(train, migrated_connection=live)
             runtime_results = (
                 tuple(runtime_consumer_results)
                 if runtime_consumer_results is not None
                 else _runtime_consumer_results(train, archive_root)
             )
             restart = _migration_runner.capture_durable_restart_convergence(
-                restarted,
+                live,
                 train,
                 runtime_consumers=runtime_results,
                 evidence_ref=f"proof:startup-restart:{train.train_id}",
             )
-        previous_revision = train.revision
-        train = prove_durable_change_train(
-            train,
-            fresh_ddl_parity=actual_parity,
-            runtime_consumers=runtime_results,
-            restart_convergence=restart,
-            proof_refs=(f"proof:startup-recovery:{train.train_id}",),
-        )
-        train = _persist_train_transition(manifest_path, train, expected_revision=previous_revision)
+            previous_revision = train.revision
+            train = prove_durable_change_train(
+                train,
+                fresh_ddl_parity=actual_parity,
+                runtime_consumers=runtime_results,
+                restart_convergence=restart,
+                proof_refs=(f"proof:startup-recovery:{train.train_id}",),
+            )
+            _verify_persisted_live_tier_continuity(live, train)
+            train = _persist_train_transition(manifest_path, train, expected_revision=previous_revision)
+        finally:
+            live.close()
     if train.state is DurableChangeTrainState.PROVEN:
-        previous_revision = train.revision
-        train = release_durable_change_train(
-            train,
-            evidence_ref=f"proof:startup-train-release:{train.train_id}",
-        )
-        train = _persist_train_transition(manifest_path, train, expected_revision=previous_revision)
+        with _open_existing_tier(tier_path) as live:
+            _verify_persisted_live_tier_continuity(live, train)
+            previous_revision = train.revision
+            train = release_durable_change_train(
+                train,
+                evidence_ref=f"proof:startup-train-release:{train.train_id}",
+            )
+            train = _persist_train_transition(manifest_path, train, expected_revision=previous_revision)
     return train
 
 
@@ -438,7 +480,7 @@ def execute_durable_change_train(
     """Execute the real maintenance route through every persisted train state."""
     reconcile_durable_change_train_startup(archive_root)
     tier_path = archive_root / f"{tier.value}.db"
-    with sqlite3.connect(tier_path) as probe:
+    with _open_existing_tier(tier_path) as probe:
         current_version = int(probe.execute("PRAGMA user_version").fetchone()[0] or 0)
     runtime_target_version = cast(dict[ArchiveTier, int], vars(_migration_runner)["ARCHIVE_VERSION_BY_TIER"])[tier]
     if current_version > runtime_target_version:
@@ -490,6 +532,14 @@ def execute_durable_change_train(
         train = _persist_train_transition(manifest_path, sidecar.train, expected_revision=-1)
 
     if train.state is DurableChangeTrainState.RELEASED:
+        with _open_existing_tier(tier_path) as live:
+            live_version = int(live.execute("PRAGMA user_version").fetchone()[0] or 0)
+            if live_version != runtime_target_version:
+                raise DurableChangeTrainError(
+                    f"released {tier.value} train {train.train_id} expects live v{runtime_target_version}, "
+                    f"found v{live_version}; authorize a new execution"
+                )
+            _verify_persisted_live_tier_continuity(live, train)
         return DurableChangeTrainExecution(train=train, manifest_path=manifest_path, migration_result=None)
 
     if train.state is DurableChangeTrainState.DECLARED:
@@ -587,10 +637,23 @@ def _reconcile_durable_change_train_startup_locked(archive_root: Path) -> tuple[
     reconciled: list[Path] = []
     for manifest_path in sorted(manifest_root.glob("*.json")):
         train = load_durable_change_train_manifest(manifest_path)
+        if train.state is DurableChangeTrainState.FAILED:
+            tier_path = archive_root / f"{train.tier.value}.db"
+            with _open_existing_tier(tier_path) as conn:
+                recovered = recover_durable_change_train(
+                    conn,
+                    train,
+                    recovery_evidence_ref=f"proof:startup-failed-recovery:{train.train_id}",
+                    writer_release_evidence_ref=f"proof:startup-writer-release:{train.train_id}",
+                )
+            train = _persist_train_transition(manifest_path, recovered, expected_revision=train.revision)
+            reconciled.append(manifest_path)
+            if train.state is DurableChangeTrainState.ADMITTED:
+                continue
         if train.state is DurableChangeTrainState.BACKUP_AUTHORIZED:
             tier_path = archive_root / f"{train.tier.value}.db"
             try:
-                with sqlite3.connect(tier_path) as conn:
+                with _open_existing_tier(tier_path) as conn:
                     recovered = reconcile_interrupted_durable_change_train(
                         conn,
                         train,
@@ -601,6 +664,11 @@ def _reconcile_durable_change_train_startup_locked(archive_root: Path) -> tuple[
                 _persist_train_transition(manifest_path, exc.failed_train, expected_revision=train.revision)
                 raise
             train = _persist_train_transition(manifest_path, recovered, expected_revision=train.revision)
+        if train.state is DurableChangeTrainState.RELEASED:
+            with _open_existing_tier(archive_root / f"{train.tier.value}.db") as live:
+                _verify_persisted_live_tier_continuity(live, train)
+            reconciled.append(manifest_path)
+            continue
         if train.state not in {
             DurableChangeTrainState.APPLIED,
             DurableChangeTrainState.PROVEN,

--- a/polylogue/storage/sqlite/migration_runner.py
+++ b/polylogue/storage/sqlite/migration_runner.py
@@ -1153,6 +1153,8 @@ class DurableDatabaseEvidence:
     quick_check: tuple[str, ...]
     schema_inventory_sha256: str
     row_counts: tuple[tuple[str, int], ...]
+    archive_identity_digest: str
+    content_sha256: str
     observed_at_ms: int
 
 
@@ -1466,14 +1468,41 @@ def capture_durable_database_evidence(
     """Capture the pre/post/restart evidence used by the train state machine."""
     quick_check = tuple(str(row[0]) for row in conn.execute("PRAGMA quick_check"))
     inventory = capture_durable_schema_inventory(conn)
+    live_path = _connection_main_path(conn)
+    from polylogue.storage.archive_identity import ArchiveIdentity
+
+    archive_identity_digest = ArchiveIdentity.resolve(live_path.parent).authority_identity_digest
+    content_hasher = hashlib.sha256()
+    for statement in conn.iterdump():
+        content_hasher.update(statement.encode("utf-8"))
+        content_hasher.update(b"\n")
     return DurableDatabaseEvidence(
         tier=tier,
         user_version=int(conn.execute("PRAGMA user_version").fetchone()[0] or 0),
         quick_check=quick_check,
         schema_inventory_sha256=inventory.sha256,
         row_counts=_durable_table_counts(conn),
+        archive_identity_digest=archive_identity_digest,
+        content_sha256=content_hasher.hexdigest(),
         observed_at_ms=_durable_now_ms(),
     )
+
+
+def _assert_durable_database_continuity(
+    actual: DurableDatabaseEvidence,
+    expected: DurableDatabaseEvidence,
+    *,
+    label: str,
+) -> None:
+    """Require the live durable file to retain its authenticated evidence."""
+    if (
+        actual.quick_check != expected.quick_check
+        or actual.quick_check != ("ok",)
+        or actual.user_version != expected.user_version
+        or actual.archive_identity_digest != expected.archive_identity_digest
+        or actual.content_sha256 != expected.content_sha256
+    ):
+        raise DurableChangeTrainError(f"{label} durable tier identity/content continuity proof failed")
 
 
 def _drop_table_names(constraints: Sequence[DurableDropConstraint]) -> set[str]:
@@ -2196,6 +2225,14 @@ def recover_durable_change_train(
     if train.failure.classification is DurableFailureClassification.ROLLED_BACK_TO_CURRENT:
         if observed != train.current_version:
             raise DurableChangeTrainError("rolled-back recovery requires the exact declared current version")
+        pre = train.failure.pre_apply_evidence
+        if pre is None:
+            raise DurableChangeTrainError("rolled-back recovery lacks pre-apply evidence for continuity")
+        _assert_durable_database_continuity(
+            capture_durable_database_evidence(conn, train.tier),
+            pre,
+            label="rolled-back recovery",
+        )
         updated = replace(
             train,
             state=DurableChangeTrainState.ADMITTED,
@@ -2521,6 +2558,8 @@ def _validate_database_evidence(
     if evidence.quick_check != ("ok",):
         raise DurableChangeTrainError(f"{label} does not contain a successful quick_check")
     _validate_sha256(evidence.schema_inventory_sha256, label=f"{label} schema inventory")
+    _validate_sha256(evidence.archive_identity_digest, label=f"{label} archive identity")
+    _validate_sha256(evidence.content_sha256, label=f"{label} content")
     if evidence.observed_at_ms < train.declared_at_ms:
         raise DurableChangeTrainError(f"{label} timestamp predates train declaration")
     tables = [table for table, _count in evidence.row_counts]

--- a/polylogue/storage/sqlite/migration_runner.py
+++ b/polylogue/storage/sqlite/migration_runner.py
@@ -2,29 +2,43 @@
 
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import json
+import logging
+import os
 import re
 import sqlite3
 import stat
+import time
+import types
+import uuid
+from collections.abc import Iterable, Mapping, Sequence
 from contextlib import closing
-from dataclasses import dataclass
+from dataclasses import dataclass, fields, is_dataclass, replace
+from enum import StrEnum
 from importlib import resources
 from pathlib import Path
+from typing import Final, cast, get_args, get_origin, get_type_hints
 
 from polylogue.storage.backup_attestation import (
     VERIFICATION_RECEIPT_FORMAT,
     BackupAttestationError,
     verify_verification_receipt,
 )
-from polylogue.storage.sqlite.archive_tiers import ARCHIVE_VERSION_BY_TIER
+from polylogue.storage.sqlite.archive_tiers import ARCHIVE_DDL_BY_TIER, ARCHIVE_VERSION_BY_TIER
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+_LOGGER = logging.getLogger(__name__)
 
 DURABLE_MIGRATION_TIERS: frozenset[ArchiveTier] = frozenset({ArchiveTier.SOURCE, ArchiveTier.USER, ArchiveTier.AUDIT})
 _MIGRATION_NAME_RE = re.compile(r"^(?P<version>\d{3,})_[a-z0-9_]+\.sql$")
 _VERIFICATION_RECEIPT_FILE = "verification-receipt.json"
 _SQLITE_SIDECAR_SUFFIXES = ("-wal", "-shm", "-journal")
 _ADDITIVE_NO_BACKUP_MARKER = "-- migration-safety: additive-no-backup"
+DURABLE_CHANGE_TRAIN_FORMAT: Final = "polylogue.durable-change-train.v1"
+DURABLE_MIGRATION_COLLISION_REPORT_FORMAT: Final = "polylogue.durable-migration-collisions.v1"
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
 class MigrationError(RuntimeError):
@@ -47,6 +61,113 @@ class MigrationResult:
     to_version: int
     applied_versions: tuple[int, ...]
     backup_receipt: Path | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DurableMigrationClaim:
+    """One numbered durable migration's globally contended ownership key."""
+
+    tier: ArchiveTier
+    target_version: int
+    slot: int
+    path: str
+    owner_ref: str
+    sql_sha256: str
+    requires_backup: bool
+
+    @property
+    def contention_key(self) -> tuple[str, int, int]:
+        return (self.tier.value, self.target_version, self.slot)
+
+
+@dataclass(frozen=True, slots=True)
+class DurableMigrationCollision:
+    """All claims that attempted to own one durable migration slot."""
+
+    tier: ArchiveTier
+    target_version: int
+    slot: int
+    claims: tuple[DurableMigrationClaim, ...]
+
+    @property
+    def contention_key(self) -> tuple[str, int, int]:
+        return (self.tier.value, self.target_version, self.slot)
+
+
+def durable_migration_claim_for_sql(
+    tier: ArchiveTier,
+    path: str | Path,
+    sql: str,
+    *,
+    owner_ref: str | None = None,
+) -> DurableMigrationClaim:
+    """Build the shared p155 contention claim for one numbered SQL resource."""
+    if tier not in DURABLE_MIGRATION_TIERS:
+        raise MigrationError(f"{tier.value} tier cannot own a durable migration slot")
+    migration_path = Path(path)
+    match = _MIGRATION_NAME_RE.match(migration_path.name)
+    if match is None:
+        raise MigrationError(f"invalid numbered durable migration path: {migration_path}")
+    version = int(match.group("version"))
+    return DurableMigrationClaim(
+        tier=tier,
+        target_version=version,
+        slot=version,
+        path=str(migration_path),
+        owner_ref=owner_ref or str(migration_path),
+        sql_sha256=hashlib.sha256(sql.encode("utf-8")).hexdigest(),
+        requires_backup=_requires_migration_backup(sql),
+    )
+
+
+def find_durable_migration_collisions(
+    claims: Iterable[DurableMigrationClaim],
+) -> tuple[DurableMigrationCollision, ...]:
+    """Return duplicate ``(tier, target version, numbered slot)`` ownership."""
+    grouped: dict[tuple[str, int, int], list[DurableMigrationClaim]] = {}
+    for claim in claims:
+        grouped.setdefault(claim.contention_key, []).append(claim)
+    collisions: list[DurableMigrationCollision] = []
+    for (tier_value, target_version, slot), contenders in sorted(grouped.items()):
+        if len(contenders) < 2:
+            continue
+        collisions.append(
+            DurableMigrationCollision(
+                tier=ArchiveTier(tier_value),
+                target_version=target_version,
+                slot=slot,
+                claims=tuple(sorted(contenders, key=lambda item: (item.path, item.owner_ref))),
+            )
+        )
+    return tuple(collisions)
+
+
+def durable_migration_collision_report(claims: Iterable[DurableMigrationClaim]) -> dict[str, object]:
+    """Emit the machine-readable collision report used by policy and admission."""
+    collisions = find_durable_migration_collisions(claims)
+    return {
+        "format": DURABLE_MIGRATION_COLLISION_REPORT_FORMAT,
+        "ok": not collisions,
+        "collisions": [
+            {
+                "tier": collision.tier.value,
+                "target_version": collision.target_version,
+                "slot": collision.slot,
+                "contention_key": [collision.tier.value, collision.target_version, collision.slot],
+                "claims": [
+                    {
+                        "path": claim.path,
+                        "owner_ref": claim.owner_ref,
+                        "sql_sha256": claim.sql_sha256,
+                        "requires_backup": claim.requires_backup,
+                    }
+                    for claim in collision.claims
+                ],
+                "recovery": "rebase and renumber every late rider onto the next unowned target slot",
+            }
+            for collision in collisions
+        ],
+    }
 
 
 def _migration_package(tier: ArchiveTier) -> str:
@@ -72,24 +193,64 @@ def _load_migrations(tier: ArchiveTier) -> tuple[MigrationStep, ...]:
     except ModuleNotFoundError:
         return ()
     steps: list[MigrationStep] = []
+    claims: list[DurableMigrationClaim] = []
     for item in sorted(files.iterdir(), key=lambda path: path.name):
-        match = _MIGRATION_NAME_RE.match(item.name)
-        if match is None:
+        if _MIGRATION_NAME_RE.match(item.name) is None:
             continue
         sql = item.read_text(encoding="utf-8")
+        claim = durable_migration_claim_for_sql(
+            tier,
+            item.name,
+            sql,
+            owner_ref=f"polylogue/storage/sqlite/migrations/{tier.value}/{item.name}",
+        )
+        claims.append(claim)
         steps.append(
             MigrationStep(
                 tier=tier,
-                version=int(match.group("version")),
+                version=claim.target_version,
                 name=item.name,
                 sql=sql,
-                requires_backup=_requires_migration_backup(sql),
+                requires_backup=claim.requires_backup,
             )
         )
-    versions = [step.version for step in steps]
-    if len(versions) != len(set(versions)):
-        raise MigrationError(f"duplicate {tier.value} migration versions: {versions}")
+    collisions = find_durable_migration_collisions(claims)
+    if collisions:
+        details = "; ".join(
+            f"{collision.tier.value}/v{collision.target_version}/slot-{collision.slot}: "
+            + ", ".join(f"{claim.path} ({claim.owner_ref})" for claim in collision.claims)
+            for collision in collisions
+        )
+        raise MigrationError("durable migration ownership collision; rebase and renumber late riders: " + details)
+    # Above the adoption floors, package resources must carry the matching
+    # deterministic <slot>.train.json authority. Keep discovery here at the
+    # existing migration choke point so every caller, including the daemon's
+    # startup probe and the maintenance CLI, observes the same admission gate.
+    from polylogue.storage.sqlite.durable_change_train import validate_durable_migration_sidecars
+
+    try:
+        validate_durable_migration_sidecars(tier, tuple((step.name, step.sql) for step in steps))
+    except Exception as exc:
+        if isinstance(exc, MigrationError):
+            raise
+        raise MigrationError(str(exc)) from exc
     return tuple(steps)
+
+
+def durable_migration_claims(tier: ArchiveTier) -> tuple[DurableMigrationClaim, ...]:
+    """Return the exact claims consumed by the shipped migration runner."""
+    return tuple(
+        DurableMigrationClaim(
+            tier=step.tier,
+            target_version=step.version,
+            slot=step.version,
+            path=step.name,
+            owner_ref=f"polylogue/storage/sqlite/migrations/{tier.value}/{step.name}",
+            sql_sha256=hashlib.sha256(step.sql.encode("utf-8")).hexdigest(),
+            requires_backup=step.requires_backup,
+        )
+        for step in _load_migrations(tier)
+    )
 
 
 def _backup_manifest_path(path: Path) -> Path:
@@ -654,6 +815,12 @@ def migrate_archive_tier(
     precheck_steps = _pending_migration_steps(
         conn, tier, current_version=precheck_version, target_version=target_version
     )
+    from polylogue.storage.sqlite.durable_change_train import validate_durable_migration_sidecars
+
+    validate_durable_migration_sidecars(
+        tier,
+        tuple((step.name, step.sql) for step in precheck_steps),
+    )
     precheck_requires_backup = any(step.requires_backup for step in precheck_steps)
     if precheck_requires_backup and backup_manifest is None:
         raise MigrationError(f"{tier.value} migration requires a verified backup manifest")
@@ -698,6 +865,10 @@ def migrate_archive_tier(
                 f"{tier.value} tier version {current_version} is newer than this runtime expects ({target_version})"
             )
         steps = _pending_migration_steps(conn, tier, current_version=current_version, target_version=target_version)
+        sidecars = validate_durable_migration_sidecars(
+            tier,
+            tuple((step.name, step.sql) for step in steps),
+        )
         requires_backup = any(step.requires_backup for step in steps)
         if requires_backup and backup_manifest is None:
             raise MigrationError(f"{tier.value} migration requires a verified backup manifest")
@@ -707,6 +878,7 @@ def migrate_archive_tier(
             else None
         )
         start_version = current_version
+        pre_transaction_evidence = capture_durable_database_evidence(conn, tier) if sidecars else None
         applied: list[int] = []
         for step in steps:
             before = int(conn.execute("PRAGMA user_version").fetchone()[0] or 0)
@@ -726,6 +898,46 @@ def migrate_archive_tier(
         quick_check = conn.execute("PRAGMA quick_check").fetchone()
         if quick_check is None or str(quick_check[0]).lower() != "ok":
             raise MigrationError(f"{tier.value} migration quick_check failed: {quick_check!r}")
+        if sidecars:
+            assert pre_transaction_evidence is not None
+            post_transaction_evidence = capture_durable_database_evidence(conn, tier)
+            foreign_key_errors = tuple(conn.execute("PRAGMA foreign_key_check").fetchall())
+            if foreign_key_errors:
+                raise MigrationError(f"{tier.value} migration foreign_key_check failed: {foreign_key_errors!r}")
+            drop_constraints = tuple(
+                constraint for sidecar in sidecars for constraint in sidecar.train.drop_constraints
+            )
+            row_change_allowances = tuple(
+                allowance for sidecar in sidecars for allowance in sidecar.train.row_change_allowances
+            )
+            row_parity = prove_durable_row_parity(
+                pre_transaction_evidence,
+                post_transaction_evidence,
+                drop_constraints=drop_constraints,
+                row_change_allowances=row_change_allowances,
+            )
+            if not row_parity.ok:
+                raise MigrationError(
+                    "durable migration row parity failed: " + "; ".join(row_parity.unauthorized_changes)
+                )
+            with closing(sqlite3.connect(":memory:")) as fresh_connection:
+                fresh_connection.execute("PRAGMA foreign_keys = ON")
+                fresh_connection.executescript(ARCHIVE_DDL_BY_TIER[tier])
+                fresh_connection.execute(f"PRAGMA user_version = {target_version}")
+                fresh_connection.commit()
+                fresh_parity = prove_durable_fresh_ddl_parity(
+                    tier,
+                    target_version,
+                    migrated_connection=conn,
+                    fresh_connection=fresh_connection,
+                    evidence_ref=f"proof:fresh-ddl-before-commit:{tier.value}:v{target_version}",
+                )
+            if not fresh_parity.matches:
+                raise MigrationError(
+                    f"{tier.value} migration canonical DDL parity failed: "
+                    f"missing={fresh_parity.missing_objects}, unexpected={fresh_parity.unexpected_objects}, "
+                    f"changed={fresh_parity.changed_objects}"
+                )
     except Exception:
         if conn.in_transaction:
             conn.rollback()
@@ -745,12 +957,2223 @@ def migrate_archive_tier(
     )
 
 
+class DurableChangeTrainState(StrEnum):
+    """Persisted lifecycle states for one durable schema-change train."""
+
+    DECLARED = "declared"
+    ADMITTED = "admitted"
+    RESERVED = "reserved"
+    BACKUP_AUTHORIZED = "backup-authorized"
+    APPLIED = "applied"
+    PROVEN = "proven"
+    RELEASED = "released"
+    FAILED = "failed"
+
+
+class DurableFailureClassification(StrEnum):
+    """Recovery branch selected from the observed durable-tier version."""
+
+    ROLLED_BACK_TO_CURRENT = "rolled-back-to-current"
+    COMMITTED_TARGET_UNPROVEN = "committed-target-unproven"
+    INDETERMINATE = "indeterminate"
+
+
+class DurableChangeTrainError(MigrationError):
+    """Raised when durable change-train authority or evidence is invalid."""
+
+
+class DurableChangeTrainApplyError(DurableChangeTrainError):
+    """Apply failure carrying the machine-readable failed train manifest."""
+
+    def __init__(self, message: str, *, failed_train: DurableChangeTrain) -> None:
+        super().__init__(message)
+        self.failed_train = failed_train
+
+
+class DurableChangeTrainRecoveryError(DurableChangeTrainError):
+    """Unsafe recovery branch carrying the machine-readable failed train."""
+
+    def __init__(self, message: str, *, failed_train: DurableChangeTrain) -> None:
+        super().__init__(message)
+        self.failed_train = failed_train
+
+
+@dataclass(frozen=True, slots=True)
+class DurableRuntimeConsumer:
+    """One production consumer that proves a rider is runtime-complete."""
+
+    consumer_id: str
+    production_ref: str
+    behavior_proof_ref: str
+    roles: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class DurableChangeRider:
+    """One schema-and-runtime unit admitted onto a train before reservation."""
+
+    rider_id: str
+    owner_ref: str
+    schema_objects: tuple[str, ...]
+    runtime_consumers: tuple[DurableRuntimeConsumer, ...]
+    behavior_proof_refs: tuple[str, ...]
+    after_rider_ids: tuple[str, ...] = ()
+    trust_floor_exception_ref: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DurableOrderingConstraint:
+    """Explicit cross-rider ordering evidence."""
+
+    before_rider_id: str
+    after_rider_id: str
+    evidence_ref: str
+
+
+@dataclass(frozen=True, slots=True)
+class DurableDropConstraint:
+    """Authority required before a durable object may disappear."""
+
+    object_ref: str
+    after_rider_ids: tuple[str, ...]
+    copy_forward_proof_ref: str
+    consent_ref: str
+
+
+@dataclass(frozen=True, slots=True)
+class DurableRowChangeAllowance:
+    """An explicitly reviewed data movement exception to row-count parity."""
+
+    table: str
+    reason_ref: str
+    expected_delta: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DurableSchemaObjectEvidence:
+    """Canonical structural fingerprint for one non-internal SQLite object."""
+
+    object_type: str
+    name: str
+    table_name: str
+    definition_sha256: str
+
+    @property
+    def object_ref(self) -> str:
+        return f"{self.object_type}:{self.name}"
+
+
+@dataclass(frozen=True, slots=True)
+class DurableSchemaInventory:
+    """Canonical inventory used by fresh-DDL and migrated-schema parity."""
+
+    objects: tuple[DurableSchemaObjectEvidence, ...]
+    sha256: str
+
+
+@dataclass(frozen=True, slots=True)
+class DurableFreshDDLParityProof:
+    """Comparison between an upgraded database and a fresh canonical create."""
+
+    tier: ArchiveTier
+    target_version: int
+    migrated_version: int
+    fresh_version: int
+    migrated_inventory_sha256: str
+    fresh_inventory_sha256: str
+    missing_objects: tuple[str, ...]
+    unexpected_objects: tuple[str, ...]
+    changed_objects: tuple[str, ...]
+    evidence_ref: str
+    matches: bool
+
+
+@dataclass(frozen=True, slots=True)
+class DurableWriterReservation:
+    """Manifest binding to the archive-root writer lease and stopped daemon."""
+
+    reservation_id: str
+    owner_ref: str
+    archive_root: str
+    tier_path: str
+    daemon_stopped_evidence_ref: str
+    single_writer_evidence_ref: str
+    reserved_at_ms: int
+    active: bool
+    released_at_ms: int | None = None
+    release_evidence_ref: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DurableBackupAuthorization:
+    """Exact backup authority bound to the live tier before apply."""
+
+    mode: str
+    live_tier_path: str
+    live_user_version: int
+    manifest_path: str | None
+    manifest_sha256: str | None
+    receipt_path: str | None
+    receipt_sha256: str | None
+    evidence_ref: str
+    authorized_at_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class DurableDatabaseEvidence:
+    """Integrity, version, schema, and row census for one durable tier."""
+
+    tier: ArchiveTier
+    user_version: int
+    quick_check: tuple[str, ...]
+    schema_inventory_sha256: str
+    row_counts: tuple[tuple[str, int], ...]
+    observed_at_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class DurableRowParityProof:
+    """Pre-existing table row-count comparison across apply."""
+
+    ok: bool
+    changed_tables: tuple[tuple[str, int, int], ...]
+    missing_tables: tuple[str, ...]
+    unauthorized_changes: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class DurableApplyEvidence:
+    """Evidence emitted around the existing numbered migration runner."""
+
+    pre: DurableDatabaseEvidence
+    post: DurableDatabaseEvidence
+    migration_result: MigrationResult
+    row_parity: DurableRowParityProof
+    recovered_after_interrupt: bool
+    applied_at_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class DurableRuntimeConsumerResult:
+    """Behavioral result for one admitted production consumer."""
+
+    consumer_id: str
+    behavior_proof_ref: str
+    passed: bool
+    detail: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class DurableRestartConvergenceProof:
+    """Post-restart durable tier and consumer convergence evidence."""
+
+    evidence_ref: str
+    observed_user_version: int
+    observed_schema_inventory_sha256: str
+    consumer_ids: tuple[str, ...]
+    converged: bool
+    observed_at_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class DurableTrainProof:
+    """Complete proof bundle required before release."""
+
+    fresh_ddl_parity: DurableFreshDDLParityProof
+    runtime_consumers: tuple[DurableRuntimeConsumerResult, ...]
+    restart_convergence: DurableRestartConvergenceProof
+    proof_refs: tuple[str, ...]
+    proven_at_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class DurableTrainFailure:
+    """Persisted failure branch and exact operator recovery obligations."""
+
+    phase: str
+    previous_state: DurableChangeTrainState
+    error_type: str
+    error_message: str
+    observed_user_version: int | None
+    classification: DurableFailureClassification
+    required_actions: tuple[str, ...]
+    failed_at_ms: int
+    pre_apply_evidence: DurableDatabaseEvidence | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DurableChangeTrain:
+    """Immutable machine-readable authority for one durable migration slot."""
+
+    manifest_format: str
+    train_id: str
+    tier: ArchiveTier
+    current_version: int
+    target_version: int
+    slot: int
+    owner_ref: str
+    migration: DurableMigrationClaim
+    riders: tuple[DurableChangeRider, ...]
+    ordering_constraints: tuple[DurableOrderingConstraint, ...]
+    drop_constraints: tuple[DurableDropConstraint, ...]
+    row_change_allowances: tuple[DurableRowChangeAllowance, ...]
+    backup_plan_ref: str | None
+    state: DurableChangeTrainState
+    revision: int
+    declared_at_ms: int
+    admitted_at_ms: int | None
+    admission_evidence_ref: str | None
+    fresh_ddl_parity: DurableFreshDDLParityProof | None
+    reservation: DurableWriterReservation | None
+    backup_authorization: DurableBackupAuthorization | None
+    pre_apply_evidence: DurableDatabaseEvidence | None
+    apply_evidence: DurableApplyEvidence | None
+    proof: DurableTrainProof | None
+    failure: DurableTrainFailure | None
+    released_at_ms: int | None
+    release_evidence_ref: str | None
+    proof_refs: tuple[str, ...]
+
+    @property
+    def contention_key(self) -> tuple[str, int, int]:
+        return (self.tier.value, self.target_version, self.slot)
+
+
+def _durable_now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _require_nonempty(value: str, *, label: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise DurableChangeTrainError(f"durable change train requires {label}")
+    return normalized
+
+
+def _append_proof_refs(existing: tuple[str, ...], *refs: str | None) -> tuple[str, ...]:
+    values = list(existing)
+    for ref in refs:
+        if ref is None:
+            continue
+        normalized = _require_nonempty(ref, label="a non-empty proof reference")
+        if normalized not in values:
+            values.append(normalized)
+    return tuple(values)
+
+
+def _normalize_schema_sql(sql: str | None) -> str:
+    """Normalize layout without rewriting literals or quoted identifiers."""
+    if sql is None:
+        return ""
+    protected: list[str] = []
+    unquoted: list[str] = []
+    index = 0
+    while index < len(sql):
+        character = sql[index]
+        if character in {"'", '"', "`", "["}:
+            closing = "]" if character == "[" else character
+            start = index
+            index += 1
+            while index < len(sql):
+                if sql[index] != closing:
+                    index += 1
+                    continue
+                if index + 1 < len(sql) and sql[index + 1] == closing:
+                    index += 2
+                    continue
+                index += 1
+                break
+            token = f"\x00quoted-{len(protected)}\x00"
+            protected.append(sql[start:index])
+            unquoted.append(token)
+            continue
+        if sql.startswith("--", index):
+            newline = sql.find("\n", index + 2)
+            index = len(sql) if newline < 0 else newline + 1
+            unquoted.append(" ")
+            continue
+        if sql.startswith("/*", index):
+            closing_comment = sql.find("*/", index + 2)
+            index = len(sql) if closing_comment < 0 else closing_comment + 2
+            unquoted.append(" ")
+            continue
+        unquoted.append(character)
+        index += 1
+    collapsed = re.sub(r"\s+", " ", "".join(unquoted)).strip()
+    collapsed = re.sub(r"\s*,\s*", ",", collapsed)
+    collapsed = re.sub(r"\s*\(\s*", "(", collapsed)
+    collapsed = re.sub(r"\s*\)", ")", collapsed)
+    for item_index, segment in enumerate(protected):
+        collapsed = collapsed.replace(f"\x00quoted-{item_index}\x00", segment)
+    return collapsed
+
+
+def _quote_sqlite_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+def _schema_pragma_rows(conn: sqlite3.Connection, pragma: str, object_name: str) -> list[list[object]]:
+    quoted = _quote_sqlite_identifier(object_name)
+    return [list(row) for row in conn.execute(f"PRAGMA {pragma}({quoted})")]
+
+
+def capture_durable_schema_inventory(conn: sqlite3.Connection) -> DurableSchemaInventory:
+    """Capture the canonical object universe from SQLite itself, not a hand list."""
+    rows = conn.execute(
+        """
+        SELECT type, name, tbl_name, sql
+        FROM sqlite_schema
+        WHERE name NOT LIKE 'sqlite_%'
+          AND type IN ('table', 'index', 'trigger', 'view')
+        ORDER BY type, name
+        """
+    ).fetchall()
+    objects: list[DurableSchemaObjectEvidence] = []
+    for raw_type, raw_name, raw_table_name, raw_sql in rows:
+        object_type = str(raw_type)
+        name = str(raw_name)
+        table_name = str(raw_table_name)
+        payload: dict[str, object] = {
+            "type": object_type,
+            "name": name,
+            "table_name": table_name,
+            "sql": _normalize_schema_sql(str(raw_sql) if raw_sql is not None else None),
+        }
+        if object_type == "table":
+            payload["table_xinfo"] = _schema_pragma_rows(conn, "table_xinfo", name)
+            payload["foreign_key_list"] = _schema_pragma_rows(conn, "foreign_key_list", name)
+        elif object_type == "index":
+            payload["index_xinfo"] = _schema_pragma_rows(conn, "index_xinfo", name)
+        objects.append(
+            DurableSchemaObjectEvidence(
+                object_type=object_type,
+                name=name,
+                table_name=table_name,
+                definition_sha256=_canonical_json_sha256(payload),
+            )
+        )
+    inventory_payload = [
+        {
+            "object_type": item.object_type,
+            "name": item.name,
+            "table_name": item.table_name,
+            "definition_sha256": item.definition_sha256,
+        }
+        for item in objects
+    ]
+    return DurableSchemaInventory(objects=tuple(objects), sha256=_canonical_json_sha256(inventory_payload))
+
+
+def prove_durable_fresh_ddl_parity(
+    tier: ArchiveTier,
+    target_version: int,
+    *,
+    migrated_connection: sqlite3.Connection,
+    fresh_connection: sqlite3.Connection,
+    evidence_ref: str,
+) -> DurableFreshDDLParityProof:
+    """Prove a migration result has the same canonical inventory as fresh DDL."""
+    if tier not in DURABLE_MIGRATION_TIERS:
+        raise DurableChangeTrainError(f"fresh-DDL parity is not a durable-tier proof for {tier.value}")
+    evidence = _require_nonempty(evidence_ref, label="fresh-DDL parity evidence")
+    migrated_version = int(migrated_connection.execute("PRAGMA user_version").fetchone()[0] or 0)
+    fresh_version = int(fresh_connection.execute("PRAGMA user_version").fetchone()[0] or 0)
+    migrated = capture_durable_schema_inventory(migrated_connection)
+    fresh = capture_durable_schema_inventory(fresh_connection)
+    migrated_by_ref = {item.object_ref: item for item in migrated.objects}
+    fresh_by_ref = {item.object_ref: item for item in fresh.objects}
+    missing = tuple(sorted(set(fresh_by_ref) - set(migrated_by_ref)))
+    unexpected = tuple(sorted(set(migrated_by_ref) - set(fresh_by_ref)))
+    changed = tuple(
+        sorted(
+            object_ref
+            for object_ref in set(migrated_by_ref) & set(fresh_by_ref)
+            if migrated_by_ref[object_ref].definition_sha256 != fresh_by_ref[object_ref].definition_sha256
+        )
+    )
+    matches = (
+        migrated_version == target_version
+        and fresh_version == target_version
+        and not missing
+        and not unexpected
+        and not changed
+        and migrated.sha256 == fresh.sha256
+    )
+    return DurableFreshDDLParityProof(
+        tier=tier,
+        target_version=target_version,
+        migrated_version=migrated_version,
+        fresh_version=fresh_version,
+        migrated_inventory_sha256=migrated.sha256,
+        fresh_inventory_sha256=fresh.sha256,
+        missing_objects=missing,
+        unexpected_objects=unexpected,
+        changed_objects=changed,
+        evidence_ref=evidence,
+        matches=matches,
+    )
+
+
+def _durable_table_counts(conn: sqlite3.Connection) -> tuple[tuple[str, int], ...]:
+    rows = conn.execute(
+        """
+        SELECT name, sql
+        FROM sqlite_schema
+        WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+        ORDER BY name
+        """
+    ).fetchall()
+    counts: list[tuple[str, int]] = []
+    for raw_name, raw_sql in rows:
+        name = str(raw_name)
+        sql = str(raw_sql or "").lstrip().upper()
+        if sql.startswith("CREATE VIRTUAL TABLE"):
+            continue
+        quoted = _quote_sqlite_identifier(name)
+        counts.append((name, int(conn.execute(f"SELECT COUNT(*) FROM {quoted}").fetchone()[0])))
+    return tuple(counts)
+
+
+def capture_durable_database_evidence(
+    conn: sqlite3.Connection,
+    tier: ArchiveTier,
+) -> DurableDatabaseEvidence:
+    """Capture the pre/post/restart evidence used by the train state machine."""
+    quick_check = tuple(str(row[0]) for row in conn.execute("PRAGMA quick_check"))
+    inventory = capture_durable_schema_inventory(conn)
+    return DurableDatabaseEvidence(
+        tier=tier,
+        user_version=int(conn.execute("PRAGMA user_version").fetchone()[0] or 0),
+        quick_check=quick_check,
+        schema_inventory_sha256=inventory.sha256,
+        row_counts=_durable_table_counts(conn),
+        observed_at_ms=_durable_now_ms(),
+    )
+
+
+def _drop_table_names(constraints: Sequence[DurableDropConstraint]) -> set[str]:
+    names: set[str] = set()
+    for constraint in constraints:
+        prefix, separator, name = constraint.object_ref.partition(":")
+        if separator and prefix == "table":
+            names.add(name)
+        elif not separator:
+            names.add(prefix)
+    return names
+
+
+def prove_durable_row_parity(
+    pre: DurableDatabaseEvidence,
+    post: DurableDatabaseEvidence,
+    *,
+    drop_constraints: Sequence[DurableDropConstraint],
+    row_change_allowances: Sequence[DurableRowChangeAllowance],
+) -> DurableRowParityProof:
+    """Require unchanged counts for old tables unless an admitted rider authorizes movement."""
+    before = dict(pre.row_counts)
+    after = dict(post.row_counts)
+    dropped = _drop_table_names(drop_constraints)
+    allowances = {allowance.table: allowance for allowance in row_change_allowances}
+    changed: list[tuple[str, int, int]] = []
+    missing: list[str] = []
+    unauthorized: list[str] = []
+    for table, before_count in sorted(before.items()):
+        if table not in after:
+            missing.append(table)
+            if table not in dropped:
+                unauthorized.append(f"{table}: missing without an admitted drop constraint")
+            continue
+        after_count = after[table]
+        if after_count == before_count:
+            continue
+        changed.append((table, before_count, after_count))
+        allowance = allowances.get(table)
+        if allowance is None:
+            unauthorized.append(f"{table}: row count changed {before_count}->{after_count} without an allowance")
+            continue
+        delta = after_count - before_count
+        if allowance.expected_delta is not None and delta != allowance.expected_delta:
+            unauthorized.append(
+                f"{table}: row-count delta {delta} did not match admitted delta {allowance.expected_delta}"
+            )
+    return DurableRowParityProof(
+        ok=not unauthorized,
+        changed_tables=tuple(changed),
+        missing_tables=tuple(missing),
+        unauthorized_changes=tuple(unauthorized),
+    )
+
+
+def declare_durable_change_train(
+    *,
+    train_id: str,
+    tier: ArchiveTier,
+    current_version: int,
+    target_version: int,
+    slot: int,
+    owner_ref: str,
+    migration: DurableMigrationClaim,
+    riders: Sequence[DurableChangeRider] = (),
+    ordering_constraints: Sequence[DurableOrderingConstraint] = (),
+    drop_constraints: Sequence[DurableDropConstraint] = (),
+    row_change_allowances: Sequence[DurableRowChangeAllowance] = (),
+    backup_plan_ref: str | None = None,
+    declared_at_ms: int | None = None,
+) -> DurableChangeTrain:
+    """Declare one next-version train; no authority is granted at this stage."""
+    if tier not in DURABLE_MIGRATION_TIERS:
+        raise DurableChangeTrainError(f"{tier.value} is not a durable migration tier")
+    if current_version < 1 or target_version != current_version + 1:
+        raise DurableChangeTrainError(
+            f"durable train must own exactly one contiguous version: current={current_version}, target={target_version}"
+        )
+    if slot != target_version:
+        raise DurableChangeTrainError(
+            f"durable train slot must equal target version {target_version}, found slot {slot}"
+        )
+    if migration.tier is not tier or migration.target_version != target_version or migration.slot != slot:
+        raise DurableChangeTrainError("durable train migration claim does not match its tier/target/slot")
+    train = DurableChangeTrain(
+        manifest_format=DURABLE_CHANGE_TRAIN_FORMAT,
+        train_id=_require_nonempty(train_id, label="train_id"),
+        tier=tier,
+        current_version=current_version,
+        target_version=target_version,
+        slot=slot,
+        owner_ref=_require_nonempty(owner_ref, label="owner_ref"),
+        migration=migration,
+        riders=tuple(riders),
+        ordering_constraints=tuple(ordering_constraints),
+        drop_constraints=tuple(drop_constraints),
+        row_change_allowances=tuple(row_change_allowances),
+        backup_plan_ref=backup_plan_ref.strip() if backup_plan_ref and backup_plan_ref.strip() else None,
+        state=DurableChangeTrainState.DECLARED,
+        revision=0,
+        declared_at_ms=declared_at_ms if declared_at_ms is not None else _durable_now_ms(),
+        admitted_at_ms=None,
+        admission_evidence_ref=None,
+        fresh_ddl_parity=None,
+        reservation=None,
+        backup_authorization=None,
+        pre_apply_evidence=None,
+        apply_evidence=None,
+        proof=None,
+        failure=None,
+        released_at_ms=None,
+        release_evidence_ref=None,
+        proof_refs=(),
+    )
+    validate_durable_change_train_manifest(train)
+    return train
+
+
+def add_durable_change_train_rider(
+    train: DurableChangeTrain,
+    rider: DurableChangeRider,
+) -> DurableChangeTrain:
+    """Add a rider only before admission; late riders must take the next train."""
+    if train.state is not DurableChangeTrainState.DECLARED:
+        raise DurableChangeTrainError(
+            f"late rider {rider.rider_id!r} cannot join {train.train_id} after {train.state.value}; "
+            f"declare a new {train.tier.value} train for target v{train.target_version + 1}"
+        )
+    if any(existing.rider_id == rider.rider_id for existing in train.riders):
+        raise DurableChangeTrainError(f"duplicate rider id on durable train: {rider.rider_id}")
+    updated = replace(train, riders=(*train.riders, rider), revision=train.revision + 1)
+    validate_durable_change_train_manifest(updated)
+    return updated
+
+
+def _validate_riders(train: DurableChangeTrain) -> None:
+    if not train.riders:
+        raise DurableChangeTrainError("durable train admission requires at least one schema-and-runtime rider")
+    rider_ids = [rider.rider_id for rider in train.riders]
+    if len(rider_ids) != len(set(rider_ids)):
+        raise DurableChangeTrainError(f"durable train has duplicate rider ids: {rider_ids}")
+    known_riders = set(rider_ids)
+    consumer_ids: set[str] = set()
+    for rider in train.riders:
+        _require_nonempty(rider.rider_id, label="rider_id")
+        _require_nonempty(rider.owner_ref, label=f"owner for rider {rider.rider_id}")
+        if not rider.schema_objects:
+            raise DurableChangeTrainError(f"rider {rider.rider_id} is schema-empty")
+        if any(not item.strip() for item in rider.schema_objects):
+            raise DurableChangeTrainError(f"rider {rider.rider_id} has an empty schema object reference")
+        production_refs = {consumer.production_ref for consumer in rider.runtime_consumers}
+        if len(production_refs) < 2 and not rider.trust_floor_exception_ref:
+            raise DurableChangeTrainError(
+                f"rider {rider.rider_id} has fewer than two materially distinct runtime consumers and no "
+                "trust-floor exception"
+            )
+        if not rider.runtime_consumers:
+            raise DurableChangeTrainError(f"rider {rider.rider_id} is schema-only; no runtime consumer was declared")
+        declared_behavior_refs = set(rider.behavior_proof_refs)
+        if not declared_behavior_refs:
+            raise DurableChangeTrainError(f"rider {rider.rider_id} has no behavioral proof references")
+        for consumer in rider.runtime_consumers:
+            _require_nonempty(consumer.consumer_id, label=f"consumer id for rider {rider.rider_id}")
+            production_ref = _require_nonempty(
+                consumer.production_ref,
+                label=f"production reference for consumer {consumer.consumer_id}",
+            )
+            if production_ref.startswith(("tests/", "test:", "fixture:")):
+                raise DurableChangeTrainError(
+                    f"consumer {consumer.consumer_id} is test-only, not a production runtime consumer: {production_ref}"
+                )
+            behavior_ref = _require_nonempty(
+                consumer.behavior_proof_ref,
+                label=f"behavior proof for consumer {consumer.consumer_id}",
+            )
+            if behavior_ref not in declared_behavior_refs:
+                raise DurableChangeTrainError(
+                    f"consumer {consumer.consumer_id} behavior proof is not owned by rider {rider.rider_id}"
+                )
+            if consumer.consumer_id in consumer_ids:
+                raise DurableChangeTrainError(f"runtime consumer is owned by multiple riders: {consumer.consumer_id}")
+            consumer_ids.add(consumer.consumer_id)
+        for predecessor in rider.after_rider_ids:
+            if predecessor not in known_riders:
+                raise DurableChangeTrainError(f"rider {rider.rider_id} orders after unknown rider {predecessor}")
+    for constraint in train.ordering_constraints:
+        if constraint.before_rider_id not in known_riders or constraint.after_rider_id not in known_riders:
+            raise DurableChangeTrainError(
+                "ordering constraint names unknown rider(s): "
+                f"{constraint.before_rider_id} -> {constraint.after_rider_id}"
+            )
+        _require_nonempty(constraint.evidence_ref, label="ordering evidence")
+    for drop_constraint in train.drop_constraints:
+        _require_nonempty(drop_constraint.object_ref, label="drop object reference")
+        _require_nonempty(drop_constraint.copy_forward_proof_ref, label="copy-forward proof")
+        _require_nonempty(drop_constraint.consent_ref, label="destructive durable-change consent")
+        unknown = set(drop_constraint.after_rider_ids) - known_riders
+        if unknown:
+            raise DurableChangeTrainError(
+                f"drop constraint {drop_constraint.object_ref} orders after unknown riders: {sorted(unknown)}"
+            )
+    allowance_tables = [allowance.table for allowance in train.row_change_allowances]
+    if len(allowance_tables) != len(set(allowance_tables)):
+        raise DurableChangeTrainError(f"duplicate row-change allowances: {allowance_tables}")
+    for allowance in train.row_change_allowances:
+        _require_nonempty(allowance.table, label="row-change allowance table")
+        _require_nonempty(allowance.reason_ref, label=f"row-change authority for {allowance.table}")
+    _validate_rider_ordering(train)
+
+
+def _validate_rider_ordering(train: DurableChangeTrain) -> None:
+    edges: dict[str, set[str]] = {rider.rider_id: set() for rider in train.riders}
+    for rider in train.riders:
+        for predecessor in rider.after_rider_ids:
+            edges[predecessor].add(rider.rider_id)
+    for constraint in train.ordering_constraints:
+        edges[constraint.before_rider_id].add(constraint.after_rider_id)
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(rider_id: str) -> None:
+        if rider_id in visited:
+            return
+        if rider_id in visiting:
+            raise DurableChangeTrainError(f"durable train rider ordering contains a cycle at {rider_id}")
+        visiting.add(rider_id)
+        for successor in sorted(edges[rider_id]):
+            visit(successor)
+        visiting.remove(rider_id)
+        visited.add(rider_id)
+
+    for rider_id in sorted(edges):
+        visit(rider_id)
+
+
+def _train_owns_contention_key(train: DurableChangeTrain) -> bool:
+    return train.state is not DurableChangeTrainState.RELEASED
+
+
+def _reject_duplicate_train_ownership(
+    train: DurableChangeTrain,
+    active_trains: Sequence[DurableChangeTrain],
+) -> None:
+    for active in active_trains:
+        if active.train_id == train.train_id or not _train_owns_contention_key(active):
+            continue
+        if active.contention_key == train.contention_key:
+            raise DurableChangeTrainError(
+                "durable train contention key already owned by "
+                f"{active.train_id} ({active.owner_ref}): {train.contention_key}"
+            )
+
+
+def admit_durable_change_train(
+    train: DurableChangeTrain,
+    *,
+    observed_current_version: int,
+    fresh_ddl_parity: DurableFreshDDLParityProof,
+    admission_evidence_ref: str,
+    active_trains: Sequence[DurableChangeTrain] = (),
+    migration_claims: Sequence[DurableMigrationClaim] | None = None,
+    canonical_target_version: int | None = None,
+    admitted_at_ms: int | None = None,
+) -> DurableChangeTrain:
+    """Admit exact migration/runtime/fresh-DDL wiring and freeze the rider set."""
+    if train.state is not DurableChangeTrainState.DECLARED:
+        raise DurableChangeTrainError(f"only a declared train may be admitted, found {train.state.value}")
+    validate_durable_change_train_manifest(train)
+    canonical_target = (
+        ARCHIVE_VERSION_BY_TIER[train.tier] if canonical_target_version is None else canonical_target_version
+    )
+    if train.target_version != canonical_target:
+        raise DurableChangeTrainError(
+            f"stale durable train target v{train.target_version}; "
+            f"shipped {train.tier.value} target is v{canonical_target}"
+        )
+    if observed_current_version != train.current_version:
+        raise DurableChangeTrainError(
+            f"stale durable train current v{train.current_version}; "
+            f"live {train.tier.value} is v{observed_current_version}"
+        )
+    _reject_duplicate_train_ownership(train, active_trains)
+    claims = tuple(migration_claims) if migration_claims is not None else durable_migration_claims(train.tier)
+    collisions = find_durable_migration_collisions(claims)
+    if collisions:
+        details = "; ".join(
+            f"{item.contention_key}: " + ", ".join(f"{claim.path} ({claim.owner_ref})" for claim in item.claims)
+            for item in collisions
+        )
+        raise DurableChangeTrainError(
+            "durable migration collision blocks train admission; rebase/renumber late riders: " + details
+        )
+    matching = tuple(claim for claim in claims if claim.contention_key == train.contention_key)
+    if len(matching) != 1:
+        raise DurableChangeTrainError(
+            "durable train requires exactly one shipped migration claim for "
+            f"{train.contention_key}; found {len(matching)}"
+        )
+    if matching[0] != train.migration:
+        raise DurableChangeTrainError(
+            "durable train migration bytes/owner/path differ from the shipped numbered migration claim"
+        )
+    if train.migration.requires_backup and not train.backup_plan_ref:
+        raise DurableChangeTrainError("durable train migration requires backup authority but declares no backup plan")
+    _validate_riders(train)
+    if (
+        fresh_ddl_parity.tier is not train.tier
+        or fresh_ddl_parity.target_version != train.target_version
+        or not fresh_ddl_parity.matches
+    ):
+        raise DurableChangeTrainError(
+            "durable train admission requires matching fresh-DDL parity for its exact tier and target; "
+            f"missing={fresh_ddl_parity.missing_objects}, unexpected={fresh_ddl_parity.unexpected_objects}, "
+            f"changed={fresh_ddl_parity.changed_objects}"
+        )
+    evidence = _require_nonempty(admission_evidence_ref, label="admission evidence")
+    updated = replace(
+        train,
+        state=DurableChangeTrainState.ADMITTED,
+        revision=train.revision + 1,
+        admitted_at_ms=admitted_at_ms if admitted_at_ms is not None else _durable_now_ms(),
+        admission_evidence_ref=evidence,
+        fresh_ddl_parity=fresh_ddl_parity,
+        proof_refs=_append_proof_refs(train.proof_refs, evidence, fresh_ddl_parity.evidence_ref),
+    )
+    validate_durable_change_train_manifest(updated)
+    return updated
+
+
+def reserve_durable_change_train(
+    train: DurableChangeTrain,
+    *,
+    reservation_id: str,
+    reservation_owner_ref: str,
+    archive_root: Path,
+    tier_path: Path,
+    daemon_stopped_evidence_ref: str,
+    single_writer_evidence_ref: str,
+    active_trains: Sequence[DurableChangeTrain] = (),
+    reserved_at_ms: int | None = None,
+) -> DurableChangeTrain:
+    """Bind an admitted train to the stopped-daemon, archive-root writer lease."""
+    if train.state is not DurableChangeTrainState.ADMITTED:
+        raise DurableChangeTrainError(f"only an admitted train may reserve a writer, found {train.state.value}")
+    validate_durable_change_train_manifest(train)
+    _reject_duplicate_train_ownership(train, active_trains)
+    reservation = _require_nonempty(reservation_id, label="writer reservation id")
+    owner = _require_nonempty(reservation_owner_ref, label="writer reservation owner")
+    if owner != train.owner_ref:
+        raise DurableChangeTrainError(
+            f"writer reservation owner {owner!r} does not match train owner {train.owner_ref!r}"
+        )
+    root = archive_root.resolve(strict=False)
+    expected_tier_path = root / f"{train.tier.value}.db"
+    actual_tier_path = tier_path.resolve(strict=False)
+    if actual_tier_path != expected_tier_path.resolve(strict=False):
+        raise DurableChangeTrainError(
+            f"writer reservation tier path must be {expected_tier_path}, found {actual_tier_path}"
+        )
+    for active in active_trains:
+        existing = active.reservation
+        if active.train_id == train.train_id or existing is None or not existing.active:
+            continue
+        if Path(existing.archive_root).resolve(strict=False) != root:
+            continue
+        if existing.reservation_id != reservation or existing.owner_ref != owner:
+            raise DurableChangeTrainError(
+                f"second writer rejected for archive root {root}: {existing.reservation_id} owned by "
+                f"{existing.owner_ref} is already active"
+            )
+    stopped_ref = _require_nonempty(daemon_stopped_evidence_ref, label="stopped-daemon evidence")
+    writer_ref = _require_nonempty(single_writer_evidence_ref, label="single-writer lease evidence")
+    writer = DurableWriterReservation(
+        reservation_id=reservation,
+        owner_ref=owner,
+        archive_root=str(root),
+        tier_path=str(actual_tier_path),
+        daemon_stopped_evidence_ref=stopped_ref,
+        single_writer_evidence_ref=writer_ref,
+        reserved_at_ms=reserved_at_ms if reserved_at_ms is not None else _durable_now_ms(),
+        active=True,
+    )
+    updated = replace(
+        train,
+        state=DurableChangeTrainState.RESERVED,
+        revision=train.revision + 1,
+        reservation=writer,
+        proof_refs=_append_proof_refs(train.proof_refs, stopped_ref, writer_ref),
+    )
+    validate_durable_change_train_manifest(updated)
+    return updated
+
+
+def authorize_durable_change_train_backup(
+    conn: sqlite3.Connection,
+    train: DurableChangeTrain,
+    *,
+    backup_manifest: Path | None,
+    evidence_ref: str,
+    authorized_at_ms: int | None = None,
+) -> DurableChangeTrain:
+    """Bind the exact live bytes and authenticated backup receipt before apply."""
+    if train.state is not DurableChangeTrainState.RESERVED:
+        raise DurableChangeTrainError(f"only a reserved train may authorize backup, found {train.state.value}")
+    validate_durable_change_train_manifest(train)
+    if train.reservation is None or not train.reservation.active:
+        raise DurableChangeTrainError("backup authorization requires an active writer reservation")
+    live_path = _connection_main_path(conn).resolve(strict=False)
+    if live_path != Path(train.reservation.tier_path).resolve(strict=False):
+        raise DurableChangeTrainError(
+            f"backup authorization connection {live_path} does not match reserved tier {train.reservation.tier_path}"
+        )
+    current_version = int(conn.execute("PRAGMA user_version").fetchone()[0] or 0)
+    if current_version != train.current_version:
+        raise DurableChangeTrainError(
+            f"backup authorization is stale: train expects v{train.current_version}, live tier is v{current_version}"
+        )
+    manifest_path: Path | None = None
+    receipt_path: Path | None = None
+    mode = "additive-no-backup"
+    if train.migration.requires_backup:
+        if backup_manifest is None:
+            raise DurableChangeTrainError(
+                f"{train.tier.value} train {train.train_id} requires an authenticated backup before apply"
+            )
+        manifest_path = _backup_manifest_path(backup_manifest).resolve(strict=False)
+        receipt_path = validate_migration_backup_manifest(backup_manifest, train.tier, connection=conn)
+        mode = "verified-backup"
+    elif backup_manifest is not None:
+        manifest_path = _backup_manifest_path(backup_manifest).resolve(strict=False)
+        receipt_path = validate_migration_backup_manifest(backup_manifest, train.tier, connection=conn)
+        mode = "verified-backup"
+    evidence = _require_nonempty(evidence_ref, label="backup authorization evidence")
+    authorization_time = authorized_at_ms if authorized_at_ms is not None else _durable_now_ms()
+    pre_apply_evidence = capture_durable_database_evidence(conn, train.tier)
+    if pre_apply_evidence.user_version != train.current_version or pre_apply_evidence.quick_check != ("ok",):
+        raise DurableChangeTrainError(
+            "backup authorization could not bind valid pre-apply evidence: "
+            f"version={pre_apply_evidence.user_version}, quick_check={pre_apply_evidence.quick_check}"
+        )
+    authorization = DurableBackupAuthorization(
+        mode=mode,
+        live_tier_path=str(live_path),
+        live_user_version=current_version,
+        manifest_path=str(manifest_path) if manifest_path is not None else None,
+        manifest_sha256=_sha256_file(manifest_path) if manifest_path is not None else None,
+        receipt_path=str(receipt_path) if receipt_path is not None else None,
+        receipt_sha256=_sha256_file(receipt_path) if receipt_path is not None else None,
+        evidence_ref=evidence,
+        authorized_at_ms=authorization_time,
+    )
+    updated = replace(
+        train,
+        state=DurableChangeTrainState.BACKUP_AUTHORIZED,
+        revision=train.revision + 1,
+        backup_authorization=authorization,
+        pre_apply_evidence=pre_apply_evidence,
+        proof_refs=_append_proof_refs(
+            train.proof_refs,
+            evidence,
+            str(receipt_path) if receipt_path else None,
+            f"pre-apply-schema:{pre_apply_evidence.schema_inventory_sha256}",
+        ),
+    )
+    validate_durable_change_train_manifest(updated)
+    return updated
+
+
+def _revalidate_backup_authorization(conn: sqlite3.Connection, train: DurableChangeTrain) -> Path | None:
+    authorization = train.backup_authorization
+    if authorization is None:
+        raise DurableChangeTrainError("apply requires backup authorization evidence")
+    live_path = _connection_main_path(conn).resolve(strict=False)
+    if str(live_path) != authorization.live_tier_path:
+        raise DurableChangeTrainError(
+            f"authorized live tier path changed: {authorization.live_tier_path} -> {live_path}"
+        )
+    version = int(conn.execute("PRAGMA user_version").fetchone()[0] or 0)
+    if version != authorization.live_user_version or version != train.current_version:
+        raise DurableChangeTrainError(
+            f"authorized live tier version changed: authorized v{authorization.live_user_version}, observed v{version}"
+        )
+    if authorization.mode == "additive-no-backup":
+        if train.migration.requires_backup:
+            raise DurableChangeTrainError("backup-required migration cannot apply under additive-no-backup authority")
+        return None
+    if authorization.manifest_path is None or authorization.receipt_path is None:
+        raise DurableChangeTrainError("verified-backup authority is missing manifest or receipt paths")
+    manifest = Path(authorization.manifest_path)
+    receipt = Path(authorization.receipt_path)
+    if _sha256_file(manifest) != authorization.manifest_sha256:
+        raise DurableChangeTrainError("authorized backup manifest bytes changed before apply")
+    if _sha256_file(receipt) != authorization.receipt_sha256:
+        raise DurableChangeTrainError("authorized backup receipt bytes changed before apply")
+    validated_receipt = validate_migration_backup_manifest(manifest, train.tier, connection=conn)
+    if validated_receipt.resolve(strict=False) != receipt.resolve(strict=False):
+        raise DurableChangeTrainError("backup validator returned a different receipt than the train authorized")
+    return manifest
+
+
+def _safe_user_version(conn: sqlite3.Connection) -> int | None:
+    try:
+        return int(conn.execute("PRAGMA user_version").fetchone()[0] or 0)
+    except sqlite3.Error:
+        _LOGGER.warning("unable to read durable tier PRAGMA user_version", exc_info=True)
+        return None
+
+
+def _failed_change_train(
+    train: DurableChangeTrain,
+    *,
+    phase: str,
+    error: Exception,
+    observed_user_version: int | None,
+    pre_apply_evidence: DurableDatabaseEvidence | None,
+) -> DurableChangeTrain:
+    actions: tuple[str, ...]
+    if observed_user_version == train.current_version:
+        classification = DurableFailureClassification.ROLLED_BACK_TO_CURRENT
+        actions = (
+            "release the writer reservation",
+            "retain the admitted train and exact rider set",
+            "reserve the writer again",
+            "reauthorize a backup against the unchanged live bytes",
+            "retry the existing numbered migration runner",
+        )
+    elif observed_user_version == train.target_version:
+        classification = DurableFailureClassification.COMMITTED_TARGET_UNPROVEN
+        actions = (
+            "do not reapply the numbered migration",
+            "release the writer reservation",
+            "capture post-apply integrity and row parity",
+            "run runtime-consumer proofs",
+            "restart and prove convergence before release",
+        )
+    else:
+        classification = DurableFailureClassification.INDETERMINATE
+        actions = (
+            "keep the daemon stopped",
+            "do not retry or release the train",
+            "restore the exact authenticated backup bound by backup_authorization",
+            "re-prove the restored current version before declaring a replacement train",
+        )
+    failure = DurableTrainFailure(
+        phase=phase,
+        previous_state=train.state,
+        error_type=type(error).__name__,
+        error_message=str(error),
+        observed_user_version=observed_user_version,
+        classification=classification,
+        required_actions=actions,
+        failed_at_ms=_durable_now_ms(),
+        pre_apply_evidence=pre_apply_evidence,
+    )
+    failed = replace(
+        train,
+        state=DurableChangeTrainState.FAILED,
+        revision=train.revision + 1,
+        failure=failure,
+    )
+    validate_durable_change_train_manifest(failed)
+    return failed
+
+
+def apply_durable_change_train(
+    conn: sqlite3.Connection,
+    train: DurableChangeTrain,
+    *,
+    active_trains: Sequence[DurableChangeTrain] = (),
+    applied_at_ms: int | None = None,
+) -> DurableChangeTrain:
+    """Apply by delegating to ``migrate_archive_tier``; this is not a second engine."""
+    if train.state is not DurableChangeTrainState.BACKUP_AUTHORIZED:
+        raise DurableChangeTrainError(f"only a backup-authorized train may apply, found {train.state.value}")
+    validate_durable_change_train_manifest(train)
+    if train.reservation is None or not train.reservation.active:
+        raise DurableChangeTrainError("apply requires an active writer reservation")
+    _reject_duplicate_train_ownership(train, active_trains)
+    pre = train.pre_apply_evidence
+    try:
+        if pre is None:
+            raise DurableChangeTrainError("apply requires persisted pre-apply evidence from authorization")
+        backup_manifest = _revalidate_backup_authorization(conn, train)
+        observed_pre = capture_durable_database_evidence(conn, train.tier)
+        if (
+            observed_pre.user_version != pre.user_version
+            or observed_pre.quick_check != pre.quick_check
+            or observed_pre.schema_inventory_sha256 != pre.schema_inventory_sha256
+            or observed_pre.row_counts != pre.row_counts
+        ):
+            raise DurableChangeTrainError("live durable tier changed after pre-apply evidence was authorized")
+        result = migrate_archive_tier(conn, train.tier, backup_manifest=backup_manifest)
+        if (
+            result.from_version != train.current_version
+            or result.to_version != train.target_version
+            or result.applied_versions != (train.target_version,)
+        ):
+            raise DurableChangeTrainError(
+                "existing migration runner did not apply this train's one exact slot: "
+                f"from={result.from_version}, to={result.to_version}, applied={result.applied_versions}"
+            )
+        post = capture_durable_database_evidence(conn, train.tier)
+        if post.user_version != train.target_version or post.quick_check != ("ok",):
+            raise DurableChangeTrainError(
+                f"post-apply evidence is invalid: version={post.user_version}, quick_check={post.quick_check}"
+            )
+        row_parity = prove_durable_row_parity(
+            pre,
+            post,
+            drop_constraints=train.drop_constraints,
+            row_change_allowances=train.row_change_allowances,
+        )
+        if not row_parity.ok:
+            raise DurableChangeTrainError("post-apply row parity failed: " + "; ".join(row_parity.unauthorized_changes))
+    except Exception as exc:
+        failed = _failed_change_train(
+            train,
+            phase="apply",
+            error=exc,
+            observed_user_version=_safe_user_version(conn),
+            pre_apply_evidence=pre,
+        )
+        raise DurableChangeTrainApplyError(
+            f"durable change train {train.train_id} apply failed: {exc}",
+            failed_train=failed,
+        ) from exc
+    apply_evidence = DurableApplyEvidence(
+        pre=pre,
+        post=post,
+        migration_result=result,
+        row_parity=row_parity,
+        recovered_after_interrupt=False,
+        applied_at_ms=applied_at_ms if applied_at_ms is not None else _durable_now_ms(),
+    )
+    updated = replace(
+        train,
+        state=DurableChangeTrainState.APPLIED,
+        revision=train.revision + 1,
+        apply_evidence=apply_evidence,
+        proof_refs=_append_proof_refs(
+            train.proof_refs,
+            f"schema-inventory:{post.schema_inventory_sha256}",
+            f"row-parity:{train.train_id}:v{train.target_version}",
+        ),
+    )
+    validate_durable_change_train_manifest(updated)
+    return updated
+
+
+def record_durable_writer_release(
+    train: DurableChangeTrain,
+    *,
+    evidence_ref: str,
+    released_at_ms: int | None = None,
+) -> DurableChangeTrain:
+    """Record that the outer archive-root lease has exited before restart proof."""
+    validate_durable_change_train_manifest(train)
+    if train.reservation is None:
+        raise DurableChangeTrainError("writer release requires a recorded reservation")
+    if not train.reservation.active:
+        raise DurableChangeTrainError("writer reservation is already released")
+    if train.state not in {
+        DurableChangeTrainState.APPLIED,
+        DurableChangeTrainState.FAILED,
+    }:
+        raise DurableChangeTrainError(f"writer cannot be released from train state {train.state.value}")
+    if (
+        train.state is DurableChangeTrainState.FAILED
+        and train.failure is not None
+        and train.failure.classification is DurableFailureClassification.INDETERMINATE
+    ):
+        raise DurableChangeTrainRecoveryError(
+            "indeterminate durable train must retain stopped-daemon/single-writer authority until exact restore",
+            failed_train=train,
+        )
+    proof_ref = _require_nonempty(evidence_ref, label="writer release evidence")
+    released = replace(
+        train.reservation,
+        active=False,
+        released_at_ms=released_at_ms if released_at_ms is not None else _durable_now_ms(),
+        release_evidence_ref=proof_ref,
+    )
+    updated = replace(
+        train,
+        reservation=released,
+        revision=train.revision + 1,
+        proof_refs=_append_proof_refs(train.proof_refs, proof_ref),
+    )
+    validate_durable_change_train_manifest(updated)
+    return updated
+
+
+def recover_durable_change_train(
+    conn: sqlite3.Connection,
+    train: DurableChangeTrain,
+    *,
+    recovery_evidence_ref: str,
+    writer_release_evidence_ref: str,
+) -> DurableChangeTrain:
+    """Resume only the two versions whose recovery is unambiguous."""
+    if train.state is not DurableChangeTrainState.FAILED or train.failure is None:
+        raise DurableChangeTrainError("only a failed train with recovery evidence may recover")
+    validate_durable_change_train_manifest(train)
+    observed = _safe_user_version(conn)
+    if observed != train.failure.observed_user_version:
+        raise DurableChangeTrainError(
+            "failed train recovery version changed: "
+            f"failure observed {train.failure.observed_user_version}, now {observed}"
+        )
+    recovery_ref = _require_nonempty(recovery_evidence_ref, label="failure recovery evidence")
+    release_ref = _require_nonempty(writer_release_evidence_ref, label="writer release evidence")
+    reservation = train.reservation
+    if reservation is None:
+        raise DurableChangeTrainError("failed train recovery requires its original writer reservation")
+    if train.failure.classification is DurableFailureClassification.ROLLED_BACK_TO_CURRENT:
+        if observed != train.current_version:
+            raise DurableChangeTrainError("rolled-back recovery requires the exact declared current version")
+        updated = replace(
+            train,
+            state=DurableChangeTrainState.ADMITTED,
+            revision=train.revision + 1,
+            reservation=None,
+            backup_authorization=None,
+            pre_apply_evidence=None,
+            apply_evidence=None,
+            failure=None,
+            proof_refs=_append_proof_refs(train.proof_refs, recovery_ref, release_ref),
+        )
+        validate_durable_change_train_manifest(updated)
+        return updated
+    if train.failure.classification is DurableFailureClassification.COMMITTED_TARGET_UNPROVEN:
+        if observed != train.target_version:
+            raise DurableChangeTrainError("committed-target recovery requires the exact declared target version")
+        pre = train.failure.pre_apply_evidence
+        if pre is None:
+            raise DurableChangeTrainError("committed-target recovery lacks pre-apply evidence for row parity")
+        post = capture_durable_database_evidence(conn, train.tier)
+        if post.quick_check != ("ok",):
+            raise DurableChangeTrainError(f"committed-target recovery quick_check failed: {post.quick_check}")
+        row_parity = prove_durable_row_parity(
+            pre,
+            post,
+            drop_constraints=train.drop_constraints,
+            row_change_allowances=train.row_change_allowances,
+        )
+        if not row_parity.ok:
+            raise DurableChangeTrainError(
+                "committed-target recovery row parity failed: " + "; ".join(row_parity.unauthorized_changes)
+            )
+        authorization = train.backup_authorization
+        backup_receipt = (
+            Path(authorization.receipt_path)
+            if authorization is not None and authorization.receipt_path is not None
+            else None
+        )
+        apply_evidence = DurableApplyEvidence(
+            pre=pre,
+            post=post,
+            migration_result=MigrationResult(
+                tier=train.tier,
+                from_version=train.current_version,
+                to_version=train.target_version,
+                applied_versions=(train.target_version,),
+                backup_receipt=backup_receipt,
+            ),
+            row_parity=row_parity,
+            recovered_after_interrupt=True,
+            applied_at_ms=_durable_now_ms(),
+        )
+        released_reservation = replace(
+            reservation,
+            active=False,
+            released_at_ms=_durable_now_ms(),
+            release_evidence_ref=release_ref,
+        )
+        updated = replace(
+            train,
+            state=DurableChangeTrainState.APPLIED,
+            revision=train.revision + 1,
+            reservation=released_reservation,
+            apply_evidence=apply_evidence,
+            failure=None,
+            proof_refs=_append_proof_refs(train.proof_refs, recovery_ref, release_ref),
+        )
+        validate_durable_change_train_manifest(updated)
+        return updated
+    raise DurableChangeTrainRecoveryError(
+        "indeterminate durable train cannot recover automatically; "
+        "keep the daemon stopped and restore the exact authenticated backup first",
+        failed_train=train,
+    )
+
+
+def capture_durable_restart_convergence(
+    conn: sqlite3.Connection,
+    train: DurableChangeTrain,
+    *,
+    runtime_consumers: Sequence[DurableRuntimeConsumerResult],
+    evidence_ref: str,
+    observed_at_ms: int | None = None,
+) -> DurableRestartConvergenceProof:
+    """Capture the reopened database state after the operator/runtime restart."""
+    validate_durable_change_train_manifest(train)
+    if train.apply_evidence is None:
+        raise DurableChangeTrainError("restart convergence requires apply evidence")
+    evidence = capture_durable_database_evidence(conn, train.tier)
+    consumer_ids = tuple(sorted(result.consumer_id for result in runtime_consumers if result.passed))
+    expected_ids = tuple(sorted(consumer.consumer_id for rider in train.riders for consumer in rider.runtime_consumers))
+    converged = (
+        evidence.user_version == train.target_version
+        and evidence.quick_check == ("ok",)
+        and evidence.schema_inventory_sha256 == train.apply_evidence.post.schema_inventory_sha256
+        and consumer_ids == expected_ids
+    )
+    return DurableRestartConvergenceProof(
+        evidence_ref=_require_nonempty(evidence_ref, label="restart convergence evidence"),
+        observed_user_version=evidence.user_version,
+        observed_schema_inventory_sha256=evidence.schema_inventory_sha256,
+        consumer_ids=consumer_ids,
+        converged=converged,
+        observed_at_ms=observed_at_ms if observed_at_ms is not None else _durable_now_ms(),
+    )
+
+
+def prove_durable_change_train(
+    train: DurableChangeTrain,
+    *,
+    fresh_ddl_parity: DurableFreshDDLParityProof,
+    runtime_consumers: Sequence[DurableRuntimeConsumerResult],
+    restart_convergence: DurableRestartConvergenceProof,
+    proof_refs: Sequence[str] = (),
+    proven_at_ms: int | None = None,
+) -> DurableChangeTrain:
+    """Prove actual migrated bytes, production behavior, and restart convergence."""
+    if train.state is not DurableChangeTrainState.APPLIED or train.apply_evidence is None:
+        raise DurableChangeTrainError(f"only an applied train may be proven, found {train.state.value}")
+    validate_durable_change_train_manifest(train)
+    if train.reservation is None or train.reservation.active:
+        raise DurableChangeTrainError("writer reservation must be released before restart convergence proof")
+    if train.fresh_ddl_parity is None:
+        raise DurableChangeTrainError("admission fresh-DDL parity evidence is missing")
+    if (
+        not fresh_ddl_parity.matches
+        or fresh_ddl_parity.tier is not train.tier
+        or fresh_ddl_parity.target_version != train.target_version
+        or fresh_ddl_parity.migrated_inventory_sha256 != train.apply_evidence.post.schema_inventory_sha256
+        or fresh_ddl_parity.fresh_inventory_sha256 != train.fresh_ddl_parity.fresh_inventory_sha256
+    ):
+        raise DurableChangeTrainError("actual post-apply bytes do not have admitted fresh-DDL parity")
+    expected_consumers = {
+        consumer.consumer_id: consumer for rider in train.riders for consumer in rider.runtime_consumers
+    }
+    result_by_id: dict[str, DurableRuntimeConsumerResult] = {}
+    for result in runtime_consumers:
+        if result.consumer_id in result_by_id:
+            raise DurableChangeTrainError(f"duplicate runtime proof result: {result.consumer_id}")
+        result_by_id[result.consumer_id] = result
+    if set(result_by_id) != set(expected_consumers):
+        raise DurableChangeTrainError(
+            "runtime proof does not cover the admitted consumers exactly: "
+            f"expected={sorted(expected_consumers)}, observed={sorted(result_by_id)}"
+        )
+    for consumer_id, declared in expected_consumers.items():
+        result = result_by_id[consumer_id]
+        if not result.passed:
+            raise DurableChangeTrainError(f"runtime consumer proof failed: {consumer_id}: {result.detail}")
+        if result.behavior_proof_ref != declared.behavior_proof_ref:
+            raise DurableChangeTrainError(
+                f"runtime consumer {consumer_id} proved a different behavior ref than admission"
+            )
+    expected_ids = tuple(sorted(expected_consumers))
+    if (
+        not restart_convergence.converged
+        or restart_convergence.observed_user_version != train.target_version
+        or restart_convergence.observed_schema_inventory_sha256 != train.apply_evidence.post.schema_inventory_sha256
+        or restart_convergence.consumer_ids != expected_ids
+    ):
+        raise DurableChangeTrainError("restart did not converge the exact target schema and runtime consumer set")
+    if train.apply_evidence.pre.quick_check != ("ok",) or train.apply_evidence.post.quick_check != ("ok",):
+        raise DurableChangeTrainError("pre/post integrity evidence is not successful")
+    if not train.apply_evidence.row_parity.ok:
+        raise DurableChangeTrainError("row parity is not successful")
+    references = train.proof_refs
+    references = _append_proof_refs(
+        references,
+        fresh_ddl_parity.evidence_ref,
+        restart_convergence.evidence_ref,
+        *[result.behavior_proof_ref for result in runtime_consumers],
+        *proof_refs,
+    )
+    proof = DurableTrainProof(
+        fresh_ddl_parity=fresh_ddl_parity,
+        runtime_consumers=tuple(sorted(runtime_consumers, key=lambda item: item.consumer_id)),
+        restart_convergence=restart_convergence,
+        proof_refs=references,
+        proven_at_ms=proven_at_ms if proven_at_ms is not None else _durable_now_ms(),
+    )
+    updated = replace(
+        train,
+        state=DurableChangeTrainState.PROVEN,
+        revision=train.revision + 1,
+        proof=proof,
+        proof_refs=references,
+    )
+    validate_durable_change_train_manifest(updated)
+    return updated
+
+
+def release_durable_change_train(
+    train: DurableChangeTrain,
+    *,
+    evidence_ref: str,
+    released_at_ms: int | None = None,
+) -> DurableChangeTrain:
+    """Release contention ownership only after proof and restart convergence."""
+    if train.state is not DurableChangeTrainState.PROVEN or train.proof is None:
+        raise DurableChangeTrainError(f"only a proven train may release, found {train.state.value}")
+    validate_durable_change_train_manifest(train)
+    if train.reservation is None or train.reservation.active:
+        raise DurableChangeTrainError("train release requires a released writer reservation")
+    if not train.proof.restart_convergence.converged:
+        raise DurableChangeTrainError("train release requires restart convergence")
+    proof_ref = _require_nonempty(evidence_ref, label="train release evidence")
+    updated = replace(
+        train,
+        state=DurableChangeTrainState.RELEASED,
+        revision=train.revision + 1,
+        released_at_ms=released_at_ms if released_at_ms is not None else _durable_now_ms(),
+        release_evidence_ref=proof_ref,
+        proof_refs=_append_proof_refs(train.proof_refs, proof_ref),
+    )
+    validate_durable_change_train_manifest(updated)
+    return updated
+
+
+def _validate_sha256(value: str, *, label: str) -> None:
+    if _SHA256_RE.fullmatch(value) is None:
+        raise DurableChangeTrainError(f"{label} is not a lowercase SHA-256 digest")
+
+
+def _validate_proof_refs(proof_refs: tuple[str, ...]) -> None:
+    if len(proof_refs) != len(set(proof_refs)):
+        raise DurableChangeTrainError("durable train proof references are not unique")
+    for proof_ref in proof_refs:
+        _require_nonempty(proof_ref, label="proof reference")
+
+
+def _validate_admission_evidence(train: DurableChangeTrain) -> None:
+    parity = train.fresh_ddl_parity
+    if train.admitted_at_ms is None or train.admitted_at_ms < train.declared_at_ms:
+        raise DurableChangeTrainError("durable train admission timestamp is invalid")
+    admission_ref = _require_nonempty(
+        train.admission_evidence_ref or "",
+        label="admission evidence",
+    )
+    if parity is None:
+        raise DurableChangeTrainError("durable train admission lacks fresh-DDL parity")
+    if (
+        parity.tier is not train.tier
+        or parity.target_version != train.target_version
+        or parity.migrated_version != train.target_version
+        or parity.fresh_version != train.target_version
+    ):
+        raise DurableChangeTrainError("fresh-DDL parity does not bind the train tier and target")
+    _validate_sha256(parity.migrated_inventory_sha256, label="migrated fresh-DDL inventory")
+    _validate_sha256(parity.fresh_inventory_sha256, label="canonical fresh-DDL inventory")
+    parity_ref = _require_nonempty(parity.evidence_ref, label="fresh-DDL parity evidence")
+    if (
+        not parity.matches
+        or parity.missing_objects
+        or parity.unexpected_objects
+        or parity.changed_objects
+        or parity.migrated_inventory_sha256 != parity.fresh_inventory_sha256
+    ):
+        raise DurableChangeTrainError("admitted fresh-DDL parity is not an exact match")
+    required_refs = {admission_ref, parity_ref}
+    if not required_refs.issubset(train.proof_refs):
+        raise DurableChangeTrainError("admission proof references are not retained by the train")
+    if train.migration.requires_backup and not train.backup_plan_ref:
+        raise DurableChangeTrainError("backup-required train lacks its admitted backup plan")
+
+
+def _validate_writer_reservation(train: DurableChangeTrain) -> None:
+    reservation = train.reservation
+    if reservation is None:
+        raise DurableChangeTrainError(f"{train.state.value} manifest lacks writer reservation")
+    if reservation.owner_ref != train.owner_ref:
+        raise DurableChangeTrainError("writer reservation owner does not match train owner")
+    _require_nonempty(reservation.reservation_id, label="writer reservation id")
+    _require_nonempty(reservation.owner_ref, label="writer reservation owner")
+    archive_root = Path(_require_nonempty(reservation.archive_root, label="archive root"))
+    tier_path = Path(_require_nonempty(reservation.tier_path, label="reserved tier path"))
+    if not archive_root.is_absolute() or not tier_path.is_absolute():
+        raise DurableChangeTrainError("writer reservation paths must be absolute")
+    expected_tier_path = archive_root / f"{train.tier.value}.db"
+    if tier_path.resolve(strict=False) != expected_tier_path.resolve(strict=False):
+        raise DurableChangeTrainError("writer reservation tier path does not match its archive root and tier")
+    stopped_ref = _require_nonempty(
+        reservation.daemon_stopped_evidence_ref,
+        label="stopped-daemon evidence",
+    )
+    writer_ref = _require_nonempty(
+        reservation.single_writer_evidence_ref,
+        label="single-writer evidence",
+    )
+    if not {stopped_ref, writer_ref}.issubset(train.proof_refs):
+        raise DurableChangeTrainError("writer authority proof references are not retained by the train")
+    if reservation.reserved_at_ms < (train.admitted_at_ms or train.declared_at_ms):
+        raise DurableChangeTrainError("writer reservation timestamp predates admission")
+    if reservation.active:
+        if reservation.released_at_ms is not None or reservation.release_evidence_ref is not None:
+            raise DurableChangeTrainError("active writer reservation contains release evidence")
+        return
+    release_ref = _require_nonempty(
+        reservation.release_evidence_ref or "",
+        label="writer release evidence",
+    )
+    if reservation.released_at_ms is None or reservation.released_at_ms < reservation.reserved_at_ms:
+        raise DurableChangeTrainError("released writer reservation has an invalid timestamp")
+    lifecycle_floor = reservation.reserved_at_ms
+    if train.apply_evidence is not None:
+        lifecycle_floor = max(lifecycle_floor, train.apply_evidence.applied_at_ms)
+    if train.failure is not None:
+        lifecycle_floor = max(lifecycle_floor, train.failure.failed_at_ms)
+    if reservation.released_at_ms < lifecycle_floor:
+        raise DurableChangeTrainError("writer release timestamp predates apply/failure evidence")
+    if release_ref not in train.proof_refs:
+        raise DurableChangeTrainError("writer release evidence is not retained by the train")
+
+
+def _validate_database_evidence(
+    evidence: DurableDatabaseEvidence,
+    train: DurableChangeTrain,
+    *,
+    expected_version: int,
+    label: str,
+) -> None:
+    if evidence.tier is not train.tier or evidence.user_version != expected_version:
+        raise DurableChangeTrainError(f"{label} does not bind the train tier/version")
+    if evidence.quick_check != ("ok",):
+        raise DurableChangeTrainError(f"{label} does not contain a successful quick_check")
+    _validate_sha256(evidence.schema_inventory_sha256, label=f"{label} schema inventory")
+    if evidence.observed_at_ms < train.declared_at_ms:
+        raise DurableChangeTrainError(f"{label} timestamp predates train declaration")
+    tables = [table for table, _count in evidence.row_counts]
+    if tables != sorted(tables) or len(tables) != len(set(tables)):
+        raise DurableChangeTrainError(f"{label} row census is not unique and canonical")
+    for table, count in evidence.row_counts:
+        _require_nonempty(table, label=f"{label} row-census table")
+        if count < 0:
+            raise DurableChangeTrainError(f"{label} row census contains a negative count")
+
+
+def _validate_backup_authorization(train: DurableChangeTrain) -> None:
+    authorization = train.backup_authorization
+    reservation = train.reservation
+    pre = train.pre_apply_evidence
+    if authorization is None or reservation is None or pre is None:
+        raise DurableChangeTrainError(f"{train.state.value} manifest lacks backup authorization or pre-apply evidence")
+    evidence_ref = _require_nonempty(
+        authorization.evidence_ref,
+        label="backup authorization evidence",
+    )
+    if evidence_ref not in train.proof_refs:
+        raise DurableChangeTrainError("backup authorization evidence is not retained by the train")
+    if authorization.authorized_at_ms < reservation.reserved_at_ms:
+        raise DurableChangeTrainError("backup authorization timestamp predates writer reservation")
+    if authorization.live_user_version != train.current_version:
+        raise DurableChangeTrainError("backup authorization is bound to the wrong live version")
+    live_path = Path(_require_nonempty(authorization.live_tier_path, label="authorized live tier path"))
+    if live_path.resolve(strict=False) != Path(reservation.tier_path).resolve(strict=False):
+        raise DurableChangeTrainError("backup authorization live path differs from the writer reservation")
+    if authorization.mode == "additive-no-backup":
+        if train.migration.requires_backup:
+            raise DurableChangeTrainError("backup-required migration has additive-no-backup authority")
+        if any(
+            value is not None
+            for value in (
+                authorization.manifest_path,
+                authorization.manifest_sha256,
+                authorization.receipt_path,
+                authorization.receipt_sha256,
+            )
+        ):
+            raise DurableChangeTrainError("additive-no-backup authority contains backup artifacts")
+    elif authorization.mode == "verified-backup":
+        manifest_path = _require_nonempty(
+            authorization.manifest_path or "",
+            label="authorized backup manifest path",
+        )
+        receipt_path = _require_nonempty(
+            authorization.receipt_path or "",
+            label="authorized backup receipt path",
+        )
+        if not Path(manifest_path).is_absolute() or not Path(receipt_path).is_absolute():
+            raise DurableChangeTrainError("authorized backup artifact paths must be absolute")
+        _validate_sha256(
+            authorization.manifest_sha256 or "",
+            label="authorized backup manifest",
+        )
+        _validate_sha256(
+            authorization.receipt_sha256 or "",
+            label="authorized backup receipt",
+        )
+    else:
+        raise DurableChangeTrainError(f"unsupported durable backup authorization mode: {authorization.mode}")
+    _validate_database_evidence(
+        pre,
+        train,
+        expected_version=train.current_version,
+        label="pre-apply evidence",
+    )
+    if pre.observed_at_ms < authorization.authorized_at_ms:
+        raise DurableChangeTrainError("pre-apply evidence predates backup authorization")
+
+
+def _validate_apply_evidence(train: DurableChangeTrain) -> None:
+    evidence = train.apply_evidence
+    pre = train.pre_apply_evidence
+    authorization = train.backup_authorization
+    if evidence is None or pre is None or authorization is None:
+        raise DurableChangeTrainError(f"{train.state.value} manifest lacks apply evidence")
+    if evidence.pre != pre:
+        raise DurableChangeTrainError("apply evidence does not retain the authorized pre-apply census")
+    _validate_database_evidence(
+        evidence.post,
+        train,
+        expected_version=train.target_version,
+        label="post-apply evidence",
+    )
+    if evidence.post.observed_at_ms < pre.observed_at_ms:
+        raise DurableChangeTrainError("post-apply evidence predates pre-apply evidence")
+    if evidence.applied_at_ms < evidence.post.observed_at_ms:
+        raise DurableChangeTrainError("apply timestamp predates post-apply evidence")
+    result = evidence.migration_result
+    if (
+        result.tier is not train.tier
+        or result.from_version != train.current_version
+        or result.to_version != train.target_version
+        or result.applied_versions != (train.target_version,)
+    ):
+        raise DurableChangeTrainError("apply evidence does not describe the train's one exact migration slot")
+    if authorization.mode == "verified-backup":
+        if result.backup_receipt is None or authorization.receipt_path is None:
+            raise DurableChangeTrainError("verified-backup apply evidence lacks its receipt")
+        if result.backup_receipt.resolve(strict=False) != Path(authorization.receipt_path).resolve(strict=False):
+            raise DurableChangeTrainError("apply evidence names a different backup receipt than authorization")
+    elif result.backup_receipt is not None:
+        raise DurableChangeTrainError("additive-no-backup apply evidence unexpectedly names a receipt")
+    if not evidence.row_parity.ok or evidence.row_parity.unauthorized_changes:
+        raise DurableChangeTrainError("apply evidence contains unsuccessful row parity")
+
+
+def _validate_train_proof(train: DurableChangeTrain) -> None:
+    proof = train.proof
+    apply_evidence = train.apply_evidence
+    admitted_parity = train.fresh_ddl_parity
+    if proof is None or apply_evidence is None or admitted_parity is None:
+        raise DurableChangeTrainError(f"{train.state.value} manifest lacks proof evidence")
+    parity = proof.fresh_ddl_parity
+    if (
+        parity.tier is not train.tier
+        or parity.target_version != train.target_version
+        or parity.migrated_version != train.target_version
+        or parity.fresh_version != train.target_version
+        or not parity.matches
+        or parity.missing_objects
+        or parity.unexpected_objects
+        or parity.changed_objects
+        or parity.migrated_inventory_sha256 != apply_evidence.post.schema_inventory_sha256
+        or parity.fresh_inventory_sha256 != admitted_parity.fresh_inventory_sha256
+    ):
+        raise DurableChangeTrainError("proof fresh-DDL parity does not bind admitted and applied schema bytes")
+    _validate_sha256(parity.migrated_inventory_sha256, label="proof migrated inventory")
+    _validate_sha256(parity.fresh_inventory_sha256, label="proof fresh inventory")
+    expected_consumers = {
+        consumer.consumer_id: consumer for rider in train.riders for consumer in rider.runtime_consumers
+    }
+    consumer_ids = tuple(result.consumer_id for result in proof.runtime_consumers)
+    if consumer_ids != tuple(sorted(expected_consumers)):
+        raise DurableChangeTrainError("proof runtime consumers do not exactly match the admitted consumer set")
+    for result in proof.runtime_consumers:
+        declared = expected_consumers[result.consumer_id]
+        if not result.passed or result.behavior_proof_ref != declared.behavior_proof_ref:
+            raise DurableChangeTrainError(f"runtime consumer proof is invalid: {result.consumer_id}")
+    restart = proof.restart_convergence
+    if (
+        not restart.converged
+        or restart.observed_user_version != train.target_version
+        or restart.observed_schema_inventory_sha256 != apply_evidence.post.schema_inventory_sha256
+        or restart.consumer_ids != consumer_ids
+    ):
+        raise DurableChangeTrainError("restart convergence does not bind the target schema and consumers")
+    _validate_sha256(
+        restart.observed_schema_inventory_sha256,
+        label="restart schema inventory",
+    )
+    if restart.observed_at_ms < apply_evidence.applied_at_ms:
+        raise DurableChangeTrainError("restart convergence timestamp predates apply")
+    reservation = train.reservation
+    if reservation is None or reservation.released_at_ms is None or restart.observed_at_ms < reservation.released_at_ms:
+        raise DurableChangeTrainError("restart convergence timestamp predates writer release")
+    if proof.proven_at_ms < restart.observed_at_ms:
+        raise DurableChangeTrainError("proof timestamp predates restart convergence")
+    _validate_proof_refs(proof.proof_refs)
+    required_refs = {
+        parity.evidence_ref,
+        restart.evidence_ref,
+        *(result.behavior_proof_ref for result in proof.runtime_consumers),
+    }
+    if not required_refs.issubset(proof.proof_refs) or not set(proof.proof_refs).issubset(train.proof_refs):
+        raise DurableChangeTrainError("proof bundle references are incomplete or not retained by the train")
+
+
+def _validate_failure_evidence(train: DurableChangeTrain) -> None:
+    failure = train.failure
+    if failure is None:
+        raise DurableChangeTrainError("failed manifest lacks exact recovery evidence")
+    if failure.previous_state is not DurableChangeTrainState.BACKUP_AUTHORIZED:
+        raise DurableChangeTrainError("failed manifest did not originate from backup-authorized apply")
+    _require_nonempty(failure.phase, label="failure phase")
+    _require_nonempty(failure.error_type, label="failure error type")
+    _require_nonempty(failure.error_message, label="failure error message")
+    if not failure.required_actions:
+        raise DurableChangeTrainError("failed manifest has no operator recovery actions")
+    for action in failure.required_actions:
+        _require_nonempty(action, label="failure recovery action")
+    if failure.failed_at_ms < (train.pre_apply_evidence.observed_at_ms if train.pre_apply_evidence else 0):
+        raise DurableChangeTrainError("failure timestamp predates pre-apply evidence")
+    if failure.pre_apply_evidence != train.pre_apply_evidence:
+        raise DurableChangeTrainError("failure does not retain the authorized pre-apply evidence")
+    if failure.observed_user_version == train.current_version:
+        expected = DurableFailureClassification.ROLLED_BACK_TO_CURRENT
+    elif failure.observed_user_version == train.target_version:
+        expected = DurableFailureClassification.COMMITTED_TARGET_UNPROVEN
+    else:
+        expected = DurableFailureClassification.INDETERMINATE
+    if failure.classification is not expected:
+        raise DurableChangeTrainError("failure classification does not match the observed durable version")
+    if (
+        failure.classification is DurableFailureClassification.INDETERMINATE
+        and train.reservation is not None
+        and not train.reservation.active
+    ):
+        raise DurableChangeTrainError("indeterminate failure released stopped-daemon/single-writer authority")
+
+
+def validate_durable_change_train_manifest(train: DurableChangeTrain) -> None:
+    """Validate cross-field lifecycle invariants for loaded and transitioned manifests."""
+    if train.manifest_format != DURABLE_CHANGE_TRAIN_FORMAT:
+        raise DurableChangeTrainError(f"unsupported durable change train format: {train.manifest_format}")
+    if train.tier not in DURABLE_MIGRATION_TIERS:
+        raise DurableChangeTrainError(f"manifest tier is not durable: {train.tier.value}")
+    if train.current_version < 1 or train.target_version != train.current_version + 1:
+        raise DurableChangeTrainError("manifest does not own one contiguous target version")
+    if train.slot != train.target_version:
+        raise DurableChangeTrainError("manifest numbered slot does not equal its target version")
+    if train.migration.contention_key != train.contention_key or train.migration.tier is not train.tier:
+        raise DurableChangeTrainError("manifest migration claim does not match train contention key")
+    _require_nonempty(train.migration.path, label="numbered migration path")
+    _require_nonempty(train.migration.owner_ref, label="numbered migration owner")
+    _validate_sha256(train.migration.sql_sha256, label="numbered migration SQL")
+    if train.revision < 0 or train.declared_at_ms < 0:
+        raise DurableChangeTrainError("manifest revision/timestamp is invalid")
+    _require_nonempty(train.train_id, label="train_id")
+    _require_nonempty(train.owner_ref, label="owner_ref")
+    _validate_proof_refs(train.proof_refs)
+    if train.state is DurableChangeTrainState.DECLARED:
+        if train.proof_refs or any(
+            value is not None
+            for value in (
+                train.admitted_at_ms,
+                train.admission_evidence_ref,
+                train.fresh_ddl_parity,
+                train.reservation,
+                train.backup_authorization,
+                train.pre_apply_evidence,
+                train.apply_evidence,
+                train.proof,
+                train.failure,
+                train.released_at_ms,
+                train.release_evidence_ref,
+            )
+        ):
+            raise DurableChangeTrainError("declared manifest contains evidence from a later lifecycle state")
+        return
+    _validate_riders(train)
+    _validate_admission_evidence(train)
+    if train.state is DurableChangeTrainState.ADMITTED:
+        if any(
+            value is not None
+            for value in (
+                train.reservation,
+                train.backup_authorization,
+                train.pre_apply_evidence,
+                train.apply_evidence,
+                train.proof,
+                train.failure,
+                train.released_at_ms,
+                train.release_evidence_ref,
+            )
+        ):
+            raise DurableChangeTrainError("admitted manifest contains later lifecycle evidence")
+        return
+    _validate_writer_reservation(train)
+    if train.state is DurableChangeTrainState.RESERVED:
+        if (
+            train.reservation is None
+            or not train.reservation.active
+            or any(
+                value is not None
+                for value in (
+                    train.backup_authorization,
+                    train.pre_apply_evidence,
+                    train.apply_evidence,
+                    train.proof,
+                    train.failure,
+                    train.released_at_ms,
+                    train.release_evidence_ref,
+                )
+            )
+        ):
+            raise DurableChangeTrainError("reserved manifest has invalid reservation/later evidence")
+        return
+    _validate_backup_authorization(train)
+    if train.state is DurableChangeTrainState.FAILED:
+        if any(
+            value is not None
+            for value in (
+                train.apply_evidence,
+                train.proof,
+                train.released_at_ms,
+                train.release_evidence_ref,
+            )
+        ):
+            raise DurableChangeTrainError("failed manifest contains apply/proof/release evidence")
+        _validate_failure_evidence(train)
+        return
+    if train.failure is not None:
+        raise DurableChangeTrainError(f"{train.state.value} manifest unexpectedly retains failure evidence")
+    if train.state is DurableChangeTrainState.BACKUP_AUTHORIZED:
+        if (
+            train.reservation is None
+            or not train.reservation.active
+            or any(
+                value is not None
+                for value in (
+                    train.apply_evidence,
+                    train.proof,
+                    train.released_at_ms,
+                    train.release_evidence_ref,
+                )
+            )
+        ):
+            raise DurableChangeTrainError("backup-authorized manifest contains invalid later evidence")
+        return
+    _validate_apply_evidence(train)
+    if train.state is DurableChangeTrainState.APPLIED:
+        if train.proof is not None or train.released_at_ms is not None or train.release_evidence_ref is not None:
+            raise DurableChangeTrainError("applied manifest contains proof/release evidence")
+        return
+    if train.reservation is None or train.reservation.active:
+        raise DurableChangeTrainError(f"{train.state.value} manifest still owns the writer")
+    _validate_train_proof(train)
+    if train.state is DurableChangeTrainState.PROVEN:
+        if train.released_at_ms is not None or train.release_evidence_ref is not None:
+            raise DurableChangeTrainError("proven manifest contains release evidence")
+        if train.proof is None or train.proof.proof_refs != train.proof_refs:
+            raise DurableChangeTrainError("proven manifest proof references differ from its proof bundle")
+        return
+    if train.state is DurableChangeTrainState.RELEASED:
+        release_ref = _require_nonempty(
+            train.release_evidence_ref or "",
+            label="train release evidence",
+        )
+        if train.released_at_ms is None or train.proof is None:
+            raise DurableChangeTrainError("released manifest lacks release evidence")
+        if train.released_at_ms < train.proof.proven_at_ms:
+            raise DurableChangeTrainError("train release timestamp predates proof")
+        if release_ref not in train.proof_refs:
+            raise DurableChangeTrainError("train release evidence is not retained by the manifest")
+        return
+    raise DurableChangeTrainError(f"unknown durable change train state: {train.state}")
+
+
+def reconcile_interrupted_durable_change_train(
+    conn: sqlite3.Connection,
+    train: DurableChangeTrain,
+    *,
+    interruption_evidence_ref: str,
+    writer_release_evidence_ref: str,
+) -> DurableChangeTrain:
+    """Reconcile a persisted pre-apply manifest after process interruption.
+
+    A crash can leave the manifest in ``backup-authorized`` while SQLite is
+    either still at ``current`` (transaction rolled back) or already at
+    ``target`` (commit completed before the manifest write).  No other version
+    is safe to infer.
+    """
+    if train.state is not DurableChangeTrainState.BACKUP_AUTHORIZED:
+        raise DurableChangeTrainError(
+            f"interruption reconciliation requires backup-authorized state, found {train.state.value}"
+        )
+    validate_durable_change_train_manifest(train)
+    evidence_ref = _require_nonempty(interruption_evidence_ref, label="interruption evidence")
+    observed = _safe_user_version(conn)
+    interrupted = RuntimeError(f"operator observed interrupted apply ({evidence_ref})")
+    failed = _failed_change_train(
+        train,
+        phase="apply-interrupted",
+        error=interrupted,
+        observed_user_version=observed,
+        pre_apply_evidence=train.pre_apply_evidence,
+    )
+    if failed.failure is None:
+        raise DurableChangeTrainError("interruption reconciliation failed to classify the train")
+    if failed.failure.classification is DurableFailureClassification.INDETERMINATE:
+        raise DurableChangeTrainRecoveryError(
+            "interrupted durable train reached an indeterminate version; "
+            "keep the daemon stopped and restore the exact authenticated backup",
+            failed_train=failed,
+        )
+    return recover_durable_change_train(
+        conn,
+        failed,
+        recovery_evidence_ref=evidence_ref,
+        writer_release_evidence_ref=writer_release_evidence_ref,
+    )
+
+
+def _manifest_json_value(value: object) -> object:
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, StrEnum):
+        return value.value
+    if is_dataclass(value) and not isinstance(value, type):
+        return {item.name: _manifest_json_value(getattr(value, item.name)) for item in fields(value)}
+    if isinstance(value, tuple | list):
+        return [_manifest_json_value(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _manifest_json_value(item) for key, item in value.items()}
+    if value is None or isinstance(value, str | int | bool | float):
+        return value
+    raise DurableChangeTrainError(f"durable manifest contains unsupported value type: {type(value).__name__}")
+
+
+def durable_change_train_to_payload(train: DurableChangeTrain) -> dict[str, object]:
+    """Encode one immutable train with a canonical payload checksum."""
+    validate_durable_change_train_manifest(train)
+    encoded = _manifest_json_value(train)
+    if not isinstance(encoded, dict):
+        raise DurableChangeTrainError("durable change train did not encode as an object")
+    payload = cast(dict[str, object], encoded)
+    payload["manifest_sha256"] = _canonical_json_sha256(payload)
+    return payload
+
+
+def _decode_manifest_value(annotation: object, value: object, *, label: str) -> object:
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+    if origin is types.UnionType:
+        non_none = tuple(item for item in args if item is not type(None))
+        if value is None and len(non_none) != len(args):
+            return None
+        errors: list[str] = []
+        for candidate in non_none:
+            try:
+                return _decode_manifest_value(candidate, value, label=label)
+            except DurableChangeTrainError as exc:
+                errors.append(str(exc))
+        raise DurableChangeTrainError(f"{label} does not match its union type: {'; '.join(errors)}")
+    if origin is tuple:
+        if not isinstance(value, list):
+            raise DurableChangeTrainError(f"{label} must be a JSON array")
+        if len(args) == 2 and args[1] is Ellipsis:
+            return tuple(
+                _decode_manifest_value(args[0], item, label=f"{label}[{index}]") for index, item in enumerate(value)
+            )
+        if len(value) != len(args):
+            raise DurableChangeTrainError(f"{label} requires {len(args)} entries, found {len(value)}")
+        return tuple(
+            _decode_manifest_value(item_type, item, label=f"{label}[{index}]")
+            for index, (item_type, item) in enumerate(zip(args, value, strict=True))
+        )
+    if annotation is str:
+        if not isinstance(value, str):
+            raise DurableChangeTrainError(f"{label} must be a string")
+        return value
+    if annotation is int:
+        if not isinstance(value, int) or isinstance(value, bool):
+            raise DurableChangeTrainError(f"{label} must be an integer")
+        return value
+    if annotation is bool:
+        if not isinstance(value, bool):
+            raise DurableChangeTrainError(f"{label} must be a boolean")
+        return value
+    if annotation is float:
+        if not isinstance(value, int | float) or isinstance(value, bool):
+            raise DurableChangeTrainError(f"{label} must be a number")
+        return float(value)
+    if annotation is Path:
+        if not isinstance(value, str):
+            raise DurableChangeTrainError(f"{label} must be a path string")
+        return Path(value)
+    if isinstance(annotation, type) and issubclass(annotation, StrEnum):
+        if not isinstance(value, str):
+            raise DurableChangeTrainError(f"{label} must be an enum string")
+        try:
+            return annotation(value)
+        except ValueError as exc:
+            raise DurableChangeTrainError(f"{label} has unsupported value {value!r}") from exc
+    if isinstance(annotation, type) and is_dataclass(annotation):
+        if not isinstance(value, dict):
+            raise DurableChangeTrainError(f"{label} must be a JSON object")
+        dataclass_fields = fields(annotation)
+        expected = {item.name for item in dataclass_fields}
+        observed = set(value)
+        missing = expected - observed
+        unexpected = observed - expected
+        if missing or unexpected:
+            raise DurableChangeTrainError(
+                f"{label} fields differ: missing={sorted(missing)}, unexpected={sorted(unexpected)}"
+            )
+        hints = get_type_hints(annotation)
+        decoded = {
+            item.name: _decode_manifest_value(
+                hints[item.name],
+                value[item.name],
+                label=f"{label}.{item.name}",
+            )
+            for item in dataclass_fields
+        }
+        return annotation(**decoded)
+    raise DurableChangeTrainError(f"{label} has unsupported manifest annotation {annotation!r}")
+
+
+def durable_change_train_from_payload(payload: Mapping[str, object]) -> DurableChangeTrain:
+    """Strictly decode and validate a checksummed durable train manifest."""
+    mutable = dict(payload)
+    checksum = mutable.pop("manifest_sha256", None)
+    if not isinstance(checksum, str) or checksum != _canonical_json_sha256(mutable):
+        raise DurableChangeTrainError("durable change train manifest checksum mismatch")
+    decoded = _decode_manifest_value(DurableChangeTrain, mutable, label="train")
+    if not isinstance(decoded, DurableChangeTrain):
+        raise DurableChangeTrainError("durable change train payload decoded to the wrong type")
+    validate_durable_change_train_manifest(decoded)
+    return decoded
+
+
+def _require_safe_manifest_parent(path: Path) -> Path:
+    parent = path.parent
+    try:
+        metadata = parent.lstat()
+    except FileNotFoundError as exc:
+        raise DurableChangeTrainError(f"durable change train parent directory is missing: {parent}") from exc
+    if stat.S_ISLNK(metadata.st_mode):
+        raise DurableChangeTrainError(f"durable change train parent is a symbolic link: {parent}")
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise DurableChangeTrainError(f"durable change train parent is not a real directory: {parent}")
+    absolute = Path(os.path.abspath(parent))
+    resolved = parent.resolve(strict=True)
+    if resolved != absolute:
+        raise DurableChangeTrainError(f"durable change train parent traverses a symbolic link: {parent}")
+    return resolved
+
+
+def load_durable_change_train_manifest(path: Path) -> DurableChangeTrain:
+    """Load one real, single-linked, checksummed authority file."""
+    _require_safe_manifest_parent(path)
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError as exc:
+        raise DurableChangeTrainError(f"durable change train manifest is missing: {path}") from exc
+    if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+        raise DurableChangeTrainError(f"durable change train manifest is not a real single-linked file: {path}")
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise DurableChangeTrainError(f"durable change train manifest is invalid JSON: {path}") from exc
+    if not isinstance(raw, dict):
+        raise DurableChangeTrainError(f"durable change train manifest must be a JSON object: {path}")
+    return durable_change_train_from_payload(cast(dict[str, object], raw))
+
+
+def _fsync_manifest_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _acquire_manifest_write_lock(path: Path) -> int:
+    lock_path = path.with_name(f".{path.name}.lock")
+    flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(lock_path, flags, 0o600)
+    except OSError as exc:
+        raise DurableChangeTrainError(f"cannot open durable train manifest lock safely: {lock_path}") from exc
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+            raise DurableChangeTrainError(f"durable train manifest lock is not a real single-linked file: {lock_path}")
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+    except Exception:
+        os.close(descriptor)
+        raise
+    return descriptor
+
+
+def write_durable_change_train_manifest(
+    path: Path,
+    train: DurableChangeTrain,
+    *,
+    expected_revision: int,
+) -> None:
+    """Atomically persist authority with serialized optimistic revision control."""
+    validate_durable_change_train_manifest(train)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    parent = _require_safe_manifest_parent(path)
+    lock_descriptor = _acquire_manifest_write_lock(path)
+    temporary: Path | None = None
+    try:
+        if path.exists() or path.is_symlink():
+            metadata = path.lstat()
+            if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+                raise DurableChangeTrainError(f"refusing to replace unsafe train manifest path: {path}")
+            current = load_durable_change_train_manifest(path)
+            if current.revision != expected_revision:
+                raise DurableChangeTrainError(
+                    f"durable train manifest revision changed: expected {expected_revision}, found {current.revision}"
+                )
+            if train.revision != expected_revision + 1:
+                raise DurableChangeTrainError(
+                    "durable train manifest update must advance exactly one revision: "
+                    f"current={expected_revision}, proposed={train.revision}"
+                )
+        elif expected_revision != -1:
+            raise DurableChangeTrainError(
+                f"durable train manifest does not exist for expected revision {expected_revision}: {path}"
+            )
+        payload = durable_change_train_to_payload(train)
+        encoded = (json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False) + "\n").encode("utf-8")
+        temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            offset = 0
+            while offset < len(encoded):
+                written = os.write(descriptor, encoded[offset:])
+                if written <= 0:
+                    raise DurableChangeTrainError("durable train manifest write made no progress")
+                offset += written
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        os.replace(temporary, path)
+        temporary = None
+        _fsync_manifest_directory(parent)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+        try:
+            fcntl.flock(lock_descriptor, fcntl.LOCK_UN)
+        finally:
+            os.close(lock_descriptor)
+
+
 __all__ = [
+    "DURABLE_CHANGE_TRAIN_FORMAT",
+    "DURABLE_MIGRATION_COLLISION_REPORT_FORMAT",
     "DURABLE_MIGRATION_TIERS",
+    "DurableApplyEvidence",
+    "DurableBackupAuthorization",
+    "DurableChangeRider",
+    "DurableChangeTrain",
+    "DurableChangeTrainApplyError",
+    "DurableChangeTrainError",
+    "DurableChangeTrainRecoveryError",
+    "DurableChangeTrainState",
+    "DurableDatabaseEvidence",
+    "DurableDropConstraint",
+    "DurableFailureClassification",
+    "DurableFreshDDLParityProof",
+    "DurableMigrationClaim",
+    "DurableMigrationCollision",
+    "DurableOrderingConstraint",
+    "DurableRestartConvergenceProof",
+    "DurableRowChangeAllowance",
+    "DurableRowParityProof",
+    "DurableRuntimeConsumer",
+    "DurableRuntimeConsumerResult",
+    "DurableSchemaInventory",
+    "DurableSchemaObjectEvidence",
+    "DurableTrainFailure",
+    "DurableTrainProof",
+    "DurableWriterReservation",
     "MigrationError",
     "MigrationResult",
     "MigrationStep",
+    "add_durable_change_train_rider",
+    "admit_durable_change_train",
+    "apply_durable_change_train",
+    "authorize_durable_change_train_backup",
+    "capture_durable_database_evidence",
+    "capture_durable_restart_convergence",
+    "capture_durable_schema_inventory",
+    "declare_durable_change_train",
+    "durable_change_train_from_payload",
+    "durable_change_train_to_payload",
+    "durable_migration_claim_for_sql",
+    "durable_migration_claims",
+    "durable_migration_collision_report",
+    "find_durable_migration_collisions",
+    "load_durable_change_train_manifest",
     "migrate_archive_tier",
+    "prove_durable_change_train",
+    "prove_durable_fresh_ddl_parity",
+    "prove_durable_row_parity",
+    "reconcile_interrupted_durable_change_train",
+    "record_durable_writer_release",
+    "recover_durable_change_train",
+    "release_durable_change_train",
+    "reserve_durable_change_train",
+    "validate_durable_change_train_manifest",
     "validate_backup_manifest_covers_derived_tier",
     "validate_migration_backup_manifest",
+    "write_durable_change_train_manifest",
 ]

--- a/polylogue/storage/sqlite/migration_runner.py
+++ b/polylogue/storage/sqlite/migration_runner.py
@@ -13,14 +13,15 @@ import stat
 import time
 import types
 import uuid
-from collections.abc import Iterable, Mapping, Sequence
-from contextlib import closing
+from collections.abc import Iterable, Iterator, Mapping, Sequence
+from contextlib import closing, contextmanager
 from dataclasses import dataclass, fields, is_dataclass, replace
 from enum import StrEnum
 from importlib import resources
 from pathlib import Path
 from typing import Final, cast, get_args, get_origin, get_type_hints
 
+from polylogue.storage.archive_identity import ArchiveLocation, OwnedArchiveLocation, assert_owns_archive_location
 from polylogue.storage.backup_attestation import (
     VERIFICATION_RECEIPT_FORMAT,
     BackupAttestationError,
@@ -36,6 +37,7 @@ _MIGRATION_NAME_RE = re.compile(r"^(?P<version>\d{3,})_[a-z0-9_]+\.sql$")
 _VERIFICATION_RECEIPT_FILE = "verification-receipt.json"
 _SQLITE_SIDECAR_SUFFIXES = ("-wal", "-shm", "-journal")
 _ADDITIVE_NO_BACKUP_MARKER = "-- migration-safety: additive-no-backup"
+_SQL_TRANSACTION_CONTROL_RE = re.compile(r"^(?:BEGIN|COMMIT|END|ROLLBACK|SAVEPOINT|RELEASE)\b", re.IGNORECASE)
 DURABLE_CHANGE_TRAIN_FORMAT: Final = "polylogue.durable-change-train.v1"
 DURABLE_MIGRATION_COLLISION_REPORT_FORMAT: Final = "polylogue.durable-migration-collisions.v1"
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
@@ -43,6 +45,15 @@ _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
 class MigrationError(RuntimeError):
     """Raised when a durable tier cannot be migrated safely."""
+
+
+@contextmanager
+def hold_durable_migration_writer(archive_root: Path, *, owner_id: str) -> Iterator[None]:
+    """Hold the established archive ownership lease around offline migration."""
+    location = ArchiveLocation.resolve(archive_root)
+    with OwnedArchiveLocation.acquire(location, owner_id=owner_id) as owned:
+        assert_owns_archive_location(owned, location)
+        yield
 
 
 @dataclass(frozen=True, slots=True)
@@ -758,7 +769,19 @@ def _execute_migration_sql(conn: sqlite3.Connection, sql: str) -> None:
         statement += line
         if sqlite3.complete_statement(statement):
             if statement.strip():
+                leading_sql = re.sub(
+                    r"(?is)^(?:\s|--[^\n]*(?:\n|$)|/\*.*?\*/)*",
+                    "",
+                    statement,
+                )
+                if _SQL_TRANSACTION_CONTROL_RE.match(leading_sql) is not None:
+                    raise MigrationError(
+                        "durable migration SQL must not control the existing transaction: "
+                        f"{leading_sql.split(None, 1)[0].upper()}"
+                    )
                 conn.execute(statement)
+                if not conn.in_transaction:
+                    raise MigrationError("durable migration SQL escaped the existing transaction")
             statement = ""
     if statement.strip():
         raise MigrationError("migration SQL ended with an incomplete statement")
@@ -894,12 +917,16 @@ def migrate_archive_tier(
 
                 migrate_saved_query_assertions(conn)
             conn.execute(f"PRAGMA user_version = {step.version}")
+            if not conn.in_transaction:
+                raise MigrationError("durable migration SQL escaped the existing transaction")
             applied.append(step.version)
         quick_check = conn.execute("PRAGMA quick_check").fetchone()
         if quick_check is None or str(quick_check[0]).lower() != "ok":
             raise MigrationError(f"{tier.value} migration quick_check failed: {quick_check!r}")
         if sidecars:
             assert pre_transaction_evidence is not None
+            if not conn.in_transaction:
+                raise MigrationError("durable migration validation lost the existing transaction")
             post_transaction_evidence = capture_durable_database_evidence(conn, tier)
             foreign_key_errors = tuple(conn.execute("PRAGMA foreign_key_check").fetchall())
             if foreign_key_errors:

--- a/polylogue/storage/sqlite/migration_runner.py
+++ b/polylogue/storage/sqlite/migration_runner.py
@@ -13,15 +13,14 @@ import stat
 import time
 import types
 import uuid
-from collections.abc import Iterable, Iterator, Mapping, Sequence
-from contextlib import closing, contextmanager
+from collections.abc import Iterable, Mapping, Sequence
+from contextlib import closing
 from dataclasses import dataclass, fields, is_dataclass, replace
 from enum import StrEnum
 from importlib import resources
 from pathlib import Path
 from typing import Final, cast, get_args, get_origin, get_type_hints
 
-from polylogue.storage.archive_identity import ArchiveLocation, OwnedArchiveLocation, assert_owns_archive_location
 from polylogue.storage.backup_attestation import (
     VERIFICATION_RECEIPT_FORMAT,
     BackupAttestationError,
@@ -45,15 +44,6 @@ _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
 class MigrationError(RuntimeError):
     """Raised when a durable tier cannot be migrated safely."""
-
-
-@contextmanager
-def hold_durable_migration_writer(archive_root: Path, *, owner_id: str) -> Iterator[None]:
-    """Hold the established archive ownership lease around offline migration."""
-    location = ArchiveLocation.resolve(archive_root)
-    with OwnedArchiveLocation.acquire(location, owner_id=owner_id) as owned:
-        assert_owns_archive_location(owned, location)
-        yield
 
 
 @dataclass(frozen=True, slots=True)
@@ -809,12 +799,20 @@ def migrate_archive_tier(
     tier: ArchiveTier,
     *,
     backup_manifest: Path | None,
+    target_version: int | None = None,
 ) -> MigrationResult:
     """Apply additive migrations for one durable tier."""
     if tier not in DURABLE_MIGRATION_TIERS:
         raise MigrationError(f"{tier.value} tier does not support in-place migrations")
     _checkpoint_live_tier(conn)
-    target_version = ARCHIVE_VERSION_BY_TIER[tier]
+    runtime_target_version = ARCHIVE_VERSION_BY_TIER[tier]
+    if target_version is None:
+        target_version = runtime_target_version
+    if target_version > runtime_target_version:
+        raise MigrationError(
+            f"{tier.value} migration target {target_version} is newer than this runtime expects "
+            f"({runtime_target_version})"
+        )
 
     # Lock-free precheck: fail fast (no wasted write-lock acquisition) when a
     # backup manifest is required but missing. This read is intentionally not
@@ -840,10 +838,7 @@ def migrate_archive_tier(
     )
     from polylogue.storage.sqlite.durable_change_train import validate_durable_migration_sidecars
 
-    validate_durable_migration_sidecars(
-        tier,
-        tuple((step.name, step.sql) for step in precheck_steps),
-    )
+    validate_durable_migration_sidecars(tier, tuple((step.name, step.sql) for step in _load_migrations(tier)))
     precheck_requires_backup = any(step.requires_backup for step in precheck_steps)
     if precheck_requires_backup and backup_manifest is None:
         raise MigrationError(f"{tier.value} migration requires a verified backup manifest")
@@ -888,10 +883,13 @@ def migrate_archive_tier(
                 f"{tier.value} tier version {current_version} is newer than this runtime expects ({target_version})"
             )
         steps = _pending_migration_steps(conn, tier, current_version=current_version, target_version=target_version)
-        sidecars = validate_durable_migration_sidecars(
+        all_steps = _load_migrations(tier)
+        all_sidecars = validate_durable_migration_sidecars(
             tier,
-            tuple((step.name, step.sql) for step in steps),
+            tuple((step.name, step.sql) for step in all_steps),
         )
+        pending_versions = {step.version for step in steps}
+        sidecars = tuple(sidecar for sidecar in all_sidecars if sidecar.slot in pending_versions)
         requires_backup = any(step.requires_backup for step in steps)
         if requires_backup and backup_manifest is None:
             raise MigrationError(f"{tier.value} migration requires a verified backup manifest")
@@ -2067,7 +2065,12 @@ def apply_durable_change_train(
             or observed_pre.row_counts != pre.row_counts
         ):
             raise DurableChangeTrainError("live durable tier changed after pre-apply evidence was authorized")
-        result = migrate_archive_tier(conn, train.tier, backup_manifest=backup_manifest)
+        result = migrate_archive_tier(
+            conn,
+            train.tier,
+            backup_manifest=backup_manifest,
+            target_version=train.target_version,
+        )
         if (
             result.from_version != train.current_version
             or result.to_version != train.target_version
@@ -2898,12 +2901,18 @@ def reconcile_interrupted_durable_change_train(
             "keep the daemon stopped and restore the exact authenticated backup",
             failed_train=failed,
         )
-    return recover_durable_change_train(
+    recovered = recover_durable_change_train(
         conn,
         failed,
         recovery_evidence_ref=evidence_ref,
         writer_release_evidence_ref=writer_release_evidence_ref,
     )
+    # The failed classification is an in-memory recovery decision. The
+    # durable manifest records one atomic startup-recovery transition and
+    # retains the recovery evidence in its proof references.
+    recovered = replace(recovered, revision=train.revision + 1)
+    validate_durable_change_train_manifest(recovered)
+    return recovered
 
 
 def _manifest_json_value(value: object) -> object:

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -6,6 +6,8 @@ import itertools
 import json
 import os
 import sqlite3
+import subprocess
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -1420,6 +1422,37 @@ def test_backup_verify_then_migrate_tier_cli_applies_user_migration_with_receipt
         assert conn.execute(
             "SELECT name FROM sqlite_master WHERE type='table' AND name='context_deliveries'"
         ).fetchone()
+
+
+def test_migrate_tier_cli_refuses_live_daemon_before_sql(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    user_db = cli_workspace["archive_root"] / "user.db"
+    _create_user_v3(user_db)
+    daemon = subprocess.Popen(
+        ["bash", "-c", "exec -a polylogued python3 -c 'import time; time.sleep(30)'"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        (cli_workspace["archive_root"] / "daemon.pid").write_text(f"{daemon.pid}\n", encoding="utf-8")
+        time.sleep(0.1)
+        result = cli_runner.invoke(
+            cli,
+            ["--plain", "ops", "maintenance", "migrate-tier", "user", "--output-format", "json"],
+            catch_exceptions=False,
+        )
+    finally:
+        daemon.terminate()
+        daemon.wait(timeout=5)
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert "daemon to be stopped" in payload["error"]
+    with sqlite3.connect(user_db) as conn:
+        assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == 3
 
 
 def test_migrate_tier_cli_rejects_unverified_backup_before_user_version_changes(

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -1424,6 +1424,116 @@ def test_backup_verify_then_migrate_tier_cli_applies_user_migration_with_receipt
         ).fetchone()
 
 
+def test_migrate_tier_cli_executes_and_persists_a_future_change_train(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from polylogue.storage.sqlite import migration_runner
+    from polylogue.storage.sqlite.archive_tiers import ARCHIVE_DDL_BY_TIER, ARCHIVE_VERSION_BY_TIER
+    from polylogue.storage.sqlite.migration_runner import (
+        DurableChangeRider,
+        DurableRuntimeConsumer,
+        declare_durable_change_train,
+        durable_change_train_to_payload,
+        durable_migration_claim_for_sql,
+    )
+
+    package_root = tmp_path / "fixture_migrations_cli"
+    source_package = package_root / "source"
+    source_package.mkdir(parents=True)
+    (package_root / "__init__.py").write_text("", encoding="utf-8")
+    (source_package / "__init__.py").write_text("", encoding="utf-8")
+    sql = "-- migration-safety: additive-no-backup\nCREATE TABLE future_items (id INTEGER PRIMARY KEY) STRICT;\n"
+    (source_package / "002_future_items.sql").write_text(sql, encoding="utf-8")
+    claim = durable_migration_claim_for_sql(
+        ArchiveTier.SOURCE,
+        "002_future_items.sql",
+        sql,
+        owner_ref="owner:cli-source",
+    )
+    rider = DurableChangeRider(
+        rider_id="rider:cli",
+        owner_ref="owner:cli-rider",
+        schema_objects=("table:future_items",),
+        runtime_consumers=(
+            DurableRuntimeConsumer(
+                "bootstrap",
+                "polylogue/storage/sqlite/archive_tiers/bootstrap.py:initialize_archive_database",
+                "proof:bootstrap",
+                ("write",),
+            ),
+            DurableRuntimeConsumer(
+                "daemon-health",
+                "polylogue/storage/sqlite/archive_tiers/bootstrap.py:initialize_archive_tier",
+                "proof:daemon-health",
+                ("read",),
+            ),
+        ),
+        behavior_proof_refs=("proof:bootstrap", "proof:daemon-health"),
+    )
+    declared = declare_durable_change_train(
+        train_id="train:source:cli-v2",
+        tier=ArchiveTier.SOURCE,
+        current_version=1,
+        target_version=2,
+        slot=2,
+        owner_ref="owner:cli-source",
+        migration=claim,
+        riders=(rider,),
+        declared_at_ms=1,
+    )
+    (source_package / "002.train.json").write_text(
+        json.dumps(durable_change_train_to_payload(declared)), encoding="utf-8"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setattr(migration_runner, "_migration_package", lambda _tier: "fixture_migrations_cli.source")
+    monkeypatch.setattr(
+        "polylogue.storage.sqlite.durable_change_train._migration_package",
+        lambda _tier: "fixture_migrations_cli.source",
+    )
+    monkeypatch.setattr(
+        "polylogue.storage.sqlite.durable_change_train.DURABLE_MIGRATION_ADOPTION_FLOORS",
+        {ArchiveTier.SOURCE: 1, ArchiveTier.USER: 1},
+    )
+    versions = dict(ARCHIVE_VERSION_BY_TIER)
+    versions[ArchiveTier.SOURCE] = 2
+    monkeypatch.setattr(migration_runner, "ARCHIVE_VERSION_BY_TIER", versions)
+    from polylogue.storage.sqlite.archive_tiers import bootstrap
+
+    monkeypatch.setattr(bootstrap, "ARCHIVE_VERSION_BY_TIER", versions)
+    ddl = dict(ARCHIVE_DDL_BY_TIER)
+    ddl[ArchiveTier.SOURCE] = (
+        "CREATE TABLE base_items (item_id TEXT PRIMARY KEY, payload TEXT NOT NULL) STRICT; "
+        "CREATE TABLE future_items (id INTEGER PRIMARY KEY) STRICT;"
+    )
+    monkeypatch.setattr(bootstrap, "ARCHIVE_DDL_BY_TIER", ddl)
+    monkeypatch.setattr(migration_runner, "ARCHIVE_DDL_BY_TIER", ddl)
+    source_db = cli_workspace["archive_root"] / "source.db"
+    source_db.unlink()
+    with sqlite3.connect(source_db) as conn:
+        conn.execute("CREATE TABLE base_items (item_id TEXT PRIMARY KEY, payload TEXT NOT NULL) STRICT")
+        conn.execute("PRAGMA user_version = 1")
+        conn.commit()
+
+    result = cli_runner.invoke(
+        cli,
+        ["--plain", "ops", "maintenance", "migrate-tier", "source", "--output-format", "json"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["train_state"] == "released"
+    assert payload["applied_versions"] == [2]
+    manifest = Path(payload["train_manifest"])
+    assert manifest.exists()
+    with sqlite3.connect(source_db) as conn:
+        assert conn.execute("PRAGMA user_version").fetchone() == (2,)
+        assert conn.execute("SELECT name FROM sqlite_schema WHERE name='future_items'").fetchone() == ("future_items",)
+
+
 def test_migrate_tier_cli_refuses_live_daemon_before_sql(
     cli_workspace: dict[str, Path],
     cli_runner: CliRunner,
@@ -1451,6 +1561,32 @@ def test_migrate_tier_cli_refuses_live_daemon_before_sql(
     payload = json.loads(result.stdout)
     assert payload["ok"] is False
     assert "daemon to be stopped" in payload["error"]
+    with sqlite3.connect(user_db) as conn:
+        assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == 3
+
+
+def test_migrate_tier_cli_uses_shared_stable_archive_lock(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    from polylogue.storage.archive_identity import ArchiveLocation, OwnedArchiveLocation
+
+    user_db = cli_workspace["archive_root"] / "user.db"
+    _create_user_v3(user_db)
+    with OwnedArchiveLocation.acquire(
+        ArchiveLocation.resolve(cli_workspace["archive_root"]),
+        owner_id="test:daemon-owner",
+    ):
+        result = cli_runner.invoke(
+            cli,
+            ["--plain", "ops", "maintenance", "migrate-tier", "user", "--output-format", "json"],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert "archive location already owned" in payload["error"]
     with sqlite3.connect(user_db) as conn:
         assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == 3
 

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -3357,6 +3357,70 @@ def test_lifecycle_start_failure_releases_pidfile(tmp_path: Path, monkeypatch: p
     assert not (tmp_path / "daemon.pid").exists()
 
 
+def test_daemon_startup_reconciles_trains_before_schema_probe(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from polylogue.daemon import cli as daemon_cli
+    from polylogue.daemon.health import HealthAlert, HealthSeverity, HealthTier
+
+    events: list[str] = []
+
+    class Coordinator:
+        async def run_sync(self, actor: str, _function: object, /, *args: object, **kwargs: object) -> object:
+            del args, kwargs
+            if actor == "daemon.lifecycle.start":
+                raise RuntimeError("startup stopped")
+            return None
+
+        async def shutdown(self, *, timeout: float) -> bool:
+            assert timeout == 5.0
+            return True
+
+    monkeypatch.setattr("polylogue.paths.archive_root", lambda: tmp_path)
+    monkeypatch.setattr(
+        "polylogue.storage.archive_identity.resolve_active_index_path", lambda *_a, **_k: tmp_path / "index.db"
+    )
+    monkeypatch.setattr(daemon_cli, "daemon_write_coordinator", lambda: Coordinator())
+
+    def reconcile(root: Path) -> tuple[Path, ...]:
+        events.append(f"reconcile:{root}")
+        return (tmp_path / "recovered.json",)
+
+    def schema_ok() -> HealthAlert:
+        events.append("schema")
+        return HealthAlert(
+            check_name="schema_version",
+            tier=HealthTier.FAST,
+            severity=HealthSeverity.OK,
+            message="ok",
+            checked_at="now",
+        )
+
+    monkeypatch.setattr(
+        "polylogue.operations.durable_change_train.reconcile_durable_change_trains_on_startup", reconcile
+    )
+    monkeypatch.setattr(
+        daemon_cli,
+        "_check_schema_version_fast",
+        schema_ok,
+    )
+
+    with pytest.raises(RuntimeError, match="startup stopped"):
+        asyncio.run(
+            daemon_cli.run_daemon_services(
+                sources=(),
+                debounce_s=1.0,
+                enable_watch=False,
+                enable_browser_capture=False,
+                browser_capture_host="127.0.0.1",
+                browser_capture_port=8765,
+                browser_capture_spool_path=None,
+            )
+        )
+
+    assert events == [f"reconcile:{tmp_path}", "schema"]
+    assert (tmp_path / ".archive-ownership.lock").exists()
+    assert not (tmp_path / "daemon.pid").exists()
+
+
 def test_run_daemon_services_checks_archive_identity_before_component_startup(tmp_path: Path) -> None:
     from polylogue.daemon import cli as daemon_cli
     from polylogue.storage.archive_identity import ArchiveIdentityConflictError

--- a/tests/unit/devtools/test_durable_schema_policy_gate.py
+++ b/tests/unit/devtools/test_durable_schema_policy_gate.py
@@ -1,0 +1,96 @@
+"""Merge-time policy coverage for durable migration slot ownership."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from devtools import verify, verify_schema_upgrade_lane
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.migration_runner import durable_migration_claim_for_sql
+
+
+def _healthy_delta_report() -> dict[str, object]:
+    return {
+        "ok": True,
+        "compatibility_floor": 1,
+        "missing_versions": (),
+        "duplicate_versions": (),
+        "invalid_versions": (),
+    }
+
+
+def test_checked_in_durable_migrations_have_unique_contention_keys() -> None:
+    claims = verify_schema_upgrade_lane._durable_migration_claims_on_disk()
+    report = verify_schema_upgrade_lane.durable_migration_collision_report(claims)
+    assert report["ok"] is True
+    assert report["collisions"] == []
+    assert {claim.tier for claim in claims} == {ArchiveTier.SOURCE, ArchiveTier.USER}
+
+
+def test_policy_json_names_every_duplicate_owner(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    first = durable_migration_claim_for_sql(
+        ArchiveTier.SOURCE,
+        Path("polylogue/storage/sqlite/migrations/source/008_first.sql"),
+        "-- migration-safety: additive-no-backup\nCREATE TABLE first (id INTEGER);\n",
+        owner_ref="owner:first",
+    )
+    second = durable_migration_claim_for_sql(
+        ArchiveTier.SOURCE,
+        Path("polylogue/storage/sqlite/migrations/source/008_second.sql"),
+        "-- migration-safety: additive-no-backup\nCREATE TABLE second (id INTEGER);\n",
+        owner_ref="owner:second",
+    )
+    monkeypatch.setattr(verify_schema_upgrade_lane, "_collect_upgrade_helpers", lambda: [])
+    monkeypatch.setattr(verify_schema_upgrade_lane, "_invalid_migration_paths", lambda: [])
+    monkeypatch.setattr(
+        verify_schema_upgrade_lane,
+        "_durable_migration_claims_on_disk",
+        lambda: (first, second),
+    )
+    monkeypatch.setattr(
+        verify_schema_upgrade_lane,
+        "index_delta_declaration_report",
+        lambda _version: _healthy_delta_report(),
+    )
+
+    assert verify_schema_upgrade_lane.main(["--json"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+    collision_report = payload["durable_migration_collisions"]
+    assert collision_report["ok"] is False
+    assert collision_report["collisions"][0]["contention_key"] == ["source", 8, 8]
+    serialized = json.dumps(collision_report)
+    assert "008_first.sql" in serialized
+    assert "008_second.sql" in serialized
+    assert "owner:first" in serialized
+    assert "owner:second" in serialized
+    assert "rebase and renumber" in serialized
+
+
+def test_schema_versioning_policy_runs_exactly_once_in_every_noncommit_fast_gate() -> None:
+    for quick, lab in ((True, False), (True, True), (False, False), (False, True)):
+        labels = [
+            label
+            for label, _command in verify.build_verify_steps(
+                quick=quick,
+                lab=lab,
+                skip_slow=True,
+            )
+        ]
+        assert labels.count("lab policy schema-versioning") == 1
+
+    commit_labels = [
+        label
+        for label, _command in verify.build_verify_steps(
+            quick=True,
+            lab=False,
+            skip_slow=True,
+            commit=True,
+        )
+    ]
+    assert "lab policy schema-versioning" not in commit_labels

--- a/tests/unit/devtools/test_durable_schema_policy_gate.py
+++ b/tests/unit/devtools/test_durable_schema_policy_gate.py
@@ -30,6 +30,22 @@ def test_checked_in_durable_migrations_have_unique_contention_keys() -> None:
     assert {claim.tier for claim in claims} == {ArchiveTier.SOURCE, ArchiveTier.USER}
 
 
+def test_schema_policy_accepts_only_canonical_train_sidecar_names(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    migrations = tmp_path / "migrations"
+    source = migrations / "source"
+    source.mkdir(parents=True)
+    (source / "027_future.sql").write_text("SELECT 1;\n", encoding="utf-8")
+    (source / "027.train.json").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setattr(verify_schema_upgrade_lane, "MIGRATIONS_DIR", migrations)
+
+    assert verify_schema_upgrade_lane._invalid_migration_paths() == []
+
+    (source / "027_future.bad.json").write_text("{}\n", encoding="utf-8")
+    assert verify_schema_upgrade_lane._invalid_migration_paths() == [source / "027_future.bad.json"]
+
+
 def test_policy_json_names_every_duplicate_owner(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],

--- a/tests/unit/storage/test_durable_change_train.py
+++ b/tests/unit/storage/test_durable_change_train.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 import sys
 from collections.abc import Iterator
@@ -518,6 +519,34 @@ def test_maintenance_route_persists_and_proves_a_future_train(tmp_path: Path, mo
     assert released == [True]
     manifest_path = durable_change_train_manifest_path(tmp_path, ArchiveTier.SOURCE, 2)
     assert load_durable_change_train_manifest(manifest_path).state is DurableChangeTrainState.RELEASED
+
+    released_bytes = db_path.read_bytes()
+    db_path.unlink()
+    with pytest.raises(DurableChangeTrainError, match="durable tier is missing"):
+        execute_durable_change_train(
+            tmp_path,
+            ArchiveTier.SOURCE,
+            backup_manifest=None,
+            daemon_stopped_evidence_ref="proof:daemon-stopped",
+            single_writer_evidence_ref="proof:archive-ownership-lock",
+            release_archive_ownership=lambda: pytest.fail("missing released tier was released again"),
+        )
+    assert not db_path.exists()
+    db_path.write_bytes(released_bytes)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA user_version = 1")
+        conn.commit()
+    with pytest.raises(
+        DurableChangeTrainError, match="(?:released source train .* expects live v2|continuity proof failed)"
+    ):
+        execute_durable_change_train(
+            tmp_path,
+            ArchiveTier.SOURCE,
+            backup_manifest=None,
+            daemon_stopped_evidence_ref="proof:daemon-stopped",
+            single_writer_evidence_ref="proof:archive-ownership-lock",
+            release_archive_ownership=lambda: pytest.fail("stale released train was released again"),
+        )
 
 
 def test_future_train_sidecar_hash_and_slot_are_admission_bound(
@@ -1056,6 +1085,148 @@ def test_bootstrap_finishes_persisted_applied_train_without_reapplying(
     assert recovered.state is DurableChangeTrainState.RELEASED
     assert recovered.proof is not None
     assert recovered.apply_evidence is not None and recovered.apply_evidence.recovered_after_interrupt is True
+
+
+@pytest.mark.parametrize("tier", (ArchiveTier.SOURCE, ArchiveTier.USER))
+@pytest.mark.parametrize("replacement", ("missing", "content", "inode"))
+def test_startup_proves_durable_continuity_before_initialization_or_release(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tier: ArchiveTier,
+    replacement: str,
+) -> None:
+    """A lost or replaced durable file cannot be bootstrapped over an APPLIED train."""
+    from polylogue.storage.sqlite.archive_tiers import bootstrap
+
+    db_path = tmp_path / f"{tier.value}.db"
+    _create_current_database(db_path)
+    _install_synthetic_migration(tmp_path, monkeypatch, tier)
+    train = _admitted(tier, rider=_production_rider())
+    with sqlite3.connect(db_path) as conn:
+        train = _reserve_and_authorize(conn, train, archive_root=tmp_path)
+        train = apply_durable_change_train(conn, train)
+    manifest = tmp_path / ".maintenance-state" / "durable-change-trains" / f"{tier.value}-002.json"
+    write_durable_change_train_manifest(manifest, train, expected_revision=-1)
+
+    if replacement == "missing":
+        db_path.unlink()
+    elif replacement == "content":
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("UPDATE base_items SET payload = 'lost' WHERE item_id = 'base-1'")
+            conn.commit()
+    else:
+        replacement_path = tmp_path / "replacement.db"
+        replacement_path.write_bytes(db_path.read_bytes())
+        os.replace(replacement_path, db_path)
+
+    with pytest.raises(DurableChangeTrainError, match="refusing startup initialization/release"):
+        bootstrap.initialize_active_archive_root(tmp_path)
+
+    recovered = load_durable_change_train_manifest(manifest)
+    assert recovered.state is DurableChangeTrainState.APPLIED
+    assert recovered.reservation is not None and recovered.reservation.active is True
+    if replacement == "missing":
+        assert not db_path.exists()
+
+
+def test_startup_recovers_persisted_rollback_failure_to_admitted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    failing_sql = """-- migration-safety: additive-no-backup
+CREATE TABLE durable_items (item_id TEXT PRIMARY KEY, payload TEXT NOT NULL) STRICT;
+INSERT INTO table_that_does_not_exist VALUES (1);
+"""
+    db_path = tmp_path / "source.db"
+    _create_current_database(db_path)
+    _install_synthetic_migration(tmp_path, monkeypatch, ArchiveTier.SOURCE, sql=failing_sql)
+    train = _admitted(ArchiveTier.SOURCE, claim=_claim(ArchiveTier.SOURCE, failing_sql))
+    with sqlite3.connect(db_path) as conn:
+        train = _reserve_and_authorize(conn, train, archive_root=tmp_path)
+        with pytest.raises(DurableChangeTrainApplyError) as exc_info:
+            apply_durable_change_train(conn, train)
+        failed = exc_info.value.failed_train
+    manifest = tmp_path / ".maintenance-state" / "durable-change-trains" / "source-002.json"
+    write_durable_change_train_manifest(manifest, failed, expected_revision=-1)
+
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import reconcile_durable_change_trains_on_startup
+
+    assert reconcile_durable_change_trains_on_startup(tmp_path) == (manifest,)
+    recovered = load_durable_change_train_manifest(manifest)
+    assert recovered.state is DurableChangeTrainState.ADMITTED
+    assert recovered.reservation is None
+    assert recovered.failure is None
+
+
+@pytest.mark.parametrize("replacement", ("content", "inode"))
+def test_startup_blocks_persisted_rollback_failure_after_replacement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    replacement: str,
+) -> None:
+    failing_sql = """-- migration-safety: additive-no-backup
+CREATE TABLE durable_items (item_id TEXT PRIMARY KEY, payload TEXT NOT NULL) STRICT;
+INSERT INTO table_that_does_not_exist VALUES (1);
+"""
+    db_path = tmp_path / "source.db"
+    _create_current_database(db_path)
+    _install_synthetic_migration(tmp_path, monkeypatch, ArchiveTier.SOURCE, sql=failing_sql)
+    train = _admitted(ArchiveTier.SOURCE, claim=_claim(ArchiveTier.SOURCE, failing_sql))
+    with sqlite3.connect(db_path) as conn:
+        train = _reserve_and_authorize(conn, train, archive_root=tmp_path)
+        with pytest.raises(DurableChangeTrainApplyError) as exc_info:
+            apply_durable_change_train(conn, train)
+        failed = exc_info.value.failed_train
+    manifest = tmp_path / ".maintenance-state" / "durable-change-trains" / "source-002.json"
+    write_durable_change_train_manifest(manifest, failed, expected_revision=-1)
+
+    if replacement == "content":
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("UPDATE base_items SET payload = 'replaced' WHERE item_id = 'base-1'")
+            conn.commit()
+    else:
+        replacement_path = tmp_path / "replacement.db"
+        replacement_path.write_bytes(db_path.read_bytes())
+        os.replace(replacement_path, db_path)
+
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import reconcile_durable_change_trains_on_startup
+
+    with pytest.raises(DurableChangeTrainError, match="rolled-back recovery durable tier identity/content continuity"):
+        reconcile_durable_change_trains_on_startup(tmp_path)
+    blocked = load_durable_change_train_manifest(manifest)
+    assert blocked.state is DurableChangeTrainState.FAILED
+    assert blocked.reservation is not None and blocked.reservation.active is True
+
+
+def test_startup_keeps_persisted_indeterminate_failure_blocked(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "source.db"
+    _create_current_database(db_path)
+    train = _admitted(ArchiveTier.SOURCE)
+    with sqlite3.connect(db_path) as conn:
+        train = _reserve_and_authorize(conn, train, archive_root=tmp_path)
+        conn.execute("PRAGMA user_version = 99")
+        conn.commit()
+        with pytest.raises(DurableChangeTrainRecoveryError) as exc_info:
+            reconcile_interrupted_durable_change_train(
+                conn,
+                train,
+                interruption_evidence_ref="proof:unknown-version",
+                writer_release_evidence_ref="proof:lease-expired",
+            )
+        failed = exc_info.value.failed_train
+    manifest = tmp_path / ".maintenance-state" / "durable-change-trains" / "source-002.json"
+    write_durable_change_train_manifest(manifest, failed, expected_revision=-1)
+
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import reconcile_durable_change_trains_on_startup
+
+    with pytest.raises(DurableChangeTrainRecoveryError, match="cannot recover automatically"):
+        reconcile_durable_change_trains_on_startup(tmp_path)
+    blocked = load_durable_change_train_manifest(manifest)
+    assert blocked.state is DurableChangeTrainState.FAILED
+    assert blocked.reservation is not None and blocked.reservation.active is True
 
 
 def test_interrupted_unknown_version_requires_authenticated_restore(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_durable_change_train.py
+++ b/tests/unit/storage/test_durable_change_train.py
@@ -18,6 +18,9 @@ from polylogue.storage.sqlite.archive_tiers import ARCHIVE_DDL_BY_TIER, ARCHIVE_
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.durable_change_train import (
     DURABLE_MIGRATION_ADOPTION_FLOORS,
+    durable_change_train_manifest_path,
+    durable_change_train_policy_report,
+    execute_durable_change_train,
     validate_durable_migration_sidecars,
 )
 from polylogue.storage.sqlite.migration_runner import (
@@ -110,6 +113,29 @@ def _rider(*, consumer_count: int = 2, trust_floor_exception_ref: str | None = N
         runtime_consumers=consumers,
         behavior_proof_refs=tuple(consumer.behavior_proof_ref for consumer in consumers),
         trust_floor_exception_ref=trust_floor_exception_ref,
+    )
+
+
+def _production_rider() -> DurableChangeRider:
+    return DurableChangeRider(
+        rider_id="rider:startup",
+        owner_ref="owner:startup-rider",
+        schema_objects=("table:durable_items",),
+        runtime_consumers=(
+            DurableRuntimeConsumer(
+                "bootstrap",
+                "polylogue/storage/sqlite/archive_tiers/bootstrap.py:initialize_archive_database",
+                "proof:bootstrap",
+                ("write",),
+            ),
+            DurableRuntimeConsumer(
+                "daemon-health",
+                "polylogue/storage/sqlite/archive_tiers/bootstrap.py:initialize_archive_tier",
+                "proof:daemon-health",
+                ("read",),
+            ),
+        ),
+        behavior_proof_refs=("proof:bootstrap", "proof:daemon-health"),
     )
 
 
@@ -402,6 +428,98 @@ def test_future_train_sidecar_discovery_uses_real_package_resources(
         assert conn.execute("SELECT name FROM sqlite_schema WHERE name='future_items'").fetchone() == ("future_items",)
 
 
+def test_maintenance_route_persists_and_proves_a_future_train(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    package_root = tmp_path / "fixture_migrations_maintenance"
+    source_package = package_root / "source"
+    source_package.mkdir(parents=True)
+    (package_root / "__init__.py").write_text("", encoding="utf-8")
+    (source_package / "__init__.py").write_text("", encoding="utf-8")
+    sql = "-- migration-safety: additive-no-backup\nCREATE TABLE future_items (id INTEGER PRIMARY KEY) STRICT;\n"
+    (source_package / "002_future_items.sql").write_text(sql, encoding="utf-8")
+    claim = durable_migration_claim_for_sql(
+        ArchiveTier.SOURCE,
+        "002_future_items.sql",
+        sql,
+        owner_ref="owner:maintenance-source",
+    )
+    rider = DurableChangeRider(
+        rider_id="rider:maintenance",
+        owner_ref="owner:maintenance-rider",
+        schema_objects=("table:future_items",),
+        runtime_consumers=(
+            DurableRuntimeConsumer(
+                "bootstrap",
+                "polylogue/storage/sqlite/archive_tiers/bootstrap.py:initialize_archive_database",
+                "proof:bootstrap",
+                ("write",),
+            ),
+            DurableRuntimeConsumer(
+                "daemon-health",
+                "polylogue/storage/sqlite/archive_tiers/bootstrap.py:initialize_archive_tier",
+                "proof:daemon-health",
+                ("read",),
+            ),
+        ),
+        behavior_proof_refs=("proof:bootstrap", "proof:daemon-health"),
+    )
+    declared = declare_durable_change_train(
+        train_id="train:source:v2",
+        tier=ArchiveTier.SOURCE,
+        current_version=1,
+        target_version=2,
+        slot=2,
+        owner_ref="owner:maintenance-source",
+        migration=claim,
+        riders=(rider,),
+        declared_at_ms=1,
+    )
+    (source_package / "002.train.json").write_text(
+        json.dumps(migration_runner.durable_change_train_to_payload(declared)), encoding="utf-8"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setattr(migration_runner, "_migration_package", lambda _tier: "fixture_migrations_maintenance.source")
+    monkeypatch.setattr(
+        "polylogue.storage.sqlite.durable_change_train._migration_package",
+        lambda _tier: "fixture_migrations_maintenance.source",
+    )
+    monkeypatch.setattr(
+        "polylogue.storage.sqlite.durable_change_train.DURABLE_MIGRATION_ADOPTION_FLOORS",
+        {ArchiveTier.SOURCE: 1, ArchiveTier.USER: 1},
+    )
+    versions = dict(ARCHIVE_VERSION_BY_TIER)
+    versions[ArchiveTier.SOURCE] = 2
+    monkeypatch.setattr("polylogue.storage.sqlite.migration_runner.ARCHIVE_VERSION_BY_TIER", versions)
+    from polylogue.storage.sqlite.archive_tiers import bootstrap
+
+    monkeypatch.setattr(bootstrap, "ARCHIVE_VERSION_BY_TIER", versions)
+    ddl = dict(ARCHIVE_DDL_BY_TIER)
+    ddl[ArchiveTier.SOURCE] = (
+        "CREATE TABLE base_items (item_id TEXT PRIMARY KEY, payload TEXT NOT NULL) STRICT; CREATE TABLE future_items (id INTEGER PRIMARY KEY) STRICT;"
+    )
+    monkeypatch.setattr(bootstrap, "ARCHIVE_DDL_BY_TIER", ddl)
+    monkeypatch.setattr(migration_runner, "ARCHIVE_DDL_BY_TIER", ddl)
+    db_path = tmp_path / "source.db"
+    _create_current_database(db_path)
+
+    released: list[bool] = []
+    result = execute_durable_change_train(
+        tmp_path,
+        ArchiveTier.SOURCE,
+        backup_manifest=None,
+        daemon_stopped_evidence_ref="proof:daemon-stopped",
+        single_writer_evidence_ref="proof:archive-ownership-lock",
+        release_archive_ownership=lambda: released.append(True),
+    )
+
+    assert result.train is not None
+    assert result.train.state is DurableChangeTrainState.RELEASED
+    assert result.migration_result is not None
+    assert result.migration_result.applied_versions == (2,)
+    assert released == [True]
+    manifest_path = durable_change_train_manifest_path(tmp_path, ArchiveTier.SOURCE, 2)
+    assert load_durable_change_train_manifest(manifest_path).state is DurableChangeTrainState.RELEASED
+
+
 def test_future_train_sidecar_hash_and_slot_are_admission_bound(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -483,6 +601,15 @@ def test_missing_future_sidecar_is_rejected_at_the_migration_runner_choke_point(
     sidecar.unlink()
     with pytest.raises(MigrationError, match="missing durable migration train sidecar"):
         migration_runner._load_migrations(ArchiveTier.SOURCE)
+    policy = durable_change_train_policy_report(ArchiveTier.SOURCE)
+    assert policy["ok"] is False
+    violations = cast(list[str], policy["violations"])
+    assert any("missing durable migration train sidecar" in violation for violation in violations)
+    (source_package / "028.train.json").write_text(
+        json.dumps(migration_runner.durable_change_train_to_payload(train)), encoding="utf-8"
+    )
+    with pytest.raises(DurableChangeTrainError, match="no matching SQL resource"):
+        validate_durable_migration_sidecars(ArchiveTier.SOURCE, ((sql_path.name, sql),))
 
 
 def test_migration_transaction_control_cannot_escape_rollback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -843,6 +970,92 @@ def test_interrupted_commit_recovers_at_applied_without_reapplying(
     assert recovered.apply_evidence is not None
     assert recovered.apply_evidence.recovered_after_interrupt is True
     assert recovered.reservation is not None and recovered.reservation.active is False
+
+
+def test_bootstrap_reconciles_and_persists_interrupted_train_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from polylogue.storage.sqlite.archive_tiers import ARCHIVE_DDL_BY_TIER, ARCHIVE_VERSION_BY_TIER, bootstrap
+
+    versions = dict(ARCHIVE_VERSION_BY_TIER)
+    versions[ArchiveTier.SOURCE] = _TARGET_VERSION
+    monkeypatch.setattr(bootstrap, "ARCHIVE_VERSION_BY_TIER", versions)
+    ddl = dict(ARCHIVE_DDL_BY_TIER)
+    ddl[ArchiveTier.SOURCE] = (
+        "CREATE TABLE base_items (item_id TEXT PRIMARY KEY, payload TEXT NOT NULL) STRICT; "
+        "CREATE TABLE durable_items (item_id TEXT PRIMARY KEY, payload TEXT NOT NULL) STRICT;"
+    )
+    monkeypatch.setattr(bootstrap, "ARCHIVE_DDL_BY_TIER", ddl)
+    db_path = tmp_path / "source.db"
+    _create_current_database(db_path)
+    train = _admitted(ArchiveTier.SOURCE, rider=_production_rider())
+    with sqlite3.connect(db_path) as conn:
+        train = _reserve_and_authorize(conn, train, archive_root=tmp_path)
+        conn.execute("CREATE TABLE durable_items (item_id TEXT PRIMARY KEY, payload TEXT NOT NULL) STRICT")
+        conn.execute(f"PRAGMA user_version = {_TARGET_VERSION}")
+        conn.commit()
+    manifest = tmp_path / ".maintenance-state" / "durable-change-trains" / "source-002.json"
+    write_durable_change_train_manifest(manifest, train, expected_revision=-1)
+
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+    initialize_active_archive_root(tmp_path)
+    recovered = load_durable_change_train_manifest(manifest)
+    assert recovered.state is DurableChangeTrainState.RELEASED
+    assert recovered.apply_evidence is not None
+    assert recovered.apply_evidence.recovered_after_interrupt is True
+    assert "proof:startup-recovery:train:source:v2" in recovered.proof_refs
+
+
+def test_bootstrap_finishes_persisted_applied_train_without_reapplying(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from polylogue.storage.sqlite.archive_tiers import ARCHIVE_DDL_BY_TIER, ARCHIVE_VERSION_BY_TIER, bootstrap
+
+    versions = dict(ARCHIVE_VERSION_BY_TIER)
+    versions[ArchiveTier.SOURCE] = _TARGET_VERSION
+    monkeypatch.setattr(bootstrap, "ARCHIVE_VERSION_BY_TIER", versions)
+    ddl = dict(ARCHIVE_DDL_BY_TIER)
+    ddl[ArchiveTier.SOURCE] = (
+        "CREATE TABLE base_items (item_id TEXT PRIMARY KEY, payload TEXT NOT NULL) STRICT; "
+        "CREATE TABLE durable_items (item_id TEXT PRIMARY KEY, payload TEXT NOT NULL) STRICT;"
+    )
+    monkeypatch.setattr(bootstrap, "ARCHIVE_DDL_BY_TIER", ddl)
+    db_path = tmp_path / "source.db"
+    _create_current_database(db_path)
+    train = _admitted(ArchiveTier.SOURCE, rider=_production_rider())
+    with sqlite3.connect(db_path) as conn:
+        train = _reserve_and_authorize(conn, train, archive_root=tmp_path)
+        conn.execute("CREATE TABLE durable_items (item_id TEXT PRIMARY KEY, payload TEXT NOT NULL) STRICT")
+        conn.execute(f"PRAGMA user_version = {_TARGET_VERSION}")
+        conn.commit()
+        train = reconcile_interrupted_durable_change_train(
+            conn,
+            train,
+            interruption_evidence_ref="proof:post-commit-crash",
+            writer_release_evidence_ref="proof:lease-expired",
+        )
+    assert train.reservation is not None
+    train = replace(
+        train,
+        revision=train.revision + 1,
+        reservation=replace(train.reservation, active=True, released_at_ms=None, release_evidence_ref=None),
+    )
+    manifest = tmp_path / ".maintenance-state" / "durable-change-trains" / "source-002.json"
+    write_durable_change_train_manifest(manifest, train, expected_revision=-1)
+    monkeypatch.setattr(
+        migration_runner,
+        "migrate_archive_tier",
+        lambda *_args, **_kwargs: pytest.fail("startup attempted to reapply a committed train"),
+    )
+
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import reconcile_durable_change_trains_on_startup
+
+    assert reconcile_durable_change_trains_on_startup(tmp_path) == (manifest,)
+    recovered = load_durable_change_train_manifest(manifest)
+    assert recovered.state is DurableChangeTrainState.RELEASED
+    assert recovered.proof is not None
+    assert recovered.apply_evidence is not None and recovered.apply_evidence.recovered_after_interrupt is True
 
 
 def test_interrupted_unknown_version_requires_authenticated_restore(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_durable_change_train.py
+++ b/tests/unit/storage/test_durable_change_train.py
@@ -1,0 +1,969 @@
+"""Lifecycle contracts for durable source/user schema-change authority."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import replace
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from polylogue.storage.sqlite import migration_runner
+from polylogue.storage.sqlite.archive_tiers import ARCHIVE_VERSION_BY_TIER
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.durable_change_train import (
+    DURABLE_MIGRATION_ADOPTION_FLOORS,
+    validate_durable_migration_sidecars,
+)
+from polylogue.storage.sqlite.migration_runner import (
+    DurableChangeRider,
+    DurableChangeTrain,
+    DurableChangeTrainApplyError,
+    DurableChangeTrainError,
+    DurableChangeTrainRecoveryError,
+    DurableChangeTrainState,
+    DurableFailureClassification,
+    DurableFreshDDLParityProof,
+    DurableMigrationClaim,
+    DurableRuntimeConsumer,
+    DurableRuntimeConsumerResult,
+    MigrationStep,
+    add_durable_change_train_rider,
+    admit_durable_change_train,
+    apply_durable_change_train,
+    authorize_durable_change_train_backup,
+    capture_durable_restart_convergence,
+    declare_durable_change_train,
+    durable_migration_claim_for_sql,
+    durable_migration_collision_report,
+    load_durable_change_train_manifest,
+    prove_durable_change_train,
+    prove_durable_fresh_ddl_parity,
+    reconcile_interrupted_durable_change_train,
+    record_durable_writer_release,
+    recover_durable_change_train,
+    release_durable_change_train,
+    reserve_durable_change_train,
+    write_durable_change_train_manifest,
+)
+
+_CURRENT_VERSION = 1
+_TARGET_VERSION = 2
+_ADDITIVE_SQL = """-- migration-safety: additive-no-backup
+CREATE TABLE durable_items (
+    item_id TEXT PRIMARY KEY,
+    payload TEXT NOT NULL
+) STRICT;
+"""
+
+
+@contextmanager
+def _memory_target(*, include_durable_items: bool = True) -> Iterator[sqlite3.Connection]:
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.execute("CREATE TABLE base_items (item_id TEXT PRIMARY KEY, payload TEXT NOT NULL) STRICT")
+        if include_durable_items:
+            conn.execute("CREATE TABLE durable_items (item_id TEXT PRIMARY KEY, payload TEXT NOT NULL) STRICT")
+        conn.execute(f"PRAGMA user_version = {_TARGET_VERSION}")
+        conn.commit()
+        yield conn
+    finally:
+        conn.close()
+
+
+def _create_current_database(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute("CREATE TABLE base_items (item_id TEXT PRIMARY KEY, payload TEXT NOT NULL) STRICT")
+        conn.execute("INSERT INTO base_items VALUES ('base-1', 'preserve-me')")
+        conn.execute(f"PRAGMA user_version = {_CURRENT_VERSION}")
+        conn.commit()
+
+
+def _claim(tier: ArchiveTier, sql: str = _ADDITIVE_SQL) -> DurableMigrationClaim:
+    return durable_migration_claim_for_sql(
+        tier,
+        "002_durable_items.sql",
+        sql,
+        owner_ref=f"owner:migration:{tier.value}:002",
+    )
+
+
+def _rider(*, consumer_count: int = 2, trust_floor_exception_ref: str | None = None) -> DurableChangeRider:
+    consumers = tuple(
+        DurableRuntimeConsumer(
+            consumer_id=f"consumer-{index}",
+            production_ref=f"polylogue/storage/{'writer' if index == 0 else 'reader'}_{index}.py:consume",
+            behavior_proof_ref=f"proof:behavior:{index}",
+            roles=("write" if index == 0 else "read",),
+        )
+        for index in range(consumer_count)
+    )
+    return DurableChangeRider(
+        rider_id="rider:durable-items",
+        owner_ref="owner:rider",
+        schema_objects=("table:durable_items",),
+        runtime_consumers=consumers,
+        behavior_proof_refs=tuple(consumer.behavior_proof_ref for consumer in consumers),
+        trust_floor_exception_ref=trust_floor_exception_ref,
+    )
+
+
+def _parity(tier: ArchiveTier, *, include_durable_items: bool = True) -> DurableFreshDDLParityProof:
+    with _memory_target(include_durable_items=include_durable_items) as migrated:
+        with _memory_target() as fresh:
+            return prove_durable_fresh_ddl_parity(
+                tier,
+                _TARGET_VERSION,
+                migrated_connection=migrated,
+                fresh_connection=fresh,
+                evidence_ref=f"proof:fresh-ddl:{tier.value}",
+            )
+
+
+def _declared(
+    tier: ArchiveTier,
+    *,
+    claim: DurableMigrationClaim | None = None,
+    rider: DurableChangeRider | None = None,
+    owner_ref: str = "owner:train",
+    backup_plan_ref: str | None = None,
+) -> DurableChangeTrain:
+    migration = claim or _claim(tier)
+    return declare_durable_change_train(
+        train_id=f"train:{tier.value}:v{_TARGET_VERSION}",
+        tier=tier,
+        current_version=_CURRENT_VERSION,
+        target_version=_TARGET_VERSION,
+        slot=_TARGET_VERSION,
+        owner_ref=owner_ref,
+        migration=migration,
+        riders=((rider or _rider()),),
+        backup_plan_ref=backup_plan_ref,
+        declared_at_ms=1,
+    )
+
+
+def _admitted(
+    tier: ArchiveTier,
+    *,
+    claim: DurableMigrationClaim | None = None,
+    rider: DurableChangeRider | None = None,
+    owner_ref: str = "owner:train",
+    backup_plan_ref: str | None = None,
+    active_trains: tuple[DurableChangeTrain, ...] = (),
+) -> DurableChangeTrain:
+    migration = claim or _claim(tier)
+    return admit_durable_change_train(
+        _declared(
+            tier,
+            claim=migration,
+            rider=rider,
+            owner_ref=owner_ref,
+            backup_plan_ref=backup_plan_ref,
+        ),
+        observed_current_version=_CURRENT_VERSION,
+        fresh_ddl_parity=_parity(tier),
+        admission_evidence_ref=f"proof:admit:{tier.value}",
+        active_trains=active_trains,
+        migration_claims=(migration,),
+        canonical_target_version=_TARGET_VERSION,
+        admitted_at_ms=2,
+    )
+
+
+def _install_synthetic_migration(
+    monkeypatch: pytest.MonkeyPatch,
+    tier: ArchiveTier,
+    *,
+    sql: str = _ADDITIVE_SQL,
+) -> None:
+    versions = dict(ARCHIVE_VERSION_BY_TIER)
+    versions[tier] = _TARGET_VERSION
+    monkeypatch.setattr(migration_runner, "ARCHIVE_VERSION_BY_TIER", versions)
+    step = MigrationStep(
+        tier=tier,
+        version=_TARGET_VERSION,
+        name="002_durable_items.sql",
+        sql=sql,
+        requires_backup=not sql.startswith("-- migration-safety: additive-no-backup"),
+    )
+    monkeypatch.setattr(
+        migration_runner,
+        "_load_migrations",
+        lambda observed_tier: (step,) if observed_tier is tier else (),
+    )
+
+
+def _reserve_and_authorize(
+    conn: sqlite3.Connection,
+    train: DurableChangeTrain,
+    *,
+    archive_root: Path,
+) -> DurableChangeTrain:
+    reserved = reserve_durable_change_train(
+        train,
+        reservation_id="lease:archive-root",
+        reservation_owner_ref=train.owner_ref,
+        archive_root=archive_root,
+        tier_path=archive_root / f"{train.tier.value}.db",
+        daemon_stopped_evidence_ref="proof:daemon-stopped",
+        single_writer_evidence_ref="proof:rebuild-lease",
+        reserved_at_ms=3,
+    )
+    return authorize_durable_change_train_backup(
+        conn,
+        reserved,
+        backup_manifest=None,
+        evidence_ref="proof:additive-no-backup",
+        authorized_at_ms=4,
+    )
+
+
+def _runtime_results() -> tuple[DurableRuntimeConsumerResult, ...]:
+    return (
+        DurableRuntimeConsumerResult("consumer-0", "proof:behavior:0", True),
+        DurableRuntimeConsumerResult("consumer-1", "proof:behavior:1", True),
+    )
+
+
+@pytest.mark.parametrize("tier", (ArchiveTier.SOURCE, ArchiveTier.USER))
+def test_synthetic_source_and_user_trains_complete_the_full_lifecycle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tier: ArchiveTier,
+) -> None:
+    """Both durable tiers persist every state and use the shipped migration transaction."""
+    db_path = tmp_path / f"{tier.value}.db"
+    manifest = tmp_path / f"{tier.value}-train.json"
+    _create_current_database(db_path)
+    _install_synthetic_migration(monkeypatch, tier)
+    original_runner = migration_runner.migrate_archive_tier
+    calls: list[ArchiveTier] = []
+
+    def observed_runner(
+        conn: sqlite3.Connection,
+        observed_tier: ArchiveTier,
+        *,
+        backup_manifest: Path | None,
+    ) -> migration_runner.MigrationResult:
+        calls.append(observed_tier)
+        return original_runner(conn, observed_tier, backup_manifest=backup_manifest)
+
+    def persist_and_reload(next_train: DurableChangeTrain, expected_revision: int) -> DurableChangeTrain:
+        write_durable_change_train_manifest(
+            manifest,
+            next_train,
+            expected_revision=expected_revision,
+        )
+        return load_durable_change_train_manifest(manifest)
+
+    monkeypatch.setattr(migration_runner, "migrate_archive_tier", observed_runner)
+    claim = _claim(tier)
+    train = _declared(tier, claim=claim)
+    train = persist_and_reload(train, -1)
+    previous_revision = train.revision
+    train = admit_durable_change_train(
+        train,
+        observed_current_version=_CURRENT_VERSION,
+        fresh_ddl_parity=_parity(tier),
+        admission_evidence_ref=f"proof:admit:{tier.value}",
+        migration_claims=(claim,),
+        canonical_target_version=_TARGET_VERSION,
+        admitted_at_ms=2,
+    )
+    train = persist_and_reload(train, previous_revision)
+    previous_revision = train.revision
+    train = reserve_durable_change_train(
+        train,
+        reservation_id="lease:archive-root",
+        reservation_owner_ref=train.owner_ref,
+        archive_root=tmp_path,
+        tier_path=db_path,
+        daemon_stopped_evidence_ref="proof:daemon-stopped",
+        single_writer_evidence_ref="proof:rebuild-lease",
+    )
+    train = persist_and_reload(train, previous_revision)
+    previous_revision = train.revision
+    with sqlite3.connect(db_path) as conn:
+        train = authorize_durable_change_train_backup(
+            conn,
+            train,
+            backup_manifest=None,
+            evidence_ref="proof:additive-no-backup",
+        )
+        train = persist_and_reload(train, previous_revision)
+        previous_revision = train.revision
+        train = apply_durable_change_train(conn, train)
+        train = persist_and_reload(train, previous_revision)
+        assert conn.execute("SELECT payload FROM base_items WHERE item_id='base-1'").fetchone() == ("preserve-me",)
+        assert conn.execute("SELECT name FROM sqlite_schema WHERE name='durable_items'").fetchone() == (
+            "durable_items",
+        )
+    assert calls == [tier]
+
+    assert train.apply_evidence is not None
+    assert train.apply_evidence.migration_result.applied_versions == (_TARGET_VERSION,)
+    assert train.apply_evidence.row_parity.ok is True
+
+    previous_revision = train.revision
+    train = record_durable_writer_release(train, evidence_ref="proof:lease-released")
+    train = persist_and_reload(train, previous_revision)
+    with sqlite3.connect(db_path) as restarted:
+        with _memory_target() as fresh:
+            actual_parity = prove_durable_fresh_ddl_parity(
+                tier,
+                _TARGET_VERSION,
+                migrated_connection=restarted,
+                fresh_connection=fresh,
+                evidence_ref=f"proof:post-apply-fresh:{tier.value}",
+            )
+        runtime_results = _runtime_results()
+        restart = capture_durable_restart_convergence(
+            restarted,
+            train,
+            runtime_consumers=runtime_results,
+            evidence_ref="proof:runtime-restart",
+        )
+    previous_revision = train.revision
+    train = prove_durable_change_train(
+        train,
+        fresh_ddl_parity=actual_parity,
+        runtime_consumers=runtime_results,
+        restart_convergence=restart,
+    )
+    train = persist_and_reload(train, previous_revision)
+    previous_revision = train.revision
+    train = release_durable_change_train(train, evidence_ref="proof:train-release")
+    train = persist_and_reload(train, previous_revision)
+
+    assert train.state is DurableChangeTrainState.RELEASED
+    assert train.revision == 7
+
+
+def test_future_train_sidecar_discovery_uses_real_package_resources(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    package_root = tmp_path / "fixture_migrations"
+    source_package = package_root / "source"
+    source_package.mkdir(parents=True)
+    (package_root / "__init__.py").write_text("", encoding="utf-8")
+    (source_package / "__init__.py").write_text("", encoding="utf-8")
+    sql = "-- migration-safety: additive-no-backup\nCREATE TABLE future_items (id INTEGER PRIMARY KEY) STRICT;\n"
+    sql_path = source_package / "027_future_items.sql"
+    sql_path.write_text(sql, encoding="utf-8")
+    claim = durable_migration_claim_for_sql(
+        ArchiveTier.SOURCE,
+        sql_path.name,
+        sql,
+        owner_ref="owner:future-source",
+    )
+    train = declare_durable_change_train(
+        train_id="train:source:v27",
+        tier=ArchiveTier.SOURCE,
+        current_version=DURABLE_MIGRATION_ADOPTION_FLOORS[ArchiveTier.SOURCE],
+        target_version=27,
+        slot=27,
+        owner_ref="owner:future-source",
+        migration=claim,
+        riders=(_rider(),),
+        declared_at_ms=1,
+    )
+    (source_package / "027.train.json").write_text(
+        json.dumps(migration_runner.durable_change_train_to_payload(train)),
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setattr(
+        "polylogue.storage.sqlite.durable_change_train._migration_package",
+        lambda _tier: "fixture_migrations.source",
+    )
+
+    observed = validate_durable_migration_sidecars(ArchiveTier.SOURCE, ((sql_path.name, sql),))
+
+    assert [item.resource_name for item in observed] == ["027.train.json"]
+    assert observed[0].train.migration.sql_sha256 == claim.sql_sha256
+    assert "fixture_migrations.source" in sys.modules
+
+
+def test_future_train_sidecar_hash_and_slot_are_admission_bound(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    package_root = tmp_path / "fixture_migrations_hash"
+    source_package = package_root / "source"
+    source_package.mkdir(parents=True)
+    (package_root / "__init__.py").write_text("", encoding="utf-8")
+    (source_package / "__init__.py").write_text("", encoding="utf-8")
+    sql = "-- migration-safety: additive-no-backup\nCREATE TABLE future_items (id INTEGER PRIMARY KEY) STRICT;\n"
+    sql_path = source_package / "027_future_items.sql"
+    sql_path.write_text(sql, encoding="utf-8")
+    claim = durable_migration_claim_for_sql(ArchiveTier.SOURCE, sql_path.name, sql, owner_ref="owner:future-source")
+    train = declare_durable_change_train(
+        train_id="train:source:v27",
+        tier=ArchiveTier.SOURCE,
+        current_version=26,
+        target_version=27,
+        slot=27,
+        owner_ref="owner:future-source",
+        migration=claim,
+        riders=(_rider(),),
+        declared_at_ms=1,
+    )
+    payload = migration_runner.durable_change_train_to_payload(train)
+    cast(dict[str, object], payload["migration"])["sql_sha256"] = "0" * 64
+    (source_package / "027.train.json").write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setattr(
+        "polylogue.storage.sqlite.durable_change_train._migration_package",
+        lambda _tier: "fixture_migrations_hash.source",
+    )
+
+    with pytest.raises(DurableChangeTrainError, match="checksum mismatch"):
+        validate_durable_migration_sidecars(ArchiveTier.SOURCE, ((sql_path.name, sql),))
+
+
+def test_canonical_inventory_preserves_trigger_literal_whitespace() -> None:
+    def inventory(trigger_literal: str, *, formatted: bool) -> str:
+        with sqlite3.connect(":memory:") as conn:
+            conn.executescript(
+                """
+                CREATE TABLE items (item_id INTEGER PRIMARY KEY);
+                CREATE TABLE audit (payload TEXT NOT NULL);
+                """
+            )
+            if formatted:
+                conn.executescript(
+                    f"""
+                    CREATE TRIGGER audit_items
+                    AFTER INSERT ON items
+                    BEGIN
+                        INSERT INTO audit(payload) VALUES ({trigger_literal});
+                    END;
+                    """
+                )
+            else:
+                conn.executescript(
+                    "CREATE TRIGGER audit_items AFTER INSERT ON items BEGIN "
+                    f"INSERT INTO audit(payload) VALUES({trigger_literal}); END;"
+                )
+            return migration_runner.capture_durable_schema_inventory(conn).sha256
+
+    spaced = inventory("'a  b'", formatted=True)
+    same_literal_compact_layout = inventory("'a  b'", formatted=False)
+    changed_literal = inventory("'a b'", formatted=False)
+
+    assert spaced == same_literal_compact_layout
+    assert spaced != changed_literal
+
+
+def test_admission_rejects_stale_current_and_target_versions() -> None:
+    train = _declared(ArchiveTier.SOURCE)
+    with pytest.raises(DurableChangeTrainError, match="stale durable train current"):
+        admit_durable_change_train(
+            train,
+            observed_current_version=0,
+            fresh_ddl_parity=_parity(ArchiveTier.SOURCE),
+            admission_evidence_ref="proof:admit",
+            migration_claims=(train.migration,),
+            canonical_target_version=_TARGET_VERSION,
+        )
+    with pytest.raises(DurableChangeTrainError, match="stale durable train target"):
+        admit_durable_change_train(
+            train,
+            observed_current_version=_CURRENT_VERSION,
+            fresh_ddl_parity=_parity(ArchiveTier.SOURCE),
+            admission_evidence_ref="proof:admit",
+            migration_claims=(train.migration,),
+            canonical_target_version=_TARGET_VERSION + 1,
+        )
+
+
+def test_source_008_009_collision_names_both_owners_and_blocks_admission() -> None:
+    source_migrations = Path(__file__).parents[3] / "polylogue" / "storage" / "sqlite" / "migrations" / "source"
+    source_008 = source_migrations / "008_raw_session_capture_mode.sql"
+    source_009 = source_migrations / "009_expand_origin_vocabulary.sql"
+    first = durable_migration_claim_for_sql(
+        ArchiveTier.SOURCE,
+        source_008.name,
+        source_008.read_text(encoding="utf-8"),
+        owner_ref="owner:source-008",
+    )
+    late_rider = durable_migration_claim_for_sql(
+        ArchiveTier.SOURCE,
+        "008_expand_origin_vocabulary.sql",
+        source_009.read_text(encoding="utf-8"),
+        owner_ref="owner:source-009-late-rider",
+    )
+    report = durable_migration_collision_report((first, late_rider))
+    assert report["ok"] is False
+    serialized = json.dumps(report)
+    assert source_008.name in serialized
+    assert "008_expand_origin_vocabulary.sql" in serialized
+    assert "owner:source-008" in serialized
+    assert "owner:source-009-late-rider" in serialized
+
+    train = declare_durable_change_train(
+        train_id="source-v8",
+        tier=ArchiveTier.SOURCE,
+        current_version=7,
+        target_version=8,
+        slot=8,
+        owner_ref="owner:source-train",
+        migration=first,
+        riders=(_rider(),),
+    )
+    parity = DurableFreshDDLParityProof(
+        tier=ArchiveTier.SOURCE,
+        target_version=8,
+        migrated_version=8,
+        fresh_version=8,
+        migrated_inventory_sha256="a" * 64,
+        fresh_inventory_sha256="a" * 64,
+        missing_objects=(),
+        unexpected_objects=(),
+        changed_objects=(),
+        evidence_ref="proof:v8-fresh",
+        matches=True,
+    )
+    with pytest.raises(DurableChangeTrainError, match="collision.*rebase/renumber") as exc_info:
+        admit_durable_change_train(
+            train,
+            observed_current_version=7,
+            fresh_ddl_parity=parity,
+            admission_evidence_ref="proof:v8-admit",
+            migration_claims=(first, late_rider),
+            canonical_target_version=8,
+        )
+    assert source_008.name in str(exc_info.value)
+    assert "008_expand_origin_vocabulary.sql" in str(exc_info.value)
+
+
+def test_duplicate_train_ownership_and_late_rider_are_rejected() -> None:
+    admitted = _admitted(ArchiveTier.SOURCE)
+    duplicate = replace(_declared(ArchiveTier.SOURCE), train_id="train:source:v2:duplicate")
+    with pytest.raises(DurableChangeTrainError, match="contention key already owned"):
+        admit_durable_change_train(
+            duplicate,
+            observed_current_version=_CURRENT_VERSION,
+            fresh_ddl_parity=_parity(ArchiveTier.SOURCE),
+            admission_evidence_ref="proof:duplicate",
+            active_trains=(admitted,),
+            migration_claims=(duplicate.migration,),
+            canonical_target_version=_TARGET_VERSION,
+        )
+    with pytest.raises(DurableChangeTrainError, match="late rider.*target v3"):
+        add_durable_change_train_rider(admitted, _rider(trust_floor_exception_ref="exception:late"))
+
+
+def test_schema_only_unproven_and_nonproduction_riders_fail_admission() -> None:
+    schema_only = _rider(consumer_count=0, trust_floor_exception_ref="exception:single-consumer-floor")
+    with pytest.raises(DurableChangeTrainError, match="schema-only"):
+        _admitted(ArchiveTier.SOURCE, rider=schema_only)
+
+    one_consumer = _rider(consumer_count=1)
+    with pytest.raises(DurableChangeTrainError, match="fewer than two"):
+        _admitted(ArchiveTier.SOURCE, rider=one_consumer)
+
+    test_only = DurableChangeRider(
+        rider_id="test-only",
+        owner_ref="owner:test-only",
+        schema_objects=("table:durable_items",),
+        runtime_consumers=(
+            DurableRuntimeConsumer("test-a", "tests/unit/test_a.py:test_a", "proof:test-a", ("read",)),
+            DurableRuntimeConsumer("test-b", "fixture:test-b", "proof:test-b", ("write",)),
+        ),
+        behavior_proof_refs=("proof:test-a", "proof:test-b"),
+    )
+    with pytest.raises(DurableChangeTrainError, match="test-only"):
+        _admitted(ArchiveTier.SOURCE, rider=test_only)
+
+
+def test_fresh_ddl_parity_mismatch_blocks_admission() -> None:
+    mismatch = _parity(ArchiveTier.SOURCE, include_durable_items=False)
+    assert mismatch.matches is False
+    train = _declared(ArchiveTier.SOURCE)
+    with pytest.raises(DurableChangeTrainError, match="fresh-DDL parity"):
+        admit_durable_change_train(
+            train,
+            observed_current_version=_CURRENT_VERSION,
+            fresh_ddl_parity=mismatch,
+            admission_evidence_ref="proof:mismatch",
+            migration_claims=(train.migration,),
+            canonical_target_version=_TARGET_VERSION,
+        )
+
+
+def test_backup_authority_timestamp_precedes_its_captured_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Authorization must not depend on two clock reads landing in one millisecond."""
+    db_path = tmp_path / "source.db"
+    _create_current_database(db_path)
+    train = _admitted(ArchiveTier.SOURCE)
+    train = reserve_durable_change_train(
+        train,
+        reservation_id="lease:source",
+        reservation_owner_ref=train.owner_ref,
+        archive_root=tmp_path,
+        tier_path=db_path,
+        daemon_stopped_evidence_ref="proof:stopped",
+        single_writer_evidence_ref="proof:lease",
+        reserved_at_ms=3,
+    )
+    timestamps = iter((10, 11))
+    monkeypatch.setattr(migration_runner, "_durable_now_ms", lambda: next(timestamps))
+
+    with sqlite3.connect(db_path) as conn:
+        authorized = authorize_durable_change_train_backup(
+            conn,
+            train,
+            backup_manifest=None,
+            evidence_ref="proof:additive-no-backup",
+        )
+
+    assert authorized.backup_authorization is not None
+    assert authorized.pre_apply_evidence is not None
+    assert authorized.backup_authorization.authorized_at_ms == 10
+    assert authorized.pre_apply_evidence.observed_at_ms == 11
+
+
+def test_missing_backup_authority_stops_a_backup_required_train(tmp_path: Path) -> None:
+    backup_sql = "CREATE TABLE durable_items (item_id TEXT PRIMARY KEY, payload TEXT NOT NULL) STRICT;\n"
+    claim = _claim(ArchiveTier.USER, backup_sql)
+    train = _admitted(
+        ArchiveTier.USER,
+        claim=claim,
+        backup_plan_ref="backup-profile:user-overlays",
+    )
+    db_path = tmp_path / "user.db"
+    _create_current_database(db_path)
+    train = reserve_durable_change_train(
+        train,
+        reservation_id="lease:user",
+        reservation_owner_ref=train.owner_ref,
+        archive_root=tmp_path,
+        tier_path=db_path,
+        daemon_stopped_evidence_ref="proof:stopped",
+        single_writer_evidence_ref="proof:lease",
+    )
+    with sqlite3.connect(db_path) as conn:
+        with pytest.raises(DurableChangeTrainError, match="requires an authenticated backup"):
+            authorize_durable_change_train_backup(
+                conn,
+                train,
+                backup_manifest=None,
+                evidence_ref="proof:missing-backup",
+            )
+
+
+def test_source_and_user_share_only_the_same_archive_writer_reservation(tmp_path: Path) -> None:
+    source = _admitted(ArchiveTier.SOURCE, owner_ref="owner:operator")
+    user = _admitted(ArchiveTier.USER, owner_ref="owner:operator")
+    source_reserved = reserve_durable_change_train(
+        source,
+        reservation_id="lease:shared",
+        reservation_owner_ref="owner:operator",
+        archive_root=tmp_path,
+        tier_path=tmp_path / "source.db",
+        daemon_stopped_evidence_ref="proof:stopped",
+        single_writer_evidence_ref="proof:lease",
+    )
+    with pytest.raises(DurableChangeTrainError, match="second writer rejected"):
+        reserve_durable_change_train(
+            user,
+            reservation_id="lease:other",
+            reservation_owner_ref="owner:operator",
+            archive_root=tmp_path,
+            tier_path=tmp_path / "user.db",
+            daemon_stopped_evidence_ref="proof:stopped",
+            single_writer_evidence_ref="proof:other-lease",
+            active_trains=(source_reserved,),
+        )
+    user_reserved = reserve_durable_change_train(
+        user,
+        reservation_id="lease:shared",
+        reservation_owner_ref="owner:operator",
+        archive_root=tmp_path,
+        tier_path=tmp_path / "user.db",
+        daemon_stopped_evidence_ref="proof:stopped",
+        single_writer_evidence_ref="proof:lease",
+        active_trains=(source_reserved,),
+    )
+    assert source_reserved.reservation is not None
+    assert user_reserved.reservation is not None
+    assert user_reserved.reservation.reservation_id == source_reserved.reservation.reservation_id
+
+
+def test_failed_transaction_exposes_exact_retry_recovery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    failing_sql = """-- migration-safety: additive-no-backup
+CREATE TABLE durable_items (item_id TEXT PRIMARY KEY, payload TEXT NOT NULL) STRICT;
+INSERT INTO table_that_does_not_exist VALUES (1);
+"""
+    db_path = tmp_path / "source.db"
+    _create_current_database(db_path)
+    claim = _claim(ArchiveTier.SOURCE, failing_sql)
+    train = _admitted(ArchiveTier.SOURCE, claim=claim)
+    _install_synthetic_migration(monkeypatch, ArchiveTier.SOURCE, sql=failing_sql)
+    with sqlite3.connect(db_path) as conn:
+        train = _reserve_and_authorize(conn, train, archive_root=tmp_path)
+        with pytest.raises(DurableChangeTrainApplyError) as exc_info:
+            apply_durable_change_train(conn, train)
+        failed = exc_info.value.failed_train
+        assert failed.state is DurableChangeTrainState.FAILED
+        assert failed.failure is not None
+        assert failed.failure.classification is DurableFailureClassification.ROLLED_BACK_TO_CURRENT
+        failure_manifest = tmp_path / "source-failed-train.json"
+        write_durable_change_train_manifest(failure_manifest, failed, expected_revision=-1)
+        failed = load_durable_change_train_manifest(failure_manifest)
+        assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == _CURRENT_VERSION
+        assert conn.execute("SELECT name FROM sqlite_schema WHERE name='durable_items'").fetchone() is None
+        recovered = recover_durable_change_train(
+            conn,
+            failed,
+            recovery_evidence_ref="proof:rollback-observed",
+            writer_release_evidence_ref="proof:lease-released",
+        )
+    assert recovered.state is DurableChangeTrainState.ADMITTED
+    assert recovered.reservation is None
+    assert recovered.backup_authorization is None
+    assert recovered.pre_apply_evidence is None
+
+
+def test_interrupted_commit_recovers_at_applied_without_reapplying(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "source.db"
+    _create_current_database(db_path)
+    train = _admitted(ArchiveTier.SOURCE)
+    with sqlite3.connect(db_path) as conn:
+        train = _reserve_and_authorize(conn, train, archive_root=tmp_path)
+        conn.execute("CREATE TABLE durable_items (item_id TEXT PRIMARY KEY, payload TEXT NOT NULL) STRICT")
+        conn.execute(f"PRAGMA user_version = {_TARGET_VERSION}")
+        conn.commit()
+
+        def must_not_reapply(*_args: object, **_kwargs: object) -> None:
+            pytest.fail("interrupted target recovery re-entered the migration engine")
+
+        monkeypatch.setattr(migration_runner, "migrate_archive_tier", must_not_reapply)
+        recovered = reconcile_interrupted_durable_change_train(
+            conn,
+            train,
+            interruption_evidence_ref="proof:process-died-after-commit",
+            writer_release_evidence_ref="proof:lease-expired",
+        )
+        recovered_manifest = tmp_path / "source-interrupted-recovered.json"
+        write_durable_change_train_manifest(recovered_manifest, recovered, expected_revision=-1)
+        recovered = load_durable_change_train_manifest(recovered_manifest)
+    assert recovered.state is DurableChangeTrainState.APPLIED
+    assert recovered.apply_evidence is not None
+    assert recovered.apply_evidence.recovered_after_interrupt is True
+    assert recovered.reservation is not None and recovered.reservation.active is False
+
+
+def test_interrupted_unknown_version_requires_authenticated_restore(tmp_path: Path) -> None:
+    db_path = tmp_path / "source.db"
+    _create_current_database(db_path)
+    train = _admitted(ArchiveTier.SOURCE)
+    with sqlite3.connect(db_path) as conn:
+        train = _reserve_and_authorize(conn, train, archive_root=tmp_path)
+        conn.execute("PRAGMA user_version = 99")
+        conn.commit()
+        with pytest.raises(
+            DurableChangeTrainRecoveryError,
+            match="restore the exact authenticated backup",
+        ) as exc_info:
+            reconcile_interrupted_durable_change_train(
+                conn,
+                train,
+                interruption_evidence_ref="proof:unknown-version",
+                writer_release_evidence_ref="proof:lease-expired",
+            )
+        failed = exc_info.value.failed_train
+        assert failed.state is DurableChangeTrainState.FAILED
+        assert failed.failure is not None
+        assert failed.failure.classification is DurableFailureClassification.INDETERMINATE
+        failure_manifest = tmp_path / "source-indeterminate-train.json"
+        write_durable_change_train_manifest(failure_manifest, failed, expected_revision=-1)
+        failed = load_durable_change_train_manifest(failure_manifest)
+        assert failed.reservation is not None and failed.reservation.active is True
+        assert failed.failure is not None
+        assert "keep the daemon stopped" in failed.failure.required_actions
+        with pytest.raises(DurableChangeTrainRecoveryError, match="retain stopped-daemon"):
+            record_durable_writer_release(failed, evidence_ref="proof:unsafe-release")
+
+
+def test_restart_and_every_runtime_consumer_are_required_before_release(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "user.db"
+    _create_current_database(db_path)
+    _install_synthetic_migration(monkeypatch, ArchiveTier.USER)
+    train = _admitted(ArchiveTier.USER)
+    with sqlite3.connect(db_path) as conn:
+        train = _reserve_and_authorize(conn, train, archive_root=tmp_path)
+        train = apply_durable_change_train(conn, train)
+    train = record_durable_writer_release(train, evidence_ref="proof:lease-release")
+    with sqlite3.connect(db_path) as restarted:
+        with _memory_target() as fresh:
+            actual_parity = prove_durable_fresh_ddl_parity(
+                ArchiveTier.USER,
+                _TARGET_VERSION,
+                migrated_connection=restarted,
+                fresh_connection=fresh,
+                evidence_ref="proof:actual-fresh",
+            )
+        incomplete = (DurableRuntimeConsumerResult("consumer-0", "proof:behavior:0", True),)
+        restart = capture_durable_restart_convergence(
+            restarted,
+            train,
+            runtime_consumers=incomplete,
+            evidence_ref="proof:incomplete-restart",
+        )
+    assert restart.converged is False
+    with pytest.raises(DurableChangeTrainError, match="runtime proof does not cover"):
+        prove_durable_change_train(
+            train,
+            fresh_ddl_parity=actual_parity,
+            runtime_consumers=incomplete,
+            restart_convergence=restart,
+        )
+    with pytest.raises(DurableChangeTrainError, match="only a proven train"):
+        release_durable_change_train(train, evidence_ref="proof:premature-release")
+
+
+def test_manifest_semantics_reject_out_of_order_lifecycle_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "source.db"
+    _create_current_database(db_path)
+    _install_synthetic_migration(monkeypatch, ArchiveTier.SOURCE)
+    train = _admitted(ArchiveTier.SOURCE)
+    with sqlite3.connect(db_path) as conn:
+        train = _reserve_and_authorize(conn, train, archive_root=tmp_path)
+        train = apply_durable_change_train(conn, train)
+    assert train.apply_evidence is not None
+
+    late_post = replace(
+        train.apply_evidence.post,
+        observed_at_ms=train.apply_evidence.applied_at_ms + 1,
+    )
+    invalid_apply = replace(
+        train,
+        apply_evidence=replace(train.apply_evidence, post=late_post),
+    )
+    with pytest.raises(DurableChangeTrainError, match="apply timestamp predates post-apply"):
+        migration_runner.validate_durable_change_train_manifest(invalid_apply)
+
+    release_time = train.apply_evidence.applied_at_ms + 100
+    released = record_durable_writer_release(
+        train,
+        evidence_ref="proof:lease-release",
+        released_at_ms=release_time,
+    )
+    assert released.reservation is not None
+    invalid_release = replace(
+        released,
+        reservation=replace(
+            released.reservation,
+            released_at_ms=train.apply_evidence.applied_at_ms - 1,
+        ),
+    )
+    with pytest.raises(DurableChangeTrainError, match="writer release timestamp predates"):
+        migration_runner.validate_durable_change_train_manifest(invalid_release)
+
+    with sqlite3.connect(db_path) as restarted:
+        with _memory_target() as fresh:
+            parity = prove_durable_fresh_ddl_parity(
+                ArchiveTier.SOURCE,
+                _TARGET_VERSION,
+                migrated_connection=restarted,
+                fresh_connection=fresh,
+                evidence_ref="proof:actual-fresh",
+            )
+        runtime_results = _runtime_results()
+        restart = capture_durable_restart_convergence(
+            restarted,
+            released,
+            runtime_consumers=runtime_results,
+            evidence_ref="proof:restart",
+        )
+    restart_before_release = replace(
+        restart,
+        observed_at_ms=train.apply_evidence.applied_at_ms + 50,
+    )
+    with pytest.raises(DurableChangeTrainError, match="restart convergence timestamp predates writer release"):
+        prove_durable_change_train(
+            released,
+            fresh_ddl_parity=parity,
+            runtime_consumers=runtime_results,
+            restart_convergence=restart_before_release,
+            proven_at_ms=release_time + 1,
+        )
+
+
+def test_manifest_checksum_revision_and_unsafe_path_are_enforced(tmp_path: Path) -> None:
+    train = _declared(ArchiveTier.SOURCE)
+    path = tmp_path / "train.json"
+    write_durable_change_train_manifest(path, train, expected_revision=-1)
+    with pytest.raises(DurableChangeTrainError, match="revision changed"):
+        write_durable_change_train_manifest(path, train, expected_revision=99)
+    with pytest.raises(DurableChangeTrainError, match="advance exactly one revision"):
+        write_durable_change_train_manifest(path, train, expected_revision=0)
+    skipped_revision = replace(train, revision=2)
+    with pytest.raises(DurableChangeTrainError, match="advance exactly one revision"):
+        write_durable_change_train_manifest(path, skipped_revision, expected_revision=0)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["owner_ref"] = "tampered"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(DurableChangeTrainError, match="checksum mismatch"):
+        load_durable_change_train_manifest(path)
+
+    real = tmp_path / "real.json"
+    write_durable_change_train_manifest(real, train, expected_revision=-1)
+    link = tmp_path / "link.json"
+    link.symlink_to(real)
+    with pytest.raises(DurableChangeTrainError, match="not a real single-linked file"):
+        load_durable_change_train_manifest(link)
+
+    parent = tmp_path / "real-parent"
+    parent.mkdir()
+    linked_parent = tmp_path / "linked-parent"
+    linked_parent.symlink_to(parent, target_is_directory=True)
+    with pytest.raises(DurableChangeTrainError, match="parent.*symbolic link"):
+        write_durable_change_train_manifest(linked_parent / "train.json", train, expected_revision=-1)
+
+    locked_path = tmp_path / "locked-train.json"
+    lock_path = tmp_path / ".locked-train.json.lock"
+    lock_target = tmp_path / "lock-target"
+    lock_target.write_text("not a lock", encoding="utf-8")
+    lock_path.symlink_to(lock_target)
+    with pytest.raises(DurableChangeTrainError, match="manifest lock safely"):
+        write_durable_change_train_manifest(locked_path, train, expected_revision=-1)
+
+
+def test_rechecks_manifest_semantics_after_a_valid_checksum(tmp_path: Path) -> None:
+    train = _admitted(ArchiveTier.USER)
+    payload = migration_runner.durable_change_train_to_payload(train)
+    parity = payload["fresh_ddl_parity"]
+    assert isinstance(parity, dict)
+    parity["matches"] = False
+    unsigned = dict(payload)
+    unsigned.pop("manifest_sha256")
+    payload["manifest_sha256"] = migration_runner._canonical_json_sha256(unsigned)
+    path = tmp_path / "forged-train.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(DurableChangeTrainError, match="fresh-DDL parity is not an exact match"):
+        load_durable_change_train_manifest(path)

--- a/tests/unit/storage/test_durable_change_train.py
+++ b/tests/unit/storage/test_durable_change_train.py
@@ -14,7 +14,7 @@ from typing import cast
 import pytest
 
 from polylogue.storage.sqlite import migration_runner
-from polylogue.storage.sqlite.archive_tiers import ARCHIVE_VERSION_BY_TIER
+from polylogue.storage.sqlite.archive_tiers import ARCHIVE_DDL_BY_TIER, ARCHIVE_VERSION_BY_TIER
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.durable_change_train import (
     DURABLE_MIGRATION_ADOPTION_FLOORS,
@@ -32,7 +32,7 @@ from polylogue.storage.sqlite.migration_runner import (
     DurableMigrationClaim,
     DurableRuntimeConsumer,
     DurableRuntimeConsumerResult,
-    MigrationStep,
+    MigrationError,
     add_durable_change_train_rider,
     admit_durable_change_train,
     apply_durable_change_train,
@@ -177,25 +177,25 @@ def _admitted(
 
 
 def _install_synthetic_migration(
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     tier: ArchiveTier,
     *,
     sql: str = _ADDITIVE_SQL,
 ) -> None:
+    package_name = f"fixture_migrations_{tier.value}_{tmp_path.name.replace('-', '_')}"
+    package_root = tmp_path / package_name
+    tier_package = package_root / tier.value
+    tier_package.mkdir(parents=True)
+    (package_root / "__init__.py").write_text("", encoding="utf-8")
+    (tier_package / "__init__.py").write_text("", encoding="utf-8")
+    (tier_package / "002_durable_items.sql").write_text(sql, encoding="utf-8")
+    monkeypatch.syspath_prepend(str(tmp_path))
     versions = dict(ARCHIVE_VERSION_BY_TIER)
     versions[tier] = _TARGET_VERSION
     monkeypatch.setattr(migration_runner, "ARCHIVE_VERSION_BY_TIER", versions)
-    step = MigrationStep(
-        tier=tier,
-        version=_TARGET_VERSION,
-        name="002_durable_items.sql",
-        sql=sql,
-        requires_backup=not sql.startswith("-- migration-safety: additive-no-backup"),
-    )
     monkeypatch.setattr(
-        migration_runner,
-        "_load_migrations",
-        lambda observed_tier: (step,) if observed_tier is tier else (),
+        migration_runner, "_migration_package", lambda observed_tier: f"{package_name}.{observed_tier.value}"
     )
 
 
@@ -241,18 +241,7 @@ def test_synthetic_source_and_user_trains_complete_the_full_lifecycle(
     db_path = tmp_path / f"{tier.value}.db"
     manifest = tmp_path / f"{tier.value}-train.json"
     _create_current_database(db_path)
-    _install_synthetic_migration(monkeypatch, tier)
-    original_runner = migration_runner.migrate_archive_tier
-    calls: list[ArchiveTier] = []
-
-    def observed_runner(
-        conn: sqlite3.Connection,
-        observed_tier: ArchiveTier,
-        *,
-        backup_manifest: Path | None,
-    ) -> migration_runner.MigrationResult:
-        calls.append(observed_tier)
-        return original_runner(conn, observed_tier, backup_manifest=backup_manifest)
+    _install_synthetic_migration(tmp_path, monkeypatch, tier)
 
     def persist_and_reload(next_train: DurableChangeTrain, expected_revision: int) -> DurableChangeTrain:
         write_durable_change_train_manifest(
@@ -262,7 +251,6 @@ def test_synthetic_source_and_user_trains_complete_the_full_lifecycle(
         )
         return load_durable_change_train_manifest(manifest)
 
-    monkeypatch.setattr(migration_runner, "migrate_archive_tier", observed_runner)
     claim = _claim(tier)
     train = _declared(tier, claim=claim)
     train = persist_and_reload(train, -1)
@@ -304,8 +292,6 @@ def test_synthetic_source_and_user_trains_complete_the_full_lifecycle(
         assert conn.execute("SELECT name FROM sqlite_schema WHERE name='durable_items'").fetchone() == (
             "durable_items",
         )
-    assert calls == [tier]
-
     assert train.apply_evidence is not None
     assert train.apply_evidence.migration_result.applied_versions == (_TARGET_VERSION,)
     assert train.apply_evidence.row_parity.ok is True
@@ -382,12 +368,38 @@ def test_future_train_sidecar_discovery_uses_real_package_resources(
         "polylogue.storage.sqlite.durable_change_train._migration_package",
         lambda _tier: "fixture_migrations.source",
     )
+    monkeypatch.setattr(
+        migration_runner,
+        "_migration_package",
+        lambda _tier: "fixture_migrations.source",
+    )
 
     observed = validate_durable_migration_sidecars(ArchiveTier.SOURCE, ((sql_path.name, sql),))
+    loaded = migration_runner._load_migrations(ArchiveTier.SOURCE)
 
     assert [item.resource_name for item in observed] == ["027.train.json"]
     assert observed[0].train.migration.sql_sha256 == claim.sql_sha256
+    assert loaded[0].version == 27
     assert "fixture_migrations.source" in sys.modules
+
+    versions = dict(ARCHIVE_VERSION_BY_TIER)
+    versions[ArchiveTier.SOURCE] = 27
+    monkeypatch.setattr(migration_runner, "ARCHIVE_VERSION_BY_TIER", versions)
+    ddl = dict(ARCHIVE_DDL_BY_TIER)
+    ddl[ArchiveTier.SOURCE] = """
+    CREATE TABLE base_items (item_id TEXT PRIMARY KEY, payload TEXT NOT NULL) STRICT;
+    CREATE TABLE future_items (id INTEGER PRIMARY KEY) STRICT;
+    """
+    monkeypatch.setattr(migration_runner, "ARCHIVE_DDL_BY_TIER", ddl)
+    db_path = tmp_path / "real-route-source.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE base_items (item_id TEXT PRIMARY KEY, payload TEXT NOT NULL) STRICT")
+        conn.execute("PRAGMA user_version = 26")
+        conn.commit()
+        result = migration_runner.migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=None)
+        assert result.applied_versions == (27,)
+        assert conn.execute("PRAGMA user_version").fetchone() == (27,)
+        assert conn.execute("SELECT name FROM sqlite_schema WHERE name='future_items'").fetchone() == ("future_items",)
 
 
 def test_future_train_sidecar_hash_and_slot_are_admission_bound(
@@ -415,6 +427,8 @@ def test_future_train_sidecar_hash_and_slot_are_admission_bound(
     )
     payload = migration_runner.durable_change_train_to_payload(train)
     cast(dict[str, object], payload["migration"])["sql_sha256"] = "0" * 64
+    payload.pop("manifest_sha256", None)
+    payload["manifest_sha256"] = migration_runner._canonical_json_sha256(payload)
     (source_package / "027.train.json").write_text(json.dumps(payload), encoding="utf-8")
     monkeypatch.syspath_prepend(str(tmp_path))
     monkeypatch.setattr(
@@ -422,8 +436,70 @@ def test_future_train_sidecar_hash_and_slot_are_admission_bound(
         lambda _tier: "fixture_migrations_hash.source",
     )
 
-    with pytest.raises(DurableChangeTrainError, match="checksum mismatch"):
+    with pytest.raises(DurableChangeTrainError, match="SQL SHA-256 mismatch"):
         validate_durable_migration_sidecars(ArchiveTier.SOURCE, ((sql_path.name, sql),))
+
+    cast(dict[str, object], payload["migration"])["sql_sha256"] = claim.sql_sha256
+    payload["slot"] = 28
+    payload.pop("manifest_sha256", None)
+    payload["manifest_sha256"] = migration_runner._canonical_json_sha256(payload)
+    (source_package / "027.train.json").write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(DurableChangeTrainError, match="slot"):
+        validate_durable_migration_sidecars(ArchiveTier.SOURCE, ((sql_path.name, sql),))
+
+
+def test_missing_future_sidecar_is_rejected_at_the_migration_runner_choke_point(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    package_root = tmp_path / "fixture_migrations_missing"
+    source_package = package_root / "source"
+    source_package.mkdir(parents=True)
+    (package_root / "__init__.py").write_text("", encoding="utf-8")
+    (source_package / "__init__.py").write_text("", encoding="utf-8")
+    sql = "-- migration-safety: additive-no-backup\nCREATE TABLE future_items (id INTEGER PRIMARY KEY) STRICT;\n"
+    sql_path = source_package / "027_future_items.sql"
+    sql_path.write_text(sql, encoding="utf-8")
+    claim = durable_migration_claim_for_sql(ArchiveTier.SOURCE, sql_path.name, sql, owner_ref="owner:future-source")
+    train = declare_durable_change_train(
+        train_id="train:source:v27",
+        tier=ArchiveTier.SOURCE,
+        current_version=26,
+        target_version=27,
+        slot=27,
+        owner_ref="owner:future-source",
+        migration=claim,
+        riders=(_rider(),),
+        declared_at_ms=1,
+    )
+    sidecar = source_package / "027.train.json"
+    sidecar.write_text(json.dumps(migration_runner.durable_change_train_to_payload(train)), encoding="utf-8")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setattr(migration_runner, "_migration_package", lambda _tier: "fixture_migrations_missing.source")
+    monkeypatch.setattr(
+        "polylogue.storage.sqlite.durable_change_train._migration_package",
+        lambda _tier: "fixture_migrations_missing.source",
+    )
+    assert migration_runner._load_migrations(ArchiveTier.SOURCE)[0].version == 27
+    sidecar.unlink()
+    with pytest.raises(MigrationError, match="missing durable migration train sidecar"):
+        migration_runner._load_migrations(ArchiveTier.SOURCE)
+
+
+def test_migration_transaction_control_cannot_escape_rollback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db_path = tmp_path / "source.db"
+    _create_current_database(db_path)
+    _install_synthetic_migration(
+        tmp_path,
+        monkeypatch,
+        ArchiveTier.SOURCE,
+        sql="-- migration-safety: additive-no-backup\nCREATE TABLE transaction_escape (id INTEGER PRIMARY KEY);\nCOMMIT;\n",
+    )
+
+    with sqlite3.connect(db_path) as conn:
+        with pytest.raises(MigrationError, match="must not control the existing transaction"):
+            migration_runner.migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=None)
+        assert conn.execute("PRAGMA user_version").fetchone() == (_CURRENT_VERSION,)
+        assert conn.execute("SELECT name FROM sqlite_schema WHERE name='transaction_escape'").fetchone() is None
 
 
 def test_canonical_inventory_preserves_trigger_literal_whitespace() -> None:
@@ -711,7 +787,7 @@ INSERT INTO table_that_does_not_exist VALUES (1);
     _create_current_database(db_path)
     claim = _claim(ArchiveTier.SOURCE, failing_sql)
     train = _admitted(ArchiveTier.SOURCE, claim=claim)
-    _install_synthetic_migration(monkeypatch, ArchiveTier.SOURCE, sql=failing_sql)
+    _install_synthetic_migration(tmp_path, monkeypatch, ArchiveTier.SOURCE, sql=failing_sql)
     with sqlite3.connect(db_path) as conn:
         train = _reserve_and_authorize(conn, train, archive_root=tmp_path)
         with pytest.raises(DurableChangeTrainApplyError) as exc_info:
@@ -807,7 +883,7 @@ def test_restart_and_every_runtime_consumer_are_required_before_release(
 ) -> None:
     db_path = tmp_path / "user.db"
     _create_current_database(db_path)
-    _install_synthetic_migration(monkeypatch, ArchiveTier.USER)
+    _install_synthetic_migration(tmp_path, monkeypatch, ArchiveTier.USER)
     train = _admitted(ArchiveTier.USER)
     with sqlite3.connect(db_path) as conn:
         train = _reserve_and_authorize(conn, train, archive_root=tmp_path)
@@ -847,7 +923,7 @@ def test_manifest_semantics_reject_out_of_order_lifecycle_evidence(
 ) -> None:
     db_path = tmp_path / "source.db"
     _create_current_database(db_path)
-    _install_synthetic_migration(monkeypatch, ArchiveTier.SOURCE)
+    _install_synthetic_migration(tmp_path, monkeypatch, ArchiveTier.SOURCE)
     train = _admitted(ArchiveTier.SOURCE)
     with sqlite3.connect(db_path) as conn:
         train = _reserve_and_authorize(conn, train, archive_root=tmp_path)

--- a/tests/unit/storage/test_durable_migrations.py
+++ b/tests/unit/storage/test_durable_migrations.py
@@ -1973,20 +1973,14 @@ def test_initialize_database_refuses_old_durable_tier_without_manifest(tmp_path:
         initialize_archive_database(db_path, ArchiveTier.USER)
 
 
-def test_initialize_database_can_apply_explicit_user_migration(
-    workspace_env: dict[str, Path],
-    tmp_path: Path,
-) -> None:
-    db_path = workspace_env["archive_root"] / "user.db"
+def test_initialize_database_does_not_apply_explicit_user_migration(tmp_path: Path) -> None:
+    db_path = tmp_path / "user.db"
     _create_user_v3(db_path)
-    manifest = _verified_backup_manifest(tmp_path / "backup", profile="user_overlays")
-
-    initialize_archive_database(db_path, ArchiveTier.USER, migration_backup_manifest=manifest)
-
+    with pytest.raises(RuntimeError, match="explicit durable-tier migration"):
+        initialize_archive_database(db_path, ArchiveTier.USER)
     conn = sqlite3.connect(db_path)
     try:
-        assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == USER_SCHEMA_VERSION
-        assert conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='user_settings'").fetchone()
+        assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == 3
     finally:
         conn.close()
 


### PR DESCRIPTION
## Summary

Ref polylogue-60i5.1. Complete the durable migration change-train route for future source.db and user.db schema slots, including policy, maintenance, daemon exclusion, bootstrap recovery, and real surface integration.

## Problem

The prior patch accepted only SQL migration filenames in the schema policy, allowed maintenance and bootstrap paths to bypass or partially execute the train authority, and left crash recovery and daemon exclusion split across pidfile and migration helpers. A persisted applied train could also be left unreleased after a process crash.

## Solution

Canonical `NNN.train.json` sidecars are accepted only when paired with the exact numbered SQL resource and rejected for malformed, orphaned, stale, missing, noncontiguous, or hash-mismatched bindings. Post-floor maintenance now preflights the complete route, upgrades historical versions only to the adoption floor, then persists declaration, admission, reservation, backup authorization, one-slot apply, writer release, proof, and terminal release transitions. The existing migration runner remains the sole SQL executor and retains verified backup, rollback classification, row parity, integrity, foreign-key, and fresh-DDL guarantees.

Daemon, bootstrap, and maintenance share the stable `.archive-ownership.lock`; `daemon.pid` remains process metadata. The lease spans bootstrap and restart proof, with scoped reentrancy for nested in-process bootstrap calls. Startup reconciles backup-authorized and applied manifests, persists recovery evidence, and releases active reservations left by an interrupted process. CLI, daemon, bootstrap, and policy tests enter real production routes with synthetic future package resources.

## Verification

- `direnv exec . devtools test tests/unit/storage/test_durable_change_train.py tests/unit/devtools/test_durable_schema_policy_gate.py tests/unit/storage/test_durable_migrations.py tests/unit/cli/test_archive_maintenance_cli.py tests/unit/daemon/test_daemon_cli.py tests/unit/daemon/test_schema_preflight.py` -> 261 passed in 11.69s.
- Ruff format/check and strict mypy on the changed runtime and test surfaces -> clean.
- `direnv exec . devtools lab policy schema-versioning` -> Schema evolution policy intact.
- Pre-push `devtools verify --quick` -> all 23 steps passed; branch pushed at `5710537543ab68f94d892614c72460647b897654`.

## Adversarial review notes

Six independent read-only passes found concrete gaps in sidecar subset validation, historical-to-post-floor routing, one-slot application, lock lifetime, bootstrap ownership, missing-chain preflight, daemon exception cleanup, and active-APPLIED crash recovery. Each finding was addressed in this branch and covered by the focused suite. The latest active-APPLIED recovery fix was verified by the final focused run; no post-fix independent reread was run.

## Residual uncertainty

The repository has no shipped post-floor migration yet, so future-slot CLI and maintenance coverage uses synthetic package resources while invoking production loaders, bootstrap functions, and the migration runner. Runtime-consumer probes intentionally support the shipped bootstrap probe shapes and zero-argument callables; a declared required-argument production reference fails closed until it has an explicit probe adapter.
