### PR TITLE
test(artifacts): align runtime graph contracts

### DIFF
--- a/polylogue/artifacts/runtime.py
+++ b/polylogue/artifacts/runtime.py
@@ -569,7 +569,7 @@ RUNTIME_ARTIFACT_NODES: tuple[ArtifactNode, ...] = (
         name="assertions",
         layer=ArtifactLayer.DURABLE,
         description="Durable user-tier assertions written by marks, tags, annotations, corrections, and saved state.",
-        code_refs=("polylogue.storage.sqlite.archive_tiers.assertions",),
+        code_refs=("polylogue.storage.sqlite.archive_tiers.user_write.upsert_assertion",),
         readiness_surfaces=("api", "mcp", "cli"),
     ),
     ArtifactNode(

--- a/tests/unit/core/test_artifact_specs.py
+++ b/tests/unit/core/test_artifact_specs.py
@@ -61,6 +61,20 @@ def test_runtime_artifact_specs_expose_the_curated_vertical_paths() -> None:
         "embedding-status-query-loop",
         "retrieval-band-readiness-loop",
         "source-acquisition-loop",
+        "tag-mutation-loop",
+        "metadata-mutation-loop",
+        "mark-mutation-loop",
+        "annotation-mutation-loop",
+        "blackboard-post-loop",
+        "assertion-candidate-capture-loop",
+        "raw-authority-blocker-resolution-loop",
+        "saved-view-mutation-loop",
+        "recall-pack-mutation-loop",
+        "workspace-mutation-loop",
+        "correction-mutation-loop",
+        "session-delete-loop",
+        "session-excision-loop",
+        "identity-reset-loop",
     }
 
 


### PR DESCRIPTION
## Summary

Align the runtime artifact catalog with its live mutation paths and assertion writer.

## Problem

The full testmon seed found the artifact-path contract omitted current mutation loops, and the assertions node referenced a removed module.

## Solution

Register the live assertion write function as the code reference and update the curated path contract to cover every declared mutation path.

## Verification

- `direnv exec . devtools test tests/unit/core/test_artifact_specs.py tests/unit/verification/test_code_refs_resolve.py`
- Result: `289 passed`
- Pre-push quick verification completed before push.