### PR TITLE
test(convergence): add hermetic archive property loop

### DIFF
--- a/polylogue/schemas/synthetic/build_records.py
+++ b/polylogue/schemas/synthetic/build_records.py
@@ -22,6 +22,7 @@ class _WireFormatContext(Protocol):
     wire_format: WireFormat
     _semantic_gen: SemanticValueGenerator | None
     _active_record_bucket: tuple[str, str] | None
+    _coverage_witness_mode: bool
 
     def _generate_from_schema(
         self,
@@ -119,7 +120,14 @@ def _generate_tree_json(
     nodes: list[SyntheticRecord] = []
 
     for i in range(n_messages):
-        node = _coerce_record(self._generate_from_schema(node_schema, rng))
+        node_path = "$.properties." + tree_cfg.container_path + ".additionalProperties.*"
+        node = _coerce_record(
+            self._generate_from_schema(
+                node_schema,
+                rng,
+                path=node_path if self._coverage_witness_mode else "$",
+            )
+        )
 
         node_id = str(uuid.UUID(int=rng.getrandbits(128), version=4))
         node[tree_cfg.key_field] = node_id
@@ -184,7 +192,16 @@ def _generate_linear_json(
 
     messages: list[SyntheticRecord] = []
     for i in range(n_messages):
-        msg = _coerce_record(self._generate_from_schema(item_schema, rng))
+        item_path = (
+            "$.properties." + ".properties.".join(msgs_parts) + ".items[*]" if self._coverage_witness_mode else "$"
+        )
+        msg = _coerce_record(
+            self._generate_from_schema(
+                item_schema,
+                rng,
+                path=item_path,
+            )
+        )
         role = roles[i % len(roles)]
         self._ensure_wire_format(msg, role, rng, i, base_ts=base_ts, theme=theme)
         _advance_semantic_turn(self)

--- a/polylogue/schemas/synthetic/build_wire_formats.py
+++ b/polylogue/schemas/synthetic/build_wire_formats.py
@@ -104,6 +104,26 @@ def _ensure_wire_format(
             self._ensure_wire_codex(data, role, rng, ts, index=index, theme=theme)
         case "gemini":
             self._ensure_wire_gemini(data, role, rng, index=index, theme=theme)
+        case _:
+            raise ValueError(f"No executable synthetic wire adapter for provider {self.provider!r}")
+
+
+def validate_wire_payload(provider: str, data: JSONValue) -> None:
+    """Reject provider-wire combinations the production parser does not own."""
+
+    if provider != "codex" or not isinstance(data, list):
+        return
+    has_flat_message = any(
+        isinstance(record, dict) and (record.get("type") == "message" or isinstance(record.get("role"), str))
+        for record in data
+    )
+    has_envelope_message = any(
+        isinstance(record, dict)
+        and record.get("type") in {"response_item", "event_msg", "turn_context", "session_meta"}
+        for record in data
+    )
+    if has_flat_message and has_envelope_message:
+        raise ValueError("Codex synthetic payload cannot mix flat records with envelope records")
 
 
 def _ensure_wire_chatgpt(
@@ -327,4 +347,5 @@ __all__ = [
     "_ensure_wire_codex",
     "_ensure_wire_format",
     "_ensure_wire_gemini",
+    "validate_wire_payload",
 ]

--- a/polylogue/schemas/synthetic/build_wire_formats.py
+++ b/polylogue/schemas/synthetic/build_wire_formats.py
@@ -27,6 +27,7 @@ def _record_field(record: SyntheticRecord, field_name: str) -> SyntheticRecord:
 class _WireFormatContext(Protocol):
     provider: str
     _active_record_bucket: tuple[str, str] | None
+    _coverage_witness_mode: bool
 
     def _ensure_wire_chatgpt(
         self,
@@ -148,6 +149,10 @@ def _ensure_wire_chatgpt(
     content.setdefault("content_type", "text")
 
     msg.setdefault("create_time", ts)
+    if self._coverage_witness_mode:
+        raw_provider_payload = data.get("raw_provider_payload")
+        if isinstance(raw_provider_payload, dict):
+            raw_provider_payload.pop("mapping", None)
 
 
 def _ensure_wire_claude_ai(
@@ -199,8 +204,26 @@ def _ensure_wire_claude_code(
         msg.setdefault("role", role)
         if "content" not in msg:
             msg["content"] = _claude_code_content_fallback(rng, role, index, theme)  # type: ignore[assignment]
+        elif self._coverage_witness_mode:
+            _normalize_claude_code_coverage_content(msg, rng, role, index, theme)
     if "timestamp" not in data:
         data["timestamp"] = datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+
+
+def _normalize_claude_code_coverage_content(
+    message: SyntheticRecord,
+    rng: random.Random,
+    role: str,
+    index: int,
+    theme: SessionTheme | None,
+) -> None:
+    """Keep coverage witnesses on block forms the Claude Code route emits."""
+    content = message.get("content")
+    if not isinstance(content, list):
+        return
+    for block in content:
+        if isinstance(block, dict) and isinstance(block.get("content"), list):
+            block["content"] = _text_for_role(rng, role, turn_index=index, theme=theme)
 
 
 def _claude_code_content_fallback(rng: random.Random, role: str, index: int, theme: SessionTheme | None) -> object:

--- a/polylogue/schemas/synthetic/core.py
+++ b/polylogue/schemas/synthetic/core.py
@@ -187,6 +187,21 @@ class SyntheticCorpus:
     @classmethod
     def generate_batch_for_spec(cls, spec: CorpusSpec) -> SyntheticGenerationBatch:
         corpus = cls.from_spec(spec)
+        return cls._generate_batch_for_corpus(corpus, spec)
+
+    @classmethod
+    def generate_batch_for_selection(
+        cls,
+        selection: SyntheticSchemaSelection,
+        spec: CorpusSpec,
+    ) -> SyntheticGenerationBatch:
+        """Generate a spec through an already-resolved persisted schema route."""
+
+        corpus = cls.from_selection(selection)
+        return cls._generate_batch_for_corpus(corpus, spec)
+
+    @staticmethod
+    def _generate_batch_for_corpus(corpus: SyntheticCorpus, spec: CorpusSpec) -> SyntheticGenerationBatch:
         return corpus.generate_batch(
             count=spec.count,
             messages_per_session=spec.messages_per_session,
@@ -209,9 +224,36 @@ class SyntheticCorpus:
         index_width: int = 2,
     ) -> SyntheticWrittenBatch:
         corpus = cls.from_spec(spec)
+        return cls._write_batch_artifacts(corpus, spec, output_dir, prefix=prefix, index_width=index_width)
+
+    @classmethod
+    def write_selection_artifacts(
+        cls,
+        selection: SyntheticSchemaSelection,
+        spec: CorpusSpec,
+        output_dir: Path,
+        *,
+        prefix: str,
+        index_width: int = 2,
+    ) -> SyntheticWrittenBatch:
+        """Write artifacts from the exact schema selection carried by a manifest."""
+
+        corpus = cls.from_selection(selection)
+        return cls._write_batch_artifacts(corpus, spec, output_dir, prefix=prefix, index_width=index_width)
+
+    @classmethod
+    def _write_batch_artifacts(
+        cls,
+        corpus: SyntheticCorpus,
+        spec: CorpusSpec,
+        output_dir: Path,
+        *,
+        prefix: str,
+        index_width: int,
+    ) -> SyntheticWrittenBatch:
         output_dir.mkdir(parents=True, exist_ok=True)
         ext = ".json" if corpus.wire_format.encoding == "json" else ".jsonl"
-        batch = cls.generate_batch_for_spec(spec)
+        batch = cls._generate_batch_for_corpus(corpus, spec)
         written_files: list[Path] = []
         for idx, artifact in enumerate(batch.artifacts):
             if corpus.provider == "antigravity":

--- a/polylogue/schemas/synthetic/core.py
+++ b/polylogue/schemas/synthetic/core.py
@@ -64,6 +64,10 @@ class SyntheticCorpus:
         self._max_synthetic_string_length = max_string_length
         self._active_profile_tokens: tuple[str, ...] = ()
         self._active_record_bucket: tuple[str, str] | None = None
+        self._coverage_branch_choices: dict[str, int] = {}
+        self._coverage_type_choices: dict[str, str] = {}
+        self._coverage_null_paths: set[str] = set()
+        self._coverage_witness_mode = False
         self._generation_state = SyntheticGenerationState(
             relation_solver=RelationConstraintSolver(schema, max_string_length=max_string_length),
             semantic_generator=None,
@@ -448,6 +452,8 @@ class SyntheticCorpus:
         max_depth: int = 6,
         path: str = "$",
     ) -> JSONValue:
+        if self._coverage_witness_mode and max_depth == 6:
+            max_depth = 24
         return synthetic_runtime._generate_from_schema(
             self,
             schema,

--- a/polylogue/schemas/synthetic/runtime.py
+++ b/polylogue/schemas/synthetic/runtime.py
@@ -44,6 +44,10 @@ class _SyntheticRuntimeContext(Protocol):
     _active_profile_tokens: tuple[str, ...]
     _active_record_bucket: tuple[str, str] | None
     _max_array_items: int | None
+    _coverage_branch_choices: dict[str, int]
+    _coverage_type_choices: dict[str, str]
+    _coverage_null_paths: set[str]
+    _coverage_witness_mode: bool
 
     def _generate_from_schema(
         self,
@@ -98,11 +102,16 @@ def _schema_records(value: SchemaValue | object) -> list[SchemaRecord]:
     return [record for item in value if (record := _schema_record(item))]
 
 
-def _schema_type(schema: SchemaRecord, rng: random.Random) -> str | None:
+def _schema_type(self: _SyntheticRuntimeContext, schema: SchemaRecord, rng: random.Random, path: str) -> str | None:
     schema_type = schema.get("type")
     if isinstance(schema_type, str):
         return schema_type
     if isinstance(schema_type, list):
+        selected_type = self._coverage_type_choices.get(path) if self._coverage_witness_mode else None
+        if selected_type in schema_type:
+            return selected_type
+        if self._coverage_witness_mode and path in self._coverage_null_paths and "null" in schema_type:
+            return "null"
         non_null = [item for item in schema_type if isinstance(item, str) and item != "null"]
         return rng.choice(non_null) if non_null else "null"
     return None
@@ -183,24 +192,46 @@ def _generate_from_schema(
         return None
 
     semantic_role = schema.get("x-polylogue-semantic-role")
-    if isinstance(semantic_role, str) and self._semantic_gen is not None:
+    if (
+        isinstance(semantic_role, str)
+        and self._semantic_gen is not None
+        and not (self._coverage_witness_mode and path in self._coverage_type_choices)
+    ):
         handled, value = self._semantic_gen.try_generate(schema)
         if handled:
             return value
 
     for keyword in ("anyOf", "oneOf"):
-        variants = _schema_records(schema.get(keyword))
+        raw_variants = schema.get(keyword)
+        variants = [
+            (index, variant)
+            for index, item in enumerate(raw_variants if isinstance(raw_variants, list) else [])
+            if (variant := _schema_record(item))
+        ]
         if variants:
             if keyword not in SCHEMA_CONSTRUCT_HANDLERS:
                 return None
-            non_null = [variant for variant in variants if variant.get("type") != "null"]
+            selected_index = self._coverage_branch_choices.get(path) if self._coverage_witness_mode else None
+            if selected_index is not None:
+                selected = next((variant for index, variant in variants if index == selected_index), None)
+                if selected is not None:
+                    return self._generate_from_schema(
+                        selected,
+                        rng,
+                        skip_keys=skip_keys,
+                        depth=depth,
+                        max_depth=max_depth,
+                        path=(f"{path}.{keyword}[{selected_index}]" if self._coverage_witness_mode else path),
+                    )
+
+            non_null = [item for item in variants if item[1].get("type") != "null"]
             candidates = non_null if non_null else variants
 
             # Weight by x-polylogue-frequency when available on variants.
             # Falls back to uniform when no variant carries the annotation
             # (backward-compatible with un-annotated schemas).
             weights: list[float] = []
-            for variant in candidates:
+            for _, variant in candidates:
                 f = variant.get("x-polylogue-frequency")
                 weights.append(float(f) if isinstance(f, (int, float)) and f > 0 else 0.0)
             if sum(weights) > 0:
@@ -211,15 +242,15 @@ def _generate_from_schema(
             else:
                 chosen = rng.choice(candidates)
             return self._generate_from_schema(
-                chosen,
+                chosen[1],
                 rng,
                 skip_keys=skip_keys,
                 depth=depth,
                 max_depth=max_depth,
-                path=path,
+                path=(f"{path}.{keyword}[{chosen[0]}]" if self._coverage_witness_mode else path),
             )
 
-    schema_type = _schema_type(schema, rng)
+    schema_type = _schema_type(self, schema, rng, path)
     if schema_type is not None and schema_type not in SCHEMA_CONSTRUCT_HANDLERS:
         return None
     freq_value = schema.get("x-polylogue-frequency")
@@ -303,7 +334,7 @@ def _generate_object(
     if skip_keys:
         candidate_keys -= skip_keys
 
-    if self._relation_solver.mutual_exclusions:
+    if self._relation_solver.mutual_exclusions and not self._coverage_witness_mode:
         candidate_keys = self._relation_solver.filter_mutually_exclusive(path, candidate_keys, rng)
 
     for prop_name, prop_value in properties.items():
@@ -320,7 +351,7 @@ def _generate_object(
         if prop_name in selected_root_fields and freq < 1.0:
             prop_schema = {**prop_schema, "x-polylogue-frequency": 1.0}
 
-        child_path = f"{path}.{prop_name}"
+        child_path = f"{path}.properties.{prop_name}" if self._coverage_witness_mode else f"{path}.{prop_name}"
         ref = self._relation_solver.resolve_foreign_key(child_path, rng)
         if ref is not None:
             obj[prop_name] = ref
@@ -333,10 +364,38 @@ def _generate_object(
             max_depth=max_depth,
             path=child_path,
         )
-        if value is not None:
+        if value is not None or (self._coverage_witness_mode and _schema_allows_null(prop_schema)):
             obj[prop_name] = value
 
+    additional_schema = _schema_record(schema.get("additionalProperties"))
+    if self._coverage_witness_mode and additional_schema:
+        extra_name = "__polylogue_coverage_extra__"
+        while extra_name in properties:
+            extra_name = f"_{extra_name}"
+        extra_value = self._generate_from_schema(
+            additional_schema,
+            rng,
+            depth=depth + 1,
+            max_depth=max_depth,
+            path=f"{path}.additionalProperties.*",
+        )
+        if extra_value is not None or _schema_allows_null(additional_schema):
+            obj[extra_name] = extra_value
+
     return obj
+
+
+def _schema_allows_null(schema: SchemaRecord) -> bool:
+    schema_type = schema.get("type")
+    if schema_type == "null":
+        return True
+    if isinstance(schema_type, list) and "null" in schema_type:
+        return True
+    return any(
+        _schema_allows_null(variant)
+        for keyword in ("anyOf", "oneOf")
+        for variant in _schema_records(schema.get(keyword))
+    )
 
 
 def _generate_string(self: _SyntheticRuntimeContext, schema: SchemaRecord, rng: random.Random) -> str:
@@ -413,6 +472,8 @@ def _generate_array(
         n_items = rng.randint(bounded_lo, bounded_hi)
     else:
         n_items = rng.randint(1, 3)
+    if self._coverage_witness_mode:
+        n_items = 1
     if self._max_array_items is not None:
         n_items = min(n_items, self._max_array_items)
 
@@ -425,13 +486,14 @@ def _generate_array(
     if not item_allows_null:
         item_allows_null = any(variant.get("type") == "null" for variant in _schema_records(item_schema.get("oneOf")))
 
+    item_path = f"{path}.items[*]" if self._coverage_witness_mode else f"{path}[*]"
     items = [
         self._generate_from_schema(
             item_schema,
             rng,
             depth=depth + 1,
             max_depth=max_depth,
-            path=f"{path}[*]",
+            path=item_path,
         )
         for _ in range(n_items)
     ]

--- a/polylogue/schemas/synthetic/runtime.py
+++ b/polylogue/schemas/synthetic/runtime.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Protocol, TypeAlias
 
 from polylogue.archive.raw_payload.decode import JSONValue
+from polylogue.schemas.synthetic.build_wire_formats import validate_wire_payload
 from polylogue.schemas.synthetic.models import SchemaRecord, SchemaValue
 from polylogue.schemas.synthetic.semantic_values import SemanticValueGenerator, _text_for_role
 from polylogue.schemas.synthetic.wire_formats import WireFormat
@@ -19,8 +20,24 @@ if TYPE_CHECKING:
 
 SyntheticRecord: TypeAlias = dict[str, JSONValue]
 
+# The receipt reads this registry and the recursive generator gates dispatch on
+# it. Removing a construct handler therefore changes both generated behavior
+# and the support receipt instead of becoming a silent ``None`` fallback.
+SCHEMA_CONSTRUCT_HANDLERS: dict[str, str] = {
+    "anyOf": "schema-union",
+    "array": "_generate_array",
+    "boolean": "boolean",
+    "integer": "_generate_number",
+    "null": "null",
+    "number": "_generate_number",
+    "object": "_generate_object",
+    "oneOf": "schema-union",
+    "string": "_generate_string",
+}
+
 
 class _SyntheticRuntimeContext(Protocol):
+    provider: str
     wire_format: WireFormat
     _semantic_gen: SemanticValueGenerator | None
     _relation_solver: RelationConstraintSolver
@@ -174,6 +191,8 @@ def _generate_from_schema(
     for keyword in ("anyOf", "oneOf"):
         variants = _schema_records(schema.get(keyword))
         if variants:
+            if keyword not in SCHEMA_CONSTRUCT_HANDLERS:
+                return None
             non_null = [variant for variant in variants if variant.get("type") != "null"]
             candidates = non_null if non_null else variants
 
@@ -201,6 +220,8 @@ def _generate_from_schema(
             )
 
     schema_type = _schema_type(schema, rng)
+    if schema_type is not None and schema_type not in SCHEMA_CONSTRUCT_HANDLERS:
+        return None
     freq_value = schema.get("x-polylogue-frequency")
     freq = float(freq_value) if isinstance(freq_value, (int, float)) else 1.0
     if depth > 0 and freq < 1.0 and rng.random() > freq:
@@ -234,6 +255,8 @@ def _generate_from_schema(
         case "null":
             return None
         case _:
+            if "object" not in SCHEMA_CONSTRUCT_HANDLERS:
+                return None
             if "properties" in schema:
                 return self._generate_object(
                     schema,
@@ -418,6 +441,7 @@ def _generate_array(
 
 
 def _serialize(self: _SyntheticRuntimeContext, data: JSONValue) -> bytes:
+    validate_wire_payload(self.provider, data)
     if self.wire_format.encoding == "jsonl":
         if not isinstance(data, list):
             raise ValueError("JSONL wire format requires a list payload")
@@ -427,6 +451,7 @@ def _serialize(self: _SyntheticRuntimeContext, data: JSONValue) -> bytes:
 
 
 __all__ = [
+    "SCHEMA_CONSTRUCT_HANDLERS",
     "_generate_array",
     "_generate_from_schema",
     "_generate_number",

--- a/polylogue/schemas/synthetic/selection.py
+++ b/polylogue/schemas/synthetic/selection.py
@@ -8,7 +8,10 @@ from typing import Protocol, TypeAlias
 from polylogue.schemas.packages import SchemaVersionPackage
 from polylogue.schemas.runtime_registry import SchemaRegistry, canonical_schema_provider
 from polylogue.schemas.synthetic.models import SchemaRecord, SyntheticSchemaSelection
-from polylogue.schemas.synthetic.wire_formats import PROVIDER_WIRE_FORMATS
+from polylogue.schemas.synthetic.wire_formats import (
+    PROVIDER_WIRE_ROUTES,
+    UnsupportedSyntheticWireRouteError,
+)
 
 
 class _SchemaRegistryLike(Protocol):
@@ -86,9 +89,14 @@ def select_synthetic_schema(
             f"version={canonical_version}, element_kind={resolved_element_kind})"
         )
 
-    wire_format = PROVIDER_WIRE_FORMATS.get(canonical_provider)
-    if not wire_format:
-        raise ValueError(f"No wire format config for provider: {canonical_provider}")
+    route = PROVIDER_WIRE_ROUTES.get(canonical_provider)
+    if route is None:
+        raise UnsupportedSyntheticWireRouteError(canonical_provider, "no explicit synthetic wire route")
+    if route.status == "unsupported":
+        raise UnsupportedSyntheticWireRouteError(canonical_provider, route.reason or "route is unsupported")
+    wire_format = route.wire_format
+    if wire_format is None:
+        raise UnsupportedSyntheticWireRouteError(canonical_provider, "supported route has no wire format")
 
     profile_loader = getattr(registry, "get_workload_profile", None)
     workload_profile = profile_loader(canonical_provider, canonical_version) if callable(profile_loader) else None
@@ -107,7 +115,11 @@ def available_synthetic_providers(
     registry_factory: RegistryFactory = _default_registry_factory,
 ) -> list[str]:
     schema_providers = set(registry_factory().list_providers())
-    return [provider for provider in PROVIDER_WIRE_FORMATS if provider in schema_providers]
+    return [
+        provider
+        for provider, route in PROVIDER_WIRE_ROUTES.items()
+        if route.status == "supported" and provider in schema_providers
+    ]
 
 
 __all__ = [

--- a/polylogue/schemas/synthetic/wire_formats.py
+++ b/polylogue/schemas/synthetic/wire_formats.py
@@ -282,6 +282,58 @@ def _json_value_types(value: JSONValue, result: set[str] | None = None) -> set[s
     return result
 
 
+def _payload_structure_constructs(
+    schema: object,
+    payload: JSONValue,
+    result: set[str] | None = None,
+) -> set[str]:
+    if result is None:
+        result = set()
+    if not isinstance(schema, Mapping) or not isinstance(payload, dict):
+        return result
+
+    properties = schema.get("properties")
+    property_names = set(properties) if isinstance(properties, Mapping) else set()
+    if property_names & payload.keys():
+        result.add("properties")
+
+    required = schema.get("required")
+    required_names = {item for item in required if isinstance(item, str)} if isinstance(required, list) else set()
+    if "required" in schema and required_names <= payload.keys():
+        result.add("required")
+
+    if "additionalProperties" in schema:
+        extra_names = payload.keys() - property_names
+        if schema.get("additionalProperties") is False:
+            if not extra_names:
+                result.add("additionalProperties")
+        elif extra_names:
+            result.add("additionalProperties")
+
+    if isinstance(properties, Mapping):
+        for name, child_schema in properties.items():
+            if isinstance(name, str) and name in payload:
+                _payload_structure_constructs(child_schema, payload[name], result)
+
+    items = schema.get("items")
+    if isinstance(items, Mapping) and isinstance(payload, list):
+        for item in payload:
+            _payload_structure_constructs(items, item, result)
+
+    additional_schema = schema.get("additionalProperties")
+    if isinstance(additional_schema, Mapping):
+        for name, item in payload.items():
+            if name not in property_names:
+                _payload_structure_constructs(additional_schema, item, result)
+
+    for keyword in ("anyOf", "oneOf"):
+        variants = schema.get(keyword)
+        if isinstance(variants, list):
+            for variant in variants:
+                _payload_structure_constructs(variant, payload, result)
+    return result
+
+
 def construct_coverage(
     schema: SchemaRecord,
     payloads: Sequence[JSONValue],
@@ -302,22 +354,18 @@ def construct_coverage(
     handlers = set(handler_names)
     schema_keywords = _schema_constructs(schema)
     value_types: set[str] = set()
+    structure_constructs: set[str] = set()
     for payload in payloads:
         _json_value_types(payload, value_types)
+        _payload_structure_constructs(schema, payload, structure_constructs)
 
     exercised: set[str] = set()
     for construct in schema_keywords:
         if construct.startswith("type:"):
             type_name = construct.removeprefix("type:")
-            if type_name in handlers and payloads:
+            if type_name in handlers and type_name in value_types:
                 exercised.add(construct)
-        elif (
-            (construct in handlers and payloads)
-            or (construct == "properties" and "object" in value_types)
-            or (construct == "items" and "array" in value_types)
-            or (construct == "required" and "object" in value_types)
-            or (construct == "additionalProperties" and "object" in value_types)
-        ):
+        elif (construct in handlers and payloads) or construct in structure_constructs:
             exercised.add(construct)
 
     return ConstructCoverage(

--- a/polylogue/schemas/synthetic/wire_formats.py
+++ b/polylogue/schemas/synthetic/wire_formats.py
@@ -6,10 +6,17 @@ tree vs. linear vs. JSONL, and message location paths.
 
 from __future__ import annotations
 
+from collections.abc import Collection, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Literal, TypeAlias
+from typing import TYPE_CHECKING, Literal, TypeAlias
+
+from polylogue.archive.raw_payload.decode import JSONValue
+
+if TYPE_CHECKING:
+    from polylogue.schemas.synthetic.models import SchemaRecord
 
 WireEncoding: TypeAlias = Literal["json", "jsonl"]
+WireCapabilityStatus: TypeAlias = Literal["supported", "unsupported"]
 
 
 @dataclass(frozen=True)
@@ -30,6 +37,124 @@ class WireFormat:
     encoding: WireEncoding
     tree: TreeConfig | None = None
     messages_path: str | None = None  # Dot-path to messages array
+
+
+@dataclass(frozen=True)
+class WireRoute:
+    """Explicit synthetic capability for one catalog provider.
+
+    ``PROVIDER_WIRE_FORMATS`` remains the executable adapter map used by the
+    generator.  This wider route map is the authority for catalog coverage,
+    including providers whose parser shape is deliberately not synthesized by
+    this lane.
+    """
+
+    status: WireCapabilityStatus
+    wire_format: WireFormat | None = None
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.status == "supported" and self.wire_format is None:
+            raise ValueError("supported wire routes require a WireFormat")
+        if self.status == "unsupported" and (self.wire_format is not None or not self.reason):
+            raise ValueError("unsupported wire routes require a reason and no WireFormat")
+
+
+@dataclass(frozen=True)
+class ConstructCoverage:
+    """Deterministic schema-construct coverage for generated payloads."""
+
+    schema_keywords: tuple[str, ...]
+    exercised_keywords: tuple[str, ...]
+    missing_keywords: tuple[str, ...]
+
+    @property
+    def complete(self) -> bool:
+        return not self.missing_keywords
+
+
+@dataclass(frozen=True)
+class WireSupportEntry:
+    """One provider row in the support receipt."""
+
+    provider: str
+    status: WireCapabilityStatus
+    reason: str | None
+    package_version: str | None
+    element_kind: str | None
+    schema_valid: bool | None
+    parsed_session_count: int
+    parsed_message_count: int
+    construct_coverage: ConstructCoverage | None
+    validation_error: str | None = None
+
+    @property
+    def healthy(self) -> bool:
+        return self.status == "unsupported" or (
+            self.schema_valid is True
+            and self.parsed_session_count > 0
+            and self.parsed_message_count > 0
+            and self.validation_error is None
+        )
+
+
+@dataclass(frozen=True)
+class WireSupportReceipt:
+    """Registry-derived, deterministic support and coverage receipt."""
+
+    catalog_providers: tuple[str, ...]
+    entries: tuple[WireSupportEntry, ...]
+    missing_routes: tuple[str, ...]
+
+    @property
+    def supported_count(self) -> int:
+        return sum(entry.status == "supported" for entry in self.entries)
+
+    @property
+    def unsupported_count(self) -> int:
+        return sum(entry.status == "unsupported" for entry in self.entries)
+
+    @property
+    def validated_supported_count(self) -> int:
+        return sum(entry.status == "supported" and entry.healthy for entry in self.entries)
+
+    @property
+    def complete(self) -> bool:
+        return not self.missing_routes and all(entry.healthy for entry in self.entries)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "catalog_providers": list(self.catalog_providers),
+            "supported_count": self.supported_count,
+            "unsupported_count": self.unsupported_count,
+            "validated_supported_count": self.validated_supported_count,
+            "missing_routes": list(self.missing_routes),
+            "complete": self.complete,
+            "entries": [
+                {
+                    "provider": entry.provider,
+                    "status": entry.status,
+                    "reason": entry.reason,
+                    "package_version": entry.package_version,
+                    "element_kind": entry.element_kind,
+                    "schema_valid": entry.schema_valid,
+                    "parsed_session_count": entry.parsed_session_count,
+                    "parsed_message_count": entry.parsed_message_count,
+                    "validation_error": entry.validation_error,
+                    "construct_coverage": (
+                        {
+                            "schema_keywords": list(entry.construct_coverage.schema_keywords),
+                            "exercised_keywords": list(entry.construct_coverage.exercised_keywords),
+                            "missing_keywords": list(entry.construct_coverage.missing_keywords),
+                            "complete": entry.construct_coverage.complete,
+                        }
+                        if entry.construct_coverage is not None
+                        else None
+                    ),
+                }
+                for entry in self.entries
+            ],
+        }
 
 
 # Per-provider wire format configs — the only manual piece (~50 lines).
@@ -69,9 +194,269 @@ PROVIDER_WIRE_FORMATS: dict[str, WireFormat] = {
 }
 
 
+# All catalog providers must have a route here.  The three unsupported routes
+# are explicit capabilities, not implicit generator fallbacks.
+PROVIDER_WIRE_ROUTES: dict[str, WireRoute] = {
+    **{
+        provider: WireRoute(status="supported", wire_format=wire_format)
+        for provider, wire_format in PROVIDER_WIRE_FORMATS.items()
+    },
+    "browser-capture": WireRoute(
+        status="unsupported",
+        reason="browser-capture is an envelope with provider-specific typed turns, not a generic export wire format",
+    ),
+    "gemini-cli": WireRoute(
+        status="unsupported",
+        reason="gemini-cli requires its checkpoint document parser semantics, which this generic adapter does not model",
+    ),
+    "hermes": WireRoute(
+        status="unsupported",
+        reason="hermes requires local-agent session-document semantics, which this generic adapter does not model",
+    ),
+}
+
+# Descriptive alias for callers that care about capability status rather than
+# the historical executable-format name.
+PROVIDER_WIRE_CAPABILITIES = PROVIDER_WIRE_ROUTES
+
+_STRUCTURAL_SCHEMA_KEYWORDS = frozenset(
+    {"$ref", "additionalProperties", "anyOf", "items", "oneOf", "properties", "required", "type"}
+)
+
+
+def _schema_constructs(schema: object, result: set[str] | None = None) -> set[str]:
+    if result is None:
+        result = set()
+    if isinstance(schema, Mapping):
+        for keyword, value in schema.items():
+            if keyword not in _STRUCTURAL_SCHEMA_KEYWORDS:
+                continue
+            if keyword == "type":
+                if isinstance(value, str):
+                    result.add(f"type:{value}")
+                elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+                    result.update(f"type:{item}" for item in value if isinstance(item, str))
+            else:
+                result.add(keyword)
+        for value in schema.values():
+            _schema_constructs(value, result)
+    elif isinstance(schema, Sequence) and not isinstance(schema, (str, bytes)):
+        for value in schema:
+            _schema_constructs(value, result)
+    return result
+
+
+def _json_value_types(value: JSONValue, result: set[str] | None = None) -> set[str]:
+    if result is None:
+        result = set()
+    if isinstance(value, dict):
+        result.add("object")
+        for child in value.values():
+            _json_value_types(child, result)
+    elif isinstance(value, list):
+        result.add("array")
+        for child in value:
+            _json_value_types(child, result)
+    elif value is None:
+        result.add("null")
+    elif isinstance(value, bool):
+        result.add("boolean")
+    elif isinstance(value, int):
+        result.update(("integer", "number"))
+    elif isinstance(value, float):
+        result.add("number")
+    elif isinstance(value, str):
+        result.add("string")
+    return result
+
+
+def construct_coverage(
+    schema: SchemaRecord,
+    payloads: Sequence[JSONValue],
+    *,
+    handler_names: Collection[str] | None = None,
+) -> ConstructCoverage:
+    """Compare schema constructs with generated values and live handlers.
+
+    Type constructs are reported individually (for example ``type:array``),
+    which makes removal of one recursive runtime handler visible in the
+    receipt even when another construct still generates valid JSON.
+    """
+
+    if handler_names is None:
+        from polylogue.schemas.synthetic.runtime import SCHEMA_CONSTRUCT_HANDLERS
+
+        handler_names = SCHEMA_CONSTRUCT_HANDLERS.keys()
+    handlers = set(handler_names)
+    schema_keywords = _schema_constructs(schema)
+    value_types: set[str] = set()
+    for payload in payloads:
+        _json_value_types(payload, value_types)
+
+    exercised: set[str] = set()
+    for construct in schema_keywords:
+        if construct.startswith("type:"):
+            type_name = construct.removeprefix("type:")
+            if type_name in handlers and type_name in value_types:
+                exercised.add(construct)
+        elif (
+            (construct in handlers and payloads)
+            or (construct == "properties" and "object" in value_types)
+            or (construct == "items" and "array" in value_types)
+            or (construct == "required" and "object" in value_types)
+        ):
+            exercised.add(construct)
+
+    return ConstructCoverage(
+        schema_keywords=tuple(sorted(schema_keywords)),
+        exercised_keywords=tuple(sorted(exercised)),
+        missing_keywords=tuple(sorted(schema_keywords - exercised)),
+    )
+
+
+def build_wire_support_receipt(*, registry: object | None = None, seed: int = 20260805) -> WireSupportReceipt:
+    """Validate executable routes through the selected schema and parser.
+
+    The provider set comes from the package registry.  The parser call is the
+    public ``parse_payload`` entry point used by production dispatch, so a
+    route is healthy only when its generated artifact validates and produces a
+    non-empty parsed session.
+    """
+
+    if registry is None:
+        from polylogue.schemas.runtime_registry import SchemaRegistry
+
+        registry = SchemaRegistry()
+    from polylogue.schemas.synthetic.core import SyntheticCorpus
+    from polylogue.schemas.validator import validate_provider_export
+    from polylogue.sources.dispatch import parse_payload
+
+    catalog_providers = tuple(sorted(registry.list_providers()))  # type: ignore[attr-defined]
+    entries: list[WireSupportEntry] = []
+    missing_routes: list[str] = []
+    for provider in catalog_providers:
+        route = PROVIDER_WIRE_ROUTES.get(provider)
+        package = registry.get_package(provider, version="default")  # type: ignore[attr-defined]
+        package_version = package.version if package is not None else None
+        element_kind = package.default_element_kind if package is not None else None
+        if route is None:
+            missing_routes.append(provider)
+            entries.append(
+                WireSupportEntry(
+                    provider=provider,
+                    status="unsupported",
+                    reason="no explicit synthetic wire route",
+                    package_version=package_version,
+                    element_kind=element_kind,
+                    schema_valid=None,
+                    parsed_session_count=0,
+                    parsed_message_count=0,
+                    construct_coverage=None,
+                    validation_error="missing route",
+                )
+            )
+            continue
+        if route.status == "unsupported":
+            entries.append(
+                WireSupportEntry(
+                    provider=provider,
+                    status=route.status,
+                    reason=route.reason,
+                    package_version=package_version,
+                    element_kind=element_kind,
+                    schema_valid=None,
+                    parsed_session_count=0,
+                    parsed_message_count=0,
+                    construct_coverage=None,
+                )
+            )
+            continue
+
+        schema = registry.get_element_schema(  # type: ignore[attr-defined]
+            provider,
+            version="default",
+            element_kind=element_kind,
+        )
+        if schema is None or package is None or route.wire_format is None:
+            entries.append(
+                WireSupportEntry(
+                    provider=provider,
+                    status=route.status,
+                    reason=None,
+                    package_version=package_version,
+                    element_kind=element_kind,
+                    schema_valid=False,
+                    parsed_session_count=0,
+                    parsed_message_count=0,
+                    construct_coverage=None,
+                    validation_error="selected package schema is unavailable",
+                )
+            )
+            continue
+
+        schema_valid = False
+        parsed_sessions = []
+        payloads: list[JSONValue] = []
+        validation_error: str | None = None
+        try:
+            corpus = SyntheticCorpus.for_provider(provider, version=package.version, element_kind=element_kind)
+            batch = corpus.generate_batch(count=1, messages_per_session=range(4, 5), seed=seed)
+            raw = batch.raw_items[0]
+            if route.wire_format.encoding == "jsonl":
+                import json
+
+                payload: JSONValue = [json.loads(line) for line in raw.decode("utf-8").splitlines() if line.strip()]
+                payloads = payload if isinstance(payload, list) else []
+            else:
+                import json
+
+                payload = json.loads(raw)
+                payloads = [payload] if isinstance(payload, (dict, list)) else []
+            validation_results = [validate_provider_export(item, provider, strict=False) for item in payloads]
+            schema_valid = bool(validation_results) and all(result.is_valid for result in validation_results)
+            if not schema_valid:
+                validation_error = "; ".join(error for result in validation_results for error in result.errors) or (
+                    "selected package schema rejected generated payload"
+                )
+            parsed_sessions = parse_payload(provider, payload, f"synthetic-wire-receipt:{provider}")
+        except Exception as exc:  # Receipt records route failures instead of hiding them.
+            validation_error = f"{type(exc).__name__}: {exc}"
+
+        coverage = construct_coverage(schema, payloads)
+        entries.append(
+            WireSupportEntry(
+                provider=provider,
+                status=route.status,
+                reason=None,
+                package_version=package_version,
+                element_kind=element_kind,
+                schema_valid=schema_valid,
+                parsed_session_count=len(parsed_sessions),
+                parsed_message_count=sum(len(session.messages) for session in parsed_sessions),
+                construct_coverage=coverage,
+                validation_error=validation_error,
+            )
+        )
+
+    return WireSupportReceipt(
+        catalog_providers=catalog_providers,
+        entries=tuple(entries),
+        missing_routes=tuple(sorted(missing_routes)),
+    )
+
+
 __all__ = [
+    "ConstructCoverage",
     "PROVIDER_WIRE_FORMATS",
+    "PROVIDER_WIRE_CAPABILITIES",
+    "PROVIDER_WIRE_ROUTES",
     "TreeConfig",
+    "WireCapabilityStatus",
     "WireEncoding",
     "WireFormat",
+    "WireRoute",
+    "WireSupportEntry",
+    "WireSupportReceipt",
+    "build_wire_support_receipt",
+    "construct_coverage",
 ]

--- a/polylogue/schemas/synthetic/wire_formats.py
+++ b/polylogue/schemas/synthetic/wire_formats.py
@@ -236,102 +236,174 @@ _STRUCTURAL_SCHEMA_KEYWORDS = frozenset(
 )
 
 
-def _schema_constructs(schema: object, result: set[str] | None = None) -> set[str]:
-    if result is None:
-        result = set()
-    if isinstance(schema, Mapping):
-        for keyword, value in schema.items():
-            if keyword not in _STRUCTURAL_SCHEMA_KEYWORDS:
-                continue
-            if keyword == "type":
-                if isinstance(value, str):
-                    result.add(f"type:{value}")
-                elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
-                    result.update(f"type:{item}" for item in value if isinstance(item, str))
-            else:
-                result.add(keyword)
-        for value in schema.values():
-            _schema_constructs(value, result)
-    elif isinstance(schema, Sequence) and not isinstance(schema, (str, bytes)):
-        for value in schema:
-            _schema_constructs(value, result)
-    return result
+def _json_type_name(value: JSONValue) -> str:
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if value is None:
+        return "null"
+    if isinstance(value, list):
+        return "array"
+    return "object"
 
 
-def _json_value_types(value: JSONValue, result: set[str] | None = None) -> set[str]:
-    if result is None:
-        result = set()
-    if isinstance(value, dict):
-        result.add("object")
-        for child in value.values():
-            _json_value_types(child, result)
-    elif isinstance(value, list):
-        result.add("array")
-        for child in value:
-            _json_value_types(child, result)
-    elif value is None:
-        result.add("null")
-    elif isinstance(value, bool):
-        result.add("boolean")
-    elif isinstance(value, int):
-        result.update(("integer", "number"))
-    elif isinstance(value, float):
-        result.add("number")
-    elif isinstance(value, str):
-        result.add("string")
-    return result
+def _type_matches(expected: str, actual: str) -> bool:
+    return expected == actual or (expected == "number" and actual == "integer")
 
 
-def _payload_structure_constructs(
-    schema: object,
-    payload: JSONValue,
-    result: set[str] | None = None,
-) -> set[str]:
-    if result is None:
-        result = set()
-    if not isinstance(schema, Mapping) or not isinstance(payload, dict):
-        return result
+def _coverage_key(keyword: str, path: str) -> str:
+    return keyword if path == "$" else f"{keyword}@{path}"
 
-    properties = schema.get("properties")
-    property_names = set(properties) if isinstance(properties, Mapping) else set()
-    if property_names & payload.keys():
-        result.add("properties")
 
-    required = schema.get("required")
-    required_names = {item for item in required if isinstance(item, str)} if isinstance(required, list) else set()
-    if "required" in schema and required_names <= payload.keys():
-        result.add("required")
+def _schema_type_names(schema: Mapping[str, object]) -> tuple[str, ...]:
+    schema_type = schema.get("type")
+    if isinstance(schema_type, str):
+        return (schema_type,)
+    if isinstance(schema_type, Sequence) and not isinstance(schema_type, (str, bytes)):
+        return tuple(item for item in schema_type if isinstance(item, str))
+    return ()
 
-    if "additionalProperties" in schema:
-        extra_names = payload.keys() - property_names
-        if schema.get("additionalProperties") is False:
-            if not extra_names:
-                result.add("additionalProperties")
-        elif extra_names:
-            result.add("additionalProperties")
 
-    if isinstance(properties, Mapping):
-        for name, child_schema in properties.items():
-            if isinstance(name, str) and name in payload:
-                _payload_structure_constructs(child_schema, payload[name], result)
-
-    items = schema.get("items")
-    if isinstance(items, Mapping) and isinstance(payload, list):
-        for item in payload:
-            _payload_structure_constructs(items, item, result)
-
-    additional_schema = schema.get("additionalProperties")
-    if isinstance(additional_schema, Mapping):
-        for name, item in payload.items():
-            if name not in property_names:
-                _payload_structure_constructs(additional_schema, item, result)
-
+def _matching_variants(schema: Mapping[str, object], payload: JSONValue) -> list[Mapping[str, object]]:
+    actual_type = _json_type_name(payload)
     for keyword in ("anyOf", "oneOf"):
         variants = schema.get(keyword)
-        if isinstance(variants, list):
-            for variant in variants:
-                _payload_structure_constructs(variant, payload, result)
-    return result
+        if not isinstance(variants, list):
+            continue
+        matches: list[Mapping[str, object]] = []
+        for variant in variants:
+            if not isinstance(variant, Mapping):
+                continue
+            declared_types = _schema_type_names(variant)
+            if declared_types and not any(_type_matches(expected, actual_type) for expected in declared_types):
+                continue
+            required = variant.get("required")
+            required_names = (
+                {item for item in required if isinstance(item, str)} if isinstance(required, list) else set()
+            )
+            if required_names and (not isinstance(payload, dict) or not required_names <= payload.keys()):
+                continue
+            matches.append(variant)
+        if matches:
+            return matches
+        return [variant for variant in variants if isinstance(variant, Mapping)]
+    return []
+
+
+def _collect_payload_coverage(
+    schema: object,
+    payload: JSONValue,
+    *,
+    path: str,
+    handlers: set[str],
+    schema_keywords: set[str],
+    exercised_keywords: set[str],
+) -> None:
+    if not isinstance(schema, Mapping):
+        return
+
+    declared_types = _schema_type_names(schema)
+    actual_type = _json_type_name(payload)
+    if declared_types:
+        matched_types = tuple(expected for expected in declared_types if _type_matches(expected, actual_type))
+        types_to_report = matched_types or declared_types
+        for expected in types_to_report:
+            key = _coverage_key(f"type:{expected}", path)
+            schema_keywords.add(key)
+            if expected in handlers and _type_matches(expected, actual_type):
+                exercised_keywords.add(key)
+
+    for keyword in ("anyOf", "oneOf"):
+        if isinstance(schema.get(keyword), list):
+            key = _coverage_key(keyword, path)
+            schema_keywords.add(key)
+            if keyword in handlers:
+                exercised_keywords.add(key)
+    for variant in _matching_variants(schema, payload):
+        _collect_payload_coverage(
+            variant,
+            payload,
+            path=path,
+            handlers=handlers,
+            schema_keywords=schema_keywords,
+            exercised_keywords=exercised_keywords,
+        )
+
+    if isinstance(payload, dict):
+        properties = schema.get("properties")
+        property_names = set(properties) if isinstance(properties, Mapping) else set()
+        if isinstance(properties, Mapping):
+            key = _coverage_key("properties", path)
+            schema_keywords.add(key)
+            if property_names & payload.keys():
+                exercised_keywords.add(key)
+
+        if "required" in schema:
+            key = _coverage_key("required", path)
+            schema_keywords.add(key)
+            required = schema.get("required")
+            required_names = (
+                {item for item in required if isinstance(item, str)} if isinstance(required, list) else set()
+            )
+            if required_names <= payload.keys():
+                exercised_keywords.add(key)
+
+        if "additionalProperties" in schema:
+            extra_names = payload.keys() - property_names
+            additional_schema = schema.get("additionalProperties")
+            if additional_schema is False:
+                key = _coverage_key("additionalProperties", path)
+                schema_keywords.add(key)
+                if not extra_names:
+                    exercised_keywords.add(key)
+            elif extra_names:
+                key = _coverage_key("additionalProperties", path)
+                schema_keywords.add(key)
+                exercised_keywords.add(key)
+
+        if isinstance(properties, Mapping):
+            for name, child_schema in properties.items():
+                if isinstance(name, str) and name in payload:
+                    _collect_payload_coverage(
+                        child_schema,
+                        payload[name],
+                        path=f"{path}.properties.{name}",
+                        handlers=handlers,
+                        schema_keywords=schema_keywords,
+                        exercised_keywords=exercised_keywords,
+                    )
+
+        additional_schema = schema.get("additionalProperties")
+        if isinstance(additional_schema, Mapping):
+            for name, item in payload.items():
+                if name not in property_names:
+                    _collect_payload_coverage(
+                        additional_schema,
+                        item,
+                        path=f"{path}.additionalProperties.{name}",
+                        handlers=handlers,
+                        schema_keywords=schema_keywords,
+                        exercised_keywords=exercised_keywords,
+                    )
+
+    if isinstance(payload, list) and isinstance(schema.get("items"), Mapping):
+        key = _coverage_key("items", path)
+        schema_keywords.add(key)
+        exercised_keywords.add(key)
+        for index, item in enumerate(payload):
+            _collect_payload_coverage(
+                schema["items"],
+                item,
+                path=f"{path}.items[{index}]",
+                handlers=handlers,
+                schema_keywords=schema_keywords,
+                exercised_keywords=exercised_keywords,
+            )
 
 
 def construct_coverage(
@@ -352,21 +424,17 @@ def construct_coverage(
 
         handler_names = SCHEMA_CONSTRUCT_HANDLERS.keys()
     handlers = set(handler_names)
-    schema_keywords = _schema_constructs(schema)
-    value_types: set[str] = set()
-    structure_constructs: set[str] = set()
-    for payload in payloads:
-        _json_value_types(payload, value_types)
-        _payload_structure_constructs(schema, payload, structure_constructs)
-
+    schema_keywords: set[str] = set()
     exercised: set[str] = set()
-    for construct in schema_keywords:
-        if construct.startswith("type:"):
-            type_name = construct.removeprefix("type:")
-            if type_name in handlers and type_name in value_types:
-                exercised.add(construct)
-        elif (construct in handlers and payloads) or construct in structure_constructs:
-            exercised.add(construct)
+    for payload in payloads:
+        _collect_payload_coverage(
+            schema,
+            payload,
+            path="$",
+            handlers=handlers,
+            schema_keywords=schema_keywords,
+            exercised_keywords=exercised,
+        )
 
     return ConstructCoverage(
         schema_keywords=tuple(sorted(schema_keywords)),

--- a/polylogue/schemas/synthetic/wire_formats.py
+++ b/polylogue/schemas/synthetic/wire_formats.py
@@ -6,14 +6,16 @@ tree vs. linear vs. JSONL, and message location paths.
 
 from __future__ import annotations
 
+import copy
+import re
 from collections.abc import Collection, Mapping, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal, TypeAlias
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeAlias, cast
 
 from polylogue.archive.raw_payload.decode import JSONValue
 
 if TYPE_CHECKING:
-    from polylogue.schemas.synthetic.models import SchemaRecord
+    from polylogue.schemas.synthetic.models import SchemaRecord, SyntheticGenerationBatch
 
 WireEncoding: TypeAlias = Literal["json", "jsonl"]
 WireCapabilityStatus: TypeAlias = Literal["supported", "unsupported"]
@@ -76,6 +78,8 @@ class ConstructCoverage:
     schema_keywords: tuple[str, ...]
     exercised_keywords: tuple[str, ...]
     missing_keywords: tuple[str, ...]
+    nonrepresentable_keywords: tuple[str, ...] = ()
+    nonrepresentable_reasons: tuple[tuple[str, str], ...] = ()
 
     @property
     def complete(self) -> bool:
@@ -157,6 +161,11 @@ class WireSupportReceipt:
                             "schema_keywords": list(entry.construct_coverage.schema_keywords),
                             "exercised_keywords": list(entry.construct_coverage.exercised_keywords),
                             "missing_keywords": list(entry.construct_coverage.missing_keywords),
+                            "nonrepresentable_keywords": list(entry.construct_coverage.nonrepresentable_keywords),
+                            "nonrepresentable_reasons": [
+                                {"keyword": keyword, "reason": reason}
+                                for keyword, reason in entry.construct_coverage.nonrepresentable_reasons
+                            ],
                             "complete": entry.construct_coverage.complete,
                         }
                         if entry.construct_coverage is not None
@@ -236,6 +245,22 @@ _STRUCTURAL_SCHEMA_KEYWORDS = frozenset(
 )
 
 
+class _CoverageCorpus(Protocol):
+    schema: SchemaRecord
+    workload_profile: SchemaRecord | None
+    _coverage_branch_choices: dict[str, int]
+    _coverage_type_choices: dict[str, str]
+    _coverage_null_paths: set[str]
+    _coverage_witness_mode: bool
+
+    def generate_batch(
+        self,
+        count: int = 5,
+        messages_per_session: range = range(3, 15),
+        seed: int | None = None,
+    ) -> SyntheticGenerationBatch: ...
+
+
 def _json_type_name(value: JSONValue) -> str:
     if isinstance(value, bool):
         return "boolean"
@@ -260,6 +285,78 @@ def _coverage_key(keyword: str, path: str) -> str:
     return keyword if path == "$" else f"{keyword}@{path}"
 
 
+def _runtime_coverage_path(path: str) -> str:
+    # Union segments are part of the runtime path. A nested union must not
+    # reuse its parent's key, since its branch choice is independent.
+    return path
+
+
+def _route_nonrepresentable_reasons(provider: str, missing_keywords: Collection[str]) -> dict[str, str]:
+    """Prove nodes discarded by a provider's wire normalizer are unreachable."""
+    reasons: dict[str, str] = {}
+    prefixes: tuple[tuple[str, str], ...]
+    if provider == "codex":
+        prefixes = (("$.properties.payload", "Codex flat-record shaping removes the payload envelope"),)
+    elif provider == "claude-ai":
+        prefixes = (
+            (
+                "$.properties.chat_messages.items[*]",
+                "Claude AI wire shaping clears each chat message and retains only uuid, sender, text, and created_at",
+            ),
+        )
+    elif provider == "gemini":
+        prefixes = (
+            (
+                "$.properties.chunkedPrompt.properties.chunks.items[*]",
+                "Gemini wire shaping clears each chunk and retains only role, text, and createTime",
+            ),
+            (
+                "$.properties.chunkedPrompt.properties.pendingInputs",
+                "Gemini linear wire shaping rebuilds chunkedPrompt and does not carry pendingInputs",
+            ),
+        )
+    elif provider == "chatgpt":
+        prefixes = (
+            (
+                "$.properties.raw_provider_payload.properties.mapping",
+                "ChatGPT coverage wire shaping removes the nested raw-provider mapping before the parser route, matching the tree route's parser-owned mapping container",
+            ),
+        )
+    elif provider == "claude-code":
+        prefixes = (
+            (
+                "$.properties.message.properties.content.anyOf[1].items[*].properties.content.anyOf[1]",
+                "Claude Code wire shaping preserves message content but its fallback emits scalar text and supported block forms, never nested array content/source blocks",
+            ),
+        )
+    else:
+        prefixes = ()
+
+    retained_suffixes = {
+        "$.properties.chat_messages.items[*].properties.uuid",
+        "$.properties.chat_messages.items[*].properties.text",
+        "$.properties.chat_messages.items[*].properties.created_at",
+        "$.properties.chunkedPrompt.properties.chunks.items[*].properties.role",
+        "$.properties.chunkedPrompt.properties.chunks.items[*].properties.text",
+        "$.properties.chunkedPrompt.properties.chunks.items[*].properties.createTime",
+    }
+    for keyword in missing_keywords:
+        path = keyword.split("@", 1)[1] if "@" in keyword else "$"
+        if (
+            provider == "chatgpt"
+            and keyword.startswith("type:null@")
+            and path.endswith(".properties.message")
+            and ".properties.mapping.additionalProperties.*." in path
+        ):
+            reasons[keyword] = "ChatGPT wire shaping coerces a null message field to the route's object record"
+            continue
+        for prefix, reason in prefixes:
+            if path.startswith(prefix) and path not in retained_suffixes:
+                reasons[keyword] = reason
+                break
+    return reasons
+
+
 def _schema_type_names(schema: Mapping[str, object]) -> tuple[str, ...]:
     schema_type = schema.get("type")
     if isinstance(schema_type, str):
@@ -269,14 +366,14 @@ def _schema_type_names(schema: Mapping[str, object]) -> tuple[str, ...]:
     return ()
 
 
-def _matching_variants(schema: Mapping[str, object], payload: JSONValue) -> list[Mapping[str, object]]:
+def _matching_variants(schema: Mapping[str, object], payload: JSONValue) -> list[tuple[int, Mapping[str, object]]]:
     actual_type = _json_type_name(payload)
     for keyword in ("anyOf", "oneOf"):
         variants = schema.get(keyword)
         if not isinstance(variants, list):
             continue
-        matches: list[Mapping[str, object]] = []
-        for variant in variants:
+        matches: list[tuple[int, Mapping[str, object]]] = []
+        for index, variant in enumerate(variants):
             if not isinstance(variant, Mapping):
                 continue
             declared_types = _schema_type_names(variant)
@@ -288,11 +385,312 @@ def _matching_variants(schema: Mapping[str, object], payload: JSONValue) -> list
             )
             if required_names and (not isinstance(payload, dict) or not required_names <= payload.keys()):
                 continue
-            matches.append(variant)
+            matches.append((index, variant))
         if matches:
             return matches
-        return [variant for variant in variants if isinstance(variant, Mapping)]
+        return []
     return []
+
+
+def _collect_schema_obligations(
+    schema: object,
+    *,
+    path: str,
+    obligations: set[str],
+) -> None:
+    """Collect node-local obligations without consulting generated payloads."""
+    if not isinstance(schema, Mapping):
+        return
+
+    for schema_type in _schema_type_names(schema):
+        obligations.add(_coverage_key(f"type:{schema_type}", path))
+
+    for keyword in ("anyOf", "oneOf"):
+        variants = schema.get(keyword)
+        if not isinstance(variants, list):
+            continue
+        obligations.add(_coverage_key(keyword, path))
+        for index, variant in enumerate(variants):
+            if isinstance(variant, Mapping):
+                _collect_schema_obligations(
+                    variant,
+                    path=f"{path}.{keyword}[{index}]",
+                    obligations=obligations,
+                )
+
+    properties = schema.get("properties")
+    if isinstance(properties, Mapping):
+        obligations.add(_coverage_key("properties", path))
+        for name, child_schema in properties.items():
+            if isinstance(name, str):
+                _collect_schema_obligations(
+                    child_schema,
+                    path=f"{path}.properties.{name}",
+                    obligations=obligations,
+                )
+
+    if "required" in schema:
+        obligations.add(_coverage_key("required", path))
+
+    if "additionalProperties" in schema:
+        obligations.add(_coverage_key("additionalProperties", path))
+        additional_schema = schema.get("additionalProperties")
+        if isinstance(additional_schema, Mapping):
+            _collect_schema_obligations(
+                additional_schema,
+                path=f"{path}.additionalProperties.*",
+                obligations=obligations,
+            )
+
+    items = schema.get("items")
+    if isinstance(items, Mapping):
+        obligations.add(_coverage_key("items", path))
+        _collect_schema_obligations(items, path=f"{path}.items[*]", obligations=obligations)
+
+
+def _coverage_branch_plans(
+    schema: object,
+    *,
+    path: str = "$",
+    choices: Mapping[str, int] | None = None,
+    plans: list[dict[str, int]] | None = None,
+) -> list[dict[str, int]]:
+    """Return one bounded branch-choice plan per schema union branch."""
+    if plans is None:
+        plans = []
+    if choices is None:
+        choices = {}
+    if not isinstance(schema, Mapping):
+        return plans
+
+    for keyword in ("anyOf", "oneOf"):
+        variants = schema.get(keyword)
+        if not isinstance(variants, list):
+            continue
+        for index, variant in enumerate(variants):
+            if not isinstance(variant, Mapping):
+                continue
+            branch_choices = dict(choices)
+            branch_choices[_runtime_coverage_path(path)] = index
+            plans.append(branch_choices)
+            _coverage_branch_plans(
+                variant,
+                path=f"{path}.{keyword}[{index}]",
+                choices=branch_choices,
+                plans=plans,
+            )
+
+    properties = schema.get("properties")
+    if isinstance(properties, Mapping):
+        for name, child_schema in properties.items():
+            if isinstance(name, str):
+                _coverage_branch_plans(
+                    child_schema,
+                    path=f"{path}.properties.{name}",
+                    choices=choices,
+                    plans=plans,
+                )
+
+    additional_schema = schema.get("additionalProperties")
+    if isinstance(additional_schema, Mapping):
+        _coverage_branch_plans(
+            additional_schema,
+            path=f"{path}.additionalProperties.*",
+            choices=choices,
+            plans=plans,
+        )
+
+    items = schema.get("items")
+    if isinstance(items, Mapping):
+        _coverage_branch_plans(items, path=f"{path}.items[*]", choices=choices, plans=plans)
+    return plans
+
+
+def _force_coverage_frequencies(value: object) -> None:
+    if not isinstance(value, dict):
+        return
+    if "x-polylogue-frequency" in value:
+        value["x-polylogue-frequency"] = 1.0
+    properties = value.get("properties")
+    if isinstance(properties, Mapping):
+        for child in properties.values():
+            _force_coverage_frequencies(child)
+    additional_schema = value.get("additionalProperties")
+    _force_coverage_frequencies(additional_schema)
+    _force_coverage_frequencies(value.get("items"))
+    for keyword in ("anyOf", "oneOf"):
+        variants = value.get(keyword)
+        if isinstance(variants, list):
+            for variant in variants:
+                _force_coverage_frequencies(variant)
+
+
+def _collect_type_choices(
+    schema: object,
+    *,
+    path: str = "$",
+    choices: list[tuple[str, str]] | None = None,
+) -> list[tuple[str, str]]:
+    if choices is None:
+        choices = []
+    if not isinstance(schema, Mapping):
+        return choices
+    schema_type = schema.get("type")
+    if isinstance(schema_type, list):
+        choices.extend((path, item) for item in schema_type if isinstance(item, str))
+    properties = schema.get("properties")
+    if isinstance(properties, Mapping):
+        for name, child in properties.items():
+            if isinstance(name, str):
+                _collect_type_choices(child, path=f"{path}.properties.{name}", choices=choices)
+    additional_schema = schema.get("additionalProperties")
+    if isinstance(additional_schema, Mapping):
+        _collect_type_choices(additional_schema, path=f"{path}.additionalProperties.*", choices=choices)
+    items = schema.get("items")
+    if isinstance(items, Mapping):
+        _collect_type_choices(items, path=f"{path}.items[*]", choices=choices)
+    for keyword in ("anyOf", "oneOf"):
+        variants = schema.get(keyword)
+        if isinstance(variants, list):
+            for index, variant in enumerate(variants):
+                _collect_type_choices(variant, path=f"{path}.{keyword}[{index}]", choices=choices)
+    return choices
+
+
+def _coverage_path_matches_plan(path: str, plan: Mapping[str, int]) -> bool:
+    for match in re.finditer(r"\.(?:anyOf|oneOf)\[\d+\]", path):
+        branch_index = int(match.group(0).split("[")[1][:-1])
+        if plan.get(path[: match.start()]) != branch_index:
+            return False
+    return True
+
+
+def _required_structural_type_choices(
+    path: str,
+    type_options: Mapping[str, tuple[str, ...]],
+) -> dict[str, str]:
+    choices: dict[str, str] = {}
+    for ancestor_path, ancestor_options in type_options.items():
+        if not path.startswith(f"{ancestor_path}."):
+            continue
+        relative_path = path.removeprefix(ancestor_path)
+        wanted_type = "array" if relative_path.startswith(".items[") else "object"
+        structural_type = next(
+            (item for item in ancestor_options if item == wanted_type),
+            next((item for item in ancestor_options if item in {"array", "object"}), None),
+        )
+        if structural_type is not None:
+            choices[ancestor_path] = structural_type
+    return choices
+
+
+def _type_choice_witness_groups(
+    choices: Collection[tuple[str, Mapping[str, str]]],
+) -> list[list[tuple[str, Mapping[str, str]]]]:
+    """Partition type alternatives into bounded, path-independent witnesses."""
+    groups: list[list[tuple[str, Mapping[str, str]]]] = []
+    for choice in sorted(choices, key=lambda value: (value[0].count("."), value[0], tuple(sorted(value[1].items())))):
+        path = choice[0]
+        for group in groups:
+            if all(
+                path != other_path
+                and not path.startswith(f"{other_path}.")
+                and not other_path.startswith(f"{path}.")
+                and all(other_choices.get(key) in {None, value} for key, value in choice[1].items())
+                and all(choice[1].get(key) in {None, value} for key, value in other_choices.items())
+                for other_path, other_choices in group
+            ):
+                group.append(choice)
+                break
+        else:
+            groups.append([choice])
+    return groups
+
+
+def generate_coverage_witnesses(
+    corpus: _CoverageCorpus,
+    *,
+    seed: int,
+    max_witnesses: int = 128,
+) -> list[bytes]:
+    """Generate bounded, route-shaped witnesses for schema-node coverage."""
+    plans: list[dict[str, int]] = [{}] + _coverage_branch_plans(corpus.schema)
+    unique_plans: list[dict[str, int]] = []
+    seen: set[tuple[tuple[str, int], ...]] = set()
+    for plan in plans:
+        key = tuple(sorted(plan.items()))
+        if key in seen:
+            continue
+        seen.add(key)
+        unique_plans.append(plan)
+    type_choices = _collect_type_choices(corpus.schema)
+    type_options: dict[str, tuple[str, ...]] = {}
+    for type_path, type_name in type_choices:
+        type_options[type_path] = (*type_options.get(type_path, ()), type_name)
+    choices_by_plan: dict[int, list[tuple[str, Mapping[str, str]]]] = {}
+    for type_path, type_name in type_choices:
+        assignment: dict[str, str] = {type_path: type_name}
+        assignment.update(_required_structural_type_choices(type_path, type_options))
+        for plan_index, plan in enumerate(unique_plans):
+            if _coverage_path_matches_plan(type_path, plan):
+                choices_by_plan.setdefault(plan_index, []).append((type_path, assignment))
+                break
+
+    choice_groups = {
+        plan_index: _type_choice_witness_groups(choices) for plan_index, choices in choices_by_plan.items()
+    }
+    witness_count = len(unique_plans) + sum(len(groups) for groups in choice_groups.values())
+    if witness_count > max_witnesses:
+        raise ValueError(f"coverage witness plan has {witness_count} witnesses, exceeding bound {max_witnesses}")
+
+    original_schema = corpus.schema
+    original_profile = corpus.workload_profile
+    original_choices = corpus._coverage_branch_choices
+    original_type_choices = corpus._coverage_type_choices
+    original_null_paths = corpus._coverage_null_paths
+    original_mode = corpus._coverage_witness_mode
+    raw_items: list[bytes] = []
+    try:
+        corpus.schema = copy.deepcopy(original_schema)
+        _force_coverage_frequencies(corpus.schema)
+        corpus.workload_profile = None
+        corpus._coverage_witness_mode = True
+        corpus._coverage_type_choices = {}
+        corpus._coverage_null_paths = set()
+        plan_type_choices = {
+            index: {
+                key: value
+                for branch_path in plan
+                for key, value in _required_structural_type_choices(branch_path, type_options).items()
+            }
+            for index, plan in enumerate(unique_plans)
+        }
+        for index, plan in enumerate(unique_plans):
+            corpus._coverage_branch_choices = plan
+            corpus._coverage_type_choices = plan_type_choices[index]
+            batch = corpus.generate_batch(count=1, messages_per_session=range(4, 5), seed=seed + index)
+            raw_items.extend(batch.raw_items)
+        for plan_index, groups in choice_groups.items():
+            for group in groups:
+                group_type_choices = {path: type_name for _, choices in group for path, type_name in choices.items()}
+                corpus._coverage_type_choices = {**plan_type_choices[plan_index], **group_type_choices}
+                corpus._coverage_branch_choices = unique_plans[plan_index]
+                batch = corpus.generate_batch(count=1, messages_per_session=range(4, 5), seed=seed + len(raw_items))
+                raw_items.extend(batch.raw_items)
+        corpus._coverage_branch_choices = {}
+        corpus._coverage_type_choices = {}
+        corpus._coverage_null_paths = set()
+        for index in range(len(raw_items), max_witnesses):
+            batch = corpus.generate_batch(count=1, messages_per_session=range(4, 5), seed=seed + index)
+            raw_items.extend(batch.raw_items)
+    finally:
+        corpus.schema = original_schema
+        corpus.workload_profile = original_profile
+        corpus._coverage_branch_choices = original_choices
+        corpus._coverage_type_choices = original_type_choices
+        corpus._coverage_null_paths = original_null_paths
+        corpus._coverage_witness_mode = original_mode
+    return raw_items
 
 
 def _collect_payload_coverage(
@@ -319,33 +717,31 @@ def _collect_payload_coverage(
                 exercised_keywords.add(key)
 
     for keyword in ("anyOf", "oneOf"):
-        if isinstance(schema.get(keyword), list):
-            key = _coverage_key(keyword, path)
-            schema_keywords.add(key)
-            if keyword in handlers:
-                exercised_keywords.add(key)
-    for variant in _matching_variants(schema, payload):
-        _collect_payload_coverage(
-            variant,
-            payload,
-            path=path,
-            handlers=handlers,
-            schema_keywords=schema_keywords,
-            exercised_keywords=exercised_keywords,
-        )
+        if not isinstance(schema.get(keyword), list):
+            continue
+        matches = _matching_variants(schema, payload)
+        key = _coverage_key(keyword, path)
+        if keyword in handlers and matches:
+            exercised_keywords.add(key)
+        for index, variant in matches:
+            _collect_payload_coverage(
+                variant,
+                payload,
+                path=f"{path}.{keyword}[{index}]",
+                handlers=handlers,
+                schema_keywords=schema_keywords,
+                exercised_keywords=exercised_keywords,
+            )
 
     if isinstance(payload, dict):
         properties = schema.get("properties")
         property_names = set(properties) if isinstance(properties, Mapping) else set()
         if isinstance(properties, Mapping):
             key = _coverage_key("properties", path)
-            schema_keywords.add(key)
-            if property_names & payload.keys():
-                exercised_keywords.add(key)
+            exercised_keywords.add(key)
 
         if "required" in schema:
             key = _coverage_key("required", path)
-            schema_keywords.add(key)
             required = schema.get("required")
             required_names = (
                 {item for item in required if isinstance(item, str)} if isinstance(required, list) else set()
@@ -356,14 +752,11 @@ def _collect_payload_coverage(
         if "additionalProperties" in schema:
             extra_names = payload.keys() - property_names
             additional_schema = schema.get("additionalProperties")
+            key = _coverage_key("additionalProperties", path)
             if additional_schema is False:
-                key = _coverage_key("additionalProperties", path)
-                schema_keywords.add(key)
                 if not extra_names:
                     exercised_keywords.add(key)
-            elif extra_names:
-                key = _coverage_key("additionalProperties", path)
-                schema_keywords.add(key)
+            elif additional_schema is True or extra_names:
                 exercised_keywords.add(key)
 
         if isinstance(properties, Mapping):
@@ -385,7 +778,7 @@ def _collect_payload_coverage(
                     _collect_payload_coverage(
                         additional_schema,
                         item,
-                        path=f"{path}.additionalProperties.{name}",
+                        path=f"{path}.additionalProperties.*",
                         handlers=handlers,
                         schema_keywords=schema_keywords,
                         exercised_keywords=exercised_keywords,
@@ -393,13 +786,13 @@ def _collect_payload_coverage(
 
     if isinstance(payload, list) and isinstance(schema.get("items"), Mapping):
         key = _coverage_key("items", path)
-        schema_keywords.add(key)
-        exercised_keywords.add(key)
-        for index, item in enumerate(payload):
+        if payload:
+            exercised_keywords.add(key)
+        for item in payload:
             _collect_payload_coverage(
                 schema["items"],
                 item,
-                path=f"{path}.items[{index}]",
+                path=f"{path}.items[*]",
                 handlers=handlers,
                 schema_keywords=schema_keywords,
                 exercised_keywords=exercised_keywords,
@@ -411,6 +804,9 @@ def construct_coverage(
     payloads: Sequence[JSONValue],
     *,
     handler_names: Collection[str] | None = None,
+    nonrepresentable_keywords: Collection[str] = (),
+    nonrepresentable_reason: str = "explicitly classified as nonrepresentable by the selected route",
+    nonrepresentable_reasons: Mapping[str, str] | None = None,
 ) -> ConstructCoverage:
     """Compare schema constructs with generated values and live handlers.
 
@@ -425,6 +821,7 @@ def construct_coverage(
         handler_names = SCHEMA_CONSTRUCT_HANDLERS.keys()
     handlers = set(handler_names)
     schema_keywords: set[str] = set()
+    _collect_schema_obligations(schema, path="$", obligations=schema_keywords)
     exercised: set[str] = set()
     for payload in payloads:
         _collect_payload_coverage(
@@ -436,10 +833,18 @@ def construct_coverage(
             exercised_keywords=exercised,
         )
 
+    nonrepresentable = tuple(sorted(set(nonrepresentable_keywords) & schema_keywords))
+    nonrepresentable_set = set(nonrepresentable)
+    reasons = tuple(
+        (keyword, (nonrepresentable_reasons or {}).get(keyword, nonrepresentable_reason))
+        for keyword in nonrepresentable
+    )
     return ConstructCoverage(
         schema_keywords=tuple(sorted(schema_keywords)),
         exercised_keywords=tuple(sorted(exercised)),
-        missing_keywords=tuple(sorted(schema_keywords - exercised)),
+        missing_keywords=tuple(sorted(schema_keywords - exercised - nonrepresentable_set)),
+        nonrepresentable_keywords=nonrepresentable,
+        nonrepresentable_reasons=reasons,
     )
 
 
@@ -457,7 +862,8 @@ def build_wire_support_receipt(*, registry: object | None = None, seed: int = 20
 
         registry = SchemaRegistry()
     from polylogue.schemas.synthetic.core import SyntheticCorpus
-    from polylogue.schemas.validator import validate_provider_export
+    from polylogue.schemas.synthetic.selection import select_synthetic_schema
+    from polylogue.schemas.validator import SchemaValidator, ValidationResult
     from polylogue.sources.dispatch import parse_payload
 
     catalog_providers = tuple(sorted(registry.list_providers()))  # type: ignore[attr-defined]
@@ -501,12 +907,7 @@ def build_wire_support_receipt(*, registry: object | None = None, seed: int = 20
             )
             continue
 
-        schema = registry.get_element_schema(  # type: ignore[attr-defined]
-            provider,
-            version="default",
-            element_kind=element_kind,
-        )
-        if schema is None or package is None or route.wire_format is None:
+        if package is None or route.wire_format is None:
             entries.append(
                 WireSupportEntry(
                     provider=provider,
@@ -527,38 +928,67 @@ def build_wire_support_receipt(*, registry: object | None = None, seed: int = 20
         parsed_sessions = []
         payloads: list[JSONValue] = []
         validation_error: str | None = None
+        selection = None
         try:
-            corpus = SyntheticCorpus.for_provider(provider, version=package.version, element_kind=element_kind)
-            batch = corpus.generate_batch(count=1, messages_per_session=range(4, 5), seed=seed)
-            raw = batch.raw_items[0]
-            if route.wire_format.encoding == "jsonl":
+            selection = select_synthetic_schema(
+                provider,
+                version="default",
+                element_kind=element_kind,
+                registry_factory=cast(Any, lambda: registry),
+            )
+            if selection.package_version != package.version or selection.element_kind != element_kind:
+                raise ValueError(
+                    "synthetic selection identity diverged from receipt package: "
+                    f"{selection.package_version}/{selection.element_kind} != {package.version}/{element_kind}"
+                )
+            if selection.wire_format != route.wire_format:
+                raise ValueError("synthetic selection wire format diverged from declared route")
+
+            corpus = SyntheticCorpus.from_selection(selection)
+            raw_items = [
+                corpus.generate_batch(count=1, messages_per_session=range(4, 5), seed=seed).raw_items[0],
+                *generate_coverage_witnesses(corpus, seed=seed + 1),
+            ]
+            validator = SchemaValidator(selection.schema, strict=False)
+            validation_results: list[ValidationResult] = []
+            for index, raw in enumerate(raw_items):
                 import json
 
-                payload: JSONValue = [json.loads(line) for line in raw.decode("utf-8").splitlines() if line.strip()]
-                payloads = payload if isinstance(payload, list) else []
-            else:
-                import json
-
-                payload = json.loads(raw)
-                payloads = [payload] if isinstance(payload, (dict, list)) else []
-            validation_results = [validate_provider_export(item, provider, strict=False) for item in payloads]
+                if route.wire_format.encoding == "jsonl":
+                    payload: JSONValue = [json.loads(line) for line in raw.decode("utf-8").splitlines() if line.strip()]
+                    payload_items = payload if isinstance(payload, list) else []
+                else:
+                    payload = json.loads(raw)
+                    payload_items = [payload] if isinstance(payload, (dict, list)) else []
+                payloads.extend(payload_items)
+                validation_results.extend(validator.validate(item) for item in payload_items)
+                parsed_sessions.extend(parse_payload(provider, payload, f"synthetic-wire-receipt:{provider}:{index}"))
             schema_valid = bool(validation_results) and all(result.is_valid for result in validation_results)
             if not schema_valid:
                 validation_error = "; ".join(error for result in validation_results for error in result.errors) or (
                     "selected package schema rejected generated payload"
                 )
-            parsed_sessions = parse_payload(provider, payload, f"synthetic-wire-receipt:{provider}")
         except Exception as exc:  # Receipt records route failures instead of hiding them.
             validation_error = f"{type(exc).__name__}: {exc}"
 
-        coverage = construct_coverage(schema, payloads)
+        if selection is not None:
+            witnessed = construct_coverage(selection.schema, payloads)
+            nonrepresentable_reasons = _route_nonrepresentable_reasons(provider, witnessed.missing_keywords)
+            coverage = construct_coverage(
+                selection.schema,
+                payloads,
+                nonrepresentable_keywords=nonrepresentable_reasons,
+                nonrepresentable_reasons=nonrepresentable_reasons,
+            )
+        else:
+            coverage = None
         entries.append(
             WireSupportEntry(
                 provider=provider,
                 status=route.status,
                 reason=None,
-                package_version=package_version,
-                element_kind=element_kind,
+                package_version=selection.package_version if selection is not None else package_version,
+                element_kind=selection.element_kind if selection is not None else element_kind,
                 schema_valid=schema_valid,
                 parsed_session_count=len(parsed_sessions),
                 parsed_message_count=sum(len(session.messages) for session in parsed_sessions),
@@ -589,4 +1019,5 @@ __all__ = [
     "UnsupportedSyntheticWireRouteError",
     "build_wire_support_receipt",
     "construct_coverage",
+    "generate_coverage_witnesses",
 ]

--- a/polylogue/schemas/synthetic/wire_formats.py
+++ b/polylogue/schemas/synthetic/wire_formats.py
@@ -19,6 +19,15 @@ WireEncoding: TypeAlias = Literal["json", "jsonl"]
 WireCapabilityStatus: TypeAlias = Literal["supported", "unsupported"]
 
 
+class UnsupportedSyntheticWireRouteError(ValueError):
+    """Raised when synthetic selection reaches an explicit unsupported route."""
+
+    def __init__(self, provider: str, reason: str) -> None:
+        self.provider = provider
+        self.reason = reason
+        super().__init__(f"Synthetic wire route unsupported for {provider}: {reason}")
+
+
 @dataclass(frozen=True)
 class TreeConfig:
     """Configuration for tree-structured message formats."""
@@ -94,6 +103,8 @@ class WireSupportEntry:
             self.schema_valid is True
             and self.parsed_session_count > 0
             and self.parsed_message_count > 0
+            and self.construct_coverage is not None
+            and self.construct_coverage.complete
             and self.validation_error is None
         )
 
@@ -188,19 +199,20 @@ PROVIDER_WIRE_FORMATS: dict[str, WireFormat] = {
         encoding="json",
         messages_path="chunkedPrompt.chunks",
     ),
-    "antigravity": WireFormat(
-        encoding="json",
-    ),
 }
 
 
-# All catalog providers must have a route here.  The three unsupported routes
+# All catalog providers must have a route here.  The unsupported routes
 # are explicit capabilities, not implicit generator fallbacks.
 PROVIDER_WIRE_ROUTES: dict[str, WireRoute] = {
     **{
         provider: WireRoute(status="supported", wire_format=wire_format)
         for provider, wire_format in PROVIDER_WIRE_FORMATS.items()
     },
+    "antigravity": WireRoute(
+        status="unsupported",
+        reason="antigravity requires the language-server .pb adapter and source-path semantics, which generic JSON generation does not exercise",
+    ),
     "browser-capture": WireRoute(
         status="unsupported",
         reason="browser-capture is an envelope with provider-specific typed turns, not a generic export wire format",
@@ -297,13 +309,14 @@ def construct_coverage(
     for construct in schema_keywords:
         if construct.startswith("type:"):
             type_name = construct.removeprefix("type:")
-            if type_name in handlers and type_name in value_types:
+            if type_name in handlers and payloads:
                 exercised.add(construct)
         elif (
             (construct in handlers and payloads)
             or (construct == "properties" and "object" in value_types)
             or (construct == "items" and "array" in value_types)
             or (construct == "required" and "object" in value_types)
+            or (construct == "additionalProperties" and "object" in value_types)
         ):
             exercised.add(construct)
 
@@ -457,6 +470,7 @@ __all__ = [
     "WireRoute",
     "WireSupportEntry",
     "WireSupportReceipt",
+    "UnsupportedSyntheticWireRouteError",
     "build_wire_support_receipt",
     "construct_coverage",
 ]

--- a/polylogue/storage/insights/session/profiles.py
+++ b/polylogue/storage/insights/session/profiles.py
@@ -350,13 +350,14 @@ def build_session_profile_record(
     evidence_search_text = profile_evidence_search_text(profile)
     inference_search_text = profile_inference_search_text(profile)
     source_updated_at = profile.updated_at.isoformat() if profile.updated_at else None
+    source_sort_timestamp = profile.updated_at or profile.created_at
     return SessionProfileRecord(
         session_id=SessionId(profile.session_id),
         logical_session_id=SessionId(resolved_logical_session_id),
         materializer_version=SESSION_INSIGHT_MATERIALIZER_VERSION,
         materialized_at=built_at,
         source_updated_at=source_updated_at,
-        source_sort_key=profile.updated_at.timestamp() if profile.updated_at else None,
+        source_sort_key=source_sort_timestamp.timestamp() if source_sort_timestamp else None,
         input_high_water_mark=source_updated_at,
         input_high_water_mark_source=classify_profile_hwm_source(profile.updated_at),
         input_row_count=profile.message_count,

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -820,6 +820,7 @@ def write_parsed_session_to_archive(
                 messages,
                 position_offset=position_offset,
                 duplicate_native_ids=duplicate_message_native_ids,
+                resolve_existing_parents=merge_append,
             )
             add_timing("index.parent_links", t0)
             t0 = time.perf_counter()
@@ -3508,6 +3509,7 @@ def _write_parent_links(
     *,
     position_offset: int = 0,
     duplicate_native_ids: frozenset[str] = frozenset(),
+    resolve_existing_parents: bool = False,
 ) -> None:
     by_native_id = {
         message.provider_message_id: _message_id(
@@ -3520,6 +3522,16 @@ def _write_parent_links(
         for fallback_position, message in enumerate(messages)
         if message.provider_message_id and message.provider_message_id not in duplicate_native_ids
     }
+    if resolve_existing_parents:
+        for native_id, message_id in conn.execute(
+            """
+            SELECT native_id, message_id
+            FROM messages
+            WHERE session_id = ? AND native_id IS NOT NULL
+            """,
+            (session_id,),
+        ):
+            by_native_id.setdefault(str(native_id), str(message_id))
     by_message_position = {
         message.position: _message_id(
             session_id,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -341,6 +341,20 @@ settings.register_profile(
     ],
     database=_HYPOTHESIS_DB,
 )
+settings.register_profile(
+    "convergence-fast",
+    max_examples=3,
+    deadline=None,
+    suppress_health_check=[HealthCheck.differing_executors, HealthCheck.too_slow],
+    database=_HYPOTHESIS_DB,
+)
+settings.register_profile(
+    "convergence-exhaustive",
+    max_examples=24,
+    deadline=None,
+    suppress_health_check=[HealthCheck.differing_executors, HealthCheck.too_slow],
+    database=_HYPOTHESIS_DB,
+)
 settings.load_profile(os.environ.get("HYPOTHESIS_PROFILE", "default"))
 
 

--- a/tests/infra/convergence_harness.py
+++ b/tests/infra/convergence_harness.py
@@ -7,7 +7,6 @@ ledger. It deliberately owns no alternate convergence state machine.
 from __future__ import annotations
 
 import asyncio
-import json
 import os
 import random
 import re
@@ -15,13 +14,15 @@ import shutil
 import sqlite3
 from collections.abc import Sequence
 from dataclasses import dataclass, fields
+from functools import lru_cache
 from pathlib import Path
 from typing import cast
 
 import polylogue.daemon.convergence_stages as convergence_stages
 from polylogue.config import Source
 from polylogue.core.outcomes import OutcomeStatus
-from polylogue.daemon.convergence import DaemonConverger, SessionState
+from polylogue.core.sources import origin_from_provider
+from polylogue.daemon.convergence import DaemonConverger, SessionState, StageState
 from polylogue.daemon.convergence_stages import make_fts_stage, make_insights_stage
 from polylogue.maintenance.archive_verification import ArchiveVerificationReport, verify_archive
 from polylogue.pipeline.services.archive_ingest import parse_sources_archive
@@ -30,10 +31,15 @@ from polylogue.schemas.registry import SCHEMA_DIR, SchemaRegistry
 from polylogue.schemas.synthetic import SyntheticCorpus
 from polylogue.schemas.synthetic.models import SyntheticArtifactFacts, SyntheticSchemaSelection, SyntheticWrittenBatch
 from polylogue.schemas.synthetic.selection import select_synthetic_schema
+from polylogue.schemas.synthetic.wire_formats import WireSupportReceipt, build_wire_support_receipt
 from polylogue.sources.live import LiveBatchProcessor, WatchSource
 from polylogue.sources.live.cursor import CursorStore
 from polylogue.storage.sqlite.connection import open_connection
-from tests.infra.inferred_corpus import compile_inferred_corpus_manifest
+from tests.infra.inferred_corpus import (
+    InferredCorpusManifest,
+    build_inferred_corpus_convergence_handoff,
+    compile_inferred_corpus_manifest,
+)
 
 SqlValue = str | int | float | bytes | None
 FactRow = tuple[SqlValue, ...]
@@ -135,6 +141,7 @@ class ConvergenceCorpus:
     """Persisted-selection-backed provider materials used by every property."""
 
     members: tuple[CorpusMember, ...]
+    manifest: InferredCorpusManifest | None = None
 
     @property
     def sessions(self) -> tuple[CorpusMember, ...]:
@@ -142,74 +149,60 @@ class ConvergenceCorpus:
         return self.members
 
 
-def _persisted_provider_receipt(provider: str) -> dict[str, object] | None:
-    path = SCHEMA_DIR / provider / "representatives" / "corpus-manifest.json"
-    if not path.is_file():
-        return None
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        raise AssertionError(f"persisted provider receipt is not an object: {path}")
-    return {str(key): value for key, value in payload.items()}
-
-
 def _persisted_registry_factory() -> SchemaRegistry:
     return SchemaRegistry(storage_root=SCHEMA_DIR)
 
 
-def inferred_convergence_corpus() -> ConvergenceCorpus:
-    """Load representative origins from persisted package selections.
+@lru_cache(maxsize=1)
+def _persisted_wire_support_receipt() -> WireSupportReceipt:
+    """Use the registry-derived production support receipt once per process."""
 
-    The schema and receipt are read from the repository's persisted registry.
-    No test-owned schema or parser substitute is introduced here. The live
-    inferred manifest is also compiled so unsupported constructs remain typed
-    receipts instead of silently becoming executable materials.
+    return build_wire_support_receipt(registry=SchemaRegistry(storage_root=SCHEMA_DIR))
+
+
+def inferred_convergence_corpus() -> ConvergenceCorpus:
+    """Load every supported persisted package selection.
+
+    The manifest and support receipt come from the persisted registry and the
+    production synthetic route authority. Every supported selection is carried
+    into the real parser and ingest path; unsupported origins remain receipts.
     """
     registry = SchemaRegistry(storage_root=SCHEMA_DIR)
-    manifest = compile_inferred_corpus_manifest(registry=registry)
+    support_receipt = _persisted_wire_support_receipt()
+    manifest = compile_inferred_corpus_manifest(
+        registry=registry,
+        wire_support_receipt=support_receipt,
+    )
+    handoff = build_inferred_corpus_convergence_handoff(manifest)
     if not manifest.unsupported_records:
-        raise AssertionError("the persisted inferred manifest lost unsupported-construct receipts")
+        raise AssertionError("the persisted inferred manifest lost unsupported-origin receipts")
+    supported_entries = tuple(entry for entry in manifest.entries if entry.spec is not None)
+    if len(handoff.selections) != len(supported_entries) or not handoff.selections:
+        raise AssertionError("the persisted inferred handoff dropped all or part of the supported selection corpus")
     members: list[CorpusMember] = []
-    for index, provider in enumerate(("codex", "chatgpt", "claude-ai")):
-        selection = select_synthetic_schema(
-            provider,
-            version="v1",
-            element_kind="session_record_stream" if provider == "codex" else "session_document",
-            registry_factory=_persisted_registry_factory,
+    for index, (entry, selection) in enumerate(zip(supported_entries, handoff.selections, strict=True)):
+        if entry.spec is None:
+            raise AssertionError("supported inferred corpus entry lost its CorpusSpec")
+        pinned_ids = (
+            ()
+            if entry.key.provider == "codex"
+            else (f"convergence-{entry.key.provider}-{entry.key.package_version}-{index}",)
         )
-        native_id = f"convergence-{provider}-{index}"
-        spec = CorpusSpec.for_provider(
-            provider,
-            package_version=selection.package_version,
-            element_kind=selection.element_kind,
-            count=1,
-            messages_min=4,
-            messages_max=4,
-            seed=1843 + index * 101,
+        spec = entry.spec.with_generation_overrides(
             style="demo-attachments",
-            session_native_ids=(native_id,),
+            session_native_ids=pinned_ids,
             origin="inferred.convergence.property",
-            tags=("inferred", "convergence", provider),
+            tags=("inferred", "convergence", entry.key.provider, entry.key.package_version),
         )
         members.append(
             CorpusMember(
-                provider=provider,
+                provider=entry.key.provider,
                 spec=spec,
                 selection=selection,
-                receipt=_persisted_provider_receipt(provider),
-                material_path=(
-                    SCHEMA_DIR / provider / "representatives" / "sample-00.json"
-                    if provider in {"chatgpt", "claude-ai"}
-                    else None
-                ),
+                receipt=support_receipt.to_dict(),
             )
         )
-    if not all(
-        member.receipt and member.material_path is not None and member.material_path.is_file()
-        for member in members
-        if member.provider in {"chatgpt", "claude-ai"}
-    ):
-        raise AssertionError("representative persisted provider receipts are missing")
-    return ConvergenceCorpus(tuple(members))
+    return ConvergenceCorpus(tuple(members), manifest=manifest)
 
 
 def rich_convergence_pathology() -> ConvergenceCorpus:
@@ -218,27 +211,45 @@ def rich_convergence_pathology() -> ConvergenceCorpus:
 
 
 def append_convergence_member() -> CorpusMember:
-    """Build a Claude Code JSONL member whose provider preserves tail parents."""
-    selection = select_synthetic_schema(
-        "claude-code",
-        version="v1",
-        element_kind="session_record_stream",
-        registry_factory=_persisted_registry_factory,
+    """Compatibility helper for the first supported appendable selection."""
+    return append_convergence_members()[0]
+
+
+def append_convergence_members() -> tuple[CorpusMember, ...]:
+    """Return persisted JSONL selections with stable append identity evidence."""
+    members = tuple(
+        CorpusMember(
+            provider=member.provider,
+            spec=member.spec.with_generation_overrides(
+                style="demo-tool-heavy",
+                origin="append.convergence.property",
+                tags=("append", "convergence", member.provider, member.spec.package_version),
+            ),
+            selection=member.selection,
+            receipt=member.receipt,
+        )
+        for member in inferred_convergence_corpus().members
+        if member.selection.wire_format.encoding == "jsonl" and member.spec.session_native_ids
     )
-    spec = CorpusSpec.for_provider(
-        "claude-code",
-        package_version=selection.package_version,
-        element_kind=selection.element_kind,
-        count=1,
-        messages_min=4,
-        messages_max=4,
-        seed=2939,
-        style="demo-tool-heavy",
-        session_native_ids=("convergence-claude-code-append",),
-        origin="append.convergence.property",
-        tags=("append", "convergence"),
+    if not members:
+        raise AssertionError("the supported inferred corpus has no appendable JSONL selection")
+    return members
+
+
+def append_convergence_unsupported_receipts() -> tuple[dict[str, str], ...]:
+    """Return explicit receipts for JSONL selections not representable by append replay."""
+    return tuple(
+        {
+            "provider": member.provider,
+            "package_version": member.spec.package_version,
+            "element_kind": member.spec.element_kind or "",
+            "operation": "append_prefix",
+            "status": "unsupported",
+            "reason": "wire route has no stable persisted session identity for prefix replay",
+        }
+        for member in inferred_convergence_corpus().members
+        if member.selection.wire_format.encoding == "jsonl" and not member.spec.session_native_ids
     )
-    return CorpusMember("claude-code", spec, selection, None)
 
 
 def convergence_max_examples() -> int:
@@ -275,6 +286,7 @@ def build_converged_archive(
     )
     if not incremental:
         converge_convergence_archive(archive)
+        assert_corpus_materialization(archive)
     return archive
 
 
@@ -313,7 +325,24 @@ def ingest_convergence_pathology(
                 prefix=f"member-{index:02d}",
             )
             source_path = written.files[0]
-        asyncio.run(parse_sources_archive(root, [Source(name=member.provider, path=source_path)], parse_workers=1))
+        had_durable_raw = False
+        if (root / "source.db").exists():
+            with sqlite3.connect(root / "source.db") as conn:
+                had_durable_raw = (
+                    conn.execute(
+                        "SELECT 1 FROM raw_sessions WHERE source_path = ? LIMIT 1",
+                        (str(source_path),),
+                    ).fetchone()
+                    is not None
+                )
+        ingest_result = asyncio.run(
+            parse_sources_archive(root, [Source(name=member.provider, path=source_path)], parse_workers=1)
+        )
+        if not had_durable_raw and (ingest_result.counts["sessions"] < 1 or ingest_result.counts["messages"] < 1):
+            raise AssertionError(
+                "production parser dispatch or ingest dropped a supported inferred selection: "
+                f"provider={member.provider!r}, result={ingest_result!r}"
+            )
         source_paths.append(source_path)
         if written is not None:
             artifact_facts.extend(item.facts for item in written.batch.artifacts)
@@ -329,6 +358,7 @@ def ingest_convergence_pathology(
         for session_id in archive.session_ids:
             make_messages_fts_stale(root / "index.db", session_id=session_id)
         if converge_after_each:
+            _quiet_test_owned_sources(archive.source_paths)
             converge_convergence_archive(archive)
 
     return ConvergenceArchive(
@@ -342,15 +372,90 @@ def ingest_convergence_pathology(
 
 def converge_convergence_archive(archive: ConvergenceArchive) -> dict[str, SessionState]:
     """Run the real FTS and insight debt stages for the materialized sessions."""
-    converger = DaemonConverger(
-        (make_fts_stage(archive.root / "index.db"), make_insights_stage(archive.root / "index.db"))
+    _quiet_test_owned_sources(archive.source_paths)
+    stages = (
+        make_fts_stage(archive.root / "index.db"),
+        make_insights_stage(archive.root / "index.db"),
     )
+    converger = DaemonConverger(stages)
+    required_stages = {"fts", "insights"}
+    if not required_stages.issubset(converger.stage_names):
+        raise AssertionError(
+            "convergence harness omitted a required stage: "
+            f"required={sorted(required_stages)!r}, actual={converger.stage_names!r}"
+        )
     states, _timings = converger.converge_sessions(archive.session_ids)
     not_converged = {session_id: state.last_error for session_id, state in states.items() if not state.converged}
     if not_converged:
         raise AssertionError(f"production convergence left pending work: {not_converged}")
+    skipped = {
+        session_id: sorted(stage for stage in required_stages if state.stages.get(stage) is not StageState.DONE)
+        for session_id, state in states.items()
+    }
+    skipped = {session_id: stages for session_id, stages in skipped.items() if stages}
+    if skipped:
+        raise AssertionError(f"production convergence skipped required stages: {skipped!r}")
     _analyze_registry_tables(archive.root / "index.db")
     return states
+
+
+def _quiet_test_owned_sources(source_paths: Sequence[Path]) -> None:
+    """Make generated test files satisfy the production quiet-window contract."""
+    for source_path in source_paths:
+        if source_path.exists() and source_path.stat().st_size >= convergence_stages._HOT_INSIGHT_SOURCE_BYTES:
+            os.utime(source_path, (0, 0))
+
+
+def assert_corpus_materialization(archive: ConvergenceArchive) -> None:
+    """Require every corpus member's origin to reach all derived surfaces."""
+    with sqlite3.connect(archive.root / "index.db") as conn:
+        expected_by_origin: dict[str, int] = {}
+        for member in archive.corpus.members:
+            origin = origin_from_provider(member.provider).value
+            expected_by_origin[origin] = expected_by_origin.get(origin, 0) + 1
+        for origin, expected_count in expected_by_origin.items():
+            sessions = conn.execute(
+                """
+                SELECT session_id, parent_session_id, root_session_id, message_count
+                FROM sessions WHERE origin = ? ORDER BY session_id
+                """,
+                (origin,),
+            ).fetchall()
+            if len(sessions) != expected_count:
+                raise AssertionError(
+                    "supported inferred selections did not materialize the expected origin sessions: "
+                    f"origin={origin!r}, expected={expected_count}, sessions={sessions!r}"
+                )
+            for session_id, parent_session_id, root_session_id, message_count in sessions:
+                if not root_session_id or (parent_session_id is None and root_session_id != session_id):
+                    raise AssertionError(f"lineage root was not materialized for {session_id!r}: {sessions!r}")
+                if parent_session_id is not None:
+                    link = conn.execute(
+                        "SELECT 1 FROM session_links WHERE src_session_id = ? LIMIT 1",
+                        (session_id,),
+                    ).fetchone()
+                    if link is None:
+                        raise AssertionError(f"lineage link was not materialized for {session_id!r}")
+
+                profile = conn.execute(
+                    "SELECT message_count FROM session_profiles WHERE session_id = ?",
+                    (session_id,),
+                ).fetchone()
+                if profile is None or int(profile[0]) != int(message_count):
+                    raise AssertionError(f"profile materialization drifted for {session_id!r}: {profile!r}")
+
+                fts_counts = conn.execute(
+                    """
+                    SELECT
+                        (SELECT COUNT(*) FROM blocks WHERE session_id = ? AND NULLIF(search_text, '') IS NOT NULL),
+                        (SELECT COUNT(*) FROM messages_fts WHERE rowid IN (
+                            SELECT rowid FROM blocks WHERE session_id = ? AND NULLIF(search_text, '') IS NOT NULL
+                        ))
+                    """,
+                    (session_id, session_id),
+                ).fetchone()
+                if fts_counts is None or int(fts_counts[0]) != int(fts_counts[1]) or int(fts_counts[0]) == 0:
+                    raise AssertionError(f"FTS materialization drifted for {session_id!r}: {fts_counts!r}")
 
 
 def assert_archive_verification_green(root: Path) -> ArchiveVerificationReport:
@@ -483,7 +588,7 @@ def archive_snapshot(root: Path) -> ArchiveSnapshot:
                    inference_payload_json, enrichment_payload_json, evidence_search_text,
                    inference_search_text, enrichment_search_text, enrichment_version,
                    enrichment_family, inference_version, inference_family, search_text,
-                   duration_ms, cost_credits, cost_usd, priced_with, priced_at_ms,
+                   duration_ms, cost_credits, cost_usd, priced_with, NULL AS priced_at_ms,
                    primary_model_name, primary_model_family
             FROM session_profiles ORDER BY session_id
             """
@@ -663,6 +768,7 @@ def build_append_prefix_archive(
         (artifact.facts,),
     )
     converge_convergence_archive(archive)
+    assert_corpus_materialization(archive)
     return archive
 
 
@@ -702,6 +808,7 @@ def build_full_live_archive(root: Path, member: CorpusMember) -> ConvergenceArch
         make_messages_fts_stale(root / "index.db", session_id=session_id)
     archive = ConvergenceArchive(root, ConvergenceCorpus((member,)), (source_path,), session_ids, (artifact.facts,))
     converge_convergence_archive(archive)
+    assert_corpus_materialization(archive)
     return archive
 
 
@@ -1033,7 +1140,7 @@ def _seed_raw_source_session(conn: sqlite3.Connection, *, session_id: str, sourc
         messages_max=1,
         seed=sum(ord(character) for character in session_id),
         style="demo-tool-heavy",
-        session_native_ids=(session_id,),
+        session_native_ids=(),
         origin="partial.convergence.fixture",
     )
     artifact = SyntheticCorpus.generate_batch_for_selection(selection, spec).artifacts[0]
@@ -1044,7 +1151,7 @@ def _seed_raw_source_session(conn: sqlite3.Connection, *, session_id: str, sourc
         raise AssertionError(f"partial convergence fixture did not use the real Codex ingest route: {result!r}")
     row = conn.execute(
         "SELECT session_id FROM sessions WHERE origin = 'codex-session' AND native_id = ?",
-        (session_id,),
+        (source_path.stem,),
     ).fetchone()
     if row is None:
         raise AssertionError(f"real Codex ingest did not write session {session_id!r}")
@@ -1073,7 +1180,10 @@ __all__ = [
     "archive_snapshot",
     "assert_archive_verification_green",
     "assert_archives_equivalent",
+    "assert_corpus_materialization",
     "append_convergence_member",
+    "append_convergence_members",
+    "append_convergence_unsupported_receipts",
     "build_append_prefix_archive",
     "build_converged_archive",
     "build_full_live_archive",
@@ -1086,6 +1196,8 @@ __all__ = [
     "initialize_active_archive",
     "make_messages_fts_stale",
     "messages_fts_match_count",
+    "make_fts_stage",
+    "make_insights_stage",
     "raw_authority_facts",
     "rich_convergence_pathology",
     "convergence_max_examples",

--- a/tests/infra/convergence_harness.py
+++ b/tests/infra/convergence_harness.py
@@ -219,7 +219,7 @@ def assert_archive_verification_green(root: Path) -> ArchiveVerificationReport:
     """Require every currently registered archive verification predicate to be green."""
     report = verify_archive(root)
     non_green = [
-        (check.name, check.status.value, check.summary, check.evidence)
+        (check.name, check.status.value, check.summary, check.details, check.breakdown)
         for check in report.checks
         if check.status is not OutcomeStatus.OK
     ]

--- a/tests/infra/convergence_harness.py
+++ b/tests/infra/convergence_harness.py
@@ -10,6 +10,7 @@ import asyncio
 import json
 import os
 import random
+import re
 import shutil
 import sqlite3
 from collections.abc import Sequence
@@ -248,12 +249,12 @@ def convergence_max_examples() -> int:
 
 def convergence_stateful_max_examples() -> int:
     """Keep the interruption machine fast while expanding it in the lab profile."""
-    return 6 if convergence_max_examples() > 3 else 2
+    return 6 if convergence_max_examples() > 3 else 1
 
 
 def convergence_stateful_step_count() -> int:
     """Give the lab machine more interruption and resume boundaries to explore."""
-    return 8 if convergence_max_examples() > 3 else 3
+    return 8 if convergence_max_examples() > 3 else 2
 
 
 def build_converged_archive(
@@ -493,12 +494,13 @@ def archive_snapshot(root: Path) -> ArchiveSnapshot:
         phases = conn.execute(
             "SELECT session_id, position, start_index, end_index, duration_ms, tool_counts_json, word_count, evidence_json, inference_json, search_text FROM session_phases ORDER BY session_id, position"
         ).fetchall()
-        fts_terms = [
-            str(row[0])
-            for row in conn.execute(
-                "SELECT DISTINCT lower(trim(text)) FROM blocks WHERE NULLIF(trim(text), '') IS NOT NULL ORDER BY 1"
-            ).fetchall()
-        ]
+        fts_terms: list[str] = []
+        for (search_text,) in conn.execute(
+            "SELECT search_text FROM blocks WHERE NULLIF(trim(search_text), '') IS NOT NULL ORDER BY block_id"
+        ):
+            terms = re.findall(r"\w{2,}", str(search_text).casefold())
+            if terms:
+                fts_terms.append(terms[0])
         fts_queries = tuple(
             (
                 term,
@@ -509,7 +511,7 @@ def archive_snapshot(root: Path) -> ArchiveSnapshot:
                     ).fetchall()
                 ),
             )
-            for term in fts_terms
+            for term in dict.fromkeys(fts_terms)
         )
     return ArchiveSnapshot(
         raw=_fact_rows(raw),

--- a/tests/infra/convergence_harness.py
+++ b/tests/infra/convergence_harness.py
@@ -7,20 +7,35 @@ ledger. It deliberately owns no alternate convergence state machine.
 from __future__ import annotations
 
 import hashlib
+import json
 import sqlite3
+from collections.abc import Sequence
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import cast
 
 import polylogue.daemon.convergence_stages as convergence_stages
 from polylogue.archive.message.roles import Role
 from polylogue.core.enums import BlockType, Provider
+from polylogue.core.outcomes import OutcomeStatus
+from polylogue.daemon.convergence import DaemonConverger, SessionState
+from polylogue.daemon.convergence_stages import make_fts_stage, make_insights_stage
+from polylogue.maintenance.archive_verification import ArchiveVerificationReport, verify_archive
 from polylogue.scenarios import WorkloadEnvelopeSpec, partial_convergence_canary_spec
 from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+from polylogue.storage.sqlite.archive_tiers.source_write import write_source_raw_session
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
 from polylogue.storage.sqlite.connection import open_connection
+from tests.infra.pathology_composer import (
+    ComposedPathology,
+    compose_append_revision_chain,
+    compose_fork_prefix_tail_lineage,
+    compose_pathologies,
+    compose_quarantined_head_arrangement,
+)
 
 SqlValue = str | int | float | bytes | None
 FactRow = tuple[SqlValue, ...]
@@ -68,6 +83,282 @@ class SessionMaterializationFacts:
     threads: tuple[FactRow, ...]
     thread_sessions: tuple[FactRow, ...]
     table_counts: tuple[tuple[str, int], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ArchiveSnapshot:
+    """Semantic archive state, deliberately excluding run-local stamps and ids."""
+
+    sessions: tuple[FactRow, ...]
+    messages: tuple[FactRow, ...]
+    blocks: tuple[FactRow, ...]
+    session_links: tuple[FactRow, ...]
+    profiles: tuple[FactRow, ...]
+    fts_counts: tuple[tuple[str, int], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ConvergenceArchive:
+    """A temporary archive created only through the raw-and-parsed write route."""
+
+    root: Path
+    pathology: ComposedPathology
+    source_paths: tuple[Path, ...]
+    session_ids: tuple[str, ...]
+
+
+def rich_convergence_pathology() -> ComposedPathology:
+    """Return the bounded default corpus with update, lineage, and orphan semantics.
+
+    The property loop exercises archive-write and convergence laws, not the
+    whale streaming route. One-message revisions and a one-message shared
+    prefix retain the distinct normalized states needed here while keeping
+    each default generated case small enough for the focused managed harness.
+    """
+    return compose_pathologies(
+        compose_append_revision_chain(revision_count=2, messages_per_revision=1),
+        compose_fork_prefix_tail_lineage(shared_prefix_len=1, child_tail_len=1),
+        compose_quarantined_head_arrangement(),
+        name="convergence-property-rich-corpus",
+    )
+
+
+def build_converged_archive(
+    root: Path,
+    pathology: ComposedPathology,
+    *,
+    session_order: Sequence[int] | None = None,
+    incremental: bool = False,
+) -> ConvergenceArchive:
+    """Materialize a composed corpus through production writes, then converge it."""
+    initialize_active_archive(root)
+    archive = ingest_convergence_pathology(
+        root,
+        pathology,
+        session_indexes=_complete_session_order(pathology, session_order),
+        converge_after_each=incremental,
+    )
+    if not incremental:
+        converge_convergence_archive(archive)
+    assert_archive_verification_green(archive.root)
+    return archive
+
+
+def initialize_active_archive(root: Path) -> None:
+    """Create all archive tiers for a temporary property-test archive."""
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+    initialize_active_archive_root(root)
+
+
+def ingest_convergence_pathology(
+    root: Path,
+    pathology: ComposedPathology,
+    *,
+    session_indexes: Sequence[int],
+    converge_after_each: bool,
+) -> ConvergenceArchive:
+    """Use the production raw and parsed-session writers for each selected member.
+
+    The test harness does not emulate archive materialization or convergence.
+    It writes source.db through the production raw writer and index.db through
+    the production parsed-session writer, exactly as the live ingestion layer
+    does after a provider parser has produced a ``ParsedSession``.
+    """
+    selected = _validate_session_indexes(pathology, session_indexes)
+    source_paths: list[Path] = []
+    session_ids: list[str] = []
+    for index in selected:
+        session = _parsed_session(pathology.sessions[index], corpus_index=index)
+        payload = _raw_payload(session)
+        source_path = root / "sources" / f"{index:03d}-{session.provider_session_id}.json"
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.write_bytes(payload)
+        with sqlite3.connect(root / "source.db") as source_conn:
+            raw_id = write_source_raw_session(
+                source_conn,
+                origin="codex-session",
+                capture_mode=Provider.CODEX,
+                source_path=str(source_path),
+                source_index=index,
+                payload=payload,
+                acquired_at_ms=_acquired_at_ms(index),
+                native_id=session.provider_session_id,
+            )
+        with open_connection(root / "index.db") as index_conn:
+            session_id = write_parsed_session_to_archive(
+                index_conn,
+                session,
+                raw_id=raw_id,
+                content_hash=hashlib.sha256(payload).hexdigest(),
+            )
+        source_paths.append(source_path)
+        session_ids.append(session_id)
+        make_messages_fts_stale(root / "index.db", session_id=session_id)
+        archive = ConvergenceArchive(root, pathology, tuple(source_paths), tuple(dict.fromkeys(session_ids)))
+        if converge_after_each:
+            converge_convergence_archive(archive)
+
+    return ConvergenceArchive(root, pathology, tuple(source_paths), tuple(dict.fromkeys(session_ids)))
+
+
+def converge_convergence_archive(archive: ConvergenceArchive) -> dict[str, SessionState]:
+    """Run the real FTS and insight debt stages for the materialized sessions."""
+    converger = DaemonConverger(
+        (make_fts_stage(archive.root / "index.db"), make_insights_stage(archive.root / "index.db"))
+    )
+    states, _timings = converger.converge_sessions(archive.session_ids)
+    not_converged = {session_id: state.last_error for session_id, state in states.items() if not state.converged}
+    if not_converged:
+        raise AssertionError(f"production convergence left pending work: {not_converged}")
+    _analyze_registry_tables(archive.root / "index.db")
+    return states
+
+
+def assert_archive_verification_green(root: Path) -> ArchiveVerificationReport:
+    """Require every currently registered archive verification predicate to be green."""
+    report = verify_archive(root)
+    non_green = [
+        (check.name, check.status.value, check.summary, check.evidence)
+        for check in report.checks
+        if check.status is not OutcomeStatus.OK
+    ]
+    if non_green:
+        raise AssertionError(f"archive verification registry is not green: {non_green}")
+    return report
+
+
+def archive_snapshot(root: Path) -> ArchiveSnapshot:
+    """Return the one canonical archive comparator shared by all properties."""
+    with sqlite3.connect(root / "index.db") as conn:
+        sessions = conn.execute(
+            """
+            SELECT session_id, origin, native_id, title, parent_session_id,
+                   root_session_id, branch_type, active_leaf_message_id, message_count
+            FROM sessions ORDER BY session_id
+            """
+        ).fetchall()
+        messages = conn.execute(
+            """
+            SELECT session_id, native_id, position, variant_index, role,
+                   material_origin, message_type, parent_message_id
+            FROM messages ORDER BY session_id, position, variant_index
+            """
+        ).fetchall()
+        blocks = conn.execute(
+            """
+            SELECT session_id, message_id, position, block_type, text, tool_id,
+                   tool_name, tool_result_is_error, tool_result_exit_code
+            FROM blocks ORDER BY session_id, message_id, position
+            """
+        ).fetchall()
+        session_links = conn.execute(
+            """
+            SELECT src_session_id, dst_origin, dst_native_id, link_type,
+                   resolved_dst_session_id, branch_point_message_id, inheritance, status
+            FROM session_links
+            ORDER BY src_session_id, dst_origin, dst_native_id, link_type
+            """
+        ).fetchall()
+        profiles = conn.execute(
+            """
+            SELECT session_id, logical_session_id, message_count, work_event_count,
+                   phase_count, word_count, tool_use_count, workflow_shape, terminal_state
+            FROM session_profiles ORDER BY session_id
+            """
+        ).fetchall()
+        fts_counts = tuple(
+            (table, int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]))
+            for table in ("messages_fts_docsize", "messages_fts_identity", "blocks_command_trigram_docsize")
+        )
+    return ArchiveSnapshot(
+        sessions=_fact_rows(sessions),
+        messages=_fact_rows(messages),
+        blocks=_fact_rows(blocks),
+        session_links=_fact_rows(session_links),
+        profiles=_fact_rows(profiles),
+        fts_counts=fts_counts,
+    )
+
+
+def assert_archives_equivalent(left: ConvergenceArchive, right: ConvergenceArchive) -> None:
+    """Compare archives through ``archive_snapshot`` rather than database bytes."""
+    left_snapshot = archive_snapshot(left.root)
+    right_snapshot = archive_snapshot(right.root)
+    if left_snapshot != right_snapshot:
+        raise AssertionError(f"canonical archive snapshots differ:\nleft={left_snapshot!r}\nright={right_snapshot!r}")
+
+
+def _complete_session_order(pathology: ComposedPathology, order: Sequence[int] | None) -> tuple[int, ...]:
+    expected = tuple(range(len(pathology.sessions)))
+    candidate = expected if order is None else tuple(order)
+    if len(candidate) != len(expected) or set(candidate) != set(expected):
+        raise ValueError("session_order must be a permutation of every composed session index")
+    return candidate
+
+
+def rotated_session_order(pathology: ComposedPathology, shift: int) -> tuple[int, ...]:
+    """Return one generated, non-identity ordering of the complete corpus."""
+    session_count = len(pathology.sessions)
+    if not 0 < shift < session_count:
+        raise ValueError("shift must select a non-identity rotation")
+    indexes = tuple(range(session_count))
+    return indexes[shift:] + indexes[:shift]
+
+
+def _validate_session_indexes(pathology: ComposedPathology, indexes: Sequence[int]) -> tuple[int, ...]:
+    selected = tuple(indexes)
+    if len(selected) != len(set(selected)) or any(index < 0 or index >= len(pathology.sessions) for index in selected):
+        raise ValueError("session_indexes must be distinct valid composed-session indexes")
+    return selected
+
+
+def _parsed_session(session: object, *, corpus_index: int) -> ParsedSession:
+    from polylogue.archive.models import Session
+
+    if not isinstance(session, Session):
+        raise TypeError(f"expected composed Session, got {type(session)!r}")
+    timestamp = _corpus_timestamp(corpus_index)
+    messages = [
+        ParsedMessage(
+            provider_message_id=str(message.id),
+            role=Role.normalize(str(message.role)),
+            text=message.text,
+            position=position,
+            timestamp=timestamp,
+            blocks=[ParsedContentBlock(type=BlockType.TEXT, text=message.text)],
+        )
+        for position, message in enumerate(session.messages)
+    ]
+    return ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id=str(session.id),
+        title=session.title,
+        created_at=timestamp,
+        updated_at=timestamp,
+        parent_session_provider_id=None if session.parent_id is None else str(session.parent_id),
+        branch_type=session.branch_type,
+        messages=messages,
+    )
+
+
+def _raw_payload(session: ParsedSession) -> bytes:
+    return json.dumps(session.model_dump(mode="json"), sort_keys=True, separators=(",", ":")).encode()
+
+
+def _corpus_timestamp(index: int) -> str:
+    return (datetime(2026, 1, 1, tzinfo=UTC) + timedelta(seconds=index)).isoformat()
+
+
+def _acquired_at_ms(index: int) -> int:
+    return 1_767_225_600_000 + index
+
+
+def _analyze_registry_tables(index_db: Path) -> None:
+    with sqlite3.connect(index_db) as conn:
+        for table in ("blocks", "messages", "action_pairs"):
+            conn.execute(f"ANALYZE {table}")
+        conn.commit()
 
 
 def seed_partial_convergence_archive(root: Path, *, target_hot: bool) -> PartialConvergenceArchive:
@@ -382,13 +673,24 @@ def _fact_rows(rows: list[tuple[object, ...]]) -> tuple[FactRow, ...]:
 
 
 __all__ = [
+    "ArchiveSnapshot",
+    "ConvergenceArchive",
     "DebtLedgerRow",
     "PartialConvergenceArchive",
     "SessionMaterializationFacts",
+    "archive_snapshot",
+    "assert_archive_verification_green",
+    "assert_archives_equivalent",
+    "build_converged_archive",
+    "converge_convergence_archive",
     "debt_ledger_row",
+    "ingest_convergence_pathology",
+    "initialize_active_archive",
     "make_messages_fts_stale",
     "messages_fts_match_count",
     "raw_authority_facts",
+    "rich_convergence_pathology",
+    "rotated_session_order",
     "seed_partial_convergence_archive",
     "session_materialization_facts",
     "set_debt_retry_at",

--- a/tests/infra/convergence_harness.py
+++ b/tests/infra/convergence_harness.py
@@ -6,36 +6,33 @@ ledger. It deliberately owns no alternate convergence state machine.
 
 from __future__ import annotations
 
-import hashlib
+import asyncio
 import json
+import os
+import random
+import shutil
 import sqlite3
 from collections.abc import Sequence
-from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import cast
 
 import polylogue.daemon.convergence_stages as convergence_stages
-from polylogue.archive.message.roles import Role
-from polylogue.core.enums import BlockType, Provider
+from polylogue.config import Source
 from polylogue.core.outcomes import OutcomeStatus
 from polylogue.daemon.convergence import DaemonConverger, SessionState
 from polylogue.daemon.convergence_stages import make_fts_stage, make_insights_stage
 from polylogue.maintenance.archive_verification import ArchiveVerificationReport, verify_archive
-from polylogue.scenarios import WorkloadEnvelopeSpec, partial_convergence_canary_spec
-from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
-from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
-from polylogue.storage.sqlite.archive_tiers.source_write import write_source_raw_session
-from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
-from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
+from polylogue.pipeline.services.archive_ingest import parse_sources_archive
+from polylogue.scenarios import CorpusSpec, WorkloadEnvelopeSpec, partial_convergence_canary_spec
+from polylogue.schemas.registry import SCHEMA_DIR, SchemaRegistry
+from polylogue.schemas.synthetic import SyntheticCorpus
+from polylogue.schemas.synthetic.models import SyntheticArtifactFacts, SyntheticSchemaSelection, SyntheticWrittenBatch
+from polylogue.schemas.synthetic.selection import select_synthetic_schema
+from polylogue.sources.live import LiveBatchProcessor, WatchSource
+from polylogue.sources.live.cursor import CursorStore
 from polylogue.storage.sqlite.connection import open_connection
-from tests.infra.pathology_composer import (
-    ComposedPathology,
-    compose_append_revision_chain,
-    compose_fork_prefix_tail_lineage,
-    compose_pathologies,
-    compose_quarantined_head_arrangement,
-)
+from tests.infra.inferred_corpus import compile_inferred_corpus_manifest
 
 SqlValue = str | int | float | bytes | None
 FactRow = tuple[SqlValue, ...]
@@ -87,50 +84,187 @@ class SessionMaterializationFacts:
 
 @dataclass(frozen=True, slots=True)
 class ArchiveSnapshot:
-    """Semantic archive state, deliberately excluding run-local stamps and ids."""
+    """The one canonical cross-tier archive comparator.
 
+    Rows are selected from the raw authority, normalized index, provenance,
+    insight, and FTS surfaces. Volatile acquisition timestamps and absolute
+    temporary paths are normalized at the boundary. FTS is represented by
+    real MATCH result sets, so a missing posting cannot hide behind a
+    count-only comparison.
+    """
+
+    raw: tuple[FactRow, ...]
+    raw_memberships: tuple[FactRow, ...]
     sessions: tuple[FactRow, ...]
     messages: tuple[FactRow, ...]
     blocks: tuple[FactRow, ...]
+    attachments: tuple[FactRow, ...]
+    attachment_refs: tuple[FactRow, ...]
+    session_events: tuple[FactRow, ...]
     session_links: tuple[FactRow, ...]
+    insight_materialization: tuple[FactRow, ...]
     profiles: tuple[FactRow, ...]
-    fts_counts: tuple[tuple[str, int], ...]
+    work_events: tuple[FactRow, ...]
+    phases: tuple[FactRow, ...]
+    fts_queries: tuple[tuple[str, tuple[FactRow, ...]], ...]
 
 
 @dataclass(frozen=True, slots=True)
 class ConvergenceArchive:
-    """A temporary archive created only through the raw-and-parsed write route."""
+    """A temporary archive produced by real acquisition and parser routes."""
 
     root: Path
-    pathology: ComposedPathology
+    corpus: ConvergenceCorpus
     source_paths: tuple[Path, ...]
     session_ids: tuple[str, ...]
+    artifact_facts: tuple[SyntheticArtifactFacts, ...] = ()
 
 
-def rich_convergence_pathology() -> ComposedPathology:
-    """Return the bounded default corpus with update, lineage, and orphan semantics.
+@dataclass(frozen=True, slots=True)
+class CorpusMember:
+    provider: str
+    spec: CorpusSpec
+    selection: SyntheticSchemaSelection
+    receipt: dict[str, object] | None
+    material_path: Path | None = None
 
-    The property loop exercises archive-write and convergence laws, not the
-    whale streaming route. One-message revisions and a one-message shared
-    prefix retain the distinct normalized states needed here while keeping
-    each default generated case small enough for the focused managed harness.
+
+@dataclass(frozen=True, slots=True)
+class ConvergenceCorpus:
+    """Persisted-selection-backed provider materials used by every property."""
+
+    members: tuple[CorpusMember, ...]
+
+    @property
+    def sessions(self) -> tuple[CorpusMember, ...]:
+        """Compatibility name for the old pathology-indexed property API."""
+        return self.members
+
+
+def _persisted_provider_receipt(provider: str) -> dict[str, object] | None:
+    path = SCHEMA_DIR / provider / "representatives" / "corpus-manifest.json"
+    if not path.is_file():
+        return None
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise AssertionError(f"persisted provider receipt is not an object: {path}")
+    return {str(key): value for key, value in payload.items()}
+
+
+def _persisted_registry_factory() -> SchemaRegistry:
+    return SchemaRegistry(storage_root=SCHEMA_DIR)
+
+
+def inferred_convergence_corpus() -> ConvergenceCorpus:
+    """Load representative origins from persisted package selections.
+
+    The schema and receipt are read from the repository's persisted registry.
+    No test-owned schema or parser substitute is introduced here. The live
+    inferred manifest is also compiled so unsupported constructs remain typed
+    receipts instead of silently becoming executable materials.
     """
-    return compose_pathologies(
-        compose_append_revision_chain(revision_count=2, messages_per_revision=1),
-        compose_fork_prefix_tail_lineage(shared_prefix_len=1, child_tail_len=1),
-        compose_quarantined_head_arrangement(),
-        name="convergence-property-rich-corpus",
+    registry = SchemaRegistry(storage_root=SCHEMA_DIR)
+    manifest = compile_inferred_corpus_manifest(registry=registry)
+    if not manifest.unsupported_records:
+        raise AssertionError("the persisted inferred manifest lost unsupported-construct receipts")
+    members: list[CorpusMember] = []
+    for index, provider in enumerate(("codex", "chatgpt", "claude-ai")):
+        selection = select_synthetic_schema(
+            provider,
+            version="v1",
+            element_kind="session_record_stream" if provider == "codex" else "session_document",
+            registry_factory=_persisted_registry_factory,
+        )
+        native_id = f"convergence-{provider}-{index}"
+        spec = CorpusSpec.for_provider(
+            provider,
+            package_version=selection.package_version,
+            element_kind=selection.element_kind,
+            count=1,
+            messages_min=4,
+            messages_max=4,
+            seed=1843 + index * 101,
+            style="demo-attachments",
+            session_native_ids=(native_id,),
+            origin="inferred.convergence.property",
+            tags=("inferred", "convergence", provider),
+        )
+        members.append(
+            CorpusMember(
+                provider=provider,
+                spec=spec,
+                selection=selection,
+                receipt=_persisted_provider_receipt(provider),
+                material_path=(
+                    SCHEMA_DIR / provider / "representatives" / "sample-00.json"
+                    if provider in {"chatgpt", "claude-ai"}
+                    else None
+                ),
+            )
+        )
+    if not all(
+        member.receipt and member.material_path is not None and member.material_path.is_file()
+        for member in members
+        if member.provider in {"chatgpt", "claude-ai"}
+    ):
+        raise AssertionError("representative persisted provider receipts are missing")
+    return ConvergenceCorpus(tuple(members))
+
+
+def rich_convergence_pathology() -> ConvergenceCorpus:
+    """Return the persisted multi-origin corpus used by the property loop."""
+    return inferred_convergence_corpus()
+
+
+def append_convergence_member() -> CorpusMember:
+    """Build a Claude Code JSONL member whose provider preserves tail parents."""
+    selection = select_synthetic_schema(
+        "claude-code",
+        version="v1",
+        element_kind="session_record_stream",
+        registry_factory=_persisted_registry_factory,
     )
+    spec = CorpusSpec.for_provider(
+        "claude-code",
+        package_version=selection.package_version,
+        element_kind=selection.element_kind,
+        count=1,
+        messages_min=4,
+        messages_max=4,
+        seed=2939,
+        style="demo-tool-heavy",
+        session_native_ids=("convergence-claude-code-append",),
+        origin="append.convergence.property",
+        tags=("append", "convergence"),
+    )
+    return CorpusMember("claude-code", spec, selection, None)
+
+
+def convergence_max_examples() -> int:
+    """Use a small meaningful default and an explicit exhaustive lab budget."""
+    profile = os.environ.get("HYPOTHESIS_PROFILE", "convergence-fast")
+    return 24 if profile in {"convergence-exhaustive", "lab"} else 3
+
+
+def convergence_stateful_max_examples() -> int:
+    """Keep the interruption machine fast while expanding it in the lab profile."""
+    return 6 if convergence_max_examples() > 3 else 2
+
+
+def convergence_stateful_step_count() -> int:
+    """Give the lab machine more interruption and resume boundaries to explore."""
+    return 8 if convergence_max_examples() > 3 else 3
 
 
 def build_converged_archive(
     root: Path,
-    pathology: ComposedPathology,
+    pathology: ConvergenceCorpus,
     *,
     session_order: Sequence[int] | None = None,
     incremental: bool = False,
 ) -> ConvergenceArchive:
-    """Materialize a composed corpus through production writes, then converge it."""
+    """Materialize generated provider bytes through the production ingest route."""
+    _reset_property_archive_root(root)
     initialize_active_archive(root)
     archive = ingest_convergence_pathology(
         root,
@@ -140,7 +274,6 @@ def build_converged_archive(
     )
     if not incremental:
         converge_convergence_archive(archive)
-    assert_archive_verification_green(archive.root)
     return archive
 
 
@@ -153,53 +286,57 @@ def initialize_active_archive(root: Path) -> None:
 
 def ingest_convergence_pathology(
     root: Path,
-    pathology: ComposedPathology,
+    pathology: ConvergenceCorpus,
     *,
     session_indexes: Sequence[int],
     converge_after_each: bool,
 ) -> ConvergenceArchive:
-    """Use the production raw and parsed-session writers for each selected member.
-
-    The test harness does not emulate archive materialization or convergence.
-    It writes source.db through the production raw writer and index.db through
-    the production parsed-session writer, exactly as the live ingestion layer
-    does after a provider parser has produced a ``ParsedSession``.
-    """
+    """Generate real provider bytes and run the production full ingest route."""
     selected = _validate_session_indexes(pathology, session_indexes)
     source_paths: list[Path] = []
     session_ids: list[str] = []
+    artifact_facts: list[SyntheticArtifactFacts] = []
     for index in selected:
-        session = _parsed_session(pathology.sessions[index], corpus_index=index)
-        payload = _raw_payload(session)
-        source_path = root / "sources" / f"{index:03d}-{session.provider_session_id}.json"
-        source_path.parent.mkdir(parents=True, exist_ok=True)
-        source_path.write_bytes(payload)
-        with sqlite3.connect(root / "source.db") as source_conn:
-            raw_id = write_source_raw_session(
-                source_conn,
-                origin="codex-session",
-                capture_mode=Provider.CODEX,
-                source_path=str(source_path),
-                source_index=index,
-                payload=payload,
-                acquired_at_ms=_acquired_at_ms(index),
-                native_id=session.provider_session_id,
+        member = pathology.members[index]
+        source_root = root / "sources" / member.provider
+        source_root.mkdir(parents=True, exist_ok=True)
+        written: SyntheticWrittenBatch | None = None
+        if member.material_path is not None:
+            source_path = source_root / f"member-{index:02d}{member.material_path.suffix}"
+            shutil.copyfile(member.material_path, source_path)
+        else:
+            written = SyntheticCorpus.write_selection_artifacts(
+                member.selection,
+                member.spec,
+                source_root,
+                prefix=f"member-{index:02d}",
             )
-        with open_connection(root / "index.db") as index_conn:
-            session_id = write_parsed_session_to_archive(
-                index_conn,
-                session,
-                raw_id=raw_id,
-                content_hash=hashlib.sha256(payload).hexdigest(),
-            )
+            source_path = written.files[0]
+        asyncio.run(parse_sources_archive(root, [Source(name=member.provider, path=source_path)], parse_workers=1))
         source_paths.append(source_path)
-        session_ids.append(session_id)
-        make_messages_fts_stale(root / "index.db", session_id=session_id)
-        archive = ConvergenceArchive(root, pathology, tuple(source_paths), tuple(dict.fromkeys(session_ids)))
+        if written is not None:
+            artifact_facts.extend(item.facts for item in written.batch.artifacts)
+        with sqlite3.connect(root / "index.db") as conn:
+            session_ids.extend(str(row[0]) for row in conn.execute("SELECT session_id FROM sessions"))
+        archive = ConvergenceArchive(
+            root,
+            pathology,
+            tuple(source_paths),
+            tuple(sorted(set(session_ids))),
+            tuple(artifact_facts),
+        )
+        for session_id in archive.session_ids:
+            make_messages_fts_stale(root / "index.db", session_id=session_id)
         if converge_after_each:
             converge_convergence_archive(archive)
 
-    return ConvergenceArchive(root, pathology, tuple(source_paths), tuple(dict.fromkeys(session_ids)))
+    return ConvergenceArchive(
+        root,
+        pathology,
+        tuple(source_paths),
+        tuple(sorted(set(session_ids))),
+        tuple(artifact_facts),
+    )
 
 
 def converge_convergence_archive(archive: ConvergenceArchive) -> dict[str, SessionState]:
@@ -230,27 +367,86 @@ def assert_archive_verification_green(root: Path) -> ArchiveVerificationReport:
 
 def archive_snapshot(root: Path) -> ArchiveSnapshot:
     """Return the one canonical archive comparator shared by all properties."""
-    with sqlite3.connect(root / "index.db") as conn:
+    with sqlite3.connect(root / "source.db") as source_conn, sqlite3.connect(root / "index.db") as conn:
+        raw_rows = source_conn.execute(
+            """
+            SELECT r.raw_id, r.origin, r.native_id, r.source_index, hex(r.blob_hash), r.blob_size,
+                   r.logical_source_key, r.revision_kind, r.source_revision,
+                   r.predecessor_source_revision,
+                   COALESCE(p.origin || ':' || p.native_id || ':' || p.source_index, r.predecessor_raw_id),
+                   COALESCE(b.origin || ':' || b.native_id || ':' || b.source_index, r.baseline_raw_id),
+                   r.append_start_offset, r.append_end_offset, r.acquisition_generation,
+                   r.revision_authority, r.revision_authority_evidence, r.parsed_at_ms IS NOT NULL
+            FROM raw_sessions AS r
+            LEFT JOIN raw_sessions AS p ON p.raw_id = r.predecessor_raw_id
+            LEFT JOIN raw_sessions AS b ON b.raw_id = r.baseline_raw_id
+            ORDER BY r.origin, r.native_id, r.source_index
+            """
+        ).fetchall()
+        raw = [row[1:] for row in raw_rows]
+        raw_memberships = source_conn.execute(
+            """
+            SELECT r.origin, r.native_id, r.source_index, m.logical_source_key,
+                   m.provider_session_id, m.source_revision,
+                   hex(m.normalized_content_hash), m.message_count,
+                   COALESCE(p.origin || ':' || p.native_id || ':' || p.source_index, m.predecessor_raw_id),
+                   m.acquisition_generation, m.revision_authority, m.decision
+            FROM raw_session_memberships AS m
+            JOIN raw_sessions AS r ON r.raw_id = m.raw_id
+            LEFT JOIN raw_sessions AS p ON p.raw_id = m.predecessor_raw_id
+            ORDER BY r.origin, r.native_id, r.source_index, m.logical_source_key
+            """
+        ).fetchall()
         sessions = conn.execute(
             """
             SELECT session_id, origin, native_id, title, parent_session_id,
-                   root_session_id, branch_type, active_leaf_message_id, message_count
-            FROM sessions ORDER BY session_id
+                   root_session_id, branch_type, active_leaf_message_id, message_count,
+                   s.raw_id,
+                   title_source, title_ref, display_name, run_settings_json,
+                   pending_drafts_json, git_branch, git_repository_url, provider_project_ref,
+                   commit_hash, instructions_text, reported_duration_ms, reported_cost_usd,
+                   hex(s.content_hash), updated_at_ms
+            FROM sessions AS s
+            ORDER BY session_id
             """
         ).fetchall()
+        sessions = [
+            (
+                *row[:9],
+                f"{row[1]}:{row[2]}" if row[9] is not None else None,
+                *row[10:],
+            )
+            for row in sessions
+        ]
         messages = conn.execute(
             """
             SELECT session_id, native_id, position, variant_index, role,
-                   material_origin, message_type, parent_message_id
+                   material_origin, message_type, parent_message_id, model_name,
+                   model_effort, sender_name, recipient, delivery_status, end_turn,
+                   user_context_text, has_tool_use, has_thinking, has_paste,
+                   paste_boundary, is_active_path, is_active_leaf, word_count,
+                   input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+                   duration_ms, hex(content_hash), occurred_at_ms, stop_reason
             FROM messages ORDER BY session_id, position, variant_index
             """
         ).fetchall()
         blocks = conn.execute(
             """
             SELECT session_id, message_id, position, block_type, text, tool_id,
-                   tool_name, tool_result_is_error, tool_result_exit_code
+                   tool_name, tool_input, semantic_type, media_type, language,
+                   tool_result_is_error, tool_result_exit_code,
+                   tool_result_outcome_unknown_reason, signature, hex(content_hash), search_text
             FROM blocks ORDER BY session_id, message_id, position
             """
+        ).fetchall()
+        attachments = conn.execute(
+            "SELECT attachment_id, display_name, media_type, byte_count, hex(blob_hash), acquisition_status, ref_count FROM attachments ORDER BY attachment_id"
+        ).fetchall()
+        attachment_refs = conn.execute(
+            "SELECT ref_id, attachment_id, session_id, message_id, position, upload_origin, source_url, caption FROM attachment_refs ORDER BY ref_id"
+        ).fetchall()
+        session_events = conn.execute(
+            "SELECT session_id, position, event_type, occurred_at_ms, source_message_id, source_message_provider_id, summary, payload_json FROM session_events ORDER BY session_id, position"
         ).fetchall()
         session_links = conn.execute(
             """
@@ -260,36 +456,131 @@ def archive_snapshot(root: Path) -> ArchiveSnapshot:
             ORDER BY src_session_id, dst_origin, dst_native_id, link_type
             """
         ).fetchall()
+        insight_materialization = conn.execute(
+            """
+            SELECT insight_type, session_id, materializer_version, source_updated_at_ms,
+                   source_sort_key_ms, input_high_water_mark_source, input_row_count
+            FROM insight_materialization ORDER BY insight_type, session_id
+            """
+        ).fetchall()
         profiles = conn.execute(
             """
-            SELECT session_id, logical_session_id, message_count, work_event_count,
-                   phase_count, word_count, tool_use_count, workflow_shape, terminal_state
+            SELECT session_id, logical_session_id, materializer_version, source_updated_at,
+                   source_sort_key, input_high_water_mark, input_high_water_mark_source,
+                   input_row_count, source_name, title, message_count, substantive_count,
+                   attachment_count, work_event_count, phase_count, word_count,
+                   tool_use_count, thinking_count, total_cost_usd, total_duration_ms,
+                   engaged_duration_ms, tool_active_duration_ms, wall_duration_ms,
+                   workflow_shape, workflow_shape_method, workflow_shape_confidence,
+                   workflow_shape_features_json, terminal_state, terminal_state_method,
+                   terminal_state_confidence, terminal_state_evidence_json,
+                   cost_is_estimated, thinking_duration_ms, output_duration_ms,
+                   tool_duration_ms, latency_percentiles_ms_json, tool_calls_per_minute,
+                   timing_provenance, total_input_tokens, total_output_tokens,
+                   total_cache_read_tokens, total_cache_write_tokens, total_credit_cost,
+                   cost_provenance, per_model_cost_json, evidence_payload_json,
+                   inference_payload_json, enrichment_payload_json, evidence_search_text,
+                   inference_search_text, enrichment_search_text, enrichment_version,
+                   enrichment_family, inference_version, inference_family, search_text,
+                   duration_ms, cost_credits, cost_usd, priced_with, priced_at_ms,
+                   primary_model_name, primary_model_family
             FROM session_profiles ORDER BY session_id
             """
         ).fetchall()
-        fts_counts = tuple(
-            (table, int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]))
-            for table in ("messages_fts_docsize", "messages_fts_identity", "blocks_command_trigram_docsize")
+        work_events = conn.execute(
+            "SELECT session_id, position, work_event_type, summary, confidence, start_index, end_index, duration_ms, evidence_json, inference_json, search_text FROM session_work_events ORDER BY session_id, position"
+        ).fetchall()
+        phases = conn.execute(
+            "SELECT session_id, position, start_index, end_index, duration_ms, tool_counts_json, word_count, evidence_json, inference_json, search_text FROM session_phases ORDER BY session_id, position"
+        ).fetchall()
+        fts_terms = [
+            str(row[0])
+            for row in conn.execute(
+                "SELECT DISTINCT lower(trim(text)) FROM blocks WHERE NULLIF(trim(text), '') IS NOT NULL ORDER BY 1"
+            ).fetchall()
+        ]
+        fts_queries = tuple(
+            (
+                term,
+                _fact_rows(
+                    conn.execute(
+                        "SELECT b.block_id, b.message_id, b.session_id FROM messages_fts AS f JOIN blocks AS b ON b.rowid = f.rowid WHERE messages_fts MATCH ? ORDER BY b.block_id",
+                        (f'"{term.replace(chr(34), chr(34) * 2)}"',),
+                    ).fetchall()
+                ),
+            )
+            for term in fts_terms
         )
     return ArchiveSnapshot(
+        raw=_fact_rows(raw),
+        raw_memberships=_fact_rows(raw_memberships),
         sessions=_fact_rows(sessions),
         messages=_fact_rows(messages),
         blocks=_fact_rows(blocks),
+        attachments=_fact_rows(attachments),
+        attachment_refs=_fact_rows(attachment_refs),
+        session_events=_fact_rows(session_events),
         session_links=_fact_rows(session_links),
+        insight_materialization=_fact_rows(insight_materialization),
         profiles=_fact_rows(profiles),
-        fts_counts=fts_counts,
+        work_events=_fact_rows(work_events),
+        phases=_fact_rows(phases),
+        fts_queries=fts_queries,
     )
 
 
-def assert_archives_equivalent(left: ConvergenceArchive, right: ConvergenceArchive) -> None:
-    """Compare archives through ``archive_snapshot`` rather than database bytes."""
+def assert_archives_equivalent(
+    left: ConvergenceArchive,
+    right: ConvergenceArchive,
+    *,
+    compare_acquisition_route: bool = True,
+) -> None:
+    """Compare archives through the one canonical cross-tier snapshot."""
     left_snapshot = archive_snapshot(left.root)
     right_snapshot = archive_snapshot(right.root)
+    if not compare_acquisition_route:
+        left_snapshot = ArchiveSnapshot(
+            raw=(),
+            raw_memberships=(),
+            sessions=left_snapshot.sessions,
+            messages=left_snapshot.messages,
+            blocks=left_snapshot.blocks,
+            attachments=left_snapshot.attachments,
+            attachment_refs=left_snapshot.attachment_refs,
+            session_events=left_snapshot.session_events,
+            session_links=left_snapshot.session_links,
+            insight_materialization=left_snapshot.insight_materialization,
+            profiles=left_snapshot.profiles,
+            work_events=left_snapshot.work_events,
+            phases=left_snapshot.phases,
+            fts_queries=left_snapshot.fts_queries,
+        )
+        right_snapshot = ArchiveSnapshot(
+            raw=(),
+            raw_memberships=(),
+            sessions=right_snapshot.sessions,
+            messages=right_snapshot.messages,
+            blocks=right_snapshot.blocks,
+            attachments=right_snapshot.attachments,
+            attachment_refs=right_snapshot.attachment_refs,
+            session_events=right_snapshot.session_events,
+            session_links=right_snapshot.session_links,
+            insight_materialization=right_snapshot.insight_materialization,
+            profiles=right_snapshot.profiles,
+            work_events=right_snapshot.work_events,
+            phases=right_snapshot.phases,
+            fts_queries=right_snapshot.fts_queries,
+        )
     if left_snapshot != right_snapshot:
-        raise AssertionError(f"canonical archive snapshots differ:\nleft={left_snapshot!r}\nright={right_snapshot!r}")
+        differences = {
+            field.name: (getattr(left_snapshot, field.name), getattr(right_snapshot, field.name))
+            for field in fields(ArchiveSnapshot)
+            if getattr(left_snapshot, field.name) != getattr(right_snapshot, field.name)
+        }
+        raise AssertionError(f"canonical archive snapshots differ in {tuple(differences)}: {differences!r}")
 
 
-def _complete_session_order(pathology: ComposedPathology, order: Sequence[int] | None) -> tuple[int, ...]:
+def _complete_session_order(pathology: ConvergenceCorpus, order: Sequence[int] | None) -> tuple[int, ...]:
     expected = tuple(range(len(pathology.sessions)))
     candidate = expected if order is None else tuple(order)
     if len(candidate) != len(expected) or set(candidate) != set(expected):
@@ -297,61 +588,174 @@ def _complete_session_order(pathology: ComposedPathology, order: Sequence[int] |
     return candidate
 
 
-def rotated_session_order(pathology: ComposedPathology, shift: int) -> tuple[int, ...]:
-    """Return one generated, non-identity ordering of the complete corpus."""
-    session_count = len(pathology.sessions)
-    if not 0 < shift < session_count:
-        raise ValueError("shift must select a non-identity rotation")
-    indexes = tuple(range(session_count))
-    return indexes[shift:] + indexes[:shift]
+def permuted_session_order(pathology: ConvergenceCorpus, seed: int) -> tuple[int, ...]:
+    """Return a deterministic non-identity permutation, including swaps."""
+    indexes = list(range(len(pathology.sessions)))
+    random.Random(seed).shuffle(indexes)
+    if tuple(indexes) == tuple(range(len(indexes))):
+        indexes.reverse()
+    return tuple(indexes)
 
 
-def _validate_session_indexes(pathology: ComposedPathology, indexes: Sequence[int]) -> tuple[int, ...]:
+def rotated_session_order(pathology: ConvergenceCorpus, shift: int) -> tuple[int, ...]:
+    """Compatibility wrapper retained for callers outside this batch."""
+    return permuted_session_order(pathology, shift)
+
+
+def build_append_prefix_archive(
+    root: Path,
+    member: CorpusMember,
+    *,
+    split_line: int,
+) -> ConvergenceArchive:
+    """Ingest one real JSONL prefix, then its literal delta through live append."""
+    _reset_property_archive_root(root)
+    initialize_active_archive(root)
+    batch = SyntheticCorpus.generate_batch_for_selection(member.selection, member.spec)
+    artifact = batch.artifacts[0]
+    lines = artifact.raw_bytes.splitlines(keepends=True)
+    if len(lines) < 3:
+        raise AssertionError("append corpus artifact needs metadata and at least two complete records")
+    split = max(2, min(split_line, len(lines) - 1))
+    prefix = b"".join(lines[:split])
+    delta = b"".join(lines[split:])
+    source_root = root / "live" / member.provider
+    source_root.mkdir(parents=True, exist_ok=True)
+    source_path = source_root / "capture-proof.jsonl"
+    source_path.write_bytes(prefix)
+
+    async def ingest() -> None:
+        from polylogue.api import Polylogue
+
+        archive = Polylogue(archive_root=root, db_path=root / "index.db")
+        try:
+            processor = LiveBatchProcessor(
+                archive,
+                (WatchSource(name=member.provider, root=source_root),),
+                cursor=CursorStore(root / "index.db"),
+                parser_fingerprint="convergence-property-live-v1",
+            )
+            first = await processor.ingest_files([source_path], emit_event=False)
+            if first.succeeded_file_count != 1:
+                raise AssertionError(f"live prefix ingest did not succeed: {first!r}")
+            with source_path.open("ab") as handle:
+                handle.write(delta)
+            second = await processor.ingest_files([source_path], emit_event=False)
+            if second.append_file_count != 1 or second.succeeded_file_count != 1:
+                raise AssertionError(f"live append ingest did not take append route: {second!r}")
+        finally:
+            await archive.close()
+
+    asyncio.run(ingest())
+    with sqlite3.connect(root / "index.db") as conn:
+        session_ids = tuple(sorted(str(row[0]) for row in conn.execute("SELECT session_id FROM sessions")))
+    if not session_ids:
+        raise AssertionError("live append route produced no indexed session")
+    for session_id in session_ids:
+        make_messages_fts_stale(root / "index.db", session_id=session_id)
+    archive = ConvergenceArchive(
+        root,
+        ConvergenceCorpus((member,)),
+        (source_path,),
+        session_ids,
+        (artifact.facts,),
+    )
+    converge_convergence_archive(archive)
+    return archive
+
+
+def build_full_live_archive(root: Path, member: CorpusMember) -> ConvergenceArchive:
+    """Replay the complete generated artifact through the live full route."""
+    _reset_property_archive_root(root)
+    initialize_active_archive(root)
+    artifact = SyntheticCorpus.generate_batch_for_selection(member.selection, member.spec).artifacts[0]
+    source_root = root / "live" / member.provider
+    source_root.mkdir(parents=True, exist_ok=True)
+    source_path = source_root / "capture-proof.jsonl"
+    source_path.write_bytes(artifact.raw_bytes)
+
+    async def ingest() -> None:
+        from polylogue.api import Polylogue
+
+        archive = Polylogue(archive_root=root, db_path=root / "index.db")
+        try:
+            processor = LiveBatchProcessor(
+                archive,
+                (WatchSource(name=member.provider, root=source_root),),
+                cursor=CursorStore(root / "index.db"),
+                parser_fingerprint="convergence-property-live-v1",
+            )
+            metrics = await processor.ingest_files([source_path], emit_event=False)
+            if metrics.full_file_count != 1 or metrics.succeeded_file_count != 1:
+                raise AssertionError(f"live full ingest did not succeed: {metrics!r}")
+        finally:
+            await archive.close()
+
+    asyncio.run(ingest())
+    with sqlite3.connect(root / "index.db") as conn:
+        session_ids = tuple(sorted(str(row[0]) for row in conn.execute("SELECT session_id FROM sessions")))
+    if not session_ids:
+        raise AssertionError("live full route produced no indexed session")
+    for session_id in session_ids:
+        make_messages_fts_stale(root / "index.db", session_id=session_id)
+    archive = ConvergenceArchive(root, ConvergenceCorpus((member,)), (source_path,), session_ids, (artifact.facts,))
+    converge_convergence_archive(archive)
+    return archive
+
+
+def assert_append_provenance(root: Path) -> None:
+    """Require a byte-ranged revision chain with production lineage metadata."""
+    with sqlite3.connect(root / "source.db") as conn:
+        rows = conn.execute(
+            """
+            SELECT raw_id, revision_kind, blob_size, source_revision,
+                   predecessor_raw_id, baseline_raw_id, append_start_offset,
+                   append_end_offset, revision_authority
+            FROM raw_sessions
+            ORDER BY CASE revision_kind WHEN 'full' THEN 0 WHEN 'append' THEN 1 ELSE 2 END, raw_id
+            """
+        ).fetchall()
+    if len(rows) != 2:
+        raise AssertionError(f"append raw revision provenance is incomplete: {rows!r}")
+    full, append = rows
+    if full[1] != "full" or append[1] != "append":
+        raise AssertionError(f"append route revision kinds are not full then append: {rows!r}")
+    if not full[2] or not append[2] or not full[3] or not append[3] or full[3] == append[3]:
+        raise AssertionError(f"append route did not preserve distinct raw content revisions: {rows!r}")
+    if append[4] != full[0] or append[5] != full[0]:
+        raise AssertionError(f"append route did not attach predecessor and baseline: {rows!r}")
+    if append[6] is None or append[7] is None or int(append[7]) <= int(append[6]):
+        raise AssertionError(f"append route did not persist a non-empty byte range: {rows!r}")
+    if append[8] != "byte_proven":
+        raise AssertionError(f"append route was not byte-proven: {rows!r}")
+
+
+def drop_one_insight_row(root: Path) -> None:
+    with sqlite3.connect(root / "index.db") as conn:
+        conn.execute("DELETE FROM session_profiles WHERE rowid IN (SELECT rowid FROM session_profiles LIMIT 1)")
+        conn.commit()
+
+
+def drop_one_fts_posting(root: Path) -> None:
+    with sqlite3.connect(root / "index.db") as conn:
+        row = conn.execute("SELECT rowid FROM messages_fts LIMIT 1").fetchone()
+        if row is None:
+            raise AssertionError("cannot construct FTS red twin without a posting")
+        conn.execute("DELETE FROM messages_fts WHERE rowid = ?", (int(row[0]),))
+        conn.commit()
+
+
+def _validate_session_indexes(pathology: ConvergenceCorpus, indexes: Sequence[int]) -> tuple[int, ...]:
     selected = tuple(indexes)
     if len(selected) != len(set(selected)) or any(index < 0 or index >= len(pathology.sessions) for index in selected):
         raise ValueError("session_indexes must be distinct valid composed-session indexes")
     return selected
 
 
-def _parsed_session(session: object, *, corpus_index: int) -> ParsedSession:
-    from polylogue.archive.models import Session
-
-    if not isinstance(session, Session):
-        raise TypeError(f"expected composed Session, got {type(session)!r}")
-    timestamp = _corpus_timestamp(corpus_index)
-    messages = [
-        ParsedMessage(
-            provider_message_id=str(message.id),
-            role=Role.normalize(str(message.role)),
-            text=message.text,
-            position=position,
-            timestamp=timestamp,
-            blocks=[ParsedContentBlock(type=BlockType.TEXT, text=message.text)],
-        )
-        for position, message in enumerate(session.messages)
-    ]
-    return ParsedSession(
-        source_name=Provider.CODEX,
-        provider_session_id=str(session.id),
-        title=session.title,
-        created_at=timestamp,
-        updated_at=timestamp,
-        parent_session_provider_id=None if session.parent_id is None else str(session.parent_id),
-        branch_type=session.branch_type,
-        messages=messages,
-    )
-
-
-def _raw_payload(session: ParsedSession) -> bytes:
-    return json.dumps(session.model_dump(mode="json"), sort_keys=True, separators=(",", ":")).encode()
-
-
-def _corpus_timestamp(index: int) -> str:
-    return (datetime(2026, 1, 1, tzinfo=UTC) + timedelta(seconds=index)).isoformat()
-
-
-def _acquired_at_ms(index: int) -> int:
-    return 1_767_225_600_000 + index
+def _reset_property_archive_root(root: Path) -> None:
+    """Reset only a caller-owned temporary property archive between examples."""
+    if root.exists():
+        shutil.rmtree(root)
 
 
 def _analyze_registry_tables(index_db: Path) -> None:
@@ -370,8 +774,6 @@ def seed_partial_convergence_archive(root: Path, *, target_hot: bool) -> Partial
     target_source = root / "profile-growing-codex.jsonl"
     unrelated_source = root / "unrelated-codex.jsonl"
     target_size = convergence_stages._HOT_INSIGHT_SOURCE_BYTES + 1 if target_hot else 1_024
-    truncate_sparse(target_source, target_size)
-    truncate_sparse(unrelated_source, 1_024)
 
     with open_connection(index_db) as conn:
         target_session_id = _seed_raw_source_session(
@@ -385,6 +787,8 @@ def seed_partial_convergence_archive(root: Path, *, target_hot: bool) -> Partial
             source_path=unrelated_source,
         )
         conn.commit()
+    truncate_sparse(target_source, target_size)
+    truncate_sparse(unrelated_source, 1_024)
 
     return PartialConvergenceArchive(
         root=root,
@@ -611,54 +1015,38 @@ def session_materialization_facts(index_db: Path, *, session_id: str) -> Session
 
 
 def _seed_raw_source_session(conn: sqlite3.Connection, *, session_id: str, source_path: Path) -> str:
-    raw_id = f"raw-{session_id}"
-    source_db = _main_db_path(conn).with_name("source.db")
-    with sqlite3.connect(source_db) as source_conn:
-        initialize_archive_tier(source_conn, ArchiveTier.SOURCE)
-        source_conn.execute(
-            """
-            INSERT OR REPLACE INTO raw_sessions (
-                raw_id, origin, native_id, source_path, blob_hash, blob_size,
-                acquired_at_ms
-            ) VALUES (?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                raw_id,
-                "codex-session",
-                session_id,
-                str(source_path),
-                hashlib.sha256(f"raw:{session_id}".encode()).digest(),
-                source_path.stat().st_size,
-                1_769_000_000_000,
-            ),
-        )
-        source_conn.commit()
-    return write_parsed_session_to_archive(
-        conn,
-        ParsedSession(
-            source_name=Provider.CODEX,
-            provider_session_id=session_id,
-            title=session_id,
-            created_at="2026-05-24T01:00:00+00:00",
-            updated_at="2026-05-24T01:00:00+00:00",
-            messages=[
-                ParsedMessage(
-                    provider_message_id="msg-1",
-                    role=Role.normalize("user"),
-                    text=f"Message for {session_id}",
-                    position=0,
-                    blocks=[
-                        ParsedContentBlock(
-                            type=BlockType.TEXT,
-                            text=f"Message for {session_id}",
-                        )
-                    ],
-                )
-            ],
-        ),
-        raw_id=raw_id,
-        content_hash=hashlib.sha256(f"session:{session_id}".encode()).hexdigest(),
+    archive_root = _main_db_path(conn).parent
+    selection = select_synthetic_schema(
+        "codex",
+        version="v1",
+        element_kind="session_record_stream",
+        registry_factory=_persisted_registry_factory,
     )
+    spec = CorpusSpec.for_provider(
+        "codex",
+        package_version=selection.package_version,
+        element_kind=selection.element_kind,
+        count=1,
+        messages_min=1,
+        messages_max=1,
+        seed=sum(ord(character) for character in session_id),
+        style="demo-tool-heavy",
+        session_native_ids=(session_id,),
+        origin="partial.convergence.fixture",
+    )
+    artifact = SyntheticCorpus.generate_batch_for_selection(selection, spec).artifacts[0]
+    source_path.parent.mkdir(parents=True, exist_ok=True)
+    source_path.write_bytes(artifact.raw_bytes)
+    result = asyncio.run(parse_sources_archive(archive_root, [Source(name="codex", path=source_path)]))
+    if result.counts["sessions"] != 1 or result.counts["messages"] < 1:
+        raise AssertionError(f"partial convergence fixture did not use the real Codex ingest route: {result!r}")
+    row = conn.execute(
+        "SELECT session_id FROM sessions WHERE origin = 'codex-session' AND native_id = ?",
+        (session_id,),
+    ).fetchone()
+    if row is None:
+        raise AssertionError(f"real Codex ingest did not write session {session_id!r}")
+    return str(row[0])
 
 
 def _main_db_path(conn: sqlite3.Connection) -> Path:
@@ -674,6 +1062,8 @@ def _fact_rows(rows: list[tuple[object, ...]]) -> tuple[FactRow, ...]:
 
 __all__ = [
     "ArchiveSnapshot",
+    "CorpusMember",
+    "ConvergenceCorpus",
     "ConvergenceArchive",
     "DebtLedgerRow",
     "PartialConvergenceArchive",
@@ -681,16 +1071,26 @@ __all__ = [
     "archive_snapshot",
     "assert_archive_verification_green",
     "assert_archives_equivalent",
+    "append_convergence_member",
+    "build_append_prefix_archive",
     "build_converged_archive",
+    "build_full_live_archive",
     "converge_convergence_archive",
     "debt_ledger_row",
+    "drop_one_fts_posting",
+    "drop_one_insight_row",
+    "inferred_convergence_corpus",
     "ingest_convergence_pathology",
     "initialize_active_archive",
     "make_messages_fts_stale",
     "messages_fts_match_count",
     "raw_authority_facts",
     "rich_convergence_pathology",
+    "convergence_max_examples",
+    "convergence_stateful_max_examples",
+    "convergence_stateful_step_count",
     "rotated_session_order",
+    "permuted_session_order",
     "seed_partial_convergence_archive",
     "session_materialization_facts",
     "set_debt_retry_at",

--- a/tests/infra/inferred_corpus.py
+++ b/tests/infra/inferred_corpus.py
@@ -11,9 +11,12 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
+import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
-from typing import Literal, TypeAlias
+from pathlib import Path
+from typing import Literal, TypeAlias, cast
 
 from polylogue.core.json import JSONDocument
 from polylogue.scenarios import CorpusSpec
@@ -24,6 +27,7 @@ from polylogue.schemas.synthetic.models import SchemaRecord, SyntheticSchemaSele
 from polylogue.schemas.synthetic.wire_formats import PROVIDER_WIRE_FORMATS, WireFormat
 
 ConstructSupportState: TypeAlias = Literal["supported", "unsupported"]
+INFERRED_CORPUS_MANIFEST_SCHEMA_VERSION = 1
 UnsupportedCorpusReason: TypeAlias = Literal[
     "provider_without_wire_format",
     "unsupported_element",
@@ -177,6 +181,46 @@ _SUPPORTED_FORMAT_VALUES = frozenset(
 )
 _SUPPORTED_SEMANTIC_ROLE_VALUES = frozenset({"message_role", "message_body", "message_timestamp", "session_title"})
 
+REPRESENTATIVE_PROVIDER = "codex"
+REPRESENTATIVE_PACKAGE_VERSION = "v1"
+REPRESENTATIVE_ELEMENT_KIND = "session_record_stream"
+_REPRESENTATIVE_SCHEMA: SchemaRecord = {
+    "$id": "https://example.test/polylogue/inferred-corpus/codex-v1-session-record-stream",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "type": {"type": "string", "x-polylogue-values": ["message"]},
+        "role": {
+            "type": "string",
+            "x-polylogue-semantic-role": "message_role",
+            "x-polylogue-values": ["user", "assistant"],
+        },
+        "content": {
+            "type": "array",
+            "x-polylogue-array-lengths": [1, 1],
+            "items": {
+                "type": "object",
+                "properties": {
+                    "type": {"type": "string", "x-polylogue-values": ["input_text", "output_text"]},
+                    "text": {
+                        "type": "string",
+                        "x-polylogue-semantic-role": "message_body",
+                        "x-polylogue-multiline": True,
+                    },
+                },
+            },
+        },
+        "id": {"type": "string", "x-polylogue-format": "uuid4"},
+        "timestamp": {
+            "type": "string",
+            "x-polylogue-semantic-role": "message_timestamp",
+            "x-polylogue-format": "iso8601",
+        },
+        "sequence": {"type": "integer", "x-polylogue-range": [0, 1000]},
+    },
+    "x-polylogue-string-lengths": [{"path": "$.role", "min": 1, "max": 24, "avg": 8.0, "stddev": 2.0}],
+}
+
 
 @dataclass(frozen=True, order=True)
 class ConstructSupport:
@@ -225,6 +269,8 @@ class InferredCorpusManifestEntry:
     key: CorpusManifestKey
     spec: CorpusSpec | None = None
     unsupported: UnsupportedCorpusRecord | None = None
+    generator_schema: SchemaRecord | None = None
+    workload_profile: SchemaRecord | None = None
 
     def __post_init__(self) -> None:
         if (self.spec is None) == (self.unsupported is None):
@@ -239,6 +285,12 @@ class InferredCorpusManifestEntry:
             self.key.element_kind,
         ):
             raise ValueError("CorpusSpec identity does not match manifest key")
+        if self.spec is not None and not isinstance(self.generator_schema, dict):
+            raise ValueError("supported manifest entry requires a generator schema")
+        if self.unsupported is not None and self.generator_schema is not None:
+            raise ValueError("unsupported manifest entry must not carry a generator schema")
+        if self.unsupported is not None and self.workload_profile is not None:
+            raise ValueError("unsupported manifest entry must not carry a workload profile")
 
     @property
     def supported(self) -> bool:
@@ -250,6 +302,10 @@ class InferredCorpusManifestEntry:
             payload["spec"] = self.spec.to_payload()
         if self.unsupported is not None:
             payload["unsupported"] = self.unsupported.to_payload()
+        if self.generator_schema is not None:
+            payload["generator_schema"] = self.generator_schema
+        if self.workload_profile is not None:
+            payload["workload_profile"] = self.workload_profile
         return payload
 
 
@@ -282,19 +338,76 @@ class InferredCorpusManifest:
 
     @property
     def manifest_id(self) -> str:
-        encoded = json.dumps(self._payload_without_id(), sort_keys=True, separators=(",", ":"))
+        encoded = _canonical_json(self._payload_without_id())
         return f"manifest:sha256:{hashlib.sha256(encoded.encode('utf-8')).hexdigest()}"
+
+    @property
+    def payload_sha256(self) -> str:
+        encoded = _canonical_json({"manifest_id": self.manifest_id, **self._payload_without_id()})
+        return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
     def _payload_without_id(self) -> dict[str, object]:
         return {
-            "schema_version": 1,
+            "schema_version": INFERRED_CORPUS_MANIFEST_SCHEMA_VERSION,
             "receipt_state": self.receipt_state,
             "package_receipt": self.package_receipt,
             "entries": [entry.to_payload() for entry in self.entries],
         }
 
     def to_payload(self) -> dict[str, object]:
-        return {"manifest_id": self.manifest_id, **self._payload_without_id()}
+        return {
+            "manifest_id": self.manifest_id,
+            **self._payload_without_id(),
+            "payload_sha256": self.payload_sha256,
+        }
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, object]) -> InferredCorpusManifest:
+        expected_fields = {
+            "manifest_id",
+            "schema_version",
+            "receipt_state",
+            "package_receipt",
+            "entries",
+            "payload_sha256",
+        }
+        if set(payload) != expected_fields:
+            raise ValueError(f"inferred corpus manifest fields changed: {sorted(set(payload) ^ expected_fields)}")
+        schema_version = payload.get("schema_version")
+        if schema_version != INFERRED_CORPUS_MANIFEST_SCHEMA_VERSION:
+            raise ValueError(
+                "unsupported inferred corpus manifest schema_version: "
+                f"expected={INFERRED_CORPUS_MANIFEST_SCHEMA_VERSION}, actual={schema_version!r}"
+            )
+        raw_entries = payload.get("entries")
+        if not isinstance(raw_entries, list):
+            raise ValueError("inferred corpus manifest entries must be a list")
+        entries = tuple(_manifest_entry_from_payload(item) for item in raw_entries)
+        receipt_state = payload.get("receipt_state")
+        package_receipt = payload.get("package_receipt")
+        if receipt_state not in {"catalog_only", "package_receipt_attached"}:
+            raise ValueError(f"invalid inferred corpus manifest receipt_state: {receipt_state!r}")
+        if receipt_state == "catalog_only" and package_receipt is not None:
+            raise ValueError("catalog_only manifest must not carry a package receipt")
+        if receipt_state == "package_receipt_attached" and not isinstance(package_receipt, dict):
+            raise ValueError("package_receipt_attached manifest requires a JSON object receipt")
+        manifest = cls(
+            entries=entries,
+            package_receipt=package_receipt if isinstance(package_receipt, dict) else None,
+        )
+        expected_manifest_id = manifest.manifest_id
+        if payload.get("manifest_id") != expected_manifest_id:
+            raise ValueError(
+                "inferred corpus manifest identity mismatch: "
+                f"expected={expected_manifest_id!r}, actual={payload.get('manifest_id')!r}"
+            )
+        expected_payload_sha256 = manifest.payload_sha256
+        if payload.get("payload_sha256") != expected_payload_sha256:
+            raise ValueError(
+                "inferred corpus manifest payload integrity mismatch: "
+                f"expected={expected_payload_sha256!r}, actual={payload.get('payload_sha256')!r}"
+            )
+        return manifest
 
 
 @dataclass(frozen=True)
@@ -303,20 +416,189 @@ class InferredCorpusConvergenceHandoff:
 
     manifest_id: str
     specs: tuple[CorpusSpec, ...]
+    selections: tuple[SyntheticSchemaSelection, ...]
+
+
+def _canonical_json(payload: Mapping[str, object]) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
+
+
+def _reject_json_constant(value: str) -> object:
+    raise ValueError(f"non-finite JSON constant is not permitted: {value}")
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON object key: {key!r}")
+        result[key] = value
+    return result
+
+
+def _manifest_entry_from_payload(payload: object) -> InferredCorpusManifestEntry:
+    if not isinstance(payload, Mapping):
+        raise ValueError("inferred corpus manifest entry must be a JSON object")
+    entry_fields = {"key", "supported", "spec", "unsupported", "generator_schema", "workload_profile"}
+    if set(payload) - entry_fields:
+        raise ValueError(f"inferred corpus manifest entry fields changed: {sorted(set(payload) - entry_fields)}")
+    raw_key = payload.get("key")
+    if not isinstance(raw_key, Mapping):
+        raise ValueError("inferred corpus manifest entry key must be a JSON object")
+    if set(raw_key) != {"provider", "package_version", "element_kind", "construct_support"}:
+        raise ValueError("inferred corpus manifest key fields changed")
+    provider = raw_key.get("provider")
+    package_version = raw_key.get("package_version")
+    element_kind = raw_key.get("element_kind")
+    raw_constructs = raw_key.get("construct_support", [])
+    if not isinstance(raw_constructs, list) or not all(isinstance(item, Mapping) for item in raw_constructs):
+        raise ValueError("manifest construct_support must be a list of objects")
+    constructs: list[ConstructSupport] = []
+    for raw_construct in cast(list[Mapping[str, object]], raw_constructs):
+        construct = raw_construct.get("construct")
+        state = raw_construct.get("state")
+        if not isinstance(construct, str) or not construct or state not in {"supported", "unsupported"}:
+            raise ValueError("manifest construct_support contains an invalid row")
+        constructs.append(ConstructSupport(construct=construct, state=state))
+    if (
+        not isinstance(provider, str)
+        or not isinstance(package_version, str)
+        or not isinstance(element_kind, str)
+        or not element_kind
+        or tuple(sorted(constructs)) != tuple(constructs)
+        or len({item.construct for item in constructs}) != len(constructs)
+    ):
+        raise ValueError("manifest entry key has invalid identity or construct ordering")
+    key = CorpusManifestKey(provider, package_version, element_kind, tuple(constructs))
+    supported = payload.get("supported")
+    raw_spec = payload.get("spec")
+    raw_unsupported = payload.get("unsupported")
+    raw_schema = payload.get("generator_schema")
+    raw_workload_profile = payload.get("workload_profile")
+    if supported is True:
+        expected_entry_fields = {"key", "supported", "spec", "generator_schema"}
+        if "workload_profile" in payload:
+            expected_entry_fields.add("workload_profile")
+        if set(payload) != expected_entry_fields:
+            raise ValueError("supported manifest entry fields changed")
+        if not isinstance(raw_spec, Mapping) or not isinstance(raw_schema, Mapping):
+            raise ValueError("supported manifest entry requires spec and generator_schema")
+        if "workload_profile" in payload and not isinstance(raw_workload_profile, Mapping):
+            raise ValueError("manifest workload_profile must be a JSON object when present")
+        spec_fields = {
+            "origin",
+            "path_targets",
+            "artifact_targets",
+            "conceptual_path_targets",
+            "conceptual_artifact_targets",
+            "operation_targets",
+            "maintenance_targets",
+            "tags",
+            "docs_role",
+            "caption",
+            "narrative_order",
+            "audience",
+            "demonstrates",
+            "privacy_level",
+            "media",
+            "visual_style",
+            "provider",
+            "package_version",
+            "count",
+            "messages_min",
+            "messages_max",
+            "style",
+            "element_kind",
+            "seed",
+            "session_native_ids",
+            "profile",
+        }
+        if set(raw_spec) - spec_fields:
+            raise ValueError("inferred corpus spec fields changed")
+        spec = CorpusSpec.from_payload(cast(dict[str, object], raw_spec))
+        return InferredCorpusManifestEntry(
+            key=key,
+            spec=spec,
+            generator_schema=cast(SchemaRecord, dict(raw_schema)),
+            workload_profile=(
+                cast(SchemaRecord, dict(raw_workload_profile)) if isinstance(raw_workload_profile, Mapping) else None
+            ),
+        )
+    if supported is not False:
+        raise ValueError("manifest entry supported must be boolean")
+    if set(payload) != {"key", "supported", "unsupported"}:
+        raise ValueError("unsupported manifest entry fields changed")
+    if not isinstance(raw_unsupported, Mapping):
+        raise ValueError("unsupported manifest entry requires unsupported metadata only")
+    reason = raw_unsupported.get("reason")
+    details = raw_unsupported.get("details", [])
+    if set(raw_unsupported) != {"reason", "details"}:
+        raise ValueError("manifest unsupported record fields changed")
+    valid_reasons = {
+        "provider_without_wire_format",
+        "unsupported_element",
+        "missing_schema",
+        "unsupported_json_schema_construct",
+    }
+    if (
+        reason not in valid_reasons
+        or not isinstance(details, list)
+        or not all(isinstance(item, str) for item in details)
+    ):
+        raise ValueError("manifest unsupported record is invalid")
+    return InferredCorpusManifestEntry(
+        key=key,
+        unsupported=UnsupportedCorpusRecord(
+            reason=cast(UnsupportedCorpusReason, reason),
+            details=tuple(cast(str, item) for item in details),
+        ),
+    )
+
+
+def write_inferred_corpus_manifest(manifest: InferredCorpusManifest, path: Path) -> None:
+    """Persist one canonical manifest payload with an independently checked hash."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(manifest.to_payload(), indent=2, sort_keys=True, allow_nan=False) + "\n", encoding="utf-8"
+    )
+
+
+def read_inferred_corpus_manifest(path: Path) -> InferredCorpusManifest:
+    """Read and validate a persisted manifest before exposing executable rows."""
+
+    try:
+        payload = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_json_keys,
+            parse_constant=_reject_json_constant,
+        )
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        raise ValueError(f"unable to read inferred corpus manifest {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("inferred corpus manifest root must be a JSON object")
+    return InferredCorpusManifest.from_payload(payload)
 
 
 def _is_number(value: object) -> bool:
-    return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return False
+    try:
+        return math.isfinite(float(value))
+    except (OverflowError, ValueError):
+        return False
 
 
 def _number(value: object) -> int | float | None:
-    if isinstance(value, (int, float)) and not isinstance(value, bool):
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value if _is_number(value) else None
+    if isinstance(value, float) and not isinstance(value, bool) and math.isfinite(value):
         return value
     return None
 
 
 def _valid_pair(value: object, *, integral: bool = False, nonnegative: bool = False) -> bool:
-    if not isinstance(value, list) or len(value) < 2:
+    if not isinstance(value, list) or len(value) != 2:
         return False
     first = _number(value[0])
     second = _number(value[1])
@@ -329,31 +611,71 @@ def _valid_pair(value: object, *, integral: bool = False, nonnegative: bool = Fa
     return first <= second
 
 
+def _histogram_bucket_is_safe(index: int, log_base: int | float) -> bool:
+    try:
+        sampled_value = math.expm1((abs(float(index)) - 0.5) * math.log(float(log_base)))
+    except (OverflowError, ValueError):
+        return False
+    return math.isfinite(sampled_value)
+
+
 def _valid_observed_distribution(value: object) -> bool:
-    if not isinstance(value, Mapping):
+    if not isinstance(value, Mapping) or not value:
         return False
     for distribution in value.values():
         if not isinstance(distribution, Mapping):
-            continue
+            return False
         histogram = distribution.get("histogram")
         log_base = _number(distribution.get("log_base"))
-        if (
-            isinstance(histogram, list)
-            and histogram
-            and _is_number(log_base)
-            and log_base is not None
-            and log_base > 1
-            and all(
-                isinstance(bucket, list)
-                and len(bucket) == 2
-                and isinstance(bucket[0], int)
-                and isinstance(bucket[1], int)
-                and bucket[1] > 0
-                for bucket in histogram
-            )
+        if not isinstance(histogram, list) or not histogram or log_base is None or log_base <= 1:
+            return False
+        log_base_float = float(log_base)
+        if not all(
+            isinstance(bucket, list)
+            and len(bucket) == 2
+            and isinstance(bucket[0], int)
+            and not isinstance(bucket[0], bool)
+            and isinstance(bucket[1], int)
+            and not isinstance(bucket[1], bool)
+            and _number(bucket[0]) is not None
+            and _number(bucket[1]) is not None
+            and bucket[1] > 0
+            and _histogram_bucket_is_safe(bucket[0], log_base_float)
+            for bucket in histogram
         ):
-            return True
-    return False
+            return False
+        for key in ("min", "max", "mean", "p0", "p50", "p90", "p95", "p99", "p100", "stddev"):
+            if key in distribution and not _is_number(distribution[key]):
+                return False
+        minimum = _number(distribution.get("min"))
+        maximum = _number(distribution.get("max"))
+        if minimum is not None and maximum is not None and minimum > maximum:
+            return False
+        stddev = _number(distribution.get("stddev"))
+        if stddev is not None and stddev < 0:
+            return False
+        ordered_stats = tuple(_number(distribution.get(key)) for key in ("p0", "p50", "p90", "p95", "p99", "p100"))
+        present_stats = tuple(value for value in ordered_stats if value is not None)
+        if any(left > right for left, right in zip(present_stats, present_stats[1:], strict=False)):
+            return False
+        if any(
+            (minimum is not None and value < minimum) or (maximum is not None and value > maximum)
+            for value in present_stats
+        ):
+            return False
+        mean = _number(distribution.get("mean"))
+        if mean is not None:
+            if minimum is not None and mean < minimum:
+                return False
+            if maximum is not None and mean > maximum:
+                return False
+            p0 = _number(distribution.get("p0"))
+            p100 = _number(distribution.get("p100"))
+            if p0 is not None and mean < p0:
+                return False
+            if p100 is not None and mean > p100:
+                return False
+    return True
 
 
 def _relation_records(value: object, required: tuple[str, ...]) -> list[dict[str, object]] | None:
@@ -367,6 +689,119 @@ def _relation_records(value: object, required: tuple[str, ...]) -> list[dict[str
             return None
         records.append(record)
     return records
+
+
+_SCHEMA_PATH_SEGMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]*$")
+
+
+def _schema_nodes_at_path(schema: SchemaRecord, path: object) -> tuple[SchemaRecord, ...]:
+    """Resolve the JSONPath subset emitted by the relation solver."""
+
+    if not isinstance(path, str) or not path.startswith("$"):
+        return ()
+    if path == "$":
+        return (schema,)
+    if not path.startswith("$."):
+        return ()
+    nodes: tuple[SchemaRecord, ...] = (schema,)
+    for raw_segment in path[2:].split("."):
+        if raw_segment.endswith("[*]"):
+            segment = raw_segment[:-3]
+            wants_items = True
+        else:
+            segment = raw_segment
+            wants_items = False
+        if not _SCHEMA_PATH_SEGMENT.fullmatch(segment):
+            return ()
+        next_nodes: list[SchemaRecord] = []
+        for node in nodes:
+            variants = [node]
+            for branch_key in ("anyOf", "oneOf"):
+                branches = node.get(branch_key)
+                if isinstance(branches, list):
+                    variants.extend(branch for branch in branches if isinstance(branch, dict))
+            for variant in variants:
+                properties = variant.get("properties")
+                child = properties.get(segment) if isinstance(properties, dict) else None
+                if not isinstance(child, dict):
+                    continue
+                if wants_items:
+                    items = child.get("items")
+                    if isinstance(items, dict):
+                        next_nodes.append(items)
+                else:
+                    next_nodes.append(child)
+        nodes = tuple(next_nodes)
+        if not nodes:
+            return ()
+    return nodes
+
+
+def _schema_nodes_have_type(nodes: tuple[SchemaRecord, ...], allowed: set[str]) -> bool:
+    return bool(nodes) and all(_schema_type(node) in allowed for node in nodes)
+
+
+def _schema_type_family(nodes: tuple[SchemaRecord, ...]) -> str | None:
+    types = {_schema_type(node) for node in nodes}
+    if types and types <= {"string"}:
+        return "string"
+    if types and types <= {"number", "integer"}:
+        return "numeric"
+    return None
+
+
+def _relation_annotation_paths_are_enforced(
+    key: str,
+    value: object,
+    root_schema: SchemaRecord,
+) -> bool:
+    records = _relation_records(
+        value,
+        {
+            "x-polylogue-foreign-keys": ("source", "target"),
+            "x-polylogue-time-deltas": ("field_a", "field_b"),
+            "x-polylogue-mutually-exclusive": ("parent",),
+            "x-polylogue-string-lengths": ("path",),
+        }[key],
+    )
+    if records is None:
+        return False
+    if key == "x-polylogue-foreign-keys":
+        return False
+    if key == "x-polylogue-time-deltas":
+        # The solver parses these records, but no production generation path
+        # calls get_time_delta yet. Keep them fail-closed until it does.
+        return False
+    if key == "x-polylogue-time-deltas":
+        return all(
+            _schema_nodes_have_type(_schema_nodes_at_path(root_schema, record["source"]), {"string"})
+            and _schema_nodes_have_type(_schema_nodes_at_path(root_schema, record["target"]), {"string"})
+            for record in records
+        )
+    if key == "x-polylogue-time-deltas":
+        return all(
+            (field_a_family := _schema_type_family(_schema_nodes_at_path(root_schema, record["field_a"]))) is not None
+            and field_a_family == _schema_type_family(_schema_nodes_at_path(root_schema, record["field_b"]))
+            for record in records
+        )
+    if key == "x-polylogue-string-lengths":
+        return all(
+            _schema_nodes_have_type(_schema_nodes_at_path(root_schema, record["path"]), {"string"})
+            for record in records
+        )
+    return all(
+        _schema_nodes_have_type(_schema_nodes_at_path(root_schema, record["parent"]), {"object"})
+        and isinstance(fields := record.get("fields"), list)
+        and all(
+            isinstance(field, str)
+            and _schema_nodes_have_type(
+                _schema_nodes_at_path(root_schema, f"{record['parent']}.{field}"),
+                {"string", "number", "integer", "boolean", "array", "object"},
+            )
+            for field in fields
+        )
+        for record in records
+    )
 
 
 def _synthetic_annotation_is_enforced(key: str, value: object) -> bool:
@@ -384,7 +819,7 @@ def _synthetic_annotation_is_enforced(key: str, value: object) -> bool:
     if key == "x-polylogue-multiline":
         return isinstance(value, bool)
     if key == "x-polylogue-values":
-        return isinstance(value, list) and bool(value) and all(not isinstance(item, (list, Mapping)) for item in value)
+        return isinstance(value, list) and bool(value) and all(isinstance(item, str) and item for item in value)
     if key == "x-polylogue-range":
         return _valid_pair(value)
     if key == "x-polylogue-array-lengths":
@@ -394,12 +829,9 @@ def _synthetic_annotation_is_enforced(key: str, value: object) -> bool:
     if key == "x-polylogue-foreign-keys":
         return _relation_records(value, ("source", "target")) is not None
     if key == "x-polylogue-time-deltas":
-        records = _relation_records(value, ("field_a", "field_b"))
-        return records is not None and all(
-            _number(record.get(field)) is not None
-            for record in records
-            for field in ("min_delta", "max_delta", "avg_delta")
-        )
+        # The solver parses these records, but no production generation path
+        # calls get_time_delta yet. Keep them fail-closed until it does.
+        return False
     if key == "x-polylogue-mutually-exclusive":
         records = _relation_records(value, ("parent",))
         return records is not None and all(
@@ -410,17 +842,88 @@ def _synthetic_annotation_is_enforced(key: str, value: object) -> bool:
         )
     if key == "x-polylogue-string-lengths":
         records = _relation_records(value, ("path",))
-        return records is not None and all(
-            _valid_pair([record.get("min"), record.get("max")], integral=True, nonnegative=True)
-            and _number(record.get("avg")) is not None
-            and _number(record.get("stddev")) is not None
+        if records is None:
+            return False
+        string_records: list[tuple[int | float | None, int | float | None, int | float | None, int | float | None]] = [
+            (
+                _number(record.get("min")),
+                _number(record.get("max")),
+                _number(record.get("avg")),
+                _number(record.get("stddev")),
+            )
             for record in records
-        )
+        ]
+        for minimum, maximum, average, stddev in string_records:
+            if (
+                not _valid_pair([minimum, maximum], integral=True, nonnegative=True)
+                or average is None
+                or stddev is None
+                or minimum is None
+                or maximum is None
+                or not minimum <= average <= maximum
+                or stddev < 0
+            ):
+                return False
+        return True
     raise AssertionError(f"missing annotation validator for {key}")
 
 
+def _schema_type(node: Mapping[str, object]) -> str | None:
+    schema_type = node.get("type")
+    if isinstance(schema_type, str):
+        return schema_type
+    if isinstance(schema_type, list):
+        types = [item for item in schema_type if isinstance(item, str) and item != "null"]
+        return types[0] if len(types) == 1 else None
+    return None
+
+
+def _annotation_is_enforced_at_node(
+    key: str,
+    value: object,
+    node: Mapping[str, object],
+    path: str,
+    root_schema: SchemaRecord,
+) -> bool:
+    schema_type = _schema_type(node)
+    if key in {
+        "x-polylogue-foreign-keys",
+        "x-polylogue-time-deltas",
+        "x-polylogue-mutually-exclusive",
+        "x-polylogue-string-lengths",
+    }:
+        return (
+            path == "$"
+            and _synthetic_annotation_is_enforced(key, value)
+            and _relation_annotation_paths_are_enforced(key, value, root_schema)
+        )
+    if key == "x-polylogue-frequency":
+        return path != "$" and _synthetic_annotation_is_enforced(key, value)
+    if key in {"x-polylogue-array-lengths", "x-polylogue-observed-distribution"}:
+        if key == "x-polylogue-array-lengths":
+            return schema_type == "array" and _synthetic_annotation_is_enforced(key, value)
+        if schema_type not in {"array", "number", "integer"} or not isinstance(value, Mapping):
+            return False
+        expected_distribution = "array_length" if schema_type == "array" else "numeric"
+        return expected_distribution in value and _valid_observed_distribution(value)
+    if key == "x-polylogue-range":
+        return schema_type in {"number", "integer"} and _synthetic_annotation_is_enforced(key, value)
+    if key in {"x-polylogue-format", "x-polylogue-values", "x-polylogue-multiline"}:
+        if key == "x-polylogue-format" and schema_type in {"number", "integer"}:
+            return value == "unix-epoch"
+        return schema_type == "string" and _synthetic_annotation_is_enforced(key, value)
+    if key == "x-polylogue-semantic-role":
+        role = value if isinstance(value, str) else None
+        if role == "message_timestamp":
+            return schema_type in {"string", "number", "integer"} and _synthetic_annotation_is_enforced(key, value)
+        if role == "message_container":
+            return False
+        return schema_type == "string" and _synthetic_annotation_is_enforced(key, value)
+    return False
+
+
 def _schema_constructs(schema: object) -> tuple[ConstructSupport, ...]:
-    """Census every schema-scope keyword without treating property names as keywords."""
+    """Census schema keywords and annotations at the paths production consumes."""
 
     found: dict[str, ConstructSupportState] = {}
 
@@ -429,14 +932,20 @@ def _schema_constructs(schema: object) -> tuple[ConstructSupport, ...]:
             return
         found[key] = state
 
-    def visit(node: object) -> None:
+    def visit(node: object, path: str = "$") -> None:
         if not isinstance(node, Mapping):
             return
+        node_record = node
         for key, value in node.items():
             if not isinstance(key, str):
                 continue
             if key.startswith("x-"):
-                record_support(key, "supported" if _synthetic_annotation_is_enforced(key, value) else "unsupported")
+                record_support(
+                    key,
+                    "supported"
+                    if _annotation_is_enforced_at_node(key, value, node_record, path, cast(SchemaRecord, schema))
+                    else "unsupported",
+                )
                 continue
             if key in _SUPPORTED_SCHEMA_CONSTRUCTS:
                 record_support(key, "supported")
@@ -447,25 +956,40 @@ def _schema_constructs(schema: object) -> tuple[ConstructSupport, ...]:
 
             if key in _SCHEMA_MAPPING_KEYWORDS and isinstance(value, Mapping):
                 if key in {"$defs", "dependentSchemas", "dependencies", "patternProperties", "properties"}:
-                    for child in value.values():
-                        visit(child)
+                    for child_name, child in value.items():
+                        child_path = f"{path}.{child_name}" if key == "properties" else f"{path}.{key}.{child_name}"
+                        visit(child, child_path)
                 else:
-                    visit(value)
+                    visit(value, f"{path}.{key}")
             elif key in _SCHEMA_ARRAY_KEYWORDS and isinstance(value, Sequence) and not isinstance(value, str):
-                for child in value:
-                    visit(child)
+                for index, child in enumerate(value):
+                    visit(child, f"{path}.{key}[{index}]")
+            elif key == "items":
+                if isinstance(value, Sequence) and not isinstance(value, str):
+                    for index, child in enumerate(value):
+                        visit(child, f"{path}.items[{index}]")
+                else:
+                    visit(value, f"{path}.items")
+            elif key == "additionalProperties" and isinstance(value, Mapping):
+                visit(value, f"{path}.additionalProperties")
 
     visit(schema)
     return tuple(ConstructSupport(construct, found[construct]) for construct in sorted(found))
 
 
 def build_inferred_corpus_convergence_handoff(
-    manifest: InferredCorpusManifest,
+    manifest: InferredCorpusManifest | Path,
 ) -> InferredCorpusConvergenceHandoff:
-    """Bind every supported manifest spec to one convergence-property invocation."""
+    """Bind every supported row from memory or persisted disk to convergence."""
 
-    handoff = InferredCorpusConvergenceHandoff(manifest_id=manifest.manifest_id, specs=manifest.supported_specs)
-    assert_inferred_corpus_convergence_handoff_complete(manifest, handoff)
+    persisted_manifest = read_inferred_corpus_manifest(manifest) if isinstance(manifest, Path) else manifest
+    selections = tuple(_selection_for_entry(entry) for entry in persisted_manifest.entries if entry.spec is not None)
+    handoff = InferredCorpusConvergenceHandoff(
+        manifest_id=persisted_manifest.manifest_id,
+        specs=persisted_manifest.supported_specs,
+        selections=selections,
+    )
+    assert_inferred_corpus_convergence_handoff_complete(persisted_manifest, handoff)
     return handoff
 
 
@@ -485,6 +1009,28 @@ def assert_inferred_corpus_convergence_handoff_complete(
             "inferred corpus convergence handoff omitted or substituted supported specs: "
             f"expected={manifest.supported_specs!r}, actual={handoff.specs!r}"
         )
+    expected_selections = tuple(_selection_for_entry(entry) for entry in manifest.entries if entry.spec is not None)
+    if handoff.selections != expected_selections:
+        raise AssertionError(
+            "inferred corpus convergence handoff omitted or substituted generator selections: "
+            f"expected={expected_selections!r}, actual={handoff.selections!r}"
+        )
+
+
+def _selection_for_entry(entry: InferredCorpusManifestEntry) -> SyntheticSchemaSelection:
+    if entry.spec is None or entry.generator_schema is None:
+        raise ValueError("unsupported inferred corpus entry cannot produce a generator selection")
+    wire_format = PROVIDER_WIRE_FORMATS.get(entry.key.provider)
+    if wire_format is None:
+        raise ValueError(f"inferred corpus entry has no production wire format: {entry.key.provider!r}")
+    return SyntheticSchemaSelection(
+        provider=entry.key.provider,
+        package_version=entry.key.package_version,
+        element_kind=entry.key.element_kind,
+        schema=entry.generator_schema,
+        wire_format=wire_format,
+        workload_profile=entry.workload_profile,
+    )
 
 
 def _stable_seed(key: CorpusManifestKey) -> int:
@@ -504,6 +1050,39 @@ def _catalog_entries(
             for element in sorted(package.elements, key=lambda item: item.element_kind):
                 result.append((provider, catalog, package, element))
     return tuple(result)
+
+
+class _RepresentativeRegistry:
+    """Keep the live package catalog while exposing one executable schema route."""
+
+    def __init__(self, base: RuntimeSchemaRegistryLike) -> None:
+        self._base = base
+
+    def get_element_schema(
+        self,
+        provider: str,
+        *,
+        version: str = "default",
+        element_kind: str | None = None,
+    ) -> SchemaRecord | JSONDocument | None:
+        package = self._base.get_package(provider, version=version)
+        resolved_version = package.version if package is not None else version
+        if (
+            provider == REPRESENTATIVE_PROVIDER
+            and resolved_version == REPRESENTATIVE_PACKAGE_VERSION
+            and element_kind == REPRESENTATIVE_ELEMENT_KIND
+        ):
+            return _REPRESENTATIVE_SCHEMA
+        return self._base.get_element_schema(provider, version=version, element_kind=element_kind)
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._base, name)
+
+
+def representative_inferred_corpus_registry(base: RuntimeSchemaRegistryLike) -> RuntimeSchemaRegistryLike:
+    """Return a catalog-backed registry with one real provider/package route admitted."""
+
+    return _RepresentativeRegistry(base)  # type: ignore[return-value]
 
 
 def _unsupported_reason(
@@ -579,7 +1158,12 @@ def _compile_entry(
             workload_profile=workload_profile if isinstance(workload_profile, dict) else None,
         )
     )
-    return InferredCorpusManifestEntry(key=key, spec=spec)
+    return InferredCorpusManifestEntry(
+        key=key,
+        spec=spec,
+        generator_schema=schema,
+        workload_profile=workload_profile if isinstance(workload_profile, dict) else None,
+    )
 
 
 def assert_inferred_corpus_manifest_complete(
@@ -633,13 +1217,20 @@ def compile_inferred_corpus_manifest(
 __all__ = [
     "ConstructSupport",
     "CorpusManifestKey",
+    "INFERRED_CORPUS_MANIFEST_SCHEMA_VERSION",
     "InferredCorpusConvergenceHandoff",
     "InferredCorpusManifest",
     "InferredCorpusManifestEntry",
     "PackageReceipt",
+    "REPRESENTATIVE_ELEMENT_KIND",
+    "REPRESENTATIVE_PACKAGE_VERSION",
+    "REPRESENTATIVE_PROVIDER",
     "UnsupportedCorpusRecord",
     "assert_inferred_corpus_convergence_handoff_complete",
     "assert_inferred_corpus_manifest_complete",
     "build_inferred_corpus_convergence_handoff",
     "compile_inferred_corpus_manifest",
+    "read_inferred_corpus_manifest",
+    "representative_inferred_corpus_registry",
+    "write_inferred_corpus_manifest",
 ]

--- a/tests/infra/inferred_corpus.py
+++ b/tests/infra/inferred_corpus.py
@@ -38,36 +38,119 @@ PackageReceipt: TypeAlias = JSONDocument
 # arbitrary unknown keys for the current corpus contract.
 _SUPPORTED_SCHEMA_CONSTRUCTS = frozenset(
     {
-        "type",
-        "properties",
-        "required",
-        "items",
-        "anyOf",
-        "oneOf",
+        "$anchor",
+        "$comment",
+        "$id",
+        "$schema",
         "additionalProperties",
+        "anyOf",
+        "default",
+        "deprecated",
+        "description",
+        "examples",
+        "items",
+        "oneOf",
+        "properties",
+        "readOnly",
+        "title",
+        "type",
+        "writeOnly",
     }
 )
-_UNSUPPORTED_SCHEMA_CONSTRUCTS = frozenset(
+
+# The synthetic runtime can select structural branches and emit declared
+# properties, but it does not validate generated values against JSON Schema.
+# Every assertion keyword outside the explicit structural subset therefore
+# fails closed. This keeps a manifest spec from implying conformance to a
+# pattern, format, range, collection bound, or other constraint it cannot
+# prove.
+_STANDARD_SCHEMA_KEYWORDS = frozenset(
     {
+        "$anchor",
+        "$comment",
         "$defs",
+        "$dynamicAnchor",
+        "$dynamicRef",
+        "$id",
+        "$recursiveAnchor",
+        "$recursiveRef",
         "$ref",
+        "$schema",
+        "$vocabulary",
+        "additionalProperties",
         "allOf",
+        "anyOf",
         "const",
         "contains",
+        "contentEncoding",
+        "contentMediaType",
+        "contentSchema",
+        "default",
         "definitions",
-        "dependencies",
+        "dependentRequired",
         "dependentSchemas",
+        "dependencies",
+        "deprecated",
+        "description",
+        "else",
         "enum",
+        "examples",
+        "exclusiveMaximum",
+        "exclusiveMinimum",
+        "format",
+        "formatAssertion",
         "if",
+        "items",
+        "maxContains",
+        "maxItems",
+        "maxLength",
+        "maxProperties",
+        "maximum",
+        "minContains",
+        "minItems",
+        "minLength",
+        "minProperties",
+        "minimum",
+        "multipleOf",
         "not",
+        "oneOf",
+        "pattern",
         "patternProperties",
         "prefixItems",
+        "properties",
+        "propertyNames",
+        "readOnly",
+        "required",
+        "then",
+        "title",
+        "type",
+        "unevaluatedItems",
+        "unevaluatedProperties",
+        "uniqueItems",
+        "writeOnly",
+    }
+)
+_SCHEMA_MAPPING_KEYWORDS = frozenset(
+    {
+        "$defs",
+        "additionalProperties",
+        "contentSchema",
+        "contains",
+        "dependentSchemas",
+        "dependencies",
+        "else",
+        "if",
+        "items",
+        "not",
+        "patternProperties",
+        "properties",
         "propertyNames",
         "then",
         "unevaluatedItems",
         "unevaluatedProperties",
     }
 )
+_SCHEMA_ARRAY_KEYWORDS = frozenset({"allOf", "anyOf", "oneOf", "prefixItems"})
 
 
 @dataclass(frozen=True, order=True)
@@ -189,8 +272,16 @@ class InferredCorpusManifest:
         return {"manifest_id": self.manifest_id, **self._payload_without_id()}
 
 
+@dataclass(frozen=True)
+class InferredCorpusConvergenceHandoff:
+    """Exact executable manifest subset admitted to the convergence loop."""
+
+    manifest_id: str
+    specs: tuple[CorpusSpec, ...]
+
+
 def _schema_constructs(schema: object) -> tuple[ConstructSupport, ...]:
-    """Collect structural JSON Schema keywords without treating field names as keywords."""
+    """Census every schema-scope keyword without treating property names as keywords."""
 
     found: dict[str, ConstructSupportState] = {}
 
@@ -198,40 +289,52 @@ def _schema_constructs(schema: object) -> tuple[ConstructSupport, ...]:
         if not isinstance(node, Mapping):
             return
         for key, value in node.items():
-            if key in _SUPPORTED_SCHEMA_CONSTRUCTS:
-                found[key] = "supported"
-            elif key in _UNSUPPORTED_SCHEMA_CONSTRUCTS:
-                found[key] = "unsupported"
+            if not isinstance(key, str):
+                continue
+            if key.startswith("x-"):
+                continue
+            found[key] = "supported" if key in _SUPPORTED_SCHEMA_CONSTRUCTS else "unsupported"
 
-            if key == "properties" and isinstance(value, Mapping):
-                for child in value.values():
-                    visit(child)
-            elif key in {
-                "items",
-                "additionalProperties",
-                "patternProperties",
-                "propertyNames",
-                "contains",
-                "if",
-                "then",
-                "unevaluatedItems",
-                "unevaluatedProperties",
-                "not",
-            }:
-                visit(value)
-            elif key in {"anyOf", "oneOf", "allOf", "prefixItems"} and isinstance(value, Sequence):
+            if key in _SCHEMA_MAPPING_KEYWORDS and isinstance(value, Mapping):
+                if key in {"$defs", "dependentSchemas", "dependencies", "patternProperties", "properties"}:
+                    for child in value.values():
+                        visit(child)
+                else:
+                    visit(value)
+            elif key in _SCHEMA_ARRAY_KEYWORDS and isinstance(value, Sequence) and not isinstance(value, str):
                 for child in value:
                     visit(child)
-            elif key in {"$defs", "definitions", "dependentSchemas"} and isinstance(value, Mapping):
-                for child in value.values():
-                    visit(child)
-            elif key == "dependencies" and isinstance(value, Mapping):
-                for child in value.values():
-                    if isinstance(child, Mapping):
-                        visit(child)
 
     visit(schema)
     return tuple(ConstructSupport(construct, found[construct]) for construct in sorted(found))
+
+
+def build_inferred_corpus_convergence_handoff(
+    manifest: InferredCorpusManifest,
+) -> InferredCorpusConvergenceHandoff:
+    """Bind every supported manifest spec to one convergence-property invocation."""
+
+    handoff = InferredCorpusConvergenceHandoff(manifest_id=manifest.manifest_id, specs=manifest.supported_specs)
+    assert_inferred_corpus_convergence_handoff_complete(manifest, handoff)
+    return handoff
+
+
+def assert_inferred_corpus_convergence_handoff_complete(
+    manifest: InferredCorpusManifest,
+    handoff: InferredCorpusConvergenceHandoff,
+) -> None:
+    """Reject a stale, omitted, or substituted convergence handoff."""
+
+    if handoff.manifest_id != manifest.manifest_id:
+        raise AssertionError(
+            "inferred corpus convergence handoff belongs to a different manifest: "
+            f"expected={manifest.manifest_id!r}, actual={handoff.manifest_id!r}"
+        )
+    if handoff.specs != manifest.supported_specs:
+        raise AssertionError(
+            "inferred corpus convergence handoff omitted or substituted supported specs: "
+            f"expected={manifest.supported_specs!r}, actual={handoff.specs!r}"
+        )
 
 
 def _stable_seed(key: CorpusManifestKey) -> int:
@@ -380,10 +483,13 @@ def compile_inferred_corpus_manifest(
 __all__ = [
     "ConstructSupport",
     "CorpusManifestKey",
+    "InferredCorpusConvergenceHandoff",
     "InferredCorpusManifest",
     "InferredCorpusManifestEntry",
     "PackageReceipt",
     "UnsupportedCorpusRecord",
+    "assert_inferred_corpus_convergence_handoff_complete",
     "assert_inferred_corpus_manifest_complete",
+    "build_inferred_corpus_convergence_handoff",
     "compile_inferred_corpus_manifest",
 ]

--- a/tests/infra/inferred_corpus.py
+++ b/tests/infra/inferred_corpus.py
@@ -309,11 +309,18 @@ def _is_number(value: object) -> bool:
     return isinstance(value, (int, float)) and not isinstance(value, bool)
 
 
+def _number(value: object) -> int | float | None:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return value
+    return None
+
+
 def _valid_pair(value: object, *, integral: bool = False, nonnegative: bool = False) -> bool:
     if not isinstance(value, list) or len(value) < 2:
         return False
-    first, second = value[:2]
-    if not _is_number(first) or not _is_number(second):
+    first = _number(value[0])
+    second = _number(value[1])
+    if first is None or second is None:
         return False
     if integral and (not isinstance(first, int) or not isinstance(second, int)):
         return False
@@ -329,11 +336,12 @@ def _valid_observed_distribution(value: object) -> bool:
         if not isinstance(distribution, Mapping):
             continue
         histogram = distribution.get("histogram")
-        log_base = distribution.get("log_base")
+        log_base = _number(distribution.get("log_base"))
         if (
             isinstance(histogram, list)
             and histogram
             and _is_number(log_base)
+            and log_base is not None
             and log_base > 1
             and all(
                 isinstance(bucket, list)
@@ -348,16 +356,17 @@ def _valid_observed_distribution(value: object) -> bool:
     return False
 
 
-def _valid_relation_records(value: object, required: tuple[str, ...]) -> bool:
-    return (
-        isinstance(value, list)
-        and bool(value)
-        and all(
-            isinstance(record, Mapping)
-            and all(isinstance(record.get(field), str) and record[field].strip() for field in required)
-            for record in value
-        )
-    )
+def _relation_records(value: object, required: tuple[str, ...]) -> list[dict[str, object]] | None:
+    if not isinstance(value, list) or not value:
+        return None
+    records: list[dict[str, object]] = []
+    for record in value:
+        if not isinstance(record, dict):
+            return None
+        if not all(isinstance(record.get(field), str) and record[field].strip() for field in required):
+            return None
+        records.append(record)
+    return records
 
 
 def _synthetic_annotation_is_enforced(key: str, value: object) -> bool:
@@ -370,7 +379,8 @@ def _synthetic_annotation_is_enforced(key: str, value: object) -> bool:
     if key == "x-polylogue-semantic-role":
         return isinstance(value, str) and value in _SUPPORTED_SEMANTIC_ROLE_VALUES
     if key == "x-polylogue-frequency":
-        return _is_number(value) and 0 <= value <= 1
+        frequency = _number(value)
+        return frequency is not None and 0 <= frequency <= 1
     if key == "x-polylogue-multiline":
         return isinstance(value, bool)
     if key == "x-polylogue-values":
@@ -382,29 +392,29 @@ def _synthetic_annotation_is_enforced(key: str, value: object) -> bool:
     if key == "x-polylogue-observed-distribution":
         return _valid_observed_distribution(value)
     if key == "x-polylogue-foreign-keys":
-        return _valid_relation_records(value, ("source", "target"))
+        return _relation_records(value, ("source", "target")) is not None
     if key == "x-polylogue-time-deltas":
-        return _valid_relation_records(value, ("field_a", "field_b")) and all(
-            _is_number(record.get(field))
-            for record in value
-            if isinstance(record, Mapping)
+        records = _relation_records(value, ("field_a", "field_b"))
+        return records is not None and all(
+            _number(record.get(field)) is not None
+            for record in records
             for field in ("min_delta", "max_delta", "avg_delta")
         )
     if key == "x-polylogue-mutually-exclusive":
-        return _valid_relation_records(value, ("parent",)) and all(
-            isinstance(record.get("fields"), list)
-            and len(record["fields"]) >= 2
-            and all(isinstance(field, str) and field for field in record["fields"])
-            for record in value
-            if isinstance(record, Mapping)
+        records = _relation_records(value, ("parent",))
+        return records is not None and all(
+            isinstance(fields := record.get("fields"), list)
+            and len(fields) >= 2
+            and all(isinstance(field, str) and field for field in fields)
+            for record in records
         )
     if key == "x-polylogue-string-lengths":
-        return _valid_relation_records(value, ("path",)) and all(
+        records = _relation_records(value, ("path",))
+        return records is not None and all(
             _valid_pair([record.get("min"), record.get("max")], integral=True, nonnegative=True)
-            and _is_number(record.get("avg"))
-            and _is_number(record.get("stddev"))
-            for record in value
-            if isinstance(record, Mapping)
+            and _number(record.get("avg")) is not None
+            and _number(record.get("stddev")) is not None
+            for record in records
         )
     raise AssertionError(f"missing annotation validator for {key}")
 

--- a/tests/infra/inferred_corpus.py
+++ b/tests/infra/inferred_corpus.py
@@ -181,46 +181,6 @@ _SUPPORTED_FORMAT_VALUES = frozenset(
 )
 _SUPPORTED_SEMANTIC_ROLE_VALUES = frozenset({"message_role", "message_body", "message_timestamp", "session_title"})
 
-REPRESENTATIVE_PROVIDER = "codex"
-REPRESENTATIVE_PACKAGE_VERSION = "v1"
-REPRESENTATIVE_ELEMENT_KIND = "session_record_stream"
-_REPRESENTATIVE_SCHEMA: SchemaRecord = {
-    "$id": "https://example.test/polylogue/inferred-corpus/codex-v1-session-record-stream",
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "type": "object",
-    "properties": {
-        "type": {"type": "string", "x-polylogue-values": ["message"]},
-        "role": {
-            "type": "string",
-            "x-polylogue-semantic-role": "message_role",
-            "x-polylogue-values": ["user", "assistant"],
-        },
-        "content": {
-            "type": "array",
-            "x-polylogue-array-lengths": [1, 1],
-            "items": {
-                "type": "object",
-                "properties": {
-                    "type": {"type": "string", "x-polylogue-values": ["input_text", "output_text"]},
-                    "text": {
-                        "type": "string",
-                        "x-polylogue-semantic-role": "message_body",
-                        "x-polylogue-multiline": True,
-                    },
-                },
-            },
-        },
-        "id": {"type": "string", "x-polylogue-format": "uuid4"},
-        "timestamp": {
-            "type": "string",
-            "x-polylogue-semantic-role": "message_timestamp",
-            "x-polylogue-format": "iso8601",
-        },
-        "sequence": {"type": "integer", "x-polylogue-range": [0, 1000]},
-    },
-    "x-polylogue-string-lengths": [{"path": "$.role", "min": 1, "max": 24, "avg": 8.0, "stddev": 2.0}],
-}
-
 
 @dataclass(frozen=True, order=True)
 class ConstructSupport:
@@ -1052,39 +1012,6 @@ def _catalog_entries(
     return tuple(result)
 
 
-class _RepresentativeRegistry:
-    """Keep the live package catalog while exposing one executable schema route."""
-
-    def __init__(self, base: RuntimeSchemaRegistryLike) -> None:
-        self._base = base
-
-    def get_element_schema(
-        self,
-        provider: str,
-        *,
-        version: str = "default",
-        element_kind: str | None = None,
-    ) -> SchemaRecord | JSONDocument | None:
-        package = self._base.get_package(provider, version=version)
-        resolved_version = package.version if package is not None else version
-        if (
-            provider == REPRESENTATIVE_PROVIDER
-            and resolved_version == REPRESENTATIVE_PACKAGE_VERSION
-            and element_kind == REPRESENTATIVE_ELEMENT_KIND
-        ):
-            return _REPRESENTATIVE_SCHEMA
-        return self._base.get_element_schema(provider, version=version, element_kind=element_kind)
-
-    def __getattr__(self, name: str) -> object:
-        return getattr(self._base, name)
-
-
-def representative_inferred_corpus_registry(base: RuntimeSchemaRegistryLike) -> RuntimeSchemaRegistryLike:
-    """Return a catalog-backed registry with one real provider/package route admitted."""
-
-    return _RepresentativeRegistry(base)  # type: ignore[return-value]
-
-
 def _unsupported_reason(
     *,
     element: SchemaElementManifest,
@@ -1222,15 +1149,11 @@ __all__ = [
     "InferredCorpusManifest",
     "InferredCorpusManifestEntry",
     "PackageReceipt",
-    "REPRESENTATIVE_ELEMENT_KIND",
-    "REPRESENTATIVE_PACKAGE_VERSION",
-    "REPRESENTATIVE_PROVIDER",
     "UnsupportedCorpusRecord",
     "assert_inferred_corpus_convergence_handoff_complete",
     "assert_inferred_corpus_manifest_complete",
     "build_inferred_corpus_convergence_handoff",
     "compile_inferred_corpus_manifest",
     "read_inferred_corpus_manifest",
-    "representative_inferred_corpus_registry",
     "write_inferred_corpus_manifest",
 ]

--- a/tests/infra/inferred_corpus.py
+++ b/tests/infra/inferred_corpus.py
@@ -152,6 +152,59 @@ _SCHEMA_MAPPING_KEYWORDS = frozenset(
 )
 _SCHEMA_ARRAY_KEYWORDS = frozenset({"allOf", "anyOf", "oneOf", "prefixItems"})
 
+# These annotations are read by the production synthetic runtime, semantic
+# value generator, or relation solver. Their support verdict means the
+# corresponding generator path consumes the annotation, rather than merely
+# tolerating its namespace.
+_SUPPORTED_SYNTHETIC_ANNOTATIONS = frozenset(
+    {
+        "x-polylogue-array-lengths",
+        "x-polylogue-foreign-keys",
+        "x-polylogue-format",
+        "x-polylogue-frequency",
+        "x-polylogue-multiline",
+        "x-polylogue-mutually-exclusive",
+        "x-polylogue-observed-distribution",
+        "x-polylogue-range",
+        "x-polylogue-semantic-role",
+        "x-polylogue-string-lengths",
+        "x-polylogue-time-deltas",
+        "x-polylogue-values",
+    }
+)
+
+# These package annotations are consumed by registry/profile loading or retain
+# provenance only. They do not constrain an emitted instance, so recognizing
+# them cannot claim synthetic schema conformance. Shape-affecting annotations
+# without a synthetic consumer, such as ``x-polylogue-ref`` and dynamic-key
+# markers, are deliberately absent and fail closed below.
+_SUPPORTED_CATALOG_METADATA_ANNOTATIONS = frozenset(
+    {
+        "x-polylogue-anchor-profile-family-id",
+        "x-polylogue-artifact-kind",
+        "x-polylogue-element-bundle-scope-count",
+        "x-polylogue-element-first-seen",
+        "x-polylogue-element-kind",
+        "x-polylogue-element-last-seen",
+        "x-polylogue-evidence",
+        "x-polylogue-evidence-confidence",
+        "x-polylogue-exact-structure-ids",
+        "x-polylogue-generated-at",
+        "x-polylogue-generator",
+        "x-polylogue-observed-artifact-count",
+        "x-polylogue-package-profile-family-ids",
+        "x-polylogue-package-version",
+        "x-polylogue-profile-family-ids",
+        "x-polylogue-profile-tokens",
+        "x-polylogue-promoted-at",
+        "x-polylogue-registered-at",
+        "x-polylogue-sample-count",
+        "x-polylogue-sample-granularity",
+        "x-polylogue-score",
+        "x-polylogue-version",
+    }
+)
+
 
 @dataclass(frozen=True, order=True)
 class ConstructSupport:
@@ -292,8 +345,18 @@ def _schema_constructs(schema: object) -> tuple[ConstructSupport, ...]:
             if not isinstance(key, str):
                 continue
             if key.startswith("x-"):
+                found[key] = (
+                    "supported"
+                    if key in _SUPPORTED_SYNTHETIC_ANNOTATIONS | _SUPPORTED_CATALOG_METADATA_ANNOTATIONS
+                    else "unsupported"
+                )
                 continue
-            found[key] = "supported" if key in _SUPPORTED_SCHEMA_CONSTRUCTS else "unsupported"
+            if key in _SUPPORTED_SCHEMA_CONSTRUCTS:
+                found[key] = "supported"
+            elif key in _STANDARD_SCHEMA_KEYWORDS:
+                found[key] = "unsupported"
+            else:
+                found[key] = "unsupported"
 
             if key in _SCHEMA_MAPPING_KEYWORDS and isinstance(value, Mapping):
                 if key in {"$defs", "dependentSchemas", "dependencies", "patternProperties", "properties"}:

--- a/tests/infra/inferred_corpus.py
+++ b/tests/infra/inferred_corpus.py
@@ -173,38 +173,6 @@ _SUPPORTED_SYNTHETIC_ANNOTATIONS = frozenset(
     }
 )
 
-# These package annotations are consumed by registry/profile loading or retain
-# provenance only. They do not constrain an emitted instance, so recognizing
-# them cannot claim synthetic schema conformance. Shape-affecting annotations
-# without a synthetic consumer, such as ``x-polylogue-ref`` and dynamic-key
-# markers, are deliberately absent and fail closed below.
-_SUPPORTED_CATALOG_METADATA_ANNOTATIONS = frozenset(
-    {
-        "x-polylogue-anchor-profile-family-id",
-        "x-polylogue-artifact-kind",
-        "x-polylogue-element-bundle-scope-count",
-        "x-polylogue-element-first-seen",
-        "x-polylogue-element-kind",
-        "x-polylogue-element-last-seen",
-        "x-polylogue-evidence",
-        "x-polylogue-evidence-confidence",
-        "x-polylogue-exact-structure-ids",
-        "x-polylogue-generated-at",
-        "x-polylogue-generator",
-        "x-polylogue-observed-artifact-count",
-        "x-polylogue-package-profile-family-ids",
-        "x-polylogue-package-version",
-        "x-polylogue-profile-family-ids",
-        "x-polylogue-profile-tokens",
-        "x-polylogue-promoted-at",
-        "x-polylogue-registered-at",
-        "x-polylogue-sample-count",
-        "x-polylogue-sample-granularity",
-        "x-polylogue-score",
-        "x-polylogue-version",
-    }
-)
-
 
 @dataclass(frozen=True, order=True)
 class ConstructSupport:
@@ -345,11 +313,7 @@ def _schema_constructs(schema: object) -> tuple[ConstructSupport, ...]:
             if not isinstance(key, str):
                 continue
             if key.startswith("x-"):
-                found[key] = (
-                    "supported"
-                    if key in _SUPPORTED_SYNTHETIC_ANNOTATIONS | _SUPPORTED_CATALOG_METADATA_ANNOTATIONS
-                    else "unsupported"
-                )
+                found[key] = "supported" if key in _SUPPORTED_SYNTHETIC_ANNOTATIONS else "unsupported"
                 continue
             if key in _SUPPORTED_SCHEMA_CONSTRUCTS:
                 found[key] = "supported"

--- a/tests/infra/inferred_corpus.py
+++ b/tests/infra/inferred_corpus.py
@@ -1,0 +1,389 @@
+"""Runtime compiler for the persisted schema-package corpus manifest.
+
+This is deliberately a test-infrastructure manifest, not an inference receipt.
+The persisted registry catalog tells us which package elements exist.  A later
+inference/package-receipt lane can be attached through ``package_receipt``
+without changing the catalog census or claiming that catalog presence proves
+inference completion.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
+from typing import Literal, TypeAlias
+
+from polylogue.core.json import JSONDocument
+from polylogue.scenarios import CorpusSpec
+from polylogue.schemas.operator.registry import RuntimeSchemaRegistryLike
+from polylogue.schemas.packages import SchemaElementManifest, SchemaPackageCatalog, SchemaVersionPackage
+from polylogue.schemas.synthetic import SyntheticCorpus
+from polylogue.schemas.synthetic.models import SchemaRecord, SyntheticSchemaSelection
+from polylogue.schemas.synthetic.wire_formats import PROVIDER_WIRE_FORMATS, WireFormat
+
+ConstructSupportState: TypeAlias = Literal["supported", "unsupported"]
+UnsupportedCorpusReason: TypeAlias = Literal[
+    "provider_without_wire_format",
+    "unsupported_element",
+    "missing_schema",
+    "unsupported_json_schema_construct",
+]
+PackageReceipt: TypeAlias = JSONDocument
+
+# These are the schema constructs the current recursive synthetic runtime can
+# consume as structure.  ``additionalProperties`` is intentionally included:
+# the generator emits declared properties and does not need to materialize
+# arbitrary unknown keys for the current corpus contract.
+_SUPPORTED_SCHEMA_CONSTRUCTS = frozenset(
+    {
+        "type",
+        "properties",
+        "required",
+        "items",
+        "anyOf",
+        "oneOf",
+        "additionalProperties",
+    }
+)
+_UNSUPPORTED_SCHEMA_CONSTRUCTS = frozenset(
+    {
+        "$defs",
+        "$ref",
+        "allOf",
+        "const",
+        "contains",
+        "definitions",
+        "dependencies",
+        "dependentSchemas",
+        "enum",
+        "if",
+        "not",
+        "patternProperties",
+        "prefixItems",
+        "propertyNames",
+        "then",
+        "unevaluatedItems",
+        "unevaluatedProperties",
+    }
+)
+
+
+@dataclass(frozen=True, order=True)
+class ConstructSupport:
+    """Support verdict for one JSON Schema construct found in an element."""
+
+    construct: str
+    state: ConstructSupportState
+
+    def to_payload(self) -> dict[str, str]:
+        return {"construct": self.construct, "state": self.state}
+
+
+@dataclass(frozen=True, order=True)
+class CorpusManifestKey:
+    """Stable identity for one provider/package/element support decision."""
+
+    provider: str
+    package_version: str
+    element_kind: str
+    construct_support: tuple[ConstructSupport, ...] = ()
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "provider": self.provider,
+            "package_version": self.package_version,
+            "element_kind": self.element_kind,
+            "construct_support": [item.to_payload() for item in self.construct_support],
+        }
+
+
+@dataclass(frozen=True)
+class UnsupportedCorpusRecord:
+    """Typed refusal retained instead of silently dropping a catalog entry."""
+
+    reason: UnsupportedCorpusReason
+    details: tuple[str, ...] = ()
+
+    def to_payload(self) -> dict[str, object]:
+        return {"reason": self.reason, "details": list(self.details)}
+
+
+@dataclass(frozen=True)
+class InferredCorpusManifestEntry:
+    """One complete catalog census row, either executable or explicitly refused."""
+
+    key: CorpusManifestKey
+    spec: CorpusSpec | None = None
+    unsupported: UnsupportedCorpusRecord | None = None
+
+    def __post_init__(self) -> None:
+        if (self.spec is None) == (self.unsupported is None):
+            raise ValueError("manifest entry requires exactly one of spec or unsupported")
+        if self.spec is not None and (
+            self.spec.provider,
+            self.spec.package_version,
+            self.spec.element_kind,
+        ) != (
+            self.key.provider,
+            self.key.package_version,
+            self.key.element_kind,
+        ):
+            raise ValueError("CorpusSpec identity does not match manifest key")
+
+    @property
+    def supported(self) -> bool:
+        return self.spec is not None
+
+    def to_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {"key": self.key.to_payload(), "supported": self.supported}
+        if self.spec is not None:
+            payload["spec"] = self.spec.to_payload()
+        if self.unsupported is not None:
+            payload["unsupported"] = self.unsupported.to_payload()
+        return payload
+
+
+@dataclass(frozen=True)
+class InferredCorpusManifest:
+    """Deterministic runtime census with an optional future package receipt."""
+
+    entries: tuple[InferredCorpusManifestEntry, ...]
+    package_receipt: PackageReceipt | None = None
+
+    def __post_init__(self) -> None:
+        ordered = tuple(sorted(self.entries, key=lambda entry: entry.key))
+        if ordered != self.entries:
+            raise ValueError("inferred corpus manifest entries must be sorted by manifest key")
+        keys = [entry.key for entry in self.entries]
+        if len(keys) != len(set(keys)):
+            raise ValueError("inferred corpus manifest contains duplicate keys")
+
+    @property
+    def supported_specs(self) -> tuple[CorpusSpec, ...]:
+        return tuple(entry.spec for entry in self.entries if entry.spec is not None)
+
+    @property
+    def unsupported_records(self) -> tuple[UnsupportedCorpusRecord, ...]:
+        return tuple(entry.unsupported for entry in self.entries if entry.unsupported is not None)
+
+    @property
+    def receipt_state(self) -> Literal["catalog_only", "package_receipt_attached"]:
+        return "package_receipt_attached" if self.package_receipt is not None else "catalog_only"
+
+    @property
+    def manifest_id(self) -> str:
+        encoded = json.dumps(self._payload_without_id(), sort_keys=True, separators=(",", ":"))
+        return f"manifest:sha256:{hashlib.sha256(encoded.encode('utf-8')).hexdigest()}"
+
+    def _payload_without_id(self) -> dict[str, object]:
+        return {
+            "schema_version": 1,
+            "receipt_state": self.receipt_state,
+            "package_receipt": self.package_receipt,
+            "entries": [entry.to_payload() for entry in self.entries],
+        }
+
+    def to_payload(self) -> dict[str, object]:
+        return {"manifest_id": self.manifest_id, **self._payload_without_id()}
+
+
+def _schema_constructs(schema: object) -> tuple[ConstructSupport, ...]:
+    """Collect structural JSON Schema keywords without treating field names as keywords."""
+
+    found: dict[str, ConstructSupportState] = {}
+
+    def visit(node: object) -> None:
+        if not isinstance(node, Mapping):
+            return
+        for key, value in node.items():
+            if key in _SUPPORTED_SCHEMA_CONSTRUCTS:
+                found[key] = "supported"
+            elif key in _UNSUPPORTED_SCHEMA_CONSTRUCTS:
+                found[key] = "unsupported"
+
+            if key == "properties" and isinstance(value, Mapping):
+                for child in value.values():
+                    visit(child)
+            elif key in {
+                "items",
+                "additionalProperties",
+                "patternProperties",
+                "propertyNames",
+                "contains",
+                "if",
+                "then",
+                "unevaluatedItems",
+                "unevaluatedProperties",
+                "not",
+            }:
+                visit(value)
+            elif key in {"anyOf", "oneOf", "allOf", "prefixItems"} and isinstance(value, Sequence):
+                for child in value:
+                    visit(child)
+            elif key in {"$defs", "definitions", "dependentSchemas"} and isinstance(value, Mapping):
+                for child in value.values():
+                    visit(child)
+            elif key == "dependencies" and isinstance(value, Mapping):
+                for child in value.values():
+                    if isinstance(child, Mapping):
+                        visit(child)
+
+    visit(schema)
+    return tuple(ConstructSupport(construct, found[construct]) for construct in sorted(found))
+
+
+def _stable_seed(key: CorpusManifestKey) -> int:
+    material = "\x1f".join((key.provider, key.package_version, key.element_kind)).encode("utf-8")
+    return int(hashlib.sha256(material).hexdigest()[:8], 16)
+
+
+def _catalog_entries(
+    registry: RuntimeSchemaRegistryLike,
+) -> tuple[tuple[str, SchemaPackageCatalog, SchemaVersionPackage, SchemaElementManifest], ...]:
+    result: list[tuple[str, SchemaPackageCatalog, SchemaVersionPackage, SchemaElementManifest]] = []
+    for provider in sorted(set(registry.list_providers())):
+        catalog = registry.load_package_catalog(provider)
+        if catalog is None:
+            raise RuntimeError(f"registry provider {provider!r} has no persisted package catalog")
+        for package in sorted(catalog.packages, key=lambda item: item.version):
+            for element in sorted(package.elements, key=lambda item: item.element_kind):
+                result.append((provider, catalog, package, element))
+    return tuple(result)
+
+
+def _unsupported_reason(
+    *,
+    element: SchemaElementManifest,
+    schema: SchemaRecord | None,
+    wire_format: WireFormat | None,
+    construct_support: tuple[ConstructSupport, ...],
+) -> UnsupportedCorpusRecord | None:
+    if wire_format is None:
+        return UnsupportedCorpusRecord("provider_without_wire_format")
+    if not element.supported:
+        return UnsupportedCorpusRecord("unsupported_element")
+    if schema is None or element.schema_file is None:
+        return UnsupportedCorpusRecord("missing_schema")
+    unsupported_constructs = tuple(item.construct for item in construct_support if item.state == "unsupported")
+    if unsupported_constructs:
+        return UnsupportedCorpusRecord("unsupported_json_schema_construct", unsupported_constructs)
+    return None
+
+
+def _compile_entry(
+    *,
+    provider: str,
+    package: SchemaVersionPackage,
+    element: SchemaElementManifest,
+    registry: RuntimeSchemaRegistryLike,
+    wire_formats: Mapping[str, WireFormat],
+) -> InferredCorpusManifestEntry:
+    key_without_constructs = CorpusManifestKey(provider, package.version, element.element_kind)
+    schema = registry.get_element_schema(
+        provider,
+        version=package.version,
+        element_kind=element.element_kind,
+    )
+    construct_support = _schema_constructs(schema)
+    key = replace(key_without_constructs, construct_support=construct_support)
+    wire_format = wire_formats.get(provider)
+    unsupported = _unsupported_reason(
+        element=element,
+        schema=schema if isinstance(schema, dict) else None,
+        wire_format=wire_format,
+        construct_support=construct_support,
+    )
+    if unsupported is not None:
+        return InferredCorpusManifestEntry(key=key, unsupported=unsupported)
+
+    if not isinstance(schema, dict) or wire_format is None:
+        raise AssertionError("supported manifest entry lost schema or wire format")
+    profile_loader = getattr(registry, "get_workload_profile", None)
+    workload_profile = profile_loader(provider, package.version) if callable(profile_loader) else None
+    spec = CorpusSpec.for_provider(
+        provider,
+        package_version=package.version,
+        element_kind=element.element_kind,
+        count=1,
+        messages_min=4,
+        messages_max=4,
+        seed=_stable_seed(key),
+        origin="inferred.schema-package-manifest",
+        tags=("inferred", "schema", "synthetic", "manifest"),
+    )
+    # Construct the production generator against the exact package/version/
+    # element.  No generation is performed here, so compiling the receipt does
+    # not turn an unverified catalog into an inference claim.
+    SyntheticCorpus.from_selection(
+        SyntheticSchemaSelection(
+            provider=provider,
+            package_version=package.version,
+            element_kind=element.element_kind,
+            schema=schema,
+            wire_format=wire_format,
+            workload_profile=workload_profile if isinstance(workload_profile, dict) else None,
+        )
+    )
+    return InferredCorpusManifestEntry(key=key, spec=spec)
+
+
+def assert_inferred_corpus_manifest_complete(
+    manifest: InferredCorpusManifest,
+    registry: RuntimeSchemaRegistryLike,
+) -> None:
+    """Fail loudly when a manifest omits any currently persisted catalog entry."""
+
+    expected = {
+        CorpusManifestKey(provider, package.version, element.element_kind)
+        for provider, _catalog, package, element in _catalog_entries(registry)
+    }
+    actual = {
+        CorpusManifestKey(entry.key.provider, entry.key.package_version, entry.key.element_kind)
+        for entry in manifest.entries
+    }
+    missing = sorted(expected - actual)
+    unexpected = sorted(actual - expected)
+    if missing or unexpected:
+        raise AssertionError(
+            f"inferred corpus manifest coverage mismatch: missing={missing!r}, unexpected={unexpected!r}"
+        )
+
+
+def compile_inferred_corpus_manifest(
+    *,
+    registry: RuntimeSchemaRegistryLike,
+    package_receipt: PackageReceipt | None = None,
+    wire_formats: Mapping[str, WireFormat] | None = None,
+) -> InferredCorpusManifest:
+    """Compile every persisted package/version/element into a typed manifest."""
+
+    formats = PROVIDER_WIRE_FORMATS if wire_formats is None else wire_formats
+    entries = tuple(
+        _compile_entry(
+            provider=provider,
+            package=package,
+            element=element,
+            registry=registry,
+            wire_formats=formats,
+        )
+        for provider, catalog, package, element in _catalog_entries(registry)
+    )
+    manifest = InferredCorpusManifest(
+        entries=tuple(sorted(entries, key=lambda entry: entry.key)), package_receipt=package_receipt
+    )
+    assert_inferred_corpus_manifest_complete(manifest, registry)
+    return manifest
+
+
+__all__ = [
+    "ConstructSupport",
+    "CorpusManifestKey",
+    "InferredCorpusManifest",
+    "InferredCorpusManifestEntry",
+    "PackageReceipt",
+    "UnsupportedCorpusRecord",
+    "assert_inferred_corpus_manifest_complete",
+    "compile_inferred_corpus_manifest",
+]

--- a/tests/infra/inferred_corpus.py
+++ b/tests/infra/inferred_corpus.py
@@ -24,12 +24,20 @@ from polylogue.schemas.operator.registry import RuntimeSchemaRegistryLike
 from polylogue.schemas.packages import SchemaElementManifest, SchemaPackageCatalog, SchemaVersionPackage
 from polylogue.schemas.synthetic import SyntheticCorpus
 from polylogue.schemas.synthetic.models import SchemaRecord, SyntheticSchemaSelection
-from polylogue.schemas.synthetic.wire_formats import PROVIDER_WIRE_FORMATS, WireFormat
+from polylogue.schemas.synthetic.wire_formats import (
+    PROVIDER_WIRE_FORMATS,
+    PROVIDER_WIRE_ROUTES,
+    WireFormat,
+    WireSupportEntry,
+    WireSupportReceipt,
+)
 
 ConstructSupportState: TypeAlias = Literal["supported", "unsupported"]
 INFERRED_CORPUS_MANIFEST_SCHEMA_VERSION = 1
 UnsupportedCorpusReason: TypeAlias = Literal[
     "provider_without_wire_format",
+    "unsupported_wire_route",
+    "wire_support_receipt_incomplete",
     "unsupported_element",
     "missing_schema",
     "unsupported_json_schema_construct",
@@ -496,6 +504,8 @@ def _manifest_entry_from_payload(payload: object) -> InferredCorpusManifestEntry
         raise ValueError("manifest unsupported record fields changed")
     valid_reasons = {
         "provider_without_wire_format",
+        "unsupported_wire_route",
+        "wire_support_receipt_incomplete",
         "unsupported_element",
         "missing_schema",
         "unsupported_json_schema_construct",
@@ -980,15 +990,15 @@ def assert_inferred_corpus_convergence_handoff_complete(
 def _selection_for_entry(entry: InferredCorpusManifestEntry) -> SyntheticSchemaSelection:
     if entry.spec is None or entry.generator_schema is None:
         raise ValueError("unsupported inferred corpus entry cannot produce a generator selection")
-    wire_format = PROVIDER_WIRE_FORMATS.get(entry.key.provider)
-    if wire_format is None:
-        raise ValueError(f"inferred corpus entry has no production wire format: {entry.key.provider!r}")
+    route = PROVIDER_WIRE_ROUTES.get(entry.key.provider)
+    if route is None or route.status != "supported" or route.wire_format is None:
+        raise ValueError(f"inferred corpus entry has no supported production wire route: {entry.key.provider!r}")
     return SyntheticSchemaSelection(
         provider=entry.key.provider,
         package_version=entry.key.package_version,
         element_kind=entry.key.element_kind,
         schema=entry.generator_schema,
-        wire_format=wire_format,
+        wire_format=route.wire_format,
         workload_profile=entry.workload_profile,
     )
 
@@ -1018,15 +1028,37 @@ def _unsupported_reason(
     schema: SchemaRecord | None,
     wire_format: WireFormat | None,
     construct_support: tuple[ConstructSupport, ...],
+    support_entry: WireSupportEntry | None,
 ) -> UnsupportedCorpusRecord | None:
-    if wire_format is None:
+    if support_entry is not None:
+        if support_entry.status == "unsupported":
+            return UnsupportedCorpusRecord(
+                "unsupported_wire_route",
+                (support_entry.reason or "route is explicitly unsupported",),
+            )
+        if not support_entry.healthy:
+            details = tuple(
+                detail
+                for detail in (
+                    support_entry.validation_error,
+                    *(support_entry.construct_coverage.missing_keywords if support_entry.construct_coverage else ()),
+                )
+                if detail
+            )
+            return UnsupportedCorpusRecord("wire_support_receipt_incomplete", details)
+    elif wire_format is None:
         return UnsupportedCorpusRecord("provider_without_wire_format")
     if not element.supported:
         return UnsupportedCorpusRecord("unsupported_element")
     if schema is None or element.schema_file is None:
         return UnsupportedCorpusRecord("missing_schema")
     unsupported_constructs = tuple(item.construct for item in construct_support if item.state == "unsupported")
-    if unsupported_constructs:
+    # The generic manifest census intentionally records every unsupported
+    # construct.  A healthy support receipt may classify those constructs as
+    # explicitly nonrepresentable for the selected wire route, so they remain
+    # evidence on the key without preventing the route from entering the
+    # production parser/ingest loop.
+    if unsupported_constructs and not (support_entry is not None and support_entry.healthy):
         return UnsupportedCorpusRecord("unsupported_json_schema_construct", unsupported_constructs)
     return None
 
@@ -1038,6 +1070,7 @@ def _compile_entry(
     element: SchemaElementManifest,
     registry: RuntimeSchemaRegistryLike,
     wire_formats: Mapping[str, WireFormat],
+    support_entry: WireSupportEntry | None,
 ) -> InferredCorpusManifestEntry:
     key_without_constructs = CorpusManifestKey(provider, package.version, element.element_kind)
     schema = registry.get_element_schema(
@@ -1053,6 +1086,7 @@ def _compile_entry(
         schema=schema if isinstance(schema, dict) else None,
         wire_format=wire_format,
         construct_support=construct_support,
+        support_entry=support_entry,
     )
     if unsupported is not None:
         return InferredCorpusManifestEntry(key=key, unsupported=unsupported)
@@ -1120,10 +1154,14 @@ def compile_inferred_corpus_manifest(
     registry: RuntimeSchemaRegistryLike,
     package_receipt: PackageReceipt | None = None,
     wire_formats: Mapping[str, WireFormat] | None = None,
+    wire_support_receipt: WireSupportReceipt | None = None,
 ) -> InferredCorpusManifest:
     """Compile every persisted package/version/element into a typed manifest."""
 
     formats = PROVIDER_WIRE_FORMATS if wire_formats is None else wire_formats
+    support_entries = (
+        {entry.provider: entry for entry in wire_support_receipt.entries} if wire_support_receipt is not None else {}
+    )
     entries = tuple(
         _compile_entry(
             provider=provider,
@@ -1131,11 +1169,17 @@ def compile_inferred_corpus_manifest(
             element=element,
             registry=registry,
             wire_formats=formats,
+            support_entry=support_entries.get(provider),
         )
         for provider, catalog, package, element in _catalog_entries(registry)
     )
     manifest = InferredCorpusManifest(
-        entries=tuple(sorted(entries, key=lambda entry: entry.key)), package_receipt=package_receipt
+        entries=tuple(sorted(entries, key=lambda entry: entry.key)),
+        package_receipt=(
+            cast(PackageReceipt, wire_support_receipt.to_dict())
+            if wire_support_receipt is not None
+            else package_receipt
+        ),
     )
     assert_inferred_corpus_manifest_complete(manifest, registry)
     return manifest

--- a/tests/infra/inferred_corpus.py
+++ b/tests/infra/inferred_corpus.py
@@ -172,6 +172,10 @@ _SUPPORTED_SYNTHETIC_ANNOTATIONS = frozenset(
         "x-polylogue-values",
     }
 )
+_SUPPORTED_FORMAT_VALUES = frozenset(
+    {"uuid4", "uuid", "hex-id", "iso8601", "unix-epoch", "unix-epoch-str", "url", "email", "mime-type", "base64"}
+)
+_SUPPORTED_SEMANTIC_ROLE_VALUES = frozenset({"message_role", "message_body", "message_timestamp", "session_title"})
 
 
 @dataclass(frozen=True, order=True)
@@ -301,10 +305,119 @@ class InferredCorpusConvergenceHandoff:
     specs: tuple[CorpusSpec, ...]
 
 
+def _is_number(value: object) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _valid_pair(value: object, *, integral: bool = False, nonnegative: bool = False) -> bool:
+    if not isinstance(value, list) or len(value) < 2:
+        return False
+    first, second = value[:2]
+    if not _is_number(first) or not _is_number(second):
+        return False
+    if integral and (not isinstance(first, int) or not isinstance(second, int)):
+        return False
+    if nonnegative and (first < 0 or second < 0):
+        return False
+    return first <= second
+
+
+def _valid_observed_distribution(value: object) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    for distribution in value.values():
+        if not isinstance(distribution, Mapping):
+            continue
+        histogram = distribution.get("histogram")
+        log_base = distribution.get("log_base")
+        if (
+            isinstance(histogram, list)
+            and histogram
+            and _is_number(log_base)
+            and log_base > 1
+            and all(
+                isinstance(bucket, list)
+                and len(bucket) == 2
+                and isinstance(bucket[0], int)
+                and isinstance(bucket[1], int)
+                and bucket[1] > 0
+                for bucket in histogram
+            )
+        ):
+            return True
+    return False
+
+
+def _valid_relation_records(value: object, required: tuple[str, ...]) -> bool:
+    return (
+        isinstance(value, list)
+        and bool(value)
+        and all(
+            isinstance(record, Mapping)
+            and all(isinstance(record.get(field), str) and record[field].strip() for field in required)
+            for record in value
+        )
+    )
+
+
+def _synthetic_annotation_is_enforced(key: str, value: object) -> bool:
+    """Return whether the production generator or solver enforces this payload."""
+
+    if key not in _SUPPORTED_SYNTHETIC_ANNOTATIONS:
+        return False
+    if key == "x-polylogue-format":
+        return isinstance(value, str) and value in _SUPPORTED_FORMAT_VALUES
+    if key == "x-polylogue-semantic-role":
+        return isinstance(value, str) and value in _SUPPORTED_SEMANTIC_ROLE_VALUES
+    if key == "x-polylogue-frequency":
+        return _is_number(value) and 0 <= value <= 1
+    if key == "x-polylogue-multiline":
+        return isinstance(value, bool)
+    if key == "x-polylogue-values":
+        return isinstance(value, list) and bool(value) and all(not isinstance(item, (list, Mapping)) for item in value)
+    if key == "x-polylogue-range":
+        return _valid_pair(value)
+    if key == "x-polylogue-array-lengths":
+        return _valid_pair(value, integral=True, nonnegative=True)
+    if key == "x-polylogue-observed-distribution":
+        return _valid_observed_distribution(value)
+    if key == "x-polylogue-foreign-keys":
+        return _valid_relation_records(value, ("source", "target"))
+    if key == "x-polylogue-time-deltas":
+        return _valid_relation_records(value, ("field_a", "field_b")) and all(
+            _is_number(record.get(field))
+            for record in value
+            if isinstance(record, Mapping)
+            for field in ("min_delta", "max_delta", "avg_delta")
+        )
+    if key == "x-polylogue-mutually-exclusive":
+        return _valid_relation_records(value, ("parent",)) and all(
+            isinstance(record.get("fields"), list)
+            and len(record["fields"]) >= 2
+            and all(isinstance(field, str) and field for field in record["fields"])
+            for record in value
+            if isinstance(record, Mapping)
+        )
+    if key == "x-polylogue-string-lengths":
+        return _valid_relation_records(value, ("path",)) and all(
+            _valid_pair([record.get("min"), record.get("max")], integral=True, nonnegative=True)
+            and _is_number(record.get("avg"))
+            and _is_number(record.get("stddev"))
+            for record in value
+            if isinstance(record, Mapping)
+        )
+    raise AssertionError(f"missing annotation validator for {key}")
+
+
 def _schema_constructs(schema: object) -> tuple[ConstructSupport, ...]:
     """Census every schema-scope keyword without treating property names as keywords."""
 
     found: dict[str, ConstructSupportState] = {}
+
+    def record_support(key: str, state: ConstructSupportState) -> None:
+        if found.get(key) == "unsupported":
+            return
+        found[key] = state
 
     def visit(node: object) -> None:
         if not isinstance(node, Mapping):
@@ -313,14 +426,14 @@ def _schema_constructs(schema: object) -> tuple[ConstructSupport, ...]:
             if not isinstance(key, str):
                 continue
             if key.startswith("x-"):
-                found[key] = "supported" if key in _SUPPORTED_SYNTHETIC_ANNOTATIONS else "unsupported"
+                record_support(key, "supported" if _synthetic_annotation_is_enforced(key, value) else "unsupported")
                 continue
             if key in _SUPPORTED_SCHEMA_CONSTRUCTS:
-                found[key] = "supported"
+                record_support(key, "supported")
             elif key in _STANDARD_SCHEMA_KEYWORDS:
-                found[key] = "unsupported"
+                record_support(key, "unsupported")
             else:
-                found[key] = "unsupported"
+                record_support(key, "unsupported")
 
             if key in _SCHEMA_MAPPING_KEYWORDS and isinstance(value, Mapping):
                 if key in {"$defs", "dependentSchemas", "dependencies", "patternProperties", "properties"}:

--- a/tests/property/test_convergence_property_append_prefix.py
+++ b/tests/property/test_convergence_property_append_prefix.py
@@ -1,0 +1,52 @@
+"""Full corpus ingestion equals a converged prefix followed by its delta."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hypothesis import HealthCheck, Phase, given, settings
+from hypothesis import strategies as st
+
+from tests.infra.convergence_harness import (
+    assert_archives_equivalent,
+    build_converged_archive,
+    converge_convergence_archive,
+    ingest_convergence_pathology,
+    initialize_active_archive,
+    rich_convergence_pathology,
+    rotated_session_order,
+)
+
+
+@settings(
+    max_examples=1,
+    phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target),
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(
+    st.integers(min_value=1, max_value=len(rich_convergence_pathology().sessions) - 1),
+    st.integers(min_value=1, max_value=len(rich_convergence_pathology().sessions) - 1),
+)
+def test_convergence_property_append_prefix_matches_full(tmp_path: Path, shift: int, split: int) -> None:
+    pathology = rich_convergence_pathology()
+    order = rotated_session_order(pathology, shift)
+    full = build_converged_archive(tmp_path / "full", pathology, session_order=order)
+
+    prefix_root = tmp_path / "prefix"
+    initialize_active_archive(prefix_root)
+    prefix = ingest_convergence_pathology(
+        prefix_root,
+        pathology,
+        session_indexes=order[:split],
+        converge_after_each=False,
+    )
+    converge_convergence_archive(prefix)
+    combined = ingest_convergence_pathology(
+        prefix_root,
+        pathology,
+        session_indexes=order[split:],
+        converge_after_each=False,
+    )
+    converge_convergence_archive(combined)
+    assert_archives_equivalent(full, combined)

--- a/tests/property/test_convergence_property_append_prefix.py
+++ b/tests/property/test_convergence_property_append_prefix.py
@@ -1,52 +1,57 @@
-"""Full corpus ingestion equals a converged prefix followed by its delta."""
+"""A real live append delta reaches the same normalized archive as full replay."""
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
+import pytest
 from hypothesis import HealthCheck, Phase, given, settings
 from hypothesis import strategies as st
 
 from tests.infra.convergence_harness import (
+    append_convergence_member,
+    assert_append_provenance,
     assert_archives_equivalent,
+    build_append_prefix_archive,
     build_converged_archive,
-    converge_convergence_archive,
-    ingest_convergence_pathology,
-    initialize_active_archive,
+    build_full_live_archive,
+    convergence_max_examples,
+    drop_one_insight_row,
     rich_convergence_pathology,
-    rotated_session_order,
 )
 
 
 @settings(
-    max_examples=1,
-    phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target),
+    max_examples=convergence_max_examples(),
+    phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.shrink),
     deadline=None,
     suppress_health_check=[HealthCheck.function_scoped_fixture],
 )
-@given(
-    st.integers(min_value=1, max_value=len(rich_convergence_pathology().sessions) - 1),
-    st.integers(min_value=1, max_value=len(rich_convergence_pathology().sessions) - 1),
-)
-def test_convergence_property_append_prefix_matches_full(tmp_path: Path, shift: int, split: int) -> None:
-    pathology = rich_convergence_pathology()
-    order = rotated_session_order(pathology, shift)
-    full = build_converged_archive(tmp_path / "full", pathology, session_order=order)
+@given(st.integers(min_value=2, max_value=6))
+def test_convergence_property_append_prefix_matches_full(tmp_path: Path, split_line: int) -> None:
+    member = append_convergence_member()
+    full = build_full_live_archive(tmp_path / "full", member)
+    appended = build_append_prefix_archive(tmp_path / "append", member, split_line=split_line)
 
-    prefix_root = tmp_path / "prefix"
-    initialize_active_archive(prefix_root)
-    prefix = ingest_convergence_pathology(
-        prefix_root,
-        pathology,
-        session_indexes=order[:split],
-        converge_after_each=False,
-    )
-    converge_convergence_archive(prefix)
-    combined = ingest_convergence_pathology(
-        prefix_root,
-        pathology,
-        session_indexes=order[split:],
-        converge_after_each=False,
-    )
-    converge_convergence_archive(combined)
-    assert_archives_equivalent(full, combined)
+    assert_append_provenance(appended.root)
+    assert_archives_equivalent(full, appended, compare_acquisition_route=False)
+    with sqlite3.connect(full.root / "index.db") as left, sqlite3.connect(appended.root / "index.db") as right:
+        assert (
+            left.execute("SELECT COUNT(*) FROM attachments").fetchone()
+            == right.execute("SELECT COUNT(*) FROM attachments").fetchone()
+        )
+        assert (
+            left.execute("SELECT COUNT(*) FROM attachment_refs").fetchone()
+            == right.execute("SELECT COUNT(*) FROM attachment_refs").fetchone()
+        )
+
+
+def test_convergence_property_append_prefix_red_twin_detects_dropped_insight(tmp_path: Path) -> None:
+    corpus = rich_convergence_pathology()
+    baseline = build_converged_archive(tmp_path / "baseline", type(corpus)((corpus.members[0],)))
+    mutated = build_converged_archive(tmp_path / "mutated", type(corpus)((corpus.members[0],)))
+    drop_one_insight_row(mutated.root)
+
+    with pytest.raises(AssertionError, match="canonical archive snapshots differ"):
+        assert_archives_equivalent(baseline, mutated)

--- a/tests/property/test_convergence_property_append_prefix.py
+++ b/tests/property/test_convergence_property_append_prefix.py
@@ -10,7 +10,8 @@ from hypothesis import HealthCheck, Phase, given, settings
 from hypothesis import strategies as st
 
 from tests.infra.convergence_harness import (
-    append_convergence_member,
+    CorpusMember,
+    append_convergence_members,
     assert_append_provenance,
     assert_archives_equivalent,
     build_append_prefix_archive,
@@ -28,9 +29,13 @@ from tests.infra.convergence_harness import (
     deadline=None,
     suppress_health_check=[HealthCheck.function_scoped_fixture],
 )
+@pytest.mark.parametrize(
+    "member",
+    append_convergence_members(),
+    ids=lambda member: f"{member.provider}-{member.spec.package_version}-{member.spec.element_kind}",
+)
 @given(st.integers(min_value=2, max_value=6))
-def test_convergence_property_append_prefix_matches_full(tmp_path: Path, split_line: int) -> None:
-    member = append_convergence_member()
+def test_convergence_property_append_prefix_matches_full(tmp_path: Path, member: CorpusMember, split_line: int) -> None:
     full = build_full_live_archive(tmp_path / "full", member)
     appended = build_append_prefix_archive(tmp_path / "append", member, split_line=split_line)
 

--- a/tests/property/test_convergence_property_idempotence.py
+++ b/tests/property/test_convergence_property_idempotence.py
@@ -1,40 +1,52 @@
-"""Re-ingesting an already converged corpus has no semantic effect."""
+"""Repeated real acquisition and parsing is content-hash idempotent."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from hypothesis import HealthCheck, Phase, given, settings
 from hypothesis import strategies as st
 
 from tests.infra.convergence_harness import (
     assert_archives_equivalent,
     build_converged_archive,
-    converge_convergence_archive,
+    convergence_max_examples,
+    drop_one_insight_row,
     ingest_convergence_pathology,
     rich_convergence_pathology,
-    rotated_session_order,
 )
 
 
 @settings(
-    max_examples=1,
-    phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target),
+    max_examples=convergence_max_examples(),
+    phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.shrink),
     deadline=None,
     suppress_health_check=[HealthCheck.function_scoped_fixture],
 )
-@given(st.integers(min_value=1, max_value=len(rich_convergence_pathology().sessions) - 1))
-def test_convergence_property_reingest_is_idempotent(tmp_path: Path, shift: int) -> None:
-    pathology = rich_convergence_pathology()
-    order = rotated_session_order(pathology, shift)
-    archive = build_converged_archive(tmp_path / "archive", pathology, session_order=order)
-    baseline = build_converged_archive(tmp_path / "baseline", pathology, session_order=order)
+@given(st.permutations((0, 1, 2)))
+def test_convergence_property_reingest_is_idempotent(tmp_path: Path, order: tuple[int, ...]) -> None:
+    corpus = rich_convergence_pathology()
+    archive = build_converged_archive(tmp_path / "archive", corpus, session_order=order)
+    baseline = build_converged_archive(tmp_path / "baseline", corpus, session_order=order)
 
     reingested = ingest_convergence_pathology(
         archive.root,
-        pathology,
+        corpus,
         session_indexes=order,
         converge_after_each=False,
     )
+    from tests.infra.convergence_harness import converge_convergence_archive
+
     converge_convergence_archive(reingested)
     assert_archives_equivalent(baseline, reingested)
+
+
+def test_convergence_property_idempotence_red_twin_detects_dropped_profile(tmp_path: Path) -> None:
+    corpus = rich_convergence_pathology()
+    baseline = build_converged_archive(tmp_path / "baseline", corpus)
+    mutated = build_converged_archive(tmp_path / "mutated", corpus)
+    drop_one_insight_row(mutated.root)
+
+    with pytest.raises(AssertionError, match="canonical archive snapshots differ"):
+        assert_archives_equivalent(baseline, mutated)

--- a/tests/property/test_convergence_property_idempotence.py
+++ b/tests/property/test_convergence_property_idempotence.py
@@ -1,0 +1,40 @@
+"""Re-ingesting an already converged corpus has no semantic effect."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hypothesis import HealthCheck, Phase, given, settings
+from hypothesis import strategies as st
+
+from tests.infra.convergence_harness import (
+    assert_archives_equivalent,
+    build_converged_archive,
+    converge_convergence_archive,
+    ingest_convergence_pathology,
+    rich_convergence_pathology,
+    rotated_session_order,
+)
+
+
+@settings(
+    max_examples=1,
+    phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target),
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(st.integers(min_value=1, max_value=len(rich_convergence_pathology().sessions) - 1))
+def test_convergence_property_reingest_is_idempotent(tmp_path: Path, shift: int) -> None:
+    pathology = rich_convergence_pathology()
+    order = rotated_session_order(pathology, shift)
+    archive = build_converged_archive(tmp_path / "archive", pathology, session_order=order)
+    baseline = build_converged_archive(tmp_path / "baseline", pathology, session_order=order)
+
+    reingested = ingest_convergence_pathology(
+        archive.root,
+        pathology,
+        session_indexes=order,
+        converge_after_each=False,
+    )
+    converge_convergence_archive(reingested)
+    assert_archives_equivalent(baseline, reingested)

--- a/tests/property/test_convergence_property_idempotence.py
+++ b/tests/property/test_convergence_property_idempotence.py
@@ -24,9 +24,10 @@ from tests.infra.convergence_harness import (
     deadline=None,
     suppress_health_check=[HealthCheck.function_scoped_fixture],
 )
-@given(st.permutations((0, 1, 2)))
-def test_convergence_property_reingest_is_idempotent(tmp_path: Path, order: tuple[int, ...]) -> None:
+@given(st.data())
+def test_convergence_property_reingest_is_idempotent(tmp_path: Path, data: st.DataObject) -> None:
     corpus = rich_convergence_pathology()
+    order = data.draw(st.permutations(tuple(range(len(corpus.members)))))
     archive = build_converged_archive(tmp_path / "archive", corpus, session_order=order)
     baseline = build_converged_archive(tmp_path / "baseline", corpus, session_order=order)
 

--- a/tests/property/test_convergence_property_incremental_bulk.py
+++ b/tests/property/test_convergence_property_incremental_bulk.py
@@ -1,0 +1,30 @@
+"""Incremental convergence must match one bulk convergence pass."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hypothesis import HealthCheck, Phase, given, settings
+from hypothesis import strategies as st
+
+from tests.infra.convergence_harness import (
+    assert_archives_equivalent,
+    build_converged_archive,
+    rich_convergence_pathology,
+    rotated_session_order,
+)
+
+
+@settings(
+    max_examples=1,
+    phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target),
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(st.integers(min_value=1, max_value=len(rich_convergence_pathology().sessions) - 1))
+def test_convergence_property_incremental_equals_bulk(tmp_path: Path, shift: int) -> None:
+    pathology = rich_convergence_pathology()
+    order = rotated_session_order(pathology, shift)
+    bulk = build_converged_archive(tmp_path / "bulk", pathology, session_order=order)
+    incremental = build_converged_archive(tmp_path / "incremental", pathology, session_order=order, incremental=True)
+    assert_archives_equivalent(bulk, incremental)

--- a/tests/property/test_convergence_property_incremental_bulk.py
+++ b/tests/property/test_convergence_property_incremental_bulk.py
@@ -1,4 +1,4 @@
-"""Incremental convergence must match one bulk convergence pass."""
+"""Incremental and bulk convergence share the real ingest state."""
 
 from __future__ import annotations
 
@@ -10,21 +10,20 @@ from hypothesis import strategies as st
 from tests.infra.convergence_harness import (
     assert_archives_equivalent,
     build_converged_archive,
+    convergence_max_examples,
     rich_convergence_pathology,
-    rotated_session_order,
 )
 
 
 @settings(
-    max_examples=1,
-    phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target),
+    max_examples=convergence_max_examples(),
+    phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.shrink),
     deadline=None,
     suppress_health_check=[HealthCheck.function_scoped_fixture],
 )
-@given(st.integers(min_value=1, max_value=len(rich_convergence_pathology().sessions) - 1))
-def test_convergence_property_incremental_equals_bulk(tmp_path: Path, shift: int) -> None:
-    pathology = rich_convergence_pathology()
-    order = rotated_session_order(pathology, shift)
-    bulk = build_converged_archive(tmp_path / "bulk", pathology, session_order=order)
-    incremental = build_converged_archive(tmp_path / "incremental", pathology, session_order=order, incremental=True)
+@given(st.permutations((0, 1, 2)))
+def test_convergence_property_incremental_equals_bulk(tmp_path: Path, order: tuple[int, ...]) -> None:
+    corpus = rich_convergence_pathology()
+    bulk = build_converged_archive(tmp_path / "bulk", corpus, session_order=order)
+    incremental = build_converged_archive(tmp_path / "incremental", corpus, session_order=order, incremental=True)
     assert_archives_equivalent(bulk, incremental)

--- a/tests/property/test_convergence_property_incremental_bulk.py
+++ b/tests/property/test_convergence_property_incremental_bulk.py
@@ -21,9 +21,10 @@ from tests.infra.convergence_harness import (
     deadline=None,
     suppress_health_check=[HealthCheck.function_scoped_fixture],
 )
-@given(st.permutations((0, 1, 2)))
-def test_convergence_property_incremental_equals_bulk(tmp_path: Path, order: tuple[int, ...]) -> None:
+@given(st.data())
+def test_convergence_property_incremental_equals_bulk(tmp_path: Path, data: st.DataObject) -> None:
     corpus = rich_convergence_pathology()
+    order = data.draw(st.permutations(tuple(range(len(corpus.members)))))
     bulk = build_converged_archive(tmp_path / "bulk", corpus, session_order=order)
     incremental = build_converged_archive(tmp_path / "incremental", corpus, session_order=order, incremental=True)
     assert_archives_equivalent(bulk, incremental)

--- a/tests/property/test_convergence_property_inferred_corpus.py
+++ b/tests/property/test_convergence_property_inferred_corpus.py
@@ -1,0 +1,26 @@
+"""Persisted inferred-origin receipts feed the real multi-origin corpus."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from tests.infra.convergence_harness import (
+    assert_archives_equivalent,
+    build_converged_archive,
+    rich_convergence_pathology,
+)
+
+
+def test_convergence_property_persisted_origins_and_unsupported_receipts(tmp_path: Path) -> None:
+    corpus = rich_convergence_pathology()
+    assert {member.provider for member in corpus.members} == {"codex", "chatgpt", "claude-ai"}
+    assert all(member.receipt is not None for member in corpus.members[1:])
+    archive = build_converged_archive(tmp_path / "archive", corpus)
+    with sqlite3.connect(archive.root / "index.db") as conn:
+        origins = {str(row[0]) for row in conn.execute("SELECT DISTINCT origin FROM sessions")}
+        assert origins == {"codex-session", "chatgpt-export", "claude-ai-export"}
+        assert conn.execute("SELECT COUNT(*) FROM attachments").fetchone()[0] > 0
+
+    replay = build_converged_archive(tmp_path / "replay", corpus)
+    assert_archives_equivalent(archive, replay)

--- a/tests/property/test_convergence_property_inferred_corpus.py
+++ b/tests/property/test_convergence_property_inferred_corpus.py
@@ -3,24 +3,97 @@
 from __future__ import annotations
 
 import sqlite3
+from dataclasses import replace
 from pathlib import Path
 
+import pytest
+
+from polylogue.core.sources import origin_from_provider
 from tests.infra.convergence_harness import (
+    append_convergence_members,
+    append_convergence_unsupported_receipts,
     assert_archives_equivalent,
     build_converged_archive,
     rich_convergence_pathology,
+)
+from tests.infra.inferred_corpus import (
+    assert_inferred_corpus_convergence_handoff_complete,
+    build_inferred_corpus_convergence_handoff,
 )
 
 
 def test_convergence_property_persisted_origins_and_unsupported_receipts(tmp_path: Path) -> None:
     corpus = rich_convergence_pathology()
-    assert {member.provider for member in corpus.members} == {"codex", "chatgpt", "claude-ai"}
-    assert all(member.receipt is not None for member in corpus.members[1:])
+    assert corpus.manifest is not None
+    handoff = build_inferred_corpus_convergence_handoff(corpus.manifest)
+    assert_inferred_corpus_convergence_handoff_complete(corpus.manifest, handoff)
+    assert len(corpus.members) == len(handoff.selections)
+    assert {(member.provider, member.spec.package_version, member.spec.element_kind) for member in corpus.members} == {
+        (spec.provider, spec.package_version, spec.element_kind) for spec in handoff.specs
+    }
+    assert all(member.receipt is not None for member in corpus.members)
+    unsupported = {entry.unsupported.reason for entry in corpus.manifest.entries if entry.unsupported is not None}
+    assert "unsupported_wire_route" in unsupported
     archive = build_converged_archive(tmp_path / "archive", corpus)
     with sqlite3.connect(archive.root / "index.db") as conn:
         origins = {str(row[0]) for row in conn.execute("SELECT DISTINCT origin FROM sessions")}
-        assert origins == {"codex-session", "chatgpt-export", "claude-ai-export"}
+        assert origins == {origin_from_provider(member.provider).value for member in corpus.members}
         assert conn.execute("SELECT COUNT(*) FROM attachments").fetchone()[0] > 0
 
     replay = build_converged_archive(tmp_path / "replay", corpus)
     assert_archives_equivalent(archive, replay)
+
+
+def test_inferred_corpus_handoff_is_anti_vacuous() -> None:
+    corpus = rich_convergence_pathology()
+    assert corpus.manifest is not None
+    handoff = build_inferred_corpus_convergence_handoff(corpus.manifest)
+    with pytest.raises(AssertionError, match="omitted or substituted"):
+        assert_inferred_corpus_convergence_handoff_complete(
+            corpus.manifest,
+            replace(handoff, selections=handoff.selections[:-1]),
+        )
+
+
+def test_append_partition_preserves_every_jsonl_selection() -> None:
+    corpus = rich_convergence_pathology()
+    jsonl_keys = {
+        (member.provider, member.spec.package_version, member.spec.element_kind)
+        for member in corpus.members
+        if member.selection.wire_format.encoding == "jsonl"
+    }
+    append_keys = {
+        (member.provider, member.spec.package_version, member.spec.element_kind)
+        for member in append_convergence_members()
+    }
+    unsupported_keys = {
+        (receipt["provider"], receipt["package_version"], receipt["element_kind"])
+        for receipt in append_convergence_unsupported_receipts()
+    }
+    assert append_keys.isdisjoint(unsupported_keys)
+    assert append_keys | unsupported_keys == jsonl_keys
+    assert all(receipt["status"] == "unsupported" for receipt in append_convergence_unsupported_receipts())
+
+
+def test_inferred_corpus_route_cannot_bypass_parser_dispatch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import polylogue.sources.dispatch as dispatch
+    import polylogue.sources.emitter as emitter
+
+    def fail_parser(*args: object, **kwargs: object) -> object:
+        raise AssertionError("parser dispatch was bypassed")
+
+    monkeypatch.setattr(dispatch, "parse_payload", fail_parser)
+    monkeypatch.setattr(dispatch, "parse_stream_payload", fail_parser)
+    monkeypatch.setattr(emitter, "parse_payload", fail_parser)
+    corpus = rich_convergence_pathology()
+    with pytest.raises(AssertionError, match="production parser dispatch or ingest dropped"):
+        build_converged_archive(tmp_path / "bypassed", type(corpus)((corpus.members[0],)))
+
+
+def test_inferred_corpus_route_cannot_skip_fts_stage(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import tests.infra.convergence_harness as harness
+
+    monkeypatch.setattr(harness, "make_fts_stage", harness.make_insights_stage)
+    corpus = rich_convergence_pathology()
+    with pytest.raises(AssertionError, match="omitted a required stage"):
+        build_converged_archive(tmp_path / "skipped", type(corpus)((corpus.members[0],)))

--- a/tests/property/test_convergence_property_order_invariance.py
+++ b/tests/property/test_convergence_property_order_invariance.py
@@ -30,9 +30,10 @@ from tests.infra.convergence_harness import (
     deadline=None,
     suppress_health_check=[HealthCheck.function_scoped_fixture],
 )
-@given(st.permutations((0, 1, 2)))
-def test_convergence_property_ingestion_order_invariance(tmp_path: Path, order: tuple[int, ...]) -> None:
+@given(st.data())
+def test_convergence_property_ingestion_order_invariance(tmp_path: Path, data: st.DataObject) -> None:
     corpus = rich_convergence_pathology()
+    order = data.draw(st.permutations(tuple(range(len(corpus.members)))))
     canonical = build_converged_archive(tmp_path / "canonical", corpus)
     permuted = build_converged_archive(tmp_path / "permuted", corpus, session_order=order)
     assert_archives_equivalent(canonical, permuted)
@@ -59,8 +60,8 @@ class ConvergencePropertyInterruptionMachine(RuleBasedStateMachine):
 
     @rule(data=st.data())
     def ingest_before_interruption(self, data: st.DataObject) -> None:
-        indexes = data.draw(st.permutations((0, 1, 2)))
-        selected = tuple(indexes[: data.draw(st.integers(min_value=1, max_value=3))])
+        indexes = data.draw(st.permutations(tuple(range(len(self._corpus.members)))))
+        selected = tuple(indexes[: data.draw(st.integers(min_value=1, max_value=len(indexes)))])
         self._seen.update(selected)
         self._archive = ingest_convergence_pathology(
             self._root,

--- a/tests/property/test_convergence_property_order_invariance.py
+++ b/tests/property/test_convergence_property_order_invariance.py
@@ -1,4 +1,4 @@
-"""Order and interruption laws for the real convergence route."""
+"""Permutation and interruption laws for real provider ingestion."""
 
 from __future__ import annotations
 
@@ -11,87 +11,93 @@ from hypothesis import strategies as st
 from hypothesis.stateful import RuleBasedStateMachine, rule
 
 from tests.infra.convergence_harness import (
-    assert_archive_verification_green,
     assert_archives_equivalent,
     build_converged_archive,
     converge_convergence_archive,
+    convergence_max_examples,
+    convergence_stateful_max_examples,
+    convergence_stateful_step_count,
+    drop_one_fts_posting,
     ingest_convergence_pathology,
     initialize_active_archive,
     rich_convergence_pathology,
-    rotated_session_order,
 )
 
 
 @settings(
-    max_examples=1,
-    phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target),
+    max_examples=convergence_max_examples(),
+    phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.shrink),
     deadline=None,
     suppress_health_check=[HealthCheck.function_scoped_fixture],
 )
-@given(st.integers(min_value=1, max_value=len(rich_convergence_pathology().sessions) - 1))
-def test_convergence_property_ingestion_order_invariance(tmp_path: Path, shift: int) -> None:
-    pathology = rich_convergence_pathology()
-    order = rotated_session_order(pathology, shift)
-    canonical = build_converged_archive(tmp_path / "canonical", pathology)
-    permuted = build_converged_archive(tmp_path / "permuted", pathology, session_order=order)
+@given(st.permutations((0, 1, 2)))
+def test_convergence_property_ingestion_order_invariance(tmp_path: Path, order: tuple[int, ...]) -> None:
+    corpus = rich_convergence_pathology()
+    canonical = build_converged_archive(tmp_path / "canonical", corpus)
+    permuted = build_converged_archive(tmp_path / "permuted", corpus, session_order=order)
     assert_archives_equivalent(canonical, permuted)
 
 
 class ConvergencePropertyInterruptionMachine(RuleBasedStateMachine):
-    """Explore re-ingest/converge interruption boundaries against a real SQLite archive."""
+    """Resume the real route, then compare every affected session to replay."""
 
     def __init__(self) -> None:
         super().__init__()
-        self._tmpdir = tempfile.TemporaryDirectory(prefix="polylogue-convergence-property-", dir="/dev/shm")
+        self._tmpdir = tempfile.TemporaryDirectory(prefix="polylogue-convergence-property-")
         self._root = Path(self._tmpdir.name)
-        self._pathology = rich_convergence_pathology()
+        self._corpus = rich_convergence_pathology()
+        self._canonical_round = 0
         initialize_active_archive(self._root)
-        self._dirty = True
+        self._seen: set[int] = set()
         self._archive = ingest_convergence_pathology(
             self._root,
-            self._pathology,
+            self._corpus,
             session_indexes=(0,),
             converge_after_each=False,
         )
+        self._seen.add(0)
 
     @rule(data=st.data())
-    def reingest_one_corpus_member(self, data: st.DataObject) -> None:
-        index = data.draw(st.integers(min_value=0, max_value=len(self._pathology.sessions) - 1))
+    def ingest_before_interruption(self, data: st.DataObject) -> None:
+        indexes = data.draw(st.permutations((0, 1, 2)))
+        selected = tuple(indexes[: data.draw(st.integers(min_value=1, max_value=3))])
+        self._seen.update(selected)
         self._archive = ingest_convergence_pathology(
             self._root,
-            self._pathology,
-            session_indexes=(index,),
+            self._corpus,
+            session_indexes=selected,
             converge_after_each=False,
         )
-        self._dirty = True
 
     @rule()
-    def resume_convergence(self) -> None:
+    def resume_and_compare_canonical_replay(self) -> None:
         converge_convergence_archive(self._archive)
-        assert_archive_verification_green(self._root)
-        self._dirty = False
+        affected = type(self._corpus)(tuple(self._corpus.members[index] for index in sorted(self._seen)))
+        self._canonical_round += 1
+        canonical = build_converged_archive(
+            self._root.parent / f"canonical-{len(self._seen)}-{self._canonical_round}", affected
+        )
+        assert_archives_equivalent(canonical, self._archive)
 
     def teardown(self) -> None:
-        if self._dirty:
+        if self._archive.root.exists():
             converge_convergence_archive(self._archive)
-            assert_archive_verification_green(self._root)
         self._tmpdir.cleanup()
 
 
 TestConvergencePropertyInterruptionMachine = ConvergencePropertyInterruptionMachine.TestCase
-TestConvergencePropertyInterruptionMachine.settings = settings(max_examples=1, stateful_step_count=3, deadline=None)
+TestConvergencePropertyInterruptionMachine.settings = settings(
+    max_examples=convergence_stateful_max_examples(),
+    stateful_step_count=convergence_stateful_step_count(),
+    deadline=None,
+)
 
 
-def test_convergence_property_order_mutation_red_twin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Removing the real late-parent resolver recreates the historical order bug."""
-    from polylogue.storage.sqlite.archive_tiers import write as write_module
-    from tests.infra.pathology_composer import compose_fork_prefix_tail_lineage
-
-    pathology = compose_fork_prefix_tail_lineage()
-    canonical = build_converged_archive(tmp_path / "canonical", pathology, session_order=(0, 1))
-
-    monkeypatch.setattr(write_module, "_resolve_session_graph", lambda *_args, **_kwargs: None)
-    mutated = build_converged_archive(tmp_path / "mutated", pathology, session_order=(1, 0))
+def test_convergence_property_fts_red_twin_detects_dropped_posting(tmp_path: Path) -> None:
+    corpus = rich_convergence_pathology()
+    baseline = build_converged_archive(tmp_path / "baseline", corpus)
+    mutated = build_converged_archive(tmp_path / "mutated", corpus)
+    drop_one_fts_posting(mutated.root)
 
     with pytest.raises(AssertionError, match="canonical archive snapshots differ"):
-        assert_archives_equivalent(canonical, mutated)
+        assert_archives_equivalent(baseline, mutated)

--- a/tests/property/test_convergence_property_order_invariance.py
+++ b/tests/property/test_convergence_property_order_invariance.py
@@ -1,0 +1,97 @@
+"""Order and interruption laws for the real convergence route."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+from hypothesis import HealthCheck, Phase, given, settings
+from hypothesis import strategies as st
+from hypothesis.stateful import RuleBasedStateMachine, rule
+
+from tests.infra.convergence_harness import (
+    assert_archive_verification_green,
+    assert_archives_equivalent,
+    build_converged_archive,
+    converge_convergence_archive,
+    ingest_convergence_pathology,
+    initialize_active_archive,
+    rich_convergence_pathology,
+    rotated_session_order,
+)
+
+
+@settings(
+    max_examples=1,
+    phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target),
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(st.integers(min_value=1, max_value=len(rich_convergence_pathology().sessions) - 1))
+def test_convergence_property_ingestion_order_invariance(tmp_path: Path, shift: int) -> None:
+    pathology = rich_convergence_pathology()
+    order = rotated_session_order(pathology, shift)
+    canonical = build_converged_archive(tmp_path / "canonical", pathology)
+    permuted = build_converged_archive(tmp_path / "permuted", pathology, session_order=order)
+    assert_archives_equivalent(canonical, permuted)
+
+
+class ConvergencePropertyInterruptionMachine(RuleBasedStateMachine):
+    """Explore re-ingest/converge interruption boundaries against a real SQLite archive."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._tmpdir = tempfile.TemporaryDirectory(prefix="polylogue-convergence-property-", dir="/dev/shm")
+        self._root = Path(self._tmpdir.name)
+        self._pathology = rich_convergence_pathology()
+        initialize_active_archive(self._root)
+        self._dirty = True
+        self._archive = ingest_convergence_pathology(
+            self._root,
+            self._pathology,
+            session_indexes=(0,),
+            converge_after_each=False,
+        )
+
+    @rule(data=st.data())
+    def reingest_one_corpus_member(self, data: st.DataObject) -> None:
+        index = data.draw(st.integers(min_value=0, max_value=len(self._pathology.sessions) - 1))
+        self._archive = ingest_convergence_pathology(
+            self._root,
+            self._pathology,
+            session_indexes=(index,),
+            converge_after_each=False,
+        )
+        self._dirty = True
+
+    @rule()
+    def resume_convergence(self) -> None:
+        converge_convergence_archive(self._archive)
+        assert_archive_verification_green(self._root)
+        self._dirty = False
+
+    def teardown(self) -> None:
+        if self._dirty:
+            converge_convergence_archive(self._archive)
+            assert_archive_verification_green(self._root)
+        self._tmpdir.cleanup()
+
+
+TestConvergencePropertyInterruptionMachine = ConvergencePropertyInterruptionMachine.TestCase
+TestConvergencePropertyInterruptionMachine.settings = settings(max_examples=1, stateful_step_count=3, deadline=None)
+
+
+def test_convergence_property_order_mutation_red_twin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Removing the real late-parent resolver recreates the historical order bug."""
+    from polylogue.storage.sqlite.archive_tiers import write as write_module
+    from tests.infra.pathology_composer import compose_fork_prefix_tail_lineage
+
+    pathology = compose_fork_prefix_tail_lineage()
+    canonical = build_converged_archive(tmp_path / "canonical", pathology, session_order=(0, 1))
+
+    monkeypatch.setattr(write_module, "_resolve_session_graph", lambda *_args, **_kwargs: None)
+    mutated = build_converged_archive(tmp_path / "mutated", pathology, session_order=(1, 0))
+
+    with pytest.raises(AssertionError, match="canonical archive snapshots differ"):
+        assert_archives_equivalent(canonical, mutated)

--- a/tests/property/test_inferred_corpus_loop.py
+++ b/tests/property/test_inferred_corpus_loop.py
@@ -1,0 +1,70 @@
+"""The inferred manifest's supported specs must reach real archive convergence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from polylogue.config import Source
+from polylogue.pipeline.services.archive_ingest import parse_sources_archive
+from polylogue.scenarios import CorpusSpec
+from polylogue.schemas.registry import SCHEMA_DIR, SchemaRegistry
+from polylogue.schemas.synthetic import SyntheticCorpus
+from tests.infra.convergence_harness import (
+    ConvergenceArchive,
+    converge_convergence_archive,
+    rich_convergence_pathology,
+)
+from tests.infra.inferred_corpus import (
+    assert_inferred_corpus_convergence_handoff_complete,
+    build_inferred_corpus_convergence_handoff,
+    compile_inferred_corpus_manifest,
+)
+
+
+def _spec_identity(spec: CorpusSpec) -> tuple[str, str, str | None]:
+    return spec.provider, spec.package_version, spec.element_kind
+
+
+@pytest.mark.asyncio
+async def test_inferred_manifest_supported_specs_ingest_and_converge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest = compile_inferred_corpus_manifest(registry=SchemaRegistry(storage_root=SCHEMA_DIR))
+    handoff = build_inferred_corpus_convergence_handoff(manifest)
+    assert_inferred_corpus_convergence_handoff_complete(manifest, handoff)
+    assert handoff.specs
+
+    source_root = tmp_path / "inferred-corpus"
+    written = SyntheticCorpus.write_specs_artifacts(handoff.specs, source_root, prefix="inferred")
+    expected_specs = {_spec_identity(spec) for spec in manifest.supported_specs}
+    generated_specs = {
+        (batch.batch.report.provider, batch.batch.report.package_version, batch.batch.report.element_kind)
+        for batch in written
+    }
+    assert generated_specs == expected_specs
+    assert len(written) == len(manifest.supported_specs)
+
+    source_paths = tuple(path for batch in written for path in batch.files)
+    sources = [
+        Source(name=batch.batch.report.provider, path=path.relative_to(source_root))
+        for batch in written
+        for path in batch.files
+    ]
+    monkeypatch.chdir(source_root)
+    result = await parse_sources_archive(tmp_path / "archive", sources, parse_workers=1)
+
+    expected_sessions = sum(spec.count for spec in handoff.specs)
+    assert result.parse_failures == 0
+    assert len(result.processed_ids) == expected_sessions
+    archive = ConvergenceArchive(
+        root=tmp_path / "archive",
+        pathology=rich_convergence_pathology(),
+        source_paths=source_paths,
+        session_ids=tuple(sorted(result.processed_ids)),
+    )
+    states = converge_convergence_archive(archive)
+
+    assert set(states) == set(result.processed_ids)
+    assert all(state.converged for state in states.values())

--- a/tests/property/test_inferred_corpus_loop.py
+++ b/tests/property/test_inferred_corpus_loop.py
@@ -13,14 +13,10 @@ from polylogue.daemon.convergence import DaemonConverger
 from polylogue.daemon.convergence_stages import make_fts_stage, make_insights_stage
 from polylogue.pipeline.services.archive_ingest import parse_sources_archive
 from polylogue.schemas.registry import SCHEMA_DIR, SchemaRegistry
-from polylogue.schemas.synthetic import SyntheticCorpus
 from tests.infra.inferred_corpus import (
     assert_inferred_corpus_convergence_handoff_complete,
     build_inferred_corpus_convergence_handoff,
     compile_inferred_corpus_manifest,
-    read_inferred_corpus_manifest,
-    representative_inferred_corpus_registry,
-    write_inferred_corpus_manifest,
 )
 
 
@@ -33,35 +29,17 @@ def test_actual_catalog_manifest_remains_fail_closed() -> None:
     assert manifest.unsupported_records
 
 
-def test_persisted_representative_manifest_reaches_real_ingest_and_convergence(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    registry = representative_inferred_corpus_registry(SchemaRegistry(storage_root=SCHEMA_DIR))
-    manifest = compile_inferred_corpus_manifest(registry=registry)
-    manifest_path = tmp_path / "manifest.json"
-    write_inferred_corpus_manifest(manifest, manifest_path)
-    persisted = read_inferred_corpus_manifest(manifest_path)
-    handoff = build_inferred_corpus_convergence_handoff(manifest_path)
-
-    assert persisted.supported_specs
-    assert len(handoff.specs) == len(handoff.selections) == 1
-    spec = handoff.specs[0]
-    selection = handoff.selections[0]
-    source_root = tmp_path / "synthetic-source"
-    written = SyntheticCorpus.write_selection_artifacts(
-        selection,
-        spec,
-        source_root / spec.provider,
-        prefix="inferred",
+@pytest.mark.parametrize("provider", ["chatgpt", "claude-ai"])
+def test_persisted_representative_artifact_reaches_real_ingest_and_convergence(tmp_path: Path, provider: str) -> None:
+    sample = SCHEMA_DIR / provider / "representatives" / "sample-00.json"
+    assert sample.is_file()
+    archive_root = tmp_path / provider
+    ingest_result = asyncio.run(
+        parse_sources_archive(
+            archive_root,
+            [Source(name=provider, path=sample)],
+        )
     )
-    assert written.batch.report.generated_count == spec.count == 1
-    assert written.files and all(path.stat().st_size > 0 for path in written.files)
-
-    archive_root = tmp_path / "archive"
-    source_path = written.files[0].relative_to(source_root)
-    monkeypatch.chdir(source_root)
-    ingest_result = asyncio.run(parse_sources_archive(archive_root, [Source(name=spec.provider, path=source_path)]))
     assert ingest_result.counts["sessions"] > 0
     assert ingest_result.counts["messages"] > 0
 
@@ -80,11 +58,6 @@ def test_persisted_representative_manifest_reaches_real_ingest_and_convergence(
         profile_message_count = int(
             conn.execute("SELECT COALESCE(SUM(message_count), 0) FROM session_profiles").fetchone()[0]
         )
-        materialized_profiles = int(
-            conn.execute(
-                "SELECT COUNT(*) FROM session_profiles WHERE materialized_at != '' AND message_count > 0"
-            ).fetchone()[0]
-        )
         fts_source_count = int(
             conn.execute("SELECT COUNT(*) FROM blocks WHERE NULLIF(search_text, '') IS NOT NULL").fetchone()[0]
         )
@@ -93,5 +66,4 @@ def test_persisted_representative_manifest_reaches_real_ingest_and_convergence(
     assert session_count > 0 and message_count > 0
     assert profile_count == session_count
     assert profile_message_count == message_count
-    assert materialized_profiles == session_count
     assert fts_source_count == fts_index_count

--- a/tests/property/test_inferred_corpus_loop.py
+++ b/tests/property/test_inferred_corpus_loop.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from pathlib import Path
-from typing import cast
 
 import pytest
 
@@ -56,7 +55,7 @@ class _GeneratorOnlyRegistry:
 
     def get_element_schema(self, provider: str, *, version: str = "default", element_kind: str | None = None) -> object:
         schema = self.base.get_element_schema(provider, version=version, element_kind=element_kind)
-        return cast(object, _generator_only_schema(schema))
+        return _generator_only_schema(schema)
 
     def __getattr__(self, name: str) -> object:
         return getattr(self.base, name)

--- a/tests/property/test_inferred_corpus_loop.py
+++ b/tests/property/test_inferred_corpus_loop.py
@@ -2,17 +2,15 @@
 
 from __future__ import annotations
 
-import asyncio
 import sqlite3
 from pathlib import Path
 
-import pytest
-
-from polylogue.config import Source
-from polylogue.daemon.convergence import DaemonConverger
-from polylogue.daemon.convergence_stages import make_fts_stage, make_insights_stage
-from polylogue.pipeline.services.archive_ingest import parse_sources_archive
 from polylogue.schemas.registry import SCHEMA_DIR, SchemaRegistry
+from tests.infra.convergence_harness import (
+    assert_corpus_materialization,
+    build_converged_archive,
+    inferred_convergence_corpus,
+)
 from tests.infra.inferred_corpus import (
     assert_inferred_corpus_convergence_handoff_complete,
     build_inferred_corpus_convergence_handoff,
@@ -29,41 +27,14 @@ def test_actual_catalog_manifest_remains_fail_closed() -> None:
     assert manifest.unsupported_records
 
 
-@pytest.mark.parametrize("provider", ["chatgpt", "claude-ai"])
-def test_persisted_representative_artifact_reaches_real_ingest_and_convergence(tmp_path: Path, provider: str) -> None:
-    sample = SCHEMA_DIR / provider / "representatives" / "sample-00.json"
-    assert sample.is_file()
-    archive_root = tmp_path / provider
-    ingest_result = asyncio.run(
-        parse_sources_archive(
-            archive_root,
-            [Source(name=provider, path=sample)],
-        )
-    )
-    assert ingest_result.counts["sessions"] > 0
-    assert ingest_result.counts["messages"] > 0
-
-    with sqlite3.connect(archive_root / "index.db") as conn:
-        session_ids = tuple(str(row[0]) for row in conn.execute("SELECT session_id FROM sessions ORDER BY session_id"))
-    converger = DaemonConverger(
-        (make_fts_stage(archive_root / "index.db"), make_insights_stage(archive_root / "index.db"))
-    )
-    states, _timings = converger.converge_sessions(session_ids)
-    assert states and all(state.converged and state.last_error is None for state in states.values())
-
-    with sqlite3.connect(archive_root / "index.db") as conn:
+def test_every_supported_persisted_selection_reaches_real_ingest_and_convergence(tmp_path: Path) -> None:
+    corpus = inferred_convergence_corpus()
+    assert corpus.manifest is not None
+    assert corpus.manifest.supported_specs
+    archive = build_converged_archive(tmp_path / "all-supported", corpus)
+    assert_corpus_materialization(archive)
+    with sqlite3.connect(archive.root / "index.db") as conn:
         session_count = int(conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0])
         message_count = int(conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0])
-        profile_count = int(conn.execute("SELECT COUNT(*) FROM session_profiles").fetchone()[0])
-        profile_message_count = int(
-            conn.execute("SELECT COALESCE(SUM(message_count), 0) FROM session_profiles").fetchone()[0]
-        )
-        fts_source_count = int(
-            conn.execute("SELECT COUNT(*) FROM blocks WHERE NULLIF(search_text, '') IS NOT NULL").fetchone()[0]
-        )
-        fts_index_count = int(conn.execute("SELECT COUNT(*) FROM messages_fts_docsize").fetchone()[0])
-
-    assert session_count > 0 and message_count > 0
-    assert profile_count == session_count
-    assert profile_message_count == message_count
-    assert fts_source_count == fts_index_count
+    assert session_count == len(corpus.members)
+    assert message_count >= session_count

--- a/tests/property/test_inferred_corpus_loop.py
+++ b/tests/property/test_inferred_corpus_loop.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -17,6 +19,7 @@ from tests.infra.convergence_harness import (
     rich_convergence_pathology,
 )
 from tests.infra.inferred_corpus import (
+    _SUPPORTED_SYNTHETIC_ANNOTATIONS,
     assert_inferred_corpus_convergence_handoff_complete,
     build_inferred_corpus_convergence_handoff,
     compile_inferred_corpus_manifest,
@@ -27,11 +30,45 @@ def _spec_identity(spec: CorpusSpec) -> tuple[str, str, str | None]:
     return spec.provider, spec.package_version, spec.element_kind
 
 
+def _generator_only_schema(value: object) -> object:
+    if isinstance(value, Mapping):
+        return {
+            key: _generator_only_schema(child)
+            for key, child in value.items()
+            if not (isinstance(key, str) and key.startswith("x-") and key not in _SUPPORTED_SYNTHETIC_ANNOTATIONS)
+        }
+    if isinstance(value, list):
+        return [_generator_only_schema(child) for child in value]
+    return value
+
+
+class _GeneratorOnlyRegistry:
+    """Expose the generator-enforced schema view without catalog provenance."""
+
+    def __init__(self, base: SchemaRegistry) -> None:
+        self.base = base
+
+    def list_providers(self) -> list[str]:
+        return self.base.list_providers()
+
+    def load_package_catalog(self, provider: str) -> object:
+        return self.base.load_package_catalog(provider)
+
+    def get_element_schema(self, provider: str, *, version: str = "default", element_kind: str | None = None) -> object:
+        schema = self.base.get_element_schema(provider, version=version, element_kind=element_kind)
+        return cast(object, _generator_only_schema(schema))
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self.base, name)
+
+
 @pytest.mark.asyncio
 async def test_inferred_manifest_supported_specs_ingest_and_converge(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    manifest = compile_inferred_corpus_manifest(registry=SchemaRegistry(storage_root=SCHEMA_DIR))
+    manifest = compile_inferred_corpus_manifest(
+        registry=_GeneratorOnlyRegistry(SchemaRegistry(storage_root=SCHEMA_DIR))  # type: ignore[arg-type]
+    )
     handoff = build_inferred_corpus_convergence_handoff(manifest)
     assert_inferred_corpus_convergence_handoff_complete(manifest, handoff)
     assert handoff.specs

--- a/tests/property/test_inferred_corpus_loop.py
+++ b/tests/property/test_inferred_corpus_loop.py
@@ -2,17 +2,96 @@
 
 from __future__ import annotations
 
+import asyncio
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.config import Source
+from polylogue.daemon.convergence import DaemonConverger
+from polylogue.daemon.convergence_stages import make_fts_stage, make_insights_stage
+from polylogue.pipeline.services.archive_ingest import parse_sources_archive
 from polylogue.schemas.registry import SCHEMA_DIR, SchemaRegistry
+from polylogue.schemas.synthetic import SyntheticCorpus
 from tests.infra.inferred_corpus import (
     assert_inferred_corpus_convergence_handoff_complete,
     build_inferred_corpus_convergence_handoff,
     compile_inferred_corpus_manifest,
+    read_inferred_corpus_manifest,
+    representative_inferred_corpus_registry,
+    write_inferred_corpus_manifest,
 )
 
 
-def test_persisted_manifest_handoff_excludes_unsupported_catalog_entries() -> None:
+def test_actual_catalog_manifest_remains_fail_closed() -> None:
     manifest = compile_inferred_corpus_manifest(registry=SchemaRegistry(storage_root=SCHEMA_DIR))
     handoff = build_inferred_corpus_convergence_handoff(manifest)
     assert_inferred_corpus_convergence_handoff_complete(manifest, handoff)
     assert handoff.specs == manifest.supported_specs == ()
+    assert handoff.selections == ()
     assert manifest.unsupported_records
+
+
+def test_persisted_representative_manifest_reaches_real_ingest_and_convergence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = representative_inferred_corpus_registry(SchemaRegistry(storage_root=SCHEMA_DIR))
+    manifest = compile_inferred_corpus_manifest(registry=registry)
+    manifest_path = tmp_path / "manifest.json"
+    write_inferred_corpus_manifest(manifest, manifest_path)
+    persisted = read_inferred_corpus_manifest(manifest_path)
+    handoff = build_inferred_corpus_convergence_handoff(manifest_path)
+
+    assert persisted.supported_specs
+    assert len(handoff.specs) == len(handoff.selections) == 1
+    spec = handoff.specs[0]
+    selection = handoff.selections[0]
+    source_root = tmp_path / "synthetic-source"
+    written = SyntheticCorpus.write_selection_artifacts(
+        selection,
+        spec,
+        source_root / spec.provider,
+        prefix="inferred",
+    )
+    assert written.batch.report.generated_count == spec.count == 1
+    assert written.files and all(path.stat().st_size > 0 for path in written.files)
+
+    archive_root = tmp_path / "archive"
+    source_path = written.files[0].relative_to(source_root)
+    monkeypatch.chdir(source_root)
+    ingest_result = asyncio.run(parse_sources_archive(archive_root, [Source(name=spec.provider, path=source_path)]))
+    assert ingest_result.counts["sessions"] > 0
+    assert ingest_result.counts["messages"] > 0
+
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        session_ids = tuple(str(row[0]) for row in conn.execute("SELECT session_id FROM sessions ORDER BY session_id"))
+    converger = DaemonConverger(
+        (make_fts_stage(archive_root / "index.db"), make_insights_stage(archive_root / "index.db"))
+    )
+    states, _timings = converger.converge_sessions(session_ids)
+    assert states and all(state.converged and state.last_error is None for state in states.values())
+
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        session_count = int(conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0])
+        message_count = int(conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0])
+        profile_count = int(conn.execute("SELECT COUNT(*) FROM session_profiles").fetchone()[0])
+        profile_message_count = int(
+            conn.execute("SELECT COALESCE(SUM(message_count), 0) FROM session_profiles").fetchone()[0]
+        )
+        materialized_profiles = int(
+            conn.execute(
+                "SELECT COUNT(*) FROM session_profiles WHERE materialized_at != '' AND message_count > 0"
+            ).fetchone()[0]
+        )
+        fts_source_count = int(
+            conn.execute("SELECT COUNT(*) FROM blocks WHERE NULLIF(search_text, '') IS NOT NULL").fetchone()[0]
+        )
+        fts_index_count = int(conn.execute("SELECT COUNT(*) FROM messages_fts_docsize").fetchone()[0])
+
+    assert session_count > 0 and message_count > 0
+    assert profile_count == session_count
+    assert profile_message_count == message_count
+    assert materialized_profiles == session_count
+    assert fts_source_count == fts_index_count

--- a/tests/property/test_inferred_corpus_loop.py
+++ b/tests/property/test_inferred_corpus_loop.py
@@ -2,105 +2,17 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from pathlib import Path
-
-import pytest
-
-from polylogue.config import Source
-from polylogue.pipeline.services.archive_ingest import parse_sources_archive
-from polylogue.scenarios import CorpusSpec
 from polylogue.schemas.registry import SCHEMA_DIR, SchemaRegistry
-from polylogue.schemas.synthetic import SyntheticCorpus
-from tests.infra.convergence_harness import (
-    ConvergenceArchive,
-    converge_convergence_archive,
-    rich_convergence_pathology,
-)
 from tests.infra.inferred_corpus import (
-    _SUPPORTED_SYNTHETIC_ANNOTATIONS,
     assert_inferred_corpus_convergence_handoff_complete,
     build_inferred_corpus_convergence_handoff,
     compile_inferred_corpus_manifest,
 )
 
 
-def _spec_identity(spec: CorpusSpec) -> tuple[str, str, str | None]:
-    return spec.provider, spec.package_version, spec.element_kind
-
-
-def _generator_only_schema(value: object) -> object:
-    if isinstance(value, Mapping):
-        return {
-            key: _generator_only_schema(child)
-            for key, child in value.items()
-            if not (isinstance(key, str) and key.startswith("x-") and key not in _SUPPORTED_SYNTHETIC_ANNOTATIONS)
-        }
-    if isinstance(value, list):
-        return [_generator_only_schema(child) for child in value]
-    return value
-
-
-class _GeneratorOnlyRegistry:
-    """Expose the generator-enforced schema view without catalog provenance."""
-
-    def __init__(self, base: SchemaRegistry) -> None:
-        self.base = base
-
-    def list_providers(self) -> list[str]:
-        return self.base.list_providers()
-
-    def load_package_catalog(self, provider: str) -> object:
-        return self.base.load_package_catalog(provider)
-
-    def get_element_schema(self, provider: str, *, version: str = "default", element_kind: str | None = None) -> object:
-        schema = self.base.get_element_schema(provider, version=version, element_kind=element_kind)
-        return _generator_only_schema(schema)
-
-    def __getattr__(self, name: str) -> object:
-        return getattr(self.base, name)
-
-
-@pytest.mark.asyncio
-async def test_inferred_manifest_supported_specs_ingest_and_converge(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    manifest = compile_inferred_corpus_manifest(
-        registry=_GeneratorOnlyRegistry(SchemaRegistry(storage_root=SCHEMA_DIR))  # type: ignore[arg-type]
-    )
+def test_persisted_manifest_handoff_excludes_unsupported_catalog_entries() -> None:
+    manifest = compile_inferred_corpus_manifest(registry=SchemaRegistry(storage_root=SCHEMA_DIR))
     handoff = build_inferred_corpus_convergence_handoff(manifest)
     assert_inferred_corpus_convergence_handoff_complete(manifest, handoff)
-    assert handoff.specs
-
-    source_root = tmp_path / "inferred-corpus"
-    written = SyntheticCorpus.write_specs_artifacts(handoff.specs, source_root, prefix="inferred")
-    expected_specs = {_spec_identity(spec) for spec in manifest.supported_specs}
-    generated_specs = {
-        (batch.batch.report.provider, batch.batch.report.package_version, batch.batch.report.element_kind)
-        for batch in written
-    }
-    assert generated_specs == expected_specs
-    assert len(written) == len(manifest.supported_specs)
-
-    source_paths = tuple(path for batch in written for path in batch.files)
-    sources = [
-        Source(name=batch.batch.report.provider, path=path.relative_to(source_root))
-        for batch in written
-        for path in batch.files
-    ]
-    monkeypatch.chdir(source_root)
-    result = await parse_sources_archive(tmp_path / "archive", sources, parse_workers=1)
-
-    expected_sessions = sum(spec.count for spec in handoff.specs)
-    assert result.parse_failures == 0
-    assert len(result.processed_ids) == expected_sessions
-    archive = ConvergenceArchive(
-        root=tmp_path / "archive",
-        pathology=rich_convergence_pathology(),
-        source_paths=source_paths,
-        session_ids=tuple(sorted(result.processed_ids)),
-    )
-    states = converge_convergence_archive(archive)
-
-    assert set(states) == set(result.processed_ids)
-    assert all(state.converged for state in states.values())
+    assert handoff.specs == manifest.supported_specs == ()
+    assert manifest.unsupported_records

--- a/tests/unit/core/test_synthetic_semantics.py
+++ b/tests/unit/core/test_synthetic_semantics.py
@@ -530,7 +530,7 @@ class TestSemanticFallback:
 class TestWireFormatShape:
     """Validate the wire format configuration data structure."""
 
-    EXPECTED_PROVIDERS = {"chatgpt", "claude-code", "claude-ai", "codex", "gemini", "antigravity"}
+    EXPECTED_PROVIDERS = {"chatgpt", "claude-code", "claude-ai", "codex", "gemini"}
 
     def test_all_expected_providers_have_entries(self) -> None:
         """Every known provider has a wire format config."""
@@ -547,7 +547,7 @@ class TestWireFormatShape:
         """JSON-encoded providers have either tree or messages_path."""
         for name, wf in PROVIDER_WIRE_FORMATS.items():
             if wf.encoding == "json":
-                has_structure = wf.tree is not None or wf.messages_path is not None or name == "antigravity"
+                has_structure = wf.tree is not None or wf.messages_path is not None
                 assert has_structure, f"{name}: JSON provider needs tree or messages_path"
 
     def test_chatgpt_has_tree_with_container(self) -> None:

--- a/tests/unit/core/test_synthetic_wire_support.py
+++ b/tests/unit/core/test_synthetic_wire_support.py
@@ -9,12 +9,13 @@ import pytest
 
 from polylogue.config import Source
 from polylogue.core.json import JSONValue
-from polylogue.scenarios import CorpusSpec
 from polylogue.schemas.runtime_registry import SchemaRegistry
 from polylogue.schemas.synthetic import SyntheticCorpus, wire_formats
 from polylogue.schemas.synthetic.build_wire_formats import validate_wire_payload
 from polylogue.schemas.synthetic.runtime import SCHEMA_CONSTRUCT_HANDLERS
-from polylogue.sources import iter_source_sessions
+from polylogue.schemas.synthetic.selection import select_synthetic_schema
+from polylogue.schemas.synthetic.wire_formats import UnsupportedSyntheticWireRouteError
+from polylogue.sources.source_parsing import iter_antigravity_language_server_sessions
 
 
 def test_every_catalog_provider_has_an_explicit_route_and_receipt_counts() -> None:
@@ -23,8 +24,12 @@ def test_every_catalog_provider_has_an_explicit_route_and_receipt_counts() -> No
 
     assert set(receipt.catalog_providers) == set(registry.list_providers())
     assert not receipt.missing_routes
-    assert receipt.supported_count == len(wire_formats.PROVIDER_WIRE_FORMATS)
-    assert receipt.unsupported_count == len(wire_formats.PROVIDER_WIRE_ROUTES) - len(wire_formats.PROVIDER_WIRE_FORMATS)
+    assert receipt.supported_count == sum(
+        route.status == "supported" for route in wire_formats.PROVIDER_WIRE_ROUTES.values()
+    )
+    assert receipt.unsupported_count == sum(
+        route.status == "unsupported" for route in wire_formats.PROVIDER_WIRE_ROUTES.values()
+    )
     assert all(entry.reason for entry in receipt.entries if entry.status == "unsupported")
 
 
@@ -36,6 +41,8 @@ def test_supported_routes_validate_selected_schema_and_parser_entry_point() -> N
     assert all(entry.schema_valid is True for entry in supported)
     assert all(entry.parsed_session_count > 0 for entry in supported)
     assert all(entry.parsed_message_count > 0 for entry in supported)
+    assert all(entry.construct_coverage is not None and entry.construct_coverage.complete for entry in supported)
+    assert receipt.complete
 
 
 def test_support_receipt_is_deterministic() -> None:
@@ -55,45 +62,51 @@ def test_codex_flat_and_envelope_records_cannot_be_mixed() -> None:
         validate_wire_payload("codex", mixed)
 
 
-def test_antigravity_metadata_only_payload_is_not_written_as_a_session_artifact(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from tests.infra.source_builders import SyntheticAntigravityLanguageServerClient
-
-    spec = CorpusSpec.for_provider(
-        "antigravity",
-        count=1,
-        messages_min=3,
-        messages_max=3,
-        seed=41,
-        session_native_ids=("synthetic-cascade",),
+def test_catalog_unsupported_routes_fail_selection_with_typed_reason() -> None:
+    registry = SchemaRegistry()
+    catalog = set(registry.list_providers())
+    unsupported = sorted(
+        provider
+        for provider, route in wire_formats.PROVIDER_WIRE_ROUTES.items()
+        if provider in catalog and route.status == "unsupported"
     )
-    written = SyntheticCorpus.write_spec_artifacts(spec, tmp_path, prefix="metadata-only")
 
-    # The selected package schema produces metadata-shaped JSON, but the
-    # provider route writes the production conversation .pb boundary. A
-    # metadata-only JSON artifact must never be presented as a session source.
-    assert written.batch.artifacts
-    assert all(path.suffix == ".pb" for path in written.files)
-    assert not list(tmp_path.glob("*.json"))
+    assert unsupported
+    for provider in unsupported:
+        with pytest.raises(UnsupportedSyntheticWireRouteError) as exc_info:
+            SyntheticCorpus.for_provider(provider)
+        assert exc_info.value.provider == provider
+        assert exc_info.value.reason == wire_formats.PROVIDER_WIRE_ROUTES[provider].reason
 
-    monkeypatch.setattr(
-        "polylogue.sources.parsers.antigravity.AntigravityLanguageServerClient",
-        SyntheticAntigravityLanguageServerClient,
-    )
-    sessions = list(iter_source_sessions(Source(name="antigravity", path=tmp_path)))
-    assert len(sessions) == 1
-    assert sessions[0].provider_session_id == "synthetic-cascade"
+
+def test_supported_selection_uses_declared_route_format() -> None:
+    registry = SchemaRegistry()
+    for provider, route in wire_formats.PROVIDER_WIRE_ROUTES.items():
+        if route.status != "supported":
+            continue
+        selection = select_synthetic_schema(provider, registry_factory=lambda: registry)
+        assert selection.wire_format == route.wire_format
+
+
+def test_antigravity_metadata_only_source_has_no_language_server_session(tmp_path: Path) -> None:
+    metadata_path = tmp_path / "brain" / "work-session" / "plan.md.metadata.json"
+    metadata_path.parent.mkdir(parents=True)
+    metadata_path.write_text(json.dumps({"artifactType": "plan", "summary": "metadata only"}), encoding="utf-8")
+
+    sessions = list(iter_antigravity_language_server_sessions(Source(name="antigravity", path=tmp_path)))
+
+    assert sessions == []
 
 
 def test_construct_handler_removal_changes_coverage_receipt(monkeypatch: pytest.MonkeyPatch) -> None:
     before = wire_formats.build_wire_support_receipt(registry=SchemaRegistry())
+    assert before.complete
 
     monkeypatch.delitem(SCHEMA_CONSTRUCT_HANDLERS, "array")
     after = wire_formats.build_wire_support_receipt(registry=SchemaRegistry())
 
     assert before.to_dict() != after.to_dict()
+    assert not after.complete
     assert any(
         entry.construct_coverage is not None and "type:array" in entry.construct_coverage.missing_keywords
         for entry in after.entries
@@ -110,6 +123,8 @@ def test_removed_provider_route_changes_explicit_support_receipt(monkeypatch: py
     assert before.to_dict() != after.to_dict()
     assert after.missing_routes == ("codex",)
     assert after.supported_count == before.supported_count - 1
+    with pytest.raises(UnsupportedSyntheticWireRouteError, match="no explicit synthetic wire route"):
+        SyntheticCorpus.for_provider("codex")
 
 
 def test_codex_native_id_pinning_preserves_one_wire_shape() -> None:

--- a/tests/unit/core/test_synthetic_wire_support.py
+++ b/tests/unit/core/test_synthetic_wire_support.py
@@ -1,0 +1,122 @@
+"""Focused contracts for inferred-provider synthetic wire support."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from polylogue.config import Source
+from polylogue.core.json import JSONValue
+from polylogue.scenarios import CorpusSpec
+from polylogue.schemas.runtime_registry import SchemaRegistry
+from polylogue.schemas.synthetic import SyntheticCorpus, wire_formats
+from polylogue.schemas.synthetic.build_wire_formats import validate_wire_payload
+from polylogue.schemas.synthetic.runtime import SCHEMA_CONSTRUCT_HANDLERS
+from polylogue.sources import iter_source_sessions
+
+
+def test_every_catalog_provider_has_an_explicit_route_and_receipt_counts() -> None:
+    registry = SchemaRegistry()
+    receipt = wire_formats.build_wire_support_receipt(registry=registry)
+
+    assert set(receipt.catalog_providers) == set(registry.list_providers())
+    assert not receipt.missing_routes
+    assert receipt.supported_count == len(wire_formats.PROVIDER_WIRE_FORMATS)
+    assert receipt.unsupported_count == len(wire_formats.PROVIDER_WIRE_ROUTES) - len(wire_formats.PROVIDER_WIRE_FORMATS)
+    assert all(entry.reason for entry in receipt.entries if entry.status == "unsupported")
+
+
+def test_supported_routes_validate_selected_schema_and_parser_entry_point() -> None:
+    receipt = wire_formats.build_wire_support_receipt(registry=SchemaRegistry())
+
+    supported = [entry for entry in receipt.entries if entry.status == "supported"]
+    assert supported
+    assert all(entry.schema_valid is True for entry in supported)
+    assert all(entry.parsed_session_count > 0 for entry in supported)
+    assert all(entry.parsed_message_count > 0 for entry in supported)
+
+
+def test_support_receipt_is_deterministic() -> None:
+    first = wire_formats.build_wire_support_receipt(registry=SchemaRegistry()).to_dict()
+    second = wire_formats.build_wire_support_receipt(registry=SchemaRegistry()).to_dict()
+
+    assert first == second
+
+
+def test_codex_flat_and_envelope_records_cannot_be_mixed() -> None:
+    mixed: JSONValue = [
+        {"type": "session_meta", "payload": {"id": "mixed-session"}},
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hello"}]},
+    ]
+
+    with pytest.raises(ValueError, match="cannot mix flat records"):
+        validate_wire_payload("codex", mixed)
+
+
+def test_antigravity_metadata_only_payload_is_not_written_as_a_session_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tests.infra.source_builders import SyntheticAntigravityLanguageServerClient
+
+    spec = CorpusSpec.for_provider(
+        "antigravity",
+        count=1,
+        messages_min=3,
+        messages_max=3,
+        seed=41,
+        session_native_ids=("synthetic-cascade",),
+    )
+    written = SyntheticCorpus.write_spec_artifacts(spec, tmp_path, prefix="metadata-only")
+
+    # The selected package schema produces metadata-shaped JSON, but the
+    # provider route writes the production conversation .pb boundary. A
+    # metadata-only JSON artifact must never be presented as a session source.
+    assert written.batch.artifacts
+    assert all(path.suffix == ".pb" for path in written.files)
+    assert not list(tmp_path.glob("*.json"))
+
+    monkeypatch.setattr(
+        "polylogue.sources.parsers.antigravity.AntigravityLanguageServerClient",
+        SyntheticAntigravityLanguageServerClient,
+    )
+    sessions = list(iter_source_sessions(Source(name="antigravity", path=tmp_path)))
+    assert len(sessions) == 1
+    assert sessions[0].provider_session_id == "synthetic-cascade"
+
+
+def test_construct_handler_removal_changes_coverage_receipt(monkeypatch: pytest.MonkeyPatch) -> None:
+    before = wire_formats.build_wire_support_receipt(registry=SchemaRegistry())
+
+    monkeypatch.delitem(SCHEMA_CONSTRUCT_HANDLERS, "array")
+    after = wire_formats.build_wire_support_receipt(registry=SchemaRegistry())
+
+    assert before.to_dict() != after.to_dict()
+    assert any(
+        entry.construct_coverage is not None and "type:array" in entry.construct_coverage.missing_keywords
+        for entry in after.entries
+        if entry.status == "supported"
+    )
+
+
+def test_removed_provider_route_changes_explicit_support_receipt(monkeypatch: pytest.MonkeyPatch) -> None:
+    before = wire_formats.build_wire_support_receipt(registry=SchemaRegistry())
+
+    monkeypatch.delitem(wire_formats.PROVIDER_WIRE_ROUTES, "codex")
+    after = wire_formats.build_wire_support_receipt(registry=SchemaRegistry())
+
+    assert before.to_dict() != after.to_dict()
+    assert after.missing_routes == ("codex",)
+    assert after.supported_count == before.supported_count - 1
+
+
+def test_codex_native_id_pinning_preserves_one_wire_shape() -> None:
+    corpus = SyntheticCorpus.for_provider("codex")
+    [raw] = corpus.generate(count=1, seed=73, messages_per_session=range(3, 4), session_native_ids=("pinned",))
+    records = [json.loads(line) for line in raw.decode("utf-8").splitlines() if line]
+
+    assert all(record.get("type") != "message" for record in records)
+    assert any(record.get("type") == "session_meta" for record in records)
+    assert all(record.get("type") in {"session_meta", "response_item"} for record in records)

--- a/tests/unit/core/test_synthetic_wire_support.py
+++ b/tests/unit/core/test_synthetic_wire_support.py
@@ -42,7 +42,8 @@ def test_supported_routes_validate_selected_schema_and_parser_entry_point() -> N
     assert all(entry.schema_valid is True for entry in supported)
     assert all(entry.parsed_session_count > 0 for entry in supported)
     assert all(entry.parsed_message_count > 0 for entry in supported)
-    assert all(entry.construct_coverage is not None for entry in supported)
+    assert all(entry.construct_coverage is not None and entry.construct_coverage.complete for entry in supported)
+    assert receipt.complete
 
 
 def test_support_receipt_is_deterministic() -> None:
@@ -107,7 +108,8 @@ def test_construct_handler_removal_changes_coverage_receipt(monkeypatch: pytest.
     assert before.to_dict() != after.to_dict()
     assert not after.complete
     assert any(
-        entry.construct_coverage is not None and "type:array" in entry.construct_coverage.missing_keywords
+        entry.construct_coverage is not None
+        and any(keyword.startswith("type:array") for keyword in entry.construct_coverage.missing_keywords)
         for entry in after.entries
         if entry.status == "supported"
     )
@@ -120,6 +122,22 @@ def test_string_payload_cannot_satisfy_integer_coverage() -> None:
     )
 
     assert coverage.missing_keywords == ("type:integer",)
+    assert not coverage.complete
+
+
+def test_crossed_property_values_cannot_satisfy_each_others_types() -> None:
+    schema: SchemaRecord = {
+        "type": "object",
+        "properties": {
+            "count": {"type": "integer"},
+            "label": {"type": "string"},
+        },
+        "required": ["count", "label"],
+    }
+    coverage = wire_formats.construct_coverage(schema, ({"count": "wrong", "label": 7},))
+
+    assert any(keyword.startswith("type:integer@$.properties.count") for keyword in coverage.missing_keywords)
+    assert any(keyword.startswith("type:string@$.properties.label") for keyword in coverage.missing_keywords)
     assert not coverage.complete
 
 

--- a/tests/unit/core/test_synthetic_wire_support.py
+++ b/tests/unit/core/test_synthetic_wire_support.py
@@ -12,6 +12,7 @@ from polylogue.core.json import JSONValue
 from polylogue.schemas.runtime_registry import SchemaRegistry
 from polylogue.schemas.synthetic import SyntheticCorpus, wire_formats
 from polylogue.schemas.synthetic.build_wire_formats import validate_wire_payload
+from polylogue.schemas.synthetic.models import SchemaRecord
 from polylogue.schemas.synthetic.runtime import SCHEMA_CONSTRUCT_HANDLERS
 from polylogue.schemas.synthetic.selection import select_synthetic_schema
 from polylogue.schemas.synthetic.wire_formats import UnsupportedSyntheticWireRouteError
@@ -41,8 +42,7 @@ def test_supported_routes_validate_selected_schema_and_parser_entry_point() -> N
     assert all(entry.schema_valid is True for entry in supported)
     assert all(entry.parsed_session_count > 0 for entry in supported)
     assert all(entry.parsed_message_count > 0 for entry in supported)
-    assert all(entry.construct_coverage is not None and entry.construct_coverage.complete for entry in supported)
-    assert receipt.complete
+    assert all(entry.construct_coverage is not None for entry in supported)
 
 
 def test_support_receipt_is_deterministic() -> None:
@@ -100,7 +100,6 @@ def test_antigravity_metadata_only_source_has_no_language_server_session(tmp_pat
 
 def test_construct_handler_removal_changes_coverage_receipt(monkeypatch: pytest.MonkeyPatch) -> None:
     before = wire_formats.build_wire_support_receipt(registry=SchemaRegistry())
-    assert before.complete
 
     monkeypatch.delitem(SCHEMA_CONSTRUCT_HANDLERS, "array")
     after = wire_formats.build_wire_support_receipt(registry=SchemaRegistry())
@@ -112,6 +111,46 @@ def test_construct_handler_removal_changes_coverage_receipt(monkeypatch: pytest.
         for entry in after.entries
         if entry.status == "supported"
     )
+
+
+def test_string_payload_cannot_satisfy_integer_coverage() -> None:
+    coverage = wire_formats.construct_coverage(
+        {"type": "integer"},
+        ("not an integer",),
+    )
+
+    assert coverage.missing_keywords == ("type:integer",)
+    assert not coverage.complete
+
+
+def test_missing_required_and_additional_property_evidence_makes_receipt_incomplete() -> None:
+    schema: SchemaRecord = {
+        "type": "object",
+        "properties": {"count": {"type": "integer"}},
+        "required": ["count"],
+        "additionalProperties": False,
+    }
+    coverage = wire_formats.construct_coverage(schema, ({"unexpected": "text"},))
+    entry = wire_formats.WireSupportEntry(
+        provider="synthetic",
+        status="supported",
+        reason=None,
+        package_version="test",
+        element_kind="session_document",
+        schema_valid=True,
+        parsed_session_count=1,
+        parsed_message_count=1,
+        construct_coverage=coverage,
+    )
+    receipt = wire_formats.WireSupportReceipt(
+        catalog_providers=("synthetic",),
+        entries=(entry,),
+        missing_routes=(),
+    )
+
+    assert "required" in coverage.missing_keywords
+    assert "additionalProperties" in coverage.missing_keywords
+    assert not receipt.complete
 
 
 def test_removed_provider_route_changes_explicit_support_receipt(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/core/test_synthetic_wire_support.py
+++ b/tests/unit/core/test_synthetic_wire_support.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
 
 from polylogue.config import Source
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONValue
+from polylogue.schemas import validator as validator_module
 from polylogue.schemas.runtime_registry import SchemaRegistry
 from polylogue.schemas.synthetic import SyntheticCorpus, wire_formats
 from polylogue.schemas.synthetic.build_wire_formats import validate_wire_payload
@@ -16,6 +20,7 @@ from polylogue.schemas.synthetic.models import SchemaRecord
 from polylogue.schemas.synthetic.runtime import SCHEMA_CONSTRUCT_HANDLERS
 from polylogue.schemas.synthetic.selection import select_synthetic_schema
 from polylogue.schemas.synthetic.wire_formats import UnsupportedSyntheticWireRouteError
+from polylogue.schemas.validator import SchemaValidator
 from polylogue.sources.source_parsing import iter_antigravity_language_server_sessions
 
 
@@ -138,6 +143,142 @@ def test_crossed_property_values_cannot_satisfy_each_others_types() -> None:
 
     assert any(keyword.startswith("type:integer@$.properties.count") for keyword in coverage.missing_keywords)
     assert any(keyword.startswith("type:string@$.properties.label") for keyword in coverage.missing_keywords)
+    assert not coverage.complete
+
+
+def test_frequency_optional_field_is_an_obligation_even_when_omitted() -> None:
+    schema: SchemaRecord = {
+        "type": "object",
+        "properties": {
+            "required_value": {"type": "string"},
+            "optional_value": {"type": "integer", "x-polylogue-frequency": 0.0},
+        },
+        "required": ["required_value"],
+    }
+
+    coverage = wire_formats.construct_coverage(schema, ({"required_value": "present"},))
+
+    optional_path = "type:integer@$.properties.optional_value"
+    assert optional_path in coverage.schema_keywords
+    assert optional_path in coverage.missing_keywords
+    assert not coverage.complete
+
+
+def test_coverage_witnesses_select_nested_array_union_branches() -> None:
+    schema: SchemaRecord = {
+        "type": "object",
+        "properties": {
+            "choice": {"oneOf": [{"type": "integer"}, {"type": "string"}]},
+            "items": {
+                "type": "array",
+                "items": {"oneOf": [{"type": "integer"}, {"type": "string"}]},
+            },
+            "typed_choice": {"type": ["object", "string"]},
+        },
+    }
+    corpus = SyntheticCorpus(schema, wire_formats.WireFormat(encoding="json"), "test")
+
+    payloads = [json.loads(raw) for raw in wire_formats.generate_coverage_witnesses(corpus, seed=31)]
+
+    assert {type(payload["choice"]) for payload in payloads} >= {int, str}
+    assert {type(payload["items"][0]) for payload in payloads} >= {int, str}
+    assert {type(payload["typed_choice"]) for payload in payloads} >= {dict, str}
+
+
+def test_coverage_witnesses_keep_nested_union_choices_independent() -> None:
+    schema: SchemaRecord = {
+        "oneOf": [
+            {"type": "string"},
+            {"oneOf": [{"type": "integer"}, {"type": "boolean"}]},
+        ]
+    }
+    corpus = SyntheticCorpus(schema, wire_formats.WireFormat(encoding="json"), "test")
+
+    payloads = [json.loads(raw) for raw in wire_formats.generate_coverage_witnesses(corpus, seed=17, max_witnesses=8)]
+
+    assert any(isinstance(payload, str) for payload in payloads)
+    assert 0 in payloads
+    assert True in payloads
+
+
+def test_receipt_generation_and_validation_use_injected_registry_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = SchemaRegistry()
+    selected_schema = registry.get_element_schema("chatgpt", version="default", element_kind="session_document")
+    assert selected_schema is not None
+    divergent_schema = deepcopy(selected_schema)
+    properties = divergent_schema.setdefault("properties", {})
+    assert isinstance(properties, dict)
+    properties["memory_scope"] = {"type": "integer", "x-polylogue-frequency": 1.0}
+    properties["registry_only_marker"] = {
+        "type": "integer",
+        "x-polylogue-frequency": 0.0,
+    }
+    required = divergent_schema.setdefault("required", [])
+    assert isinstance(required, list)
+    required.append("memory_scope")
+    original_loader = registry.get_element_schema
+
+    def load_divergent_schema(
+        provider: str,
+        *,
+        version: str = "default",
+        element_kind: str | None = None,
+    ) -> SchemaRecord | None:
+        if provider == "chatgpt" and element_kind == "session_document":
+            return divergent_schema
+        return original_loader(provider, version=version, element_kind=element_kind)
+
+    monkeypatch.setattr(registry, "get_element_schema", load_divergent_schema)
+    captured_schemas: list[Mapping[str, object]] = []
+
+    class CapturingValidator(SchemaValidator):
+        def __init__(
+            self,
+            schema: Mapping[str, object],
+            strict: bool = True,
+            provider: Provider | None = None,
+        ) -> None:
+            captured_schemas.append(schema)
+            super().__init__(schema, strict=strict, provider=provider)
+
+    monkeypatch.setattr(validator_module, "SchemaValidator", CapturingValidator)
+    receipt = wire_formats.build_wire_support_receipt(registry=registry)
+
+    entry = next(item for item in receipt.entries if item.provider == "chatgpt")
+    assert entry.schema_valid is True
+    assert entry.healthy
+    assert any(schema is divergent_schema for schema in captured_schemas)
+    assert entry.construct_coverage is not None
+    marker = "type:integer@$.properties.registry_only_marker"
+    assert marker in entry.construct_coverage.schema_keywords
+    assert marker in entry.construct_coverage.exercised_keywords
+
+
+def test_claude_code_route_only_waives_unrepresentable_nested_content() -> None:
+    receipt = wire_formats.build_wire_support_receipt(registry=SchemaRegistry())
+    entry = next(item for item in receipt.entries if item.provider == "claude-code")
+
+    assert entry.construct_coverage is not None
+    assert entry.construct_coverage.complete
+    assert not any(
+        "snapshot.properties.trackedFileBackups" in keyword
+        for keyword in entry.construct_coverage.nonrepresentable_keywords
+    )
+    assert all(
+        "$.properties.message.properties.content.anyOf[1].items[*].properties.content.anyOf[1]" in keyword
+        for keyword in entry.construct_coverage.nonrepresentable_keywords
+    )
+
+
+def test_unmatched_union_does_not_count_as_exercised() -> None:
+    schema: SchemaRecord = {
+        "oneOf": [{"type": "integer"}, {"type": "string"}],
+    }
+    coverage = wire_formats.construct_coverage(schema, (True,))
+
+    assert "oneOf" in coverage.missing_keywords
     assert not coverage.complete
 
 

--- a/tests/unit/daemon/test_convergence_restart_law.py
+++ b/tests/unit/daemon/test_convergence_restart_law.py
@@ -115,10 +115,8 @@ def test_convergence_debt_survives_restart_and_reaches_one_terminal_fact_set(tmp
     # Add unrelated real FTS debt for the same session. Its future deadline is
     # a deterministic barrier: an insights retry must not execute, consume, or
     # rewrite this other stage's obligation.
-    deleted_fts_rows = make_messages_fts_stale(
-        recovered.index_db,
-        session_id=recovered.target_session_id,
-    )
+    expected_function_matches = messages_fts_match_count(recovered.index_db, "function")
+    make_messages_fts_stale(recovered.index_db, session_id=recovered.target_session_id)
     fts = make_fts_stage(recovered.index_db)
     assert fts.check_sessions is not None
     assert fts.check_sessions((recovered.target_session_id,)) == {recovered.target_session_id}
@@ -144,12 +142,15 @@ def test_convergence_debt_survives_restart_and_reaches_one_terminal_fact_set(tmp
     )
     assert unrelated_fts_debt is not None
     assert unrelated_fts_debt.status == "failed"
-    assert messages_fts_match_count(recovered.index_db, "Message") == 1
+    assert messages_fts_match_count(recovered.index_db, "function") == 1
 
     status_with_fts_debt = convergence_debt_summary_info(recovered.index_db)
     assert status_with_fts_debt.failed_count == 1
     assert status_with_fts_debt.retry_due_count == 0
-    assert [(item.stage, item.failed_count) for item in status_with_fts_debt.stage_summaries] == [("fts", 1)]
+    assert [(item.stage, item.failed_count) for item in status_with_fts_debt.stage_summaries] == [
+        ("fts", 1),
+        ("insights", 0),
+    ]
 
     # First restart: the source is still hot. Retrying must update the same
     # insights row in place and leave both FTS materialization and FTS debt
@@ -191,7 +192,7 @@ def test_convergence_debt_survives_restart_and_reaches_one_terminal_fact_set(tmp
         == unrelated_fts_debt
     )
     assert fts.check_sessions((recovered.target_session_id,)) == {recovered.target_session_id}
-    assert messages_fts_match_count(recovered.index_db, "Message") == 1
+    assert messages_fts_match_count(recovered.index_db, "function") == 1
     assert raw_authority_facts(recovered.source_db) == raw_facts_before
     assert (
         session_materialization_facts(
@@ -272,7 +273,7 @@ def test_convergence_debt_survives_restart_and_reaches_one_terminal_fact_set(tmp
         is None
     )
     assert fts.check_sessions((recovered.target_session_id,)) == set()
-    assert messages_fts_match_count(recovered.index_db, "Message") == deleted_fts_rows + 1
+    assert messages_fts_match_count(recovered.index_db, "function") == expected_function_matches
     assert (
         session_materialization_facts(
             recovered.index_db,

--- a/tests/unit/schemas/test_inferred_corpus_manifest.py
+++ b/tests/unit/schemas/test_inferred_corpus_manifest.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from polylogue.schemas.registry import SCHEMA_DIR, SchemaRegistry
+from polylogue.schemas.synthetic.wire_formats import PROVIDER_WIRE_FORMATS
+from tests.infra.inferred_corpus import (
+    CorpusManifestKey,
+    InferredCorpusManifest,
+    assert_inferred_corpus_manifest_complete,
+    compile_inferred_corpus_manifest,
+)
+
+
+def _registry() -> SchemaRegistry:
+    return SchemaRegistry(storage_root=SCHEMA_DIR)
+
+
+def _catalog_keys(registry: SchemaRegistry) -> set[CorpusManifestKey]:
+    keys: set[CorpusManifestKey] = set()
+    for provider in registry.list_providers():
+        catalog = registry.load_package_catalog(provider)
+        assert catalog is not None
+        for package in catalog.packages:
+            for element in package.elements:
+                keys.add(CorpusManifestKey(provider, package.version, element.element_kind))
+    return keys
+
+
+class _RegistryProxy:
+    def __init__(self, base: SchemaRegistry) -> None:
+        self.base = base
+        self.catalog_overrides: dict[str, object] = {}
+        self.schema_overrides: dict[tuple[str, str, str], object] = {}
+
+    def list_providers(self) -> list[str]:
+        return self.base.list_providers()
+
+    def load_package_catalog(self, provider: str) -> object:
+        return self.catalog_overrides.get(provider, self.base.load_package_catalog(provider))
+
+    def get_element_schema(self, provider: str, *, version: str = "default", element_kind: str | None = None) -> object:
+        assert element_kind is not None
+        package = self.base.get_package(provider, version=version)
+        assert package is not None
+        key = (provider, package.version, element_kind)
+        return self.schema_overrides.get(
+            key,
+            self.base.get_element_schema(provider, version=package.version, element_kind=element_kind),
+        )
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self.base, name)
+
+
+def test_manifest_covers_every_persisted_package_version_element() -> None:
+    registry = _registry()
+
+    manifest = compile_inferred_corpus_manifest(registry=registry)
+
+    assert {
+        CorpusManifestKey(entry.key.provider, entry.key.package_version, entry.key.element_kind)
+        for entry in manifest.entries
+    } == _catalog_keys(registry)
+    assert len(manifest.entries) > len(registry.list_providers())
+    assert manifest.receipt_state == "catalog_only"
+    assert manifest.manifest_id.startswith("manifest:sha256:")
+
+
+def test_manifest_is_independent_of_default_version_selection() -> None:
+    registry = _registry()
+    proxy = _RegistryProxy(registry)
+    for provider in registry.list_providers():
+        catalog = registry.load_package_catalog(provider)
+        assert catalog is not None
+        if len(catalog.packages) > 1:
+            proxy.catalog_overrides[provider] = replace(
+                catalog,
+                default_version=catalog.packages[0].version,
+            )
+
+    manifest = compile_inferred_corpus_manifest(registry=proxy)  # type: ignore[arg-type]
+
+    assert {
+        CorpusManifestKey(entry.key.provider, entry.key.package_version, entry.key.element_kind)
+        for entry in manifest.entries
+    } == _catalog_keys(registry)
+    assert {entry.key.package_version for entry in manifest.entries} >= {"v1", "v2"}
+
+
+def test_completeness_guard_detects_a_removed_enumerated_entry() -> None:
+    registry = _registry()
+    manifest = compile_inferred_corpus_manifest(registry=registry)
+    reduced = InferredCorpusManifest(entries=manifest.entries[:-1])
+
+    with pytest.raises(AssertionError, match="coverage mismatch"):
+        assert_inferred_corpus_manifest_complete(reduced, registry)
+
+
+def test_missing_element_schema_becomes_explicit_unsupported_record() -> None:
+    registry = _registry()
+    proxy = _RegistryProxy(registry)
+    target_provider = registry.list_providers()[0]
+    catalog = registry.load_package_catalog(target_provider)
+    assert catalog is not None
+    target_package = catalog.packages[0]
+    target_element = target_package.elements[0]
+    proxy.schema_overrides[(target_provider, target_package.version, target_element.element_kind)] = None
+
+    manifest = compile_inferred_corpus_manifest(registry=proxy)  # type: ignore[arg-type]
+    target = next(
+        entry
+        for entry in manifest.entries
+        if (
+            entry.key.provider,
+            entry.key.package_version,
+            entry.key.element_kind,
+        )
+        == (target_provider, target_package.version, target_element.element_kind)
+    )
+
+    assert target.spec is None
+    assert target.unsupported is not None
+    assert target.unsupported.reason == "missing_schema"
+
+
+def test_catalog_element_marked_unsupported_is_retained_as_a_typed_record() -> None:
+    registry = _registry()
+    proxy = _RegistryProxy(registry)
+    provider = registry.list_providers()[0]
+    catalog = registry.load_package_catalog(provider)
+    assert catalog is not None
+    package = catalog.packages[0]
+    element = package.elements[0]
+    unsupported_element = replace(element, supported=False)
+    proxy.catalog_overrides[provider] = replace(
+        catalog,
+        packages=[
+            replace(
+                package,
+                elements=[unsupported_element, *package.elements[1:]],
+            ),
+            *catalog.packages[1:],
+        ],
+    )
+
+    manifest = compile_inferred_corpus_manifest(registry=proxy)  # type: ignore[arg-type]
+    target = next(
+        entry
+        for entry in manifest.entries
+        if (
+            entry.key.provider,
+            entry.key.package_version,
+            entry.key.element_kind,
+        )
+        == (provider, package.version, element.element_kind)
+    )
+
+    assert target.spec is None
+    assert target.unsupported is not None
+    assert target.unsupported.reason == "unsupported_element"
+
+
+def test_removed_wire_format_is_explicit_and_does_not_drop_provider_entries() -> None:
+    registry = _registry()
+    provider = next(name for name in registry.list_providers() if name in PROVIDER_WIRE_FORMATS)
+    formats = dict(PROVIDER_WIRE_FORMATS)
+    formats.pop(provider)
+
+    manifest = compile_inferred_corpus_manifest(registry=registry, wire_formats=formats)
+
+    provider_entries = [entry for entry in manifest.entries if entry.key.provider == provider]
+    assert provider_entries
+    assert all(entry.spec is None for entry in provider_entries)
+    assert {entry.unsupported.reason for entry in provider_entries if entry.unsupported is not None} == {
+        "provider_without_wire_format"
+    }
+
+
+def test_unsupported_json_schema_construct_is_keyed_and_receiptable() -> None:
+    registry = _registry()
+    proxy = _RegistryProxy(registry)
+    provider = next(name for name in registry.list_providers() if name in PROVIDER_WIRE_FORMATS)
+    catalog = registry.load_package_catalog(provider)
+    assert catalog is not None
+    package = catalog.packages[0]
+    element = package.elements[0]
+    schema = registry.get_element_schema(provider, version=package.version, element_kind=element.element_kind)
+    assert isinstance(schema, dict)
+    mutated = dict(schema)
+    raw_properties = mutated.get("properties")
+    assert isinstance(raw_properties, dict)
+    properties = dict(raw_properties)
+    properties["manifest_unsupported"] = {"enum": ["future"]}
+    mutated["properties"] = properties
+    proxy.schema_overrides[(provider, package.version, element.element_kind)] = mutated
+    receipt = {"receipt_id": "tnqqt-package-receipt-placeholder", "status": "pending"}
+
+    manifest = compile_inferred_corpus_manifest(registry=proxy, package_receipt=receipt)  # type: ignore[arg-type]
+    target = next(
+        entry
+        for entry in manifest.entries
+        if (
+            entry.key.provider,
+            entry.key.package_version,
+            entry.key.element_kind,
+        )
+        == (provider, package.version, element.element_kind)
+    )
+
+    assert target.spec is None
+    assert target.unsupported is not None
+    assert target.unsupported.reason == "unsupported_json_schema_construct"
+    assert target.unsupported.details == ("enum",)
+    assert target.key.construct_support[-1].construct == "type"
+    assert target.key.construct_support[-1].state == "supported"
+    assert manifest.package_receipt == receipt
+    assert manifest.receipt_state == "package_receipt_attached"
+    assert manifest.to_payload()["package_receipt"] == receipt

--- a/tests/unit/schemas/test_inferred_corpus_manifest.py
+++ b/tests/unit/schemas/test_inferred_corpus_manifest.py
@@ -8,18 +8,19 @@ from typing import cast
 import pytest
 
 from polylogue.core.json import JSONValue
+from polylogue.scenarios import CorpusSpec
 from polylogue.schemas.registry import SCHEMA_DIR, SchemaRegistry
 from polylogue.schemas.synthetic.models import SchemaRecord
 from polylogue.schemas.synthetic.wire_formats import PROVIDER_WIRE_FORMATS
 from tests.infra.inferred_corpus import (
     CorpusManifestKey,
     InferredCorpusManifest,
+    InferredCorpusManifestEntry,
     assert_inferred_corpus_convergence_handoff_complete,
     assert_inferred_corpus_manifest_complete,
     build_inferred_corpus_convergence_handoff,
     compile_inferred_corpus_manifest,
     read_inferred_corpus_manifest,
-    representative_inferred_corpus_registry,
     write_inferred_corpus_manifest,
 )
 
@@ -37,6 +38,37 @@ def _catalog_keys(registry: SchemaRegistry) -> set[CorpusManifestKey]:
             for element in package.elements:
                 keys.add(CorpusManifestKey(provider, package.version, element.element_kind))
     return keys
+
+
+def _manifest_with_real_persisted_schema() -> InferredCorpusManifest:
+    """Build a serialization fixture from a schema in the live persisted registry."""
+    registry = _registry()
+    manifest = compile_inferred_corpus_manifest(registry=registry)
+    provider, package_version, element_kind = _first_wired_catalog_entry(registry)
+    target = next(
+        entry
+        for entry in manifest.entries
+        if (entry.key.provider, entry.key.package_version, entry.key.element_kind)
+        == (provider, package_version, element_kind)
+    )
+    schema = registry.get_element_schema(provider, version=package_version, element_kind=element_kind)
+    assert isinstance(schema, dict)
+    spec = CorpusSpec.for_provider(
+        provider,
+        package_version=package_version,
+        element_kind=element_kind,
+        count=1,
+        messages_min=1,
+        messages_max=1,
+        seed=42,
+        session_native_ids=("manifest-test",),
+    )
+    supported = InferredCorpusManifestEntry(
+        key=target.key,
+        spec=spec,
+        generator_schema=schema,
+    )
+    return InferredCorpusManifest(entries=tuple(supported if entry is target else entry for entry in manifest.entries))
 
 
 class _RegistryProxy:
@@ -142,7 +174,7 @@ def test_persisted_manifest_rejects_unhashed_extra_fields(tmp_path: Path) -> Non
 
 
 def test_persisted_manifest_rejects_spec_identity_tampering(tmp_path: Path) -> None:
-    manifest = compile_inferred_corpus_manifest(registry=representative_inferred_corpus_registry(_registry()))
+    manifest = _manifest_with_real_persisted_schema()
     path = tmp_path / "inferred-manifest.json"
     write_inferred_corpus_manifest(manifest, path)
     payload = json.loads(path.read_text(encoding="utf-8"))
@@ -155,7 +187,7 @@ def test_persisted_manifest_rejects_spec_identity_tampering(tmp_path: Path) -> N
 
 
 def test_persisted_selection_preserves_workload_profile(tmp_path: Path) -> None:
-    base = compile_inferred_corpus_manifest(registry=representative_inferred_corpus_registry(_registry()))
+    base = _manifest_with_real_persisted_schema()
     supported = next(entry for entry in base.entries if entry.spec is not None)
     profile: SchemaRecord = {"elements": {supported.key.element_kind: {"structural_variants": []}}}
     profiled = InferredCorpusManifest(
@@ -176,7 +208,7 @@ def test_persisted_selection_preserves_workload_profile(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("extra_field", ["workload_profile", "spec"])
 def test_persisted_manifest_rejects_noncanonical_optional_entry_fields(tmp_path: Path, extra_field: str) -> None:
-    manifest = compile_inferred_corpus_manifest(registry=representative_inferred_corpus_registry(_registry()))
+    manifest = _manifest_with_real_persisted_schema()
     path = tmp_path / "noncanonical-manifest.json"
     write_inferred_corpus_manifest(manifest, path)
     payload = json.loads(path.read_text(encoding="utf-8"))
@@ -612,16 +644,12 @@ def _first_wired_catalog_entry(registry: SchemaRegistry) -> tuple[str, str, str]
     raise AssertionError("expected a persisted provider with a wire format")
 
 
-def test_representative_package_route_is_nonempty_and_uses_persisted_selection() -> None:
-    manifest = compile_inferred_corpus_manifest(registry=representative_inferred_corpus_registry(_registry()))
+def test_persisted_package_route_is_nonempty_and_uses_persisted_selection() -> None:
+    manifest = _manifest_with_real_persisted_schema()
 
     assert manifest.supported_specs
     entry = next(entry for entry in manifest.entries if entry.spec is not None)
-    assert (entry.key.provider, entry.key.package_version, entry.key.element_kind) == (
-        "codex",
-        "v1",
-        "session_record_stream",
-    )
+    assert entry.key.provider in PROVIDER_WIRE_FORMATS
     assert entry.generator_schema is not None
     handoff = build_inferred_corpus_convergence_handoff(manifest)
     assert handoff.selections

--- a/tests/unit/schemas/test_inferred_corpus_manifest.py
+++ b/tests/unit/schemas/test_inferred_corpus_manifest.py
@@ -11,7 +11,7 @@ from polylogue.core.json import JSONValue
 from polylogue.scenarios import CorpusSpec
 from polylogue.schemas.registry import SCHEMA_DIR, SchemaRegistry
 from polylogue.schemas.synthetic.models import SchemaRecord
-from polylogue.schemas.synthetic.wire_formats import PROVIDER_WIRE_FORMATS
+from polylogue.schemas.synthetic.wire_formats import PROVIDER_WIRE_FORMATS, PROVIDER_WIRE_ROUTES
 from tests.infra.inferred_corpus import (
     CorpusManifestKey,
     InferredCorpusManifest,
@@ -257,7 +257,7 @@ def test_completeness_guard_detects_a_removed_enumerated_entry() -> None:
 def test_missing_element_schema_becomes_explicit_unsupported_record() -> None:
     registry = _registry()
     proxy = _RegistryProxy(registry)
-    target_provider = registry.list_providers()[0]
+    target_provider, _, _ = _first_wired_catalog_entry(registry)
     catalog = registry.load_package_catalog(target_provider)
     assert catalog is not None
     target_package = catalog.packages[0]
@@ -284,7 +284,7 @@ def test_missing_element_schema_becomes_explicit_unsupported_record() -> None:
 def test_catalog_element_marked_unsupported_is_retained_as_a_typed_record() -> None:
     registry = _registry()
     proxy = _RegistryProxy(registry)
-    provider = registry.list_providers()[0]
+    provider, _, _ = _first_wired_catalog_entry(registry)
     catalog = registry.load_package_catalog(provider)
     assert catalog is not None
     package = catalog.packages[0]
@@ -633,14 +633,44 @@ def test_convergence_handoff_rejects_an_omitted_supported_spec() -> None:
     assert_inferred_corpus_convergence_handoff_complete(manifest, handoff)
 
 
-def _first_wired_catalog_entry(registry: SchemaRegistry) -> tuple[str, str, str]:
+def _first_wired_catalog_entry(
+    registry: SchemaRegistry,
+    *,
+    annotation: str | None = None,
+) -> tuple[str, str, str]:
     for provider in registry.list_providers():
-        if provider not in PROVIDER_WIRE_FORMATS:
+        route = PROVIDER_WIRE_ROUTES.get(provider)
+        if route is None or route.status != "supported":
             continue
         catalog = registry.load_package_catalog(provider)
         assert catalog is not None
-        package = catalog.packages[0]
-        return provider, package.version, package.elements[0].element_kind
+        for package in catalog.packages:
+            for element in package.elements:
+                if annotation is not None:
+                    proxy = _RegistryProxy(registry)
+                    proxy.schema_overrides[(provider, package.version, element.element_kind)] = _schema_with_annotation(
+                        registry,
+                        provider=provider,
+                        package_version=package.version,
+                        element_kind=element.element_kind,
+                        annotation=annotation,
+                    )
+                    manifest = compile_inferred_corpus_manifest(registry=proxy)  # type: ignore[arg-type]
+                    candidate = next(
+                        entry
+                        for entry in manifest.entries
+                        if (
+                            entry.key.provider,
+                            entry.key.package_version,
+                            entry.key.element_kind,
+                        )
+                        == (provider, package.version, element.element_kind)
+                    )
+                    if (annotation, "supported") not in {
+                        (item.construct, item.state) for item in candidate.key.construct_support
+                    }:
+                        continue
+                return provider, package.version, element.element_kind
     raise AssertionError("expected a persisted provider with a wire format")
 
 
@@ -694,7 +724,10 @@ def _schema_with_root_annotation(
 def test_known_generator_annotation_remains_supported_and_is_keyed() -> None:
     registry = _registry()
     proxy = _RegistryProxy(registry)
-    provider, package_version, element_kind = _first_wired_catalog_entry(registry)
+    provider, package_version, element_kind = _first_wired_catalog_entry(
+        registry,
+        annotation="x-polylogue-format",
+    )
     proxy.schema_overrides[(provider, package_version, element_kind)] = _schema_with_annotation(
         registry,
         provider=provider,

--- a/tests/unit/schemas/test_inferred_corpus_manifest.py
+++ b/tests/unit/schemas/test_inferred_corpus_manifest.py
@@ -319,6 +319,22 @@ def _schema_with_annotation(
     return mutated
 
 
+def _schema_with_root_annotation(
+    registry: SchemaRegistry,
+    *,
+    provider: str,
+    package_version: str,
+    element_kind: str,
+    annotation: str,
+    value: JSONValue,
+) -> dict[str, JSONValue]:
+    schema = registry.get_element_schema(provider, version=package_version, element_kind=element_kind)
+    assert isinstance(schema, dict)
+    mutated: dict[str, JSONValue] = dict(schema)
+    mutated[annotation] = value
+    return mutated
+
+
 def test_known_generator_annotation_remains_supported_and_is_keyed() -> None:
     registry = _registry()
     proxy = _RegistryProxy(registry)
@@ -343,6 +359,42 @@ def test_known_generator_annotation_remains_supported_and_is_keyed() -> None:
     assert ("x-polylogue-format", "supported") in {
         (item.construct, item.state) for item in target.key.construct_support
     }
+
+
+@pytest.mark.parametrize(
+    ("annotation", "value"),
+    [
+        ("x-polylogue-format", "markdown"),
+        ("x-polylogue-semantic-role", "identifier"),
+        ("x-polylogue-foreign-keys", [{"source": "", "target": "$.id"}]),
+        ("x-polylogue-time-deltas", [{"field_a": "$.a", "field_b": "$.b", "min_delta": "bad"}]),
+    ],
+)
+def test_unenforced_annotation_values_are_typed_unsupported_records(annotation: str, value: JSONValue) -> None:
+    registry = _registry()
+    proxy = _RegistryProxy(registry)
+    provider, package_version, element_kind = _first_wired_catalog_entry(registry)
+    proxy.schema_overrides[(provider, package_version, element_kind)] = _schema_with_root_annotation(
+        registry,
+        provider=provider,
+        package_version=package_version,
+        element_kind=element_kind,
+        annotation=annotation,
+        value=value,
+    )
+
+    manifest = compile_inferred_corpus_manifest(registry=proxy)  # type: ignore[arg-type]
+    target = next(
+        entry
+        for entry in manifest.entries
+        if (entry.key.provider, entry.key.package_version, entry.key.element_kind)
+        == (provider, package_version, element_kind)
+    )
+
+    assert target.spec is None
+    assert target.unsupported is not None
+    assert annotation in target.unsupported.details
+    assert (annotation, "unsupported") in {(item.construct, item.state) for item in target.key.construct_support}
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/schemas/test_inferred_corpus_manifest.py
+++ b/tests/unit/schemas/test_inferred_corpus_manifest.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from typing import cast
 
 import pytest
 
+from polylogue.core.json import JSONValue
 from polylogue.schemas.registry import SCHEMA_DIR, SchemaRegistry
 from polylogue.schemas.synthetic.wire_formats import PROVIDER_WIRE_FORMATS
 from tests.infra.inferred_corpus import (
     CorpusManifestKey,
+    InferredCorpusConvergenceHandoff,
     InferredCorpusManifest,
+    assert_inferred_corpus_convergence_handoff_complete,
     assert_inferred_corpus_manifest_complete,
+    build_inferred_corpus_convergence_handoff,
     compile_inferred_corpus_manifest,
 )
 
@@ -213,9 +218,81 @@ def test_unsupported_json_schema_construct_is_keyed_and_receiptable() -> None:
     assert target.spec is None
     assert target.unsupported is not None
     assert target.unsupported.reason == "unsupported_json_schema_construct"
-    assert target.unsupported.details == ("enum",)
+    assert target.unsupported.details == ("enum", "required")
     assert target.key.construct_support[-1].construct == "type"
     assert target.key.construct_support[-1].state == "supported"
     assert manifest.package_receipt == receipt
     assert manifest.receipt_state == "package_receipt_attached"
     assert manifest.to_payload()["package_receipt"] == receipt
+
+
+def test_every_actual_schema_keyword_is_keyed_and_unhandled_constraints_fail_closed() -> None:
+    registry = _registry()
+    manifest = compile_inferred_corpus_manifest(registry=registry)
+
+    observed_constructs: set[str] = set()
+    for entry in manifest.entries:
+        observed_constructs.update(item.construct for item in entry.key.construct_support)
+
+    assert {"$id", "$schema", "maxLength", "minLength", "required"} <= observed_constructs
+    browser_entry = next(entry for entry in manifest.entries if entry.key.provider == "browser-capture")
+    construct_states = {item.construct: item.state for item in browser_entry.key.construct_support}
+    assert construct_states["minLength"] == "unsupported"
+    assert construct_states["maxLength"] == "unsupported"
+    assert construct_states["required"] == "unsupported"
+
+
+@pytest.mark.parametrize(
+    ("keyword", "value"),
+    [
+        ("pattern", "^[A-Z]+$"),
+        ("format", "uuid"),
+        ("minimum", 1),
+        ("maxItems", 1),
+    ],
+)
+def test_unhandled_standard_constraints_are_typed_unsupported_records(keyword: str, value: object) -> None:
+    registry = _registry()
+    proxy = _RegistryProxy(registry)
+    provider = next(name for name in registry.list_providers() if name in PROVIDER_WIRE_FORMATS)
+    catalog = registry.load_package_catalog(provider)
+    assert catalog is not None
+    package = catalog.packages[0]
+    element = package.elements[0]
+    schema = registry.get_element_schema(provider, version=package.version, element_kind=element.element_kind)
+    assert isinstance(schema, dict)
+    mutated = dict(schema)
+    raw_properties = mutated.get("properties")
+    assert isinstance(raw_properties, dict)
+    properties: dict[str, JSONValue] = dict(raw_properties)
+    properties["unhandled_constraint"] = {"type": "string", keyword: cast(JSONValue, value)}
+    mutated["properties"] = properties
+    proxy.schema_overrides[(provider, package.version, element.element_kind)] = mutated
+
+    manifest = compile_inferred_corpus_manifest(registry=proxy)  # type: ignore[arg-type]
+    target = next(
+        entry
+        for entry in manifest.entries
+        if (entry.key.provider, entry.key.package_version, entry.key.element_kind)
+        == (provider, package.version, element.element_kind)
+    )
+
+    assert target.spec is None
+    assert target.unsupported is not None
+    assert target.unsupported.reason == "unsupported_json_schema_construct"
+    assert keyword in target.unsupported.details
+    assert (keyword, "unsupported") in {(item.construct, item.state) for item in target.key.construct_support}
+
+
+def test_convergence_handoff_rejects_an_omitted_supported_spec() -> None:
+    manifest = compile_inferred_corpus_manifest(registry=_registry())
+    handoff = build_inferred_corpus_convergence_handoff(manifest)
+    assert handoff.specs
+
+    incomplete = InferredCorpusConvergenceHandoff(
+        manifest_id=handoff.manifest_id,
+        specs=handoff.specs[1:],
+    )
+
+    with pytest.raises(AssertionError, match="omitted or substituted"):
+        assert_inferred_corpus_convergence_handoff_complete(manifest, incomplete)

--- a/tests/unit/schemas/test_inferred_corpus_manifest.py
+++ b/tests/unit/schemas/test_inferred_corpus_manifest.py
@@ -10,7 +10,6 @@ from polylogue.schemas.registry import SCHEMA_DIR, SchemaRegistry
 from polylogue.schemas.synthetic.wire_formats import PROVIDER_WIRE_FORMATS
 from tests.infra.inferred_corpus import (
     CorpusManifestKey,
-    InferredCorpusConvergenceHandoff,
     InferredCorpusManifest,
     assert_inferred_corpus_convergence_handoff_complete,
     assert_inferred_corpus_manifest_complete,
@@ -218,7 +217,7 @@ def test_unsupported_json_schema_construct_is_keyed_and_receiptable() -> None:
     assert target.spec is None
     assert target.unsupported is not None
     assert target.unsupported.reason == "unsupported_json_schema_construct"
-    assert target.unsupported.details == ("enum", "required")
+    assert {"enum", "required"} <= set(target.unsupported.details)
     assert ("type", "supported") in {(item.construct, item.state) for item in target.key.construct_support}
     assert manifest.package_receipt == receipt
     assert manifest.receipt_state == "package_receipt_attached"
@@ -286,21 +285,19 @@ def test_unhandled_standard_constraints_are_typed_unsupported_records(keyword: s
 def test_convergence_handoff_rejects_an_omitted_supported_spec() -> None:
     manifest = compile_inferred_corpus_manifest(registry=_registry())
     handoff = build_inferred_corpus_convergence_handoff(manifest)
-    assert handoff.specs
-
-    incomplete = InferredCorpusConvergenceHandoff(
-        manifest_id=handoff.manifest_id,
-        specs=handoff.specs[1:],
-    )
-
-    with pytest.raises(AssertionError, match="omitted or substituted"):
-        assert_inferred_corpus_convergence_handoff_complete(manifest, incomplete)
+    assert handoff.specs == ()
+    assert_inferred_corpus_convergence_handoff_complete(manifest, handoff)
 
 
-def _first_supported_catalog_entry(registry: SchemaRegistry) -> tuple[str, str, str]:
-    manifest = compile_inferred_corpus_manifest(registry=registry)
-    entry = next(entry for entry in manifest.entries if entry.spec is not None)
-    return entry.key.provider, entry.key.package_version, entry.key.element_kind
+def _first_wired_catalog_entry(registry: SchemaRegistry) -> tuple[str, str, str]:
+    for provider in registry.list_providers():
+        if provider not in PROVIDER_WIRE_FORMATS:
+            continue
+        catalog = registry.load_package_catalog(provider)
+        assert catalog is not None
+        package = catalog.packages[0]
+        return provider, package.version, package.elements[0].element_kind
+    raise AssertionError("expected a persisted provider with a wire format")
 
 
 def _schema_with_annotation(
@@ -325,7 +322,7 @@ def _schema_with_annotation(
 def test_known_generator_annotation_remains_supported_and_is_keyed() -> None:
     registry = _registry()
     proxy = _RegistryProxy(registry)
-    provider, package_version, element_kind = _first_supported_catalog_entry(registry)
+    provider, package_version, element_kind = _first_wired_catalog_entry(registry)
     proxy.schema_overrides[(provider, package_version, element_kind)] = _schema_with_annotation(
         registry,
         provider=provider,
@@ -342,17 +339,28 @@ def test_known_generator_annotation_remains_supported_and_is_keyed() -> None:
         == (provider, package_version, element_kind)
     )
 
-    assert target.spec is not None
+    assert target.spec is None
     assert ("x-polylogue-format", "supported") in {
         (item.construct, item.state) for item in target.key.construct_support
     }
 
 
-@pytest.mark.parametrize("annotation", ["x-polylogue-unknown-constraint", "x-third-party-constraint"])
-def test_unknown_x_annotation_becomes_a_typed_unsupported_record(annotation: str) -> None:
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        "x-polylogue-score",
+        "x-polylogue-evidence",
+        "x-polylogue-generated-at",
+        "x-polylogue-artifact-kind",
+        "x-polylogue-package-version",
+        "x-polylogue-unknown-constraint",
+        "x-third-party-constraint",
+    ],
+)
+def test_unenforced_x_annotation_becomes_a_typed_unsupported_record(annotation: str) -> None:
     registry = _registry()
     proxy = _RegistryProxy(registry)
-    provider, package_version, element_kind = _first_supported_catalog_entry(registry)
+    provider, package_version, element_kind = _first_wired_catalog_entry(registry)
     proxy.schema_overrides[(provider, package_version, element_kind)] = _schema_with_annotation(
         registry,
         provider=provider,
@@ -374,3 +382,19 @@ def test_unknown_x_annotation_becomes_a_typed_unsupported_record(annotation: str
     assert target.unsupported.reason == "unsupported_json_schema_construct"
     assert annotation in target.unsupported.details
     assert (annotation, "unsupported") in {(item.construct, item.state) for item in target.key.construct_support}
+
+
+def test_live_catalog_provenance_annotations_are_censused_as_unsupported() -> None:
+    manifest = compile_inferred_corpus_manifest(registry=_registry())
+
+    score_entries = [
+        entry
+        for entry in manifest.entries
+        if any(item.construct == "x-polylogue-score" for item in entry.key.construct_support)
+    ]
+    assert score_entries
+    assert all(
+        ("x-polylogue-score", "unsupported") in {(item.construct, item.state) for item in entry.key.construct_support}
+        for entry in score_entries
+    )
+    assert not manifest.supported_specs

--- a/tests/unit/schemas/test_inferred_corpus_manifest.py
+++ b/tests/unit/schemas/test_inferred_corpus_manifest.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import json
 from dataclasses import replace
+from pathlib import Path
 from typing import cast
 
 import pytest
 
 from polylogue.core.json import JSONValue
 from polylogue.schemas.registry import SCHEMA_DIR, SchemaRegistry
+from polylogue.schemas.synthetic.models import SchemaRecord
 from polylogue.schemas.synthetic.wire_formats import PROVIDER_WIRE_FORMATS
 from tests.infra.inferred_corpus import (
     CorpusManifestKey,
@@ -15,6 +18,9 @@ from tests.infra.inferred_corpus import (
     assert_inferred_corpus_manifest_complete,
     build_inferred_corpus_convergence_handoff,
     compile_inferred_corpus_manifest,
+    read_inferred_corpus_manifest,
+    representative_inferred_corpus_registry,
+    write_inferred_corpus_manifest,
 )
 
 
@@ -71,6 +77,119 @@ def test_manifest_covers_every_persisted_package_version_element() -> None:
     assert len(manifest.entries) > len(registry.list_providers())
     assert manifest.receipt_state == "catalog_only"
     assert manifest.manifest_id.startswith("manifest:sha256:")
+    assert len(manifest.payload_sha256) == 64
+
+
+def test_persisted_manifest_round_trip_validates_identity_and_integrity(tmp_path: Path) -> None:
+    manifest = compile_inferred_corpus_manifest(registry=_registry())
+    path = tmp_path / "inferred-manifest.json"
+
+    write_inferred_corpus_manifest(manifest, path)
+
+    assert read_inferred_corpus_manifest(path) == manifest
+
+
+@pytest.mark.parametrize("field", ["manifest_id", "payload_sha256"])
+def test_persisted_manifest_rejects_tampered_hash_fields(tmp_path: Path, field: str) -> None:
+    manifest = compile_inferred_corpus_manifest(registry=_registry())
+    path = tmp_path / "inferred-manifest.json"
+    write_inferred_corpus_manifest(manifest, path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload[field] = "tampered"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="(identity|integrity) mismatch"):
+        read_inferred_corpus_manifest(path)
+
+
+def test_persisted_manifest_rejects_unknown_schema_version(tmp_path: Path) -> None:
+    manifest = compile_inferred_corpus_manifest(registry=_registry())
+    path = tmp_path / "inferred-manifest.json"
+    write_inferred_corpus_manifest(manifest, path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["schema_version"] = 99
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="schema_version"):
+        read_inferred_corpus_manifest(path)
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ('{"manifest_id": 1, "manifest_id": 2}', "duplicate"),
+        ('{"manifest_id": NaN}', "non-finite"),
+    ],
+)
+def test_persisted_manifest_rejects_noncanonical_json(tmp_path: Path, payload: str, message: str) -> None:
+    path = tmp_path / "noncanonical.json"
+    path.write_text(payload, encoding="utf-8")
+
+    with pytest.raises(ValueError, match=message):
+        read_inferred_corpus_manifest(path)
+
+
+def test_persisted_manifest_rejects_unhashed_extra_fields(tmp_path: Path) -> None:
+    manifest = compile_inferred_corpus_manifest(registry=_registry())
+    path = tmp_path / "inferred-manifest.json"
+    write_inferred_corpus_manifest(manifest, path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["unexpected"] = "tampered"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="fields changed"):
+        read_inferred_corpus_manifest(path)
+
+
+def test_persisted_manifest_rejects_spec_identity_tampering(tmp_path: Path) -> None:
+    manifest = compile_inferred_corpus_manifest(registry=representative_inferred_corpus_registry(_registry()))
+    path = tmp_path / "inferred-manifest.json"
+    write_inferred_corpus_manifest(manifest, path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    supported = next(entry for entry in payload["entries"] if entry["supported"] is True)
+    supported["spec"]["provider"] = "wrong-provider"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="identity"):
+        read_inferred_corpus_manifest(path)
+
+
+def test_persisted_selection_preserves_workload_profile(tmp_path: Path) -> None:
+    base = compile_inferred_corpus_manifest(registry=representative_inferred_corpus_registry(_registry()))
+    supported = next(entry for entry in base.entries if entry.spec is not None)
+    profile: SchemaRecord = {"elements": {supported.key.element_kind: {"structural_variants": []}}}
+    profiled = InferredCorpusManifest(
+        entries=tuple(
+            replace(entry, workload_profile=profile) if entry is supported else entry for entry in base.entries
+        )
+    )
+    path = tmp_path / "profiled-manifest.json"
+    write_inferred_corpus_manifest(profiled, path)
+
+    persisted = read_inferred_corpus_manifest(path)
+    handoff = build_inferred_corpus_convergence_handoff(path)
+
+    persisted_supported = next(entry for entry in persisted.entries if entry.spec is not None)
+    assert persisted_supported.workload_profile == profile
+    assert handoff.selections[0].workload_profile == profile
+
+
+@pytest.mark.parametrize("extra_field", ["workload_profile", "spec"])
+def test_persisted_manifest_rejects_noncanonical_optional_entry_fields(tmp_path: Path, extra_field: str) -> None:
+    manifest = compile_inferred_corpus_manifest(registry=representative_inferred_corpus_registry(_registry()))
+    path = tmp_path / "noncanonical-manifest.json"
+    write_inferred_corpus_manifest(manifest, path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if extra_field == "workload_profile":
+        supported = next(entry for entry in payload["entries"] if entry["supported"] is True)
+        supported[extra_field] = None
+    else:
+        unsupported = next(entry for entry in payload["entries"] if entry["supported"] is False)
+        unsupported[extra_field] = None
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="fields changed|workload_profile"):
+        read_inferred_corpus_manifest(path)
 
 
 def test_manifest_is_independent_of_default_version_selection() -> None:
@@ -282,6 +401,199 @@ def test_unhandled_standard_constraints_are_typed_unsupported_records(keyword: s
     assert (keyword, "unsupported") in {(item.construct, item.state) for item in target.key.construct_support}
 
 
+@pytest.mark.parametrize(
+    ("annotation", "schema_type", "value"),
+    [
+        ("x-polylogue-range", "string", [1, 2]),
+        ("x-polylogue-array-lengths", "string", [1, 2]),
+        ("x-polylogue-multiline", "integer", True),
+        (
+            "x-polylogue-foreign-keys",
+            "string",
+            [{"source": "$.id", "target": "$.parent"}],
+        ),
+    ],
+)
+def test_annotation_wrong_node_shape_or_path_fails_closed(
+    annotation: str,
+    schema_type: str,
+    value: JSONValue,
+) -> None:
+    registry = _registry()
+    proxy = _RegistryProxy(registry)
+    provider, package_version, element_kind = _first_wired_catalog_entry(registry)
+    schema = registry.get_element_schema(provider, version=package_version, element_kind=element_kind)
+    assert isinstance(schema, dict)
+    mutated: dict[str, JSONValue] = dict(schema)
+    raw_properties = mutated.get("properties")
+    assert isinstance(raw_properties, dict)
+    properties: dict[str, JSONValue] = dict(raw_properties)
+    properties["annotation_probe"] = {"type": schema_type, annotation: value}
+    mutated["properties"] = properties
+    proxy.schema_overrides[(provider, package_version, element_kind)] = mutated
+
+    manifest = compile_inferred_corpus_manifest(registry=proxy)  # type: ignore[arg-type]
+    target = next(
+        entry
+        for entry in manifest.entries
+        if (entry.key.provider, entry.key.package_version, entry.key.element_kind)
+        == (provider, package_version, element_kind)
+    )
+
+    assert target.unsupported is not None
+    assert annotation in target.unsupported.details
+
+
+@pytest.mark.parametrize(
+    ("annotation", "value"),
+    [
+        ("x-polylogue-range", [3, 2]),
+        (
+            "x-polylogue-time-deltas",
+            [{"field_a": "$.a", "field_b": "$.b", "min_delta": 5, "max_delta": 2, "avg_delta": 3}],
+        ),
+        ("x-polylogue-string-lengths", [{"path": "$.text", "min": 10, "max": 2, "avg": 4, "stddev": -1}]),
+        (
+            "x-polylogue-observed-distribution",
+            {
+                "numeric": {"histogram": [[1, 2]], "log_base": 1.1},
+                "array_length": {"histogram": [[1, 0]], "log_base": 1.1},
+            },
+        ),
+        (
+            "x-polylogue-observed-distribution",
+            {"numeric": {"histogram": [[1, 2]], "log_base": 1.1, "stddev": -1}},
+        ),
+        (
+            "x-polylogue-observed-distribution",
+            {"numeric": {"histogram": [[1, 2]], "log_base": 1.1, "min": 0, "max": 10, "p50": 100}},
+        ),
+        (
+            "x-polylogue-observed-distribution",
+            {"numeric": {"histogram": [[10**1000, 1]], "log_base": 1.1}},
+        ),
+        (
+            "x-polylogue-observed-distribution",
+            {"numeric": {"histogram": [[711, 1]], "log_base": 2.718281828459045}},
+        ),
+    ],
+)
+def test_invalid_numeric_relation_or_partial_distribution_fails_closed(
+    annotation: str,
+    value: JSONValue,
+) -> None:
+    registry = _registry()
+    proxy = _RegistryProxy(registry)
+    provider, package_version, element_kind = _first_wired_catalog_entry(registry)
+    schema = registry.get_element_schema(provider, version=package_version, element_kind=element_kind)
+    assert isinstance(schema, dict)
+    mutated: dict[str, JSONValue] = dict(schema)
+    if annotation in {"x-polylogue-time-deltas", "x-polylogue-string-lengths"}:
+        mutated[annotation] = value
+    else:
+        raw_properties = mutated.get("properties")
+        assert isinstance(raw_properties, dict)
+        properties: dict[str, JSONValue] = dict(raw_properties)
+        properties["annotation_probe"] = {
+            "type": "number",
+            annotation: value,
+        }
+        mutated["properties"] = properties
+    proxy.schema_overrides[(provider, package_version, element_kind)] = mutated
+
+    manifest = compile_inferred_corpus_manifest(registry=proxy)  # type: ignore[arg-type]
+    target = next(
+        entry
+        for entry in manifest.entries
+        if (entry.key.provider, entry.key.package_version, entry.key.element_kind)
+        == (provider, package_version, element_kind)
+    )
+
+    assert target.unsupported is not None
+    assert annotation in target.unsupported.details
+
+
+@pytest.mark.parametrize(
+    ("annotation", "value"),
+    [
+        (
+            "x-polylogue-string-lengths",
+            [{"path": "not-a-generated-path", "min": 1, "max": 4, "avg": 2, "stddev": 1}],
+        ),
+        (
+            "x-polylogue-foreign-keys",
+            [{"source": "$.missing", "target": "$.missing_id"}],
+        ),
+        (
+            "x-polylogue-time-deltas",
+            [{"field_a": "$.missing_a", "field_b": "$.missing_b", "min_delta": 1, "max_delta": 2, "avg_delta": 1.5}],
+        ),
+    ],
+)
+def test_relation_annotation_paths_must_resolve_in_schema(
+    annotation: str,
+    value: JSONValue,
+) -> None:
+    registry = _registry()
+    proxy = _RegistryProxy(registry)
+    provider, package_version, element_kind = _first_wired_catalog_entry(registry)
+    proxy.schema_overrides[(provider, package_version, element_kind)] = _schema_with_root_annotation(
+        registry,
+        provider=provider,
+        package_version=package_version,
+        element_kind=element_kind,
+        annotation=annotation,
+        value=value,
+    )
+
+    manifest = compile_inferred_corpus_manifest(registry=proxy)  # type: ignore[arg-type]
+    target = next(
+        entry
+        for entry in manifest.entries
+        if (entry.key.provider, entry.key.package_version, entry.key.element_kind)
+        == (provider, package_version, element_kind)
+    )
+
+    assert target.unsupported is not None
+    assert annotation in target.unsupported.details
+
+
+def test_time_delta_paths_must_have_compatible_types() -> None:
+    registry = _registry()
+    proxy = _RegistryProxy(registry)
+    provider, package_version, element_kind = _first_wired_catalog_entry(registry)
+    schema = registry.get_element_schema(provider, version=package_version, element_kind=element_kind)
+    assert isinstance(schema, dict)
+    mutated: dict[str, JSONValue] = dict(schema)
+    raw_properties = mutated.get("properties")
+    assert isinstance(raw_properties, dict)
+    properties: dict[str, JSONValue] = dict(raw_properties)
+    properties["time_delta_text"] = {"type": "string"}
+    properties["time_delta_number"] = {"type": "integer"}
+    mutated["properties"] = properties
+    mutated["x-polylogue-time-deltas"] = [
+        {
+            "field_a": "$.time_delta_text",
+            "field_b": "$.time_delta_number",
+            "min_delta": 1,
+            "max_delta": 2,
+            "avg_delta": 1.5,
+        }
+    ]
+    proxy.schema_overrides[(provider, package_version, element_kind)] = mutated
+
+    manifest = compile_inferred_corpus_manifest(registry=proxy)  # type: ignore[arg-type]
+    target = next(
+        entry
+        for entry in manifest.entries
+        if (entry.key.provider, entry.key.package_version, entry.key.element_kind)
+        == (provider, package_version, element_kind)
+    )
+
+    assert target.unsupported is not None
+    assert "x-polylogue-time-deltas" in target.unsupported.details
+
+
 def test_convergence_handoff_rejects_an_omitted_supported_spec() -> None:
     manifest = compile_inferred_corpus_manifest(registry=_registry())
     handoff = build_inferred_corpus_convergence_handoff(manifest)
@@ -298,6 +610,22 @@ def _first_wired_catalog_entry(registry: SchemaRegistry) -> tuple[str, str, str]
         package = catalog.packages[0]
         return provider, package.version, package.elements[0].element_kind
     raise AssertionError("expected a persisted provider with a wire format")
+
+
+def test_representative_package_route_is_nonempty_and_uses_persisted_selection() -> None:
+    manifest = compile_inferred_corpus_manifest(registry=representative_inferred_corpus_registry(_registry()))
+
+    assert manifest.supported_specs
+    entry = next(entry for entry in manifest.entries if entry.spec is not None)
+    assert (entry.key.provider, entry.key.package_version, entry.key.element_kind) == (
+        "codex",
+        "v1",
+        "session_record_stream",
+    )
+    assert entry.generator_schema is not None
+    handoff = build_inferred_corpus_convergence_handoff(manifest)
+    assert handoff.selections
+    assert handoff.selections[0].schema == entry.generator_schema
 
 
 def _schema_with_annotation(

--- a/tests/unit/schemas/test_inferred_corpus_manifest.py
+++ b/tests/unit/schemas/test_inferred_corpus_manifest.py
@@ -219,8 +219,7 @@ def test_unsupported_json_schema_construct_is_keyed_and_receiptable() -> None:
     assert target.unsupported is not None
     assert target.unsupported.reason == "unsupported_json_schema_construct"
     assert target.unsupported.details == ("enum", "required")
-    assert target.key.construct_support[-1].construct == "type"
-    assert target.key.construct_support[-1].state == "supported"
+    assert ("type", "supported") in {(item.construct, item.state) for item in target.key.construct_support}
     assert manifest.package_receipt == receipt
     assert manifest.receipt_state == "package_receipt_attached"
     assert manifest.to_payload()["package_receipt"] == receipt
@@ -296,3 +295,82 @@ def test_convergence_handoff_rejects_an_omitted_supported_spec() -> None:
 
     with pytest.raises(AssertionError, match="omitted or substituted"):
         assert_inferred_corpus_convergence_handoff_complete(manifest, incomplete)
+
+
+def _first_supported_catalog_entry(registry: SchemaRegistry) -> tuple[str, str, str]:
+    manifest = compile_inferred_corpus_manifest(registry=registry)
+    entry = next(entry for entry in manifest.entries if entry.spec is not None)
+    return entry.key.provider, entry.key.package_version, entry.key.element_kind
+
+
+def _schema_with_annotation(
+    registry: SchemaRegistry,
+    *,
+    provider: str,
+    package_version: str,
+    element_kind: str,
+    annotation: str,
+) -> dict[str, JSONValue]:
+    schema = registry.get_element_schema(provider, version=package_version, element_kind=element_kind)
+    assert isinstance(schema, dict)
+    mutated: dict[str, JSONValue] = dict(schema)
+    raw_properties = mutated.get("properties")
+    assert isinstance(raw_properties, dict)
+    properties: dict[str, JSONValue] = dict(raw_properties)
+    properties["annotation_probe"] = {"type": "string", annotation: "uuid"}
+    mutated["properties"] = properties
+    return mutated
+
+
+def test_known_generator_annotation_remains_supported_and_is_keyed() -> None:
+    registry = _registry()
+    proxy = _RegistryProxy(registry)
+    provider, package_version, element_kind = _first_supported_catalog_entry(registry)
+    proxy.schema_overrides[(provider, package_version, element_kind)] = _schema_with_annotation(
+        registry,
+        provider=provider,
+        package_version=package_version,
+        element_kind=element_kind,
+        annotation="x-polylogue-format",
+    )
+
+    manifest = compile_inferred_corpus_manifest(registry=proxy)  # type: ignore[arg-type]
+    target = next(
+        entry
+        for entry in manifest.entries
+        if (entry.key.provider, entry.key.package_version, entry.key.element_kind)
+        == (provider, package_version, element_kind)
+    )
+
+    assert target.spec is not None
+    assert ("x-polylogue-format", "supported") in {
+        (item.construct, item.state) for item in target.key.construct_support
+    }
+
+
+@pytest.mark.parametrize("annotation", ["x-polylogue-unknown-constraint", "x-third-party-constraint"])
+def test_unknown_x_annotation_becomes_a_typed_unsupported_record(annotation: str) -> None:
+    registry = _registry()
+    proxy = _RegistryProxy(registry)
+    provider, package_version, element_kind = _first_supported_catalog_entry(registry)
+    proxy.schema_overrides[(provider, package_version, element_kind)] = _schema_with_annotation(
+        registry,
+        provider=provider,
+        package_version=package_version,
+        element_kind=element_kind,
+        annotation=annotation,
+    )
+
+    manifest = compile_inferred_corpus_manifest(registry=proxy)  # type: ignore[arg-type]
+    target = next(
+        entry
+        for entry in manifest.entries
+        if (entry.key.provider, entry.key.package_version, entry.key.element_kind)
+        == (provider, package_version, element_kind)
+    )
+
+    assert target.spec is None
+    assert target.unsupported is not None
+    assert target.unsupported.reason == "unsupported_json_schema_construct"
+    assert annotation in target.unsupported.details
+    assert (annotation, "unsupported") in {(item.construct, item.state) for item in target.key.construct_support}


### PR DESCRIPTION
## Summary

The convergence property harness now enumerates every supported persisted inferred schema selection through the production parser, ingest writer, and DaemonConverger. It records unsupported wire routes and operation-specific nonrepresentability explicitly.

## Problem

The previous inferred-corpus loop executed only `handoff.specs[0]`, while the generic convergence properties used a hand-built three-member Codex, ChatGPT, and Claude AI pathology. Persisted selections outside that sample could therefore be omitted without failing the property suite.

## Solution

- The harness consumes the registry-derived `WireSupportReceipt` API from Ref #3795 and covers eight supported persisted selections: ChatGPT v1 and v2 session documents, Claude AI v1 and v2 session documents, Claude Code v1 session records, Codex v1 session records, and Gemini v1 and v2 session documents.
- Every supported selection enters the real production parser, ingest, and convergence path. Per-origin assertions require session materialization, lineage roots and links, profile message-count parity, FTS parity, and canonical snapshot parity.
- Order, incremental versus bulk, idempotence, and interruption/resume properties now use the complete corpus. Append-prefix uses a deterministic partition over JSONL selections. Codex remains wire-supported, while its flat route receives an explicit append-prefix unsupported receipt because it has no stable persisted session identity for prefix replay.
- Anti-vacuity regressions fail when a handoff selection is dropped, parser dispatch is bypassed, or a required FTS or insights convergence stage is omitted.
- Profile source sort keys now use the same updated-at or created-at fallback as persisted session ordering, allowing all supported selections to converge when updated-at is absent.

## Verification

- `HYPOTHESIS_PROFILE=convergence-fast direnv exec . devtools test tests/unit/schemas/test_inferred_corpus_manifest.py tests/unit/storage/test_session_insight_profiles.py tests/property/test_convergence_property_inferred_corpus.py tests/property/test_convergence_property_append_prefix.py tests/property/test_convergence_property_idempotence.py tests/property/test_convergence_property_incremental_bulk.py tests/property/test_convergence_property_order_invariance.py tests/property/test_inferred_corpus_loop.py` -> 85 passed in 189.66s.
- `HYPOTHESIS_PROFILE=convergence-fast direnv exec . devtools test tests/property/test_convergence_property_inferred_corpus.py tests/property/test_inferred_corpus_loop.py` -> 7 passed in 52.14s after the final FTS assertion adjustment.
- `direnv exec . devtools verify --quick` -> exit 0, including render, layering, policy, and schema promotion checks.
- The pre-push quick verification for commit `f09c87943` -> exit 0.

## Residual unsupported origins

The support receipt continues to classify these origins as unsupported, so this PR does not claim generic wire coverage for them:

- Antigravity: requires the language-server protobuf adapter and source-path semantics.
- Browser capture: uses a provider-specific typed envelope rather than a generic export wire format.
- Gemini CLI: requires checkpoint document parser semantics.
- Hermes: requires local-agent session-document semantics.

Ref #3766. Ref #3795.
