### PR TITLE
fix(daemon): preserve convergence debt status transitions

### DIFF
--- a/polylogue/daemon/convergence_debt_status.py
+++ b/polylogue/daemon/convergence_debt_status.py
@@ -45,6 +45,8 @@ class ConvergenceDebtItem(BaseModel):
 
 
 class ConvergenceDebtSummary(BaseModel):
+    available: bool = True
+    error: str | None = None
     failed_count: int = 0
     deferred_count: int = 0
     retry_due_count: int = 0
@@ -56,16 +58,13 @@ class ConvergenceDebtSummary(BaseModel):
 def convergence_debt_summary_info(dbf: Path, *, ops_db: Path | None = None) -> ConvergenceDebtSummary:
     """Return durable post-ingest convergence debt snapshots."""
     resolved_ops_db = ops_db if ops_db is not None else dbf.with_name("ops.db")
-    ops_summary = _archive_convergence_debt_summary_info(dbf, resolved_ops_db)
-    if ops_summary is not None:
-        return ops_summary
-    return ConvergenceDebtSummary()
+    return _archive_convergence_debt_summary_info(dbf, resolved_ops_db)
 
 
-def _archive_convergence_debt_summary_info(dbf: Path, ops_db: Path) -> ConvergenceDebtSummary | None:
+def _archive_convergence_debt_summary_info(dbf: Path, ops_db: Path) -> ConvergenceDebtSummary:
     """Return the archive ops convergence-debt projection when populated."""
     if not ops_db.exists():
-        return None
+        return ConvergenceDebtSummary(available=False, error=f"convergence debt database is missing: {ops_db}")
     try:
         conn = open_readonly_connection(ops_db)
         try:
@@ -73,7 +72,10 @@ def _archive_convergence_debt_summary_info(dbf: Path, ops_db: Path) -> Convergen
                 "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'convergence_debt'"
             ).fetchone()
             if has_table is None:
-                return None
+                return ConvergenceDebtSummary(
+                    available=False,
+                    error="convergence debt table is unavailable",
+                )
             rows = conn.execute(
                 """
                 SELECT stage, target_type, target_id, status, attempts,
@@ -83,17 +85,15 @@ def _archive_convergence_debt_summary_info(dbf: Path, ops_db: Path) -> Convergen
                 """
             ).fetchall()
             if not rows:
-                return None
+                return ConvergenceDebtSummary()
         finally:
             conn.close()
     except sqlite3.Error as exc:
-        # Falls through to convergence_debt_summary_info()'s bare
-        # ConvergenceDebtSummary() default, which reports zero debt — the
-        # same shape as a genuinely converged archive. Log loudly so a
-        # transient ops.db failure isn't mistaken for "no debt"
-        # (polylogue-cpf.4).
+        # An unreadable authoritative debt ledger is unknown, not empty. The
+        # claim guard must be able to distinguish this from a genuinely empty
+        # convergence_debt table (polylogue-cpf.4).
         logger.warning("convergence-debt summary query failed for %s: %s", ops_db, exc, exc_info=True)
-        return None
+        return ConvergenceDebtSummary(available=False, error=f"convergence debt status unavailable: {exc}")
 
     items = [
         ConvergenceDebtItem(

--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -2047,6 +2047,7 @@ def _daemon_claim_guard(
     raw_frontier_integrity: RawFrontierIntegrity,
     fts_readiness: FTSReadiness,
     live_ingest_attempts: LiveIngestAttemptSummary,
+    convergence: ConvergenceDebtSummary,
 ) -> dict[str, object]:
     """Derive the claim-guard block for the daemon-serving status path."""
     raw_component = _component_from_raw_materialization_readiness(raw_materialization_readiness)
@@ -2058,6 +2059,18 @@ def _daemon_claim_guard(
         writer_parts.append(f"{live_ingest_attempts.running_count} live ingest attempt(s) running")
     if rebuild_attempts:
         writer_parts.append(f"{rebuild_attempts} index rebuild attempt(s) running")
+    convergence_debt_pending = convergence.failed_count > 0 or convergence.deferred_count > 0
+    if not convergence.available:
+        convergence_debt_summary = convergence.error or "convergence debt unavailable; convergence state is unknown"
+    elif convergence_debt_pending:
+        pending_parts: list[str] = []
+        if convergence.failed_count:
+            pending_parts.append(f"{convergence.failed_count} failed")
+        if convergence.deferred_count:
+            pending_parts.append(f"{convergence.deferred_count} deferred")
+        convergence_debt_summary = f"convergence debt pending: {', '.join(pending_parts)}"
+    else:
+        convergence_debt_summary = "no pending convergence debt"
     guard = derive_claim_guard(
         archive_schema_ready=archive_storage.archive_schema_ready,
         schema_mismatches=archive_storage.schema_mismatches,
@@ -2070,6 +2083,9 @@ def _daemon_claim_guard(
         search_summary=fts_component.summary,
         active_writer=active_writer,
         active_writer_summary="; ".join(writer_parts),
+        convergence_debt_available=convergence.available,
+        convergence_debt_pending=convergence_debt_pending,
+        convergence_debt_summary=convergence_debt_summary,
     )
     return cast(dict[str, object], guard.to_dict())
 
@@ -2790,6 +2806,7 @@ def build_daemon_status(
             raw_frontier_integrity=raw_frontier_integrity,
             fts_readiness=fts_readiness,
             live_ingest_attempts=live_ingest_attempts,
+            convergence=convergence,
         ),
         health=health,
         health_tiers=health_tiers,

--- a/polylogue/readiness/claim_guard.py
+++ b/polylogue/readiness/claim_guard.py
@@ -80,6 +80,9 @@ def derive_claim_guard(
     search_summary: str,
     active_writer: bool,
     active_writer_summary: str = "",
+    convergence_debt_available: bool = True,
+    convergence_debt_pending: bool = False,
+    convergence_debt_summary: str = "no pending convergence debt",
 ) -> ClaimGuard:
     """Derive the claim-guard block from already-computed readiness signals.
 
@@ -123,6 +126,20 @@ def derive_claim_guard(
             value=False,
             reason=raw_materialization_summary,
             signal="raw_materialization_readiness (debt zero or fully classified)",
+        )
+    elif not convergence_debt_available:
+        converged = ClaimGuardEntry(
+            claim="converged",
+            value=False,
+            reason=convergence_debt_summary or "convergence debt unavailable; convergence state is unknown",
+            signal="convergence_debt_summary.available (unknown debt blocks convergence)",
+        )
+    elif convergence_debt_pending:
+        converged = ClaimGuardEntry(
+            claim="converged",
+            value=False,
+            reason=convergence_debt_summary,
+            signal="convergence_debt_summary (pending failed or deferred debt)",
         )
     elif not raw_frontier_integrity_ready:
         # polylogue-yla8.7: raw materialization can look fully converged while

--- a/polylogue/sources/live/convergence_debt_retry.py
+++ b/polylogue/sources/live/convergence_debt_retry.py
@@ -147,10 +147,15 @@ def same_pending_convergence_debt(
     next_retry_at: object,
     last_error: object,
     *,
+    status: object,
     error: str | None,
+    deferred: bool,
     now: str,
     retry_at: datetime,
 ) -> bool:
+    expected_status = "deferred" if deferred else "failed"
+    if status != expected_status:
+        return False
     if last_error != error:
         return False
     existing = parse_retry_datetime(next_retry_at)

--- a/polylogue/sources/live/cursor.py
+++ b/polylogue/sources/live/cursor.py
@@ -472,7 +472,7 @@ class CursorStore:
                 conn.execute("BEGIN IMMEDIATE")
                 row = conn.execute(
                     """
-                    SELECT attempts, next_retry_at, last_error
+                    SELECT attempts, next_retry_at, last_error, status
                     FROM convergence_debt
                     WHERE stage = ? AND target_type = ? AND target_id = ?
                     """,
@@ -488,7 +488,13 @@ class CursorStore:
                     archive_root=self._db_path.parent,
                 )
                 if row is not None and same_pending_convergence_debt(
-                    row[1], row[2], error=error, now=now, retry_at=retry_at
+                    row[1],
+                    row[2],
+                    status=row[3],
+                    error=error,
+                    deferred=deferred,
+                    now=now,
+                    retry_at=retry_at,
                 ):
                     return
                 attempts_delta = 0 if row is not None and retry_is_future(row[1], now=now) and row[2] == error else 1

--- a/polylogue/sources/live/cursor.py
+++ b/polylogue/sources/live/cursor.py
@@ -497,16 +497,24 @@ class CursorStore:
                     retry_at=retry_at,
                 ):
                     return
-                attempts_delta = 0 if row is not None and retry_is_future(row[1], now=now) and row[2] == error else 1
-                failure_count = existing_attempts + attempts_delta
-                retry_at = convergence_debt_retry_at(
-                    conn,
-                    failure_count=max(failure_count, 1),
-                    error=error,
-                    subject_type=subject_type,
-                    subject_id=subject_id,
-                    archive_root=self._db_path.parent,
+                expected_status = "deferred" if deferred else "failed"
+                status_only_transition = row is not None and row[2] == error and row[3] != expected_status
+                attempts_delta = (
+                    0
+                    if status_only_transition
+                    or (row is not None and retry_is_future(row[1], now=now) and row[2] == error)
+                    else 1
                 )
+                failure_count = existing_attempts + attempts_delta
+                if not status_only_transition:
+                    retry_at = convergence_debt_retry_at(
+                        conn,
+                        failure_count=max(failure_count, 1),
+                        error=error,
+                        subject_type=subject_type,
+                        subject_id=subject_id,
+                        archive_root=self._db_path.parent,
+                    )
                 add_archive_convergence_debt(
                     conn,
                     stage=stage,
@@ -520,7 +528,7 @@ class CursorStore:
                     ),
                     attempts=attempts_delta,
                     last_error=error,
-                    next_retry_at=retry_at.isoformat(),
+                    next_retry_at=row[1] if status_only_transition else retry_at.isoformat(),
                     materializer_version=materializer_version,
                     created_at_ms=now_ms,
                     updated_at_ms=now_ms,

--- a/tests/unit/core/test_claim_guard.py
+++ b/tests/unit/core/test_claim_guard.py
@@ -114,6 +114,28 @@ def test_raw_materialization_not_ready_takes_precedence_over_frontier_integrity(
     assert guard["converged"]["reason"] == "raw evidence pending materialization"
 
 
+def test_pending_convergence_debt_blocks_converged() -> None:
+    kwargs = _base_kwargs()
+    kwargs["convergence_debt_pending"] = True
+    kwargs["convergence_debt_summary"] = "convergence debt pending: 1 deferred"
+    guard = derive_claim_guard(**kwargs).to_dict()  # type: ignore[arg-type]
+
+    assert guard["converged"]["value"] is False
+    assert guard["converged"]["reason"] == "convergence debt pending: 1 deferred"
+    assert "convergence_debt_summary" in str(guard["converged"]["signal"])
+
+
+def test_unavailable_convergence_debt_blocks_converged_as_unknown() -> None:
+    kwargs = _base_kwargs()
+    kwargs["convergence_debt_available"] = False
+    kwargs["convergence_debt_summary"] = "convergence debt status unavailable: disk I/O error"
+    guard = derive_claim_guard(**kwargs).to_dict()  # type: ignore[arg-type]
+
+    assert guard["converged"]["value"] is False
+    assert guard["converged"]["reason"] == "convergence debt status unavailable: disk I/O error"
+    assert "unknown debt" in str(guard["converged"]["signal"])
+
+
 def test_search_not_ready_reports_component_summary() -> None:
     kwargs = _base_kwargs()
     kwargs["search_ready"] = False

--- a/tests/unit/daemon/test_convergence_debt_alert.py
+++ b/tests/unit/daemon/test_convergence_debt_alert.py
@@ -263,6 +263,20 @@ def test_convergence_debt_summary_ignores_old_single_file_debt_when_ops_empty(tm
     assert summary.recent == []
 
 
+def test_convergence_debt_summary_marks_unreadable_ops_as_unavailable(tmp_path: Path) -> None:
+    db_path = tmp_path / "archive.db"
+    ops_path = tmp_path / "ops.db"
+    db_path.touch()
+    ops_path.write_bytes(b"not a sqlite database")
+
+    summary = convergence_debt_summary_info(db_path, ops_db=ops_path)
+
+    assert summary.available is False
+    assert summary.failed_count == 0
+    assert summary.deferred_count == 0
+    assert "unavailable" in (summary.error or "")
+
+
 # ---------------------------------------------------------------------------
 # Threshold resolution
 # ---------------------------------------------------------------------------

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -36,6 +36,7 @@ from polylogue.storage.sqlite.archive_tiers.bootstrap import (
     initialize_archive_tier,
 )
 from polylogue.storage.sqlite.archive_tiers.ops_write import (
+    add_convergence_debt,
     record_daemon_stage_event,
     record_ingest_attempt,
     upsert_ingest_cursor,
@@ -1618,6 +1619,77 @@ def test_build_daemon_status_claim_guard_reports_openable_but_not_converged(tmp_
     assert claim_guard["perf_measurable"]["value"] is True
 
 
+@pytest.mark.parametrize("debt_setup", ["pending", "unreadable"])
+def test_build_daemon_status_claim_guard_blocks_pending_or_unknown_convergence_debt(
+    tmp_path: Path, debt_setup: str
+) -> None:
+    """The production status route must never claim convergence without debt authority."""
+    storage = status_module.ArchiveStorageStatus(
+        active_store="archive_file_set",
+        active_db_path=str(tmp_path / "index.db"),
+        archive_root=str(tmp_path),
+        configured_archive_root=str(tmp_path),
+        archive_ready=True,
+        archive_materialization_ready=True,
+        final_shape_ready=True,
+        archive_schema_ready=True,
+        present_tiers=["source", "index", "embeddings", "user", "ops"],
+    )
+    raw_readiness = status_module.RawMaterializationReadiness(
+        available=True,
+        raw_authority_frontier={"lifecycle_status": "completed"},
+    )
+    frontier = status_module.RawFrontierIntegrity(available=True, overall_status="healthy")
+    if debt_setup == "pending":
+        initialize_archive_database(tmp_path / "ops.db", ArchiveTier.OPS)
+        with sqlite3.connect(tmp_path / "ops.db") as conn:
+            add_convergence_debt(
+                conn,
+                stage="fts",
+                target_type="source_path",
+                target_id="pending.jsonl",
+                status="deferred",
+                attempts=1,
+                last_error="bounded deferral",
+                created_at_ms=1_770_000_000_000,
+                updated_at_ms=1_770_000_000_000,
+            )
+    else:
+        (tmp_path / "ops.db").write_bytes(b"not a sqlite database")
+
+    with (
+        patch("polylogue.daemon.status.archive_root", return_value=tmp_path),
+        patch("polylogue.daemon.status._active_status_db_path", return_value=tmp_path / "index.db"),
+        patch("polylogue.daemon.status._archive_storage_info", return_value=storage),
+        patch("polylogue.daemon.status._raw_materialization_readiness_info", return_value=raw_readiness),
+        patch("polylogue.daemon.status._raw_frontier_integrity_info", return_value=frontier),
+        patch("polylogue.daemon.status._db_size_info", return_value={}),
+        patch("polylogue.daemon.status._fts_readiness_info", return_value={"messages_ready": True}),
+        patch("polylogue.daemon.status._insight_freshness_info", return_value={}),
+        patch("polylogue.daemon.status._live_cursor_summary_info", return_value=status_module.LiveCursorSummary()),
+        patch(
+            "polylogue.daemon.status._live_ingest_attempt_summary_info",
+            return_value=status_module.LiveIngestAttemptSummary(),
+        ),
+        patch("polylogue.daemon.status.cursor_lag_summary_info", return_value=status_module.CursorLagSummary()),
+        patch("polylogue.daemon.status.catchup_status_info", return_value=status_module.CatchupStatus()),
+        patch("polylogue.daemon.status._raw_failure_info", return_value={}),
+        patch("polylogue.daemon.status.embedding_readiness_info", return_value={}),
+        patch("polylogue.daemon.status._check_daemon_liveness", return_value=False),
+    ):
+        status = build_daemon_status(sources=(), browser_capture_enabled=False)
+
+    assert status.convergence.available is (debt_setup == "pending")
+    claim_guard = cast(dict[str, dict[str, object]], status.claim_guard)
+    assert claim_guard["converged"]["value"] is False
+    reason = str(claim_guard["converged"]["reason"])
+    if debt_setup == "pending":
+        assert reason == "convergence debt pending: 1 deferred"
+    else:
+        assert "convergence debt status unavailable" in reason
+        assert "unknown debt" in str(claim_guard["converged"]["signal"])
+
+
 def test_build_daemon_status_detects_broken_append_head_blocks_converged(tmp_path: Path) -> None:
     """polylogue-yla8.7 AC: a current accepted append head whose predecessor
     chain is broken must surface through ``raw_frontier_integrity``, render
@@ -1785,6 +1857,7 @@ def test_daemon_and_direct_claim_guard_share_mixed_frontier_summary(tmp_path: Pa
         raw_frontier_integrity=integrity,
         fts_readiness=FTSReadiness(messages_ready=True),
         live_ingest_attempts=status_module.LiveIngestAttemptSummary(),
+        convergence=status_module.ConvergenceDebtSummary(),
     )
     direct_guard = _direct_claim_guard(
         archive_tiers={

--- a/tests/unit/sources/test_convergence_debt_deferred_vocabulary.py
+++ b/tests/unit/sources/test_convergence_debt_deferred_vocabulary.py
@@ -19,8 +19,11 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
+from unittest.mock import patch
 
-from polylogue.daemon.convergence import FileState, StageState
+from polylogue.daemon.convergence import ConvergenceStage, DaemonConverger, FileState, StageState
+from polylogue.daemon.convergence_debt_status import convergence_debt_summary_info
+from polylogue.daemon.status import daemon_status_payload, format_daemon_status_lines
 from polylogue.sources.live.convergence_debt import (
     ConvergenceDebt,
     convergence_debt_from_state,
@@ -152,3 +155,115 @@ def test_record_convergence_outcome_persists_deferred_and_failed_statuses(tmp_pa
         str(deferred_path): "deferred",
         str(failed_path): "failed",
     }
+
+
+def test_real_converger_outcomes_reach_status_and_read_surfaces(tmp_path: Path) -> None:
+    """The real converger route preserves pending and failed stage outcomes.
+
+    This is deliberately a red twin for the production handoff: a stage that
+    returns False with ``false_means_pending`` must remain deferred all the way
+    through the ops ledger and status projections, while an exception remains
+    failed. A test of ``StageState`` or ``ConvergenceDebt.deferred`` alone
+    would miss either writer or read-surface regressions.
+    """
+    deferred_path = tmp_path / "deferred.jsonl"
+    failed_path = tmp_path / "failed.jsonl"
+
+    def execute(path: Path) -> bool:
+        if path == deferred_path:
+            return False
+        raise RuntimeError("fts writer failed")
+
+    converger = DaemonConverger(
+        (
+            ConvergenceStage(
+                name="fts",
+                description="bounded FTS convergence",
+                check=lambda _path: True,
+                execute=execute,
+                false_means_pending=True,
+            ),
+        )
+    )
+    states, _timings = converger.converge_batch((deferred_path, failed_path))
+    assert states[deferred_path].stages == {"fts": StageState.PENDING}
+    assert states[failed_path].stages == {"fts": StageState.FAILED}
+
+    index_db = tmp_path / "index.db"
+    cursor = CursorStore(index_db)
+    record_convergence_outcome(
+        cursor,
+        deferred_path,
+        convergence_debt_from_states((deferred_path,), states),
+    )
+    record_convergence_outcome(
+        cursor,
+        failed_path,
+        convergence_debt_from_states((failed_path,), states),
+    )
+
+    summary = convergence_debt_summary_info(index_db)
+    assert summary.failed_count == 1
+    assert summary.deferred_count == 1
+    assert {item.status for item in summary.recent} == {"failed", "deferred"}
+
+    with (
+        patch("polylogue.daemon.status.archive_root", return_value=tmp_path),
+        patch("polylogue.daemon.status._active_status_db_path", return_value=index_db),
+        patch("polylogue.daemon.status._check_daemon_liveness", return_value=False),
+        patch("polylogue.daemon.status._blob_size_info", return_value=0),
+        patch("polylogue.daemon.status._fts_readiness_info", return_value={}),
+        patch("polylogue.daemon.status._insight_freshness_info", return_value={}),
+    ):
+        payload = daemon_status_payload(sources=())
+
+    convergence = payload["convergence"]
+    assert isinstance(convergence, dict)
+    assert convergence["failed_count"] == 1
+    assert convergence["deferred_count"] == 1
+    lines = format_daemon_status_lines(payload)
+    assert "Convergence debt: 1 failed, 1 deferred, 0 retry due" in lines
+
+
+def test_convergence_debt_status_transition_updates_same_pending_row(tmp_path: Path) -> None:
+    """A status change cannot be hidden by the same-error retry fast path."""
+    index_db = tmp_path / "index.db"
+    cursor = CursorStore(index_db)
+    subject_id = str(tmp_path / "source.jsonl")
+    error = "stage fts returned False"
+    cursor.record_convergence_debt(
+        stage="fts",
+        subject_type="source_path",
+        subject_id=subject_id,
+        error=error,
+    )
+
+    with sqlite3.connect(tmp_path / "ops.db") as conn:
+        conn.execute(
+            """
+            UPDATE convergence_debt
+            SET next_retry_at = '9999-01-01T00:00:00+00:00'
+            WHERE stage = 'fts' AND target_type = 'source_path' AND target_id = ?
+            """,
+            (subject_id,),
+        )
+        conn.commit()
+
+    cursor.record_convergence_debt(
+        stage="fts",
+        subject_type="source_path",
+        subject_id=subject_id,
+        error=error,
+        deferred=True,
+    )
+
+    with sqlite3.connect(tmp_path / "ops.db") as conn:
+        row = conn.execute(
+            """
+            SELECT status, attempts
+            FROM convergence_debt
+            WHERE stage = 'fts' AND target_type = 'source_path' AND target_id = ?
+            """,
+            (subject_id,),
+        ).fetchone()
+    assert row == ("deferred", 1)

--- a/tests/unit/sources/test_convergence_debt_deferred_vocabulary.py
+++ b/tests/unit/sources/test_convergence_debt_deferred_vocabulary.py
@@ -21,6 +21,8 @@ import sqlite3
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from polylogue.daemon.convergence import ConvergenceStage, DaemonConverger, FileState, StageState
 from polylogue.daemon.convergence_debt_status import convergence_debt_summary_info
 from polylogue.daemon.status import daemon_status_payload, format_daemon_status_lines
@@ -225,8 +227,11 @@ def test_real_converger_outcomes_reach_status_and_read_surfaces(tmp_path: Path) 
     assert "Convergence debt: 1 failed, 1 deferred, 0 retry due" in lines
 
 
-def test_convergence_debt_status_transition_updates_same_pending_row(tmp_path: Path) -> None:
-    """A status change cannot be hidden by the same-error retry fast path."""
+@pytest.mark.parametrize("initial_deferred,next_deferred", [(False, True), (True, False)])
+def test_convergence_debt_status_transition_preserves_attempts_and_deadline(
+    tmp_path: Path, initial_deferred: bool, next_deferred: bool
+) -> None:
+    """A classification-only change preserves retry scheduling in both directions."""
     index_db = tmp_path / "index.db"
     cursor = CursorStore(index_db)
     subject_id = str(tmp_path / "source.jsonl")
@@ -236,16 +241,18 @@ def test_convergence_debt_status_transition_updates_same_pending_row(tmp_path: P
         subject_type="source_path",
         subject_id=subject_id,
         error=error,
+        deferred=initial_deferred,
     )
 
+    exact_deadline = "9999-01-01T00:00:00+00:00"
     with sqlite3.connect(tmp_path / "ops.db") as conn:
         conn.execute(
             """
             UPDATE convergence_debt
-            SET next_retry_at = '9999-01-01T00:00:00+00:00'
+            SET next_retry_at = ?
             WHERE stage = 'fts' AND target_type = 'source_path' AND target_id = ?
             """,
-            (subject_id,),
+            (exact_deadline, subject_id),
         )
         conn.commit()
 
@@ -254,16 +261,16 @@ def test_convergence_debt_status_transition_updates_same_pending_row(tmp_path: P
         subject_type="source_path",
         subject_id=subject_id,
         error=error,
-        deferred=True,
+        deferred=next_deferred,
     )
 
     with sqlite3.connect(tmp_path / "ops.db") as conn:
         row = conn.execute(
             """
-            SELECT status, attempts
+            SELECT status, attempts, next_retry_at
             FROM convergence_debt
             WHERE stage = 'fts' AND target_type = 'source_path' AND target_id = ?
             """,
             (subject_id,),
         ).fetchone()
-    assert row == ("deferred", 1)
+    assert row == ("deferred" if next_deferred else "failed", 1, exact_deadline)


### PR DESCRIPTION
## Summary

Make convergence claims fail closed when authoritative convergence debt is pending or unreadable, and preserve retry scheduling across debt classification changes.

## Problem

The daemon status route collected convergence debt but did not pass that authoritative summary into the claim guard, so pending debt could coexist with `converged=true`. SQLite read failures in the debt projection were returned as an empty zero-debt summary. CursorStore status-only failed/deferred transitions also recalculated `next_retry_at`, which could make a retry eligible earlier than the stored deadline.

## Solution

- Add explicit `available` and `error` fields to `ConvergenceDebtSummary`. Empty authoritative tables remain available zero-debt; missing, malformed, or unreadable ops debt is unavailable and therefore unknown.
- Pass the collected summary through the daemon production status route into the shared claim guard. Pending failed/deferred debt and unavailable debt both block `converged`, with an auditable reason and signal.
- Preserve the existing attempt count and exact stored retry deadline for same-error status-only failed/deferred transitions.
- Add pure claim-guard, SQLite unreadable-ledger, daemon production-route, and bidirectional CursorStore regressions.
- Scope excludes the pre-existing restart-law failure and unrelated archive lifecycle, reindex, blob, or live archive changes.

## Verification

- `direnv exec /realm/worktrees/polylogue-6krh-luna2 devtools test tests/unit/core/test_claim_guard.py tests/unit/daemon/test_convergence_debt_alert.py tests/unit/daemon/test_daemon_status.py tests/unit/sources/test_convergence_debt_deferred_vocabulary.py`: 117 passed.
- `direnv exec /realm/worktrees/polylogue-6krh-luna2 devtools verify --quick`: all 23 steps exited 0.
- Normal `git push` pre-push quick baseline at commit `5e12d6f8a`: all 23 steps exited 0.

## Acceptance criteria

| Criterion | Result |
| --- | --- |
| Pending convergence debt cannot produce `converged=true` through the daemon production route | Satisfied. A real deferred ops row is consumed by `build_daemon_status` and blocks the claim. |
| Unreadable or unavailable debt cannot produce `converged=true` | Satisfied. Corrupt SQLite authority yields `available=false`, an unknown-debt signal, and a blocked claim. |
| SQLite read errors do not collapse into zero debt | Satisfied. The summary regression asserts unavailable state and preserves zero counts as unknown rather than healthy. |
| Failed/deferred status-only transitions preserve attempts and exact retry deadline | Satisfied. Real CursorStore regressions cover failed to deferred and deferred to failed. |
| Existing empty authoritative ledgers remain zero-debt | Satisfied. Empty ops-table coverage remains green. |
| Scope stays within convergence debt status, claim guarding, retry scheduling, and focused tests | Satisfied. Eight files changed. |

## Residual uncertainty

The pre-existing restart-law failure was not rerun or changed, per lane scope.

Ref #3763