### PR TITLE
fix(storage): add typed SQLite memory budget contract

### DIFF
--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -638,6 +638,11 @@ default off) and `ce0cd45cf`/`5e23e6abf` if the GIL parse path itself needs
 to come back; neither revert is expected to be necessary since the warm has
 no writer-hold interaction and degrades safely on any interpreter.
 
+### SQLite memory budget
+
+The optional `POLYLOGUE_MEMORY_BUDGET_BYTES` startup setting declares the
+process memory budget in bytes. The SQLite read, write, daemon-write, and bulk-build mmap and cache limits scale together from that value. The same setting is available through the layered config contract as `[resource].memory_budget_bytes`. When absent, the measured 18 GiB default preserves the existing profile constants. Values must be positive base-10 integers; invalid values fail configuration resolution loudly. Daemon startup observability reports both the mapped SQLite budget and the effective declared memory budget before comparing the mapped budget with cgroup limits.
+
 ### Operator-Owned Tasks
 
 These are heavier operations that should run outside the daemon via

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -641,7 +641,7 @@ no writer-hold interaction and degrades safely on any interpreter.
 ### SQLite memory budget
 
 The optional `POLYLOGUE_MEMORY_BUDGET_BYTES` startup setting declares the
-process memory budget in bytes. The SQLite read, write, daemon-write, and bulk-build mmap and cache limits scale together from that value. The same setting is available through the layered config contract as `[resource].memory_budget_bytes`. When absent, the measured 18 GiB default preserves the existing profile constants. Values must be positive base-10 integers; invalid values fail configuration resolution loudly. Daemon startup observability reports both the mapped SQLite budget and the effective declared memory budget before comparing the mapped budget with cgroup limits.
+process memory budget in bytes. The SQLite read, write, daemon-write, bulk-build, bounded FTS-repair, and schema-observation-journal cache/mmap limits scale together from that value. The mapped budget includes one concurrent instance of every production profile plus the configured concurrent read allowance. The same setting is available through the layered config contract as `[resource].memory_budget_bytes`. When absent, the measured 18 GiB default preserves the existing profile constants. Values must be positive base-10 integers no larger than 64 GiB; invalid values fail configuration resolution loudly before SQLite profile construction. Daemon startup observability reports the raw mapped budget, its concurrent allowance components, and the effective declared memory budget before comparing the mapped budget with cgroup limits.
 
 ### Operator-Owned Tasks
 

--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -228,6 +228,21 @@ def _parse_bool_token(value: str) -> bool | None:
     return None
 
 
+def _parse_memory_budget_bytes(value: object, *, source: str) -> int | None:
+    """Parse an optional positive process memory budget in bytes."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ConfigError(f"{source}={value!r} is not a valid positive integer byte budget.")
+    try:
+        parsed = int(str(value).strip(), 10)
+    except (TypeError, ValueError) as exc:
+        raise ConfigError(f"{source}={value!r} is not a valid positive integer byte budget.") from exc
+    if parsed <= 0:
+        raise ConfigError(f"{source}={value!r} must be greater than zero.")
+    return parsed
+
+
 def _require_bool_config_value(data: Mapping[str, object], key: str) -> bool:
     """Strictly resolve a capability-boundary boolean config value.
 
@@ -271,6 +286,7 @@ class PolylogueConfig:
 
     def __post_init__(self) -> None:
         frozen_data = {str(key): _freeze_config_value(value) for key, value in self._data.items()}
+        _parse_memory_budget_bytes(frozen_data.get("memory_budget_bytes"), source="memory_budget_bytes")
         object.__setattr__(self, "_data", MappingProxyType(frozen_data))
         object.__setattr__(self, "_layers", MappingProxyType(dict(self._layers)))
         object.__setattr__(self, "_layer_paths", MappingProxyType(dict(self._layer_paths)))
@@ -728,6 +744,11 @@ class PolylogueConfig:
         if value is None:
             return None
         return float(str(value))
+
+    @property
+    def memory_budget_bytes(self) -> int | None:
+        """Optional positive process memory budget used by SQLite profiles."""
+        return _parse_memory_budget_bytes(self._data.get("memory_budget_bytes"), source="memory_budget_bytes")
 
     @property
     def mcp_write_enabled(self) -> bool:
@@ -1380,6 +1401,17 @@ _CONFIG_INVENTORY: tuple[ConfigInventoryEntry, ...] = (
         description="Maximum concurrent workers for live full-artifact ingestion.",
     ),
     ConfigInventoryEntry(
+        "memory_budget_bytes",
+        toml_path="resource.memory_budget_bytes",
+        env_var="POLYLOGUE_MEMORY_BUDGET_BYTES",
+        owner_class="resource-policy",
+        reload_behavior="startup-bound",
+        description=(
+            "Optional process memory budget in bytes. SQLite mmap/cache profile "
+            "limits scale proportionally; absent preserves the measured default."
+        ),
+    ),
+    ConfigInventoryEntry(
         "raw_authority_commit_batch_size",
         toml_path="pipeline.raw_authority.commit_batch_size",
         env_var="POLYLOGUE_RAW_AUTHORITY_COMMIT_BATCH_SIZE",
@@ -1589,6 +1621,7 @@ _INT_CONFIG_KEYS = frozenset(
         "notification_email_max_per_hour",
         "ingest_commit_batch_messages",
         "live_full_ingest_workers",
+        "memory_budget_bytes",
         "judgment_automation_interval_s",
         "judgment_automation_batch_limit",
         "raw_authority_commit_batch_size",
@@ -1816,6 +1849,7 @@ def _default_config_values(bootstrap: _BootstrapPaths | None = None) -> dict[str
         "antigravity_language_server": None,
         "ingest_commit_batch_messages": 8000,
         "live_full_ingest_workers": 1,
+        "memory_budget_bytes": None,
         "raw_authority_commit_batch_size": None,
         "raw_authority_whale_payload_bytes": None,
         "subscription_plans": (),
@@ -2027,6 +2061,8 @@ def _coerce_env_value(cfg_key: str, env_var: str, value: str) -> object:
             "use one of 1/true/yes/on or 0/false/no/off (case-insensitive)."
         )
     if cfg_key in _INT_CONFIG_KEYS:
+        if cfg_key == "memory_budget_bytes":
+            return _parse_memory_budget_bytes(value, source=env_var)
         try:
             return int(value)
         except ValueError:

--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -217,6 +217,10 @@ def _thaw_config_value(value: object) -> object:
 _TRUE_TOKENS = ("1", "true", "yes", "on")
 _FALSE_TOKENS = ("0", "false", "no", "off")
 
+# Keep pathological values from producing SQLite PRAGMA settings that are
+# accepted by the Python config layer but lose their meaning in SQLite.
+MAX_MEMORY_BUDGET_BYTES = 64 * 1024**3
+
 
 def _parse_bool_token(value: str) -> bool | None:
     """Parse a canonical boolean string token, or ``None`` if unrecognized."""
@@ -240,6 +244,10 @@ def _parse_memory_budget_bytes(value: object, *, source: str) -> int | None:
         raise ConfigError(f"{source}={value!r} is not a valid positive integer byte budget.") from exc
     if parsed <= 0:
         raise ConfigError(f"{source}={value!r} must be greater than zero.")
+    if parsed > MAX_MEMORY_BUDGET_BYTES:
+        raise ConfigError(
+            f"{source}={value!r} exceeds the maximum supported memory budget of {MAX_MEMORY_BUDGET_BYTES} bytes."
+        )
     return parsed
 
 

--- a/polylogue/core/metrics.py
+++ b/polylogue/core/metrics.py
@@ -14,6 +14,8 @@ from pathlib import Path
 
 from polylogue.core.json import JSONDocument, is_json_value, require_json_value
 
+_CGROUP_V2_ROOT = Path("/sys/fs/cgroup")
+
 
 def _read_proc_status_kb(field_name: str) -> int | None:
     """Read a numeric memory field from ``/proc/self/status`` in KiB."""
@@ -75,11 +77,19 @@ def _cgroup_file(name: str) -> Path | None:
     cgroup_path = read_cgroup_path()
     if cgroup_path is None:
         return None
-    return Path("/sys/fs/cgroup") / cgroup_path.lstrip("/") / name
+    return _CGROUP_V2_ROOT / cgroup_path.lstrip("/") / name
 
 
-def _read_cgroup_int(name: str) -> int | None:
-    path = _cgroup_file(name)
+def _cgroup_limit_files(name: str) -> tuple[Path, ...]:
+    """Return the leaf-to-root cgroup v2 paths for one hierarchical limit."""
+    cgroup_path = read_cgroup_path()
+    if cgroup_path is None:
+        return ()
+    components = tuple(part for part in cgroup_path.split("/") if part)
+    return tuple(_CGROUP_V2_ROOT.joinpath(*components[:depth], name) for depth in range(len(components), -1, -1))
+
+
+def _read_cgroup_int_from_path(path: Path | None) -> int | None:
     if path is None:
         return None
     try:
@@ -92,6 +102,16 @@ def _read_cgroup_int(name: str) -> int | None:
         return int(value)
     except ValueError:
         return None
+
+
+def _read_cgroup_int(name: str) -> int | None:
+    return _read_cgroup_int_from_path(_cgroup_file(name))
+
+
+def _read_cgroup_limit_int(name: str) -> int | None:
+    """Return the minimum finite value across this cgroup and its ancestors."""
+    values = [value for path in _cgroup_limit_files(name) if (value := _read_cgroup_int_from_path(path)) is not None]
+    return min(values) if values else None
 
 
 def _bytes_to_mb(value: int | None) -> float | None:
@@ -116,27 +136,28 @@ def read_cgroup_memory_swap_current_mb() -> float | None:
 
 
 def read_cgroup_memory_max_bytes() -> int | None:
-    """Return this cgroup's ``memory.max`` (hard ceiling) in bytes.
+    """Return the effective cgroup hierarchy ``memory.max`` hard ceiling in bytes.
 
-    ``None`` when the cgroup v2 controller is not mounted, the file is
-    missing (no controller delegated, e.g. outside a cgroup or in a
-    container without ``memory`` enabled), or the limit is literally
-    ``max`` (unlimited) -- ``_read_cgroup_int`` already treats ``max`` as
-    ``None``, which is the correct "no ceiling" reading here too.
+    The effective limit is the minimum finite value exposed by the process'
+    cgroup and each ancestor. ``None`` when the cgroup v2 controller is not
+    mounted, no hierarchy file is available, or every visible limit is
+    literally ``max`` (unlimited).
     """
-    return _read_cgroup_int("memory.max")
+    return _read_cgroup_limit_int("memory.max")
 
 
 def read_cgroup_memory_high_bytes() -> int | None:
-    """Return this cgroup's ``memory.high`` (soft throttle threshold) in bytes.
+    """Return the effective cgroup hierarchy ``memory.high`` threshold in bytes.
 
-    ``None`` under the same conditions as :func:`read_cgroup_memory_max_bytes`.
+    The effective threshold is the minimum finite value exposed by the
+    process' cgroup and each ancestor. ``None`` under the same conditions as
+    :func:`read_cgroup_memory_max_bytes`.
     Reclaimable/mmap'd file-backed pages are throttled (evict-under-pressure)
     once usage crosses this threshold, before ``memory.max`` would ever OOM-kill
     -- see ``polylogue.storage.sqlite.connection_profile.mapped_bytes_budget``
     for why this threshold matters independently of the hard ceiling.
     """
-    return _read_cgroup_int("memory.high")
+    return _read_cgroup_limit_int("memory.high")
 
 
 def read_cgroup_memory_stat_mb() -> dict[str, float]:

--- a/polylogue/schemas/generation/observation_journal.py
+++ b/polylogue/schemas/generation/observation_journal.py
@@ -24,6 +24,7 @@ from polylogue.paths import cache_home
 from polylogue.schemas.generation.models import _ProfileSummary, _UnitMembership
 from polylogue.schemas.observation import SchemaUnit
 from polylogue.schemas.observation_models import ObservationTerminalStatus
+from polylogue.storage.sqlite.connection_profile import OBSERVATION_JOURNAL_CACHE_SIZE_KIB
 
 logger = get_logger(__name__)
 
@@ -257,11 +258,11 @@ class ObservationJournal:
             connection = sqlite3.connect(path)
             connection.row_factory = sqlite3.Row
             connection.executescript(
-                """
+                f"""
                 PRAGMA journal_mode = WAL;
                 PRAGMA synchronous = NORMAL;
                 PRAGMA temp_store = FILE;
-                PRAGMA cache_size = -65536;
+                PRAGMA cache_size = -{OBSERVATION_JOURNAL_CACHE_SIZE_KIB};
 
                 CREATE TABLE journal_meta (
                     format_version INTEGER NOT NULL,

--- a/polylogue/storage/fts/dangling_repair.py
+++ b/polylogue/storage/fts/dangling_repair.py
@@ -26,7 +26,7 @@ from polylogue.storage.sqlite.connection_profile import (
 BOUNDED_REPAIR_PRAGMAS = (
     "PRAGMA temp_store = FILE",
     f"PRAGMA cache_size = -{BOUNDED_REPAIR_CACHE_SIZE_KIB}",
-    f"PRAGMA mmap_size = {BOUNDED_REPAIR_MMAP_SIZE_BYTES}",
+    f"PRAGMA main.mmap_size = {BOUNDED_REPAIR_MMAP_SIZE_BYTES}",
 )
 
 

--- a/polylogue/storage/fts/dangling_repair.py
+++ b/polylogue/storage/fts/dangling_repair.py
@@ -18,11 +18,15 @@ from polylogue.storage.fts.sql import (
     FTS_INDEXABLE_MESSAGE_COUNT_SQL,
 )
 from polylogue.storage.introspection import table_exists as _table_exists
+from polylogue.storage.sqlite.connection_profile import (
+    BOUNDED_REPAIR_CACHE_SIZE_KIB,
+    BOUNDED_REPAIR_MMAP_SIZE_BYTES,
+)
 
 BOUNDED_REPAIR_PRAGMAS = (
     "PRAGMA temp_store = FILE",
-    "PRAGMA cache_size = -32768",
-    "PRAGMA mmap_size = 134217728",
+    f"PRAGMA cache_size = -{BOUNDED_REPAIR_CACHE_SIZE_KIB}",
+    f"PRAGMA mmap_size = {BOUNDED_REPAIR_MMAP_SIZE_BYTES}",
 )
 
 

--- a/polylogue/storage/sqlite/connection_profile.py
+++ b/polylogue/storage/sqlite/connection_profile.py
@@ -118,6 +118,13 @@ READ_CACHE_SIZE_KIB = _scale_profile_size(32768)  # 32 MiB
 WRITE_MMAP_SIZE_BYTES = _scale_profile_size(1073741824)  # 1 GiB
 DAEMON_WRITE_MMAP_SIZE_BYTES = _scale_profile_size(67108864)  # 64 MiB
 READ_MMAP_SIZE_BYTES = _scale_profile_size(134217728)  # 128 MiB
+# The bounded FTS repair connection is opened separately from the daemon's
+# ordinary writer and must remain inside the same process budget.
+BOUNDED_REPAIR_CACHE_SIZE_KIB = _scale_profile_size(32768)  # 32 MiB
+BOUNDED_REPAIR_MMAP_SIZE_BYTES = _scale_profile_size(134217728)  # 128 MiB
+# Schema inference keeps its own WAL journal connection alive while it scans
+# provider artifacts. It has no mmap allowance, only this page-cache limit.
+OBSERVATION_JOURNAL_CACHE_SIZE_KIB = _scale_profile_size(65536)  # 64 MiB
 WAL_AUTOCHECKPOINT_PAGES = 10000
 # #1614: soft cap on the WAL file. After any checkpoint that frees
 # pages, SQLite truncates the WAL down to this size. Without this cap
@@ -261,12 +268,11 @@ def mapped_bytes_budget(*, concurrent_read_connections: int = 4) -> int:
     concurrently with the daemon's own long-lived write connection
     (`DAEMON_WRITE_CONNECTION_PROFILE`) and a handful of concurrent
     short-lived read connections (CLI/MCP/API reads against the live
-    archive while a rebuild is in flight). It deliberately excludes the
-    ad hoc `WRITE_CONNECTION_PROFILE` (1 GiB mmap) that one-shot
-    maintenance/CLI writers use -- those do not overlap with a
-    daemon-triggered bulk rebuild in the failure mode this budget guards
-    against, and folding it in would inflate the budget past what was ever
-    observed live without adding real signal.
+    archive while a rebuild is in flight), plus one ordinary writer, one
+    bounded FTS repair connection, and one schema-observation journal
+    connection. This is a conservative upper bound across the production
+    profiles, including one-shot maintenance/CLI writers, so cgroup allowance
+    does not depend on an assumed lifecycle ordering.
 
     `concurrent_read_connections` defaults to 4: a conservative but not
     extreme estimate of simultaneous interactive reads (CLI/MCP/API) during
@@ -276,9 +282,14 @@ def mapped_bytes_budget(*, concurrent_read_connections: int = 4) -> int:
     return (
         BULK_BUILD_MMAP_SIZE_BYTES
         + BULK_BUILD_CACHE_SIZE_KIB * 1024
+        + WRITE_MMAP_SIZE_BYTES
+        + WRITE_CACHE_SIZE_KIB * 1024
         + DAEMON_WRITE_MMAP_SIZE_BYTES
         + DAEMON_WRITE_CACHE_SIZE_KIB * 1024
         + concurrent_read_connections * (READ_MMAP_SIZE_BYTES + READ_CACHE_SIZE_KIB * 1024)
+        + BOUNDED_REPAIR_MMAP_SIZE_BYTES
+        + BOUNDED_REPAIR_CACHE_SIZE_KIB * 1024
+        + OBSERVATION_JOURNAL_CACHE_SIZE_KIB * 1024
     )
 
 
@@ -303,6 +314,28 @@ class MappedBytesBudgetCheck:
     @property
     def memory_budget_mb(self) -> float:
         return round(self.effective_memory_budget_bytes / (1024 * 1024), 1)
+
+    @property
+    def concurrent_read_budget_bytes(self) -> int:
+        return self.concurrent_read_connections * (READ_MMAP_SIZE_BYTES + READ_CACHE_SIZE_KIB * 1024)
+
+    @property
+    def concurrent_profile_budget_bytes(self) -> int:
+        return (
+            BULK_BUILD_MMAP_SIZE_BYTES
+            + BULK_BUILD_CACHE_SIZE_KIB * 1024
+            + WRITE_MMAP_SIZE_BYTES
+            + WRITE_CACHE_SIZE_KIB * 1024
+            + DAEMON_WRITE_MMAP_SIZE_BYTES
+            + DAEMON_WRITE_CACHE_SIZE_KIB * 1024
+            + BOUNDED_REPAIR_MMAP_SIZE_BYTES
+            + BOUNDED_REPAIR_CACHE_SIZE_KIB * 1024
+            + OBSERVATION_JOURNAL_CACHE_SIZE_KIB * 1024
+        )
+
+    @property
+    def concurrent_allowance_bytes(self) -> int:
+        return self.concurrent_read_budget_bytes + self.concurrent_profile_budget_bytes
 
     @property
     def memory_max_mb(self) -> float | None:
@@ -368,7 +401,11 @@ def log_mapped_bytes_budget_check(logger: BoundLoggerLike, check: MappedBytesBud
             "mmap_budget_no_cgroup_limit_detected",
             memory_budget_bytes=check.effective_memory_budget_bytes,
             memory_budget_mb=check.memory_budget_mb,
+            budget_bytes=check.budget_bytes,
             budget_mb=check.budget_mb,
+            concurrent_allowance_bytes=check.concurrent_allowance_bytes,
+            concurrent_read_budget_bytes=check.concurrent_read_budget_bytes,
+            concurrent_profile_budget_bytes=check.concurrent_profile_budget_bytes,
             concurrent_read_connections=check.concurrent_read_connections,
         )
         return
@@ -378,7 +415,11 @@ def log_mapped_bytes_budget_check(logger: BoundLoggerLike, check: MappedBytesBud
             "mmap_budget_at_or_above_cgroup_limit",
             memory_budget_bytes=check.effective_memory_budget_bytes,
             memory_budget_mb=check.memory_budget_mb,
+            budget_bytes=check.budget_bytes,
             budget_mb=check.budget_mb,
+            concurrent_allowance_bytes=check.concurrent_allowance_bytes,
+            concurrent_read_budget_bytes=check.concurrent_read_budget_bytes,
+            concurrent_profile_budget_bytes=check.concurrent_profile_budget_bytes,
             memory_max_mb=check.memory_max_mb,
             memory_high_mb=check.memory_high_mb,
             at_risk_limits=list(at_risk),
@@ -389,7 +430,11 @@ def log_mapped_bytes_budget_check(logger: BoundLoggerLike, check: MappedBytesBud
             "mmap_budget_within_cgroup_limit",
             memory_budget_bytes=check.effective_memory_budget_bytes,
             memory_budget_mb=check.memory_budget_mb,
+            budget_bytes=check.budget_bytes,
             budget_mb=check.budget_mb,
+            concurrent_allowance_bytes=check.concurrent_allowance_bytes,
+            concurrent_read_budget_bytes=check.concurrent_read_budget_bytes,
+            concurrent_profile_budget_bytes=check.concurrent_profile_budget_bytes,
             memory_max_mb=check.memory_max_mb,
             memory_high_mb=check.memory_high_mb,
             concurrent_read_connections=check.concurrent_read_connections,
@@ -540,6 +585,8 @@ def connection_context(path: str | Path, *, timeout: float = DB_TIMEOUT) -> Iter
 __all__ = [
     "DB_TIMEOUT",
     "DEFAULT_MEMORY_BUDGET_BYTES",
+    "BOUNDED_REPAIR_CACHE_SIZE_KIB",
+    "BOUNDED_REPAIR_MMAP_SIZE_BYTES",
     "BULK_BUILD_CACHE_SIZE_KIB",
     "BULK_BUILD_MMAP_SIZE_BYTES",
     "BULK_BUILD_WRITE_CONNECTION_PRAGMA_STATEMENTS",
@@ -551,6 +598,7 @@ __all__ = [
     "MEMORY_BUDGET_BYTES",
     "MEMORY_BUDGET_ENV_VAR",
     "MappedBytesBudgetCheck",
+    "OBSERVATION_JOURNAL_CACHE_SIZE_KIB",
     "READ_CACHE_SIZE_KIB",
     "READ_CONNECTION_PRAGMA_STATEMENTS",
     "READ_CONNECTION_PROFILE",

--- a/polylogue/storage/sqlite/connection_profile.py
+++ b/polylogue/storage/sqlite/connection_profile.py
@@ -89,12 +89,35 @@ DB_TIMEOUT = 30
 # wait out the checkpoint and succeed while staying far below the 30 s writer
 # timeout, so reads remain responsive.
 READ_DB_TIMEOUT = 5
-WRITE_CACHE_SIZE_KIB = 131072  # 128 MiB
-DAEMON_WRITE_CACHE_SIZE_KIB = 16384  # 16 MiB
-READ_CACHE_SIZE_KIB = 32768  # 32 MiB
-WRITE_MMAP_SIZE_BYTES = 1073741824  # 1 GiB
-DAEMON_WRITE_MMAP_SIZE_BYTES = 67108864  # 64 MiB
-READ_MMAP_SIZE_BYTES = 134217728  # 128 MiB
+MEMORY_BUDGET_ENV_VAR = "POLYLOGUE_MEMORY_BUDGET_BYTES"
+DEFAULT_MEMORY_BUDGET_BYTES = 18 * 1024**3
+
+
+def _read_declared_memory_budget_bytes() -> int:
+    """Resolve the optional typed config/env budget, preserving current defaults."""
+    from polylogue.config import load_polylogue_config
+
+    configured = load_polylogue_config().memory_budget_bytes
+    return configured if configured is not None else DEFAULT_MEMORY_BUDGET_BYTES
+
+
+MEMORY_BUDGET_BYTES = _read_declared_memory_budget_bytes()
+
+
+def _scale_profile_size(default_size: int) -> int:
+    """Scale one mmap/cache limit proportionally to the effective budget."""
+    return max(1, round(default_size * MEMORY_BUDGET_BYTES / DEFAULT_MEMORY_BUDGET_BYTES))
+
+
+# The measured defaults remain unchanged when no budget is configured. The
+# service unit can export MEMORY_BUDGET_ENV_VAR from the same declared budget
+# used for its cgroup limits, moving every SQLite mmap/cache allowance together.
+WRITE_CACHE_SIZE_KIB = _scale_profile_size(131072)  # 128 MiB
+DAEMON_WRITE_CACHE_SIZE_KIB = _scale_profile_size(16384)  # 16 MiB
+READ_CACHE_SIZE_KIB = _scale_profile_size(32768)  # 32 MiB
+WRITE_MMAP_SIZE_BYTES = _scale_profile_size(1073741824)  # 1 GiB
+DAEMON_WRITE_MMAP_SIZE_BYTES = _scale_profile_size(67108864)  # 64 MiB
+READ_MMAP_SIZE_BYTES = _scale_profile_size(134217728)  # 128 MiB
 WAL_AUTOCHECKPOINT_PAGES = 10000
 # #1614: soft cap on the WAL file. After any checkpoint that frees
 # pages, SQLite truncates the WAL down to this size. Without this cap
@@ -158,8 +181,8 @@ DAEMON_WRITE_CONNECTION_PROFILE = SQLiteConnectionProfile(
 #     built) is far larger than one incremental daemon write, and there is no
 #     competing live-writer cgroup budget to share (this is a throwaway,
 #     single-purpose process).
-BULK_BUILD_CACHE_SIZE_KIB = 524288  # 512 MiB
-BULK_BUILD_MMAP_SIZE_BYTES = 4294967296  # 4 GiB
+BULK_BUILD_CACHE_SIZE_KIB = _scale_profile_size(524288)  # 512 MiB
+BULK_BUILD_MMAP_SIZE_BYTES = _scale_profile_size(4294967296)  # 4 GiB
 
 BULK_BUILD_WRITE_CONNECTION_PROFILE = SQLiteConnectionProfile(
     role="write",
@@ -267,10 +290,19 @@ class MappedBytesBudgetCheck:
     memory_max_bytes: int | None
     memory_high_bytes: int | None
     concurrent_read_connections: int
+    memory_budget_bytes: int | None = None
 
     @property
     def budget_mb(self) -> float:
         return round(self.budget_bytes / (1024 * 1024), 1)
+
+    @property
+    def effective_memory_budget_bytes(self) -> int:
+        return self.memory_budget_bytes if self.memory_budget_bytes is not None else MEMORY_BUDGET_BYTES
+
+    @property
+    def memory_budget_mb(self) -> float:
+        return round(self.effective_memory_budget_bytes / (1024 * 1024), 1)
 
     @property
     def memory_max_mb(self) -> float | None:
@@ -316,6 +348,7 @@ def check_mapped_bytes_budget_against_cgroup_limit(*, concurrent_read_connection
         memory_max_bytes=read_cgroup_memory_max_bytes(),
         memory_high_bytes=read_cgroup_memory_high_bytes(),
         concurrent_read_connections=concurrent_read_connections,
+        memory_budget_bytes=MEMORY_BUDGET_BYTES,
     )
 
 
@@ -333,6 +366,8 @@ def log_mapped_bytes_budget_check(logger: BoundLoggerLike, check: MappedBytesBud
     if check.memory_max_bytes is None and check.memory_high_bytes is None:
         logger.debug(
             "mmap_budget_no_cgroup_limit_detected",
+            memory_budget_bytes=check.effective_memory_budget_bytes,
+            memory_budget_mb=check.memory_budget_mb,
             budget_mb=check.budget_mb,
             concurrent_read_connections=check.concurrent_read_connections,
         )
@@ -341,6 +376,8 @@ def log_mapped_bytes_budget_check(logger: BoundLoggerLike, check: MappedBytesBud
     if at_risk:
         logger.warning(
             "mmap_budget_at_or_above_cgroup_limit",
+            memory_budget_bytes=check.effective_memory_budget_bytes,
+            memory_budget_mb=check.memory_budget_mb,
             budget_mb=check.budget_mb,
             memory_max_mb=check.memory_max_mb,
             memory_high_mb=check.memory_high_mb,
@@ -350,6 +387,8 @@ def log_mapped_bytes_budget_check(logger: BoundLoggerLike, check: MappedBytesBud
     else:
         logger.info(
             "mmap_budget_within_cgroup_limit",
+            memory_budget_bytes=check.effective_memory_budget_bytes,
+            memory_budget_mb=check.memory_budget_mb,
             budget_mb=check.budget_mb,
             memory_max_mb=check.memory_max_mb,
             memory_high_mb=check.memory_high_mb,
@@ -500,6 +539,7 @@ def connection_context(path: str | Path, *, timeout: float = DB_TIMEOUT) -> Iter
 
 __all__ = [
     "DB_TIMEOUT",
+    "DEFAULT_MEMORY_BUDGET_BYTES",
     "BULK_BUILD_CACHE_SIZE_KIB",
     "BULK_BUILD_MMAP_SIZE_BYTES",
     "BULK_BUILD_WRITE_CONNECTION_PRAGMA_STATEMENTS",
@@ -508,6 +548,8 @@ __all__ = [
     "DAEMON_WRITE_CONNECTION_PRAGMA_STATEMENTS",
     "DAEMON_WRITE_CONNECTION_PROFILE",
     "DAEMON_WRITE_MMAP_SIZE_BYTES",
+    "MEMORY_BUDGET_BYTES",
+    "MEMORY_BUDGET_ENV_VAR",
     "MappedBytesBudgetCheck",
     "READ_CACHE_SIZE_KIB",
     "READ_CONNECTION_PRAGMA_STATEMENTS",

--- a/polylogue/storage/sqlite/connection_profile.py
+++ b/polylogue/storage/sqlite/connection_profile.py
@@ -61,7 +61,11 @@ class SQLiteConnectionProfile:
             statements.append(f"PRAGMA synchronous = {self.synchronous}")
         statements.extend(
             (
-                f"PRAGMA mmap_size = {self.mmap_size_bytes}",
+                # Qualify the schema explicitly.  An unqualified mmap_size
+                # pragma becomes the default for databases attached later,
+                # charging every sibling tier against a budget that counts
+                # this profile once.
+                f"PRAGMA main.mmap_size = {self.mmap_size_bytes}",
                 f"PRAGMA temp_store = {self.temp_store}",
             )
         )

--- a/tests/unit/core/test_config_inventory.py
+++ b/tests/unit/core/test_config_inventory.py
@@ -79,6 +79,7 @@ def test_inventory_env_mapping_is_executable(monkeypatch: pytest.MonkeyPatch, wo
     monkeypatch.setenv("POLYLOGUE_BROWSER_CAPTURE_AUTH_TOKEN", "receiver-token")
     monkeypatch.setenv("POLYLOGUE_BROWSER_CAPTURE_SPOOL_PATH", "/tmp/polylogue-spool")
     monkeypatch.setenv("POLYLOGUE_HEALTH_BLOB_INTEGRITY_SAMPLE_SIZE", "3")
+    monkeypatch.setenv("POLYLOGUE_MEMORY_BUDGET_BYTES", "123456789")
     monkeypatch.setenv("NO_COLOR", "1")
 
     cfg = load_polylogue_config()
@@ -92,7 +93,31 @@ def test_inventory_env_mapping_is_executable(monkeypatch: pytest.MonkeyPatch, wo
     assert cfg.browser_capture_auth_token == "receiver-token"
     assert cfg.browser_capture_spool_path == "/tmp/polylogue-spool"
     assert cfg.health_blob_integrity_sample_size == 3
+    assert inventory["memory_budget_bytes"].env_var == "POLYLOGUE_MEMORY_BUDGET_BYTES"
+    assert cfg.memory_budget_bytes == 123456789
+    assert cfg.layer_of("memory_budget_bytes") == "env"
     assert cfg.no_color is True
+
+
+def test_memory_budget_is_typed_across_toml_and_env_and_rejects_invalid_values(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_env: dict[str, Path],
+) -> None:
+    from polylogue.config import ConfigError, load_polylogue_config
+
+    monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", "")
+    config_path = tmp_path / "polylogue.toml"
+    config_path.write_text("[resource]\nmemory_budget_bytes = 987654321\n", encoding="utf-8")
+
+    cfg = load_polylogue_config(config_path=config_path)
+    assert cfg.memory_budget_bytes == 987654321
+    assert cfg.layer_of("memory_budget_bytes") == "user"
+
+    for raw_value in ("", "0", "-1", "not-a-number"):
+        monkeypatch.setenv("POLYLOGUE_MEMORY_BUDGET_BYTES", raw_value)
+        with pytest.raises(ConfigError, match=re.escape(f"POLYLOGUE_MEMORY_BUDGET_BYTES={raw_value!r}")):
+            load_polylogue_config()
 
 
 def test_effective_config_payload_redacts_secret_presence_and_exposes_source_layer(

--- a/tests/unit/core/test_metrics_cgroup_memory_limits.py
+++ b/tests/unit/core/test_metrics_cgroup_memory_limits.py
@@ -1,10 +1,10 @@
 """polylogue-e98k: cgroup memory.max/memory.high readers used by the mmap budget check.
 
 Production dependency exercised: the real ``read_cgroup_memory_max_bytes``/
-``read_cgroup_memory_high_bytes`` -> ``_read_cgroup_int`` -> ``_cgroup_file``
-chain, not a reimplemented parser. Reverting either reader to always return
-``None`` (or to mis-treat the literal ``"max"`` value as a real 0-byte limit)
-would make these tests fail.
+``read_cgroup_memory_high_bytes`` -> ancestor-aware limit reader, not a
+reimplemented parser. Reverting either reader to always return ``None``, to
+read only the leaf cgroup, or to mis-treat the literal ``"max"`` value as a
+real 0-byte limit would make these tests fail.
 """
 
 from __future__ import annotations
@@ -17,22 +17,20 @@ from polylogue.core import metrics as metrics_module
 from polylogue.core.metrics import read_cgroup_memory_high_bytes, read_cgroup_memory_max_bytes
 
 
-def _patch_cgroup_file(monkeypatch: pytest.MonkeyPatch, cgroup_dir: Path) -> None:
-    def _fake_cgroup_file(name: str) -> Path:
-        return cgroup_dir / name
-
-    monkeypatch.setattr(metrics_module, "_cgroup_file", _fake_cgroup_file)
+def _patch_cgroup_hierarchy(monkeypatch: pytest.MonkeyPatch, cgroup_root: Path, cgroup_path: str = "/") -> None:
+    monkeypatch.setattr(metrics_module, "_CGROUP_V2_ROOT", cgroup_root)
+    monkeypatch.setattr(metrics_module, "read_cgroup_path", lambda: cgroup_path)
 
 
 def test_read_cgroup_memory_max_bytes_parses_numeric_limit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     (tmp_path / "memory.max").write_text("19327352832\n")  # 18 GiB
-    _patch_cgroup_file(monkeypatch, tmp_path)
+    _patch_cgroup_hierarchy(monkeypatch, tmp_path)
     assert read_cgroup_memory_max_bytes() == 19327352832
 
 
 def test_read_cgroup_memory_high_bytes_parses_numeric_limit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     (tmp_path / "memory.high").write_text("15032385536\n")  # 14 GiB
-    _patch_cgroup_file(monkeypatch, tmp_path)
+    _patch_cgroup_hierarchy(monkeypatch, tmp_path)
     assert read_cgroup_memory_high_bytes() == 15032385536
 
 
@@ -40,7 +38,7 @@ def test_read_cgroup_memory_max_bytes_treats_literal_max_as_unlimited(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     (tmp_path / "memory.max").write_text("max\n")
-    _patch_cgroup_file(monkeypatch, tmp_path)
+    _patch_cgroup_hierarchy(monkeypatch, tmp_path)
     assert read_cgroup_memory_max_bytes() is None
 
 
@@ -49,11 +47,46 @@ def test_read_cgroup_memory_max_bytes_missing_file_returns_none(
 ) -> None:
     """No cgroup file at all (no controller / not in a cgroup) degrades to None,
     never an exception -- the dev-machine / cloud-sandbox ordinary case."""
-    _patch_cgroup_file(monkeypatch, tmp_path)  # directory exists but no memory.max inside
+    _patch_cgroup_hierarchy(monkeypatch, tmp_path)  # directory exists but no memory.max inside
     assert read_cgroup_memory_max_bytes() is None
 
 
+def test_read_cgroup_memory_limits_use_minimum_finite_nested_ancestor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "cgroup"
+    parent = root / "parent"
+    leaf = parent / "leaf"
+    leaf.mkdir(parents=True)
+    (root / "memory.max").write_text("max\n")
+    (root / "memory.high").write_text("21474836480\n")  # 20 GiB
+    (parent / "memory.max").write_text("12884901888\n")  # 12 GiB
+    (parent / "memory.high").write_text("10737418240\n")  # 10 GiB
+    (leaf / "memory.max").write_text("17179869184\n")  # 16 GiB
+    (leaf / "memory.high").write_text("max\n")
+    _patch_cgroup_hierarchy(monkeypatch, root, "/parent/leaf")
+
+    assert read_cgroup_memory_max_bytes() == 12884901888
+    assert read_cgroup_memory_high_bytes() == 10737418240
+
+
+def test_read_cgroup_memory_limits_return_none_when_nested_hierarchy_is_unlimited(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "cgroup"
+    parent = root / "parent"
+    leaf = parent / "leaf"
+    leaf.mkdir(parents=True)
+    for cgroup_dir in (root, parent, leaf):
+        (cgroup_dir / "memory.max").write_text("max\n")
+        (cgroup_dir / "memory.high").write_text("max\n")
+    _patch_cgroup_hierarchy(monkeypatch, root, "/parent/leaf")
+
+    assert read_cgroup_memory_max_bytes() is None
+    assert read_cgroup_memory_high_bytes() is None
+
+
 def test_read_cgroup_memory_max_bytes_no_cgroup_path_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(metrics_module, "_cgroup_file", lambda name: None)
+    monkeypatch.setattr(metrics_module, "read_cgroup_path", lambda: None)
     assert read_cgroup_memory_max_bytes() is None
     assert read_cgroup_memory_high_bytes() is None

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -475,6 +475,42 @@ def test_archive_fts_global_repair_defers_sqlite_lock(
     assert stages.repair_messages_fts_surface(archive_db) is False
 
 
+def test_archive_fts_global_repair_scopes_bounded_mmap_to_main_tier(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The real archive repair route must not map its attached sibling tiers."""
+    from polylogue.storage.fts import dangling_repair
+    from polylogue.storage.sqlite.connection_profile import (
+        BOUNDED_REPAIR_MMAP_SIZE_BYTES,
+        DAEMON_WRITE_MMAP_SIZE_BYTES,
+    )
+
+    archive_db = tmp_path / "index.db"
+    source_path = tmp_path / "codex.jsonl"
+    _seed_minimal_archive(archive_db, source_path)
+    for tier_name in ("user.db", "embeddings.db", "ops.db"):
+        sqlite3.connect(tmp_path / tier_name).close()
+
+    observed: dict[str, int] = {}
+    real_configure = dangling_repair.configure_bounded_repair_connection
+
+    def configure_and_capture(conn: sqlite3.Connection) -> None:
+        real_configure(conn)
+        for schema_name in ("main", "source_tier", "user_tier", "embeddings", "ops_tier"):
+            observed[schema_name] = int(conn.execute(f"PRAGMA {schema_name}.mmap_size").fetchone()[0])
+
+    monkeypatch.setattr(dangling_repair, "configure_bounded_repair_connection", configure_and_capture)
+
+    assert stages.repair_messages_fts_surface(archive_db) is True
+    assert observed == {
+        "main": BOUNDED_REPAIR_MMAP_SIZE_BYTES,
+        "source_tier": DAEMON_WRITE_MMAP_SIZE_BYTES,
+        "user_tier": DAEMON_WRITE_MMAP_SIZE_BYTES,
+        "embeddings": DAEMON_WRITE_MMAP_SIZE_BYTES,
+        "ops_tier": DAEMON_WRITE_MMAP_SIZE_BYTES,
+    }
+
+
 def test_archive_fts_optional_surface_repair_uses_stale_surface_repair(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -482,7 +482,6 @@ def test_archive_fts_global_repair_scopes_bounded_mmap_to_main_tier(
     from polylogue.storage.fts import dangling_repair
     from polylogue.storage.sqlite.connection_profile import (
         BOUNDED_REPAIR_MMAP_SIZE_BYTES,
-        DAEMON_WRITE_MMAP_SIZE_BYTES,
     )
 
     archive_db = tmp_path / "index.db"
@@ -504,10 +503,10 @@ def test_archive_fts_global_repair_scopes_bounded_mmap_to_main_tier(
     assert stages.repair_messages_fts_surface(archive_db) is True
     assert observed == {
         "main": BOUNDED_REPAIR_MMAP_SIZE_BYTES,
-        "source_tier": DAEMON_WRITE_MMAP_SIZE_BYTES,
-        "user_tier": DAEMON_WRITE_MMAP_SIZE_BYTES,
-        "embeddings": DAEMON_WRITE_MMAP_SIZE_BYTES,
-        "ops_tier": DAEMON_WRITE_MMAP_SIZE_BYTES,
+        "source_tier": 0,
+        "user_tier": 0,
+        "embeddings": 0,
+        "ops_tier": 0,
     }
 
 

--- a/tests/unit/storage/test_mapped_bytes_budget.py
+++ b/tests/unit/storage/test_mapped_bytes_budget.py
@@ -19,15 +19,21 @@ import sys
 
 import pytest
 
+from polylogue.config import MAX_MEMORY_BUDGET_BYTES
 from polylogue.storage.sqlite.connection_profile import (
+    BOUNDED_REPAIR_CACHE_SIZE_KIB,
+    BOUNDED_REPAIR_MMAP_SIZE_BYTES,
     BULK_BUILD_CACHE_SIZE_KIB,
     BULK_BUILD_MMAP_SIZE_BYTES,
     DAEMON_WRITE_CACHE_SIZE_KIB,
     DAEMON_WRITE_MMAP_SIZE_BYTES,
     DEFAULT_MEMORY_BUDGET_BYTES,
     MEMORY_BUDGET_BYTES,
+    OBSERVATION_JOURNAL_CACHE_SIZE_KIB,
     READ_CACHE_SIZE_KIB,
     READ_MMAP_SIZE_BYTES,
+    WRITE_CACHE_SIZE_KIB,
+    WRITE_MMAP_SIZE_BYTES,
     MappedBytesBudgetCheck,
     check_mapped_bytes_budget_against_cgroup_limit,
     log_mapped_bytes_budget_check,
@@ -43,11 +49,14 @@ def _import_profile_values(*, budget_bytes: int | None) -> dict[str, int]:
         env["POLYLOGUE_MEMORY_BUDGET_BYTES"] = str(budget_bytes)
     code = """
 from polylogue.storage.sqlite.connection_profile import (
+    BOUNDED_REPAIR_CACHE_SIZE_KIB,
+    BOUNDED_REPAIR_MMAP_SIZE_BYTES,
     BULK_BUILD_CACHE_SIZE_KIB,
     BULK_BUILD_MMAP_SIZE_BYTES,
     DAEMON_WRITE_CACHE_SIZE_KIB,
     DAEMON_WRITE_MMAP_SIZE_BYTES,
     MEMORY_BUDGET_BYTES,
+    OBSERVATION_JOURNAL_CACHE_SIZE_KIB,
     READ_CACHE_SIZE_KIB,
     READ_MMAP_SIZE_BYTES,
     WRITE_CACHE_SIZE_KIB,
@@ -63,6 +72,9 @@ print(" ".join(str(value) for value in (
     DAEMON_WRITE_MMAP_SIZE_BYTES,
     READ_MMAP_SIZE_BYTES,
     BULK_BUILD_MMAP_SIZE_BYTES,
+    BOUNDED_REPAIR_CACHE_SIZE_KIB,
+    BOUNDED_REPAIR_MMAP_SIZE_BYTES,
+    OBSERVATION_JOURNAL_CACHE_SIZE_KIB,
 )))
 """
     completed = subprocess.run(
@@ -83,6 +95,9 @@ print(" ".join(str(value) for value in (
         "daemon_write_mmap_size_bytes",
         "read_mmap_size_bytes",
         "bulk_build_mmap_size_bytes",
+        "bounded_repair_cache_size_kib",
+        "bounded_repair_mmap_size_bytes",
+        "observation_journal_cache_size_kib",
     )
     return dict(zip(keys, values, strict=True))
 
@@ -99,6 +114,9 @@ def test_declared_budget_preserves_defaults_when_absent() -> None:
         "daemon_write_mmap_size_bytes": 67108864,
         "read_mmap_size_bytes": 134217728,
         "bulk_build_mmap_size_bytes": 4294967296,
+        "bounded_repair_cache_size_kib": 32768,
+        "bounded_repair_mmap_size_bytes": 134217728,
+        "observation_journal_cache_size_kib": 65536,
     }
 
 
@@ -114,7 +132,39 @@ def test_declared_budget_scales_all_profile_mmap_and_cache_sizes() -> None:
         "daemon_write_mmap_size_bytes": 33554432,
         "read_mmap_size_bytes": 67108864,
         "bulk_build_mmap_size_bytes": 2147483648,
+        "bounded_repair_cache_size_kib": 16384,
+        "bounded_repair_mmap_size_bytes": 67108864,
+        "observation_journal_cache_size_kib": 32768,
     }
+
+
+def test_declared_budget_reaches_omitted_profile_routes() -> None:
+    env = os.environ.copy()
+    env["POLYLOGUE_MEMORY_BUDGET_BYTES"] = str(DEFAULT_MEMORY_BUDGET_BYTES // 2)
+    code = """
+import sqlite3
+import tempfile
+from pathlib import Path
+from polylogue.schemas.generation.observation_journal import ObservationJournal
+from polylogue.storage.fts.dangling_repair import configure_bounded_repair_connection
+with tempfile.TemporaryDirectory() as root:
+    repair = sqlite3.connect(Path(root) / 'repair.db')
+    configure_bounded_repair_connection(repair)
+    with ObservationJournal.create(root=Path(root)) as journal:
+        print(
+            repair.execute('PRAGMA cache_size').fetchone()[0],
+            repair.execute('PRAGMA mmap_size').fetchone()[0],
+            journal._connection.execute('PRAGMA cache_size').fetchone()[0],
+        )
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert completed.stdout.strip() == "-16384 67108864 -32768"
 
 
 def test_scaled_budget_drives_startup_warning_threshold() -> None:
@@ -146,7 +196,7 @@ print(check.memory_budget_bytes, check.budget_bytes, check.at_risk_limits)
     assert thresholds == "('memory.max', 'memory.high')"
 
 
-@pytest.mark.parametrize("raw_budget", ["", "0", "-1", "not-a-number"])
+@pytest.mark.parametrize("raw_budget", ["", "0", "-1", "not-a-number", str(MAX_MEMORY_BUDGET_BYTES + 1)])
 def test_invalid_declared_budget_fails_loudly(raw_budget: str) -> None:
     env = os.environ.copy()
     env["POLYLOGUE_MEMORY_BUDGET_BYTES"] = raw_budget
@@ -163,7 +213,7 @@ def test_invalid_declared_budget_fails_loudly(raw_budget: str) -> None:
 
 
 def test_mapped_bytes_budget_reflects_documented_worst_case() -> None:
-    """Budget = bulk-build + daemon-write + N concurrent read connections.
+    """Budget includes all modeled concurrent SQLite profile allowances.
 
     Not just the single largest constant (``BULK_BUILD_MMAP_SIZE_BYTES``) --
     that was exactly the gap the 2026-07-31 incident exposed: one bulk-build
@@ -173,9 +223,14 @@ def test_mapped_bytes_budget_reflects_documented_worst_case() -> None:
     expected = (
         BULK_BUILD_MMAP_SIZE_BYTES
         + BULK_BUILD_CACHE_SIZE_KIB * 1024
+        + WRITE_MMAP_SIZE_BYTES
+        + WRITE_CACHE_SIZE_KIB * 1024
         + DAEMON_WRITE_MMAP_SIZE_BYTES
         + DAEMON_WRITE_CACHE_SIZE_KIB * 1024
         + 4 * (READ_MMAP_SIZE_BYTES + READ_CACHE_SIZE_KIB * 1024)
+        + BOUNDED_REPAIR_MMAP_SIZE_BYTES
+        + BOUNDED_REPAIR_CACHE_SIZE_KIB * 1024
+        + OBSERVATION_JOURNAL_CACHE_SIZE_KIB * 1024
     )
     assert mapped_bytes_budget() == expected
     # Strictly greater than the single largest constant alone -- proves this
@@ -200,6 +255,10 @@ def test_check_reads_cgroup_limits_via_core_metrics(monkeypatch: pytest.MonkeyPa
     assert check.memory_high_bytes == 16 * 1024 * 1024 * 1024
     assert check.budget_bytes == mapped_bytes_budget()
     assert check.memory_budget_bytes == MEMORY_BUDGET_BYTES
+    assert (
+        check.concurrent_allowance_bytes == check.concurrent_read_budget_bytes + check.concurrent_profile_budget_bytes
+    )
+    assert check.concurrent_allowance_bytes == check.budget_bytes
 
 
 def test_at_risk_when_limit_at_or_below_budget() -> None:
@@ -292,6 +351,8 @@ def test_warns_when_at_risk() -> None:
     assert message == "mmap_budget_at_or_above_cgroup_limit"
     assert kw["at_risk_limits"] == ["memory.high"]
     assert kw["memory_budget_bytes"] == MEMORY_BUDGET_BYTES
+    assert kw["budget_bytes"] == budget
+    assert kw["concurrent_allowance_bytes"] == check.concurrent_allowance_bytes
 
 
 def test_warning_threshold_uses_effective_budget() -> None:

--- a/tests/unit/storage/test_mapped_bytes_budget.py
+++ b/tests/unit/storage/test_mapped_bytes_budget.py
@@ -127,6 +127,7 @@ async def test_async_attached_tier_profiles_map_main_only(
         for schema in ("main", *_ATTACHED_SCHEMAS):
             cursor = await conn.execute(f"PRAGMA {schema}.mmap_size")
             row = await cursor.fetchone()
+            assert row is not None
             values[schema] = int(row[0])
         assert values == {
             "main": configured_mmap_size,

--- a/tests/unit/storage/test_mapped_bytes_budget.py
+++ b/tests/unit/storage/test_mapped_bytes_budget.py
@@ -13,6 +13,10 @@ empty would make ``test_at_risk_when_limit_at_or_below_budget`` fail to warn.
 
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
+
 import pytest
 
 from polylogue.storage.sqlite.connection_profile import (
@@ -20,6 +24,8 @@ from polylogue.storage.sqlite.connection_profile import (
     BULK_BUILD_MMAP_SIZE_BYTES,
     DAEMON_WRITE_CACHE_SIZE_KIB,
     DAEMON_WRITE_MMAP_SIZE_BYTES,
+    DEFAULT_MEMORY_BUDGET_BYTES,
+    MEMORY_BUDGET_BYTES,
     READ_CACHE_SIZE_KIB,
     READ_MMAP_SIZE_BYTES,
     MappedBytesBudgetCheck,
@@ -27,6 +33,133 @@ from polylogue.storage.sqlite.connection_profile import (
     log_mapped_bytes_budget_check,
     mapped_bytes_budget,
 )
+
+
+def _import_profile_values(*, budget_bytes: int | None) -> dict[str, int]:
+    env = os.environ.copy()
+    if budget_bytes is None:
+        env.pop("POLYLOGUE_MEMORY_BUDGET_BYTES", None)
+    else:
+        env["POLYLOGUE_MEMORY_BUDGET_BYTES"] = str(budget_bytes)
+    code = """
+from polylogue.storage.sqlite.connection_profile import (
+    BULK_BUILD_CACHE_SIZE_KIB,
+    BULK_BUILD_MMAP_SIZE_BYTES,
+    DAEMON_WRITE_CACHE_SIZE_KIB,
+    DAEMON_WRITE_MMAP_SIZE_BYTES,
+    MEMORY_BUDGET_BYTES,
+    READ_CACHE_SIZE_KIB,
+    READ_MMAP_SIZE_BYTES,
+    WRITE_CACHE_SIZE_KIB,
+    WRITE_MMAP_SIZE_BYTES,
+)
+print(" ".join(str(value) for value in (
+    MEMORY_BUDGET_BYTES,
+    WRITE_CACHE_SIZE_KIB,
+    DAEMON_WRITE_CACHE_SIZE_KIB,
+    READ_CACHE_SIZE_KIB,
+    BULK_BUILD_CACHE_SIZE_KIB,
+    WRITE_MMAP_SIZE_BYTES,
+    DAEMON_WRITE_MMAP_SIZE_BYTES,
+    READ_MMAP_SIZE_BYTES,
+    BULK_BUILD_MMAP_SIZE_BYTES,
+)))
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    values = [int(value) for value in completed.stdout.split()]
+    keys = (
+        "memory_budget_bytes",
+        "write_cache_size_kib",
+        "daemon_write_cache_size_kib",
+        "read_cache_size_kib",
+        "bulk_build_cache_size_kib",
+        "write_mmap_size_bytes",
+        "daemon_write_mmap_size_bytes",
+        "read_mmap_size_bytes",
+        "bulk_build_mmap_size_bytes",
+    )
+    return dict(zip(keys, values, strict=True))
+
+
+def test_declared_budget_preserves_defaults_when_absent() -> None:
+    values = _import_profile_values(budget_bytes=None)
+    assert values == {
+        "memory_budget_bytes": DEFAULT_MEMORY_BUDGET_BYTES,
+        "write_cache_size_kib": 131072,
+        "daemon_write_cache_size_kib": 16384,
+        "read_cache_size_kib": 32768,
+        "bulk_build_cache_size_kib": 524288,
+        "write_mmap_size_bytes": 1073741824,
+        "daemon_write_mmap_size_bytes": 67108864,
+        "read_mmap_size_bytes": 134217728,
+        "bulk_build_mmap_size_bytes": 4294967296,
+    }
+
+
+def test_declared_budget_scales_all_profile_mmap_and_cache_sizes() -> None:
+    values = _import_profile_values(budget_bytes=DEFAULT_MEMORY_BUDGET_BYTES // 2)
+    assert values == {
+        "memory_budget_bytes": DEFAULT_MEMORY_BUDGET_BYTES // 2,
+        "write_cache_size_kib": 65536,
+        "daemon_write_cache_size_kib": 8192,
+        "read_cache_size_kib": 16384,
+        "bulk_build_cache_size_kib": 262144,
+        "write_mmap_size_bytes": 536870912,
+        "daemon_write_mmap_size_bytes": 33554432,
+        "read_mmap_size_bytes": 67108864,
+        "bulk_build_mmap_size_bytes": 2147483648,
+    }
+
+
+def test_scaled_budget_drives_startup_warning_threshold() -> None:
+    env = os.environ.copy()
+    env["POLYLOGUE_MEMORY_BUDGET_BYTES"] = str(DEFAULT_MEMORY_BUDGET_BYTES // 2)
+    code = """
+import polylogue.core.metrics as metrics
+from polylogue.storage.sqlite.connection_profile import (
+    MEMORY_BUDGET_BYTES,
+    check_mapped_bytes_budget_against_cgroup_limit,
+    mapped_bytes_budget,
+)
+budget = mapped_bytes_budget()
+metrics.read_cgroup_memory_max_bytes = lambda: budget
+metrics.read_cgroup_memory_high_bytes = lambda: budget
+check = check_mapped_bytes_budget_against_cgroup_limit()
+print(check.memory_budget_bytes, check.budget_bytes, check.at_risk_limits)
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    budget_value, mapped_value, thresholds = completed.stdout.strip().split(maxsplit=2)
+    assert int(budget_value) == DEFAULT_MEMORY_BUDGET_BYTES // 2
+    assert int(mapped_value) > 0
+    assert thresholds == "('memory.max', 'memory.high')"
+
+
+@pytest.mark.parametrize("raw_budget", ["", "0", "-1", "not-a-number"])
+def test_invalid_declared_budget_fails_loudly(raw_budget: str) -> None:
+    env = os.environ.copy()
+    env["POLYLOGUE_MEMORY_BUDGET_BYTES"] = raw_budget
+    code = "from polylogue.storage.sqlite.connection_profile import MEMORY_BUDGET_BYTES; print(MEMORY_BUDGET_BYTES)"
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert completed.returncode != 0
+    assert "POLYLOGUE_MEMORY_BUDGET_BYTES" in completed.stderr
 
 
 def test_mapped_bytes_budget_reflects_documented_worst_case() -> None:
@@ -66,6 +199,7 @@ def test_check_reads_cgroup_limits_via_core_metrics(monkeypatch: pytest.MonkeyPa
     assert check.memory_max_bytes == 20 * 1024 * 1024 * 1024
     assert check.memory_high_bytes == 16 * 1024 * 1024 * 1024
     assert check.budget_bytes == mapped_bytes_budget()
+    assert check.memory_budget_bytes == MEMORY_BUDGET_BYTES
 
 
 def test_at_risk_when_limit_at_or_below_budget() -> None:
@@ -157,6 +291,38 @@ def test_warns_when_at_risk() -> None:
     assert level == "warning"
     assert message == "mmap_budget_at_or_above_cgroup_limit"
     assert kw["at_risk_limits"] == ["memory.high"]
+    assert kw["memory_budget_bytes"] == MEMORY_BUDGET_BYTES
+
+
+def test_warning_threshold_uses_effective_budget() -> None:
+    budget = mapped_bytes_budget()
+    check = MappedBytesBudgetCheck(
+        budget_bytes=budget,
+        memory_max_bytes=budget,
+        memory_high_bytes=budget,
+        concurrent_read_connections=4,
+        memory_budget_bytes=MEMORY_BUDGET_BYTES,
+    )
+
+    class _Recorder:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, str, dict[str, object]]] = []
+
+        def debug(self, message: str, **kw: object) -> None:
+            self.calls.append(("debug", message, kw))
+
+        def info(self, message: str, **kw: object) -> None:
+            self.calls.append(("info", message, kw))
+
+        def warning(self, message: str, **kw: object) -> None:
+            self.calls.append(("warning", message, kw))
+
+    recorder = _Recorder()
+    log_mapped_bytes_budget_check(recorder, check)  # type: ignore[arg-type]
+
+    assert recorder.calls[0][0] == "warning"
+    assert recorder.calls[0][2]["memory_budget_bytes"] == MEMORY_BUDGET_BYTES
+    assert recorder.calls[0][2]["budget_mb"] == round(budget / (1024 * 1024), 1)
 
 
 def test_logs_info_when_within_limits() -> None:

--- a/tests/unit/storage/test_mapped_bytes_budget.py
+++ b/tests/unit/storage/test_mapped_bytes_budget.py
@@ -14,12 +14,17 @@ empty would make ``test_at_risk_when_limit_at_or_below_budget`` fail to warn.
 from __future__ import annotations
 
 import os
+import sqlite3
 import subprocess
 import sys
+from collections.abc import Awaitable, Callable
+from pathlib import Path
 
+import aiosqlite
 import pytest
 
 from polylogue.config import MAX_MEMORY_BUDGET_BYTES
+from polylogue.storage.sqlite.async_sqlite import configure_connection, configure_read_connection
 from polylogue.storage.sqlite.connection_profile import (
     BOUNDED_REPAIR_CACHE_SIZE_KIB,
     BOUNDED_REPAIR_MMAP_SIZE_BYTES,
@@ -31,14 +36,107 @@ from polylogue.storage.sqlite.connection_profile import (
     MEMORY_BUDGET_BYTES,
     OBSERVATION_JOURNAL_CACHE_SIZE_KIB,
     READ_CACHE_SIZE_KIB,
+    READ_CONNECTION_PROFILE,
     READ_MMAP_SIZE_BYTES,
     WRITE_CACHE_SIZE_KIB,
+    WRITE_CONNECTION_PROFILE,
     WRITE_MMAP_SIZE_BYTES,
     MappedBytesBudgetCheck,
+    SQLiteConnectionProfile,
     check_mapped_bytes_budget_against_cgroup_limit,
     log_mapped_bytes_budget_check,
     mapped_bytes_budget,
+    open_connection,
+    open_daemon_connection,
 )
+
+_ATTACHED_SCHEMAS = ("source_tier", "user_tier", "embeddings", "ops_tier")
+
+
+def _seed_attached_archive_tiers(root: Path) -> None:
+    for filename in ("source.db", "user.db", "embeddings.db", "ops.db"):
+        sqlite3.connect(root / filename).close()
+
+
+def _mmap_values(conn: sqlite3.Connection) -> dict[str, int]:
+    return {
+        schema: int(conn.execute(f"PRAGMA {schema}.mmap_size").fetchone()[0]) for schema in ("main", *_ATTACHED_SCHEMAS)
+    }
+
+
+def test_all_connection_profiles_scope_mmap_to_main() -> None:
+    profiles: tuple[SQLiteConnectionProfile, ...] = (
+        WRITE_CONNECTION_PROFILE,
+        READ_CONNECTION_PROFILE,
+    )
+    from polylogue.storage.sqlite.connection_profile import (
+        BULK_BUILD_WRITE_CONNECTION_PROFILE,
+        DAEMON_WRITE_CONNECTION_PROFILE,
+    )
+
+    profiles += (DAEMON_WRITE_CONNECTION_PROFILE, BULK_BUILD_WRITE_CONNECTION_PROFILE)
+    for profile in profiles:
+        mmap_statements = tuple(statement for statement in profile.pragma_statements if "mmap_size" in statement)
+        assert mmap_statements == (f"PRAGMA main.mmap_size = {profile.mmap_size_bytes}",)
+
+
+@pytest.mark.parametrize(
+    ("factory", "configured_mmap_size"),
+    (
+        (open_connection, WRITE_MMAP_SIZE_BYTES),
+        (open_daemon_connection, DAEMON_WRITE_MMAP_SIZE_BYTES),
+    ),
+)
+def test_sync_attached_tier_profiles_map_main_only(
+    tmp_path: Path,
+    factory: Callable[[str | Path], sqlite3.Connection],
+    configured_mmap_size: int,
+) -> None:
+    _seed_attached_archive_tiers(tmp_path)
+    conn = factory(tmp_path / "index.db")
+    try:
+        assert _mmap_values(conn) == {
+            "main": configured_mmap_size,
+            "source_tier": 0,
+            "user_tier": 0,
+            "embeddings": 0,
+            "ops_tier": 0,
+        }
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("configure", "configured_mmap_size"),
+    (
+        (configure_connection, WRITE_MMAP_SIZE_BYTES),
+        (configure_read_connection, READ_MMAP_SIZE_BYTES),
+    ),
+)
+async def test_async_attached_tier_profiles_map_main_only(
+    tmp_path: Path,
+    configure: Callable[[aiosqlite.Connection], Awaitable[None]],
+    configured_mmap_size: int,
+) -> None:
+    _seed_attached_archive_tiers(tmp_path)
+    conn = await aiosqlite.connect(tmp_path / "index.db")
+    try:
+        await configure(conn)
+        values: dict[str, int] = {}
+        for schema in ("main", *_ATTACHED_SCHEMAS):
+            cursor = await conn.execute(f"PRAGMA {schema}.mmap_size")
+            row = await cursor.fetchone()
+            values[schema] = int(row[0])
+        assert values == {
+            "main": configured_mmap_size,
+            "source_tier": 0,
+            "user_tier": 0,
+            "embeddings": 0,
+            "ops_tier": 0,
+        }
+    finally:
+        await conn.close()
 
 
 def _import_profile_values(*, budget_bytes: int | None) -> dict[str, int]:


### PR DESCRIPTION
## Summary
Adds the Polylogue half of the SQLite memory-budget contract. `POLYLOGUE_MEMORY_BUDGET_BYTES` and `[resource].memory_budget_bytes` are optional, typed positive-byte inputs that scale every SQLite mmap/cache profile together.

## Problem
SQLite profile limits were fixed independently from the process memory budget. The existing startup mapped-budget observability also did not identify the effective declared budget, and invalid budget input could not fail through the typed config surface.

## Solution
- Added `memory_budget_bytes` to the layered config inventory with TOML and environment mappings.
- Validate absent or positive base-10 integer values; invalid values raise `ConfigError` during config resolution.
- Scale write, daemon-write, read, and bulk-build mmap/cache constants proportionally from the effective budget. Absent input preserves the existing 18 GiB-derived defaults.
- Preserved the existing startup warning threshold and included the effective declared budget in debug, info, and warning payloads.
- Documented the operator contract in `docs/daemon.md`.

## Verification
- `direnv exec . devtools test tests/unit/core/test_config_inventory.py tests/unit/storage/test_mapped_bytes_budget.py` -> `89 passed in 4.19s`
- `direnv exec . devtools verify --quick` -> exit code `0`; Ruff, mypy, render, layering, docs coverage, and policy checks passed.
- Pre-push hook reran `devtools verify --quick` at commit `79f1be0c5` -> exit code `0`.

## Acceptance criteria
| Criterion | Result |
| --- | --- |
| Optional typed config/env contract | Satisfied by `memory_budget_bytes`, `[resource].memory_budget_bytes`, and `POLYLOGUE_MEMORY_BUDGET_BYTES`. |
| Changed budget moves all relevant profile limits | Satisfied by subprocess coverage for write, daemon-write, read, and bulk-build mmap/cache values. |
| Defaults remain stable when absent | Satisfied by subprocess coverage against all previous constants and the 18 GiB effective default. |
| Invalid values fail loudly | Satisfied for blank, zero, negative, and non-numeric values through config and profile-import tests. |
| Existing startup warning uses effective values | Satisfied by scaled-budget threshold coverage and log assertions for the effective budget. |
| Current observability retained | Satisfied; existing debug/info/warning branches remain and now report `memory_budget_bytes` and `memory_budget_mb`. |

## Scope
Sinnix/systemd wiring is intentionally excluded from this Polylogue-only lane. No production archive or main checkout was touched.