### PR TITLE
test(sources): preserve absent provider message IDs

### DIFF
--- a/tests/unit/sources/test_gemini_drive_normalization_laws.py
+++ b/tests/unit/sources/test_gemini_drive_normalization_laws.py
@@ -374,7 +374,7 @@ def test_ai_studio_normalizes_identity_authorship_config_blocks_artifacts_usage_
     assert len(session.attachments) == 8
 
 
-def test_native_turn_facts_survive_reordering_while_missing_ids_use_source_position() -> None:
+def test_native_turn_facts_survive_reordering_while_missing_ids_stay_absent() -> None:
     payload = _ai_studio_payload()
     [ordered] = parse_payload(Provider.GEMINI, payload, "ordered")
     reordered_payload = deepcopy(payload)
@@ -464,7 +464,8 @@ def test_native_turn_facts_survive_reordering_while_missing_ids_use_source_posit
     }
     [missing_id_session] = parse_payload(Provider.GEMINI, missing_id_payload, "missing-id-session")
     assert missing_id_session.provider_session_id == "missing-id-session"
-    assert [message.provider_message_id for message in missing_id_session.messages] == ["chunk-1", "chunk-2"]
+    assert [message.provider_message_id for message in missing_id_session.messages] == ["", ""]
+    assert [message.position for message in missing_id_session.messages] == [0, 1]
 
 
 def test_ambiguous_branch_child_declarations_do_not_invent_a_parent() -> None:
@@ -514,7 +515,8 @@ def test_nested_drive_like_wrappers_lower_through_the_production_dispatch_route(
     assert [session.provider_session_id for session in sessions] == ["nested-session-one", "nested-session-two"]
     assert [session.source_name for session in sessions] == [Provider.DRIVE, Provider.DRIVE]
     assert [session.messages[0].text for session in sessions] == ["first nested turn", "second nested turn"]
-    assert [session.messages[0].provider_message_id for session in sessions] == ["chunk-1", "chunk-1"]
+    assert [session.messages[0].provider_message_id for session in sessions] == ["", ""]
+    assert [session.messages[0].position for session in sessions] == [0, 0]
     assert [session.models_used for session in sessions] == [
         ["models/gemini-nested-safe"],
         ["models/gemini-nested-safe"],

--- a/tests/unit/storage/test_archive_tiers_provider_fixtures.py
+++ b/tests/unit/storage/test_archive_tiers_provider_fixtures.py
@@ -63,16 +63,12 @@ def test_archive_tiers_writer_materializes_drive_payload(tmp_path: Path) -> None
     assert envelope.origin == "aistudio-drive"
     assert envelope.native_id == "gem-text-only"
     assert envelope.title == "Capital trivia"
-    assert envelope.active_leaf_message_id == "aistudio-drive:gem-text-only:chunk-4"
-    assert [message.message_id for message in envelope.messages] == [
-        "aistudio-drive:gem-text-only:chunk-1",
-        "aistudio-drive:gem-text-only:chunk-2",
-        "aistudio-drive:gem-text-only:chunk-3",
-        "aistudio-drive:gem-text-only:chunk-4",
-    ]
+    message_ids = [message.message_id for message in envelope.messages]
+    assert envelope.active_leaf_message_id == message_ids[-1]
+    assert message_ids == [f"aistudio-drive:gem-text-only:{position}.0" for position in range(4)]
     assert [message.role for message in envelope.messages] == ["user", "assistant", "user", "assistant"]
     assert [message.is_active_leaf for message in envelope.messages] == [False, False, False, True]
-    assert search_archive_blocks(conn, "Paris") == ["aistudio-drive:gem-text-only:chunk-2:0"]
+    assert search_archive_blocks(conn, "Paris") == [f"{message_ids[1]}:0"]
 
 
 def test_archive_tiers_writer_materializes_antigravity_payload(tmp_path: Path) -> None:
@@ -84,12 +80,9 @@ def test_archive_tiers_writer_materializes_antigravity_payload(tmp_path: Path) -
 
     assert envelope.origin == "antigravity-session"
     assert envelope.native_id == "anti-fixture-001"
-    assert [message.message_id for message in envelope.messages] == [
-        "antigravity-session:anti-fixture-001:anti-fixture-001:0:user_input",
-        "antigravity-session:anti-fixture-001:anti-fixture-001:1:planner_response",
-    ]
+    message_ids = [message.message_id for message in envelope.messages]
+    assert len(message_ids) == len(set(message_ids)) == 2
+    assert all(message_id.startswith("antigravity-session:anti-fixture-001:synthetic-") for message_id in message_ids)
     assert [message.role for message in envelope.messages] == ["user", "assistant"]
     assert envelope.messages[1].is_active_leaf is True
-    assert search_archive_blocks(conn, "complete") == [
-        "antigravity-session:anti-fixture-001:anti-fixture-001:1:planner_response:0"
-    ]
+    assert search_archive_blocks(conn, "complete") == [f"{message_ids[1]}:0"]


### PR DESCRIPTION
## Summary

Align provider fixture and normalization laws with the current native-ID contract.

## Problem

The full testmon seed found tests expecting positional `chunk-N` IDs that parsers intentionally no longer synthesize when native IDs are absent.

## Solution

Assert preserved native absence, recorded source positions, and deterministic persisted identities. The fixture coverage continues to use real parser and writer routes.

## Verification

- `direnv exec . devtools test tests/unit/storage/test_archive_tiers_provider_fixtures.py tests/unit/sources/test_gemini_drive_normalization_laws.py`
- Result: `11 passed`
- Pre-push quick verification completed before push.