### PR TITLE
fix(schema): preserve legacy Codex direct streams

### DIFF
--- a/polylogue/archive/artifact_taxonomy/runtime.py
+++ b/polylogue/archive/artifact_taxonomy/runtime.py
@@ -410,6 +410,27 @@ def _classify_list(
             reason="Beads interaction-history stream",
         )
 
+    # A Codex rollout can be truncated to repeated bare session headers while
+    # still remaining a JSONL record stream.  A single bare ``type`` is too
+    # weak to admit generically, but multiple exact Codex session-meta records
+    # with a declared Codex origin are provider-specific structural evidence.
+    # Keep this before the generic record predicate so the narrow recovery
+    # shape reaches schema inference without reopening the generic type-only
+    # false-positive class.
+    if (
+        provider is Provider.CODEX
+        and len(dict_items) > 1
+        and all(item == {"type": "session_meta"} for item in dict_items)
+    ):
+        return ArtifactClassification(
+            provider=provider,
+            kind=ArtifactKind.SESSION_RECORD_STREAM,
+            parse_as_session=True,
+            schema_eligible=True,
+            default_priority=120,
+            reason="repeated bare Codex session-meta record stream",
+        )
+
     if dict_items and looks_like_record_stream(dict_items):
         subagent = is_subagent_path(source_path)
         kind = ArtifactKind.AGENT_TRANSCRIPT if subagent else ArtifactKind.SESSION_RECORD_STREAM

--- a/polylogue/archive/artifact_taxonomy/runtime.py
+++ b/polylogue/archive/artifact_taxonomy/runtime.py
@@ -410,26 +410,29 @@ def _classify_list(
             reason="Beads interaction-history stream",
         )
 
-    # A Codex rollout can be truncated to repeated bare session headers while
-    # still remaining a JSONL record stream.  A single bare ``type`` is too
-    # weak to admit generically, but multiple exact Codex session-meta records
-    # with a declared Codex origin are provider-specific structural evidence.
-    # Keep this before the generic record predicate so the narrow recovery
-    # shape reaches schema inference without reopening the generic type-only
-    # false-positive class.
-    if (
-        provider is Provider.CODEX
-        and len(dict_items) > 1
-        and all(item == {"type": "session_meta"} for item in dict_items)
-    ):
-        return ArtifactClassification(
-            provider=provider,
-            kind=ArtifactKind.SESSION_RECORD_STREAM,
-            parse_as_session=True,
-            schema_eligible=True,
-            default_priority=120,
-            reason="repeated bare Codex session-meta record stream",
-        )
+    if provider is Provider.CODEX:
+        from polylogue.sources.parsers.codex import is_supported_session_stream
+
+        if is_supported_session_stream(payload):
+            subagent = is_subagent_path(source_path)
+            kind = ArtifactKind.AGENT_TRANSCRIPT if subagent else ArtifactKind.SESSION_RECORD_STREAM
+            return ArtifactClassification(
+                provider=provider,
+                kind=kind,
+                parse_as_session=True,
+                schema_eligible=True,
+                default_priority=90 if subagent else 120,
+                reason="parser-supported Codex session record stream",
+            )
+        if dict_items and any(looks_like_record_entry(item) for item in dict_items):
+            return ArtifactClassification(
+                provider=provider,
+                kind=ArtifactKind.UNKNOWN,
+                parse_as_session=False,
+                schema_eligible=False,
+                default_priority=0,
+                reason="Codex record stream contains unsupported session records",
+            )
 
     if dict_items and looks_like_record_stream(dict_items):
         subagent = is_subagent_path(source_path)

--- a/polylogue/sources/parsers/codex.py
+++ b/polylogue/sources/parsers/codex.py
@@ -2324,6 +2324,10 @@ def is_supported_session_stream(payload: Sequence[object]) -> bool:
 
     if not has_message:
         return False
+    if has_direct_record and has_envelope_record:
+        # The parser supports these wire formats independently, but their
+        # records cannot be combined into one trustworthy session stream.
+        return False
     # The legacy direct-message format has no session header. Its parser uses
     # the acquisition fallback id, so a complete stream of direct records is
     # still materializable. Header-bearing streams must prove their header;

--- a/polylogue/sources/parsers/codex.py
+++ b/polylogue/sources/parsers/codex.py
@@ -2281,6 +2281,8 @@ def is_supported_session_stream(payload: Sequence[object]) -> bool:
     """
     has_session_header = False
     has_message = False
+    has_envelope_record = False
+    has_direct_record = False
     supported_envelope_types = {
         "session_meta",
         "response_item",
@@ -2299,6 +2301,7 @@ def is_supported_session_stream(payload: Sequence[object]) -> bool:
             return False
         record_type = _record_type(record)
         if record_type in supported_envelope_types:
+            has_envelope_record = True
             if not _is_envelope(record):
                 return False
             session_meta = _session_meta_record(record)
@@ -2310,6 +2313,7 @@ def is_supported_session_stream(payload: Sequence[object]) -> bool:
         if _is_state(record):
             continue
         if _is_direct_message(record):
+            has_direct_record = True
             has_message = True
             continue
         session_meta = _session_meta_record(record)
@@ -2318,7 +2322,13 @@ def is_supported_session_stream(payload: Sequence[object]) -> bool:
             continue
         return False
 
-    return has_session_header and has_message
+    if not has_message:
+        return False
+    # The legacy direct-message format has no session header. Its parser uses
+    # the acquisition fallback id, so a complete stream of direct records is
+    # still materializable. Header-bearing streams must prove their header;
+    # this keeps bare or truncated envelope prefixes ineligible.
+    return has_session_header or (has_direct_record and not has_envelope_record)
 
 
 def _parse_records(records: Iterable[object], fallback_id: str) -> ParsedSession:

--- a/polylogue/sources/parsers/codex.py
+++ b/polylogue/sources/parsers/codex.py
@@ -2272,6 +2272,55 @@ def looks_like(payload: Sequence[object]) -> bool:
     return False
 
 
+def is_supported_session_stream(payload: Sequence[object]) -> bool:
+    """Return whether every record forms a materializable Codex session stream.
+
+    This is stricter than :func:`looks_like`, which only needs one record to
+    identify the parser. Artifact classification uses this full-stream
+    contract before it lets a Codex JSONL payload reach schema inference.
+    """
+    has_session_header = False
+    has_message = False
+    supported_envelope_types = {
+        "session_meta",
+        "response_item",
+        "event_msg",
+        "compacted",
+        "turn_context",
+        "world_state",
+        "reasoning",
+    }
+
+    for index, item in enumerate(payload, start=1):
+        if not _is_plausibly_codex_record(item):
+            return False
+        record = _dict_record(item)
+        if record is None or _validate_record(record, index=index, context="session stream") is None:
+            return False
+        record_type = _record_type(record)
+        if record_type in supported_envelope_types:
+            if not _is_envelope(record):
+                return False
+            session_meta = _session_meta_record(record)
+            if session_meta is not None:
+                has_session_header = has_session_header or _record_id(session_meta) is not None
+            if _message_record(record) is not None:
+                has_message = True
+            continue
+        if _is_state(record):
+            continue
+        if _is_direct_message(record):
+            has_message = True
+            continue
+        session_meta = _session_meta_record(record)
+        if session_meta is not None:
+            has_session_header = has_session_header or _record_id(session_meta) is not None
+            continue
+        return False
+
+    return has_session_header and has_message
+
+
 def _parse_records(records: Iterable[object], fallback_id: str) -> ParsedSession:
     """Parse Codex JSONL session file using typed CodexRecord model.
 

--- a/tests/unit/core/test_raw_payload_decode.py
+++ b/tests/unit/core/test_raw_payload_decode.py
@@ -66,6 +66,23 @@ def test_build_raw_payload_envelope_reports_first_bad_jsonl_line(tmp_path: Path)
     assert "line 2" in envelope.malformed_jsonl_detail
 
 
+def test_build_raw_payload_envelope_admits_repeated_bare_codex_session_meta_records() -> None:
+    """Repeated Codex headers remain eligible even when their envelopes were truncated."""
+    raw_content = (b'{"type":"session_meta"}\n' * 1024) + b"not json at all\n"
+
+    envelope = build_raw_payload_envelope(
+        raw_content,
+        source_path="/tmp/rollout-repeated.jsonl",
+        fallback_provider="codex",
+        jsonl_dict_only=True,
+    )
+
+    assert envelope.wire_format == "jsonl"
+    assert envelope.artifact.kind is ArtifactKind.SESSION_RECORD_STREAM
+    assert envelope.artifact.schema_eligible is True
+    assert envelope.malformed_jsonl_lines == 1
+
+
 def test_jsonl_sampling_can_stop_after_bounded_prefix(tmp_path: Path) -> None:
     path = tmp_path / "bounded.jsonl"
     path.write_text('{"ok": 1}\n{"ok": 2}\n{"broken": \n', encoding="utf-8")

--- a/tests/unit/core/test_raw_payload_decode.py
+++ b/tests/unit/core/test_raw_payload_decode.py
@@ -142,6 +142,27 @@ def test_build_raw_payload_envelope_admits_legacy_direct_codex_stream() -> None:
     assert envelope.artifact.schema_eligible is True
 
 
+def test_build_raw_payload_envelope_refuses_mixed_codex_envelope_and_direct_stream() -> None:
+    raw_content = (
+        b'{"type":"session_meta","payload":{"id":"mixed-stream"}}\n'
+        b'{"type":"response_item","payload":{"type":"message","role":"user",'
+        b'"content":[{"type":"input_text","text":"envelope"}]}}\n'
+        b'{"type":"message","id":"legacy-user","role":"user",'
+        b'"content":[{"type":"input_text","text":"direct"}]}\n'
+    )
+
+    envelope = build_raw_payload_envelope(
+        raw_content,
+        source_path="/tmp/mixed-envelope-direct.jsonl",
+        fallback_provider="codex",
+        jsonl_dict_only=True,
+    )
+
+    assert envelope.artifact.kind is ArtifactKind.UNKNOWN
+    assert envelope.artifact.parse_as_session is False
+    assert envelope.artifact.schema_eligible is False
+
+
 def test_jsonl_sampling_can_stop_after_bounded_prefix(tmp_path: Path) -> None:
     path = tmp_path / "bounded.jsonl"
     path.write_text('{"ok": 1}\n{"ok": 2}\n{"broken": \n', encoding="utf-8")

--- a/tests/unit/core/test_raw_payload_decode.py
+++ b/tests/unit/core/test_raw_payload_decode.py
@@ -66,21 +66,64 @@ def test_build_raw_payload_envelope_reports_first_bad_jsonl_line(tmp_path: Path)
     assert "line 2" in envelope.malformed_jsonl_detail
 
 
-def test_build_raw_payload_envelope_admits_repeated_bare_codex_session_meta_records() -> None:
-    """Repeated Codex headers remain eligible even when their envelopes were truncated."""
-    raw_content = (b'{"type":"session_meta"}\n' * 1024) + b"not json at all\n"
-
+def test_build_raw_payload_envelope_refuses_bare_session_meta_for_non_codex() -> None:
     envelope = build_raw_payload_envelope(
-        raw_content,
+        b'{"type":"session_meta"}\n' * 2,
         source_path="/tmp/rollout-repeated.jsonl",
+        fallback_provider="claude-code",
+        jsonl_dict_only=True,
+    )
+
+    assert envelope.artifact.parse_as_session is False
+    assert envelope.artifact.schema_eligible is False
+
+
+def test_build_raw_payload_envelope_refuses_codex_single_session_header() -> None:
+    envelope = build_raw_payload_envelope(
+        b'{"type":"session_meta","payload":{"id":"header-only"}}\n',
+        source_path="/tmp/header-only.jsonl",
         fallback_provider="codex",
         jsonl_dict_only=True,
     )
 
-    assert envelope.wire_format == "jsonl"
+    assert envelope.artifact.parse_as_session is False
+    assert envelope.artifact.schema_eligible is False
+
+
+def test_build_raw_payload_envelope_refuses_non_session_record_after_codex_prefix() -> None:
+    raw_content = (
+        b'{"type":"session_meta","payload":{"id":"mixed-after-prefix"}}\n'
+        + (
+            b'{"type":"response_item","payload":{"type":"message","role":"user",'
+            b'"content":[{"type":"input_text","text":"hello"}]}}\n' * 31
+        )
+        + b'{"type":"settings"}\n'
+    )
+
+    envelope = build_raw_payload_envelope(
+        raw_content,
+        source_path="/tmp/mixed-after-prefix.jsonl",
+        fallback_provider="codex",
+        jsonl_dict_only=True,
+    )
+
+    assert envelope.artifact.parse_as_session is False
+    assert envelope.artifact.schema_eligible is False
+
+
+def test_build_raw_payload_envelope_admits_real_codex_session_stream() -> None:
+    envelope = build_raw_payload_envelope(
+        b'{"type":"session_meta","payload":{"id":"real-stream"}}\n'
+        b'{"type":"response_item","payload":{"type":"message","role":"user",'
+        b'"content":[{"type":"input_text","text":"hello"}]}}\n',
+        source_path="/tmp/real-stream.jsonl",
+        fallback_provider="codex",
+        jsonl_dict_only=True,
+    )
+
     assert envelope.artifact.kind is ArtifactKind.SESSION_RECORD_STREAM
+    assert envelope.artifact.parse_as_session is True
     assert envelope.artifact.schema_eligible is True
-    assert envelope.malformed_jsonl_lines == 1
 
 
 def test_jsonl_sampling_can_stop_after_bounded_prefix(tmp_path: Path) -> None:

--- a/tests/unit/core/test_raw_payload_decode.py
+++ b/tests/unit/core/test_raw_payload_decode.py
@@ -126,6 +126,22 @@ def test_build_raw_payload_envelope_admits_real_codex_session_stream() -> None:
     assert envelope.artifact.schema_eligible is True
 
 
+def test_build_raw_payload_envelope_admits_legacy_direct_codex_stream() -> None:
+    envelope = build_raw_payload_envelope(
+        b'{"type":"message","id":"legacy-user","timestamp":"2024-01-01T00:00:00Z",'
+        b'"role":"user","content":[{"type":"input_text","text":"hello"}]}\n'
+        b'{"type":"message","id":"legacy-assistant","timestamp":"2024-01-01T00:00:01Z",'
+        b'"role":"assistant","content":[{"type":"text","text":"world"}]}\n',
+        source_path="/tmp/legacy.jsonl",
+        fallback_provider="codex",
+        jsonl_dict_only=True,
+    )
+
+    assert envelope.artifact.kind is ArtifactKind.SESSION_RECORD_STREAM
+    assert envelope.artifact.parse_as_session is True
+    assert envelope.artifact.schema_eligible is True
+
+
 def test_jsonl_sampling_can_stop_after_bounded_prefix(tmp_path: Path) -> None:
     path = tmp_path / "bounded.jsonl"
     path.write_text('{"ok": 1}\n{"ok": 2}\n{"broken": \n', encoding="utf-8")

--- a/tests/unit/core/test_sampling.py
+++ b/tests/unit/core/test_sampling.py
@@ -269,7 +269,6 @@ class TestLoadSamplesFromDb:
         raw_content = "\n".join(
             json.dumps(record)
             for record in [
-                {"type": "session_meta", "id": "sess-1"},
                 {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "x" * 2048}]},
                 {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "hello"}]},
             ]
@@ -289,8 +288,8 @@ class TestLoadSamplesFromDb:
 
         result = load_samples_from_db("codex", db_path=db, max_samples=2)
         assert len(result) == 2
-        assert {sample["type"] for sample in result} == {"session_meta", "message"}
-        message_sample = next(sample for sample in result if sample["type"] == "message")
+        assert {sample["type"] for sample in result} == {"message"}
+        message_sample = result[0]
         content = message_sample.get("content")
         assert isinstance(content, list)
         first_block = schema_node(content[0]) if content else {}
@@ -306,9 +305,7 @@ class TestLoadSamplesFromDb:
         record_count = 1_024
         raw_content = "\n".join(
             json.dumps(
-                {"type": "session_meta", "id": "sess-1"}
-                if index == 0
-                else {
+                {
                     "type": "message",
                     "role": "user" if index % 2 else "assistant",
                     "content": [{"type": "input_text", "text": f"message-{index}"}],
@@ -329,7 +326,7 @@ class TestLoadSamplesFromDb:
         samples = units[0].schema_samples
         assert isinstance(samples, ReplayableRecordSamples)
         assert len(samples) == record_count
-        assert samples[0]["type"] == "session_meta"
+        assert samples[0]["type"] == "message"
         assert samples[-1]["type"] == "message"
 
         generation = generate_provider_schema("codex", db_path=db, full_corpus=True)
@@ -398,7 +395,11 @@ class TestLoadSamplesFromDb:
             db_path=db,
             origin="codex-session",
             source_path="/tmp/good.jsonl",
-            raw_content=b'{"type":"session_meta","payload":{"id":"sess-1"}}\n',
+            raw_content=(
+                b'{"type":"session_meta","payload":{"id":"sess-1"}}\n'
+                b'{"type":"response_item","payload":{"type":"message","role":"user",'
+                b'"content":[{"type":"input_text","text":"hello"}]}}\n'
+            ),
         )
         bad_raw_id = _insert_raw_session(
             db_path=db,
@@ -449,17 +450,12 @@ class TestLoadSamplesFromDb:
         from polylogue.storage.sqlite.connection import open_connection
 
         db = _archive_index_db(tmp_path)
-        # A record-granularity codex session needs at least one message-shaped
-        # record to be schema-eligible -- a lone ``session_meta`` line (as used
-        # by other tests in this file that only assert on decode/terminal
-        # bookkeeping) does not register any schema unit, which would make
-        # ``iter_schema_units`` fall through to its real
-        # ``~/.codex/sessions`` directory-scan fallback and defeat this test's
-        # isolation.
+        # A record-granularity Codex session needs at least one supported
+        # message-shaped record to be schema-eligible. Pure direct-message
+        # streams use the acquisition fallback identity.
         raw_content = (
             b"\n".join(
                 [
-                    b'{"type":"session_meta","id":"sess-1"}',
                     b'{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}',
                 ]
             )
@@ -508,10 +504,20 @@ class TestLoadSamplesFromDb:
             "reason": "duplicate_blob_content",
         }
 
-    def test_schema_observation_includes_repeated_bare_codex_session_meta_records(self, tmp_path: Path) -> None:
-        """The DB-backed record sampler reaches the shared envelope eligibility route."""
+    def test_schema_observation_classifies_supported_and_unsupported_codex_streams(self, tmp_path: Path) -> None:
+        """DB sampling admits real envelopes and refuses bare session headers."""
         db = _archive_index_db(tmp_path)
-        raw_id = _insert_raw_session(
+        supported_raw_id = _insert_raw_session(
+            db_path=db,
+            origin="codex-session",
+            source_path="/tmp/rollout-supported.jsonl",
+            raw_content=(
+                b'{"type":"session_meta","payload":{"id":"supported-session"}}\n'
+                b'{"type":"response_item","payload":{"type":"message","role":"user",'
+                b'"content":[{"type":"input_text","text":"hello"}]}}\n'
+            ),
+        )
+        unsupported_raw_id = _insert_raw_session(
             db_path=db,
             origin="codex-session",
             source_path="/tmp/rollout-repeated.jsonl",
@@ -528,16 +534,22 @@ class TestLoadSamplesFromDb:
             )
         )
 
-        assert [(unit.raw_id, unit.artifact_kind) for unit in units] == [(raw_id, "session_record_stream")]
-        assert [outcome for outcome in outcomes if outcome["raw_id"] == raw_id] == [
-            {
-                "raw_id": raw_id,
-                "status": "included",
-                "artifact_kind": "session_record_stream",
-                "source_path": "/tmp/rollout-repeated.jsonl",
-                "reason": "observed_schema_units",
-            }
-        ]
+        assert [(unit.raw_id, unit.artifact_kind) for unit in units] == [(supported_raw_id, "session_record_stream")]
+        outcomes_by_raw_id = {outcome["raw_id"]: outcome for outcome in outcomes}
+        assert outcomes_by_raw_id[supported_raw_id] == {
+            "raw_id": supported_raw_id,
+            "status": "included",
+            "artifact_kind": "session_record_stream",
+            "source_path": "/tmp/rollout-supported.jsonl",
+            "reason": "observed_schema_units",
+        }
+        assert outcomes_by_raw_id[unsupported_raw_id] == {
+            "raw_id": unsupported_raw_id,
+            "status": "unsupported",
+            "artifact_kind": None,
+            "source_path": "/tmp/rollout-repeated.jsonl",
+            "reason": "no_schema_eligible_units",
+        }
 
     def test_schema_observation_excludes_hermes_sqlite_evidence_before_json_decode(self, tmp_path: Path) -> None:
         db = _archive_index_db(tmp_path)

--- a/tests/unit/core/test_sampling.py
+++ b/tests/unit/core/test_sampling.py
@@ -508,6 +508,37 @@ class TestLoadSamplesFromDb:
             "reason": "duplicate_blob_content",
         }
 
+    def test_schema_observation_includes_repeated_bare_codex_session_meta_records(self, tmp_path: Path) -> None:
+        """The DB-backed record sampler reaches the shared envelope eligibility route."""
+        db = _archive_index_db(tmp_path)
+        raw_id = _insert_raw_session(
+            db_path=db,
+            origin="codex-session",
+            source_path="/tmp/rollout-repeated.jsonl",
+            raw_content=b'{"type":"session_meta"}\n' * 1024,
+        )
+        outcomes: list[dict[str, object]] = []
+
+        units = list(
+            iter_schema_units(
+                "codex",
+                db_path=db,
+                full_corpus=True,
+                terminal_recorder=lambda **outcome: outcomes.append(outcome),
+            )
+        )
+
+        assert [(unit.raw_id, unit.artifact_kind) for unit in units] == [(raw_id, "session_record_stream")]
+        assert [outcome for outcome in outcomes if outcome["raw_id"] == raw_id] == [
+            {
+                "raw_id": raw_id,
+                "status": "included",
+                "artifact_kind": "session_record_stream",
+                "source_path": "/tmp/rollout-repeated.jsonl",
+                "reason": "observed_schema_units",
+            }
+        ]
+
     def test_schema_observation_excludes_hermes_sqlite_evidence_before_json_decode(self, tmp_path: Path) -> None:
         db = _archive_index_db(tmp_path)
         raw_id = _insert_raw_session(

--- a/tests/unit/sources/test_parsers_codex.py
+++ b/tests/unit/sources/test_parsers_codex.py
@@ -151,6 +151,36 @@ class TestSessionStreamContract:
             == []
         )
 
+    def test_mixed_envelope_and_direct_stream_fails_admission_and_evidence_gate(self) -> None:
+        from polylogue.sources.dispatch import parse_stream_payload, require_positive_conversational_evidence
+
+        payload = [
+            {"type": "session_meta", "payload": {"id": "mixed-stream"}},
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "envelope"}],
+                },
+            },
+            {
+                "type": "message",
+                "id": "legacy-user",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "direct"}],
+            },
+        ]
+
+        assert not is_supported_session_stream(payload)
+        sessions = parse_stream_payload("codex", iter(payload), "fallback", source_path="/tmp/mixed.jsonl")
+
+        assert sessions[0].messages
+        assert (
+            require_positive_conversational_evidence(sessions, provider="codex", source_path="/tmp/mixed.jsonl")
+            == sessions
+        )
+
 
 # =============================================================================
 # Session Metadata

--- a/tests/unit/sources/test_parsers_codex.py
+++ b/tests/unit/sources/test_parsers_codex.py
@@ -107,6 +107,36 @@ class TestSessionStreamContract:
             == sessions
         )
 
+    def test_legacy_direct_stream_uses_fallback_identity_and_passes_contract(self) -> None:
+        from polylogue.sources.dispatch import parse_stream_payload, require_positive_conversational_evidence
+
+        payload = [
+            {
+                "type": "message",
+                "id": "legacy-user",
+                "timestamp": "2024-01-01T00:00:00Z",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "hello"}],
+            },
+            {
+                "type": "message",
+                "id": "legacy-assistant",
+                "timestamp": "2024-01-01T00:00:01Z",
+                "role": "assistant",
+                "content": [{"type": "text", "text": "world"}],
+            },
+        ]
+
+        assert is_supported_session_stream(payload)
+        sessions = parse_stream_payload("codex", iter(payload), "legacy-fallback", source_path="/tmp/legacy.jsonl")
+
+        assert [session.provider_session_id for session in sessions] == ["legacy-fallback"]
+        assert len(sessions[0].messages) == 2
+        assert (
+            require_positive_conversational_evidence(sessions, provider="codex", source_path="/tmp/legacy.jsonl")
+            == sessions
+        )
+
     def test_bare_session_headers_fail_parser_contract_and_materialization_gate(self) -> None:
         from polylogue.sources.dispatch import parse_stream_payload, require_positive_conversational_evidence
 

--- a/tests/unit/sources/test_parsers_codex.py
+++ b/tests/unit/sources/test_parsers_codex.py
@@ -16,7 +16,7 @@ from polylogue.archive.session_revision_membership import MembershipRevision, cl
 from polylogue.core.enums import BlockType, MaterialOrigin, Role
 from polylogue.pipeline.ids import session_content_hash, session_revision_projection
 from polylogue.sources.parsers.base import ParsedSession
-from polylogue.sources.parsers.codex import _tool_input_from_arguments, parse_stream
+from polylogue.sources.parsers.codex import _tool_input_from_arguments, is_supported_session_stream, parse_stream
 from polylogue.sources.parsers.codex import looks_like as _looks_like_impl
 from polylogue.sources.parsers.codex import parse as _parse_impl
 from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
@@ -80,6 +80,46 @@ class TestLooksLike:
     def test_non_dict_items_skipped(self) -> None:
         payload = ["string", 42, None, {"type": "message", "role": "user", "content": []}]
         assert looks_like(payload)  # The dict item matches
+
+
+class TestSessionStreamContract:
+    def test_real_wire_stream_parses_and_passes_materialization_evidence_gate(self) -> None:
+        from polylogue.sources.dispatch import parse_stream_payload, require_positive_conversational_evidence
+
+        payload = [
+            {"type": "session_meta", "payload": {"id": "real-stream"}},
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "hello"}],
+                },
+            },
+        ]
+
+        assert is_supported_session_stream(payload)
+        sessions = parse_stream_payload("codex", iter(payload), "fallback", source_path="/tmp/real-stream.jsonl")
+
+        assert [session.provider_session_id for session in sessions] == ["real-stream"]
+        assert (
+            require_positive_conversational_evidence(sessions, provider="codex", source_path="/tmp/real-stream.jsonl")
+            == sessions
+        )
+
+    def test_bare_session_headers_fail_parser_contract_and_materialization_gate(self) -> None:
+        from polylogue.sources.dispatch import parse_stream_payload, require_positive_conversational_evidence
+
+        payload = [{"type": "session_meta"}, {"type": "session_meta"}]
+
+        assert not is_supported_session_stream(payload)
+        sessions = parse_stream_payload("codex", iter(payload), "fallback", source_path="/tmp/bare-headers.jsonl")
+
+        assert sessions[0].messages == []
+        assert (
+            require_positive_conversational_evidence(sessions, provider="codex", source_path="/tmp/bare-headers.jsonl")
+            == []
+        )
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Repair the strict Codex raw-payload classification so the approved legacy direct-message demo stream remains ingestible. The branch now contains the complete-stream hardening, plus the compatibility correction required by the existing parser contract.

## Problem

The strict classifier required every admitted Codex stream to contain a `session_meta` header. The deterministic `codex/demo-00.jsonl` fixture is a valid legacy direct-message stream with eight supported message records and no header; the parser already supports this format using the acquisition fallback id. The branch-only output delta was one removed session, `codex-session:demo-00`, changing the tour from 19 sessions and 71 messages to 18 sessions and 63 messages. The downstream failed-action aggregate changed from 7 to 5, and the semantic demo verifier failed because the expected session was absent.

## Solution

`is_supported_session_stream()` now admits a complete stream containing only supported direct-message records and at least one message. Envelope-bearing streams still require a valid session header. Unsupported records, bare session headers, and mixed incomplete prefixes remain ineligible. Focused parser and raw-envelope tests cover the accepted legacy shape and the rejection boundaries.

The generated demo artifact was not regenerated because its delta was unintended. The committed artifact remains authoritative and fresh after the parser correction.

## Verification

- `direnv exec /realm/worktrees/polylogue-o8c3m-envelope-current devtools test tests/unit/core/test_raw_payload_decode.py tests/unit/sources/test_parsers_codex.py` -> 109 passed.
- `direnv exec /realm/worktrees/polylogue-o8c3m-envelope-current devtools render all --check` -> exit 0; all generated surfaces synchronized.
- `direnv exec /realm/worktrees/polylogue-o8c3m-envelope-current devtools lab policy demo-tour-freshness` -> fresh tour output matches committed `docs/examples/demo-tour/`.
- `direnv exec /realm/worktrees/polylogue-o8c3m-envelope-current devtools verify --quick` -> exit 0; render, classifier, demo-tour, type, layering, and schema checks passed.
- Normal `git push` ran the pre-push quick verification baseline and published `fadb2d80f` without force-pushing.

## Acceptance criteria

| Criterion | Result |
| --- | --- |
| Determine whether the demo output delta was intended | Satisfied: it was an unintended rejection of a valid legacy direct stream. |
| Preserve incomplete-stream rejection | Satisfied: header-only, unsupported, and mixed-prefix cases remain rejected by focused tests. |
| Keep the authoritative generated artifact unchanged when parser behavior is corrected | Satisfied. |
| Publish the fresh successor branch without rewriting history | Satisfied: `fadb2d80f` is on `origin/feature/fix/raw-payload-envelope-current`. |
