### PR TITLE
fix(devtools): stabilize demo corpus datasheet coverage

### DIFF
--- a/devtools/render_demo_corpus_datasheet.py
+++ b/devtools/render_demo_corpus_datasheet.py
@@ -96,12 +96,12 @@ def _render_family_table() -> list[str]:
 
 def _render_construct_table(seed: DemoSeedResult) -> list[str]:
     lines = [
-        "| Construct | Observed | Minimum | Status |",
-        "| --- | ---: | ---: | --- |",
+        "| Construct | Required coverage | Status |",
+        "| --- | ---: | --- |",
     ]
     for row in seed.construct_coverage:
         status = "ok" if row.ok else "missing"
-        lines.append(f"| {row.label} (`{row.construct_id}`) | {row.observed} | {row.minimum} | `{status}` |")
+        lines.append(f"| {row.label} (`{row.construct_id}`) | >= {row.minimum} | `{status}` |")
     return lines
 
 

--- a/docs/plans/demo-corpus-construct-audit.md
+++ b/docs/plans/demo-corpus-construct-audit.md
@@ -44,48 +44,48 @@ This datasheet is generated from the deterministic demo family registry, the dec
 
 ## Declared Construct Coverage
 
-| Construct | Observed | Minimum | Status |
-| --- | ---: | ---: | --- |
-| Multi-origin sessions (`multi_origin_sessions`) | 8 | 3 | `ok` |
-| Session profiles (`session_profiles`) | 19 | 3 | `ok` |
-| Tool-use blocks (`tool_use_blocks`) | 26 | 1 | `ok` |
-| Tool-result blocks (`tool_result_blocks`) | 28 | 1 | `ok` |
-| Failed tool results (`failed_tool_results`) | 7 | 1 | `ok` |
-| Provider usage messages (`provider_usage_messages`) | 9 | 1 | `ok` |
-| Attachment rows (`attachment_rows`) | 1 | 1 | `ok` |
-| Acquired attachment rows (`acquired_attachment_rows`) | 1 | 1 | `ok` |
-| Temporary session rows (`temporary_session_rows`) | 1 | 1 | `ok` |
-| Token-budget web constructs (`token_budget_web_constructs`) | 1 | 1 | `ok` |
-| Capture-gap events (`capture_gap_events`) | 1 | 1 | `ok` |
-| Browser-capture raw variants (`browser_capture_raw_variants`) | 3 | 3 | `ok` |
-| Browser-capture coalesced session (`browser_capture_coalesced_session`) | 1 | 1 | `ok` |
-| Source-outage interval events (`source_outage_interval_events`) | 1 | 1 | `ok` |
-| Ambiguous cross-material duplicate (`ambiguous_cross_material_duplicate`) | 2 | 1 | `ok` |
-| Compaction omits a failed attempt (`compaction_omits_failed_attempt`) | 1 | 1 | `ok` |
-| Gemini CLI origin rows (`gemini_cli_origin_rows`) | 1 | 1 | `ok` |
-| Antigravity origin rows (`antigravity_origin_rows`) | 1 | 1 | `ok` |
-| Hermes origin rows (`hermes_origin_rows`) | 1 | 1 | `ok` |
-| Session-link rows (`session_link_rows`) | 3 | 1 | `ok` |
-| Generic branch links (`generic_branch_links`) | 1 | 1 | `ok` |
-| Prefix-sharing lineage links (`prefix_sharing_links`) | 2 | 1 | `ok` |
-| Continuation links (`continuation_links`) | 1 | 1 | `ok` |
-| Subagent links (`subagent_links`) | 1 | 1 | `ok` |
-| Sidechain sessions (`sidechain_sessions`) | 1 | 1 | `ok` |
-| Compaction events (`compaction_events`) | 1 | 1 | `ok` |
-| Run projection rows (`run_projection_rows`) | 19 | 1 | `ok` |
-| Observed-event rows (`observed_event_rows`) | 43 | 1 | `ok` |
-| Context snapshot rows (`context_snapshot_rows`) | 19 | 1 | `ok` |
-| Subagent context snapshots (`subagent_context_snapshots`) | 1 | 1 | `ok` |
-| Subagent run rows (`subagent_run_rows`) | 1 | 1 | `ok` |
-| Unfinished terminal-state rows (`unfinished_terminal_state_rows`) | 5 | 1 | `ok` |
-| Error terminal-state rows (`error_terminal_state_rows`) | 2 | 1 | `ok` |
-| Receipts failed test action (`receipts_failed_test_action`) | 1 | 1 | `ok` |
-| Receipts successful recovery action (`receipts_successful_recovery_action`) | 1 | 1 | `ok` |
-| Receipts conflicting claim (`receipts_conflicting_claim`) | 1 | 1 | `ok` |
-| Anti-grep negative control (`anti_grep_control`) | 1 | 1 | `ok` |
-| Embedding candidate prose messages (`embedding_candidate_prose_messages`) | 41 | 1 | `ok` |
-| Synthetic message embedding rows (`synthetic_message_embedding_rows`) | 2 | 1 | `ok` |
-| Embedding status rows (`embedding_status_rows`) | 1 | 1 | `ok` |
+| Construct | Required coverage | Status |
+| --- | ---: | --- |
+| Multi-origin sessions (`multi_origin_sessions`) | >= 3 | `ok` |
+| Session profiles (`session_profiles`) | >= 3 | `ok` |
+| Tool-use blocks (`tool_use_blocks`) | >= 1 | `ok` |
+| Tool-result blocks (`tool_result_blocks`) | >= 1 | `ok` |
+| Failed tool results (`failed_tool_results`) | >= 1 | `ok` |
+| Provider usage messages (`provider_usage_messages`) | >= 1 | `ok` |
+| Attachment rows (`attachment_rows`) | >= 1 | `ok` |
+| Acquired attachment rows (`acquired_attachment_rows`) | >= 1 | `ok` |
+| Temporary session rows (`temporary_session_rows`) | >= 1 | `ok` |
+| Token-budget web constructs (`token_budget_web_constructs`) | >= 1 | `ok` |
+| Capture-gap events (`capture_gap_events`) | >= 1 | `ok` |
+| Browser-capture raw variants (`browser_capture_raw_variants`) | >= 3 | `ok` |
+| Browser-capture coalesced session (`browser_capture_coalesced_session`) | >= 1 | `ok` |
+| Source-outage interval events (`source_outage_interval_events`) | >= 1 | `ok` |
+| Ambiguous cross-material duplicate (`ambiguous_cross_material_duplicate`) | >= 1 | `ok` |
+| Compaction omits a failed attempt (`compaction_omits_failed_attempt`) | >= 1 | `ok` |
+| Gemini CLI origin rows (`gemini_cli_origin_rows`) | >= 1 | `ok` |
+| Antigravity origin rows (`antigravity_origin_rows`) | >= 1 | `ok` |
+| Hermes origin rows (`hermes_origin_rows`) | >= 1 | `ok` |
+| Session-link rows (`session_link_rows`) | >= 1 | `ok` |
+| Generic branch links (`generic_branch_links`) | >= 1 | `ok` |
+| Prefix-sharing lineage links (`prefix_sharing_links`) | >= 1 | `ok` |
+| Continuation links (`continuation_links`) | >= 1 | `ok` |
+| Subagent links (`subagent_links`) | >= 1 | `ok` |
+| Sidechain sessions (`sidechain_sessions`) | >= 1 | `ok` |
+| Compaction events (`compaction_events`) | >= 1 | `ok` |
+| Run projection rows (`run_projection_rows`) | >= 1 | `ok` |
+| Observed-event rows (`observed_event_rows`) | >= 1 | `ok` |
+| Context snapshot rows (`context_snapshot_rows`) | >= 1 | `ok` |
+| Subagent context snapshots (`subagent_context_snapshots`) | >= 1 | `ok` |
+| Subagent run rows (`subagent_run_rows`) | >= 1 | `ok` |
+| Unfinished terminal-state rows (`unfinished_terminal_state_rows`) | >= 1 | `ok` |
+| Error terminal-state rows (`error_terminal_state_rows`) | >= 1 | `ok` |
+| Receipts failed test action (`receipts_failed_test_action`) | >= 1 | `ok` |
+| Receipts successful recovery action (`receipts_successful_recovery_action`) | >= 1 | `ok` |
+| Receipts conflicting claim (`receipts_conflicting_claim`) | >= 1 | `ok` |
+| Anti-grep negative control (`anti_grep_control`) | >= 1 | `ok` |
+| Embedding candidate prose messages (`embedding_candidate_prose_messages`) | >= 1 | `ok` |
+| Synthetic message embedding rows (`synthetic_message_embedding_rows`) | >= 1 | `ok` |
+| Embedding status rows (`embedding_status_rows`) | >= 1 | `ok` |
 
 ## Interpretation Notes
 

--- a/tests/unit/devtools/test_render_demo_corpus_datasheet.py
+++ b/tests/unit/devtools/test_render_demo_corpus_datasheet.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 
 from devtools import render_demo_corpus_datasheet
@@ -54,8 +55,36 @@ def test_build_document_is_generated_from_families_and_measurements() -> None:
     assert "| Sessions | 2 |" in rendered
     assert "| Blocks | 6 |" in rendered
     assert "`agent-lineage-matrix`" in rendered
-    assert "Compaction events (`compaction_events`) | 1 | 1 | `ok`" in rendered
+    assert "Compaction events (`compaction_events`) | >= 1 | `ok`" in rendered
     assert "fork-vs-resume" in rendered
+
+
+def test_build_document_ignores_volatile_observed_counts() -> None:
+    baseline = _seed_result()
+    changed_observed = replace(
+        baseline,
+        construct_coverage=tuple(
+            DemoConstructCoverage(
+                row.construct_id,
+                row.label,
+                row.observed + 40 if row.construct_id == "compaction_events" else row.observed,
+                row.minimum,
+                row.ok,
+            )
+            for row in baseline.construct_coverage
+        ),
+    )
+    measurement = render_demo_corpus_datasheet.DemoCorpusMeasurement(
+        blocks=6,
+        origins=("chatgpt-export", "codex-session"),
+        run_rows=2,
+        observed_event_rows=3,
+        context_snapshot_rows=2,
+    )
+
+    assert render_demo_corpus_datasheet.build_document(baseline, _verify_result(), measurement) == (
+        render_demo_corpus_datasheet.build_document(changed_observed, _verify_result(), measurement)
+    )
 
 
 def test_main_check_reports_out_of_sync(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Stabilize the generated demo-corpus construct audit so parser-only changes do not rewrite the tracked datasheet's construct rows when declared coverage is unchanged.

## Problem

The authoritative demo contract declares a minimum for each construct and the runtime verifier checks `observed >= minimum`. The renderer persisted the incidental exact observed count in the generated Markdown. The recent `gzgyl` authored-prose classification changed one such count from 38 to 41 and caused managed pre-push drift in unrelated worktrees, even though the construct contract remained satisfied.

## Solution

- Update `devtools/render_demo_corpus_datasheet.py` to render each construct's required coverage floor and status, while leaving exact observations in the seed and verifier.
- Add `tests/unit/devtools/test_render_demo_corpus_datasheet.py::test_build_document_ignores_volatile_observed_counts` to prove count-only changes do not alter the generated construct table.
- Regenerate `docs/plans/demo-corpus-construct-audit.md` from the corrected renderer.

## Acceptance criteria

| Criterion | Result | Evidence |
| --- | --- | --- |
| Identify and repair the source/generator contract | Satisfied | Renderer now follows the minimum-coverage contract from `polylogue/demo/constructs.py`; output was regenerated only after the source fix. |
| Prevent count-only generated-doc drift | Satisfied | Regression passes with a changed observed count and unchanged contract status. |
| Rendered datasheet is synchronized | Satisfied | `devtools render demo-corpus-datasheet --check` reports `sync OK`. |
| Managed quick gate remains green | Satisfied | `devtools verify --quick` completed all 23 steps with exit code 0; the pre-push hook reran the same quick baseline successfully. |
| Scope stays isolated | Satisfied | The commit changes only the renderer, its focused test, and the generated datasheet. |

## Verification

- `env -u VIRTUAL_ENV direnv exec . devtools test tests/unit/devtools/test_render_demo_corpus_datasheet.py` -> 3 passed.
- `env -u VIRTUAL_ENV direnv exec . devtools render demo-corpus-datasheet --check` -> `render demo-corpus-datasheet: sync OK`.
- `env -u VIRTUAL_ENV direnv exec . devtools verify --quick` -> exit code 0.
- Push pre-push hook -> quick verification exit code 0.

Residual uncertainty: the separate current-archive snapshot rows in the datasheet still show exact session/message/block counts by design. This change targets the construct-coverage count drift that caused the current pre-push failure; a future request to make that snapshot fully stable would be a separate docs-contract decision.
