### PR TITLE
fix(status): fail closed on unavailable convergence debt

### DIFF
--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -926,89 +926,102 @@ def _ops_workload_status(active_root: Path, *, now_ms: int) -> dict[str, Any]:
     except sqlite3.Error as exc:
         return {"available": False, "reason": f"convergence debt status unavailable: {exc}"}
     try:
-        if not _table_exists(conn, "ingest_attempts"):
-            return {"available": False, "reason": "missing_ingest_attempts"}
-        if not _table_exists(conn, "convergence_debt"):
-            return {"available": False, "reason": "missing_convergence_debt"}
+        try:
+            if not _table_exists(conn, "ingest_attempts"):
+                return {"available": False, "reason": "missing_ingest_attempts"}
+        except Exception as exc:
+            return {"available": False, "reason": f"ops workload status unavailable: {exc}"}
 
-        running_rows = conn.execute(
-            """
-            SELECT phase, origin, started_at_ms, heartbeat_at_ms,
-                   parsed_raw_count, materialized_count
-            FROM ingest_attempts
-            WHERE status = 'running'
-            ORDER BY started_at_ms DESC
-            """
-        ).fetchall()
-        running: list[dict[str, Any]] = []
-        actively_ingesting = False
-        for row in running_rows:
-            heartbeat = _safe_int(row[3], 0)
-            heartbeat_age_ms = now_ms - heartbeat if heartbeat else None
-            fresh = heartbeat_age_ms is not None and heartbeat_age_ms <= _WORKLOAD_HEARTBEAT_STALE_MS
-            actively_ingesting = actively_ingesting or fresh
-            running.append(
-                {
-                    "phase": row[0],
-                    "origin": row[1],
-                    "age_ms": now_ms - _safe_int(row[2], now_ms),
-                    "heartbeat_age_ms": heartbeat_age_ms,
-                    "heartbeat_fresh": fresh,
+        try:
+            if not _table_exists(conn, "convergence_debt"):
+                return {"available": False, "reason": "missing_convergence_debt"}
+        except Exception as exc:
+            return {"available": False, "reason": f"convergence debt status unavailable: {exc}"}
+
+        try:
+            running_rows = conn.execute(
+                """
+                SELECT phase, origin, started_at_ms, heartbeat_at_ms,
+                       parsed_raw_count, materialized_count
+                FROM ingest_attempts
+                WHERE status = 'running'
+                ORDER BY started_at_ms DESC
+                """
+            ).fetchall()
+            running: list[dict[str, Any]] = []
+            actively_ingesting = False
+            for row in running_rows:
+                heartbeat = _safe_int(row[3], 0)
+                heartbeat_age_ms = now_ms - heartbeat if heartbeat else None
+                fresh = heartbeat_age_ms is not None and heartbeat_age_ms <= _WORKLOAD_HEARTBEAT_STALE_MS
+                actively_ingesting = actively_ingesting or fresh
+                running.append(
+                    {
+                        "phase": row[0],
+                        "origin": row[1],
+                        "age_ms": now_ms - _safe_int(row[2], now_ms),
+                        "heartbeat_age_ms": heartbeat_age_ms,
+                        "heartbeat_fresh": fresh,
+                    }
+                )
+
+            window_start = now_ms - _WORKLOAD_THROUGHPUT_WINDOW_MS
+            tput = conn.execute(
+                """
+                SELECT COUNT(*),
+                       COALESCE(SUM(parsed_raw_count), 0),
+                       COALESCE(SUM(materialized_count), 0),
+                       COALESCE(SUM(finished_at_ms - started_at_ms), 0)
+                FROM ingest_attempts
+                WHERE status = 'completed' AND finished_at_ms >= ?
+                """,
+                (window_start,),
+            ).fetchone()
+            window_batches = _safe_int(tput[0], 0) if tput else 0
+            window_files = _safe_int(tput[1], 0) if tput else 0
+            window_materialized = _safe_int(tput[2], 0) if tput else 0
+            window_busy_ms = _safe_int(tput[3], 0) if tput else 0
+            files_per_s = (window_files / (window_busy_ms / 1000.0)) if window_busy_ms > 0 else 0.0
+
+            lifetime = {
+                status: _safe_int(count, 0)
+                for status, count in conn.execute(
+                    "SELECT status, COUNT(*) FROM ingest_attempts GROUP BY status"
+                ).fetchall()
+            }
+
+            cursor: dict[str, int] = {}
+            if _table_exists(conn, "ingest_cursor"):
+                cursor = {
+                    "tracked": _fast_count(conn, "SELECT COUNT(*) FROM ingest_cursor"),
+                    "excluded": _fast_count(conn, "SELECT COUNT(*) FROM ingest_cursor WHERE excluded = 1"),
+                    "retry_pending": _fast_count(
+                        conn,
+                        "SELECT COUNT(*) FROM ingest_cursor WHERE failure_count > 0 AND excluded = 0",
+                    ),
                 }
+        except Exception as exc:
+            return {"available": False, "reason": f"ops workload status unavailable: {exc}"}
+
+        try:
+            debt_rows = conn.execute("SELECT status, COUNT(*) FROM convergence_debt GROUP BY status").fetchall()
+            unknown_statuses = sorted(
+                {repr(status) for status, _count in debt_rows if status not in _CONVERGENCE_DEBT_STATUSES}
             )
-
-        window_start = now_ms - _WORKLOAD_THROUGHPUT_WINDOW_MS
-        tput = conn.execute(
-            """
-            SELECT COUNT(*),
-                   COALESCE(SUM(parsed_raw_count), 0),
-                   COALESCE(SUM(materialized_count), 0),
-                   COALESCE(SUM(finished_at_ms - started_at_ms), 0)
-            FROM ingest_attempts
-            WHERE status = 'completed' AND finished_at_ms >= ?
-            """,
-            (window_start,),
-        ).fetchone()
-        window_batches = _safe_int(tput[0], 0) if tput else 0
-        window_files = _safe_int(tput[1], 0) if tput else 0
-        window_materialized = _safe_int(tput[2], 0) if tput else 0
-        window_busy_ms = _safe_int(tput[3], 0) if tput else 0
-        files_per_s = (window_files / (window_busy_ms / 1000.0)) if window_busy_ms > 0 else 0.0
-
-        lifetime = {
-            status: _safe_int(count, 0)
-            for status, count in conn.execute("SELECT status, COUNT(*) FROM ingest_attempts GROUP BY status").fetchall()
-        }
-
-        cursor: dict[str, int] = {}
-        if _table_exists(conn, "ingest_cursor"):
-            cursor = {
-                "tracked": _fast_count(conn, "SELECT COUNT(*) FROM ingest_cursor"),
-                "excluded": _fast_count(conn, "SELECT COUNT(*) FROM ingest_cursor WHERE excluded = 1"),
-                "retry_pending": _fast_count(
-                    conn,
-                    "SELECT COUNT(*) FROM ingest_cursor WHERE failure_count > 0 AND excluded = 0",
-                ),
-            }
-
-        debt_rows = conn.execute("SELECT status, COUNT(*) FROM convergence_debt GROUP BY status").fetchall()
-        unknown_statuses = sorted(
-            {repr(status) for status, _count in debt_rows if status not in _CONVERGENCE_DEBT_STATUSES}
-        )
-        if unknown_statuses:
-            return {
-                "available": False,
-                "reason": "convergence debt status unavailable: "
-                f"unknown status value(s): {', '.join(unknown_statuses)}",
-            }
-        debt = {status: _safe_int(count, 0) for status, count in debt_rows}
-        debt_total = sum(debt.values())
-    except Exception as exc:
-        # A present but malformed ledger is unknown, not an empty workload.
-        # Keep this explicit so both direct status renderers can preserve the
-        # ledger failure and block claims instead of falling into the generic
-        # archive-query fallback.
-        return {"available": False, "reason": f"convergence debt status unavailable: {exc}"}
+            if unknown_statuses:
+                return {
+                    "available": False,
+                    "reason": "convergence debt status unavailable: "
+                    f"unknown status value(s): {', '.join(unknown_statuses)}",
+                }
+            debt = {status: _safe_int(count, 0) for status, count in debt_rows}
+            debt_total = sum(debt.values())
+        except Exception as exc:
+            # A present but malformed ledger is unknown, not an empty workload.
+            # Keep this explicit so both direct status renderers can preserve
+            # the ledger failure and block claims instead of falling into the
+            # generic archive-query fallback.
+            return {"available": False, "reason": f"convergence debt status unavailable: {exc}"}
     finally:
         conn.close()
 

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -924,7 +924,7 @@ def _ops_workload_status(active_root: Path, *, now_ms: int) -> dict[str, Any]:
     try:
         conn = sqlite3.connect(f"file:{ops_db}?mode=ro", uri=True)
     except sqlite3.Error as exc:
-        return {"available": False, "reason": f"convergence debt status unavailable: {exc}"}
+        return {"available": False, "reason": f"ops workload status unavailable: {exc}"}
     try:
         try:
             if not _table_exists(conn, "ingest_attempts"):

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -908,6 +908,7 @@ def _archive_source_table_count(conn: Any, *, table: str, sql: str, configured_r
 # cannot substantiate.
 _WORKLOAD_THROUGHPUT_WINDOW_MS = 5 * 60 * 1000
 _WORKLOAD_HEARTBEAT_STALE_MS = 90 * 1000
+_CONVERGENCE_DEBT_STATUSES = frozenset(("failed", "deferred"))
 
 
 def _ops_workload_status(active_root: Path, *, now_ms: int) -> dict[str, Any]:
@@ -990,13 +991,24 @@ def _ops_workload_status(active_root: Path, *, now_ms: int) -> dict[str, Any]:
                 ),
             }
 
-        debt = {
-            status: _safe_int(count, 0)
-            for status, count in conn.execute(
-                "SELECT status, COUNT(*) FROM convergence_debt GROUP BY status"
-            ).fetchall()
-        }
+        debt_rows = conn.execute("SELECT status, COUNT(*) FROM convergence_debt GROUP BY status").fetchall()
+        unknown_statuses = sorted(
+            {repr(status) for status, _count in debt_rows if status not in _CONVERGENCE_DEBT_STATUSES}
+        )
+        if unknown_statuses:
+            return {
+                "available": False,
+                "reason": "convergence debt status unavailable: "
+                f"unknown status value(s): {', '.join(unknown_statuses)}",
+            }
+        debt = {status: _safe_int(count, 0) for status, count in debt_rows}
         debt_total = sum(debt.values())
+    except Exception as exc:
+        # A present but malformed ledger is unknown, not an empty workload.
+        # Keep this explicit so both direct status renderers can preserve the
+        # ledger failure and block claims instead of falling into the generic
+        # archive-query fallback.
+        return {"available": False, "reason": f"convergence debt status unavailable: {exc}"}
     finally:
         conn.close()
 

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -924,7 +924,7 @@ def _ops_workload_status(active_root: Path, *, now_ms: int) -> dict[str, Any]:
     try:
         conn = sqlite3.connect(f"file:{ops_db}?mode=ro", uri=True)
     except sqlite3.Error as exc:
-        return {"available": False, "reason": str(exc)}
+        return {"available": False, "reason": f"convergence debt status unavailable: {exc}"}
     try:
         if not _table_exists(conn, "ingest_attempts"):
             return {"available": False, "reason": "missing_ingest_attempts"}

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -927,6 +927,8 @@ def _ops_workload_status(active_root: Path, *, now_ms: int) -> dict[str, Any]:
     try:
         if not _table_exists(conn, "ingest_attempts"):
             return {"available": False, "reason": "missing_ingest_attempts"}
+        if not _table_exists(conn, "convergence_debt"):
+            return {"available": False, "reason": "missing_convergence_debt"}
 
         running_rows = conn.execute(
             """
@@ -988,14 +990,12 @@ def _ops_workload_status(active_root: Path, *, now_ms: int) -> dict[str, Any]:
                 ),
             }
 
-        debt: dict[str, int] = {}
-        if _table_exists(conn, "convergence_debt"):
-            debt = {
-                status: _safe_int(count, 0)
-                for status, count in conn.execute(
-                    "SELECT status, COUNT(*) FROM convergence_debt GROUP BY status"
-                ).fetchall()
-            }
+        debt = {
+            status: _safe_int(count, 0)
+            for status, count in conn.execute(
+                "SELECT status, COUNT(*) FROM convergence_debt GROUP BY status"
+            ).fetchall()
+        }
         debt_total = sum(debt.values())
     finally:
         conn.close()
@@ -2051,6 +2051,28 @@ def _render_ingest_workload(env: AppEnv, workload: dict[str, Any]) -> None:
         env.ui.console.print(f"    convergence debt: [yellow]{debt_total}[/yellow] ({detail})")
 
 
+def _render_convergence_debt(env: AppEnv, summary: ConvergenceDebtSummary) -> None:
+    """Render the authoritative convergence-debt ledger state."""
+    if not summary.available:
+        env.ui.console.print("  Convergence debt: [yellow]unavailable[/yellow]")
+        if summary.error:
+            env.ui.console.print(f"    [yellow]{summary.error}[/yellow]")
+        return
+
+    pending_parts = [
+        f"{summary.failed_count} failed" if summary.failed_count else "",
+        f"{summary.deferred_count} deferred" if summary.deferred_count else "",
+    ]
+    pending_parts = [part for part in pending_parts if part]
+    if not pending_parts:
+        env.ui.console.print("  Convergence debt: [green]none (ledger healthy)[/green]")
+        return
+
+    if summary.retry_due_count:
+        pending_parts.append(f"{summary.retry_due_count} retry due")
+    env.ui.console.print(f"  Convergence debt: [yellow]{', '.join(pending_parts)}[/yellow]")
+
+
 def _render_schema_drift_status(env: AppEnv, drift: dict[str, Any]) -> None:
     """Render windowed format-drift rates: 'origin X: N% ... carry unseen shapes'.
 
@@ -2243,6 +2265,8 @@ def _show_direct_status(
         if active_db.name == "index.db":
             active_root = active_db.parent
             _render_ingest_workload(env, workload)
+            convergence = convergence_debt_summary_info(active_db, ops_db=active_root / "ops.db")
+            _render_convergence_debt(env, convergence)
             _render_schema_drift_status(env, schema_drift_status(active_root, now_ms=now_ms))
             tiers = _archive_tier_status(active_root)
             present = ", ".join(tier for tier, info in tiers.items() if info["exists"])

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -14,6 +14,7 @@ from urllib.request import Request, urlopen
 import click
 
 from polylogue.cli.shared.types import AppEnv
+from polylogue.daemon.convergence_debt_status import ConvergenceDebtSummary, convergence_debt_summary_info
 from polylogue.insights.schema_drift import schema_drift_status
 from polylogue.logging import get_logger
 from polylogue.readiness.capability import (
@@ -1649,6 +1650,10 @@ def _show_direct_json(
     )
     archive_tiers = _archive_tier_status(active_root)
     ingest_workload = _ops_workload_status(active_root, now_ms=int(time.time() * 1000))
+    convergence = convergence_debt_summary_info(
+        active_root / "index.db",
+        ops_db=active_root / "ops.db",
+    )
     schema_drift = schema_drift_status(active_root, now_ms=int(time.time() * 1000))
     payload: dict[str, Any] = {
         "ok": _direct_status_ok(component_readiness),
@@ -1663,6 +1668,7 @@ def _show_direct_json(
         "archive_tiers": archive_tiers,
         "sqlite_maintenance": _sqlite_maintenance_status(active_root),
         "ingest_workload": ingest_workload,
+        "convergence": convergence.model_dump(mode="json"),
         "schema_drift": schema_drift,
         "raw_replay_backlog": _raw_replay_backlog_status(active_root),
         "archive_readiness": archive_readiness,
@@ -1678,6 +1684,7 @@ def _show_direct_json(
             raw_frontier_integrity=raw_frontier_integrity,
             component_readiness=component_readiness,
             ingest_workload=ingest_workload,
+            convergence=convergence,
         ),
         "next_action": diag.next_action,
         "diagnostic": diagnostic_payload(diag),
@@ -1830,6 +1837,7 @@ def _direct_claim_guard(
     raw_frontier_integrity: dict[str, Any],
     component_readiness: dict[str, Any],
     ingest_workload: dict[str, Any],
+    convergence: ConvergenceDebtSummary,
 ) -> dict[str, Any]:
     """Derive the claim-guard block for the no-daemon direct SQLite fallback."""
     missing_tiers = [tier for tier, info in archive_tiers.items() if not info.get("exists")]
@@ -1872,6 +1880,23 @@ def _direct_claim_guard(
         search_summary=search_summary,
         active_writer=active_writer,
         active_writer_summary=active_writer_summary,
+        convergence_debt_available=convergence.available,
+        convergence_debt_pending=convergence.failed_count > 0 or convergence.deferred_count > 0,
+        convergence_debt_summary=(
+            convergence.error
+            or (
+                "convergence debt pending: "
+                + ", ".join(
+                    part
+                    for part in (
+                        f"{convergence.failed_count} failed" if convergence.failed_count else "",
+                        f"{convergence.deferred_count} deferred" if convergence.deferred_count else "",
+                    )
+                    if part
+                )
+            )
+            or "no pending convergence debt"
+        ),
     ).to_dict()
 
 

--- a/polylogue/daemon/convergence_debt_status.py
+++ b/polylogue/daemon/convergence_debt_status.py
@@ -15,6 +15,24 @@ from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 
 logger = get_logger(__name__)
 
+_REQUIRED_CONVERGENCE_DEBT_COLUMNS = frozenset(
+    (
+        "debt_id",
+        "stage",
+        "target_type",
+        "target_id",
+        "status",
+        "priority",
+        "attempts",
+        "last_error",
+        "next_retry_at",
+        "materializer_version",
+        "created_at_ms",
+        "updated_at_ms",
+    )
+)
+_CONVERGENCE_DEBT_STATUSES = frozenset(("failed", "deferred"))
+
 
 class ConvergenceDebtStageSummary(BaseModel):
     stage: str
@@ -75,6 +93,11 @@ def _archive_convergence_debt_summary_info(dbf: Path, ops_db: Path) -> Convergen
                     available=False,
                     error="convergence debt table is unavailable",
                 )
+            table_info = conn.execute("PRAGMA table_info(convergence_debt)").fetchall()
+            columns = {str(row[1]) for row in table_info if len(row) > 1}
+            missing_columns = sorted(_REQUIRED_CONVERGENCE_DEBT_COLUMNS - columns)
+            if missing_columns:
+                raise ValueError("convergence_debt is missing required column(s): " + ", ".join(missing_columns))
             rows = conn.execute(
                 """
                 SELECT stage, target_type, target_id, status, attempts,
@@ -91,7 +114,7 @@ def _archive_convergence_debt_summary_info(dbf: Path, ops_db: Path) -> Convergen
         # An unreadable authoritative debt ledger is unknown, not empty. The
         # claim guard must be able to distinguish this from a genuinely empty
         # convergence_debt table (polylogue-cpf.4).
-        logger.warning("convergence-debt summary query failed for %s: %s", ops_db, exc, exc_info=True)
+        logger.warning("convergence-debt summary query failed for %s: %s", ops_db, exc)
         return ConvergenceDebtSummary(available=False, error=f"convergence debt status unavailable: {exc}")
 
     try:
@@ -111,6 +134,12 @@ def _archive_convergence_debt_summary_info(dbf: Path, ops_db: Path) -> Convergen
         ]
         if not items:
             return ConvergenceDebtSummary()
+
+        unknown_statuses = sorted(
+            {repr(item.status) for item in items if item.status not in _CONVERGENCE_DEBT_STATUSES}
+        )
+        if unknown_statuses:
+            raise ValueError("convergence_debt contains unknown status value(s): " + ", ".join(unknown_statuses))
 
         now = datetime.now(UTC)
         recent = [
@@ -141,7 +170,7 @@ def _archive_convergence_debt_summary_info(dbf: Path, ops_db: Path) -> Convergen
         ]
         return _summary_from_parts(stage_summaries=stage_summaries, recent=recent)
     except Exception as exc:
-        logger.warning("convergence-debt summary projection failed for %s: %s", ops_db, exc, exc_info=True)
+        logger.warning("convergence-debt summary projection failed for %s: %s", ops_db, exc)
         return ConvergenceDebtSummary(available=False, error=f"convergence debt status unavailable: {exc}")
 
 

--- a/polylogue/daemon/convergence_debt_status.py
+++ b/polylogue/daemon/convergence_debt_status.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -88,58 +87,62 @@ def _archive_convergence_debt_summary_info(dbf: Path, ops_db: Path) -> Convergen
                 return ConvergenceDebtSummary()
         finally:
             conn.close()
-    except sqlite3.Error as exc:
+    except Exception as exc:
         # An unreadable authoritative debt ledger is unknown, not empty. The
         # claim guard must be able to distinguish this from a genuinely empty
         # convergence_debt table (polylogue-cpf.4).
         logger.warning("convergence-debt summary query failed for %s: %s", ops_db, exc, exc_info=True)
         return ConvergenceDebtSummary(available=False, error=f"convergence debt status unavailable: {exc}")
 
-    items = [
-        ConvergenceDebtItem(
-            stage=_required_str(row[0]),
-            subject_type=_required_str(row[1]),
-            subject_id=_required_str(row[2]),
-            status=_required_str(row[3]),
-            failure_count=_row_int(row[4]),
-            last_failed_at=_iso_from_epoch_ms(row[5]),
-            next_retry_at=_optional_str(row[7]),
-            retry_due=False,
-            last_error=_optional_str(row[6]),
-        )
-        for row in rows
-    ]
-    if not items:
-        return ConvergenceDebtSummary()
+    try:
+        items = [
+            ConvergenceDebtItem(
+                stage=_required_str(row[0]),
+                subject_type=_required_str(row[1]),
+                subject_id=_required_str(row[2]),
+                status=_required_str(row[3]),
+                failure_count=_row_int(row[4]),
+                last_failed_at=_iso_from_epoch_ms(row[5]),
+                next_retry_at=_optional_str(row[7]),
+                retry_due=False,
+                last_error=_optional_str(row[6]),
+            )
+            for row in rows
+        ]
+        if not items:
+            return ConvergenceDebtSummary()
 
-    now = datetime.now(UTC)
-    recent = [
-        item.model_copy(update={"retry_due": item.status == "failed" and _retry_due(item.next_retry_at, now=now)})
-        for item in items[:10]
-    ]
-    failed_by_stage: dict[str, int] = {}
-    deferred_by_stage: dict[str, int] = {}
-    retry_due_by_stage: dict[str, int] = {}
-    for item in items:
-        if item.status == "failed":
-            failed_by_stage[item.stage] = failed_by_stage.get(item.stage, 0) + 1
-            if _retry_due(item.next_retry_at, now=now):
-                retry_due_by_stage[item.stage] = retry_due_by_stage.get(item.stage, 0) + 1
-        elif item.status == "deferred":
-            deferred_by_stage[item.stage] = deferred_by_stage.get(item.stage, 0) + 1
-    stage_summaries = [
-        ConvergenceDebtStageSummary(
-            stage=stage,
-            failed_count=failed_by_stage.get(stage, 0),
-            deferred_count=deferred_by_stage.get(stage, 0),
-            retry_due_count=retry_due_by_stage.get(stage, 0),
-        )
-        for stage in sorted(
-            set(failed_by_stage) | set(deferred_by_stage),
-            key=lambda stage: (-(failed_by_stage.get(stage, 0) + deferred_by_stage.get(stage, 0)), stage),
-        )
-    ]
-    return _summary_from_parts(stage_summaries=stage_summaries, recent=recent)
+        now = datetime.now(UTC)
+        recent = [
+            item.model_copy(update={"retry_due": item.status == "failed" and _retry_due(item.next_retry_at, now=now)})
+            for item in items[:10]
+        ]
+        failed_by_stage: dict[str, int] = {}
+        deferred_by_stage: dict[str, int] = {}
+        retry_due_by_stage: dict[str, int] = {}
+        for item in items:
+            if item.status == "failed":
+                failed_by_stage[item.stage] = failed_by_stage.get(item.stage, 0) + 1
+                if _retry_due(item.next_retry_at, now=now):
+                    retry_due_by_stage[item.stage] = retry_due_by_stage.get(item.stage, 0) + 1
+            elif item.status == "deferred":
+                deferred_by_stage[item.stage] = deferred_by_stage.get(item.stage, 0) + 1
+        stage_summaries = [
+            ConvergenceDebtStageSummary(
+                stage=stage,
+                failed_count=failed_by_stage.get(stage, 0),
+                deferred_count=deferred_by_stage.get(stage, 0),
+                retry_due_count=retry_due_by_stage.get(stage, 0),
+            )
+            for stage in sorted(
+                set(failed_by_stage) | set(deferred_by_stage),
+                key=lambda stage: (-(failed_by_stage.get(stage, 0) + deferred_by_stage.get(stage, 0)), stage),
+            )
+        ]
+        return _summary_from_parts(stage_summaries=stage_summaries, recent=recent)
+    except Exception as exc:
+        logger.warning("convergence-debt summary projection failed for %s: %s", ops_db, exc, exc_info=True)
+        return ConvergenceDebtSummary(available=False, error=f"convergence debt status unavailable: {exc}")
 
 
 def _summary_from_parts(

--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -2006,6 +2006,21 @@ def _attach_collection_state(
         }
 
 
+def _convergence_debt_from_snapshot(snapshot: ComponentSnapshot) -> ConvergenceDebtSummary:
+    """Adapt a registry snapshot without treating unavailable debt as empty."""
+    if snapshot.state != "fresh" or snapshot.value is None or snapshot.error is not None:
+        return ConvergenceDebtSummary(
+            available=False,
+            error=snapshot.error or f"convergence debt status {snapshot.state}",
+        )
+    if not isinstance(snapshot.value, ConvergenceDebtSummary):
+        return ConvergenceDebtSummary(
+            available=False,
+            error="convergence debt snapshot returned an unexpected value",
+        )
+    return snapshot.value
+
+
 def _daemon_component_readiness(
     *,
     component_state: ComponentState,
@@ -2669,7 +2684,7 @@ def build_daemon_status(
     )
     live_cursor = _v("live_cursor", LiveCursorSummary())
     live_ingest_attempts = _v("live_ingest_attempts", LiveIngestAttemptSummary())
-    convergence = _v("convergence", ConvergenceDebtSummary())
+    convergence = _convergence_debt_from_snapshot(snapshots["convergence"])
     cursor_lag = _v("cursor_lag", CursorLagSummary())
     catchup = catchup_status_info(
         active_db,

--- a/polylogue/readiness/claim_guard.py
+++ b/polylogue/readiness/claim_guard.py
@@ -79,8 +79,8 @@ def derive_claim_guard(
     search_ready: bool,
     search_summary: str,
     active_writer: bool,
+    convergence_debt_available: bool,
     active_writer_summary: str = "",
-    convergence_debt_available: bool = True,
     convergence_debt_pending: bool = False,
     convergence_debt_summary: str = "no pending convergence debt",
 ) -> ClaimGuard:

--- a/tests/integration/test_basic_usage_cli.py
+++ b/tests/integration/test_basic_usage_cli.py
@@ -10,11 +10,12 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sqlite3
 from pathlib import Path
 
 import pytest
 
-from tests.infra.cli_subprocess import CliResult, run_cli
+from tests.infra.cli_subprocess import CliResult, run_cli, setup_isolated_workspace
 
 
 @pytest.fixture
@@ -119,3 +120,22 @@ def test_status_reports_direct_archive_fallback_when_daemon_is_unreachable(cli_e
     result = _run(["status", "--daemon-url", "http://127.0.0.1:1"], env=cli_env)
     assert "Sessions:" in result.output
     assert "daemon not running" in result.output.lower()
+
+
+@pytest.mark.parametrize("ledger_state", ["empty", "missing_table"])
+def test_status_text_reports_authoritative_convergence_debt_state(tmp_path: Path, ledger_state: str) -> None:
+    workspace = setup_isolated_workspace(tmp_path)
+    if ledger_state == "missing_table":
+        with sqlite3.connect(workspace["paths"]["archive_root"] / "ops.db") as conn:
+            conn.execute("DROP TABLE convergence_debt")
+            conn.commit()
+
+    result = _run(["--plain", "ops", "status"], env=workspace["env"])
+    output = result.output.lower()
+
+    assert "convergence debt:" in output
+    if ledger_state == "empty":
+        assert "none (ledger healthy)" in output
+    else:
+        assert "unavailable" in output
+        assert "convergence debt table is unavailable" in output

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -1558,6 +1558,23 @@ class TestNoArchiveStatus:
             "reason": "ops workload status unavailable: no such column: phase",
         }
 
+    def test_ops_workload_status_connection_failure_is_not_a_ledger_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ops_db = tmp_path / "ops.db"
+        ops_db.touch()
+        monkeypatch.setattr(
+            "polylogue.cli.commands.status.sqlite3.connect",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(sqlite3.OperationalError("simulated open failure")),
+        )
+
+        workload = _ops_workload_status(tmp_path, now_ms=1_770_000_000_000)
+
+        assert workload == {
+            "available": False,
+            "reason": "ops workload status unavailable: simulated open failure",
+        }
+
     def test_direct_status_requires_raw_frontier_component_presence(self) -> None:
         assert _direct_status_ok({}) is False
         assert _direct_status_ok({"raw_frontier_integrity": {"state": "unknown"}}) is False

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -22,6 +22,7 @@ from polylogue.cli.commands.status import (
     _archive_facade_route_status,
     _direct_claim_guard,
     _direct_status_ok,
+    _ops_workload_status,
     _render_raw_replay_backlog,
     _show_daemon_status,
     _show_direct_json,
@@ -1532,6 +1533,16 @@ class TestNoArchiveStatus:
             convergence=ConvergenceDebtSummary(),
         )
         assert idle_guard["perf_measurable"]["value"] is True
+
+    def test_ops_workload_status_requires_convergence_debt_table(self, tmp_path: Path) -> None:
+        initialize_archive_database(tmp_path / "ops.db", ArchiveTier.OPS)
+        with sqlite3.connect(tmp_path / "ops.db") as conn:
+            conn.execute("DROP TABLE convergence_debt")
+            conn.commit()
+
+        workload = _ops_workload_status(tmp_path, now_ms=1_770_000_000_000)
+
+        assert workload == {"available": False, "reason": "missing_convergence_debt"}
 
     def test_direct_status_requires_raw_frontier_component_presence(self) -> None:
         assert _direct_status_ok({}) is False

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -1544,6 +1544,20 @@ class TestNoArchiveStatus:
 
         assert workload == {"available": False, "reason": "missing_convergence_debt"}
 
+    def test_ops_workload_status_keeps_non_ledger_failure_separate(self, tmp_path: Path) -> None:
+        initialize_archive_database(tmp_path / "ops.db", ArchiveTier.OPS)
+        with sqlite3.connect(tmp_path / "ops.db") as conn:
+            conn.execute("DROP TABLE ingest_attempts")
+            conn.execute("CREATE TABLE ingest_attempts (wrong_column TEXT)")
+            conn.commit()
+
+        workload = _ops_workload_status(tmp_path, now_ms=1_770_000_000_000)
+
+        assert workload == {
+            "available": False,
+            "reason": "ops workload status unavailable: no such column: phase",
+        }
+
     def test_direct_status_requires_raw_frontier_component_presence(self) -> None:
         assert _direct_status_ok({}) is False
         assert _direct_status_ok({"raw_frontier_integrity": {"state": "unknown"}}) is False
@@ -2302,6 +2316,22 @@ class TestStatusDiagnosticIntegration:
             conn.commit()
         return archive_root
 
+    def _malformed_ingest_attempts_archive(self, tmp_path: Path) -> Path:
+        archive_root = tmp_path / "polylogue"
+        for tier in (
+            ArchiveTier.SOURCE,
+            ArchiveTier.INDEX,
+            ArchiveTier.EMBEDDINGS,
+            ArchiveTier.USER,
+            ArchiveTier.OPS,
+        ):
+            initialize_archive_database(archive_root / f"{tier.value}.db", tier)
+        with sqlite3.connect(archive_root / "ops.db") as conn:
+            conn.execute("DROP TABLE ingest_attempts")
+            conn.execute("CREATE TABLE ingest_attempts (wrong_column TEXT)")
+            conn.commit()
+        return archive_root
+
     def _malformed_archive_env(self, tmp_path: Path, archive_root: Path) -> dict[str, str]:
         env = self._xdg_env(tmp_path)
         env["POLYLOGUE_ARCHIVE_ROOT"] = str(archive_root)
@@ -2341,6 +2371,47 @@ class TestStatusDiagnosticIntegration:
         assert result.exit_code == 0, result.output
         assert "convergence debt: unavailable" in output_lower
         assert "convergence debt status unavailable" in output_lower
+        assert "could not be queried" not in output_lower
+        assert "traceback" not in output_lower
+
+    @pytest.mark.integration
+    def test_status_subprocess_malformed_ingest_attempts_json_keeps_convergence_healthy(self, tmp_path: Path) -> None:
+        """A malformed workload table must not mislabel the independent debt ledger."""
+        from tests.infra.cli_subprocess import run_cli
+
+        archive_root = self._malformed_ingest_attempts_archive(tmp_path)
+        result = run_cli(
+            ["--plain", "ops", "status", "--json", "--full"],
+            env=self._malformed_archive_env(tmp_path, archive_root),
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["ingest_workload"] == {
+            "available": False,
+            "reason": "ops workload status unavailable: no such column: phase",
+        }
+        assert payload["convergence"]["available"] is True
+        assert payload["convergence"]["error"] is None
+        assert payload["claim_guard"]["converged"]["reason"] == "ready"
+        assert payload["claim_guard"]["perf_measurable"]["value"] is False
+
+    @pytest.mark.integration
+    def test_status_subprocess_malformed_ingest_attempts_human_keeps_convergence_healthy(self, tmp_path: Path) -> None:
+        """Human status must keep the healthy ledger message for a workload-only failure."""
+        from tests.infra.cli_subprocess import run_cli
+
+        archive_root = self._malformed_ingest_attempts_archive(tmp_path)
+        result = run_cli(
+            ["--plain", "ops", "status"],
+            env=self._malformed_archive_env(tmp_path, archive_root),
+        )
+
+        output_lower = result.output.lower()
+        assert result.exit_code == 0, result.output
+        assert "convergence debt: none (ledger healthy)" in output_lower
+        assert "convergence debt status unavailable" not in output_lower
+        assert "ops workload status unavailable" not in output_lower
         assert "could not be queried" not in output_lower
         assert "traceback" not in output_lower
 

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -2286,6 +2286,64 @@ class TestStatusDiagnosticIntegration:
             "POLYLOGUE_DAEMON_URL": "http://127.0.0.1:1",
         }
 
+    def _malformed_convergence_debt_archive(self, tmp_path: Path) -> Path:
+        archive_root = tmp_path / "polylogue"
+        for tier in (
+            ArchiveTier.SOURCE,
+            ArchiveTier.INDEX,
+            ArchiveTier.EMBEDDINGS,
+            ArchiveTier.USER,
+            ArchiveTier.OPS,
+        ):
+            initialize_archive_database(archive_root / f"{tier.value}.db", tier)
+        with sqlite3.connect(archive_root / "ops.db") as conn:
+            conn.execute("DROP TABLE convergence_debt")
+            conn.execute("CREATE TABLE convergence_debt (wrong_column TEXT)")
+            conn.commit()
+        return archive_root
+
+    def _malformed_archive_env(self, tmp_path: Path, archive_root: Path) -> dict[str, str]:
+        env = self._xdg_env(tmp_path)
+        env["POLYLOGUE_ARCHIVE_ROOT"] = str(archive_root)
+        return env
+
+    @pytest.mark.integration
+    def test_status_subprocess_malformed_convergence_debt_json_is_explicitly_unavailable(self, tmp_path: Path) -> None:
+        """Malformed convergence debt must yield valid JSON and block convergence claims."""
+        from tests.infra.cli_subprocess import run_cli
+
+        archive_root = self._malformed_convergence_debt_archive(tmp_path)
+        result = run_cli(
+            ["--plain", "ops", "status", "--json", "--full"],
+            env=self._malformed_archive_env(tmp_path, archive_root),
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["ingest_workload"]["available"] is False
+        assert "convergence debt status unavailable" in payload["ingest_workload"]["reason"]
+        assert payload["convergence"]["available"] is False
+        assert "convergence debt status unavailable" in payload["convergence"]["error"]
+        assert payload["claim_guard"]["converged"]["value"] is False
+
+    @pytest.mark.integration
+    def test_status_subprocess_malformed_convergence_debt_human_is_explicitly_unavailable(self, tmp_path: Path) -> None:
+        """Malformed convergence debt must not collapse human status into generic unavailable output."""
+        from tests.infra.cli_subprocess import run_cli
+
+        archive_root = self._malformed_convergence_debt_archive(tmp_path)
+        result = run_cli(
+            ["--plain", "ops", "status"],
+            env=self._malformed_archive_env(tmp_path, archive_root),
+        )
+
+        output_lower = result.output.lower()
+        assert result.exit_code == 0, result.output
+        assert "convergence debt: unavailable" in output_lower
+        assert "convergence debt status unavailable" in output_lower
+        assert "could not be queried" not in output_lower
+        assert "traceback" not in output_lower
+
     @pytest.mark.integration
     def test_status_subprocess_schema_mismatch(self, tmp_path: Path) -> None:
         """A db with the wrong PRAGMA user_version yields actionable text, no traceback."""

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -32,6 +32,7 @@ from polylogue.cli.commands.status import (
 )
 from polylogue.cli.shared.types import AppEnv
 from polylogue.core.enums import ArtifactSupportStatus
+from polylogue.daemon.convergence_debt_status import ConvergenceDebtSummary
 from polylogue.maintenance.failure_routing import route_failure_sample
 from polylogue.maintenance.planner import FailureSample
 from polylogue.storage.sqlite.archive_tiers import ARCHIVE_VERSION_BY_TIER
@@ -1303,6 +1304,7 @@ class TestNoArchiveStatus:
 
         payload = json.loads(_combined_calls(env))
         claim_guard = payload["claim_guard"]
+        assert payload["convergence"]["available"] is True
         assert set(claim_guard) == {"openable", "converged", "search_ready", "perf_measurable"}
         assert claim_guard["openable"]["value"] is True
         assert claim_guard["converged"]["value"] is True
@@ -1512,6 +1514,7 @@ class TestNoArchiveStatus:
                 raw_frontier_integrity=raw_frontier_integrity,
                 component_readiness=component_readiness,
                 ingest_workload=unavailable_workload,
+                convergence=ConvergenceDebtSummary(),
             )
             assert guard["perf_measurable"]["value"] is False, unavailable_workload
             assert "unavailable" in guard["perf_measurable"]["reason"]
@@ -1526,6 +1529,7 @@ class TestNoArchiveStatus:
             raw_frontier_integrity=raw_frontier_integrity,
             component_readiness=component_readiness,
             ingest_workload={"available": True, "actively_ingesting": False, "running_count": 0},
+            convergence=ConvergenceDebtSummary(),
         )
         assert idle_guard["perf_measurable"]["value"] is True
 
@@ -1533,6 +1537,63 @@ class TestNoArchiveStatus:
         assert _direct_status_ok({}) is False
         assert _direct_status_ok({"raw_frontier_integrity": {"state": "unknown"}}) is False
         assert _direct_status_ok({"raw_frontier_integrity": {"state": "ready"}}) is True
+
+    @pytest.mark.parametrize("ledger_state", ["missing_table", "collector_error", "empty"])
+    def test_direct_status_claim_guard_uses_convergence_debt_ledger(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        ledger_state: str,
+    ) -> None:
+        """The direct production status route must retain debt authority state."""
+        env = _make_app_env()
+        for tier in (
+            ArchiveTier.SOURCE,
+            ArchiveTier.INDEX,
+            ArchiveTier.EMBEDDINGS,
+            ArchiveTier.USER,
+            ArchiveTier.OPS,
+        ):
+            initialize_archive_database(tmp_path / f"{tier.value}.db", tier)
+        if ledger_state == "missing_table":
+            with sqlite3.connect(tmp_path / "ops.db") as conn:
+                conn.execute("DROP TABLE convergence_debt")
+                conn.commit()
+        elif ledger_state == "collector_error":
+            monkeypatch.setattr(
+                "polylogue.daemon.convergence_debt_status.open_readonly_connection",
+                lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("simulated collector failure")),
+            )
+
+        archive_readiness = {
+            "checked": True,
+            "counts": {"session_count": 0},
+            "surfaces": {"search": {"ready": True, "blockers": [], "evidence": {}}},
+        }
+        with (
+            patch("polylogue.paths.db_path", return_value=tmp_path / "index.db"),
+            patch("polylogue.paths.archive_root", return_value=tmp_path),
+            patch("polylogue.cli.commands.status._archive_readiness_status", return_value=archive_readiness),
+            patch(
+                "polylogue.storage.archive_readiness.raw_materialization_readiness_snapshot",
+                return_value=_completed_raw_materialization_readiness(),
+            ),
+            patch("polylogue.storage.embeddings.status_payload.embedding_status_payload", side_effect=RuntimeError),
+        ):
+            _show_direct_json(env, include_archive_readiness=True)
+
+        payload = json.loads(_combined_calls(env))
+        convergence = payload["convergence"]
+        claim_guard = payload["claim_guard"]
+        if ledger_state == "empty":
+            assert convergence["available"] is True
+            assert convergence["error"] is None
+            assert claim_guard["converged"]["value"] is True
+        else:
+            assert convergence["available"] is False
+            assert convergence["error"]
+            assert claim_guard["converged"]["value"] is False
+            assert "convergence debt" in claim_guard["converged"]["reason"]
 
     def test_direct_status_json_blocks_transforms_when_archive_readiness_fails(
         self,

--- a/tests/unit/core/test_claim_guard.py
+++ b/tests/unit/core/test_claim_guard.py
@@ -29,6 +29,7 @@ def _base_kwargs() -> dict[str, object]:
         "search_ready": True,
         "search_summary": "ready",
         "active_writer": False,
+        "convergence_debt_available": True,
         "active_writer_summary": "",
     }
 

--- a/tests/unit/daemon/test_convergence_debt_alert.py
+++ b/tests/unit/daemon/test_convergence_debt_alert.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -275,6 +276,51 @@ def test_convergence_debt_summary_marks_unreadable_ops_as_unavailable(tmp_path: 
     assert summary.failed_count == 0
     assert summary.deferred_count == 0
     assert "unavailable" in (summary.error or "")
+
+
+@pytest.mark.parametrize("ledger_state", ["missing_db", "missing_table"])
+def test_convergence_debt_summary_preserves_missing_ledger_provenance(tmp_path: Path, ledger_state: str) -> None:
+    db_path = tmp_path / "archive.db"
+    ops_path = tmp_path / "ops.db"
+    db_path.touch()
+    if ledger_state == "missing_table":
+        initialize_archive_database(ops_path, ArchiveTier.OPS)
+        with sqlite3.connect(ops_path) as conn:
+            conn.execute("DROP TABLE convergence_debt")
+            conn.commit()
+
+    summary = convergence_debt_summary_info(db_path, ops_db=ops_path)
+
+    assert summary.available is False
+    assert summary.error
+    assert summary.failed_count == 0
+    assert summary.deferred_count == 0
+
+
+def test_convergence_debt_summary_preserves_projection_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    ops_path = tmp_path / "ops.db"
+    initialize_archive_database(ops_path, ArchiveTier.OPS)
+    monkeypatch.setattr(
+        "polylogue.daemon.convergence_debt_status.open_readonly_connection",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("simulated collector failure")),
+    )
+
+    summary = convergence_debt_summary_info(tmp_path / "archive.db", ops_db=ops_path)
+
+    assert summary.available is False
+    assert summary.error == "convergence debt status unavailable: simulated collector failure"
+
+
+def test_convergence_debt_summary_fresh_empty_ledger_is_healthy(tmp_path: Path) -> None:
+    ops_path = tmp_path / "ops.db"
+    initialize_archive_database(ops_path, ArchiveTier.OPS)
+
+    summary = convergence_debt_summary_info(tmp_path / "archive.db", ops_db=ops_path)
+
+    assert summary.available is True
+    assert summary.error is None
+    assert summary.failed_count == 0
+    assert summary.deferred_count == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/daemon/test_convergence_debt_alert.py
+++ b/tests/unit/daemon/test_convergence_debt_alert.py
@@ -323,6 +323,45 @@ def test_convergence_debt_summary_fresh_empty_ledger_is_healthy(tmp_path: Path) 
     assert summary.deferred_count == 0
 
 
+def test_convergence_debt_summary_rejects_unknown_status(tmp_path: Path) -> None:
+    ops_path = tmp_path / "ops.db"
+    initialize_archive_database(ops_path, ArchiveTier.OPS)
+    with sqlite3.connect(ops_path) as conn:
+        conn.execute("PRAGMA ignore_check_constraints = ON")
+        add_convergence_debt(
+            conn,
+            stage="fts",
+            target_type="session_id",
+            target_id="corrupt-status",
+            status="corrupt",
+            attempts=1,
+            created_at_ms=1_770_000_000_000,
+            updated_at_ms=1_770_000_000_000,
+        )
+
+    summary = convergence_debt_summary_info(tmp_path / "archive.db", ops_db=ops_path)
+
+    assert summary.available is False
+    assert summary.failed_count == 0
+    assert summary.deferred_count == 0
+    assert "unknown status" in (summary.error or "")
+    assert "corrupt" in (summary.error or "")
+
+
+def test_convergence_debt_summary_rejects_missing_required_columns(tmp_path: Path) -> None:
+    ops_path = tmp_path / "ops.db"
+    with sqlite3.connect(ops_path) as conn:
+        conn.execute("CREATE TABLE convergence_debt (status TEXT NOT NULL)")
+        conn.commit()
+
+    summary = convergence_debt_summary_info(tmp_path / "archive.db", ops_db=ops_path)
+
+    assert summary.available is False
+    assert summary.failed_count == 0
+    assert summary.deferred_count == 0
+    assert "missing required column" in (summary.error or "")
+
+
 # ---------------------------------------------------------------------------
 # Threshold resolution
 # ---------------------------------------------------------------------------

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -1690,6 +1690,89 @@ def test_build_daemon_status_claim_guard_blocks_pending_or_unknown_convergence_d
         assert "unknown debt" in str(claim_guard["converged"]["signal"])
 
 
+@pytest.mark.parametrize("collector_state", ["timeout", "error", "empty"])
+def test_build_daemon_status_claim_guard_uses_real_registry_convergence_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, collector_state: str
+) -> None:
+    """A registry failure cannot be converted into a healthy empty ledger."""
+    import time
+
+    storage = status_module.ArchiveStorageStatus(
+        active_store="archive_file_set",
+        active_db_path=str(tmp_path / "index.db"),
+        archive_root=str(tmp_path),
+        configured_archive_root=str(tmp_path),
+        archive_ready=True,
+        archive_materialization_ready=True,
+        final_shape_ready=True,
+        archive_schema_ready=True,
+        present_tiers=["source", "index", "embeddings", "user", "ops"],
+    )
+    raw_readiness = status_module.RawMaterializationReadiness(
+        available=True,
+        raw_authority_frontier={"lifecycle_status": "completed"},
+    )
+    frontier = status_module.RawFrontierIntegrity(available=True, overall_status="healthy")
+
+    def convergence_collector(*_args: object, **_kwargs: object) -> status_module.ConvergenceDebtSummary:
+        if collector_state == "timeout":
+            time.sleep(1.0)
+        if collector_state == "error":
+            raise RuntimeError("simulated convergence collector failure")
+        return status_module.ConvergenceDebtSummary()
+
+    monkeypatch.setattr(status_module, "_db_size_info", lambda: {})
+    monkeypatch.setattr(status_module, "_blob_size_info", lambda: 0)
+    monkeypatch.setattr(status_module, "_archive_storage_info", lambda: storage)
+    monkeypatch.setattr(status_module, "_fts_readiness_info", lambda: {"messages_ready": True})
+    monkeypatch.setattr(status_module, "_insight_freshness_info", lambda: {})
+    monkeypatch.setattr(status_module, "_raw_materialization_readiness_info", lambda **_: raw_readiness)
+    monkeypatch.setattr(status_module, "_raw_replay_backlog_info", lambda **_: {})
+    monkeypatch.setattr(status_module, "_live_cursor_summary_info", lambda: status_module.LiveCursorSummary())
+    monkeypatch.setattr(
+        status_module,
+        "_live_ingest_attempt_summary_info",
+        lambda: status_module.LiveIngestAttemptSummary(),
+    )
+    monkeypatch.setattr(status_module, "convergence_debt_summary_info", convergence_collector)
+    monkeypatch.setattr(status_module, "cursor_lag_summary_info", lambda **_: status_module.CursorLagSummary())
+    monkeypatch.setattr(status_module, "_raw_failure_info", lambda: {})
+    monkeypatch.setattr(
+        status_module,
+        "_blob_publication_reservation_info",
+        lambda: status_module.BlobPublicationReservationStatus(),
+    )
+    monkeypatch.setattr(status_module, "embedding_readiness_info", lambda *_: {})
+    monkeypatch.setattr(status_module, "_active_status_db_path", lambda: tmp_path / "index.db")
+    monkeypatch.setattr(status_module, "archive_root", lambda: tmp_path)
+    monkeypatch.setattr(status_module, "_raw_frontier_integrity_info", lambda _: frontier)
+    monkeypatch.setattr(status_module, "catchup_status_info", lambda *_a, **_k: status_module.CatchupStatus())
+    monkeypatch.setattr(status_module, "_check_daemon_liveness", lambda *_: False)
+    monkeypatch.setattr(status_module, "check_health", lambda **_: DaemonHealth())
+
+    specs = status_module._daemon_status_component_specs(
+        checked_health=lambda: DaemonHealth(),
+        include_raw_replay_backlog=False,
+        include_exact_raw_materialization_readiness=False,
+    )
+    status = build_daemon_status(
+        sources=(),
+        browser_capture_enabled=False,
+        include_raw_replay_backlog=False,
+        include_exact_raw_materialization_readiness=False,
+        registry=StatusComponentRegistry(specs),
+    )
+
+    claim_guard = cast(dict[str, dict[str, object]], status.claim_guard)
+    if collector_state == "empty":
+        assert status.convergence.available is True
+        assert claim_guard["converged"]["value"] is True
+        assert claim_guard["converged"]["reason"] == "ready"
+    else:
+        assert status.convergence.available is False
+        assert claim_guard["converged"]["value"] is False
+
+
 def test_build_daemon_status_detects_broken_append_head_blocks_converged(tmp_path: Path) -> None:
     """polylogue-yla8.7 AC: a current accepted append head whose predecessor
     chain is broken must surface through ``raw_frontier_integrity``, render

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -1619,9 +1619,11 @@ def test_build_daemon_status_claim_guard_reports_openable_but_not_converged(tmp_
     assert claim_guard["perf_measurable"]["value"] is True
 
 
-@pytest.mark.parametrize("debt_setup", ["pending", "unreadable"])
+@pytest.mark.parametrize(
+    "debt_setup", ["pending", "unreadable", "missing_db", "missing_table", "collector_error", "empty"]
+)
 def test_build_daemon_status_claim_guard_blocks_pending_or_unknown_convergence_debt(
-    tmp_path: Path, debt_setup: str
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, debt_setup: str
 ) -> None:
     """The production status route must never claim convergence without debt authority."""
     storage = status_module.ArchiveStorageStatus(
@@ -1654,8 +1656,21 @@ def test_build_daemon_status_claim_guard_blocks_pending_or_unknown_convergence_d
                 created_at_ms=1_770_000_000_000,
                 updated_at_ms=1_770_000_000_000,
             )
-    else:
+    elif debt_setup == "unreadable":
         (tmp_path / "ops.db").write_bytes(b"not a sqlite database")
+    elif debt_setup == "missing_table":
+        initialize_archive_database(tmp_path / "ops.db", ArchiveTier.OPS)
+        with sqlite3.connect(tmp_path / "ops.db") as conn:
+            conn.execute("DROP TABLE convergence_debt")
+            conn.commit()
+    elif debt_setup == "collector_error":
+        initialize_archive_database(tmp_path / "ops.db", ArchiveTier.OPS)
+        monkeypatch.setattr(
+            "polylogue.daemon.convergence_debt_status.open_readonly_connection",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("simulated collector failure")),
+        )
+    elif debt_setup == "empty":
+        initialize_archive_database(tmp_path / "ops.db", ArchiveTier.OPS)
 
     with (
         patch("polylogue.daemon.status.archive_root", return_value=tmp_path),
@@ -1679,14 +1694,18 @@ def test_build_daemon_status_claim_guard_blocks_pending_or_unknown_convergence_d
     ):
         status = build_daemon_status(sources=(), browser_capture_enabled=False)
 
-    assert status.convergence.available is (debt_setup == "pending")
+    assert status.convergence.available is (debt_setup in {"pending", "empty"})
     claim_guard = cast(dict[str, dict[str, object]], status.claim_guard)
-    assert claim_guard["converged"]["value"] is False
     reason = str(claim_guard["converged"]["reason"])
     if debt_setup == "pending":
+        assert claim_guard["converged"]["value"] is False
         assert reason == "convergence debt pending: 1 deferred"
+    elif debt_setup == "empty":
+        assert claim_guard["converged"]["value"] is True
+        assert reason == "ready"
     else:
-        assert "convergence debt status unavailable" in reason
+        assert claim_guard["converged"]["value"] is False
+        assert reason == status.convergence.error
         assert "unknown debt" in str(claim_guard["converged"]["signal"])
 
 
@@ -1954,6 +1973,7 @@ def test_daemon_and_direct_claim_guard_share_mixed_frontier_summary(tmp_path: Pa
             "search": {"state": "ready", "summary": "ready"},
         },
         ingest_workload={"available": True, "actively_ingesting": False, "running_count": 0},
+        convergence=status_module.ConvergenceDebtSummary(),
     )
 
     daemon_converged = cast(dict[str, object], daemon_guard["converged"])


### PR DESCRIPTION
## Summary

Repair human-readable direct fallback status so convergence-debt authority is visible and unavailable ledgers fail closed.

## Problem

The JSON and daemon routes already preserved unavailable convergence-debt state, but the human fallback skipped the authoritative collector. Its workload probe also treated a missing `convergence_debt` table as a readable empty ledger, so text status could omit the problem entirely.

## Solution

- Require `convergence_debt` alongside the other required ops tables for workload availability.
- Render the shared `convergence_debt_summary_info` result from `_show_direct_status`.
- Show explicit unavailable, pending, and healthy-empty text states.
- Add a unit regression for the missing required table and a real subprocess CLI regression for missing-table and fresh-empty ledgers.

## Verification

- `direnv exec . devtools test tests/unit/cli/test_status.py tests/integration/test_basic_usage_cli.py -k 'convergence_debt or authoritative_convergence or ops_workload_status_requires'`: 7 passed, 73 deselected.
- `direnv exec . devtools verify --quick`: exit 0, all 23 checks passed.
- `direnv exec . git push -u origin feature/fix/convergence-debt-unavailable`: pre-push quick verification passed and branch pushed.
- `git diff --check`: passed before commit.

## Acceptance criteria

| Criterion | Result | Evidence |
| --- | --- | --- |
| Human direct status uses authoritative convergence-debt data | Satisfied | `_show_direct_status` calls `convergence_debt_summary_info` and renders its result. |
| Missing or unreadable ledger fails loudly | Satisfied | Missing required table returns unavailable workload state and text prints the collector error. |
| Fresh empty ledger remains healthy | Satisfied | Text renders `none (ledger healthy)` and the subprocess regression asserts it. |
| Real CLI regression | Satisfied | `test_status_text_reports_authoritative_convergence_debt_state` runs `polylogue --plain ops status` in a subprocess for both states. |

## Adversarial review notes

One independent review iteration was attempted. The Codex reviewer did not return a usable verdict after entering an interactive analysis flow, and the Claude fallback was unavailable due to the weekly quota. No reviewer finding is being claimed. Manual cross-checks covered the production call site, the missing-table guard, archive-root selection, and mutation sensitivity of both regression cases.

No schema or storage migration changes.
