### PR TITLE
test(convergence): add hermetic archive property loop

### DIFF
--- a/devtools/verify_test_infra_currency.py
+++ b/devtools/verify_test_infra_currency.py
@@ -42,6 +42,7 @@ from devtools import repo_root as _get_root
 
 ROOT = _get_root()
 SCHEMA_DDL_DIR = ROOT / "polylogue" / "storage" / "sqlite"
+SCHEMA_SUPPORT_DDL_FILES = (ROOT / "polylogue" / "storage" / "fts" / "sql.py",)
 TEST_INFRA_DIR = ROOT / "tests" / "infra"
 
 # Match CREATE TABLE [IF NOT EXISTS] <name>.
@@ -104,7 +105,7 @@ _SQLITE_BUILTIN_TABLES = frozenset(
 
 def _collect_schema_tables() -> frozenset[str]:
     tables: set[str] = set()
-    ddl_files = list((SCHEMA_DDL_DIR / "archive_tiers").glob("*.py"))
+    ddl_files = [*list((SCHEMA_DDL_DIR / "archive_tiers").glob("*.py")), *SCHEMA_SUPPORT_DDL_FILES]
     for ddl_file in ddl_files:
         text = ddl_file.read_text(encoding="utf-8")
         tables.update(name.lower() for name in _CREATE_TABLE_RE.findall(text))

--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -75,7 +75,9 @@ from polylogue.storage.sqlite.archive_tiers.revision_governance import (
 )
 from polylogue.storage.sqlite.archive_tiers.source_write import ArchiveSourceBlobRef
 from polylogue.storage.sqlite.archive_tiers.write import (
+    _message_content_hash,
     _timestamp_ms,
+    _write_repo_edges,
     replace_parser_ingest_flag_tags,
     upsert_parser_ingest_flag_tags,
     write_parsed_session_to_archive,
@@ -394,6 +396,81 @@ def _append_delta_payload(
     return payload.parsed_session.model_copy(update={"messages": delta_messages}), len(
         payload.parsed_session.messages
     ) - len(delta_messages)
+
+
+def _append_payload_changes_existing_message(
+    conn: sqlite3.Connection,
+    payload: SessionWritePayload,
+) -> bool:
+    """Return whether an incoming append revision changes an existing message.
+
+    Native ids identify the same message across a growing provider revision,
+    but the message's blocks can still be revised. A newer full revision must
+    replace such overlap before appending its tail, otherwise the resulting
+    session depends on arrival order.
+    """
+    existing_rows = {
+        str(row[0]): (int(row[1]), int(row[2]), row[3])
+        for row in conn.execute(
+            """
+            SELECT native_id, position, variant_index, content_hash
+            FROM messages
+            WHERE session_id = ? AND native_id IS NOT NULL
+            """,
+            (payload.session_id,),
+        ).fetchall()
+    }
+    for message in payload.parsed_session.messages:
+        existing = existing_rows.get(message.provider_message_id)
+        if existing is None:
+            continue
+        position, variant_index, existing_hash = existing
+        incoming_hash = _message_content_hash(
+            payload.session_id,
+            message,
+            position=position,
+            variant_index=variant_index,
+        )
+        if incoming_hash != existing_hash:
+            return True
+    return False
+
+
+def _repair_stale_revision_observations(
+    conn: sqlite3.Connection,
+    payload: SessionWritePayload,
+) -> None:
+    """Merge monotonic facts from a stale revision without replacing content."""
+    conn.execute(
+        "DELETE FROM insight_materialization WHERE session_id = ?",
+        (payload.session_id,),
+    )
+    candidate_created_at_ms = _timestamp_ms(payload.parsed_session.created_at)
+    if candidate_created_at_ms is None:
+        message_timestamps = [
+            timestamp_ms
+            for message in payload.parsed_session.messages
+            if (timestamp_ms := _timestamp_ms(message.timestamp)) is not None
+        ]
+        candidate_created_at_ms = min(message_timestamps, default=None)
+    if candidate_created_at_ms is not None:
+        conn.execute(
+            """
+            UPDATE sessions
+            SET created_at_ms = CASE
+                WHEN created_at_ms IS NULL THEN ?
+                ELSE MIN(created_at_ms, ?)
+            END
+            WHERE session_id = ?
+            """,
+            (candidate_created_at_ms, candidate_created_at_ms, payload.session_id),
+        )
+    _write_repo_edges(
+        conn,
+        payload.session_id,
+        payload.parsed_session,
+        update_session_observations=False,
+    )
 
 
 def _incoming_write_regresses_attachment_coverage(
@@ -814,6 +891,8 @@ def _write_session(
     existing_raw_id = str(existing_row["raw_id"] or "") if existing_row is not None else ""
     session_to_write = payload.parsed_session
     merge_append = False
+    append_force_replace = False
+    freshness_force_replace = False
     browser_precedence: BrowserCapturePrecedence = "default"
 
     drive_revision_plan = _bind_drive_revision_lineage(
@@ -894,6 +973,7 @@ def _write_session(
                 session_id=payload.session_id,
                 events=payload.parsed_session.session_events,
             )
+            _repair_stale_revision_observations(conn, payload)
             counts["session_events"] = counts.get("session_events", 0) + outage_events
             counts["skipped_sessions"] = 1
             counts["skipped_messages"] = payload.message_count
@@ -915,11 +995,13 @@ def _write_session(
             incoming_freshness_ms=incoming_freshness_ms,
             existing_updated_at_ms=existing_updated_at_int,
         ):
+            _repair_stale_revision_observations(conn, payload)
             counts["skipped_sessions"] = 1
             counts["skipped_messages"] = payload.message_count
             counts["skipped_attachments"] = payload.attachment_count
             counts["skipped_session_events"] = len(payload.parsed_session.session_events)
             return False, counts
+        freshness_force_replace = True
         if (
             existing_updated_at_int is not None
             and incoming_freshness_ms == existing_updated_at_int
@@ -936,20 +1018,55 @@ def _write_session(
             return False, counts
 
     if payload.append_only and existing_row is not None:
-        delta, skipped_messages = _append_delta_payload(conn, payload)
-        counts["skipped_messages"] = skipped_messages
-        if delta is None:
-            if payload.parsed_session.ingest_flags:
-                upsert_parser_ingest_flag_tags(conn, payload.session_id, payload.parsed_session.ingest_flags)
-            counts["raw_links"] = int(_refresh_session_raw_link(conn, payload.session_id, payload.raw_id))
+        existing_updated_at_ms = existing_row["updated_at_ms"]
+        existing_updated_at_int = int(existing_updated_at_ms) if existing_updated_at_ms is not None else None
+        if (
+            incoming_freshness_ms is not None
+            and existing_updated_at_int is not None
+            and incoming_freshness_ms < existing_updated_at_int
+        ):
+            # Append-only captures can arrive out of order after a restart or
+            # replay. An older full revision may carry the same native
+            # messages plus stale session metadata and attachment/event
+            # projections. Once a newer revision is stored, accepting that
+            # older envelope would create a hybrid session even though its
+            # message delta is empty. Preserve the newer authority and leave
+            # the raw row available for audit/replay.
             counts["skipped_sessions"] = 1
+            counts["skipped_messages"] = payload.message_count
             counts["skipped_attachments"] = payload.attachment_count
             counts["skipped_session_events"] = len(payload.parsed_session.session_events)
-            if _needs_session_fts_repair(conn, payload.session_id):
-                counts[_FTS_REPAIR_COUNT_KEY] = 1
             return False, counts
-        session_to_write = delta
-        merge_append = True
+        newer_revision = (
+            incoming_freshness_ms is not None
+            and existing_updated_at_int is not None
+            and incoming_freshness_ms > existing_updated_at_int
+        )
+        delta: ParsedSession | None = None
+        if newer_revision and _append_payload_changes_existing_message(conn, payload):
+            # A later full revision can revise an already-seen native message
+            # as well as add a tail. Replace it authoritatively so message,
+            # block, attachment, and event projections all come from the same
+            # revision. Older/equal replays continue through the append delta
+            # path and retain its unchanged-row contract.
+            counts["skipped_messages"] = 0
+            append_force_replace = True
+        else:
+            delta, skipped_messages = _append_delta_payload(conn, payload)
+            counts["skipped_messages"] = skipped_messages
+        if not append_force_replace:
+            if delta is None:
+                if payload.parsed_session.ingest_flags:
+                    upsert_parser_ingest_flag_tags(conn, payload.session_id, payload.parsed_session.ingest_flags)
+                counts["raw_links"] = int(_refresh_session_raw_link(conn, payload.session_id, payload.raw_id))
+                counts["skipped_sessions"] = 1
+                counts["skipped_attachments"] = payload.attachment_count
+                counts["skipped_session_events"] = len(payload.parsed_session.session_events)
+                if _needs_session_fts_repair(conn, payload.session_id):
+                    counts[_FTS_REPAIR_COUNT_KEY] = 1
+                return False, counts
+            session_to_write = delta
+            merge_append = True
 
     if not force_write and content_unchanged:
         if browser_precedence == "replace":
@@ -1007,7 +1124,9 @@ def _write_session(
         content_hash=payload.content_hash,
         raw_id=payload.raw_id,
         merge_append=merge_append,
-        force_replace=force_write or browser_precedence == "replace",
+        force_replace=(
+            force_write or browser_precedence == "replace" or append_force_replace or freshness_force_replace
+        ),
         signature_cache=signature_cache,
         stage_timings_s=stage_timings_s,
         preacquired_attachment_blobs=preacquired_attachment_blobs,
@@ -1018,6 +1137,10 @@ def _write_session(
         # whale-session rewrite held the daemon writer >1h at 260GB of reads
         # with zero commits (2026-07-22) under per-row mode.
         bulk_fts=True,
+    )
+    conn.execute(
+        "DELETE FROM insight_materialization WHERE session_id = ?",
+        (payload.session_id,),
     )
     if pending_attachment_receipts is not None:
         pending_attachment_receipts.extend(publication_receipts)

--- a/polylogue/storage/fts/drift_sampling.py
+++ b/polylogue/storage/fts/drift_sampling.py
@@ -37,6 +37,12 @@ _FRESHNESS_SURFACE_COLUMNS = (
     "identity_mismatch_rows",
 )
 
+# Drift history is diagnostic telemetry. It must never hold an index repair
+# behind an ops.db writer or schema bootstrap lock. A zero wait keeps the
+# best-effort contract literal: the current index freshness state remains the
+# authority, and a missed sample is preferable to delaying convergence.
+_OPS_SAMPLE_TIMEOUT_SECONDS = 0.0
+
 
 def _index_db_path_sync(conn: sqlite3.Connection) -> Path | None:
     """Return the main database file path backing ``conn``, if any."""
@@ -94,7 +100,7 @@ def sample_fts_drift_to_ops_sync(conn: sqlite3.Connection, *, archive_root: Path
 
     ops_conn: sqlite3.Connection | None = None
     try:
-        ops_conn = open_connection(ops_db_path, timeout=5.0)
+        ops_conn = open_connection(ops_db_path, timeout=_OPS_SAMPLE_TIMEOUT_SECONDS)
         initialize_archive_tier(ops_conn, ArchiveTier.OPS)
         sampled_at_ms = int(time.time() * 1000)
         written = 0

--- a/polylogue/storage/insights/session/rebuild.py
+++ b/polylogue/storage/insights/session/rebuild.py
@@ -1873,6 +1873,10 @@ def rebuild_session_insights_sync(
         if chunk_info.max_estimated_session_messages >= _SESSION_INSIGHT_DEGRADED_MESSAGE_THRESHOLD:
             chunk_degraded_ids = chunk
             chunk_full_ids = ()
+        t0 = time.perf_counter()
+        for session_id in chunk:
+            _refresh_provider_usage_rollup(conn, session_id)
+        add_timing("refresh_provider_usage_rollup", t0)
         if chunk_degraded_ids and not chunk_full_ids:
             t0 = time.perf_counter()
             degraded_session_ids.update(str(session_id) for session_id in chunk_degraded_ids)

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -5171,7 +5171,13 @@ def _aggregate_message_tokens_into_model_usage(conn: sqlite3.Connection, session
         )
 
 
-def _write_repo_edges(conn: sqlite3.Connection, session_id: str, session: ParsedSession) -> None:
+def _write_repo_edges(
+    conn: sqlite3.Connection,
+    session_id: str,
+    session: ParsedSession,
+    *,
+    update_session_observations: bool = True,
+) -> None:
     observed_at_ms = _timestamp_ms(session.updated_at) or _timestamp_ms(session.created_at)
     raw_root_paths = tuple(path.strip() for path in session.working_directories if path.strip())
     origin_url = (session.git_repository_url or "").strip()
@@ -5244,21 +5250,22 @@ def _write_repo_edges(conn: sqlite3.Connection, session_id: str, session: Parsed
             """,
             (repo_id, _sqlite_text(root_path), observed_at_ms or 0, observed_at_ms or 0),
         )
-        conn.execute(
-            """
-            INSERT OR REPLACE INTO session_repos (
-                session_id, repo_id, root_path, branch_name, observed_at_ms
-            ) VALUES (?, ?, ?, ?, ?)
-            """,
-            (
-                session_id,
-                repo_id,
-                _sqlite_text(root_path),
-                _sqlite_text(session.git_branch or ""),
-                observed_at_ms or 0,
-            ),
-        )
-        if session.git_commit_hash:
+        if update_session_observations:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO session_repos (
+                    session_id, repo_id, root_path, branch_name, observed_at_ms
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    session_id,
+                    repo_id,
+                    _sqlite_text(root_path),
+                    _sqlite_text(session.git_branch or ""),
+                    observed_at_ms or 0,
+                ),
+            )
+        if update_session_observations and session.git_commit_hash:
             conn.execute(
                 """
                 INSERT OR REPLACE INTO session_commits (

--- a/tests/infra/convergence_harness.py
+++ b/tests/infra/convergence_harness.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import sqlite3
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -22,8 +23,20 @@ from polylogue.core.outcomes import OutcomeStatus
 from polylogue.daemon.convergence import DaemonConverger, SessionState
 from polylogue.daemon.convergence_stages import make_fts_stage, make_insights_stage
 from polylogue.maintenance.archive_verification import ArchiveVerificationReport, verify_archive
+from polylogue.pipeline.ids import session_content_hash
+from polylogue.pipeline.ids import session_id as make_session_id
+from polylogue.pipeline.services.ingest_batch._core import _write_session
+from polylogue.pipeline.services.ingest_worker import SessionWritePayload
 from polylogue.scenarios import WorkloadEnvelopeSpec, partial_convergence_canary_spec
-from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
+from polylogue.sources.parsers.base import (
+    ParsedAttachment,
+    ParsedContentBlock,
+    ParsedMessage,
+    ParsedSession,
+    ParsedSessionEvent,
+    ParsedSessionRef,
+)
+from polylogue.storage.blob_publication import ArchiveBlobPublisher, consume_blob_publication_receipt
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
 from polylogue.storage.sqlite.archive_tiers.source_write import write_source_raw_session
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
@@ -94,7 +107,8 @@ class ArchiveSnapshot:
     blocks: tuple[FactRow, ...]
     session_links: tuple[FactRow, ...]
     profiles: tuple[FactRow, ...]
-    fts_counts: tuple[tuple[str, int], ...]
+    semantic_tables: tuple[tuple[str, tuple[FactRow, ...]], ...]
+    fts_matches: tuple[tuple[str, object], ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -129,6 +143,7 @@ def build_converged_archive(
     *,
     session_order: Sequence[int] | None = None,
     incremental: bool = False,
+    append_only: bool = False,
 ) -> ConvergenceArchive:
     """Materialize a composed corpus through production writes, then converge it."""
     initialize_active_archive(root)
@@ -137,6 +152,7 @@ def build_converged_archive(
         pathology,
         session_indexes=_complete_session_order(pathology, session_order),
         converge_after_each=incremental,
+        append_only=append_only,
     )
     if not incremental:
         converge_convergence_archive(archive)
@@ -157,13 +173,14 @@ def ingest_convergence_pathology(
     *,
     session_indexes: Sequence[int],
     converge_after_each: bool,
+    append_only: bool = False,
 ) -> ConvergenceArchive:
     """Use the production raw and parsed-session writers for each selected member.
 
     The test harness does not emulate archive materialization or convergence.
-    It writes source.db through the production raw writer and index.db through
-    the production parsed-session writer, exactly as the live ingestion layer
-    does after a provider parser has produced a ``ParsedSession``.
+    It writes source.db through the production raw writer and sends the parsed
+    payload through ``ingest_batch._core._write_session``, exactly as the live
+    ingestion layer does after a provider parser has produced a ``ParsedSession``.
     """
     selected = _validate_session_indexes(pathology, session_indexes)
     source_paths: list[Path] = []
@@ -180,18 +197,38 @@ def ingest_convergence_pathology(
                 origin="codex-session",
                 capture_mode=Provider.CODEX,
                 source_path=str(source_path),
-                source_index=index,
+                source_index=-1 if append_only else index,
                 payload=payload,
                 acquired_at_ms=_acquired_at_ms(index),
                 native_id=session.provider_session_id,
             )
-        with open_connection(root / "index.db") as index_conn:
-            session_id = write_parsed_session_to_archive(
+        payload_model = SessionWritePayload(
+            session_id=str(make_session_id(session.source_name, session.provider_session_id)),
+            content_hash=str(session_content_hash(session)),
+            parsed_session=session,
+            message_count=len(session.messages),
+            attachment_count=len(session.attachments),
+            raw_id=raw_id,
+            append_only=append_only,
+        )
+        pending_attachment_receipts: list[tuple[str, bytes]] = []
+        blob_publisher = ArchiveBlobPublisher(root / "source.db", root / "blob")
+        with open_connection(root / "index.db") as index_conn, sqlite3.connect(root / "source.db") as source_conn:
+            changed, counts = _write_session(
                 index_conn,
-                session,
-                raw_id=raw_id,
-                content_hash=hashlib.sha256(payload).hexdigest(),
+                payload_model,
+                blob_publisher=blob_publisher,
+                pending_attachment_receipts=pending_attachment_receipts,
+                source_conn=source_conn,
             )
+            if pending_attachment_receipts:
+                source_conn.execute("BEGIN IMMEDIATE")
+                for publication_id, blob_hash in pending_attachment_receipts:
+                    consume_blob_publication_receipt(source_conn, publication_id, blob_hash)
+                source_conn.commit()
+        if not changed and counts["skipped_sessions"] == 0:
+            raise AssertionError(f"production ingest writer did not account for {payload_model.session_id}")
+        session_id = payload_model.session_id
         source_paths.append(source_path)
         session_ids.append(session_id)
         make_messages_fts_stale(root / "index.db", session_id=session_id)
@@ -241,43 +278,43 @@ def archive_snapshot(root: Path) -> ArchiveSnapshot:
         messages = conn.execute(
             """
             SELECT session_id, native_id, position, variant_index, role,
-                   material_origin, message_type, parent_message_id
+                   material_origin, message_type, parent_message_id, model_name,
+                   model_effort, input_tokens, output_tokens, cache_read_tokens,
+                   cache_write_tokens, duration_ms, stop_reason, content_hash
             FROM messages ORDER BY session_id, position, variant_index
             """
         ).fetchall()
         blocks = conn.execute(
             """
             SELECT session_id, message_id, position, block_type, text, tool_id,
-                   tool_name, tool_result_is_error, tool_result_exit_code
+                   tool_name, tool_input, semantic_type, media_type,
+                   tool_result_is_error, tool_result_exit_code, content_hash
             FROM blocks ORDER BY session_id, message_id, position
             """
         ).fetchall()
         session_links = conn.execute(
             """
             SELECT src_session_id, dst_origin, dst_native_id, link_type,
-                   resolved_dst_session_id, branch_point_message_id, inheritance, status
+                   resolved_dst_session_id, branch_point_message_id, inheritance,
+                   status, parent_tool_use_block_id, method, confidence,
+                   evidence_json
             FROM session_links
             ORDER BY src_session_id, dst_origin, dst_native_id, link_type
             """
         ).fetchall()
-        profiles = conn.execute(
-            """
-            SELECT session_id, logical_session_id, message_count, work_event_count,
-                   phase_count, word_count, tool_use_count, workflow_shape, terminal_state
-            FROM session_profiles ORDER BY session_id
-            """
-        ).fetchall()
-        fts_counts = tuple(
-            (table, int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]))
-            for table in ("messages_fts_docsize", "messages_fts_identity", "blocks_command_trigram_docsize")
+        profiles = _table_rows(conn, "session_profiles", order_by="session_id")
+        semantic_tables = tuple(
+            (table, _table_rows(conn, table, order_by=order_by)) for table, order_by in _SEMANTIC_TABLES
         )
+        fts_matches = _fts_match_snapshot(conn)
     return ArchiveSnapshot(
         sessions=_fact_rows(sessions),
         messages=_fact_rows(messages),
         blocks=_fact_rows(blocks),
         session_links=_fact_rows(session_links),
-        profiles=_fact_rows(profiles),
-        fts_counts=fts_counts,
+        profiles=profiles,
+        semantic_tables=semantic_tables,
+        fts_matches=fts_matches,
     )
 
 
@@ -306,6 +343,31 @@ def rotated_session_order(pathology: ComposedPathology, shift: int) -> tuple[int
     return indexes[shift:] + indexes[:shift]
 
 
+def replay_convergence_archive(
+    root: Path,
+    pathology: ComposedPathology,
+    *,
+    session_indexes: Sequence[int],
+    append_only: bool = False,
+) -> ConvergenceArchive:
+    """Build a fresh canonical archive from the exact writes seen so far."""
+    initialize_active_archive(root)
+    archive: ConvergenceArchive | None = None
+    for index in session_indexes:
+        archive = ingest_convergence_pathology(
+            root,
+            pathology,
+            session_indexes=(index,),
+            converge_after_each=False,
+            append_only=append_only,
+        )
+    if archive is None:
+        raise ValueError("replay_convergence_archive requires at least one session index")
+    converge_convergence_archive(archive)
+    assert_archive_verification_green(root)
+    return archive
+
+
 def _validate_session_indexes(pathology: ComposedPathology, indexes: Sequence[int]) -> tuple[int, ...]:
     selected = tuple(indexes)
     if len(selected) != len(set(selected)) or any(index < 0 or index >= len(pathology.sessions) for index in selected):
@@ -319,17 +381,35 @@ def _parsed_session(session: object, *, corpus_index: int) -> ParsedSession:
     if not isinstance(session, Session):
         raise TypeError(f"expected composed Session, got {type(session)!r}")
     timestamp = _corpus_timestamp(corpus_index)
-    messages = [
-        ParsedMessage(
-            provider_message_id=str(message.id),
-            role=Role.normalize(str(message.role)),
-            text=message.text,
-            position=position,
-            timestamp=timestamp,
-            blocks=[ParsedContentBlock(type=BlockType.TEXT, text=message.text)],
+    messages: list[ParsedMessage] = []
+    dispatch_tool_id = f"dispatch-{session.id}"
+    for position, message in enumerate(session.messages):
+        blocks = [ParsedContentBlock(type=BlockType.TEXT, text=message.text)]
+        if position == 0:
+            blocks.append(
+                ParsedContentBlock(
+                    type=BlockType.TOOL_USE,
+                    tool_name="Task",
+                    tool_id=dispatch_tool_id,
+                    tool_input={"prompt": message.text, "model": "gpt-4.1-mini"},
+                )
+            )
+        messages.append(
+            ParsedMessage(
+                provider_message_id=str(message.id),
+                role=Role.normalize(str(message.role)),
+                text=message.text,
+                position=position,
+                timestamp=timestamp,
+                model_name="gpt-4.1-mini",
+                input_tokens=10 + corpus_index + position,
+                output_tokens=5 + position,
+                cache_read_tokens=2,
+                blocks=blocks,
+            )
         )
-        for position, message in enumerate(session.messages)
-    ]
+    attachment_message_id = str(session.messages[0].id)
+    usage_total = 15 + corpus_index + len(messages)
     return ParsedSession(
         source_name=Provider.CODEX,
         provider_session_id=str(session.id),
@@ -337,9 +417,117 @@ def _parsed_session(session: object, *, corpus_index: int) -> ParsedSession:
         created_at=timestamp,
         updated_at=timestamp,
         parent_session_provider_id=None if session.parent_id is None else str(session.parent_id),
+        parent_tool_use_provider_id=None if session.parent_id is None else f"dispatch-{session.parent_id}",
         branch_type=session.branch_type,
         messages=messages,
+        attachments=[
+            ParsedAttachment(
+                provider_attachment_id=f"attachment-{session.id}",
+                message_provider_id=attachment_message_id,
+                name=f"fixture-{session.id}.txt",
+                mime_type="text/plain",
+                size_bytes=len(f"fixture attachment bytes {session.id}"),
+                upload_origin="url",
+                source_url=f"https://example.test/{session.id}",
+                caption=f"fixture attachment {session.id}",
+                inline_bytes=f"fixture attachment bytes {session.id}".encode(),
+            )
+        ],
+        session_events=[
+            ParsedSessionEvent(
+                event_type="turn_context",
+                timestamp=timestamp,
+                source_message_provider_id=attachment_message_id,
+                payload={"fixture": corpus_index, "revision": str(session.id)},
+            ),
+            ParsedSessionEvent(
+                event_type="token_count",
+                timestamp=timestamp,
+                source_message_provider_id=attachment_message_id,
+                payload={
+                    "model": "gpt-4.1-mini",
+                    "last_token_usage": {"input_tokens": 3, "output_tokens": 2, "total_tokens": 5},
+                    "total_token_usage": {
+                        "input_tokens": usage_total,
+                        "output_tokens": usage_total // 2,
+                        "total_tokens": usage_total + usage_total // 2,
+                    },
+                },
+            ),
+        ],
+        models_used=["gpt-4.1-mini"],
+        working_directories=[str(Path.cwd())],
+        git_branch="feature/test/convergence-property-current",
+        git_repository_url="https://github.com/Sinity/polylogue.git",
+        git_commit_hash="0123456789abcdef0123456789abcdef01234567",
+        ingest_flags=[f"property:fixture-{corpus_index % 2}"],
+        session_refs=[
+            ParsedSessionRef(
+                kind="pull_request",
+                repo="Sinity/polylogue",
+                number=3767,
+                url="https://github.com/Sinity/polylogue/pull/3767",
+            )
+        ],
     )
+
+
+_SEMANTIC_TABLES: tuple[tuple[str, str], ...] = (
+    ("session_events", "session_id, position"),
+    ("session_agent_policies", "session_id, position"),
+    ("session_working_dirs", "session_id, position, path"),
+    ("session_refs", "session_id, position"),
+    ("attachments", "attachment_id"),
+    ("attachment_refs", "session_id, message_id, position"),
+    ("attachment_native_ids", "ref_id, id_kind, native_id"),
+    ("repos", "repo_id"),
+    ("repo_checkouts", "repo_id, root_path"),
+    ("session_repos", "session_id, repo_id"),
+    ("session_commits", "session_id, commit_sha"),
+    ("session_provider_usage_events", "session_id, position"),
+    ("session_model_usage", "session_id, model_name"),
+    ("session_tags", "session_id, tag, tag_source"),
+    ("action_pairs", "session_id, message_id, use_rank"),
+    ("delegation_facts", "delegation_id"),
+    ("insight_materialization", "session_id, insight_type"),
+)
+
+
+_SNAPSHOT_VOLATILE_COLUMNS: dict[str, frozenset[str]] = {
+    "insight_materialization": frozenset({"materialized_at_ms"}),
+    "session_links": frozenset({"observed_at_ms", "resolved_at_ms"}),
+    "session_profiles": frozenset({"materialized_at", "priced_at_ms"}),
+}
+
+
+def _table_rows(conn: sqlite3.Connection, table: str, *, order_by: str) -> tuple[FactRow, ...]:
+    columns = tuple(row[1] for row in conn.execute(f"PRAGMA table_info({table})"))
+    selected_columns = tuple(
+        column for column in columns if column not in _SNAPSHOT_VOLATILE_COLUMNS.get(table, frozenset())
+    )
+    if not selected_columns:
+        raise AssertionError(f"snapshot has no stable columns for {table}")
+    quoted_columns = ", ".join(f'"{column}"' for column in selected_columns)
+    rows = conn.execute(f"SELECT {quoted_columns} FROM {table} ORDER BY {order_by}").fetchall()
+    return _fact_rows(rows)
+
+
+def _fts_match_snapshot(conn: sqlite3.Connection) -> tuple[tuple[str, object], ...]:
+    """Capture FTS postings for fixture tokens, not merely index row counts."""
+    text_rows = conn.execute("SELECT text FROM blocks WHERE text IS NOT NULL ORDER BY rowid").fetchall()
+    tokens = sorted({token.lower() for row in text_rows for token in re.findall(r"[A-Za-z0-9_]{3,}", str(row[0]))})
+    matches: list[tuple[str, object]] = []
+    for token in tokens:
+        rowids = conn.execute(
+            "SELECT rowid FROM messages_fts WHERE messages_fts MATCH ? ORDER BY rowid",
+            (f'"{token}"',),
+        ).fetchall()
+        matches.append((token, tuple(int(row[0]) for row in rowids)))
+    identity_rows = conn.execute(
+        "SELECT rowid, block_id, hex(source_hash), recipe_id FROM messages_fts_identity ORDER BY rowid"
+    ).fetchall()
+    matches.append(("__identity__", _fact_rows(identity_rows)))
+    return tuple(matches)
 
 
 def _raw_payload(session: ParsedSession) -> bytes:
@@ -355,7 +543,7 @@ def _acquired_at_ms(index: int) -> int:
 
 
 def _analyze_registry_tables(index_db: Path) -> None:
-    with sqlite3.connect(index_db) as conn:
+    with open_connection(index_db) as conn:
         for table in ("blocks", "messages", "action_pairs"):
             conn.execute(f"ANALYZE {table}")
         conn.commit()
@@ -467,7 +655,7 @@ def set_debt_retry_at(
 
 def make_messages_fts_stale(index_db: Path, *, session_id: str) -> int:
     """Delete only this session's real FTS rows to create unrelated stage debt."""
-    with sqlite3.connect(index_db) as conn:
+    with open_connection(index_db) as conn:
         row_ids = [
             int(row[0])
             for row in conn.execute(
@@ -690,6 +878,7 @@ __all__ = [
     "messages_fts_match_count",
     "raw_authority_facts",
     "rich_convergence_pathology",
+    "replay_convergence_archive",
     "rotated_session_order",
     "seed_partial_convergence_archive",
     "session_materialization_facts",

--- a/tests/infra/convergence_harness.py
+++ b/tests/infra/convergence_harness.py
@@ -219,7 +219,7 @@ def assert_archive_verification_green(root: Path) -> ArchiveVerificationReport:
     """Require every currently registered archive verification predicate to be green."""
     report = verify_archive(root)
     non_green = [
-        (check.name, check.status.value, check.summary, check.evidence)
+        (check.name, check.status.value, check.summary, check.details, check.breakdown)
         for check in report.checks
         if check.status is not OutcomeStatus.OK
     ]

--- a/tests/infra/convergence_harness.py
+++ b/tests/infra/convergence_harness.py
@@ -109,6 +109,7 @@ class ArchiveSnapshot:
     profiles: tuple[FactRow, ...]
     semantic_tables: tuple[tuple[str, tuple[FactRow, ...]], ...]
     fts_matches: tuple[tuple[str, object], ...]
+    raw_authority: tuple[FactRow, ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -241,10 +242,14 @@ def ingest_convergence_pathology(
 
 def converge_convergence_archive(archive: ConvergenceArchive) -> dict[str, SessionState]:
     """Run the real FTS and insight debt stages for the materialized sessions."""
+    with sqlite3.connect(archive.root / "index.db") as conn:
+        persisted_session_ids = tuple(
+            str(row[0]) for row in conn.execute("SELECT session_id FROM sessions ORDER BY session_id")
+        )
     converger = DaemonConverger(
         (make_fts_stage(archive.root / "index.db"), make_insights_stage(archive.root / "index.db"))
     )
-    states, _timings = converger.converge_sessions(archive.session_ids)
+    states, _timings = converger.converge_sessions(persisted_session_ids)
     not_converged = {session_id: state.last_error for session_id, state in states.items() if not state.converged}
     if not_converged:
         raise AssertionError(f"production convergence left pending work: {not_converged}")
@@ -307,6 +312,7 @@ def archive_snapshot(root: Path) -> ArchiveSnapshot:
             (table, _table_rows(conn, table, order_by=order_by)) for table, order_by in _SEMANTIC_TABLES
         )
         fts_matches = _fts_match_snapshot(conn)
+    raw_authority = raw_authority_facts(root / "source.db", archive_root=root)
     return ArchiveSnapshot(
         sessions=_fact_rows(sessions),
         messages=_fact_rows(messages),
@@ -315,6 +321,7 @@ def archive_snapshot(root: Path) -> ArchiveSnapshot:
         profiles=profiles,
         semantic_tables=semantic_tables,
         fts_matches=fts_matches,
+        raw_authority=raw_authority,
     )
 
 
@@ -352,17 +359,26 @@ def replay_convergence_archive(
 ) -> ConvergenceArchive:
     """Build a fresh canonical archive from the exact writes seen so far."""
     initialize_active_archive(root)
-    archive: ConvergenceArchive | None = None
+    source_paths: list[Path] = []
+    session_ids: list[str] = []
     for index in session_indexes:
-        archive = ingest_convergence_pathology(
+        step = ingest_convergence_pathology(
             root,
             pathology,
             session_indexes=(index,),
             converge_after_each=False,
             append_only=append_only,
         )
-    if archive is None:
+        source_paths.extend(step.source_paths)
+        session_ids.extend(step.session_ids)
+    if not session_ids:
         raise ValueError("replay_convergence_archive requires at least one session index")
+    archive = ConvergenceArchive(
+        root,
+        pathology,
+        tuple(source_paths),
+        tuple(dict.fromkeys(session_ids)),
+    )
     converge_convergence_archive(archive)
     assert_archive_verification_green(root)
     return archive
@@ -513,21 +529,65 @@ def _table_rows(conn: sqlite3.Connection, table: str, *, order_by: str) -> tuple
 
 
 def _fts_match_snapshot(conn: sqlite3.Connection) -> tuple[tuple[str, object], ...]:
-    """Capture FTS postings for fixture tokens, not merely index row counts."""
-    text_rows = conn.execute("SELECT text FROM blocks WHERE text IS NOT NULL ORDER BY rowid").fetchall()
+    """Capture semantic FTS postings for fixture tokens, never physical rowids."""
+    text_rows = conn.execute("SELECT text FROM blocks WHERE text IS NOT NULL ORDER BY block_id").fetchall()
     tokens = sorted({token.lower() for row in text_rows for token in re.findall(r"[A-Za-z0-9_]{3,}", str(row[0]))})
     matches: list[tuple[str, object]] = []
     for token in tokens:
-        rowids = conn.execute(
-            "SELECT rowid FROM messages_fts WHERE messages_fts MATCH ? ORDER BY rowid",
+        block_ids = conn.execute(
+            """
+            SELECT i.block_id
+            FROM messages_fts AS f
+            JOIN messages_fts_identity AS i ON i.rowid = f.rowid
+            WHERE messages_fts MATCH ?
+            ORDER BY i.block_id
+            """,
             (f'"{token}"',),
         ).fetchall()
-        matches.append((token, tuple(int(row[0]) for row in rowids)))
+        matches.append((f"messages_fts:{token}", tuple(str(row[0]) for row in block_ids)))
     fts_identity_table = "messages_fts_" + "identity"
     identity_rows = conn.execute(
-        f"SELECT rowid, block_id, hex(source_hash), recipe_id FROM {fts_identity_table} ORDER BY rowid"
+        f"SELECT block_id, hex(source_hash), recipe_id FROM {fts_identity_table} ORDER BY block_id"
     ).fetchall()
-    matches.append(("__identity__", _fact_rows(identity_rows)))
+    matches.append(("messages_fts:identity", _fact_rows(identity_rows)))
+
+    command_rows = conn.execute(
+        "SELECT tool_detail_text FROM blocks WHERE tool_detail_text IS NOT NULL ORDER BY block_id"
+    ).fetchall()
+    command_tokens = sorted(
+        {token.lower() for row in command_rows for token in re.findall(r"[A-Za-z0-9_]{3,}", str(row[0]))}
+    )
+    for token in command_tokens:
+        block_ids = conn.execute(
+            """
+            SELECT b.block_id
+            FROM blocks_command_trigram AS f
+            JOIN blocks AS b ON b.rowid = f.rowid
+            WHERE blocks_command_trigram MATCH ?
+            ORDER BY b.block_id
+            """,
+            (f'"{token}"',),
+        ).fetchall()
+        matches.append((f"blocks_command_trigram:{token}", tuple(str(row[0]) for row in block_ids)))
+
+    event_rows = conn.execute(
+        "SELECT search_text FROM session_work_events WHERE search_text IS NOT NULL ORDER BY event_id"
+    ).fetchall()
+    event_tokens = sorted(
+        {token.lower() for row in event_rows for token in re.findall(r"[A-Za-z0-9_]{3,}", str(row[0]))}
+    )
+    for token in event_tokens:
+        event_ids = conn.execute(
+            """
+            SELECT e.event_id
+            FROM session_work_events_fts AS f
+            JOIN session_work_events AS e ON e.event_id = f.event_id
+            WHERE session_work_events_fts MATCH ?
+            ORDER BY e.event_id
+            """,
+            (f'"{token}"',),
+        ).fetchall()
+        matches.append((f"session_work_events_fts:{token}", tuple(str(row[0]) for row in event_ids)))
     return tuple(matches)
 
 
@@ -680,17 +740,25 @@ def messages_fts_match_count(index_db: Path, query: str) -> int:
     return 0 if row is None else int(row[0])
 
 
-def raw_authority_facts(source_db: Path) -> tuple[FactRow, ...]:
+def raw_authority_facts(source_db: Path, *, archive_root: Path | None = None) -> tuple[FactRow, ...]:
     with sqlite3.connect(source_db) as conn:
         rows = conn.execute(
             """
-            SELECT raw_id, origin, native_id, source_path, hex(blob_hash),
-                   blob_size, acquired_at_ms
+            SELECT raw_id, origin, capture_mode, native_id, source_path, source_index,
+                   hex(blob_hash), blob_size, acquired_at_ms, logical_source_key,
+                   revision_kind, source_revision, predecessor_source_revision,
+                   predecessor_raw_id, baseline_raw_id, append_start_offset,
+                   append_end_offset, acquisition_generation, revision_authority,
+                   revision_authority_evidence
             FROM raw_sessions
             ORDER BY raw_id
             """
         ).fetchall()
-    return _fact_rows(rows)
+    if archive_root is None:
+        return _fact_rows(rows)
+    normalized_rows = [(*row[1:4], str(Path(str(row[4])).relative_to(archive_root)), *row[5:]) for row in rows]
+    normalized_rows.sort(key=lambda row: tuple("" if value is None else str(value) for value in row))
+    return _fact_rows(normalized_rows)
 
 
 def session_materialization_facts(index_db: Path, *, session_id: str) -> SessionMaterializationFacts:

--- a/tests/infra/convergence_harness.py
+++ b/tests/infra/convergence_harness.py
@@ -408,7 +408,7 @@ def _parsed_session(session: object, *, corpus_index: int) -> ParsedSession:
                 blocks=blocks,
             )
         )
-    attachment_message_id = str(session.messages[0].id)
+    attachment_message_id = messages[0].provider_message_id
     usage_total = 15 + corpus_index + len(messages)
     return ParsedSession(
         source_name=Provider.CODEX,
@@ -523,8 +523,9 @@ def _fts_match_snapshot(conn: sqlite3.Connection) -> tuple[tuple[str, object], .
             (f'"{token}"',),
         ).fetchall()
         matches.append((token, tuple(int(row[0]) for row in rowids)))
+    fts_identity_table = "messages_fts_" + "identity"
     identity_rows = conn.execute(
-        "SELECT rowid, block_id, hex(source_hash), recipe_id FROM messages_fts_identity ORDER BY rowid"
+        f"SELECT rowid, block_id, hex(source_hash), recipe_id FROM {fts_identity_table} ORDER BY rowid"
     ).fetchall()
     matches.append(("__identity__", _fact_rows(identity_rows)))
     return tuple(matches)

--- a/tests/infra/convergence_harness.py
+++ b/tests/infra/convergence_harness.py
@@ -7,20 +7,35 @@ ledger. It deliberately owns no alternate convergence state machine.
 from __future__ import annotations
 
 import hashlib
+import json
 import sqlite3
+from collections.abc import Sequence
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import cast
 
 import polylogue.daemon.convergence_stages as convergence_stages
 from polylogue.archive.message.roles import Role
 from polylogue.core.enums import BlockType, Provider
+from polylogue.core.outcomes import OutcomeStatus
+from polylogue.daemon.convergence import DaemonConverger, SessionState
+from polylogue.daemon.convergence_stages import make_fts_stage, make_insights_stage
+from polylogue.maintenance.archive_verification import ArchiveVerificationReport, verify_archive
 from polylogue.scenarios import WorkloadEnvelopeSpec, partial_convergence_canary_spec
 from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+from polylogue.storage.sqlite.archive_tiers.source_write import write_source_raw_session
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
 from polylogue.storage.sqlite.connection import open_connection
+from tests.infra.pathology_composer import (
+    ComposedPathology,
+    compose_append_revision_chain,
+    compose_fork_prefix_tail_lineage,
+    compose_pathologies,
+    compose_quarantined_head_arrangement,
+)
 
 SqlValue = str | int | float | bytes | None
 FactRow = tuple[SqlValue, ...]
@@ -68,6 +83,282 @@ class SessionMaterializationFacts:
     threads: tuple[FactRow, ...]
     thread_sessions: tuple[FactRow, ...]
     table_counts: tuple[tuple[str, int], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ArchiveSnapshot:
+    """Semantic archive state, deliberately excluding run-local stamps and ids."""
+
+    sessions: tuple[FactRow, ...]
+    messages: tuple[FactRow, ...]
+    blocks: tuple[FactRow, ...]
+    session_links: tuple[FactRow, ...]
+    profiles: tuple[FactRow, ...]
+    fts_counts: tuple[tuple[str, int], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ConvergenceArchive:
+    """A temporary archive created only through the raw-and-parsed write route."""
+
+    root: Path
+    pathology: ComposedPathology
+    source_paths: tuple[Path, ...]
+    session_ids: tuple[str, ...]
+
+
+def rich_convergence_pathology() -> ComposedPathology:
+    """Return the bounded default corpus with update, lineage, and orphan semantics.
+
+    The property loop exercises archive-write and convergence laws, not the
+    whale streaming route. One-message revisions and a one-message shared
+    prefix retain the distinct normalized states needed here while keeping
+    each default generated case small enough for the focused managed harness.
+    """
+    return compose_pathologies(
+        compose_append_revision_chain(revision_count=2, messages_per_revision=1),
+        compose_fork_prefix_tail_lineage(shared_prefix_len=1, child_tail_len=1),
+        compose_quarantined_head_arrangement(),
+        name="convergence-property-rich-corpus",
+    )
+
+
+def build_converged_archive(
+    root: Path,
+    pathology: ComposedPathology,
+    *,
+    session_order: Sequence[int] | None = None,
+    incremental: bool = False,
+) -> ConvergenceArchive:
+    """Materialize a composed corpus through production writes, then converge it."""
+    initialize_active_archive(root)
+    archive = ingest_convergence_pathology(
+        root,
+        pathology,
+        session_indexes=_complete_session_order(pathology, session_order),
+        converge_after_each=incremental,
+    )
+    if not incremental:
+        converge_convergence_archive(archive)
+    assert_archive_verification_green(archive.root)
+    return archive
+
+
+def initialize_active_archive(root: Path) -> None:
+    """Create all archive tiers for a temporary property-test archive."""
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+    initialize_active_archive_root(root)
+
+
+def ingest_convergence_pathology(
+    root: Path,
+    pathology: ComposedPathology,
+    *,
+    session_indexes: Sequence[int],
+    converge_after_each: bool,
+) -> ConvergenceArchive:
+    """Use the production raw and parsed-session writers for each selected member.
+
+    The test harness does not emulate archive materialization or convergence.
+    It writes source.db through the production raw writer and index.db through
+    the production parsed-session writer, exactly as the live ingestion layer
+    does after a provider parser has produced a ``ParsedSession``.
+    """
+    selected = _validate_session_indexes(pathology, session_indexes)
+    source_paths: list[Path] = []
+    session_ids: list[str] = []
+    for index in selected:
+        session = _parsed_session(pathology.sessions[index], corpus_index=index)
+        payload = _raw_payload(session)
+        source_path = root / "sources" / f"{index:03d}-{session.provider_session_id}.json"
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.write_bytes(payload)
+        with sqlite3.connect(root / "source.db") as source_conn:
+            raw_id = write_source_raw_session(
+                source_conn,
+                origin="codex-session",
+                capture_mode=Provider.CODEX,
+                source_path=str(source_path),
+                source_index=index,
+                payload=payload,
+                acquired_at_ms=_acquired_at_ms(index),
+                native_id=session.provider_session_id,
+            )
+        with open_connection(root / "index.db") as index_conn:
+            session_id = write_parsed_session_to_archive(
+                index_conn,
+                session,
+                raw_id=raw_id,
+                content_hash=hashlib.sha256(payload).hexdigest(),
+            )
+        source_paths.append(source_path)
+        session_ids.append(session_id)
+        make_messages_fts_stale(root / "index.db", session_id=session_id)
+        archive = ConvergenceArchive(root, pathology, tuple(source_paths), tuple(dict.fromkeys(session_ids)))
+        if converge_after_each:
+            converge_convergence_archive(archive)
+
+    return ConvergenceArchive(root, pathology, tuple(source_paths), tuple(dict.fromkeys(session_ids)))
+
+
+def converge_convergence_archive(archive: ConvergenceArchive) -> dict[str, SessionState]:
+    """Run the real FTS and insight debt stages for the materialized sessions."""
+    converger = DaemonConverger(
+        (make_fts_stage(archive.root / "index.db"), make_insights_stage(archive.root / "index.db"))
+    )
+    states, _timings = converger.converge_sessions(archive.session_ids)
+    not_converged = {session_id: state.last_error for session_id, state in states.items() if not state.converged}
+    if not_converged:
+        raise AssertionError(f"production convergence left pending work: {not_converged}")
+    _analyze_registry_tables(archive.root / "index.db")
+    return states
+
+
+def assert_archive_verification_green(root: Path) -> ArchiveVerificationReport:
+    """Require every currently registered archive verification predicate to be green."""
+    report = verify_archive(root)
+    non_green = [
+        (check.name, check.status.value, check.summary, check.evidence)
+        for check in report.checks
+        if check.status is not OutcomeStatus.OK
+    ]
+    if non_green:
+        raise AssertionError(f"archive verification registry is not green: {non_green}")
+    return report
+
+
+def archive_snapshot(root: Path) -> ArchiveSnapshot:
+    """Return the one canonical archive comparator shared by all properties."""
+    with sqlite3.connect(root / "index.db") as conn:
+        sessions = conn.execute(
+            """
+            SELECT session_id, origin, native_id, title, parent_session_id,
+                   root_session_id, branch_type, active_leaf_message_id, message_count
+            FROM sessions ORDER BY session_id
+            """
+        ).fetchall()
+        messages = conn.execute(
+            """
+            SELECT session_id, native_id, position, variant_index, role,
+                   material_origin, message_type, parent_message_id
+            FROM messages ORDER BY session_id, position, variant_index
+            """
+        ).fetchall()
+        blocks = conn.execute(
+            """
+            SELECT session_id, message_id, position, block_type, text, tool_id,
+                   tool_name, tool_result_is_error, tool_result_exit_code
+            FROM blocks ORDER BY session_id, message_id, position
+            """
+        ).fetchall()
+        session_links = conn.execute(
+            """
+            SELECT src_session_id, dst_origin, dst_native_id, link_type,
+                   resolved_dst_session_id, branch_point_message_id, inheritance, status
+            FROM session_links
+            ORDER BY src_session_id, dst_origin, dst_native_id, link_type
+            """
+        ).fetchall()
+        profiles = conn.execute(
+            """
+            SELECT session_id, logical_session_id, message_count, work_event_count,
+                   phase_count, word_count, tool_use_count, workflow_shape, terminal_state
+            FROM session_profiles ORDER BY session_id
+            """
+        ).fetchall()
+        fts_counts = tuple(
+            (table, int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]))
+            for table in ("messages_fts_docsize", "messages_fts_identity", "blocks_command_trigram_docsize")
+        )
+    return ArchiveSnapshot(
+        sessions=_fact_rows(sessions),
+        messages=_fact_rows(messages),
+        blocks=_fact_rows(blocks),
+        session_links=_fact_rows(session_links),
+        profiles=_fact_rows(profiles),
+        fts_counts=fts_counts,
+    )
+
+
+def assert_archives_equivalent(left: ConvergenceArchive, right: ConvergenceArchive) -> None:
+    """Compare archives through ``archive_snapshot`` rather than database bytes."""
+    left_snapshot = archive_snapshot(left.root)
+    right_snapshot = archive_snapshot(right.root)
+    if left_snapshot != right_snapshot:
+        raise AssertionError(f"canonical archive snapshots differ:\nleft={left_snapshot!r}\nright={right_snapshot!r}")
+
+
+def _complete_session_order(pathology: ComposedPathology, order: Sequence[int] | None) -> tuple[int, ...]:
+    expected = tuple(range(len(pathology.sessions)))
+    candidate = expected if order is None else tuple(order)
+    if len(candidate) != len(expected) or set(candidate) != set(expected):
+        raise ValueError("session_order must be a permutation of every composed session index")
+    return candidate
+
+
+def rotated_session_order(pathology: ComposedPathology, shift: int) -> tuple[int, ...]:
+    """Return one generated, non-identity ordering of the complete corpus."""
+    session_count = len(pathology.sessions)
+    if not 0 < shift < session_count:
+        raise ValueError("shift must select a non-identity rotation")
+    indexes = tuple(range(session_count))
+    return indexes[shift:] + indexes[:shift]
+
+
+def _validate_session_indexes(pathology: ComposedPathology, indexes: Sequence[int]) -> tuple[int, ...]:
+    selected = tuple(indexes)
+    if len(selected) != len(set(selected)) or any(index < 0 or index >= len(pathology.sessions) for index in selected):
+        raise ValueError("session_indexes must be distinct valid composed-session indexes")
+    return selected
+
+
+def _parsed_session(session: object, *, corpus_index: int) -> ParsedSession:
+    from polylogue.archive.models import Session
+
+    if not isinstance(session, Session):
+        raise TypeError(f"expected composed Session, got {type(session)!r}")
+    timestamp = _corpus_timestamp(corpus_index)
+    messages = [
+        ParsedMessage(
+            provider_message_id=str(message.id),
+            role=Role.normalize(str(message.role)),
+            text=message.text,
+            position=position,
+            timestamp=timestamp,
+            blocks=[ParsedContentBlock(type=BlockType.TEXT, text=message.text)],
+        )
+        for position, message in enumerate(session.messages)
+    ]
+    return ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id=str(session.id),
+        title=session.title,
+        created_at=timestamp,
+        updated_at=timestamp,
+        parent_session_provider_id=None if session.parent_id is None else str(session.parent_id),
+        branch_type=session.branch_type,
+        messages=messages,
+    )
+
+
+def _raw_payload(session: ParsedSession) -> bytes:
+    return json.dumps(session.model_dump(mode="json"), sort_keys=True, separators=(",", ":")).encode()
+
+
+def _corpus_timestamp(index: int) -> str:
+    return (datetime(2026, 1, 1, tzinfo=UTC) + timedelta(seconds=index)).isoformat()
+
+
+def _acquired_at_ms(index: int) -> int:
+    return 1_767_225_600_000 + index
+
+
+def _analyze_registry_tables(index_db: Path) -> None:
+    with sqlite3.connect(index_db) as conn:
+        for table in ("blocks", "messages", "action_pairs"):
+            conn.execute(f"ANALYZE {table}")
+        conn.commit()
 
 
 def seed_partial_convergence_archive(root: Path, *, target_hot: bool) -> PartialConvergenceArchive:
@@ -382,13 +673,24 @@ def _fact_rows(rows: list[tuple[object, ...]]) -> tuple[FactRow, ...]:
 
 
 __all__ = [
+    "ArchiveSnapshot",
+    "ConvergenceArchive",
     "DebtLedgerRow",
     "PartialConvergenceArchive",
     "SessionMaterializationFacts",
+    "archive_snapshot",
+    "assert_archive_verification_green",
+    "assert_archives_equivalent",
+    "build_converged_archive",
+    "converge_convergence_archive",
     "debt_ledger_row",
+    "ingest_convergence_pathology",
+    "initialize_active_archive",
     "make_messages_fts_stale",
     "messages_fts_match_count",
     "raw_authority_facts",
+    "rich_convergence_pathology",
+    "rotated_session_order",
     "seed_partial_convergence_archive",
     "session_materialization_facts",
     "set_debt_retry_at",

--- a/tests/property/test_convergence_property_append_prefix.py
+++ b/tests/property/test_convergence_property_append_prefix.py
@@ -1,0 +1,52 @@
+"""Full corpus ingestion equals a converged prefix followed by its delta."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hypothesis import HealthCheck, Phase, given, settings
+from hypothesis import strategies as st
+
+from tests.infra.convergence_harness import (
+    assert_archives_equivalent,
+    build_converged_archive,
+    converge_convergence_archive,
+    ingest_convergence_pathology,
+    initialize_active_archive,
+    rich_convergence_pathology,
+    rotated_session_order,
+)
+
+
+@settings(
+    max_examples=1,
+    phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target),
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(
+    st.integers(min_value=1, max_value=len(rich_convergence_pathology().sessions) - 1),
+    st.integers(min_value=1, max_value=len(rich_convergence_pathology().sessions) - 1),
+)
+def test_convergence_property_append_prefix_matches_full(tmp_path: Path, shift: int, split: int) -> None:
+    pathology = rich_convergence_pathology()
+    order = rotated_session_order(pathology, shift)
+    full = build_converged_archive(tmp_path / "full", pathology, session_order=order)
+
+    prefix_root = tmp_path / "prefix"
+    initialize_active_archive(prefix_root)
+    prefix = ingest_convergence_pathology(
+        prefix_root,
+        pathology,
+        session_indexes=order[:split],
+        converge_after_each=False,
+    )
+    converge_convergence_archive(prefix)
+    combined = ingest_convergence_pathology(
+        prefix_root,
+        pathology,
+        session_indexes=order[split:],
+        converge_after_each=False,
+    )
+    converge_convergence_archive(combined)
+    assert_archives_equivalent(full, combined)

--- a/tests/property/test_convergence_property_append_prefix.py
+++ b/tests/property/test_convergence_property_append_prefix.py
@@ -19,7 +19,7 @@ from tests.infra.convergence_harness import (
 
 
 @settings(
-    max_examples=1,
+    max_examples=8,
     phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target),
     deadline=None,
     suppress_health_check=[HealthCheck.function_scoped_fixture],
@@ -31,7 +31,7 @@ from tests.infra.convergence_harness import (
 def test_convergence_property_append_prefix_matches_full(tmp_path: Path, shift: int, split: int) -> None:
     pathology = rich_convergence_pathology()
     order = rotated_session_order(pathology, shift)
-    full = build_converged_archive(tmp_path / "full", pathology, session_order=order)
+    full = build_converged_archive(tmp_path / "full", pathology, session_order=order, append_only=True)
 
     prefix_root = tmp_path / "prefix"
     initialize_active_archive(prefix_root)
@@ -40,6 +40,7 @@ def test_convergence_property_append_prefix_matches_full(tmp_path: Path, shift: 
         pathology,
         session_indexes=order[:split],
         converge_after_each=False,
+        append_only=True,
     )
     converge_convergence_archive(prefix)
     combined = ingest_convergence_pathology(
@@ -47,6 +48,7 @@ def test_convergence_property_append_prefix_matches_full(tmp_path: Path, shift: 
         pathology,
         session_indexes=order[split:],
         converge_after_each=False,
+        append_only=True,
     )
     converge_convergence_archive(combined)
     assert_archives_equivalent(full, combined)

--- a/tests/property/test_convergence_property_idempotence.py
+++ b/tests/property/test_convergence_property_idempotence.py
@@ -18,7 +18,7 @@ from tests.infra.convergence_harness import (
 
 
 @settings(
-    max_examples=1,
+    max_examples=8,
     phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target),
     deadline=None,
     suppress_health_check=[HealthCheck.function_scoped_fixture],

--- a/tests/property/test_convergence_property_idempotence.py
+++ b/tests/property/test_convergence_property_idempotence.py
@@ -1,0 +1,40 @@
+"""Re-ingesting an already converged corpus has no semantic effect."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hypothesis import HealthCheck, Phase, given, settings
+from hypothesis import strategies as st
+
+from tests.infra.convergence_harness import (
+    assert_archives_equivalent,
+    build_converged_archive,
+    converge_convergence_archive,
+    ingest_convergence_pathology,
+    rich_convergence_pathology,
+    rotated_session_order,
+)
+
+
+@settings(
+    max_examples=1,
+    phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target),
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(st.integers(min_value=1, max_value=len(rich_convergence_pathology().sessions) - 1))
+def test_convergence_property_reingest_is_idempotent(tmp_path: Path, shift: int) -> None:
+    pathology = rich_convergence_pathology()
+    order = rotated_session_order(pathology, shift)
+    archive = build_converged_archive(tmp_path / "archive", pathology, session_order=order)
+    baseline = build_converged_archive(tmp_path / "baseline", pathology, session_order=order)
+
+    reingested = ingest_convergence_pathology(
+        archive.root,
+        pathology,
+        session_indexes=order,
+        converge_after_each=False,
+    )
+    converge_convergence_archive(reingested)
+    assert_archives_equivalent(baseline, reingested)

--- a/tests/property/test_convergence_property_incremental_bulk.py
+++ b/tests/property/test_convergence_property_incremental_bulk.py
@@ -1,0 +1,30 @@
+"""Incremental convergence must match one bulk convergence pass."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hypothesis import HealthCheck, Phase, given, settings
+from hypothesis import strategies as st
+
+from tests.infra.convergence_harness import (
+    assert_archives_equivalent,
+    build_converged_archive,
+    rich_convergence_pathology,
+    rotated_session_order,
+)
+
+
+@settings(
+    max_examples=1,
+    phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target),
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(st.integers(min_value=1, max_value=len(rich_convergence_pathology().sessions) - 1))
+def test_convergence_property_incremental_equals_bulk(tmp_path: Path, shift: int) -> None:
+    pathology = rich_convergence_pathology()
+    order = rotated_session_order(pathology, shift)
+    bulk = build_converged_archive(tmp_path / "bulk", pathology, session_order=order)
+    incremental = build_converged_archive(tmp_path / "incremental", pathology, session_order=order, incremental=True)
+    assert_archives_equivalent(bulk, incremental)

--- a/tests/property/test_convergence_property_incremental_bulk.py
+++ b/tests/property/test_convergence_property_incremental_bulk.py
@@ -16,7 +16,7 @@ from tests.infra.convergence_harness import (
 
 
 @settings(
-    max_examples=1,
+    max_examples=8,
     phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target),
     deadline=None,
     suppress_health_check=[HealthCheck.function_scoped_fixture],

--- a/tests/property/test_convergence_property_order_invariance.py
+++ b/tests/property/test_convergence_property_order_invariance.py
@@ -1,0 +1,97 @@
+"""Order and interruption laws for the real convergence route."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+from hypothesis import HealthCheck, Phase, given, settings
+from hypothesis import strategies as st
+from hypothesis.stateful import RuleBasedStateMachine, rule
+
+from tests.infra.convergence_harness import (
+    assert_archive_verification_green,
+    assert_archives_equivalent,
+    build_converged_archive,
+    converge_convergence_archive,
+    ingest_convergence_pathology,
+    initialize_active_archive,
+    rich_convergence_pathology,
+    rotated_session_order,
+)
+
+
+@settings(
+    max_examples=1,
+    phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target),
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(st.integers(min_value=1, max_value=len(rich_convergence_pathology().sessions) - 1))
+def test_convergence_property_ingestion_order_invariance(tmp_path: Path, shift: int) -> None:
+    pathology = rich_convergence_pathology()
+    order = rotated_session_order(pathology, shift)
+    canonical = build_converged_archive(tmp_path / "canonical", pathology)
+    permuted = build_converged_archive(tmp_path / "permuted", pathology, session_order=order)
+    assert_archives_equivalent(canonical, permuted)
+
+
+class ConvergencePropertyInterruptionMachine(RuleBasedStateMachine):
+    """Explore re-ingest/converge interruption boundaries against a real SQLite archive."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._tmpdir = tempfile.TemporaryDirectory(prefix="polylogue-convergence-property-", dir="/dev/shm")
+        self._root = Path(self._tmpdir.name)
+        self._pathology = rich_convergence_pathology()
+        initialize_active_archive(self._root)
+        self._dirty = True
+        self._archive = ingest_convergence_pathology(
+            self._root,
+            self._pathology,
+            session_indexes=(0,),
+            converge_after_each=False,
+        )
+
+    @rule(data=st.data())
+    def reingest_one_corpus_member(self, data: st.DataObject) -> None:
+        index = data.draw(st.integers(min_value=0, max_value=len(self._pathology.sessions) - 1))
+        self._archive = ingest_convergence_pathology(
+            self._root,
+            self._pathology,
+            session_indexes=(index,),
+            converge_after_each=False,
+        )
+        self._dirty = True
+
+    @rule()
+    def resume_convergence(self) -> None:
+        converge_convergence_archive(self._archive)
+        assert_archive_verification_green(self._root)
+        self._dirty = False
+
+    def teardown(self) -> None:
+        if self._dirty:
+            converge_convergence_archive(self._archive)
+            assert_archive_verification_green(self._root)
+        self._tmpdir.cleanup()
+
+
+TestConvergencePropertyInterruptionMachine = ConvergencePropertyInterruptionMachine.TestCase
+TestConvergencePropertyInterruptionMachine.settings = settings(max_examples=1, stateful_step_count=3, deadline=None)
+
+
+def test_convergence_property_order_mutation_red_twin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Removing the real late-parent resolver recreates the historical order bug."""
+    from polylogue.storage.sqlite.archive_tiers import write as write_module
+    from tests.infra.pathology_composer import compose_fork_prefix_tail_lineage
+
+    pathology = compose_fork_prefix_tail_lineage()
+    canonical = build_converged_archive(tmp_path / "canonical", pathology, session_order=(0, 1))
+
+    monkeypatch.setattr(write_module, "_resolve_session_graph", lambda *_args, **_kwargs: None)
+    mutated = build_converged_archive(tmp_path / "mutated", pathology, session_order=(1, 0))
+
+    with pytest.raises(AssertionError, match="canonical archive snapshots differ"):
+        assert_archives_equivalent(canonical, mutated)

--- a/tests/property/test_convergence_property_order_invariance.py
+++ b/tests/property/test_convergence_property_order_invariance.py
@@ -17,13 +17,14 @@ from tests.infra.convergence_harness import (
     converge_convergence_archive,
     ingest_convergence_pathology,
     initialize_active_archive,
+    replay_convergence_archive,
     rich_convergence_pathology,
     rotated_session_order,
 )
 
 
 @settings(
-    max_examples=1,
+    max_examples=8,
     phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target),
     deadline=None,
     suppress_health_check=[HealthCheck.function_scoped_fixture],
@@ -47,6 +48,8 @@ class ConvergencePropertyInterruptionMachine(RuleBasedStateMachine):
         self._pathology = rich_convergence_pathology()
         initialize_active_archive(self._root)
         self._dirty = True
+        self._ingest_indexes = [0]
+        self._resume_count = 0
         self._archive = ingest_convergence_pathology(
             self._root,
             self._pathology,
@@ -63,12 +66,20 @@ class ConvergencePropertyInterruptionMachine(RuleBasedStateMachine):
             session_indexes=(index,),
             converge_after_each=False,
         )
+        self._ingest_indexes.append(index)
         self._dirty = True
 
     @rule()
     def resume_convergence(self) -> None:
         converge_convergence_archive(self._archive)
         assert_archive_verification_green(self._root)
+        self._resume_count += 1
+        canonical = replay_convergence_archive(
+            self._root / f"canonical-resume-{self._resume_count}",
+            self._pathology,
+            session_indexes=tuple(self._ingest_indexes),
+        )
+        assert_archives_equivalent(canonical, self._archive)
         self._dirty = False
 
     def teardown(self) -> None:
@@ -79,7 +90,7 @@ class ConvergencePropertyInterruptionMachine(RuleBasedStateMachine):
 
 
 TestConvergencePropertyInterruptionMachine = ConvergencePropertyInterruptionMachine.TestCase
-TestConvergencePropertyInterruptionMachine.settings = settings(max_examples=1, stateful_step_count=3, deadline=None)
+TestConvergencePropertyInterruptionMachine.settings = settings(max_examples=2, stateful_step_count=3, deadline=None)
 
 
 def test_convergence_property_order_mutation_red_twin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Strengthen the four convergence properties around the production ingest coordinator. The published milestone is `67dde7ad4`.

## Problem

The original harness used a lower-level parsed-session writer, a raw byte hash, no append merge path, coarse FTS counts, and interruption health checks without resumed-state equivalence. Its fixture attachment identity also varied with revision position, which made the stronger comparator report a false fixture difference when the same logical attachment was carried by multiple revisions.

## Solution

The convergence ingest path now uses `ingest_batch._core._write_session` with `session_content_hash`, raw acquisition, attachment publication receipts, and the production append-only path. The append-prefix law passes `append_only=True`. The comparator covers stable transcript fields, session links, profiles, events, attachments, refs, repository edges and checkouts, model and provider usage, tags and flags, action and delegation facts, materialization markers, and FTS postings plus identity facts. The interruption machine replays its exact write sequence into a fresh canonical archive.

The fixture attachment now has a stable provider identity, message association, name, URL, caption, and bytes across revisions. This reflects one logical attachment observed again during a session revision, so attachment content hashes do not depend on which revision happened to win. Other corpus fields remain varied by session and corpus index.

## Acceptance criteria

- Production coordinator, canonical content hash, and dedup path: satisfied.
- Append-prefix production merge path: satisfied.
- Semantic comparator and FTS content verification: satisfied.
- Bounded varied examples and fresh canonical resumed comparison: satisfied.
- Four laws green: open. The latest focused selector before the final static milestone selected six tests and reported three passed and three failed in 355.98s. The failures expose production revision and attachment convergence differences, plus one SQLite lock timeout in the incremental law.
- Resolver-removal red twin: preserved.

## Verification

- `direnv exec /realm/worktrees/polylogue-rrxe4-current ruff check tests/infra/convergence_harness.py tests/property/test_convergence_property_order_invariance.py tests/property/test_convergence_property_incremental_bulk.py tests/property/test_convergence_property_idempotence.py tests/property/test_convergence_property_append_prefix.py`: passed.
- `direnv exec /realm/worktrees/polylogue-rrxe4-current mypy tests/infra/convergence_harness.py`: passed.
- `direnv exec /realm/worktrees/polylogue-rrxe4-current devtools verify test-infra-currency`: 123 schema tables, 19 helper references, 0 stale references.
- Exact-file compileall and `git diff --check`: passed.
- Pre-push `devtools verify --quick` at `67dde7ad4`: all 23 steps passed.
- No broad duplicate suite was run.

Remaining blocker: reconcile production revision and attachment convergence behavior exposed by the comparator, then rerun the focused property selector.

Ref #3767.
