### PR TITLE
test: cover durable settings command surface

### DIFF
--- a/polylogue/cli/commands/setting.py
+++ b/polylogue/cli/commands/setting.py
@@ -44,7 +44,7 @@ def setting_command() -> None:
 
 @setting_command.command("get")
 @click.argument("setting_key")
-@click.option("--format", "output_format", type=click.Choice(("text", "json")), default="text", show_default=True)
+@click.option("-f", "--format", "output_format", type=click.Choice(("text", "json")), default="text", show_default=True)
 def setting_get_command(setting_key: str, output_format: str) -> None:
     """Print one setting's stored value, or report it as unset."""
 
@@ -67,7 +67,7 @@ def setting_get_command(setting_key: str, output_format: str) -> None:
 @setting_command.command("set")
 @click.argument("setting_key")
 @click.argument("value")
-@click.option("--format", "output_format", type=click.Choice(("text", "json")), default="text", show_default=True)
+@click.option("-f", "--format", "output_format", type=click.Choice(("text", "json")), default="text", show_default=True)
 def setting_set_command(setting_key: str, value: str, output_format: str) -> None:
     """Insert-or-update one typed setting row (rejects unknown keys/values)."""
 
@@ -85,7 +85,7 @@ def setting_set_command(setting_key: str, value: str, output_format: str) -> Non
 
 
 @setting_command.command("list")
-@click.option("--format", "output_format", type=click.Choice(("text", "json")), default="text", show_default=True)
+@click.option("-f", "--format", "output_format", type=click.Choice(("text", "json")), default="text", show_default=True)
 def setting_list_command(output_format: str) -> None:
     """List every stored setting row."""
 

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -291,6 +291,11 @@ BESPOKE_METHODS: frozenset[str] = frozenset(
         # (test_resolve_ref_renders_finding_claim_with_controls above).
         "record_comparative_judgment",
         "list_comparative_judgments",
+        # Durable settings are covered end-to-end in
+        # tests/unit/api/test_settings_surface.py.
+        "get_setting",
+        "list_settings",
+        "set_setting",
     }
 )
 

--- a/tests/unit/cli/__snapshots__/test_help_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_help_snapshots.ambr
@@ -198,6 +198,7 @@
       agent        Install executable agent guidance.
       annotations  Import typed annotation batches.
       compare      Blind pairwise comparative judgment and calibration.
+      setting      Get, set, and list durable user settings.
   
   '''
 # ---

--- a/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
@@ -204,6 +204,7 @@
       agent        Install executable agent guidance.
       annotations  Import typed annotation batches.
       compare      Blind pairwise comparative judgment and calibration.
+      setting      Get, set, and list durable user settings.
   '''
 # ---
 # name: TestTerminalDimensions.test_help_at_narrow_width
@@ -493,6 +494,7 @@
       annotations  Import typed annotation batches.
       compare      Blind pairwise comparative judgment and
                    calibration.
+      setting      Get, set, and list durable user settings.
   '''
 # ---
 # name: TestTerminalDimensions.test_help_at_wide_width
@@ -684,5 +686,6 @@
       agent        Install executable agent guidance.
       annotations  Import typed annotation batches.
       compare      Blind pairwise comparative judgment and calibration.
+      setting      Get, set, and list durable user settings.
   '''
 # ---

--- a/tests/unit/cli/test_setting_command.py
+++ b/tests/unit/cli/test_setting_command.py
@@ -6,13 +6,16 @@ import json
 from pathlib import Path
 from typing import cast
 
+import pytest
 from click.testing import CliRunner
 
 from polylogue.cli import cli
+from polylogue.cli.commands.setting import setting_command
 
 
 def _run(args: list[str]) -> dict[str, object] | list[object]:
     result = CliRunner().invoke(cli, ["--plain", "setting", *args], catch_exceptions=False)
+
     assert result.exit_code == 0, result.output
     return cast("dict[str, object] | list[object]", json.loads(result.output))
 
@@ -47,3 +50,12 @@ def test_setting_set_rejects_invalid_tier_value(cli_workspace: dict[str, Path]) 
     result = CliRunner().invoke(cli, ["--plain", "setting", "set", "subscription_tier", "not-a-tier"])
     assert result.exit_code != 0
     assert "subscription_tier must be one of" in result.output
+
+
+@pytest.mark.parametrize("subcommand", ("get", "set", "list"))
+def test_setting_subcommands_expose_standard_format_alias(subcommand: str) -> None:
+    """Every settings read/write route accepts the CLI-wide ``-f`` shorthand."""
+    result = CliRunner().invoke(setting_command, [subcommand, "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "-f, --format" in result.output


### PR DESCRIPTION
## Summary

Completes the public contract around the existing durable settings command.

## Problem

The registered command was missing from pinned root help, did not support the standard `-f` output-format alias, and the API facade contract did not categorize its already-tested async methods.

## Solution

Adds the alias on all three Click routes, records the methods in the facade contract, refreshes root and terminal help snapshots, and pins the alias on the real commands.

## Verification

`direnv exec . devtools test tests/unit/api/test_facade_contracts.py::test_no_undiscovered_async_methods tests/unit/api/test_settings_surface.py tests/unit/cli/test_setting_command.py tests/unit/cli/test_help_snapshots.py::test_root_help_snapshot tests/unit/cli/test_terminal_snapshots.py::TestHelpOutput::test_help_output_snapshot tests/unit/cli/test_terminal_snapshots.py::TestTerminalDimensions`

18 passed. Pre-push `devtools verify --quick` is the publish gate.