### PR TITLE
fix(devtools): accept active testmon seed ledger

### DIFF
--- a/devtools/checkout_guard.py
+++ b/devtools/checkout_guard.py
@@ -129,6 +129,7 @@ class CheckoutEnvironmentFingerprint:
 
 _TESTMON_STATE_DIR = Path(".cache/testmon")
 _TESTMON_STATE_MARKER = _TESTMON_STATE_DIR / "seed.json"
+_TESTMON_SEED_ATTEMPT = _TESTMON_STATE_DIR / "seed-attempt.json"
 _VERIFY_STATE_DIR = Path(".cache/verify")
 _VERIFY_STATE_MARKER = _VERIFY_STATE_DIR / "current-run.json"
 
@@ -257,6 +258,59 @@ def _marker_origin(marker: Path) -> Path | None:
     return Path(raw).resolve()
 
 
+def _is_valid_in_progress_testmon_seed_attempt(attempt: Path) -> bool:
+    """Recognize the live seed ledger before its completion marker exists.
+
+    ``verify --seed-testmon`` writes this receipt before pytest starts and
+    rewrites it after the run. It is the only unmarked testmon state that a
+    linked worktree may trust. Keep this contract local to the guard so a
+    random JSON file cannot turn an inherited cache into accepted state.
+    """
+    try:
+        payload = json.loads(attempt.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    if not isinstance(payload, Mapping) or payload.get("status") not in {"running", "incomplete"}:
+        return False
+    protocol_version = payload.get("protocol_version")
+    if not isinstance(protocol_version, int) or isinstance(protocol_version, bool) or protocol_version <= 0:
+        return False
+    identity = payload.get("identity")
+    if not isinstance(identity, Mapping):
+        return False
+    if not isinstance(identity.get("worktree_fingerprint"), str) or not identity["worktree_fingerprint"]:
+        return False
+    if not isinstance(identity.get("python"), str) or not identity["python"]:
+        return False
+    if not isinstance(identity.get("skip_slow"), bool) or not isinstance(identity.get("lab"), bool):
+        return False
+    git_head = identity.get("git_head")
+    if git_head is not None and (not isinstance(git_head, str) or not git_head):
+        return False
+    if "checkout_root" in payload:
+        return False
+    expected_nodeids = payload.get("expected_nodeids")
+    if not isinstance(expected_nodeids, list) or any(
+        not isinstance(nodeid, str) or not nodeid for nodeid in expected_nodeids
+    ):
+        return False
+    expected_count = payload.get("expected_count")
+    if (
+        not isinstance(expected_count, int)
+        or isinstance(expected_count, bool)
+        or expected_count != len(expected_nodeids)
+    ):
+        return False
+    if not isinstance(payload.get("resume"), bool):
+        return False
+    for key in ("started_at", "run_id", "artifact_dir", "testmon_data_before"):
+        value = payload.get(key)
+        if not isinstance(value, str) or not value:
+            return False
+    artifact_dir = Path(payload["artifact_dir"])
+    return not artifact_dir.is_absolute() and artifact_dir.parts[:3] == (".cache", "verify", "runs")
+
+
 def _cache_artifact(
     *,
     repo_root: Path,
@@ -274,9 +328,17 @@ def _cache_artifact(
             return None, None
     except OSError:
         pass
-    origin = _marker_origin(repo_root / marker)
+    marker_path = repo_root / marker
+    origin = _marker_origin(marker_path)
     if origin == repo_root:
         return origin, None
+    if (
+        origin is None
+        and not marker_path.exists()
+        and state_dir == _TESTMON_STATE_DIR
+        and _is_valid_in_progress_testmon_seed_attempt(repo_root / _TESTMON_SEED_ATTEMPT)
+    ):
+        return None, None
     if origin is None:
         detail = f"{state_path} has no verifiable checkout-root marker"
     else:

--- a/tests/unit/devtools/test_checkout_guard.py
+++ b/tests/unit/devtools/test_checkout_guard.py
@@ -164,6 +164,32 @@ def _fake_linked_checkout(tmp_path: Path) -> Path:
     return root
 
 
+def _write_in_progress_seed_attempt(root: Path, *, status: str = "running", **overrides: object) -> Path:
+    payload: dict[str, object] = {
+        "protocol_version": verify.TESTMON_SEED_PROTOCOL_VERSION,
+        "status": status,
+        "identity": {
+            "git_head": "head",
+            "worktree_fingerprint": "fingerprint",
+            "python": "3.14",
+            "skip_slow": True,
+            "lab": False,
+        },
+        "resume": False,
+        "expected_nodeids": [],
+        "expected_count": 0,
+        "started_at": "2026-08-05T12:00:00+00:00",
+        "run_id": "seed-testmon-20260805T120000Z",
+        "artifact_dir": ".cache/verify/runs/seed-testmon-20260805T120000Z",
+        "testmon_data_before": "missing",
+    }
+    payload.update(overrides)
+    attempt = root / ".cache" / "testmon" / "seed-attempt.json"
+    attempt.parent.mkdir(parents=True, exist_ok=True)
+    attempt.write_text(json.dumps(payload))
+    return attempt
+
+
 def test_checkout_environment_fingerprint_accepts_clean_linked_worktree(tmp_path: Path) -> None:
     root = _fake_linked_checkout(tmp_path)
     fingerprint = checkout_environment_fingerprint(
@@ -175,6 +201,82 @@ def test_checkout_environment_fingerprint_accepts_clean_linked_worktree(tmp_path
     assert fingerprint.clean
     assert fingerprint.linked_worktree is True
     assert fingerprint.python_environment_root == root
+
+
+def test_checkout_environment_fingerprint_accepts_current_in_progress_seed_attempt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _fake_linked_checkout(tmp_path)
+    attempt = _write_in_progress_seed_attempt(root)
+    (root / ".cache" / "testmon" / "testmondata").write_text("partial")
+    package_path = root / "polylogue" / "__init__.py"
+    monkeypatch.setattr("devtools.checkout_guard.resolved_polylogue_path", lambda: package_path)
+
+    fingerprint = assert_polylogue_matches_checkout(
+        root,
+        context="seed-testmon bootstrap",
+        python_executable=root / ".venv" / "bin" / "python",
+    )
+
+    assert fingerprint.clean
+    assert fingerprint.testmon_state_origin is None
+    assert attempt.is_file()
+
+
+@pytest.mark.parametrize(
+    ("status", "overrides"),
+    [
+        ("running", {"identity": {}}),
+        ("running", {"expected_count": 1}),
+        ("running", {"artifact_dir": "/foreign/.cache/verify/runs/seed"}),
+        ("complete", {}),
+    ],
+)
+def test_checkout_environment_fingerprint_rejects_invalid_or_completed_seed_attempt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    status: str,
+    overrides: dict[str, object],
+) -> None:
+    root = _fake_linked_checkout(tmp_path)
+    attempt = _write_in_progress_seed_attempt(root, status=status, **overrides)
+    (root / ".cache" / "testmon" / "testmondata").write_text("foreign or incomplete")
+    package_path = root / "polylogue" / "__init__.py"
+    monkeypatch.setattr("devtools.checkout_guard.resolved_polylogue_path", lambda: package_path)
+
+    with pytest.raises(CheckoutEnvironmentMismatchError) as excinfo:
+        assert_polylogue_matches_checkout(
+            root,
+            context="invalid testmon state",
+            python_executable=root / ".venv" / "bin" / "python",
+        )
+
+    message = str(excinfo.value)
+    assert str(attempt.parent) in message
+    assert "no verifiable checkout-root marker" in message
+
+
+def test_checkout_environment_fingerprint_requires_provenance_for_completed_seed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _fake_linked_checkout(tmp_path)
+    seed_dir = root / ".cache" / "testmon"
+    seed_dir.mkdir(parents=True)
+    (seed_dir / "testmondata").write_text("complete")
+    (seed_dir / "seed.json").write_text(
+        json.dumps({"protocol_version": verify.TESTMON_SEED_PROTOCOL_VERSION, "status": "complete"})
+    )
+    package_path = root / "polylogue" / "__init__.py"
+    monkeypatch.setattr("devtools.checkout_guard.resolved_polylogue_path", lambda: package_path)
+
+    with pytest.raises(CheckoutEnvironmentMismatchError) as excinfo:
+        assert_polylogue_matches_checkout(
+            root,
+            context="completed testmon state",
+            python_executable=root / ".venv" / "bin" / "python",
+        )
+
+    assert str(seed_dir / "seed.json") in str(excinfo.value)
 
 
 def test_checkout_preflight_reports_seeded_artifacts_and_main_interpreter(


### PR DESCRIPTION
## Summary

Allow a linked worktree to pass the checkout guard while `devtools verify --seed-testmon` is actively building its local dependency baseline.

## Problem

The seed command writes `.cache/testmon/seed-attempt.json` before pytest starts and only writes the provenance-bearing `seed.json` after completion. The guard saw the valid in-progress directory as an unmarked inherited cache and rejected the run before the seed could finish. This blocked the merge-gate repair tracked by Ref #3768.

## Solution

`devtools/checkout_guard.py` now validates the current running/incomplete seed-attempt structure and accepts it only when `seed.json` is absent. Marker-present state still requires a checkout-root marker, and malformed, completed-without-provenance, or foreign unmarked state remains rejected. `tests/unit/devtools/test_checkout_guard.py` covers the current bootstrap ledger and each rejection boundary.

## Verification

- `direnv exec . devtools test tests/unit/devtools/test_checkout_guard.py tests/unit/devtools/test_testmon_bootstrap.py` -> 34 passed.
- `direnv exec . devtools verify --quick` -> all 23 steps passed, including ruff format/check, mypy, render all, layering, policy, and schema promotion.
- The pre-push hook reran `devtools verify --quick` at commit `eb8ef3934148a6cb0277ec8656878e983481114a` -> exit 0.

## Acceptance criteria

| Criterion | Result |
| --- | --- |
| Valid in-progress `seed-attempt.json` is safe local state | Satisfied. |
| Malformed or foreign unmarked testmon cache remains rejected | Satisfied. |
| Completed seed state requires checkout provenance | Satisfied. |
| Focused guard/bootstrap tests pass | Satisfied, 34 passed. |

## Residual uncertainty

The guard validates the persisted in-progress receipt shape. It does not inspect process liveness, which is outside the guard's filesystem-only contract.
