### PR TITLE
fix(reindex): reject invalid candidates before insights

### DIFF
--- a/.agent/CONVENTIONS.md
+++ b/.agent/CONVENTIONS.md
@@ -135,6 +135,10 @@ dump. The tracked `.agent` surface stays small (this file, README, scripts,
 demos, reports, task-history, tools, archive); everything else is ignored
 live state. New tracked files get a deliberate `.gitignore` allowlist entry.
 
+## Pathology Zoo Growth Rule
+
+Every production incident adds its smallest production-ingested reproduction to `tests/infra/pathology_zoo.py` in the fix PR. Add the pathology label and motivating bead id to the queryable manifest with the fixture, rather than leaving the incident represented only by a comment or a parser-local example.
+
 ## Fixture Identifier Hygiene
 
 This repo is **public**. Never commit a real session/conversation identifier

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -399,8 +399,8 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         "devtools.reindex_canary",
         use_when="Exercise the bounded semantic reindex canary before paying for a full rebuild.",
         examples=(
-            "devtools reindex-canary --input /path/to/index.db --sample 100 --report /path/to/canary.json --no-promote",
-            "devtools reindex-canary --pathology-session-id codex-session:whale --report /path/to/canary.json --no-promote",
+            "devtools reindex-canary --archive-root /path/to/isolated-archive --input /path/to/index.db --sample 100 --report /path/to/canary.json --no-promote",
+            "devtools reindex-canary --archive-root /path/to/isolated-archive --pathology-session-id codex-session:whale --report /path/to/canary.json --no-promote",
         ),
     ),
     CommandSpec(

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -294,7 +294,8 @@ Read-only with respect to the active index. Before a full reindex, this command 
 
 ```bash
 polylogue ops maintenance reindex-canary \
-  --input /realm/db/polylogue/index.db \
+  --archive-root /realm/tmp/polylogue-canary-archive \
+  --input /realm/tmp/polylogue-canary-archive/index.db \
   --sample 100 \
   --report /realm/tmp/polylogue-reindex-canary.json \
   --no-promote \

--- a/polylogue/cli/commands/maintenance/_reindex_canary.py
+++ b/polylogue/cli/commands/maintenance/_reindex_canary.py
@@ -7,10 +7,14 @@ from pathlib import Path
 
 import click
 
-from polylogue.paths import archive_root
-
 
 @click.command("reindex-canary")
+@click.option(
+    "--archive-root",
+    type=click.Path(path_type=Path, exists=True, file_okay=False, readable=True),
+    required=True,
+    help="Explicit isolated archive containing durable source.db and the active index candidate.",
+)
 @click.option(
     "--input-index",
     "--input",
@@ -52,6 +56,7 @@ from polylogue.paths import archive_root
     help="Required safety gate: leave the rebuilt candidate inactive for comparison.",
 )
 def reindex_canary_command(
+    archive_root: Path,
     input_index: Path | None,
     sessions_per_origin: int,
     pathology_session_id: tuple[str, ...],
@@ -77,7 +82,7 @@ def reindex_canary_command(
     result: CanaryRunResult | None = None
     try:
         result = run_reindex_canary(
-            archive_root(),
+            archive_root,
             input_index=input_index,
             sessions_per_origin=sessions_per_origin,
             pathology_session_ids=pathology_session_id,

--- a/polylogue/maintenance/archive_verification.py
+++ b/polylogue/maintenance/archive_verification.py
@@ -1031,6 +1031,52 @@ def _check_pathology_zoo_invariants(archive_root: Path, _sample_limit: int) -> A
     )
 
 
+def _check_pathology_zoo_invariants_at_index_path(
+    archive_root: Path, index_path: Path, _sample_limit: int
+) -> ArchiveVerificationCheck:
+    """Run pathology-zoo invariants against an inactive index and live durable tiers."""
+    from polylogue.maintenance.pathology_zoo import (
+        PATHOLOGY_ZOO_MANIFEST,
+        PathologyZooMember,
+        pathology_zoo_is_present,
+    )
+
+    if not pathology_zoo_is_present(archive_root, index_path_override=index_path):
+        return ArchiveVerificationCheck(
+            name="pathology-zoo-invariants",
+            status=OutcomeStatus.OK,
+            summary="no pathology-zoo corpus detected; zoo-specific invariants are not applicable",
+            evidence={"active": False, "checked_member_ids": [], "failed_member_ids": []},
+        )
+
+    failed: list[PathologyZooMember] = []
+    for member in PATHOLOGY_ZOO_MANIFEST:
+        try:
+            satisfied = member.invariant.is_satisfied(archive_root, index_path_override=index_path)
+        except sqlite3.Error:
+            satisfied = False
+        if not satisfied:
+            failed.append(member)
+    return ArchiveVerificationCheck(
+        name="pathology-zoo-invariants",
+        status=OutcomeStatus.ERROR if failed else OutcomeStatus.OK,
+        summary=(
+            f"{len(failed)} pathology-zoo invariant(s) failed"
+            if failed
+            else f"all {len(PATHOLOGY_ZOO_MANIFEST)} pathology-zoo invariants hold"
+        ),
+        count=len(failed),
+        details=[f"{member.member_id}: {member.invariant.condition}" for member in failed],
+        evidence={
+            "active": True,
+            "checked_member_ids": [member.member_id for member in PATHOLOGY_ZOO_MANIFEST],
+            "failed_member_ids": [member.member_id for member in failed],
+            "index_path": str(index_path),
+            "durable_archive_root": str(archive_root),
+        },
+    )
+
+
 # ---------------------------------------------------------------------------
 # Check: embeddings refs resolve in the index tier (I4, polylogue-t0m73)
 # ---------------------------------------------------------------------------
@@ -2047,6 +2093,7 @@ ARCHIVE_VERIFICATION_CHECKS: tuple[ArchiveVerificationCheckSpec, ...] = (
         "Every present pathology-zoo member satisfies its production-owned invariant.",
         _check_pathology_zoo_invariants,
         ArchiveVerificationCheckClass.STATE_INVARIANT,
+        _check_pathology_zoo_invariants_at_index_path,
     ),
     ArchiveVerificationCheckSpec(
         "embeddings-refs-liveness",
@@ -2169,6 +2216,22 @@ REINDEX_ACCEPTANCE_CHECKS: tuple[str, ...] = (
     "planner-stats",
 )
 
+#: Candidate checks that need the durable archive tiers as well as the
+#: inactive generation's index. These are run with ``index_path_override`` so
+#: they cannot silently fall back to the active/default index.
+REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS: tuple[str, ...] = (
+    "corpus-absences",
+    "corpus-attachment-fidelity",
+    "corpus-revision-fidelity",
+    "pathology-zoo-invariants",
+)
+
+#: A partial reindex-canary candidate is intentionally not a complete source
+#: replay, so full corpus-fidelity checks would reject every useful canary.
+#: Its candidate-specific gate still runs the pathology-zoo contract against
+#: the candidate index and the durable source tiers.
+REINDEX_CANARY_ACCEPTANCE_CHECKS: tuple[str, ...] = ("pathology-zoo-invariants",)
+
 
 def _select_check_specs(checks: Sequence[str] | None) -> tuple[ArchiveVerificationCheckSpec, ...]:
     if checks is None:
@@ -2247,6 +2310,8 @@ __all__ = [
     "ARCHIVE_VERIFICATION_CHECK_NAMES",
     "ARCHIVE_VERIFICATION_WAIVERS",
     "CORPUS_FIDELITY_CHECKS",
+    "REINDEX_CANARY_ACCEPTANCE_CHECKS",
+    "REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS",
     "REINDEX_ACCEPTANCE_CHECKS",
     "ArchiveVerificationCheck",
     "ArchiveVerificationCheckClass",

--- a/polylogue/maintenance/archive_verification.py
+++ b/polylogue/maintenance/archive_verification.py
@@ -989,6 +989,48 @@ def _check_blob_refs_liveness(archive_root: Path, sample_limit: int) -> ArchiveV
     )
 
 
+def _check_pathology_zoo_invariants(archive_root: Path, _sample_limit: int) -> ArchiveVerificationCheck:
+    """Run each production-owned pathology-zoo invariant when its corpus is present."""
+    from polylogue.maintenance.pathology_zoo import (
+        PATHOLOGY_ZOO_MANIFEST,
+        PathologyZooMember,
+        pathology_zoo_is_present,
+    )
+
+    if not pathology_zoo_is_present(archive_root):
+        return ArchiveVerificationCheck(
+            name="pathology-zoo-invariants",
+            status=OutcomeStatus.OK,
+            summary="no pathology-zoo corpus detected; zoo-specific invariants are not applicable",
+            evidence={"active": False, "checked_member_ids": [], "failed_member_ids": []},
+        )
+
+    failed: list[PathologyZooMember] = []
+    for member in PATHOLOGY_ZOO_MANIFEST:
+        try:
+            satisfied = member.invariant.is_satisfied(archive_root)
+        except sqlite3.Error:
+            satisfied = False
+        if not satisfied:
+            failed.append(member)
+    return ArchiveVerificationCheck(
+        name="pathology-zoo-invariants",
+        status=OutcomeStatus.ERROR if failed else OutcomeStatus.OK,
+        summary=(
+            f"{len(failed)} pathology-zoo invariant(s) failed"
+            if failed
+            else f"all {len(PATHOLOGY_ZOO_MANIFEST)} pathology-zoo invariants hold"
+        ),
+        count=len(failed),
+        details=[f"{member.member_id}: {member.invariant.condition}" for member in failed],
+        evidence={
+            "active": True,
+            "checked_member_ids": [member.member_id for member in PATHOLOGY_ZOO_MANIFEST],
+            "failed_member_ids": [member.member_id for member in failed],
+        },
+    )
+
+
 # ---------------------------------------------------------------------------
 # Check: embeddings refs resolve in the index tier (I4, polylogue-t0m73)
 # ---------------------------------------------------------------------------
@@ -1999,6 +2041,12 @@ ARCHIVE_VERIFICATION_CHECKS: tuple[ArchiveVerificationCheckSpec, ...] = (
         "not membership in blob_refs itself (polylogue-t0m73 I3).",
         _check_blob_refs_liveness,
         ArchiveVerificationCheckClass.LIVENESS,
+    ),
+    ArchiveVerificationCheckSpec(
+        "pathology-zoo-invariants",
+        "Every present pathology-zoo member satisfies its production-owned invariant.",
+        _check_pathology_zoo_invariants,
+        ArchiveVerificationCheckClass.STATE_INVARIANT,
     ),
     ArchiveVerificationCheckSpec(
         "embeddings-refs-liveness",

--- a/polylogue/maintenance/pathology_zoo.py
+++ b/polylogue/maintenance/pathology_zoo.py
@@ -38,8 +38,12 @@ class PathologyZooInvariant:
     parameters: tuple[object, ...]
     expected: tuple[object, ...] | None
 
-    def is_satisfied(self, archive_root: Path) -> bool:
-        path = _tier_path(archive_root, self.tier)
+    def is_satisfied(self, archive_root: Path, *, index_path_override: Path | None = None) -> bool:
+        path = (
+            index_path_override
+            if self.tier == "index" and index_path_override is not None
+            else _tier_path(archive_root, self.tier)
+        )
         with sqlite3.connect(f"file:{path}?mode=ro", uri=True) as connection:
             return bool(connection.execute(self.query, self.parameters).fetchone() == self.expected)
 
@@ -356,10 +360,10 @@ def pathology_zoo_session_ids() -> tuple[str, ...]:
     )
 
 
-def pathology_zoo_is_present(archive_root: Path) -> bool:
+def pathology_zoo_is_present(archive_root: Path, *, index_path_override: Path | None = None) -> bool:
     """Return whether an archive contains any durable pathology-zoo evidence."""
     session_ids = pathology_zoo_session_ids()
-    index_path = _tier_path(archive_root, "index")
+    index_path = index_path_override if index_path_override is not None else _tier_path(archive_root, "index")
     if index_path.exists():
         placeholders = ", ".join("?" for _ in session_ids)
         try:

--- a/polylogue/maintenance/pathology_zoo.py
+++ b/polylogue/maintenance/pathology_zoo.py
@@ -1,0 +1,399 @@
+"""Private-data-free pathology-zoo contracts used by production maintenance.
+
+Fixture construction belongs under :mod:`tests.infra.pathology_zoo`; this
+module deliberately contains only the stable identities and read-only archive
+invariants that a real canary or archive verifier must consume.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+
+def _tier_path(archive_root: Path, tier: str) -> Path:
+    if tier == "index":
+        from polylogue.storage.archive_identity import resolve_active_index_path
+
+        return resolve_active_index_path(archive_root)
+    return archive_root / f"{tier}.db"
+
+
+class PathologyZooCanaryEligibility(StrEnum):
+    """Whether a pathology has a replayable session identity."""
+
+    SESSION_BACKED = "session_backed"
+    NON_SESSION_ONLY = "non_session_only"
+
+
+@dataclass(frozen=True, slots=True)
+class PathologyZooInvariant:
+    """One independently valuable, read-only SQLite invariant."""
+
+    condition: str
+    tier: str
+    query: str
+    parameters: tuple[object, ...]
+    expected: tuple[object, ...] | None
+
+    def is_satisfied(self, archive_root: Path) -> bool:
+        path = _tier_path(archive_root, self.tier)
+        with sqlite3.connect(f"file:{path}?mode=ro", uri=True) as connection:
+            return bool(connection.execute(self.query, self.parameters).fetchone() == self.expected)
+
+
+@dataclass(frozen=True, slots=True)
+class PathologyZooMember:
+    """One pathology whose durable invariant is checked by maintenance."""
+
+    member_id: str
+    pathology: str
+    motivating_beads: tuple[str, ...]
+    session_ids: tuple[str, ...]
+    raw_paths: tuple[str, ...]
+    canary_eligibility: PathologyZooCanaryEligibility
+    invariant: PathologyZooInvariant
+    durable_paths: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.canary_eligibility is PathologyZooCanaryEligibility.SESSION_BACKED and not self.session_ids:
+            raise ValueError(f"session-backed pathology {self.member_id!r} must declare session_ids")
+        if self.canary_eligibility is PathologyZooCanaryEligibility.NON_SESSION_ONLY and self.session_ids:
+            raise ValueError(f"non-session pathology {self.member_id!r} must not declare session_ids")
+
+
+def _invariant(
+    condition: str, tier: str, query: str, parameters: tuple[object, ...], expected: tuple[object, ...] | None
+) -> PathologyZooInvariant:
+    return PathologyZooInvariant(condition, tier, query, parameters, expected)
+
+
+_CODEX = "codex-session"
+_CLAUDE_AI = "claude-ai-export"
+_CLAUDE_CODE = "claude-code-session"
+_CHATGPT = "chatgpt-export"
+_DESIGN = "claude-design-session"
+_GEMINI = "aistudio-drive"
+
+
+PATHOLOGY_ZOO_MANIFEST: tuple[PathologyZooMember, ...] = (
+    PathologyZooMember(
+        "whale-component",
+        "whale-component",
+        ("polylogue-yazae",),
+        (f"{_CODEX}:zoo-whale",),
+        ("generated/zoo-00-00.jsonl",),
+        PathologyZooCanaryEligibility.SESSION_BACKED,
+        _invariant(
+            "the whale retains at least 48 materialized messages",
+            "index",
+            "SELECT message_count >= 48 FROM sessions WHERE session_id = ?",
+            (f"{_CODEX}:zoo-whale",),
+            (1,),
+        ),
+    ),
+    PathologyZooMember(
+        "append-self-describing",
+        "append-revision-chain",
+        ("polylogue-yazae",),
+        (f"{_CODEX}:zoo-append-self",),
+        ("generated/zoo-01-00.jsonl", "generated/zoo-02-00.jsonl"),
+        PathologyZooCanaryEligibility.SESSION_BACKED,
+        _invariant(
+            "the self-describing append retains both raw revisions",
+            "source",
+            "SELECT COUNT(*) FROM raw_sessions WHERE native_id = 'zoo-append-self'",
+            (),
+            (2,),
+        ),
+    ),
+    PathologyZooMember(
+        "append-opaque",
+        "append-revision-chain",
+        ("polylogue-yazae",),
+        (f"{_CODEX}:zoo-append-opaque",),
+        ("generated/zoo-03-00.jsonl", "generated/zoo-04-00.jsonl"),
+        PathologyZooCanaryEligibility.SESSION_BACKED,
+        _invariant(
+            "the opaque append retains both raw revisions",
+            "source",
+            "SELECT COUNT(*) FROM raw_sessions WHERE native_id = 'zoo-append-opaque'",
+            (),
+            (2,),
+        ),
+    ),
+    PathologyZooMember(
+        "fork-prefix-tail",
+        "fork-resume-prefix-tail-lineage",
+        ("polylogue-yazae",),
+        (f"{_CODEX}:zoo-lineage-parent", f"{_CODEX}:zoo-lineage-child"),
+        ("manual/lineage-parent.jsonl", "manual/lineage-child.jsonl"),
+        PathologyZooCanaryEligibility.SESSION_BACKED,
+        _invariant(
+            "the fork child resolves to its prefix-sharing parent",
+            "index",
+            "SELECT resolved_dst_session_id FROM session_links WHERE src_session_id = ?",
+            (f"{_CODEX}:zoo-lineage-child",),
+            (f"{_CODEX}:zoo-lineage-parent",),
+        ),
+    ),
+    PathologyZooMember(
+        "lineage-cycle",
+        "lineage-cycle-candidate",
+        ("polylogue-yazae",),
+        (f"{_CODEX}:zoo-cycle-a", f"{_CODEX}:zoo-cycle-b"),
+        ("manual/lineage-cycle-a.jsonl", "manual/lineage-cycle-b.jsonl", "manual/lineage-cycle-z-a-update.jsonl"),
+        PathologyZooCanaryEligibility.SESSION_BACKED,
+        _invariant(
+            "the cyclic lineage candidate is quarantined",
+            "index",
+            "SELECT status, resolved_dst_session_id FROM session_links WHERE src_session_id = ?",
+            (f"{_CODEX}:zoo-cycle-a",),
+            ("quarantined", None),
+        ),
+    ),
+    PathologyZooMember(
+        "grouped-jsonl",
+        "multi-session-raw",
+        ("polylogue-yazae",),
+        (f"{_CLAUDE_CODE}:zoo-group-a", f"{_CLAUDE_CODE}:zoo-group-b"),
+        ("manual/grouped.jsonl",),
+        PathologyZooCanaryEligibility.SESSION_BACKED,
+        _invariant(
+            "the grouped JSONL raw materializes both sessions",
+            "index",
+            "SELECT COUNT(*) FROM sessions WHERE session_id IN (?, ?)",
+            (f"{_CLAUDE_CODE}:zoo-group-a", f"{_CLAUDE_CODE}:zoo-group-b"),
+            (2,),
+        ),
+    ),
+    PathologyZooMember(
+        "quarantined-head",
+        "quarantined-head-open-blocker",
+        ("polylogue-yazae",),
+        (f"{_CODEX}:zoo-orphan-head",),
+        ("manual/lineage-orphan.jsonl",),
+        PathologyZooCanaryEligibility.SESSION_BACKED,
+        _invariant(
+            "the unresolved head remains an open blocker",
+            "index",
+            "SELECT status, resolved_dst_session_id FROM session_links WHERE src_session_id = ?",
+            (f"{_CODEX}:zoo-orphan-head",),
+            (None, None),
+        ),
+    ),
+    PathologyZooMember(
+        "empty-session",
+        "genuinely-empty-session",
+        ("polylogue-yazae",),
+        (f"{_CLAUDE_CODE}:zoo-empty",),
+        ("manual/empty.jsonl",),
+        PathologyZooCanaryEligibility.SESSION_BACKED,
+        _invariant(
+            "the empty session has no materialized messages",
+            "index",
+            "SELECT message_count FROM sessions WHERE session_id = ?",
+            (f"{_CLAUDE_CODE}:zoo-empty",),
+            (0,),
+        ),
+    ),
+    PathologyZooMember(
+        "hook-event",
+        "hook-event-raw",
+        ("polylogue-yazae",),
+        (),
+        ("hook-spool/zoo-hook-event.json",),
+        PathologyZooCanaryEligibility.NON_SESSION_ONLY,
+        _invariant(
+            "the hook spool becomes a durable PostToolUse event",
+            "source",
+            "SELECT session_native_id, event_type FROM raw_hook_events WHERE hook_event_id = 'hook:zoo-hook-event'",
+            (),
+            ("zoo-hook-parent", "PostToolUse"),
+        ),
+    ),
+    PathologyZooMember(
+        "claude-design",
+        "claude-design-session-origin",
+        ("polylogue-yazae",),
+        (f"{_DESIGN}:zoo-design-session",),
+        ("manual/design.json",),
+        PathologyZooCanaryEligibility.SESSION_BACKED,
+        _invariant(
+            "the design export materializes under its distinct origin",
+            "index",
+            "SELECT origin FROM sessions WHERE session_id = ?",
+            (f"{_DESIGN}:zoo-design-session",),
+            (_DESIGN,),
+        ),
+    ),
+    PathologyZooMember(
+        "vintage-reorder",
+        "export-vintage-reorder",
+        ("polylogue-yazae", "polylogue-slshy"),
+        (f"{_CHATGPT}:zoo-vintage-reorder",),
+        ("manual/vintage-old.json", "manual/vintage-new.json"),
+        PathologyZooCanaryEligibility.SESSION_BACKED,
+        _invariant(
+            "the vintage reorder retains both raw revisions",
+            "source",
+            "SELECT COUNT(*) FROM raw_sessions WHERE native_id = 'zoo-vintage-reorder'",
+            (),
+            (2,),
+        ),
+    ),
+    PathologyZooMember(
+        "content-blocks-vintage",
+        "content-blocks-vintage",
+        ("polylogue-yazae", "polylogue-0qfy"),
+        (f"{_CLAUDE_AI}:zoo-content-blocks-vintage",),
+        ("manual/content-blocks-old.json", "manual/content-blocks-new.json"),
+        PathologyZooCanaryEligibility.SESSION_BACKED,
+        _invariant(
+            "the content-block vintage keeps its parsed text block",
+            "index",
+            "SELECT COUNT(*) FROM blocks WHERE session_id = ?",
+            (f"{_CLAUDE_AI}:zoo-content-blocks-vintage",),
+            (1,),
+        ),
+    ),
+    PathologyZooMember(
+        "lifecycle-anchor-drift",
+        "lifecycle-anchor-drift",
+        ("polylogue-yazae", "polylogue-uqwd"),
+        (f"{_CHATGPT}:zoo-lifecycle-anchor-drift",),
+        ("manual/lifecycle-old.json", "manual/lifecycle-new.json"),
+        PathologyZooCanaryEligibility.SESSION_BACKED,
+        _invariant(
+            "the lifecycle event keeps the revised provider-message anchor",
+            "index",
+            "SELECT source_message_provider_id FROM session_events WHERE session_id = ? AND event_type = 'generation_lifecycle'",
+            (f"{_CHATGPT}:zoo-lifecycle-anchor-drift",),
+            ("lifecycle-b",),
+        ),
+    ),
+    PathologyZooMember(
+        "non-stream-safe",
+        "non-stream-safe-origin",
+        ("polylogue-yazae",),
+        ("antigravity-session:zoo-06-00:zoo-06-00.md",),
+        ("generated",),
+        PathologyZooCanaryEligibility.SESSION_BACKED,
+        _invariant(
+            "the non-stream-safe source is retained under the Antigravity origin",
+            "index",
+            "SELECT origin FROM sessions WHERE session_id = ?",
+            ("antigravity-session:zoo-06-00:zoo-06-00.md",),
+            ("antigravity-session",),
+        ),
+    ),
+    PathologyZooMember(
+        "attachment-with-bytes",
+        "attachment-with-acquired-bytes",
+        ("polylogue-yazae",),
+        (f"{_GEMINI}:zoo-attachment-bytes",),
+        ("generated/zoo-05-00.json",),
+        PathologyZooCanaryEligibility.SESSION_BACKED,
+        _invariant(
+            "the acquired attachment retains bytes and a blob hash",
+            "index",
+            "SELECT a.byte_count > 0 AND a.blob_hash IS NOT NULL AND a.acquisition_status = 'acquired' FROM attachments a JOIN attachment_refs r ON r.attachment_id = a.attachment_id WHERE r.session_id = ?",
+            (f"{_GEMINI}:zoo-attachment-bytes",),
+            (1,),
+        ),
+    ),
+    PathologyZooMember(
+        "attachment-without-bytes",
+        "attachment-without-acquired-bytes",
+        ("polylogue-yazae",),
+        (f"{_CLAUDE_AI}:zoo-attachment-metadata",),
+        ("manual/attachment-metadata.json",),
+        PathologyZooCanaryEligibility.SESSION_BACKED,
+        _invariant(
+            "the unavailable attachment remains structured metadata without acquired bytes",
+            "index",
+            "SELECT a.byte_count = 0 AND a.blob_hash IS NULL AND a.acquisition_status = 'unfetched' FROM attachments a JOIN attachment_refs r ON r.attachment_id = a.attachment_id WHERE r.session_id = ?",
+            (f"{_CLAUDE_AI}:zoo-attachment-metadata",),
+            (1,),
+        ),
+    ),
+    PathologyZooMember(
+        "events-sidecars",
+        "session-events-and-sidecars",
+        ("polylogue-yazae",),
+        (f"{_CHATGPT}:zoo-lifecycle-anchor-drift",),
+        ("manual/lifecycle-old.json",),
+        PathologyZooCanaryEligibility.SESSION_BACKED,
+        _invariant(
+            "the lifecycle session retains its parsed sidecar event",
+            "index",
+            "SELECT COUNT(*) FROM session_events WHERE session_id = ?",
+            (f"{_CHATGPT}:zoo-lifecycle-anchor-drift",),
+            (1,),
+        ),
+    ),
+)
+
+
+def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
+    """Return the one manifest production consumers must share."""
+    return PATHOLOGY_ZOO_MANIFEST
+
+
+def pathology_zoo_session_ids() -> tuple[str, ...]:
+    """Return every session-backed pathology, explicitly excluding hook-only members."""
+    return tuple(
+        sorted(
+            {
+                session_id
+                for member in PATHOLOGY_ZOO_MANIFEST
+                if member.canary_eligibility is PathologyZooCanaryEligibility.SESSION_BACKED
+                for session_id in member.session_ids
+            }
+        )
+    )
+
+
+def pathology_zoo_is_present(archive_root: Path) -> bool:
+    """Return whether an archive contains any durable pathology-zoo evidence."""
+    session_ids = pathology_zoo_session_ids()
+    index_path = _tier_path(archive_root, "index")
+    if index_path.exists():
+        placeholders = ", ".join("?" for _ in session_ids)
+        try:
+            with sqlite3.connect(f"file:{index_path}?mode=ro", uri=True) as connection:
+                if (
+                    connection.execute(
+                        f"SELECT 1 FROM sessions WHERE session_id IN ({placeholders}) LIMIT 1", session_ids
+                    ).fetchone()
+                    is not None
+                ):
+                    return True
+        except sqlite3.Error:
+            pass
+    source_path = archive_root / "source.db"
+    if source_path.exists():
+        try:
+            with sqlite3.connect(f"file:{source_path}?mode=ro", uri=True) as connection:
+                return (
+                    connection.execute(
+                        "SELECT 1 FROM raw_hook_events WHERE hook_event_id = 'hook:zoo-hook-event' LIMIT 1"
+                    ).fetchone()
+                    is not None
+                )
+        except sqlite3.Error:
+            pass
+    return False
+
+
+__all__ = [
+    "PATHOLOGY_ZOO_MANIFEST",
+    "PathologyZooCanaryEligibility",
+    "PathologyZooInvariant",
+    "PathologyZooMember",
+    "pathology_zoo_is_present",
+    "pathology_zoo_manifest",
+    "pathology_zoo_session_ids",
+]

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -243,6 +243,7 @@ class RebuildIndexRequest:
     raw_ids: tuple[str, ...] = ()
     max_blob_mb: float | None = None
     promote: bool = True
+    candidate_acceptance_checks: tuple[str, ...] | None = None
     operation_id: str | None = None
     raw_batch_size: int = 500
     pass_byte_budget_mb: float | None = None
@@ -652,8 +653,8 @@ async def _rebuild_index_from_source_owned(
 ) -> RebuildIndexReceipt:
     """Ownership-proven body of :func:`rebuild_index_from_source`."""
     from polylogue.maintenance.archive_verification import (
-        CORPUS_FIDELITY_CHECKS,
         REINDEX_ACCEPTANCE_CHECKS,
+        REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS,
         verify_archive,
     )
     from polylogue.maintenance.replay import rebuild_index_from_source as replay_source
@@ -1092,7 +1093,11 @@ async def _rebuild_index_from_source_owned(
                 # source tier at the archive root before promotion.
                 verify_archive(
                     root,
-                    checks=CORPUS_FIDELITY_CHECKS,
+                    checks=(
+                        request.candidate_acceptance_checks
+                        if request.candidate_acceptance_checks is not None
+                        else REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS
+                    ),
                     index_path_override=Path(generation.index_path),
                 ),
             )

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -1039,22 +1039,6 @@ async def _rebuild_index_from_source_owned(
             # not a parallel one, so every receipt shape (deferred, paused,
             # replayed) carries the identical key for this phase.
             terminal_timings_s: dict[str, float] = {"selection_s": selection_elapsed_s}
-            terminal_started_at = time.perf_counter()
-            insight_result = repair_session_insights(
-                config,
-                dry_run=False,
-                archive_root_override=generation_root,
-                owned_inactive_generation=(generation.generation_id, generation.owner_id),
-            )
-            terminal_timings_s["terminal.session_insights"] = time.perf_counter() - terminal_started_at
-            logger.info(
-                "rebuild_terminal_stage_complete",
-                generation_id=generation.generation_id,
-                stage="session_insights",
-                elapsed_s=round(terminal_timings_s["terminal.session_insights"], 3),
-            )
-            if not insight_result.success:
-                raise RuntimeError(f"session insight materialization failed: {insight_result.detail}")
             if source_revision_snapshot(root) != generation.source_snapshot:
                 if transaction is not None:
                     transaction = generation_store.checkpoint_transaction(
@@ -1118,6 +1102,26 @@ async def _rebuild_index_from_source_owned(
                 raise RuntimeError(
                     f"reindex acceptance gate failed for generation {generation.generation_id}: {failing}"
                 )
+            # Derived insight materialization assumes a coherent lineage graph.
+            # Reject a structurally invalid inactive candidate before invoking
+            # it, so the acceptance receipt names the actual bad invariant
+            # instead of reporting an incidental derived-model failure.
+            terminal_started_at = time.perf_counter()
+            insight_result = repair_session_insights(
+                config,
+                dry_run=False,
+                archive_root_override=generation_root,
+                owned_inactive_generation=(generation.generation_id, generation.owner_id),
+            )
+            terminal_timings_s["terminal.session_insights"] = time.perf_counter() - terminal_started_at
+            logger.info(
+                "rebuild_terminal_stage_complete",
+                generation_id=generation.generation_id,
+                stage="session_insights",
+                elapsed_s=round(terminal_timings_s["terminal.session_insights"], 3),
+            )
+            if not insight_result.success:
+                raise RuntimeError(f"session insight materialization failed: {insight_result.detail}")
             terminal_started_at = time.perf_counter()
             readiness = archive_readiness_status(generation_root)
             terminal_timings_s["terminal.readiness"] = time.perf_counter() - terminal_started_at

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -295,9 +295,12 @@ def run_reindex_canary(
             "run it against an explicitly provisioned isolated canary archive"
         )
     current_index = Path(input_index) if input_index is not None else ArchiveLocation.resolve(root).active_index_path
-    from polylogue.maintenance.pathology_zoo import pathology_zoo_session_ids
+    from polylogue.maintenance.archive_verification import REINDEX_CANARY_ACCEPTANCE_CHECKS
+    from polylogue.maintenance.pathology_zoo import pathology_zoo_is_present, pathology_zoo_session_ids
 
-    automatic_pathology_ids = pathology_zoo_session_ids()
+    automatic_pathology_ids = (
+        pathology_zoo_session_ids() if pathology_zoo_is_present(root, index_path_override=current_index) else ()
+    )
     requested_pathology_ids = tuple(dict.fromkeys((*automatic_pathology_ids, *pathology_session_ids)))
     selection = select_canary_sessions(
         current_index,
@@ -310,6 +313,7 @@ def run_reindex_canary(
             archive_root=root,
             raw_ids=selection.selected_raw_ids,
             promote=False,
+            candidate_acceptance_checks=REINDEX_CANARY_ACCEPTANCE_CHECKS,
         )
     )
     candidate_path = _validate_canary_candidate(

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -286,7 +286,6 @@ def run_reindex_canary(
         raise CanarySelectionError("reindex canary requires --no-promote")
     from polylogue.config import resolve_archive_root
     from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
-    from polylogue.storage.archive_identity import ArchiveLocation
 
     root = Path(archive_root)
     if root.resolve() == resolve_archive_root().resolve():
@@ -294,7 +293,7 @@ def run_reindex_canary(
             "reindex canary refuses the configured live archive root; "
             "run it against an explicitly provisioned isolated canary archive"
         )
-    current_index = Path(input_index) if input_index is not None else ArchiveLocation.resolve(root).active_index_path
+    current_index = _resolve_canary_input_index(root, input_index)
     from polylogue.maintenance.archive_verification import REINDEX_CANARY_ACCEPTANCE_CHECKS
     from polylogue.maintenance.pathology_zoo import pathology_zoo_is_present, pathology_zoo_session_ids
 
@@ -332,6 +331,31 @@ def run_reindex_canary(
         comparison=comparison,
         rebuild_receipt=receipt.to_dict(),
     )
+
+
+def _resolve_canary_input_index(archive_root: Path, input_index: Path | None) -> Path:
+    """Resolve an explicit index only when it belongs to the selected archive."""
+    from polylogue.storage.archive_identity import ArchiveLocation
+
+    location = ArchiveLocation.resolve(archive_root)
+    if input_index is None:
+        return location.active_index_path
+
+    candidate = Path(input_index)
+    try:
+        candidate_resolved = candidate.resolve()
+        archive_resolved = Path(archive_root).resolve()
+    except (OSError, RuntimeError) as exc:
+        raise CanarySelectionError("explicit canary input index path cannot be resolved") from exc
+
+    try:
+        candidate_resolved.relative_to(archive_resolved)
+    except ValueError:
+        if candidate_resolved != location.active_index.resolved_path:
+            raise CanarySelectionError(
+                "explicit canary input index must be inside or bound to the selected archive root"
+            ) from None
+    return candidate
 
 
 def _validate_canary_candidate(

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -295,10 +295,14 @@ def run_reindex_canary(
             "run it against an explicitly provisioned isolated canary archive"
         )
     current_index = Path(input_index) if input_index is not None else ArchiveLocation.resolve(root).active_index_path
+    from polylogue.maintenance.pathology_zoo import pathology_zoo_session_ids
+
+    automatic_pathology_ids = pathology_zoo_session_ids()
+    requested_pathology_ids = tuple(dict.fromkeys((*automatic_pathology_ids, *pathology_session_ids)))
     selection = select_canary_sessions(
         current_index,
         sessions_per_origin=sessions_per_origin,
-        pathology_session_ids=pathology_session_ids,
+        pathology_session_ids=requested_pathology_ids,
         sample_session_ids=sample_session_ids,
     )
     receipt = rebuild_index_from_source_sync(

--- a/polylogue/storage/insights/session/threads.py
+++ b/polylogue/storage/insights/session/threads.py
@@ -27,12 +27,17 @@ _ROOT_THREAD_IDS_SQL = """
     WHERE parent.session_id IS NULL
     ORDER BY c.session_id
 """
+# These walks use ``UNION`` deliberately.  A parent cycle revisits the same
+# session row, so deduplicating recursive rows terminates the walk while the
+# root predicates still return no fabricated root for the cyclic component.
+# Keep the same cycle boundary across the single-root, batched-root,
+# descendant, and profile-loading queries below.
 _THREAD_ROOT_ID_SQL = """
     WITH RECURSIVE ancestors(session_id, parent_session_id) AS (
         SELECT session_id, parent_session_id
         FROM sessions
         WHERE session_id = ?
-        UNION ALL
+        UNION
         SELECT c.session_id, c.parent_session_id
         FROM sessions c
         JOIN ancestors a ON a.parent_session_id = c.session_id
@@ -47,7 +52,7 @@ _THREAD_ROOT_IDS_SQL_TEMPLATE = """
         SELECT session_id, session_id, parent_session_id
         FROM sessions
         WHERE session_id IN ({placeholders})
-        UNION ALL
+        UNION
         SELECT a.target_id, c.session_id, c.parent_session_id
         FROM sessions c
         JOIN ancestors a ON a.parent_session_id = c.session_id
@@ -61,7 +66,7 @@ _THREAD_SESSION_IDS_SQL = """
         SELECT session_id
         FROM sessions
         WHERE session_id = ?
-        UNION ALL
+        UNION
         SELECT c.session_id
         FROM sessions c
         JOIN descendants d ON c.parent_session_id = d.session_id
@@ -75,7 +80,7 @@ _THREAD_PROFILE_RECORDS_BY_ROOT_SQL_TEMPLATE = """
         SELECT session_id, session_id
         FROM sessions
         WHERE session_id IN ({placeholders})
-        UNION ALL
+        UNION
         SELECT d.root_id, c.session_id
         FROM sessions c
         JOIN descendants d ON c.parent_session_id = d.session_id

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -1665,8 +1665,13 @@ class ArchiveStore:
                 from polylogue.storage.index_generation import IndexGenerationStore
 
                 generation_id, owner_id = owned_inactive_generation
-                configured_root = configured_archive_root()
-                generation = IndexGenerationStore.for_archive_root(configured_root).load(generation_id)
+                # An inactive generation is opened from its generation root,
+                # while the configured root may intentionally point at a
+                # different live archive. Resolve the owning archive from the
+                # candidate path instead of routing this safety check through
+                # global configuration.
+                generation_archive_root = archive_root.parent.parent
+                generation = IndexGenerationStore.for_archive_root(generation_archive_root).load(generation_id)
                 if (
                     generation.owner_id != owner_id
                     or generation.state != "inactive"

--- a/tests/infra/pathology_zoo.py
+++ b/tests/infra/pathology_zoo.py
@@ -1,7 +1,9 @@
 """Curated production-ingest fixture archive for known pathology shapes.
 
-The zoo is test memory, not a second writer.  Every member starts as a wire
+The zoo is test memory, not a second writer. Every member starts as a wire
 artifact and reaches SQLite only through :func:`parse_sources_archive`.
+Production owns the manifest and read-only invariants. This module owns only
+fixture generation and the SQL mutations that make those invariants red.
 """
 
 from __future__ import annotations
@@ -9,9 +11,8 @@ from __future__ import annotations
 import asyncio
 import json
 import sqlite3
-from collections.abc import Callable, Iterable
+from collections.abc import Iterable
 from dataclasses import dataclass, replace
-from enum import StrEnum
 from pathlib import Path
 
 from polylogue.config import Source
@@ -19,7 +20,7 @@ from polylogue.maintenance.pathology_zoo import (
     PATHOLOGY_ZOO_MANIFEST as PRODUCTION_PATHOLOGY_ZOO_MANIFEST,
 )
 from polylogue.maintenance.pathology_zoo import (
-    PathologyZooMember as ProductionPathologyZooMember,
+    PathologyZooMember,
 )
 from polylogue.maintenance.pathology_zoo import (
     pathology_zoo_session_ids as production_pathology_zoo_session_ids,
@@ -29,414 +30,118 @@ from polylogue.scenarios import CorpusSpec
 from polylogue.schemas.synthetic import SyntheticCorpus
 from polylogue.sources.hooks import drain_hook_event_spool, enqueue_hook_event
 
-ArchiveCondition = Callable[[Path], bool]
-ArchiveMutation = Callable[[Path], None]
-
-
-class PathologyZooCanaryEligibility(StrEnum):
-    """Whether a pathology has a session identity for replay canaries."""
-
-    SESSION_BACKED = "session_backed"
-    NON_SESSION_ONLY = "non_session_only"
-
-
-@dataclass(frozen=True, slots=True)
-class PathologyZooVerificationContract:
-    """An executable archive invariant and the mutation that must falsify it."""
-
-    condition: str
-    check: ArchiveCondition
-    mutate_red: ArchiveMutation
-
-    def is_satisfied(self, archive_root: Path) -> bool:
-        return self.check(archive_root)
-
-    def make_red(self, archive_root: Path) -> None:
-        self.mutate_red(archive_root)
-
-
-@dataclass(frozen=True, slots=True)
-class PathologyZooMember:
-    """One queryable pathology label and its motivating Beads evidence."""
-
-    member_id: str
-    pathology: str
-    motivating_beads: tuple[str, ...]
-    session_ids: tuple[str, ...]
-    raw_paths: tuple[str, ...]
-    canary_eligibility: PathologyZooCanaryEligibility
-    verification: PathologyZooVerificationContract
-    durable_paths: tuple[str, ...] = ()
-
-    def __post_init__(self) -> None:
-        if self.canary_eligibility is PathologyZooCanaryEligibility.SESSION_BACKED and not self.session_ids:
-            raise ValueError(f"session-backed pathology {self.member_id!r} must declare session_ids")
-        if self.canary_eligibility is PathologyZooCanaryEligibility.NON_SESSION_ONLY and self.session_ids:
-            raise ValueError(f"non-session pathology {self.member_id!r} must not declare session_ids")
-
 
 @dataclass(frozen=True, slots=True)
 class PathologyZoo:
-    """A materialized archive plus its manifest of intentional pathologies."""
+    """A materialized archive plus the production-owned manifest."""
 
     archive_root: Path
-    manifest: tuple[ProductionPathologyZooMember, ...]
+    manifest: tuple[PathologyZooMember, ...]
 
-    def members_for(self, pathology: str) -> tuple[ProductionPathologyZooMember, ...]:
+    def members_for(self, pathology: str) -> tuple[PathologyZooMember, ...]:
         return tuple(member for member in self.manifest if member.pathology == pathology)
 
     @property
     def canary_session_ids(self) -> tuple[str, ...]:
-        """The fixture exposes the production canary manifest without re-declaring it."""
+        """Expose the production manifest's replayable session identities."""
         return production_pathology_zoo_session_ids()
+
+
+@dataclass(frozen=True, slots=True)
+class PathologyZooMutation:
+    """Fixture-only SQL that deliberately falsifies one production invariant."""
+
+    tier: str
+    statement: str
+    parameters: tuple[object, ...] = ()
+
+    def apply(self, archive_root: Path) -> None:
+        if self.tier == "index":
+            from polylogue.storage.archive_identity import resolve_active_index_path
+
+            path = resolve_active_index_path(archive_root)
+        else:
+            path = archive_root / f"{self.tier}.db"
+        with sqlite3.connect(path) as connection:
+            connection.execute(self.statement, self.parameters)
+            connection.commit()
+
+
+_PATHOLOGY_ZOO_MUTATIONS: dict[str, PathologyZooMutation] = {
+    "whale-component": PathologyZooMutation(
+        "index", "UPDATE sessions SET message_count = 47 WHERE session_id = ?", ("codex-session:zoo-whale",)
+    ),
+    "append-self-describing": PathologyZooMutation(
+        "source", "DELETE FROM raw_sessions WHERE source_path LIKE '%zoo-02-00.jsonl'"
+    ),
+    "append-opaque": PathologyZooMutation(
+        "source", "DELETE FROM raw_sessions WHERE source_path LIKE '%zoo-04-00.jsonl'"
+    ),
+    "fork-prefix-tail": PathologyZooMutation(
+        "index",
+        "UPDATE session_links SET resolved_dst_session_id = NULL WHERE src_session_id = ?",
+        ("codex-session:zoo-lineage-child",),
+    ),
+    "lineage-cycle": PathologyZooMutation(
+        "index",
+        "UPDATE session_links SET status = NULL WHERE src_session_id = ?",
+        ("codex-session:zoo-cycle-a",),
+    ),
+    "grouped-jsonl": PathologyZooMutation(
+        "index",
+        "DELETE FROM sessions WHERE session_id = ?",
+        ("claude-code-session:zoo-group-b",),
+    ),
+    "quarantined-head": PathologyZooMutation(
+        "index",
+        "DELETE FROM session_links WHERE src_session_id = ?",
+        ("codex-session:zoo-orphan-head",),
+    ),
+    "empty-session": PathologyZooMutation(
+        "index",
+        "UPDATE sessions SET message_count = 1 WHERE session_id = ?",
+        ("claude-code-session:zoo-empty",),
+    ),
+    "hook-event": PathologyZooMutation(
+        "source", "DELETE FROM raw_hook_events WHERE hook_event_id = 'hook:zoo-hook-event'"
+    ),
+    "claude-design": PathologyZooMutation(
+        "index", "UPDATE sessions SET origin = 'codex-session' WHERE native_id = 'zoo-design-session'"
+    ),
+    "vintage-reorder": PathologyZooMutation(
+        "source", "DELETE FROM raw_sessions WHERE source_path LIKE '%vintage-new.json'"
+    ),
+    "content-blocks-vintage": PathologyZooMutation(
+        "index", "DELETE FROM blocks WHERE session_id = ?", ("claude-ai-export:zoo-content-blocks-vintage",)
+    ),
+    "lifecycle-anchor-drift": PathologyZooMutation(
+        "index",
+        "UPDATE session_events SET source_message_provider_id = 'lifecycle-a' WHERE session_id = ? AND event_type = 'generation_lifecycle'",
+        ("chatgpt-export:zoo-lifecycle-anchor-drift",),
+    ),
+    "non-stream-safe": PathologyZooMutation(
+        "index", "DELETE FROM sessions WHERE session_id = ?", ("antigravity-session:zoo-06-00:zoo-06-00.md",)
+    ),
+    "attachment-with-bytes": PathologyZooMutation(
+        "index",
+        "UPDATE attachments SET blob_hash = NULL, acquisition_status = 'unfetched' WHERE attachment_id IN (SELECT attachment_id FROM attachment_refs WHERE session_id = ?)",
+        ("aistudio-drive:zoo-attachment-bytes",),
+    ),
+    "attachment-without-bytes": PathologyZooMutation(
+        "index",
+        "UPDATE attachments SET acquisition_status = 'acquired' WHERE attachment_id IN (SELECT attachment_id FROM attachment_refs WHERE session_id = ?)",
+        ("claude-ai-export:zoo-attachment-metadata",),
+    ),
+    "events-sidecars": PathologyZooMutation(
+        "index", "DELETE FROM session_events WHERE session_id = ?", ("chatgpt-export:zoo-lifecycle-anchor-drift",)
+    ),
+}
 
 
 _CODEX = "codex-session"
 _CLAUDE_AI = "claude-ai-export"
 _CLAUDE_CODE = "claude-code-session"
 _CHATGPT = "chatgpt-export"
-_DESIGN = "claude-design-session"
-_GEMINI = "aistudio-drive"
-
-
-def _archive_row_matches(
-    tier: str, query: str, parameters: tuple[object, ...], expected: tuple[object, ...] | None
-) -> ArchiveCondition:
-    def check(archive_root: Path) -> bool:
-        with sqlite3.connect(archive_root / f"{tier}.db") as conn:
-            return bool(conn.execute(query, parameters).fetchone() == expected)
-
-    return check
-
-
-def _mutate_archive(tier: str, statement: str, parameters: tuple[object, ...]) -> ArchiveMutation:
-    def mutate(archive_root: Path) -> None:
-        with sqlite3.connect(archive_root / f"{tier}.db") as conn:
-            conn.execute(statement, parameters)
-            conn.commit()
-
-    return mutate
-
-
-def _contract(
-    condition: str,
-    *,
-    check_tier: str,
-    query: str,
-    expected: tuple[object, ...] | None,
-    mutate_tier: str,
-    statement: str,
-    parameters: tuple[object, ...] = (),
-    mutation_parameters: tuple[object, ...] = (),
-) -> PathologyZooVerificationContract:
-    return PathologyZooVerificationContract(
-        condition,
-        _archive_row_matches(check_tier, query, parameters, expected),
-        _mutate_archive(mutate_tier, statement, mutation_parameters),
-    )
-
-
-def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
-    """Return the stable labels consumers should iterate rather than duplicate."""
-    return (
-        PathologyZooMember(
-            "whale-component",
-            "whale-component",
-            ("polylogue-yazae",),
-            (f"{_CODEX}:zoo-whale",),
-            ("generated/zoo-00-00.jsonl",),
-            PathologyZooCanaryEligibility.SESSION_BACKED,
-            _contract(
-                "the whale retains at least 48 materialized messages",
-                check_tier="index",
-                query="SELECT message_count >= 48 FROM sessions WHERE session_id = ?",
-                parameters=(f"{_CODEX}:zoo-whale",),
-                expected=(1,),
-                mutate_tier="index",
-                statement="UPDATE sessions SET message_count = 47 WHERE session_id = ?",
-                mutation_parameters=(f"{_CODEX}:zoo-whale",),
-            ),
-        ),
-        PathologyZooMember(
-            "append-self-describing",
-            "append-revision-chain",
-            ("polylogue-yazae",),
-            (f"{_CODEX}:zoo-append-self",),
-            ("generated/zoo-01-00.jsonl", "generated/zoo-02-00.jsonl"),
-            PathologyZooCanaryEligibility.SESSION_BACKED,
-            _contract(
-                "the self-describing append retains both raw revisions",
-                check_tier="source",
-                query="SELECT COUNT(*) FROM raw_sessions WHERE native_id = 'zoo-append-self'",
-                expected=(2,),
-                mutate_tier="source",
-                statement="DELETE FROM raw_sessions WHERE source_path LIKE '%zoo-02-00.jsonl'",
-            ),
-        ),
-        PathologyZooMember(
-            "append-opaque",
-            "append-revision-chain",
-            ("polylogue-yazae",),
-            (f"{_CODEX}:zoo-append-opaque",),
-            ("generated/zoo-03-00.jsonl", "generated/zoo-04-00.jsonl"),
-            PathologyZooCanaryEligibility.SESSION_BACKED,
-            _contract(
-                "the opaque append retains both raw revisions",
-                check_tier="source",
-                query="SELECT COUNT(*) FROM raw_sessions WHERE native_id = 'zoo-append-opaque'",
-                expected=(2,),
-                mutate_tier="source",
-                statement="DELETE FROM raw_sessions WHERE source_path LIKE '%zoo-04-00.jsonl'",
-            ),
-        ),
-        PathologyZooMember(
-            "fork-prefix-tail",
-            "fork-resume-prefix-tail-lineage",
-            ("polylogue-yazae",),
-            (f"{_CODEX}:zoo-lineage-parent", f"{_CODEX}:zoo-lineage-child"),
-            ("manual/lineage-parent.jsonl", "manual/lineage-child.jsonl"),
-            PathologyZooCanaryEligibility.SESSION_BACKED,
-            _contract(
-                "the fork child resolves to its prefix-sharing parent",
-                check_tier="index",
-                query="SELECT resolved_dst_session_id FROM session_links WHERE src_session_id = ?",
-                parameters=(f"{_CODEX}:zoo-lineage-child",),
-                expected=(f"{_CODEX}:zoo-lineage-parent",),
-                mutate_tier="index",
-                statement="UPDATE session_links SET resolved_dst_session_id = NULL WHERE src_session_id = ?",
-                mutation_parameters=(f"{_CODEX}:zoo-lineage-child",),
-            ),
-        ),
-        PathologyZooMember(
-            "lineage-cycle",
-            "lineage-cycle-candidate",
-            ("polylogue-yazae",),
-            (f"{_CODEX}:zoo-cycle-a", f"{_CODEX}:zoo-cycle-b"),
-            ("manual/lineage-cycle-a.jsonl", "manual/lineage-cycle-b.jsonl", "manual/lineage-cycle-z-a-update.jsonl"),
-            PathologyZooCanaryEligibility.SESSION_BACKED,
-            _contract(
-                "the cyclic lineage candidate is quarantined",
-                check_tier="index",
-                query="SELECT status, resolved_dst_session_id FROM session_links WHERE src_session_id = ?",
-                parameters=(f"{_CODEX}:zoo-cycle-a",),
-                expected=("quarantined", None),
-                mutate_tier="index",
-                statement="UPDATE session_links SET status = NULL WHERE src_session_id = ?",
-                mutation_parameters=(f"{_CODEX}:zoo-cycle-a",),
-            ),
-        ),
-        PathologyZooMember(
-            "grouped-jsonl",
-            "multi-session-raw",
-            ("polylogue-yazae",),
-            (f"{_CLAUDE_CODE}:zoo-group-a", f"{_CLAUDE_CODE}:zoo-group-b"),
-            ("manual/grouped.jsonl",),
-            PathologyZooCanaryEligibility.SESSION_BACKED,
-            _contract(
-                "the grouped JSONL raw materializes both sessions",
-                check_tier="index",
-                query="SELECT COUNT(*) FROM sessions WHERE session_id IN (?, ?)",
-                parameters=(f"{_CLAUDE_CODE}:zoo-group-a", f"{_CLAUDE_CODE}:zoo-group-b"),
-                expected=(2,),
-                mutate_tier="index",
-                statement="DELETE FROM sessions WHERE session_id = ?",
-                mutation_parameters=(f"{_CLAUDE_CODE}:zoo-group-b",),
-            ),
-        ),
-        PathologyZooMember(
-            "quarantined-head",
-            "quarantined-head-open-blocker",
-            ("polylogue-yazae",),
-            (f"{_CODEX}:zoo-orphan-head",),
-            ("manual/lineage-orphan.jsonl",),
-            PathologyZooCanaryEligibility.SESSION_BACKED,
-            _contract(
-                "the unresolved head remains an open blocker",
-                check_tier="index",
-                query="SELECT status, resolved_dst_session_id FROM session_links WHERE src_session_id = ?",
-                parameters=(f"{_CODEX}:zoo-orphan-head",),
-                expected=(None, None),
-                mutate_tier="index",
-                statement="DELETE FROM session_links WHERE src_session_id = ?",
-                mutation_parameters=(f"{_CODEX}:zoo-orphan-head",),
-            ),
-        ),
-        PathologyZooMember(
-            "empty-session",
-            "genuinely-empty-session",
-            ("polylogue-yazae",),
-            (f"{_CLAUDE_CODE}:zoo-empty",),
-            ("manual/empty.jsonl",),
-            PathologyZooCanaryEligibility.SESSION_BACKED,
-            _contract(
-                "the empty session has no materialized messages",
-                check_tier="index",
-                query="SELECT message_count FROM sessions WHERE session_id = ?",
-                parameters=(f"{_CLAUDE_CODE}:zoo-empty",),
-                expected=(0,),
-                mutate_tier="index",
-                statement="UPDATE sessions SET message_count = 1 WHERE session_id = ?",
-                mutation_parameters=(f"{_CLAUDE_CODE}:zoo-empty",),
-            ),
-        ),
-        PathologyZooMember(
-            "hook-event",
-            "hook-event-raw",
-            ("polylogue-yazae",),
-            (),
-            ("hook-spool/zoo-hook-event.json",),
-            PathologyZooCanaryEligibility.NON_SESSION_ONLY,
-            _contract(
-                "the hook spool becomes a durable PostToolUse event",
-                check_tier="source",
-                query="SELECT session_native_id, event_type FROM raw_hook_events WHERE hook_event_id = 'hook:zoo-hook-event'",
-                expected=("zoo-hook-parent", "PostToolUse"),
-                mutate_tier="source",
-                statement="DELETE FROM raw_hook_events WHERE hook_event_id = 'hook:zoo-hook-event'",
-            ),
-        ),
-        PathologyZooMember(
-            "claude-design",
-            "claude-design-session-origin",
-            ("polylogue-yazae",),
-            (f"{_DESIGN}:zoo-design-session",),
-            ("manual/design.json",),
-            PathologyZooCanaryEligibility.SESSION_BACKED,
-            _contract(
-                "the design export materializes under its distinct origin",
-                check_tier="index",
-                query="SELECT origin FROM sessions WHERE session_id = ?",
-                parameters=(f"{_DESIGN}:zoo-design-session",),
-                expected=(_DESIGN,),
-                mutate_tier="index",
-                statement="UPDATE sessions SET origin = 'codex-session' WHERE native_id = 'zoo-design-session'",
-            ),
-        ),
-        PathologyZooMember(
-            "vintage-reorder",
-            "export-vintage-reorder",
-            ("polylogue-yazae", "polylogue-slshy"),
-            (f"{_CHATGPT}:zoo-vintage-reorder",),
-            ("manual/vintage-old.json", "manual/vintage-new.json"),
-            PathologyZooCanaryEligibility.SESSION_BACKED,
-            _contract(
-                "the vintage reorder retains both raw revisions",
-                check_tier="source",
-                query="SELECT COUNT(*) FROM raw_sessions WHERE native_id = 'zoo-vintage-reorder'",
-                expected=(2,),
-                mutate_tier="source",
-                statement="DELETE FROM raw_sessions WHERE source_path LIKE '%vintage-new.json'",
-            ),
-        ),
-        PathologyZooMember(
-            "content-blocks-vintage",
-            "content-blocks-vintage",
-            ("polylogue-yazae", "polylogue-0qfy"),
-            (f"{_CLAUDE_AI}:zoo-content-blocks-vintage",),
-            ("manual/content-blocks-old.json", "manual/content-blocks-new.json"),
-            PathologyZooCanaryEligibility.SESSION_BACKED,
-            _contract(
-                "the content-block vintage keeps its parsed text block",
-                check_tier="index",
-                query="SELECT COUNT(*) FROM blocks WHERE session_id = ?",
-                parameters=(f"{_CLAUDE_AI}:zoo-content-blocks-vintage",),
-                expected=(1,),
-                mutate_tier="index",
-                statement="DELETE FROM blocks WHERE session_id = ?",
-                mutation_parameters=(f"{_CLAUDE_AI}:zoo-content-blocks-vintage",),
-            ),
-        ),
-        PathologyZooMember(
-            "lifecycle-anchor-drift",
-            "lifecycle-anchor-drift",
-            ("polylogue-yazae", "polylogue-uqwd"),
-            (f"{_CHATGPT}:zoo-lifecycle-anchor-drift",),
-            ("manual/lifecycle-old.json", "manual/lifecycle-new.json"),
-            PathologyZooCanaryEligibility.SESSION_BACKED,
-            _contract(
-                "the lifecycle event keeps the revised provider-message anchor",
-                check_tier="index",
-                query="SELECT source_message_provider_id FROM session_events WHERE session_id = ? AND event_type = 'generation_lifecycle'",
-                parameters=(f"{_CHATGPT}:zoo-lifecycle-anchor-drift",),
-                expected=("lifecycle-b",),
-                mutate_tier="index",
-                statement="UPDATE session_events SET source_message_provider_id = 'lifecycle-a' WHERE session_id = ? AND event_type = 'generation_lifecycle'",
-                mutation_parameters=(f"{_CHATGPT}:zoo-lifecycle-anchor-drift",),
-            ),
-        ),
-        PathologyZooMember(
-            "non-stream-safe",
-            "non-stream-safe-origin",
-            ("polylogue-yazae",),
-            ("antigravity-session:zoo-06-00:zoo-06-00.md",),
-            ("generated",),
-            PathologyZooCanaryEligibility.SESSION_BACKED,
-            _contract(
-                "the non-stream-safe source is retained under the Antigravity origin",
-                check_tier="index",
-                query="SELECT origin FROM sessions WHERE session_id = ?",
-                parameters=("antigravity-session:zoo-06-00:zoo-06-00.md",),
-                expected=("antigravity-session",),
-                mutate_tier="index",
-                statement="DELETE FROM sessions WHERE session_id = ?",
-                mutation_parameters=("antigravity-session:zoo-06-00:zoo-06-00.md",),
-            ),
-        ),
-        PathologyZooMember(
-            "attachment-with-bytes",
-            "attachment-with-acquired-bytes",
-            ("polylogue-yazae",),
-            (f"{_GEMINI}:zoo-attachment-bytes",),
-            ("generated/zoo-05-00.json",),
-            PathologyZooCanaryEligibility.SESSION_BACKED,
-            _contract(
-                "the acquired attachment retains bytes and a blob hash",
-                check_tier="index",
-                query="SELECT a.byte_count > 0 AND a.blob_hash IS NOT NULL AND a.acquisition_status = 'acquired' FROM attachments a JOIN attachment_refs r ON r.attachment_id = a.attachment_id WHERE r.session_id = ?",
-                parameters=(f"{_GEMINI}:zoo-attachment-bytes",),
-                expected=(1,),
-                mutate_tier="index",
-                statement="UPDATE attachments SET blob_hash = NULL, acquisition_status = 'unfetched' WHERE attachment_id IN (SELECT attachment_id FROM attachment_refs WHERE session_id = ?)",
-                mutation_parameters=(f"{_GEMINI}:zoo-attachment-bytes",),
-            ),
-        ),
-        PathologyZooMember(
-            "attachment-without-bytes",
-            "attachment-without-acquired-bytes",
-            ("polylogue-yazae",),
-            (f"{_CLAUDE_AI}:zoo-attachment-metadata",),
-            ("manual/attachment-metadata.json",),
-            PathologyZooCanaryEligibility.SESSION_BACKED,
-            _contract(
-                "the unavailable attachment remains structured metadata without acquired bytes",
-                check_tier="index",
-                query="SELECT a.byte_count = 0 AND a.blob_hash IS NULL AND a.acquisition_status = 'unfetched' FROM attachments a JOIN attachment_refs r ON r.attachment_id = a.attachment_id WHERE r.session_id = ?",
-                parameters=(f"{_CLAUDE_AI}:zoo-attachment-metadata",),
-                expected=(1,),
-                mutate_tier="index",
-                statement="UPDATE attachments SET acquisition_status = 'acquired' WHERE attachment_id IN (SELECT attachment_id FROM attachment_refs WHERE session_id = ?)",
-                mutation_parameters=(f"{_CLAUDE_AI}:zoo-attachment-metadata",),
-            ),
-        ),
-        PathologyZooMember(
-            "events-sidecars",
-            "session-events-and-sidecars",
-            ("polylogue-yazae",),
-            (f"{_CHATGPT}:zoo-lifecycle-anchor-drift",),
-            ("manual/lifecycle-old.json",),
-            PathologyZooCanaryEligibility.SESSION_BACKED,
-            _contract(
-                "the lifecycle session retains its parsed sidecar event",
-                check_tier="index",
-                query="SELECT COUNT(*) FROM session_events WHERE session_id = ?",
-                parameters=(f"{_CHATGPT}:zoo-lifecycle-anchor-drift",),
-                expected=(1,),
-                mutate_tier="index",
-                statement="DELETE FROM session_events WHERE session_id = ?",
-                mutation_parameters=(f"{_CHATGPT}:zoo-lifecycle-anchor-drift",),
-            ),
-        ),
-    )
 
 
 def _write_json(path: Path, payload: object) -> Path:
@@ -686,15 +391,14 @@ def _write_generated_members(root: Path, *, indexes: tuple[int, ...] | None = No
     )
     paths: list[Path] = []
     for index in indexes or tuple(range(len(specs))):
-        spec = specs[index]
-        written = SyntheticCorpus.write_spec_artifacts(spec, generated, prefix=f"zoo-{index:02d}")
+        written = SyntheticCorpus.write_spec_artifacts(specs[index], generated, prefix=f"zoo-{index:02d}")
         paths.extend(written.files)
     return tuple(paths)
 
 
 def _bind_durable_paths(
-    manifest: tuple[ProductionPathologyZooMember, ...], wire_root: Path, hook_event_path: Path
-) -> tuple[ProductionPathologyZooMember, ...]:
+    manifest: tuple[PathologyZooMember, ...], wire_root: Path, hook_event_path: Path
+) -> tuple[PathologyZooMember, ...]:
     return tuple(
         replace(
             member,
@@ -706,7 +410,7 @@ def _bind_durable_paths(
     )
 
 
-def _validate_manifest(root: Path, manifest: tuple[ProductionPathologyZooMember, ...]) -> None:
+def _validate_manifest(root: Path, manifest: tuple[PathologyZooMember, ...]) -> None:
     try:
         with sqlite3.connect(root / "index.db") as conn:
             session_ids = {str(row[0]) for row in conn.execute("SELECT session_id FROM sessions")}
@@ -748,13 +452,7 @@ def build_pathology_zoo(archive_root: Path) -> PathologyZoo:
     _write_generated_members(wire_root, indexes=(0, 1, 3, 5, 6))
     _write_manual_members(wire_root)
     sources = [Source(name="pathology-zoo", path=wire_root), Source(name="antigravity", path=wire_root / "generated")]
-    asyncio.run(
-        parse_sources_archive(
-            archive_root,
-            sources,
-            parse_workers=1,
-        )
-    )
+    asyncio.run(parse_sources_archive(archive_root, sources, parse_workers=1))
     _write_generated_members(wire_root, indexes=(2, 4))
     _write_jsonl(
         wire_root / "manual" / "lineage-cycle-z-a-update.jsonl",
@@ -778,15 +476,12 @@ def build_pathology_zoo(archive_root: Path) -> PathologyZoo:
 
 
 def make_pathology_zoo_member_red(archive_root: Path, member_id: str) -> None:
-    """Apply the fixture-only red mutation for one production manifest member."""
-    legacy_member = next(member for member in pathology_zoo_manifest() if member.member_id == member_id)
-    legacy_member.verification.make_red(archive_root)
+    """Apply only the fixture mutation for one production manifest member."""
+    try:
+        mutation = _PATHOLOGY_ZOO_MUTATIONS[member_id]
+    except KeyError as exc:
+        raise ValueError(f"no fixture mutation for pathology-zoo member {member_id!r}") from exc
+    mutation.apply(archive_root)
 
 
-__all__ = [
-    "PathologyZoo",
-    "PathologyZooMember",
-    "build_pathology_zoo",
-    "make_pathology_zoo_member_red",
-    "pathology_zoo_manifest",
-]
+__all__ = ["PathologyZoo", "PathologyZooMutation", "build_pathology_zoo", "make_pathology_zoo_member_red"]

--- a/tests/infra/pathology_zoo.py
+++ b/tests/infra/pathology_zoo.py
@@ -10,13 +10,14 @@ import asyncio
 import json
 import sqlite3
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 from polylogue.config import Source
 from polylogue.pipeline.services.archive_ingest import parse_sources_archive
 from polylogue.scenarios import CorpusSpec
 from polylogue.schemas.synthetic import SyntheticCorpus
+from polylogue.sources.hooks import drain_hook_event_spool, enqueue_hook_event
 
 
 @dataclass(frozen=True, slots=True)
@@ -28,6 +29,7 @@ class PathologyZooMember:
     motivating_beads: tuple[str, ...]
     session_ids: tuple[str, ...]
     raw_paths: tuple[str, ...]
+    durable_paths: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -65,35 +67,35 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             "whale-component",
             ("polylogue-yazae",),
             (f"{_CODEX}:zoo-whale",),
-            ("generated/codex-00.jsonl",),
+            ("generated/zoo-00-00.jsonl",),
         ),
         PathologyZooMember(
             "append-self-describing",
             "append-revision-chain",
             ("polylogue-yazae",),
             (f"{_CODEX}:zoo-append-self",),
-            ("generated/codex-01.jsonl", "generated/codex-02.jsonl"),
+            ("generated/zoo-01-00.jsonl", "generated/zoo-02-00.jsonl"),
         ),
         PathologyZooMember(
             "append-opaque",
             "append-revision-chain",
             ("polylogue-yazae",),
             (f"{_CODEX}:zoo-append-opaque",),
-            ("generated/codex-03.jsonl", "generated/codex-04.jsonl"),
+            ("generated/zoo-03-00.jsonl", "generated/zoo-04-00.jsonl"),
         ),
         PathologyZooMember(
             "fork-prefix-tail",
             "fork-resume-prefix-tail-lineage",
             ("polylogue-yazae",),
-            (f"{_CLAUDE_CODE}:zoo-lineage-parent", f"{_CLAUDE_CODE}:zoo-lineage-child"),
-            ("manual/lineage.jsonl",),
+            (f"{_CODEX}:zoo-lineage-parent", f"{_CODEX}:zoo-lineage-child"),
+            ("manual/lineage-parent.jsonl", "manual/lineage-child.jsonl"),
         ),
         PathologyZooMember(
             "lineage-cycle",
             "lineage-cycle-candidate",
             ("polylogue-yazae",),
-            (f"{_CLAUDE_CODE}:zoo-cycle-a", f"{_CLAUDE_CODE}:zoo-cycle-b"),
-            ("manual/lineage.jsonl",),
+            (f"{_CODEX}:zoo-cycle-a", f"{_CODEX}:zoo-cycle-b"),
+            ("manual/lineage-cycle-a.jsonl", "manual/lineage-cycle-b.jsonl", "manual/lineage-cycle-z-a-update.jsonl"),
         ),
         PathologyZooMember(
             "grouped-jsonl",
@@ -106,8 +108,8 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             "quarantined-head",
             "quarantined-head-open-blocker",
             ("polylogue-yazae",),
-            (f"{_CLAUDE_CODE}:zoo-orphan-head",),
-            ("manual/lineage.jsonl",),
+            (f"{_CODEX}:zoo-orphan-head",),
+            ("manual/lineage-orphan.jsonl",),
         ),
         PathologyZooMember(
             "empty-session",
@@ -120,8 +122,8 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             "hook-event",
             "hook-event-raw",
             ("polylogue-yazae",),
-            (f"{_CLAUDE_CODE}:zoo-hook-event",),
-            ("manual/hook-event.jsonl",),
+            (),
+            ("hook-spool/zoo-hook-event.json",),
         ),
         PathologyZooMember(
             "claude-design",
@@ -156,14 +158,14 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             "non-stream-safe-origin",
             ("polylogue-yazae",),
             ("antigravity-session:zoo-06-00:zoo-06-00.md",),
-            ("generated/brain/zoo-06-00/zoo-06-00.md.metadata.json",),
+            ("generated",),
         ),
         PathologyZooMember(
             "attachment-with-bytes",
             "attachment-with-acquired-bytes",
             ("polylogue-yazae",),
             (f"{_GEMINI}:zoo-attachment-bytes",),
-            ("generated/gemini-00.json",),
+            ("generated/zoo-05-00.json",),
         ),
         PathologyZooMember(
             "attachment-without-bytes",
@@ -185,10 +187,6 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
 def pathology_zoo_integration_gaps() -> tuple[PathologyZooIntegrationGap, ...]:
     """Keep absent consumer hooks visible until their owning lanes expose one."""
     return (
-        PathologyZooIntegrationGap(
-            "polylogue-t0m73",
-            "No registry pytest binding exists in this checkout; iterate pathology_zoo_manifest() when the red-twin extension point lands.",
-        ),
         PathologyZooIntegrationGap(
             "polylogue-0x7nh",
             "No differ canary-set extension point exists in this checkout; include pathology_zoo_manifest() members when the canary registry lands.",
@@ -223,6 +221,30 @@ def _code_record(
     return record
 
 
+def _codex_records(
+    session_id: str, texts: tuple[str, ...], *, parent: str | None = None, subagent: bool = False
+) -> tuple[dict[str, object], ...]:
+    meta: dict[str, object] = {"id": session_id, "timestamp": "2026-08-04T00:00:00Z"}
+    if parent is not None:
+        meta["forked_from_id"] = parent
+    if subagent:
+        meta["source"] = {"subagent": {"thread_spawn": True}}
+    records: list[dict[str, object]] = [{"type": "session_meta", "payload": meta}]
+    for position, text in enumerate(texts):
+        records.append(
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "id": f"{session_id}-m{position}",
+                    "role": "user" if position % 2 == 0 else "assistant",
+                    "content": [{"type": "input_text", "text": text}],
+                },
+            }
+        )
+    return tuple(records)
+
+
 def _chatgpt_payload(conversation_id: str, nodes: list[dict[str, object]]) -> dict[str, object]:
     return {
         "id": conversation_id,
@@ -252,15 +274,6 @@ def _chatgpt_node(
 
 def _write_manual_members(root: Path) -> tuple[Path, ...]:
     manual = root / "manual"
-    lineage_records = (
-        _code_record("zoo-lineage-parent", "parent-1", "user", "shared prompt"),
-        _code_record("zoo-lineage-parent", "parent-2", "assistant", "parent tail", parent="parent-1"),
-        _code_record("zoo-lineage-child", "parent-1", "user", "shared prompt"),
-        _code_record("zoo-lineage-child", "child-2", "assistant", "child tail", parent="parent-1"),
-        _code_record("zoo-cycle-a", "cycle-a", "user", "cycle A", parent="cycle-b"),
-        _code_record("zoo-cycle-b", "cycle-b", "assistant", "cycle B", parent="cycle-a"),
-        _code_record("zoo-orphan-head", "orphan-1", "assistant", "unresolved parent", parent="missing-parent"),
-    )
     grouped_records = (
         _code_record("zoo-group-a", "group-a-1", "user", "grouped A"),
         _code_record("zoo-group-b", "group-b-1", "user", "grouped B"),
@@ -277,12 +290,24 @@ def _write_manual_members(root: Path) -> tuple[Path, ...]:
         _chatgpt_node("lifecycle-b", "assistant", "answer", parent="lifecycle-a", lifecycle=True),
     ]
     return (
-        _write_jsonl(manual / "lineage.jsonl", lineage_records),
+        _write_jsonl(
+            manual / "lineage-parent.jsonl", _codex_records("zoo-lineage-parent", ("shared prompt", "parent tail"))
+        ),
+        _write_jsonl(
+            manual / "lineage-child.jsonl",
+            _codex_records("zoo-lineage-child", ("shared prompt", "child tail"), parent="zoo-lineage-parent"),
+        ),
+        _write_jsonl(manual / "lineage-cycle-a.jsonl", _codex_records("zoo-cycle-a", ("cycle A",))),
+        _write_jsonl(
+            manual / "lineage-cycle-b.jsonl",
+            _codex_records("zoo-cycle-b", ("cycle B",), parent="zoo-cycle-a", subagent=True),
+        ),
+        _write_jsonl(
+            manual / "lineage-orphan.jsonl",
+            _codex_records("zoo-orphan-head", ("unresolved parent",), parent="never-ingested"),
+        ),
         _write_jsonl(manual / "grouped.jsonl", grouped_records),
         _write_jsonl(manual / "empty.jsonl", ({"type": "progress", "sessionId": "zoo-empty", "uuid": "empty-1"},)),
-        _write_jsonl(
-            manual / "hook-event.jsonl", (_code_record("zoo-hook-event", "hook-1", "user", "hook-backed transcript"),)
-        ),
         _write_json(manual / "vintage-old.json", _chatgpt_payload("zoo-vintage-reorder", vintage_nodes)),
         _write_json(
             manual / "vintage-new.json", _chatgpt_payload("zoo-vintage-reorder", list(reversed(vintage_nodes)))
@@ -339,7 +364,7 @@ def _write_manual_members(root: Path) -> tuple[Path, ...]:
     )
 
 
-def _write_generated_members(root: Path) -> tuple[Path, ...]:
+def _write_generated_members(root: Path, *, indexes: tuple[int, ...] | None = None) -> tuple[Path, ...]:
     generated = root / "generated"
     specs = (
         CorpusSpec.for_provider(
@@ -415,10 +440,25 @@ def _write_generated_members(root: Path) -> tuple[Path, ...]:
         ),
     )
     paths: list[Path] = []
-    for index, spec in enumerate(specs):
+    for index in indexes or tuple(range(len(specs))):
+        spec = specs[index]
         written = SyntheticCorpus.write_spec_artifacts(spec, generated, prefix=f"zoo-{index:02d}")
         paths.extend(written.files)
     return tuple(paths)
+
+
+def _bind_durable_paths(
+    manifest: tuple[PathologyZooMember, ...], wire_root: Path, hook_event_path: Path
+) -> tuple[PathologyZooMember, ...]:
+    return tuple(
+        replace(
+            member,
+            durable_paths=(str(hook_event_path),)
+            if member.member_id == "hook-event"
+            else tuple(str(wire_root / raw_path) for raw_path in member.raw_paths),
+        )
+        for member in manifest
+    )
 
 
 def _validate_manifest(root: Path, manifest: tuple[PathologyZooMember, ...]) -> None:
@@ -430,21 +470,64 @@ def _validate_manifest(root: Path, manifest: tuple[PathologyZooMember, ...]) -> 
     missing = sorted({session_id for member in manifest for session_id in member.session_ids} - session_ids)
     if missing:
         raise RuntimeError(f"pathology zoo members missing after production ingest: {missing}")
+    with sqlite3.connect(root / "source.db") as conn:
+        for member in manifest:
+            table = "raw_hook_events" if member.member_id == "hook-event" else "raw_sessions"
+            missing_paths = [
+                path
+                for path in member.durable_paths
+                if conn.execute(f"SELECT 1 FROM {table} WHERE source_path = ?", (path,)).fetchone() is None
+            ]
+            if missing_paths:
+                raise RuntimeError(
+                    f"pathology zoo durable {table} rows missing for {member.member_id}: {missing_paths}"
+                )
+    with sqlite3.connect(root / "index.db") as conn:
+        cycle = conn.execute(
+            "SELECT status, resolved_dst_session_id FROM session_links WHERE src_session_id = ?",
+            (f"{_CODEX}:zoo-cycle-a",),
+        ).fetchone()
+        orphan = conn.execute(
+            "SELECT status, resolved_dst_session_id FROM session_links WHERE src_session_id = ?",
+            (f"{_CODEX}:zoo-orphan-head",),
+        ).fetchone()
+    if cycle != ("quarantined", None):
+        raise RuntimeError(f"pathology zoo cycle link was not quarantined: {cycle}")
+    if orphan != (None, None):
+        raise RuntimeError(f"pathology zoo orphan link was not unresolved: {orphan}")
 
 
 def build_pathology_zoo(archive_root: Path) -> PathologyZoo:
     """Build the v0 zoo through the production source-to-archive harness."""
     wire_root = archive_root / "wire"
-    _write_generated_members(wire_root)
+    _write_generated_members(wire_root, indexes=(0, 1, 3, 5, 6))
     _write_manual_members(wire_root)
+    sources = [Source(name="pathology-zoo", path=wire_root), Source(name="antigravity", path=wire_root / "generated")]
     asyncio.run(
         parse_sources_archive(
             archive_root,
-            [Source(name="pathology-zoo", path=wire_root), Source(name="antigravity", path=wire_root / "generated")],
+            sources,
             parse_workers=1,
         )
     )
-    manifest = pathology_zoo_manifest()
+    _write_generated_members(wire_root, indexes=(2, 4))
+    _write_jsonl(
+        wire_root / "manual" / "lineage-cycle-z-a-update.jsonl",
+        _codex_records("zoo-cycle-a", ("cycle A", "cycle A revised"), parent="zoo-cycle-b", subagent=True),
+    )
+    asyncio.run(parse_sources_archive(archive_root, sources, parse_workers=1))
+    hook_event_path = enqueue_hook_event(
+        event_id="zoo-hook-event",
+        provider="claude-code",
+        event_type="PostToolUse",
+        session_id="zoo-hook-parent",
+        timestamp="2026-08-04T00:00:00Z",
+        payload={"tool_name": "Bash", "tool_call_id": "zoo-hook-call"},
+        root=archive_root / "hook-spool",
+    )
+    if drain_hook_event_spool(archive_root, root=archive_root / "hook-spool").acknowledged != 1:
+        raise RuntimeError("pathology zoo hook event did not drain through the durable source route")
+    manifest = _bind_durable_paths(pathology_zoo_manifest(), wire_root, hook_event_path)
     _validate_manifest(archive_root, manifest)
     return PathologyZoo(archive_root=archive_root, manifest=manifest)
 

--- a/tests/infra/pathology_zoo.py
+++ b/tests/infra/pathology_zoo.py
@@ -431,19 +431,6 @@ def _validate_manifest(root: Path, manifest: tuple[PathologyZooMember, ...]) -> 
                 raise RuntimeError(
                     f"pathology zoo durable {table} rows missing for {member.member_id}: {missing_paths}"
                 )
-    with sqlite3.connect(root / "index.db") as conn:
-        cycle = conn.execute(
-            "SELECT status, resolved_dst_session_id FROM session_links WHERE src_session_id = ?",
-            (f"{_CODEX}:zoo-cycle-a",),
-        ).fetchone()
-        orphan = conn.execute(
-            "SELECT status, resolved_dst_session_id FROM session_links WHERE src_session_id = ?",
-            (f"{_CODEX}:zoo-orphan-head",),
-        ).fetchone()
-    if cycle != ("quarantined", None):
-        raise RuntimeError(f"pathology zoo cycle link was not quarantined: {cycle}")
-    if orphan != (None, None):
-        raise RuntimeError(f"pathology zoo orphan link was not unresolved: {orphan}")
 
 
 def build_pathology_zoo(archive_root: Path) -> PathologyZoo:

--- a/tests/infra/pathology_zoo.py
+++ b/tests/infra/pathology_zoo.py
@@ -1,0 +1,459 @@
+"""Curated production-ingest fixture archive for known pathology shapes.
+
+The zoo is test memory, not a second writer.  Every member starts as a wire
+artifact and reaches SQLite only through :func:`parse_sources_archive`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from polylogue.config import Source
+from polylogue.pipeline.services.archive_ingest import parse_sources_archive
+from polylogue.scenarios import CorpusSpec
+from polylogue.schemas.synthetic import SyntheticCorpus
+
+
+@dataclass(frozen=True, slots=True)
+class PathologyZooMember:
+    """One queryable pathology label and its motivating Beads evidence."""
+
+    member_id: str
+    pathology: str
+    motivating_beads: tuple[str, ...]
+    session_ids: tuple[str, ...]
+    raw_paths: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class PathologyZooIntegrationGap:
+    """A consumer named by the zoo design but not yet extensible in this tree."""
+
+    consumer: str
+    follow_up: str
+
+
+@dataclass(frozen=True, slots=True)
+class PathologyZoo:
+    """A materialized archive plus its manifest of intentional pathologies."""
+
+    archive_root: Path
+    manifest: tuple[PathologyZooMember, ...]
+
+    def members_for(self, pathology: str) -> tuple[PathologyZooMember, ...]:
+        return tuple(member for member in self.manifest if member.pathology == pathology)
+
+
+_CODEX = "codex-session"
+_CLAUDE_AI = "claude-ai-export"
+_CLAUDE_CODE = "claude-code-session"
+_CHATGPT = "chatgpt-export"
+_DESIGN = "claude-design-session"
+_GEMINI = "aistudio-drive"
+
+
+def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
+    """Return the stable labels consumers should iterate rather than duplicate."""
+    return (
+        PathologyZooMember(
+            "whale-component",
+            "whale-component",
+            ("polylogue-yazae",),
+            (f"{_CODEX}:zoo-whale",),
+            ("generated/codex-00.jsonl",),
+        ),
+        PathologyZooMember(
+            "append-self-describing",
+            "append-revision-chain",
+            ("polylogue-yazae",),
+            (f"{_CODEX}:zoo-append-self",),
+            ("generated/codex-01.jsonl", "generated/codex-02.jsonl"),
+        ),
+        PathologyZooMember(
+            "append-opaque",
+            "append-revision-chain",
+            ("polylogue-yazae",),
+            (f"{_CODEX}:zoo-append-opaque",),
+            ("generated/codex-03.jsonl", "generated/codex-04.jsonl"),
+        ),
+        PathologyZooMember(
+            "fork-prefix-tail",
+            "fork-resume-prefix-tail-lineage",
+            ("polylogue-yazae",),
+            (f"{_CLAUDE_CODE}:zoo-lineage-parent", f"{_CLAUDE_CODE}:zoo-lineage-child"),
+            ("manual/lineage.jsonl",),
+        ),
+        PathologyZooMember(
+            "lineage-cycle",
+            "lineage-cycle-candidate",
+            ("polylogue-yazae",),
+            (f"{_CLAUDE_CODE}:zoo-cycle-a", f"{_CLAUDE_CODE}:zoo-cycle-b"),
+            ("manual/lineage.jsonl",),
+        ),
+        PathologyZooMember(
+            "grouped-jsonl",
+            "multi-session-raw",
+            ("polylogue-yazae",),
+            (f"{_CLAUDE_CODE}:zoo-group-a", f"{_CLAUDE_CODE}:zoo-group-b"),
+            ("manual/grouped.jsonl",),
+        ),
+        PathologyZooMember(
+            "quarantined-head",
+            "quarantined-head-open-blocker",
+            ("polylogue-yazae",),
+            (f"{_CLAUDE_CODE}:zoo-orphan-head",),
+            ("manual/lineage.jsonl",),
+        ),
+        PathologyZooMember(
+            "empty-session",
+            "genuinely-empty-session",
+            ("polylogue-yazae",),
+            (f"{_CLAUDE_CODE}:zoo-empty",),
+            ("manual/empty.jsonl",),
+        ),
+        PathologyZooMember(
+            "hook-event",
+            "hook-event-raw",
+            ("polylogue-yazae",),
+            (f"{_CLAUDE_CODE}:zoo-hook-event",),
+            ("manual/hook-event.jsonl",),
+        ),
+        PathologyZooMember(
+            "claude-design",
+            "claude-design-session-origin",
+            ("polylogue-yazae",),
+            (f"{_DESIGN}:zoo-design-session",),
+            ("manual/design.json",),
+        ),
+        PathologyZooMember(
+            "vintage-reorder",
+            "export-vintage-reorder",
+            ("polylogue-yazae", "polylogue-slshy"),
+            (f"{_CHATGPT}:zoo-vintage-reorder",),
+            ("manual/vintage-old.json", "manual/vintage-new.json"),
+        ),
+        PathologyZooMember(
+            "content-blocks-vintage",
+            "content-blocks-vintage",
+            ("polylogue-yazae", "polylogue-0qfy"),
+            (f"{_CLAUDE_AI}:zoo-content-blocks-vintage",),
+            ("manual/content-blocks-old.json", "manual/content-blocks-new.json"),
+        ),
+        PathologyZooMember(
+            "lifecycle-anchor-drift",
+            "lifecycle-anchor-drift",
+            ("polylogue-yazae", "polylogue-uqwd"),
+            (f"{_CHATGPT}:zoo-lifecycle-anchor-drift",),
+            ("manual/lifecycle-old.json", "manual/lifecycle-new.json"),
+        ),
+        PathologyZooMember(
+            "non-stream-safe",
+            "non-stream-safe-origin",
+            ("polylogue-yazae",),
+            ("antigravity-session:zoo-06-00:zoo-06-00.md",),
+            ("generated/brain/zoo-06-00/zoo-06-00.md.metadata.json",),
+        ),
+        PathologyZooMember(
+            "attachment-with-bytes",
+            "attachment-with-acquired-bytes",
+            ("polylogue-yazae",),
+            (f"{_GEMINI}:zoo-attachment-bytes",),
+            ("generated/gemini-00.json",),
+        ),
+        PathologyZooMember(
+            "attachment-without-bytes",
+            "attachment-without-acquired-bytes",
+            ("polylogue-yazae",),
+            (f"{_CLAUDE_AI}:zoo-attachment-metadata",),
+            ("manual/attachment-metadata.json",),
+        ),
+        PathologyZooMember(
+            "events-sidecars",
+            "session-events-and-sidecars",
+            ("polylogue-yazae",),
+            (f"{_CHATGPT}:zoo-lifecycle-anchor-drift",),
+            ("manual/lifecycle-old.json",),
+        ),
+    )
+
+
+def pathology_zoo_integration_gaps() -> tuple[PathologyZooIntegrationGap, ...]:
+    """Keep absent consumer hooks visible until their owning lanes expose one."""
+    return (
+        PathologyZooIntegrationGap(
+            "polylogue-t0m73",
+            "No registry pytest binding exists in this checkout; iterate pathology_zoo_manifest() when the red-twin extension point lands.",
+        ),
+        PathologyZooIntegrationGap(
+            "polylogue-0x7nh",
+            "No differ canary-set extension point exists in this checkout; include pathology_zoo_manifest() members when the canary registry lands.",
+        ),
+    )
+
+
+def _write_json(path: Path, payload: object) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=False) + "\n", encoding="utf-8")
+    return path
+
+
+def _write_jsonl(path: Path, records: Iterable[object]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(record) + "\n" for record in records), encoding="utf-8")
+    return path
+
+
+def _code_record(
+    session_id: str, message_id: str, role: str, text: str, *, parent: str | None = None
+) -> dict[str, object]:
+    record: dict[str, object] = {
+        "type": role,
+        "sessionId": session_id,
+        "uuid": message_id,
+        "timestamp": "2026-08-04T00:00:00Z",
+        "message": {"role": role, "content": [{"type": "text", "text": text}]},
+    }
+    if parent is not None:
+        record["parentUuid"] = parent
+    return record
+
+
+def _chatgpt_payload(conversation_id: str, nodes: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "id": conversation_id,
+        "conversation_id": conversation_id,
+        "create_time": 1_700_000_000.0,
+        "current_node": str(nodes[-1]["id"]),
+        "mapping": {str(node["id"]): node for node in nodes},
+    }
+
+
+def _chatgpt_node(
+    message_id: str, role: str, text: str, *, parent: str | None = None, lifecycle: bool = False
+) -> dict[str, object]:
+    message: dict[str, object] = {
+        "id": message_id,
+        "author": {"role": role},
+        "content": {"content_type": "text", "parts": [text]},
+        "create_time": 1_700_000_000.0,
+    }
+    if lifecycle:
+        message["metadata"] = {"finished_duration_sec": 5}
+    node: dict[str, object] = {"id": message_id, "message": message, "children": []}
+    if parent is not None:
+        node["parent"] = parent
+    return node
+
+
+def _write_manual_members(root: Path) -> tuple[Path, ...]:
+    manual = root / "manual"
+    lineage_records = (
+        _code_record("zoo-lineage-parent", "parent-1", "user", "shared prompt"),
+        _code_record("zoo-lineage-parent", "parent-2", "assistant", "parent tail", parent="parent-1"),
+        _code_record("zoo-lineage-child", "parent-1", "user", "shared prompt"),
+        _code_record("zoo-lineage-child", "child-2", "assistant", "child tail", parent="parent-1"),
+        _code_record("zoo-cycle-a", "cycle-a", "user", "cycle A", parent="cycle-b"),
+        _code_record("zoo-cycle-b", "cycle-b", "assistant", "cycle B", parent="cycle-a"),
+        _code_record("zoo-orphan-head", "orphan-1", "assistant", "unresolved parent", parent="missing-parent"),
+    )
+    grouped_records = (
+        _code_record("zoo-group-a", "group-a-1", "user", "grouped A"),
+        _code_record("zoo-group-b", "group-b-1", "user", "grouped B"),
+        _code_record("zoo-group-a", "group-a-2", "assistant", "grouped A reply", parent="group-a-1"),
+        _code_record("zoo-group-b", "group-b-2", "assistant", "grouped B reply", parent="group-b-1"),
+    )
+    vintage_nodes = [
+        _chatgpt_node("vintage-user", "user", "same conversation"),
+        _chatgpt_node("vintage-assistant", "assistant", "same answer", parent="vintage-user"),
+    ]
+    lifecycle_nodes = [
+        _chatgpt_node("lifecycle-user", "user", "do the work"),
+        _chatgpt_node("lifecycle-a", "assistant", "draft", parent="lifecycle-user", lifecycle=True),
+        _chatgpt_node("lifecycle-b", "assistant", "answer", parent="lifecycle-a", lifecycle=True),
+    ]
+    return (
+        _write_jsonl(manual / "lineage.jsonl", lineage_records),
+        _write_jsonl(manual / "grouped.jsonl", grouped_records),
+        _write_jsonl(manual / "empty.jsonl", ({"type": "progress", "sessionId": "zoo-empty", "uuid": "empty-1"},)),
+        _write_jsonl(
+            manual / "hook-event.jsonl", (_code_record("zoo-hook-event", "hook-1", "user", "hook-backed transcript"),)
+        ),
+        _write_json(manual / "vintage-old.json", _chatgpt_payload("zoo-vintage-reorder", vintage_nodes)),
+        _write_json(
+            manual / "vintage-new.json", _chatgpt_payload("zoo-vintage-reorder", list(reversed(vintage_nodes)))
+        ),
+        _write_json(manual / "lifecycle-old.json", _chatgpt_payload("zoo-lifecycle-anchor-drift", lifecycle_nodes)),
+        _write_json(
+            manual / "lifecycle-new.json",
+            _chatgpt_payload("zoo-lifecycle-anchor-drift", list(reversed(lifecycle_nodes))),
+        ),
+        _write_json(
+            manual / "content-blocks-old.json",
+            {
+                "uuid": "zoo-content-blocks-vintage",
+                "chat_messages": [{"uuid": "content-1", "sender": "human", "text": "same content"}],
+            },
+        ),
+        _write_json(
+            manual / "content-blocks-new.json",
+            {
+                "uuid": "zoo-content-blocks-vintage",
+                "chat_messages": [
+                    {"uuid": "content-1", "sender": "human", "content": [{"type": "text", "text": "same content"}]}
+                ],
+            },
+        ),
+        _write_json(
+            manual / "attachment-metadata.json",
+            {
+                "uuid": "zoo-attachment-metadata",
+                "chat_messages": [
+                    {
+                        "uuid": "attachment-1",
+                        "sender": "human",
+                        "text": "attachment metadata",
+                        "attachments": [{"id": "zoo-no-bytes", "name": "metadata-only.txt", "mime_type": "text/plain"}],
+                    }
+                ],
+            },
+        ),
+        _write_json(
+            manual / "design.json",
+            {
+                "id": "zoo-design-session",
+                "project": {"id": "zoo-project"},
+                "messages": [
+                    {
+                        "uuid": "design-1",
+                        "role": "assistant",
+                        "content": {"contentBlocks": [{"type": "text", "text": "design response"}]},
+                    }
+                ],
+            },
+        ),
+    )
+
+
+def _write_generated_members(root: Path) -> tuple[Path, ...]:
+    generated = root / "generated"
+    specs = (
+        CorpusSpec.for_provider(
+            "codex",
+            count=1,
+            messages_min=48,
+            messages_max=48,
+            seed=31,
+            style="tool-heavy",
+            session_native_ids=("zoo-whale",),
+            origin="test.pathology-zoo",
+            tags=("pathology-zoo",),
+        ),
+        CorpusSpec.for_provider(
+            "codex",
+            count=1,
+            messages_min=2,
+            messages_max=2,
+            seed=32,
+            session_native_ids=("zoo-append-self",),
+            origin="test.pathology-zoo",
+            tags=("pathology-zoo",),
+        ),
+        CorpusSpec.for_provider(
+            "codex",
+            count=1,
+            messages_min=4,
+            messages_max=4,
+            seed=33,
+            session_native_ids=("zoo-append-self",),
+            origin="test.pathology-zoo",
+            tags=("pathology-zoo",),
+        ),
+        CorpusSpec.for_provider(
+            "codex",
+            count=1,
+            messages_min=2,
+            messages_max=2,
+            seed=34,
+            session_native_ids=("zoo-append-opaque",),
+            origin="test.pathology-zoo",
+            tags=("pathology-zoo",),
+        ),
+        CorpusSpec.for_provider(
+            "codex",
+            count=1,
+            messages_min=4,
+            messages_max=4,
+            seed=35,
+            session_native_ids=("zoo-append-opaque",),
+            origin="test.pathology-zoo",
+            tags=("pathology-zoo",),
+        ),
+        CorpusSpec.for_provider(
+            "gemini",
+            count=1,
+            messages_min=2,
+            messages_max=2,
+            seed=36,
+            style="demo-attachments",
+            session_native_ids=("zoo-attachment-bytes",),
+            origin="test.pathology-zoo",
+            tags=("pathology-zoo",),
+        ),
+        CorpusSpec.for_provider(
+            "antigravity",
+            count=1,
+            messages_min=2,
+            messages_max=2,
+            seed=37,
+            origin="test.pathology-zoo",
+            tags=("pathology-zoo",),
+        ),
+    )
+    paths: list[Path] = []
+    for index, spec in enumerate(specs):
+        written = SyntheticCorpus.write_spec_artifacts(spec, generated, prefix=f"zoo-{index:02d}")
+        paths.extend(written.files)
+    return tuple(paths)
+
+
+def _validate_manifest(root: Path, manifest: tuple[PathologyZooMember, ...]) -> None:
+    try:
+        with sqlite3.connect(root / "index.db") as conn:
+            session_ids = {str(row[0]) for row in conn.execute("SELECT session_id FROM sessions")}
+    except sqlite3.Error as exc:
+        raise RuntimeError("pathology zoo has no queryable archive after production ingest") from exc
+    missing = sorted({session_id for member in manifest for session_id in member.session_ids} - session_ids)
+    if missing:
+        raise RuntimeError(f"pathology zoo members missing after production ingest: {missing}")
+
+
+def build_pathology_zoo(archive_root: Path) -> PathologyZoo:
+    """Build the v0 zoo through the production source-to-archive harness."""
+    wire_root = archive_root / "wire"
+    _write_generated_members(wire_root)
+    _write_manual_members(wire_root)
+    asyncio.run(
+        parse_sources_archive(
+            archive_root,
+            [Source(name="pathology-zoo", path=wire_root), Source(name="antigravity", path=wire_root / "generated")],
+            parse_workers=1,
+        )
+    )
+    manifest = pathology_zoo_manifest()
+    _validate_manifest(archive_root, manifest)
+    return PathologyZoo(archive_root=archive_root, manifest=manifest)
+
+
+__all__ = [
+    "PathologyZoo",
+    "PathologyZooIntegrationGap",
+    "PathologyZooMember",
+    "build_pathology_zoo",
+    "pathology_zoo_integration_gaps",
+    "pathology_zoo_manifest",
+]

--- a/tests/infra/pathology_zoo.py
+++ b/tests/infra/pathology_zoo.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 import asyncio
 import json
 import sqlite3
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, replace
+from enum import StrEnum
 from pathlib import Path
 
 from polylogue.config import Source
@@ -18,6 +19,31 @@ from polylogue.pipeline.services.archive_ingest import parse_sources_archive
 from polylogue.scenarios import CorpusSpec
 from polylogue.schemas.synthetic import SyntheticCorpus
 from polylogue.sources.hooks import drain_hook_event_spool, enqueue_hook_event
+
+ArchiveCondition = Callable[[Path], bool]
+ArchiveMutation = Callable[[Path], None]
+
+
+class PathologyZooCanaryEligibility(StrEnum):
+    """Whether a pathology has a session identity for replay canaries."""
+
+    SESSION_BACKED = "session_backed"
+    NON_SESSION_ONLY = "non_session_only"
+
+
+@dataclass(frozen=True, slots=True)
+class PathologyZooVerificationContract:
+    """An executable archive invariant and the mutation that must falsify it."""
+
+    condition: str
+    check: ArchiveCondition
+    mutate_red: ArchiveMutation
+
+    def is_satisfied(self, archive_root: Path) -> bool:
+        return self.check(archive_root)
+
+    def make_red(self, archive_root: Path) -> None:
+        self.mutate_red(archive_root)
 
 
 @dataclass(frozen=True, slots=True)
@@ -29,8 +55,15 @@ class PathologyZooMember:
     motivating_beads: tuple[str, ...]
     session_ids: tuple[str, ...]
     raw_paths: tuple[str, ...]
-    archive_verification_checks: tuple[str, ...]
+    canary_eligibility: PathologyZooCanaryEligibility
+    verification: PathologyZooVerificationContract
     durable_paths: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.canary_eligibility is PathologyZooCanaryEligibility.SESSION_BACKED and not self.session_ids:
+            raise ValueError(f"session-backed pathology {self.member_id!r} must declare session_ids")
+        if self.canary_eligibility is PathologyZooCanaryEligibility.NON_SESSION_ONLY and self.session_ids:
+            raise ValueError(f"non-session pathology {self.member_id!r} must not declare session_ids")
 
 
 @dataclass(frozen=True, slots=True)
@@ -46,12 +79,16 @@ class PathologyZoo:
     @property
     def canary_session_ids(self) -> tuple[str, ...]:
         """Every replayable zoo session supplied to the production canary selector."""
-        return tuple(sorted({session_id for member in self.manifest for session_id in member.session_ids}))
-
-    @property
-    def archive_verification_checks(self) -> tuple[str, ...]:
-        """Registry checks that consume the fixture's durable pathology evidence."""
-        return tuple(sorted({check for member in self.manifest for check in member.archive_verification_checks}))
+        return tuple(
+            sorted(
+                {
+                    session_id
+                    for member in self.manifest
+                    if member.canary_eligibility is PathologyZooCanaryEligibility.SESSION_BACKED
+                    for session_id in member.session_ids
+                }
+            )
+        )
 
 
 _CODEX = "codex-session"
@@ -60,6 +97,43 @@ _CLAUDE_CODE = "claude-code-session"
 _CHATGPT = "chatgpt-export"
 _DESIGN = "claude-design-session"
 _GEMINI = "aistudio-drive"
+
+
+def _archive_row_matches(
+    tier: str, query: str, parameters: tuple[object, ...], expected: tuple[object, ...] | None
+) -> ArchiveCondition:
+    def check(archive_root: Path) -> bool:
+        with sqlite3.connect(archive_root / f"{tier}.db") as conn:
+            return bool(conn.execute(query, parameters).fetchone() == expected)
+
+    return check
+
+
+def _mutate_archive(tier: str, statement: str, parameters: tuple[object, ...]) -> ArchiveMutation:
+    def mutate(archive_root: Path) -> None:
+        with sqlite3.connect(archive_root / f"{tier}.db") as conn:
+            conn.execute(statement, parameters)
+            conn.commit()
+
+    return mutate
+
+
+def _contract(
+    condition: str,
+    *,
+    check_tier: str,
+    query: str,
+    expected: tuple[object, ...] | None,
+    mutate_tier: str,
+    statement: str,
+    parameters: tuple[object, ...] = (),
+    mutation_parameters: tuple[object, ...] = (),
+) -> PathologyZooVerificationContract:
+    return PathologyZooVerificationContract(
+        condition,
+        _archive_row_matches(check_tier, query, parameters, expected),
+        _mutate_archive(mutate_tier, statement, mutation_parameters),
+    )
 
 
 def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
@@ -71,7 +145,17 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             (f"{_CODEX}:zoo-whale",),
             ("generated/zoo-00-00.jsonl",),
-            ("corpus-absences",),
+            PathologyZooCanaryEligibility.SESSION_BACKED,
+            _contract(
+                "the whale retains at least 48 materialized messages",
+                check_tier="index",
+                query="SELECT message_count >= 48 FROM sessions WHERE session_id = ?",
+                parameters=(f"{_CODEX}:zoo-whale",),
+                expected=(1,),
+                mutate_tier="index",
+                statement="UPDATE sessions SET message_count = 47 WHERE session_id = ?",
+                mutation_parameters=(f"{_CODEX}:zoo-whale",),
+            ),
         ),
         PathologyZooMember(
             "append-self-describing",
@@ -79,7 +163,15 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             (f"{_CODEX}:zoo-append-self",),
             ("generated/zoo-01-00.jsonl", "generated/zoo-02-00.jsonl"),
-            ("corpus-absences",),
+            PathologyZooCanaryEligibility.SESSION_BACKED,
+            _contract(
+                "the self-describing append retains both raw revisions",
+                check_tier="source",
+                query="SELECT COUNT(*) FROM raw_sessions WHERE native_id = 'zoo-append-self'",
+                expected=(2,),
+                mutate_tier="source",
+                statement="DELETE FROM raw_sessions WHERE source_path LIKE '%zoo-02-00.jsonl'",
+            ),
         ),
         PathologyZooMember(
             "append-opaque",
@@ -87,7 +179,15 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             (f"{_CODEX}:zoo-append-opaque",),
             ("generated/zoo-03-00.jsonl", "generated/zoo-04-00.jsonl"),
-            ("corpus-absences",),
+            PathologyZooCanaryEligibility.SESSION_BACKED,
+            _contract(
+                "the opaque append retains both raw revisions",
+                check_tier="source",
+                query="SELECT COUNT(*) FROM raw_sessions WHERE native_id = 'zoo-append-opaque'",
+                expected=(2,),
+                mutate_tier="source",
+                statement="DELETE FROM raw_sessions WHERE source_path LIKE '%zoo-04-00.jsonl'",
+            ),
         ),
         PathologyZooMember(
             "fork-prefix-tail",
@@ -95,7 +195,17 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             (f"{_CODEX}:zoo-lineage-parent", f"{_CODEX}:zoo-lineage-child"),
             ("manual/lineage-parent.jsonl", "manual/lineage-child.jsonl"),
-            ("corpus-absences",),
+            PathologyZooCanaryEligibility.SESSION_BACKED,
+            _contract(
+                "the fork child resolves to its prefix-sharing parent",
+                check_tier="index",
+                query="SELECT resolved_dst_session_id FROM session_links WHERE src_session_id = ?",
+                parameters=(f"{_CODEX}:zoo-lineage-child",),
+                expected=(f"{_CODEX}:zoo-lineage-parent",),
+                mutate_tier="index",
+                statement="UPDATE session_links SET resolved_dst_session_id = NULL WHERE src_session_id = ?",
+                mutation_parameters=(f"{_CODEX}:zoo-lineage-child",),
+            ),
         ),
         PathologyZooMember(
             "lineage-cycle",
@@ -103,7 +213,17 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             (f"{_CODEX}:zoo-cycle-a", f"{_CODEX}:zoo-cycle-b"),
             ("manual/lineage-cycle-a.jsonl", "manual/lineage-cycle-b.jsonl", "manual/lineage-cycle-z-a-update.jsonl"),
-            ("corpus-absences",),
+            PathologyZooCanaryEligibility.SESSION_BACKED,
+            _contract(
+                "the cyclic lineage candidate is quarantined",
+                check_tier="index",
+                query="SELECT status, resolved_dst_session_id FROM session_links WHERE src_session_id = ?",
+                parameters=(f"{_CODEX}:zoo-cycle-a",),
+                expected=("quarantined", None),
+                mutate_tier="index",
+                statement="UPDATE session_links SET status = NULL WHERE src_session_id = ?",
+                mutation_parameters=(f"{_CODEX}:zoo-cycle-a",),
+            ),
         ),
         PathologyZooMember(
             "grouped-jsonl",
@@ -111,7 +231,17 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             (f"{_CLAUDE_CODE}:zoo-group-a", f"{_CLAUDE_CODE}:zoo-group-b"),
             ("manual/grouped.jsonl",),
-            ("corpus-absences",),
+            PathologyZooCanaryEligibility.SESSION_BACKED,
+            _contract(
+                "the grouped JSONL raw materializes both sessions",
+                check_tier="index",
+                query="SELECT COUNT(*) FROM sessions WHERE session_id IN (?, ?)",
+                parameters=(f"{_CLAUDE_CODE}:zoo-group-a", f"{_CLAUDE_CODE}:zoo-group-b"),
+                expected=(2,),
+                mutate_tier="index",
+                statement="DELETE FROM sessions WHERE session_id = ?",
+                mutation_parameters=(f"{_CLAUDE_CODE}:zoo-group-b",),
+            ),
         ),
         PathologyZooMember(
             "quarantined-head",
@@ -119,7 +249,17 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             (f"{_CODEX}:zoo-orphan-head",),
             ("manual/lineage-orphan.jsonl",),
-            ("corpus-absences",),
+            PathologyZooCanaryEligibility.SESSION_BACKED,
+            _contract(
+                "the unresolved head remains an open blocker",
+                check_tier="index",
+                query="SELECT status, resolved_dst_session_id FROM session_links WHERE src_session_id = ?",
+                parameters=(f"{_CODEX}:zoo-orphan-head",),
+                expected=(None, None),
+                mutate_tier="index",
+                statement="DELETE FROM session_links WHERE src_session_id = ?",
+                mutation_parameters=(f"{_CODEX}:zoo-orphan-head",),
+            ),
         ),
         PathologyZooMember(
             "empty-session",
@@ -127,7 +267,17 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             (f"{_CLAUDE_CODE}:zoo-empty",),
             ("manual/empty.jsonl",),
-            ("corpus-absences",),
+            PathologyZooCanaryEligibility.SESSION_BACKED,
+            _contract(
+                "the empty session has no materialized messages",
+                check_tier="index",
+                query="SELECT message_count FROM sessions WHERE session_id = ?",
+                parameters=(f"{_CLAUDE_CODE}:zoo-empty",),
+                expected=(0,),
+                mutate_tier="index",
+                statement="UPDATE sessions SET message_count = 1 WHERE session_id = ?",
+                mutation_parameters=(f"{_CLAUDE_CODE}:zoo-empty",),
+            ),
         ),
         PathologyZooMember(
             "hook-event",
@@ -135,7 +285,15 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             (),
             ("hook-spool/zoo-hook-event.json",),
-            ("blob-refs-liveness",),
+            PathologyZooCanaryEligibility.NON_SESSION_ONLY,
+            _contract(
+                "the hook spool becomes a durable PostToolUse event",
+                check_tier="source",
+                query="SELECT session_native_id, event_type FROM raw_hook_events WHERE hook_event_id = 'hook:zoo-hook-event'",
+                expected=("zoo-hook-parent", "PostToolUse"),
+                mutate_tier="source",
+                statement="DELETE FROM raw_hook_events WHERE hook_event_id = 'hook:zoo-hook-event'",
+            ),
         ),
         PathologyZooMember(
             "claude-design",
@@ -143,7 +301,16 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             (f"{_DESIGN}:zoo-design-session",),
             ("manual/design.json",),
-            ("corpus-absences",),
+            PathologyZooCanaryEligibility.SESSION_BACKED,
+            _contract(
+                "the design export materializes under its distinct origin",
+                check_tier="index",
+                query="SELECT origin FROM sessions WHERE session_id = ?",
+                parameters=(f"{_DESIGN}:zoo-design-session",),
+                expected=(_DESIGN,),
+                mutate_tier="index",
+                statement="UPDATE sessions SET origin = 'codex-session' WHERE native_id = 'zoo-design-session'",
+            ),
         ),
         PathologyZooMember(
             "vintage-reorder",
@@ -151,7 +318,15 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae", "polylogue-slshy"),
             (f"{_CHATGPT}:zoo-vintage-reorder",),
             ("manual/vintage-old.json", "manual/vintage-new.json"),
-            ("corpus-absences",),
+            PathologyZooCanaryEligibility.SESSION_BACKED,
+            _contract(
+                "the vintage reorder retains both raw revisions",
+                check_tier="source",
+                query="SELECT COUNT(*) FROM raw_sessions WHERE native_id = 'zoo-vintage-reorder'",
+                expected=(2,),
+                mutate_tier="source",
+                statement="DELETE FROM raw_sessions WHERE source_path LIKE '%vintage-new.json'",
+            ),
         ),
         PathologyZooMember(
             "content-blocks-vintage",
@@ -159,7 +334,17 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae", "polylogue-0qfy"),
             (f"{_CLAUDE_AI}:zoo-content-blocks-vintage",),
             ("manual/content-blocks-old.json", "manual/content-blocks-new.json"),
-            ("corpus-absences",),
+            PathologyZooCanaryEligibility.SESSION_BACKED,
+            _contract(
+                "the content-block vintage keeps its parsed text block",
+                check_tier="index",
+                query="SELECT COUNT(*) FROM blocks WHERE session_id = ?",
+                parameters=(f"{_CLAUDE_AI}:zoo-content-blocks-vintage",),
+                expected=(1,),
+                mutate_tier="index",
+                statement="DELETE FROM blocks WHERE session_id = ?",
+                mutation_parameters=(f"{_CLAUDE_AI}:zoo-content-blocks-vintage",),
+            ),
         ),
         PathologyZooMember(
             "lifecycle-anchor-drift",
@@ -167,7 +352,17 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae", "polylogue-uqwd"),
             (f"{_CHATGPT}:zoo-lifecycle-anchor-drift",),
             ("manual/lifecycle-old.json", "manual/lifecycle-new.json"),
-            ("corpus-absences",),
+            PathologyZooCanaryEligibility.SESSION_BACKED,
+            _contract(
+                "the lifecycle event keeps the revised provider-message anchor",
+                check_tier="index",
+                query="SELECT source_message_provider_id FROM session_events WHERE session_id = ? AND event_type = 'generation_lifecycle'",
+                parameters=(f"{_CHATGPT}:zoo-lifecycle-anchor-drift",),
+                expected=("lifecycle-b",),
+                mutate_tier="index",
+                statement="UPDATE session_events SET source_message_provider_id = 'lifecycle-a' WHERE session_id = ? AND event_type = 'generation_lifecycle'",
+                mutation_parameters=(f"{_CHATGPT}:zoo-lifecycle-anchor-drift",),
+            ),
         ),
         PathologyZooMember(
             "non-stream-safe",
@@ -175,7 +370,17 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             ("antigravity-session:zoo-06-00:zoo-06-00.md",),
             ("generated",),
-            ("corpus-absences",),
+            PathologyZooCanaryEligibility.SESSION_BACKED,
+            _contract(
+                "the non-stream-safe source is retained under the Antigravity origin",
+                check_tier="index",
+                query="SELECT origin FROM sessions WHERE session_id = ?",
+                parameters=("antigravity-session:zoo-06-00:zoo-06-00.md",),
+                expected=("antigravity-session",),
+                mutate_tier="index",
+                statement="DELETE FROM sessions WHERE session_id = ?",
+                mutation_parameters=("antigravity-session:zoo-06-00:zoo-06-00.md",),
+            ),
         ),
         PathologyZooMember(
             "attachment-with-bytes",
@@ -183,7 +388,17 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             (f"{_GEMINI}:zoo-attachment-bytes",),
             ("generated/zoo-05-00.json",),
-            ("corpus-absences",),
+            PathologyZooCanaryEligibility.SESSION_BACKED,
+            _contract(
+                "the acquired attachment retains bytes and a blob hash",
+                check_tier="index",
+                query="SELECT a.byte_count > 0 AND a.blob_hash IS NOT NULL AND a.acquisition_status = 'acquired' FROM attachments a JOIN attachment_refs r ON r.attachment_id = a.attachment_id WHERE r.session_id = ?",
+                parameters=(f"{_GEMINI}:zoo-attachment-bytes",),
+                expected=(1,),
+                mutate_tier="index",
+                statement="UPDATE attachments SET blob_hash = NULL, acquisition_status = 'unfetched' WHERE attachment_id IN (SELECT attachment_id FROM attachment_refs WHERE session_id = ?)",
+                mutation_parameters=(f"{_GEMINI}:zoo-attachment-bytes",),
+            ),
         ),
         PathologyZooMember(
             "attachment-without-bytes",
@@ -191,7 +406,17 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             (f"{_CLAUDE_AI}:zoo-attachment-metadata",),
             ("manual/attachment-metadata.json",),
-            ("corpus-absences",),
+            PathologyZooCanaryEligibility.SESSION_BACKED,
+            _contract(
+                "the unavailable attachment remains structured metadata without acquired bytes",
+                check_tier="index",
+                query="SELECT a.byte_count = 0 AND a.blob_hash IS NULL AND a.acquisition_status = 'unfetched' FROM attachments a JOIN attachment_refs r ON r.attachment_id = a.attachment_id WHERE r.session_id = ?",
+                parameters=(f"{_CLAUDE_AI}:zoo-attachment-metadata",),
+                expected=(1,),
+                mutate_tier="index",
+                statement="UPDATE attachments SET acquisition_status = 'acquired' WHERE attachment_id IN (SELECT attachment_id FROM attachment_refs WHERE session_id = ?)",
+                mutation_parameters=(f"{_CLAUDE_AI}:zoo-attachment-metadata",),
+            ),
         ),
         PathologyZooMember(
             "events-sidecars",
@@ -199,7 +424,17 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             (f"{_CHATGPT}:zoo-lifecycle-anchor-drift",),
             ("manual/lifecycle-old.json",),
-            ("corpus-absences",),
+            PathologyZooCanaryEligibility.SESSION_BACKED,
+            _contract(
+                "the lifecycle session retains its parsed sidecar event",
+                check_tier="index",
+                query="SELECT COUNT(*) FROM session_events WHERE session_id = ?",
+                parameters=(f"{_CHATGPT}:zoo-lifecycle-anchor-drift",),
+                expected=(1,),
+                mutate_tier="index",
+                statement="DELETE FROM session_events WHERE session_id = ?",
+                mutation_parameters=(f"{_CHATGPT}:zoo-lifecycle-anchor-drift",),
+            ),
         ),
     )
 

--- a/tests/infra/pathology_zoo.py
+++ b/tests/infra/pathology_zoo.py
@@ -29,15 +29,8 @@ class PathologyZooMember:
     motivating_beads: tuple[str, ...]
     session_ids: tuple[str, ...]
     raw_paths: tuple[str, ...]
+    archive_verification_checks: tuple[str, ...]
     durable_paths: tuple[str, ...] = ()
-
-
-@dataclass(frozen=True, slots=True)
-class PathologyZooIntegrationGap:
-    """A consumer named by the zoo design but not yet extensible in this tree."""
-
-    consumer: str
-    follow_up: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -49,6 +42,16 @@ class PathologyZoo:
 
     def members_for(self, pathology: str) -> tuple[PathologyZooMember, ...]:
         return tuple(member for member in self.manifest if member.pathology == pathology)
+
+    @property
+    def canary_session_ids(self) -> tuple[str, ...]:
+        """Every replayable zoo session supplied to the production canary selector."""
+        return tuple(sorted({session_id for member in self.manifest for session_id in member.session_ids}))
+
+    @property
+    def archive_verification_checks(self) -> tuple[str, ...]:
+        """Registry checks that consume the fixture's durable pathology evidence."""
+        return tuple(sorted({check for member in self.manifest for check in member.archive_verification_checks}))
 
 
 _CODEX = "codex-session"
@@ -68,6 +71,7 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             (f"{_CODEX}:zoo-whale",),
             ("generated/zoo-00-00.jsonl",),
+            ("corpus-absences",),
         ),
         PathologyZooMember(
             "append-self-describing",
@@ -75,6 +79,7 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             (f"{_CODEX}:zoo-append-self",),
             ("generated/zoo-01-00.jsonl", "generated/zoo-02-00.jsonl"),
+            ("corpus-absences",),
         ),
         PathologyZooMember(
             "append-opaque",
@@ -82,6 +87,7 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             (f"{_CODEX}:zoo-append-opaque",),
             ("generated/zoo-03-00.jsonl", "generated/zoo-04-00.jsonl"),
+            ("corpus-absences",),
         ),
         PathologyZooMember(
             "fork-prefix-tail",
@@ -89,6 +95,7 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             (f"{_CODEX}:zoo-lineage-parent", f"{_CODEX}:zoo-lineage-child"),
             ("manual/lineage-parent.jsonl", "manual/lineage-child.jsonl"),
+            ("corpus-absences",),
         ),
         PathologyZooMember(
             "lineage-cycle",
@@ -96,6 +103,7 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             (f"{_CODEX}:zoo-cycle-a", f"{_CODEX}:zoo-cycle-b"),
             ("manual/lineage-cycle-a.jsonl", "manual/lineage-cycle-b.jsonl", "manual/lineage-cycle-z-a-update.jsonl"),
+            ("corpus-absences",),
         ),
         PathologyZooMember(
             "grouped-jsonl",
@@ -103,6 +111,7 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             (f"{_CLAUDE_CODE}:zoo-group-a", f"{_CLAUDE_CODE}:zoo-group-b"),
             ("manual/grouped.jsonl",),
+            ("corpus-absences",),
         ),
         PathologyZooMember(
             "quarantined-head",
@@ -110,6 +119,7 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             (f"{_CODEX}:zoo-orphan-head",),
             ("manual/lineage-orphan.jsonl",),
+            ("corpus-absences",),
         ),
         PathologyZooMember(
             "empty-session",
@@ -117,6 +127,7 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             (f"{_CLAUDE_CODE}:zoo-empty",),
             ("manual/empty.jsonl",),
+            ("corpus-absences",),
         ),
         PathologyZooMember(
             "hook-event",
@@ -124,6 +135,7 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             (),
             ("hook-spool/zoo-hook-event.json",),
+            ("blob-refs-liveness",),
         ),
         PathologyZooMember(
             "claude-design",
@@ -131,6 +143,7 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             (f"{_DESIGN}:zoo-design-session",),
             ("manual/design.json",),
+            ("corpus-absences",),
         ),
         PathologyZooMember(
             "vintage-reorder",
@@ -138,6 +151,7 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae", "polylogue-slshy"),
             (f"{_CHATGPT}:zoo-vintage-reorder",),
             ("manual/vintage-old.json", "manual/vintage-new.json"),
+            ("corpus-absences",),
         ),
         PathologyZooMember(
             "content-blocks-vintage",
@@ -145,6 +159,7 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae", "polylogue-0qfy"),
             (f"{_CLAUDE_AI}:zoo-content-blocks-vintage",),
             ("manual/content-blocks-old.json", "manual/content-blocks-new.json"),
+            ("corpus-absences",),
         ),
         PathologyZooMember(
             "lifecycle-anchor-drift",
@@ -152,6 +167,7 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae", "polylogue-uqwd"),
             (f"{_CHATGPT}:zoo-lifecycle-anchor-drift",),
             ("manual/lifecycle-old.json", "manual/lifecycle-new.json"),
+            ("corpus-absences",),
         ),
         PathologyZooMember(
             "non-stream-safe",
@@ -159,6 +175,7 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             ("antigravity-session:zoo-06-00:zoo-06-00.md",),
             ("generated",),
+            ("corpus-absences",),
         ),
         PathologyZooMember(
             "attachment-with-bytes",
@@ -166,6 +183,7 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             (f"{_GEMINI}:zoo-attachment-bytes",),
             ("generated/zoo-05-00.json",),
+            ("corpus-absences",),
         ),
         PathologyZooMember(
             "attachment-without-bytes",
@@ -173,6 +191,7 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             (f"{_CLAUDE_AI}:zoo-attachment-metadata",),
             ("manual/attachment-metadata.json",),
+            ("corpus-absences",),
         ),
         PathologyZooMember(
             "events-sidecars",
@@ -180,16 +199,7 @@ def pathology_zoo_manifest() -> tuple[PathologyZooMember, ...]:
             ("polylogue-yazae",),
             (f"{_CHATGPT}:zoo-lifecycle-anchor-drift",),
             ("manual/lifecycle-old.json",),
-        ),
-    )
-
-
-def pathology_zoo_integration_gaps() -> tuple[PathologyZooIntegrationGap, ...]:
-    """Keep absent consumer hooks visible until their owning lanes expose one."""
-    return (
-        PathologyZooIntegrationGap(
-            "polylogue-0x7nh",
-            "No differ canary-set extension point exists in this checkout; include pathology_zoo_manifest() members when the canary registry lands.",
+            ("corpus-absences",),
         ),
     )
 
@@ -534,9 +544,7 @@ def build_pathology_zoo(archive_root: Path) -> PathologyZoo:
 
 __all__ = [
     "PathologyZoo",
-    "PathologyZooIntegrationGap",
     "PathologyZooMember",
     "build_pathology_zoo",
-    "pathology_zoo_integration_gaps",
     "pathology_zoo_manifest",
 ]

--- a/tests/infra/pathology_zoo.py
+++ b/tests/infra/pathology_zoo.py
@@ -15,6 +15,15 @@ from enum import StrEnum
 from pathlib import Path
 
 from polylogue.config import Source
+from polylogue.maintenance.pathology_zoo import (
+    PATHOLOGY_ZOO_MANIFEST as PRODUCTION_PATHOLOGY_ZOO_MANIFEST,
+)
+from polylogue.maintenance.pathology_zoo import (
+    PathologyZooMember as ProductionPathologyZooMember,
+)
+from polylogue.maintenance.pathology_zoo import (
+    pathology_zoo_session_ids as production_pathology_zoo_session_ids,
+)
 from polylogue.pipeline.services.archive_ingest import parse_sources_archive
 from polylogue.scenarios import CorpusSpec
 from polylogue.schemas.synthetic import SyntheticCorpus
@@ -71,24 +80,15 @@ class PathologyZoo:
     """A materialized archive plus its manifest of intentional pathologies."""
 
     archive_root: Path
-    manifest: tuple[PathologyZooMember, ...]
+    manifest: tuple[ProductionPathologyZooMember, ...]
 
-    def members_for(self, pathology: str) -> tuple[PathologyZooMember, ...]:
+    def members_for(self, pathology: str) -> tuple[ProductionPathologyZooMember, ...]:
         return tuple(member for member in self.manifest if member.pathology == pathology)
 
     @property
     def canary_session_ids(self) -> tuple[str, ...]:
-        """Every replayable zoo session supplied to the production canary selector."""
-        return tuple(
-            sorted(
-                {
-                    session_id
-                    for member in self.manifest
-                    if member.canary_eligibility is PathologyZooCanaryEligibility.SESSION_BACKED
-                    for session_id in member.session_ids
-                }
-            )
-        )
+        """The fixture exposes the production canary manifest without re-declaring it."""
+        return production_pathology_zoo_session_ids()
 
 
 _CODEX = "codex-session"
@@ -693,8 +693,8 @@ def _write_generated_members(root: Path, *, indexes: tuple[int, ...] | None = No
 
 
 def _bind_durable_paths(
-    manifest: tuple[PathologyZooMember, ...], wire_root: Path, hook_event_path: Path
-) -> tuple[PathologyZooMember, ...]:
+    manifest: tuple[ProductionPathologyZooMember, ...], wire_root: Path, hook_event_path: Path
+) -> tuple[ProductionPathologyZooMember, ...]:
     return tuple(
         replace(
             member,
@@ -706,7 +706,7 @@ def _bind_durable_paths(
     )
 
 
-def _validate_manifest(root: Path, manifest: tuple[PathologyZooMember, ...]) -> None:
+def _validate_manifest(root: Path, manifest: tuple[ProductionPathologyZooMember, ...]) -> None:
     try:
         with sqlite3.connect(root / "index.db") as conn:
             session_ids = {str(row[0]) for row in conn.execute("SELECT session_id FROM sessions")}
@@ -772,14 +772,21 @@ def build_pathology_zoo(archive_root: Path) -> PathologyZoo:
     )
     if drain_hook_event_spool(archive_root, root=archive_root / "hook-spool").acknowledged != 1:
         raise RuntimeError("pathology zoo hook event did not drain through the durable source route")
-    manifest = _bind_durable_paths(pathology_zoo_manifest(), wire_root, hook_event_path)
+    manifest = _bind_durable_paths(PRODUCTION_PATHOLOGY_ZOO_MANIFEST, wire_root, hook_event_path)
     _validate_manifest(archive_root, manifest)
     return PathologyZoo(archive_root=archive_root, manifest=manifest)
+
+
+def make_pathology_zoo_member_red(archive_root: Path, member_id: str) -> None:
+    """Apply the fixture-only red mutation for one production manifest member."""
+    legacy_member = next(member for member in pathology_zoo_manifest() if member.member_id == member_id)
+    legacy_member.verification.make_red(archive_root)
 
 
 __all__ = [
     "PathologyZoo",
     "PathologyZooMember",
     "build_pathology_zoo",
+    "make_pathology_zoo_member_red",
     "pathology_zoo_manifest",
 ]

--- a/tests/unit/cli/test_reindex_canary_cli.py
+++ b/tests/unit/cli/test_reindex_canary_cli.py
@@ -63,6 +63,46 @@ def test_reindex_canary_cli_requires_no_promote(tmp_path: Path) -> None:
     assert "requires --no-promote" in result.output
 
 
+def test_reindex_canary_cli_rejects_input_outside_archive_root_before_rebuild(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive_root = tmp_path / "archive"
+    archive_root.mkdir()
+    external_index = tmp_path / "external" / "index.db"
+    external_index.parent.mkdir()
+    external_index.touch()
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path / "configured-live"))
+    rebuild_called = False
+
+    def unexpected_rebuild(*args: object, **kwargs: object) -> None:
+        nonlocal rebuild_called
+        rebuild_called = True
+        raise AssertionError("the CLI must reject an outside-root input before rebuild")
+
+    monkeypatch.setattr("polylogue.maintenance.rebuild_index.rebuild_index_from_source_sync", unexpected_rebuild)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--archive-root",
+            str(archive_root),
+            "--input",
+            str(external_index),
+            "--report",
+            str(tmp_path / "canary.json"),
+            "--no-promote",
+        ],
+    )
+
+    assert result.exit_code == 1, result.output
+    assert "inside or bound to the selected archive root" in result.output
+    assert not rebuild_called
+
+
 def test_reindex_canary_cli_runs_real_no_promote_route(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/cli/test_reindex_canary_cli.py
+++ b/tests/unit/cli/test_reindex_canary_cli.py
@@ -1,21 +1,20 @@
 from __future__ import annotations
 
-import json
+import stat
 from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
 
 from polylogue.cli.click_app import cli
-from polylogue.cli.commands.maintenance import _reindex_canary as command_module
 from polylogue.maintenance.reindex_canary import (
     CanaryDiffReport,
     CanaryRunResult,
     CanarySelection,
-    DurableCanaryReport,
     UnclassifiedCanaryDiffError,
     run_reindex_canary,
 )
+from tests.infra.workload_artifacts import build_seeded_archive
 
 
 def _run_result(index_path: Path, *, differences: tuple[object, ...] = ()) -> CanaryRunResult:
@@ -51,6 +50,8 @@ def test_reindex_canary_cli_requires_no_promote(tmp_path: Path) -> None:
             "ops",
             "maintenance",
             "reindex-canary",
+            "--archive-root",
+            str(tmp_path),
             "--input",
             str(index_path),
             "--report",
@@ -62,33 +63,16 @@ def test_reindex_canary_cli_requires_no_promote(tmp_path: Path) -> None:
     assert "requires --no-promote" in result.output
 
 
-def test_reindex_canary_cli_routes_selection_and_report_without_rebuild_duplication(
+def test_reindex_canary_cli_runs_real_no_promote_route(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    index_path = tmp_path / "index.db"
-    index_path.touch()
+    archive_root = build_seeded_archive(cache_root=tmp_path / "cache").root
+    for path in (archive_root, *archive_root.rglob("*")):
+        path.chmod(path.stat().st_mode | stat.S_IWUSR)
+    index_path = archive_root / "index.db"
     report_path = tmp_path / "reports" / "canary.json"
-    run_result = _run_result(index_path)
-    captured: dict[str, object] = {}
-
-    def fake_run(*args: object, **kwargs: object) -> CanaryRunResult:
-        captured["args"] = args
-        captured["kwargs"] = kwargs
-        return run_result
-
-    def fake_write(path: Path, **kwargs: object) -> DurableCanaryReport:
-        captured["report_path"] = path
-        captured["report_kwargs"] = kwargs
-        return DurableCanaryReport(
-            selection=run_result.selection,
-            comparison=run_result.comparison,
-            reviews=(),
-        )
-
-    monkeypatch.setattr(command_module, "archive_root", lambda: tmp_path)
-    monkeypatch.setattr("polylogue.maintenance.reindex_canary.run_reindex_canary", fake_run)
-    monkeypatch.setattr("polylogue.maintenance.reindex_canary.write_canary_report", fake_write)
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path / "configured-live-root"))
 
     result = CliRunner().invoke(
         cli,
@@ -97,14 +81,12 @@ def test_reindex_canary_cli_routes_selection_and_report_without_rebuild_duplicat
             "ops",
             "maintenance",
             "reindex-canary",
+            "--archive-root",
+            str(archive_root),
             "--input",
             str(index_path),
             "--sample",
-            "2",
-            "--pathology-session-id",
-            "codex-session:pathology",
-            "--sample-session-id",
-            "codex-session:sample",
+            "1000",
             "--report",
             str(report_path),
             "--no-promote",
@@ -114,20 +96,10 @@ def test_reindex_canary_cli_routes_selection_and_report_without_rebuild_duplicat
         catch_exceptions=False,
     )
 
-    assert result.exit_code == 0
-    assert captured["args"] == (tmp_path,)
-    assert captured["kwargs"] == {
-        "input_index": index_path,
-        "sessions_per_origin": 2,
-        "pathology_session_ids": ("codex-session:pathology",),
-        "sample_session_ids": ("codex-session:sample",),
-        "no_promote": True,
-    }
-    assert captured["report_path"] == report_path
-    report_kwargs = captured["report_kwargs"]
-    assert isinstance(report_kwargs, dict)
-    assert report_kwargs["reviews"] == ()
-    assert json.loads(result.stdout)["selection"]["selected_raw_ids"] == ["raw-sample"]
+    assert result.exit_code == 1, result.output
+    assert "canary report classification is incomplete" in result.output
+    assert "refuses the configured live archive root" not in result.output
+    assert not report_path.exists()
 
 
 def test_reindex_canary_cli_refuses_to_write_unclassified_report(
@@ -136,7 +108,6 @@ def test_reindex_canary_cli_refuses_to_write_unclassified_report(
     index_path = tmp_path / "index.db"
     index_path.touch()
     run_result = _run_result(index_path, differences=(object(),))
-    monkeypatch.setattr(command_module, "archive_root", lambda: tmp_path)
     monkeypatch.setattr("polylogue.maintenance.reindex_canary.run_reindex_canary", lambda *args, **kwargs: run_result)
     monkeypatch.setattr(
         "polylogue.maintenance.reindex_canary.write_canary_report",
@@ -150,6 +121,8 @@ def test_reindex_canary_cli_refuses_to_write_unclassified_report(
             "ops",
             "maintenance",
             "reindex-canary",
+            "--archive-root",
+            str(tmp_path),
             "--input",
             str(index_path),
             "--report",

--- a/tests/unit/devtools/test_reindex_canary.py
+++ b/tests/unit/devtools/test_reindex_canary.py
@@ -23,7 +23,12 @@ def test_devtools_reindex_canary_delegates_to_product_cli(
 
     monkeypatch.setattr(reindex_canary, "invoke_polylogue_cli", fake_invoke)
 
-    assert reindex_canary.main(["--report", "/tmp/canary.json", "--no-promote", "--json"]) == 0
+    assert (
+        reindex_canary.main(
+            ["--archive-root", "/tmp/isolated-archive", "--report", "/tmp/canary.json", "--no-promote", "--json"]
+        )
+        == 0
+    )
     execution = captured["execution"]
     assert isinstance(execution, ExecutionSpec)
     assert execution.command == (
@@ -32,6 +37,8 @@ def test_devtools_reindex_canary_delegates_to_product_cli(
         "ops",
         "maintenance",
         "reindex-canary",
+        "--archive-root",
+        "/tmp/isolated-archive",
         "--report",
         "/tmp/canary.json",
         "--no-promote",

--- a/tests/unit/infra/test_pathology_zoo.py
+++ b/tests/unit/infra/test_pathology_zoo.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 import sqlite3
+from pathlib import Path
+from shutil import copytree
 
 import pytest
 
+from polylogue.maintenance.reindex_canary import CanarySelectionError, select_canary_sessions
 from tests.infra.pathology_zoo import (
     PathologyZoo,
     build_pathology_zoo,
-    pathology_zoo_integration_gaps,
-    pathology_zoo_manifest,
 )
 
 
@@ -40,7 +41,8 @@ def test_pathology_zoo_manifest_covers_every_v0_dimension(pathology_zoo: Patholo
     }
     assert expected <= {member.pathology for member in pathology_zoo.manifest}
     assert all(
-        member.motivating_beads and member.raw_paths and member.durable_paths for member in pathology_zoo.manifest
+        member.motivating_beads and member.raw_paths and member.durable_paths and member.archive_verification_checks
+        for member in pathology_zoo.manifest
     )
 
 
@@ -207,8 +209,28 @@ def test_zoo_preserves_the_named_vintage_and_lifecycle_red_cases(pathology_zoo: 
     assert vintage_raws == (2,)
 
 
-def test_only_the_absent_canary_hook_is_deferred() -> None:
-    """The archive-verification consumer exists; only the differ canary remains absent."""
-    manifest_ids = {member.member_id for member in pathology_zoo_manifest()}
-    assert {"vintage-reorder", "content-blocks-vintage", "lifecycle-anchor-drift"} <= manifest_ids
-    assert [gap.consumer for gap in pathology_zoo_integration_gaps()] == ["polylogue-0x7nh"]
+def test_pathology_zoo_manifest_is_consumed_by_real_canary_selection(
+    pathology_zoo: PathologyZoo, tmp_path: Path
+) -> None:
+    """0x7nh's selector receives every replayable manifest member as a raw-id input."""
+    selection = select_canary_sessions(
+        pathology_zoo.archive_root / "index.db",
+        sessions_per_origin=1,
+        pathology_session_ids=pathology_zoo.canary_session_ids,
+    )
+
+    assert selection.pathology_session_ids == pathology_zoo.canary_session_ids
+    assert set(pathology_zoo.canary_session_ids) <= set(selection.selected_session_ids)
+    assert len(selection.selected_raw_ids) == len(set(selection.selected_raw_ids))
+
+    mutated_root = tmp_path / "pathology-zoo-canary-mutation"
+    copytree(pathology_zoo.archive_root, mutated_root)
+    with sqlite3.connect(mutated_root / "index.db") as conn:
+        conn.execute("DELETE FROM sessions WHERE session_id = ?", ("codex-session:zoo-append-self",))
+        conn.commit()
+    with pytest.raises(CanarySelectionError, match="not indexed"):
+        select_canary_sessions(
+            mutated_root / "index.db",
+            sessions_per_origin=1,
+            pathology_session_ids=pathology_zoo.canary_session_ids,
+        )

--- a/tests/unit/infra/test_pathology_zoo.py
+++ b/tests/unit/infra/test_pathology_zoo.py
@@ -8,10 +8,10 @@ from shutil import copytree
 
 import pytest
 
+from polylogue.maintenance.pathology_zoo import PATHOLOGY_ZOO_MANIFEST, PathologyZooCanaryEligibility
 from polylogue.maintenance.reindex_canary import CanarySelectionError, select_canary_sessions
 from tests.infra.pathology_zoo import (
     PathologyZoo,
-    PathologyZooCanaryEligibility,
     build_pathology_zoo,
 )
 
@@ -67,22 +67,6 @@ def test_pathology_zoo_manifest_binds_every_wire_path_to_durable_evidence(pathol
                 ).fetchone() == (1,)
 
 
-def test_pathology_zoo_contracts_are_green_then_red_on_their_own_mutation(
-    pathology_zoo: PathologyZoo, tmp_path: Path
-) -> None:
-    """Every declared pathology has a specific production-archive red twin."""
-    for member in pathology_zoo.manifest:
-        assert member.verification.is_satisfied(pathology_zoo.archive_root), member.verification.condition
-
-        mutated_root = tmp_path / member.member_id
-        copytree(pathology_zoo.archive_root, mutated_root)
-        member.verification.make_red(mutated_root)
-
-        assert not member.verification.is_satisfied(mutated_root), (
-            f"{member.member_id}: {member.verification.condition} stayed green after its red mutation"
-        )
-
-
 def test_pathology_zoo_canary_eligibility_is_explicit(pathology_zoo: PathologyZoo) -> None:
     session_backed = [
         member
@@ -123,6 +107,16 @@ def test_pathology_zoo_manifest_is_consumed_by_real_canary_selection(
     pathology_zoo: PathologyZoo, tmp_path: Path
 ) -> None:
     """0x7nh's selector receives every replayable manifest member as a raw-id input."""
+    assert pathology_zoo.canary_session_ids == tuple(
+        sorted(
+            {
+                session_id
+                for member in PATHOLOGY_ZOO_MANIFEST
+                if member.canary_eligibility is PathologyZooCanaryEligibility.SESSION_BACKED
+                for session_id in member.session_ids
+            }
+        )
+    )
     selection = select_canary_sessions(
         pathology_zoo.archive_root / "index.db",
         sessions_per_origin=1,

--- a/tests/unit/infra/test_pathology_zoo.py
+++ b/tests/unit/infra/test_pathology_zoo.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import sqlite3
-from pathlib import Path
 
 import pytest
 
@@ -40,7 +39,9 @@ def test_pathology_zoo_manifest_covers_every_v0_dimension(pathology_zoo: Patholo
         "session-events-and-sidecars",
     }
     assert expected <= {member.pathology for member in pathology_zoo.manifest}
-    assert all(member.motivating_beads and member.session_ids and member.raw_paths for member in pathology_zoo.manifest)
+    assert all(
+        member.motivating_beads and member.raw_paths and member.durable_paths for member in pathology_zoo.manifest
+    )
 
 
 def test_pathology_zoo_members_are_queryable_after_real_ingest(pathology_zoo: PathologyZoo) -> None:
@@ -51,6 +52,140 @@ def test_pathology_zoo_members_are_queryable_after_real_ingest(pathology_zoo: Pa
         "polylogue-yazae",
         "polylogue-0qfy",
     )
+
+
+def test_pathology_zoo_manifest_binds_every_wire_path_to_durable_evidence(pathology_zoo: PathologyZoo) -> None:
+    """Every named wire input has a source-tier receipt, including the hook spool."""
+    with sqlite3.connect(pathology_zoo.archive_root / "source.db") as conn:
+        for member in pathology_zoo.manifest:
+            table = "raw_hook_events" if member.member_id == "hook-event" else "raw_sessions"
+            for durable_path in member.durable_paths:
+                assert conn.execute(
+                    f"SELECT COUNT(*) > 0 FROM {table} WHERE source_path = ?", (durable_path,)
+                ).fetchone() == (1,)
+
+
+def test_pathology_zoo_pathologies_have_production_structural_assertions(pathology_zoo: PathologyZoo) -> None:
+    """Every manifest member names a durable, queryable archive condition."""
+    with (
+        sqlite3.connect(pathology_zoo.archive_root / "source.db") as source,
+        sqlite3.connect(pathology_zoo.archive_root / "index.db") as index,
+    ):
+        assertions = {
+            "whale-component": lambda: (
+                index.execute(
+                    "SELECT message_count >= 48 FROM sessions WHERE session_id = ?", ("codex-session:zoo-whale",)
+                ).fetchone()
+                == (1,)
+            ),
+            "append-self-describing": lambda: (
+                source.execute(
+                    "SELECT COUNT(*) FROM raw_sessions WHERE source_path IN (?, ?)",
+                    pathology_zoo.members_for("append-revision-chain")[0].durable_paths,
+                ).fetchone()
+                == (2,)
+            ),
+            "append-opaque": lambda: (
+                source.execute(
+                    "SELECT COUNT(*) FROM raw_sessions WHERE source_path IN (?, ?)",
+                    pathology_zoo.members_for("append-revision-chain")[1].durable_paths,
+                ).fetchone()
+                == (2,)
+            ),
+            "fork-prefix-tail": lambda: (
+                index.execute(
+                    "SELECT resolved_dst_session_id FROM session_links WHERE src_session_id = ?",
+                    ("codex-session:zoo-lineage-child",),
+                ).fetchone()
+                == ("codex-session:zoo-lineage-parent",)
+            ),
+            "lineage-cycle": lambda: (
+                index.execute(
+                    "SELECT status, resolved_dst_session_id FROM session_links WHERE src_session_id = ?",
+                    ("codex-session:zoo-cycle-a",),
+                ).fetchone()
+                == ("quarantined", None)
+            ),
+            "grouped-jsonl": lambda: (
+                index.execute(
+                    "SELECT COUNT(*) FROM sessions WHERE session_id IN (?, ?)",
+                    ("claude-code-session:zoo-group-a", "claude-code-session:zoo-group-b"),
+                ).fetchone()
+                == (2,)
+            ),
+            "quarantined-head": lambda: (
+                index.execute(
+                    "SELECT status, resolved_dst_session_id FROM session_links WHERE src_session_id = ?",
+                    ("codex-session:zoo-orphan-head",),
+                ).fetchone()
+                == (None, None)
+            ),
+            "empty-session": lambda: (
+                index.execute(
+                    "SELECT message_count FROM sessions WHERE session_id = ?", ("claude-code-session:zoo-empty",)
+                ).fetchone()
+                == (0,)
+            ),
+            "hook-event": lambda: (
+                source.execute(
+                    "SELECT session_native_id, event_type FROM raw_hook_events WHERE hook_event_id = 'hook:zoo-hook-event'"
+                ).fetchone()
+                == ("zoo-hook-parent", "PostToolUse")
+            ),
+            "claude-design": lambda: (
+                index.execute(
+                    "SELECT origin FROM sessions WHERE session_id = ?", ("claude-design-session:zoo-design-session",)
+                ).fetchone()
+                == ("claude-design-session",)
+            ),
+            "vintage-reorder": lambda: (
+                source.execute("SELECT COUNT(*) FROM raw_sessions WHERE source_path LIKE '%vintage-%.json'").fetchone()
+                == (2,)
+            ),
+            "content-blocks-vintage": lambda: (
+                index.execute(
+                    "SELECT COUNT(*) FROM blocks WHERE session_id = ?", ("claude-ai-export:zoo-content-blocks-vintage",)
+                ).fetchone()
+                == (1,)
+            ),
+            "lifecycle-anchor-drift": lambda: (
+                index.execute(
+                    "SELECT source_message_provider_id FROM session_events WHERE session_id = ? AND event_type = 'generation_lifecycle'",
+                    ("chatgpt-export:zoo-lifecycle-anchor-drift",),
+                ).fetchone()
+                == ("lifecycle-b",)
+            ),
+            "non-stream-safe": lambda: (
+                index.execute(
+                    "SELECT COUNT(*) FROM sessions WHERE session_id = ?",
+                    ("antigravity-session:zoo-06-00:zoo-06-00.md",),
+                ).fetchone()
+                == (1,)
+            ),
+            "attachment-with-bytes": lambda: (
+                index.execute(
+                    "SELECT COUNT(*) > 0 FROM attachment_refs WHERE session_id = ?",
+                    ("aistudio-drive:zoo-attachment-bytes",),
+                ).fetchone()
+                == (1,)
+            ),
+            "attachment-without-bytes": lambda: (
+                index.execute(
+                    "SELECT COUNT(*) > 0 FROM attachment_refs WHERE session_id = ?",
+                    ("claude-ai-export:zoo-attachment-metadata",),
+                ).fetchone()
+                == (1,)
+            ),
+            "events-sidecars": lambda: (
+                index.execute(
+                    "SELECT COUNT(*) > 0 FROM session_events WHERE session_id = ?",
+                    ("chatgpt-export:zoo-lifecycle-anchor-drift",),
+                ).fetchone()
+                == (1,)
+            ),
+        }
+        assert {member.member_id for member in pathology_zoo.manifest} == set(assertions)
+        assert all(assertions[member.member_id]() for member in pathology_zoo.manifest)
 
 
 def test_zoo_preserves_the_named_vintage_and_lifecycle_red_cases(pathology_zoo: PathologyZoo) -> None:
@@ -72,24 +207,8 @@ def test_zoo_preserves_the_named_vintage_and_lifecycle_red_cases(pathology_zoo: 
     assert vintage_raws == (2,)
 
 
-def test_pathology_zoo_fails_when_the_production_ingest_route_is_bypassed(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Anti-vacuity: replacing the real parse harness leaves no archive to validate."""
-    import tests.infra.pathology_zoo as zoo_module
-
-    async def bypassed_ingest(*_args: object, **_kwargs: object) -> None:
-        return None
-
-    monkeypatch.setattr(zoo_module, "parse_sources_archive", bypassed_ingest)
-    with pytest.raises(RuntimeError, match="after production ingest"):
-        build_pathology_zoo(tmp_path / "bypassed")
-
-
-def test_absent_registry_and_canary_hooks_are_explicitly_not_faked() -> None:
-    """t0m73 and 0x7nh have no extension point in this checkout; retain the gap as evidence."""
+def test_only_the_absent_canary_hook_is_deferred() -> None:
+    """The archive-verification consumer exists; only the differ canary remains absent."""
     manifest_ids = {member.member_id for member in pathology_zoo_manifest()}
     assert {"vintage-reorder", "content-blocks-vintage", "lifecycle-anchor-drift"} <= manifest_ids
-    gaps = {gap.consumer: gap.follow_up for gap in pathology_zoo_integration_gaps()}
-    assert set(gaps) == {"polylogue-t0m73", "polylogue-0x7nh"}
-    assert all("extension point" in follow_up for follow_up in gaps.values())
+    assert [gap.consumer for gap in pathology_zoo_integration_gaps()] == ["polylogue-0x7nh"]

--- a/tests/unit/infra/test_pathology_zoo.py
+++ b/tests/unit/infra/test_pathology_zoo.py
@@ -1,0 +1,95 @@
+"""Focused contract tests for the production-ingested pathology zoo."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from tests.infra.pathology_zoo import (
+    PathologyZoo,
+    build_pathology_zoo,
+    pathology_zoo_integration_gaps,
+    pathology_zoo_manifest,
+)
+
+
+@pytest.fixture(scope="module")
+def pathology_zoo(tmp_path_factory: pytest.TempPathFactory) -> PathologyZoo:
+    return build_pathology_zoo(tmp_path_factory.mktemp("pathology-zoo"))
+
+
+def test_pathology_zoo_manifest_covers_every_v0_dimension(pathology_zoo: PathologyZoo) -> None:
+    expected = {
+        "whale-component",
+        "append-revision-chain",
+        "fork-resume-prefix-tail-lineage",
+        "lineage-cycle-candidate",
+        "multi-session-raw",
+        "quarantined-head-open-blocker",
+        "genuinely-empty-session",
+        "hook-event-raw",
+        "claude-design-session-origin",
+        "export-vintage-reorder",
+        "content-blocks-vintage",
+        "lifecycle-anchor-drift",
+        "non-stream-safe-origin",
+        "attachment-with-acquired-bytes",
+        "attachment-without-acquired-bytes",
+        "session-events-and-sidecars",
+    }
+    assert expected <= {member.pathology for member in pathology_zoo.manifest}
+    assert all(member.motivating_beads and member.session_ids and member.raw_paths for member in pathology_zoo.manifest)
+
+
+def test_pathology_zoo_members_are_queryable_after_real_ingest(pathology_zoo: PathologyZoo) -> None:
+    with sqlite3.connect(pathology_zoo.archive_root / "index.db") as conn:
+        session_ids = {str(row[0]) for row in conn.execute("SELECT session_id FROM sessions")}
+    assert {session_id for member in pathology_zoo.manifest for session_id in member.session_ids} <= session_ids
+    assert pathology_zoo.members_for("content-blocks-vintage")[0].motivating_beads == (
+        "polylogue-yazae",
+        "polylogue-0qfy",
+    )
+
+
+def test_zoo_preserves_the_named_vintage_and_lifecycle_red_cases(pathology_zoo: PathologyZoo) -> None:
+    """The three K-class entries remain production-ingested, not parser-only samples."""
+    with sqlite3.connect(pathology_zoo.archive_root / "index.db") as conn:
+        content_blocks = conn.execute(
+            "SELECT COUNT(*) FROM blocks WHERE session_id = ?", ("claude-ai-export:zoo-content-blocks-vintage",)
+        ).fetchone()
+        lifecycle = conn.execute(
+            "SELECT source_message_provider_id FROM session_events WHERE session_id = ? AND event_type = 'generation_lifecycle'",
+            ("chatgpt-export:zoo-lifecycle-anchor-drift",),
+        ).fetchall()
+    with sqlite3.connect(pathology_zoo.archive_root / "source.db") as conn:
+        vintage_raws = conn.execute(
+            "SELECT COUNT(*) FROM raw_sessions WHERE source_path LIKE ?", ("%vintage-%.json",)
+        ).fetchone()
+    assert content_blocks == (1,)
+    assert lifecycle == [("lifecycle-b",)]
+    assert vintage_raws == (2,)
+
+
+def test_pathology_zoo_fails_when_the_production_ingest_route_is_bypassed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Anti-vacuity: replacing the real parse harness leaves no archive to validate."""
+    import tests.infra.pathology_zoo as zoo_module
+
+    async def bypassed_ingest(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(zoo_module, "parse_sources_archive", bypassed_ingest)
+    with pytest.raises(RuntimeError, match="after production ingest"):
+        build_pathology_zoo(tmp_path / "bypassed")
+
+
+def test_absent_registry_and_canary_hooks_are_explicitly_not_faked() -> None:
+    """t0m73 and 0x7nh have no extension point in this checkout; retain the gap as evidence."""
+    manifest_ids = {member.member_id for member in pathology_zoo_manifest()}
+    assert {"vintage-reorder", "content-blocks-vintage", "lifecycle-anchor-drift"} <= manifest_ids
+    gaps = {gap.consumer: gap.follow_up for gap in pathology_zoo_integration_gaps()}
+    assert set(gaps) == {"polylogue-t0m73", "polylogue-0x7nh"}
+    assert all("extension point" in follow_up for follow_up in gaps.values())

--- a/tests/unit/infra/test_pathology_zoo.py
+++ b/tests/unit/infra/test_pathology_zoo.py
@@ -11,6 +11,7 @@ import pytest
 from polylogue.maintenance.reindex_canary import CanarySelectionError, select_canary_sessions
 from tests.infra.pathology_zoo import (
     PathologyZoo,
+    PathologyZooCanaryEligibility,
     build_pathology_zoo,
 )
 
@@ -41,8 +42,7 @@ def test_pathology_zoo_manifest_covers_every_v0_dimension(pathology_zoo: Patholo
     }
     assert expected <= {member.pathology for member in pathology_zoo.manifest}
     assert all(
-        member.motivating_beads and member.raw_paths and member.durable_paths and member.archive_verification_checks
-        for member in pathology_zoo.manifest
+        member.motivating_beads and member.raw_paths and member.durable_paths for member in pathology_zoo.manifest
     )
 
 
@@ -67,127 +67,37 @@ def test_pathology_zoo_manifest_binds_every_wire_path_to_durable_evidence(pathol
                 ).fetchone() == (1,)
 
 
-def test_pathology_zoo_pathologies_have_production_structural_assertions(pathology_zoo: PathologyZoo) -> None:
-    """Every manifest member names a durable, queryable archive condition."""
-    with (
-        sqlite3.connect(pathology_zoo.archive_root / "source.db") as source,
-        sqlite3.connect(pathology_zoo.archive_root / "index.db") as index,
-    ):
-        assertions = {
-            "whale-component": lambda: (
-                index.execute(
-                    "SELECT message_count >= 48 FROM sessions WHERE session_id = ?", ("codex-session:zoo-whale",)
-                ).fetchone()
-                == (1,)
-            ),
-            "append-self-describing": lambda: (
-                source.execute(
-                    "SELECT COUNT(*) FROM raw_sessions WHERE source_path IN (?, ?)",
-                    pathology_zoo.members_for("append-revision-chain")[0].durable_paths,
-                ).fetchone()
-                == (2,)
-            ),
-            "append-opaque": lambda: (
-                source.execute(
-                    "SELECT COUNT(*) FROM raw_sessions WHERE source_path IN (?, ?)",
-                    pathology_zoo.members_for("append-revision-chain")[1].durable_paths,
-                ).fetchone()
-                == (2,)
-            ),
-            "fork-prefix-tail": lambda: (
-                index.execute(
-                    "SELECT resolved_dst_session_id FROM session_links WHERE src_session_id = ?",
-                    ("codex-session:zoo-lineage-child",),
-                ).fetchone()
-                == ("codex-session:zoo-lineage-parent",)
-            ),
-            "lineage-cycle": lambda: (
-                index.execute(
-                    "SELECT status, resolved_dst_session_id FROM session_links WHERE src_session_id = ?",
-                    ("codex-session:zoo-cycle-a",),
-                ).fetchone()
-                == ("quarantined", None)
-            ),
-            "grouped-jsonl": lambda: (
-                index.execute(
-                    "SELECT COUNT(*) FROM sessions WHERE session_id IN (?, ?)",
-                    ("claude-code-session:zoo-group-a", "claude-code-session:zoo-group-b"),
-                ).fetchone()
-                == (2,)
-            ),
-            "quarantined-head": lambda: (
-                index.execute(
-                    "SELECT status, resolved_dst_session_id FROM session_links WHERE src_session_id = ?",
-                    ("codex-session:zoo-orphan-head",),
-                ).fetchone()
-                == (None, None)
-            ),
-            "empty-session": lambda: (
-                index.execute(
-                    "SELECT message_count FROM sessions WHERE session_id = ?", ("claude-code-session:zoo-empty",)
-                ).fetchone()
-                == (0,)
-            ),
-            "hook-event": lambda: (
-                source.execute(
-                    "SELECT session_native_id, event_type FROM raw_hook_events WHERE hook_event_id = 'hook:zoo-hook-event'"
-                ).fetchone()
-                == ("zoo-hook-parent", "PostToolUse")
-            ),
-            "claude-design": lambda: (
-                index.execute(
-                    "SELECT origin FROM sessions WHERE session_id = ?", ("claude-design-session:zoo-design-session",)
-                ).fetchone()
-                == ("claude-design-session",)
-            ),
-            "vintage-reorder": lambda: (
-                source.execute("SELECT COUNT(*) FROM raw_sessions WHERE source_path LIKE '%vintage-%.json'").fetchone()
-                == (2,)
-            ),
-            "content-blocks-vintage": lambda: (
-                index.execute(
-                    "SELECT COUNT(*) FROM blocks WHERE session_id = ?", ("claude-ai-export:zoo-content-blocks-vintage",)
-                ).fetchone()
-                == (1,)
-            ),
-            "lifecycle-anchor-drift": lambda: (
-                index.execute(
-                    "SELECT source_message_provider_id FROM session_events WHERE session_id = ? AND event_type = 'generation_lifecycle'",
-                    ("chatgpt-export:zoo-lifecycle-anchor-drift",),
-                ).fetchone()
-                == ("lifecycle-b",)
-            ),
-            "non-stream-safe": lambda: (
-                index.execute(
-                    "SELECT COUNT(*) FROM sessions WHERE session_id = ?",
-                    ("antigravity-session:zoo-06-00:zoo-06-00.md",),
-                ).fetchone()
-                == (1,)
-            ),
-            "attachment-with-bytes": lambda: (
-                index.execute(
-                    "SELECT COUNT(*) > 0 FROM attachment_refs WHERE session_id = ?",
-                    ("aistudio-drive:zoo-attachment-bytes",),
-                ).fetchone()
-                == (1,)
-            ),
-            "attachment-without-bytes": lambda: (
-                index.execute(
-                    "SELECT COUNT(*) > 0 FROM attachment_refs WHERE session_id = ?",
-                    ("claude-ai-export:zoo-attachment-metadata",),
-                ).fetchone()
-                == (1,)
-            ),
-            "events-sidecars": lambda: (
-                index.execute(
-                    "SELECT COUNT(*) > 0 FROM session_events WHERE session_id = ?",
-                    ("chatgpt-export:zoo-lifecycle-anchor-drift",),
-                ).fetchone()
-                == (1,)
-            ),
-        }
-        assert {member.member_id for member in pathology_zoo.manifest} == set(assertions)
-        assert all(assertions[member.member_id]() for member in pathology_zoo.manifest)
+def test_pathology_zoo_contracts_are_green_then_red_on_their_own_mutation(
+    pathology_zoo: PathologyZoo, tmp_path: Path
+) -> None:
+    """Every declared pathology has a specific production-archive red twin."""
+    for member in pathology_zoo.manifest:
+        assert member.verification.is_satisfied(pathology_zoo.archive_root), member.verification.condition
+
+        mutated_root = tmp_path / member.member_id
+        copytree(pathology_zoo.archive_root, mutated_root)
+        member.verification.make_red(mutated_root)
+
+        assert not member.verification.is_satisfied(mutated_root), (
+            f"{member.member_id}: {member.verification.condition} stayed green after its red mutation"
+        )
+
+
+def test_pathology_zoo_canary_eligibility_is_explicit(pathology_zoo: PathologyZoo) -> None:
+    session_backed = [
+        member
+        for member in pathology_zoo.manifest
+        if member.canary_eligibility is PathologyZooCanaryEligibility.SESSION_BACKED
+    ]
+    non_session_only = [
+        member
+        for member in pathology_zoo.manifest
+        if member.canary_eligibility is PathologyZooCanaryEligibility.NON_SESSION_ONLY
+    ]
+
+    assert all(member.session_ids for member in session_backed)
+    assert non_session_only == [pathology_zoo.members_for("hook-event-raw")[0]]
+    assert all(not member.session_ids for member in non_session_only)
 
 
 def test_zoo_preserves_the_named_vintage_and_lifecycle_red_cases(pathology_zoo: PathologyZoo) -> None:

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
+from shutil import copytree
 from typing import Any
 
 import pytest
@@ -26,6 +27,7 @@ from polylogue.maintenance.archive_verification import (
 )
 from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS, initialize_active_archive_root
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from tests.infra.pathology_zoo import build_pathology_zoo, make_pathology_zoo_member_red
 from tests.infra.workload_artifacts import SeededArchiveArtifact
 
 
@@ -1150,6 +1152,14 @@ def test_every_registered_check_has_a_class_tag() -> None:
         assert isinstance(spec.check_class, ArchiveVerificationCheckClass), spec.name
 
 
+def test_pathology_zoo_contract_is_production_owned_and_registered() -> None:
+    """The archive verifier, rather than tests, owns the zoo's enforcement boundary."""
+    from polylogue.maintenance.pathology_zoo import PATHOLOGY_ZOO_MANIFEST
+
+    assert len(PATHOLOGY_ZOO_MANIFEST) == 17
+    assert "pathology-zoo-invariants" in ARCHIVE_VERIFICATION_CHECK_NAMES
+
+
 def test_check_class_is_stamped_onto_every_report_check(tmp_path: Path) -> None:
     _seed_coherent_archive(tmp_path)
     by_name = {spec.name: spec for spec in ARCHIVE_VERIFICATION_CHECKS}
@@ -1281,6 +1291,7 @@ RED_TWIN_TESTS: dict[str, str] = {
     "lineage-sanity": "test_dangling_resolved_dst_trips_lineage_sanity",
     "enum-superset-check": "test_missing_enum_value_trips_enum_superset_check",
     "blob-refs-liveness": "test_blob_ref_with_no_referent_trips_blob_refs_liveness",
+    "pathology-zoo-invariants": "test_pathology_zoo_invariants_red_twin",
     "embeddings-refs-liveness": "test_orphaned_embedding_ref_trips_embeddings_refs_liveness",
     "session-lineage-acyclic": "test_parent_session_id_cycle_trips_session_lineage_acyclic",
     "message-count-projection": "test_drifted_message_count_trips_message_count_projection",
@@ -1354,6 +1365,25 @@ def test_corpus_revision_fidelity_red_twin(tmp_path: Path) -> None:
         )
     report = verify_archive(tmp_path, checks=("corpus-revision-fidelity",))
     assert _check(report, "corpus-revision-fidelity").status is OutcomeStatus.ERROR
+
+
+def test_pathology_zoo_invariants_red_twin(tmp_path: Path) -> None:
+    """Every production manifest member makes its registered verifier red when mutated."""
+    from polylogue.maintenance.pathology_zoo import PATHOLOGY_ZOO_MANIFEST
+
+    zoo = build_pathology_zoo(tmp_path / "zoo")
+    green = verify_archive(zoo.archive_root, checks=("pathology-zoo-invariants",))
+    assert _check(green, "pathology-zoo-invariants").status is OutcomeStatus.OK
+
+    for member in PATHOLOGY_ZOO_MANIFEST:
+        mutated_root = tmp_path / member.member_id
+        copytree(zoo.archive_root, mutated_root)
+        make_pathology_zoo_member_red(mutated_root, member.member_id)
+
+        red = verify_archive(mutated_root, checks=("pathology-zoo-invariants",))
+        check = _check(red, "pathology-zoo-invariants")
+        assert check.status is OutcomeStatus.ERROR, member.invariant.condition
+        assert member.member_id in check.evidence["failed_member_ids"]
 
 
 def test_every_non_complexity_check_has_a_red_twin_test() -> None:

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -6,6 +6,7 @@ incoherence it claims to detect -- not merely that *some* check fails.
 
 from __future__ import annotations
 
+import shutil
 import sqlite3
 from pathlib import Path
 from shutil import copytree
@@ -19,6 +20,7 @@ from polylogue.maintenance.archive_verification import (
     ARCHIVE_VERIFICATION_CHECKS,
     ARCHIVE_VERIFICATION_WAIVERS,
     REINDEX_ACCEPTANCE_CHECKS,
+    REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS,
     ArchiveVerificationCheck,
     ArchiveVerificationCheckClass,
     ArchiveVerificationReport,
@@ -1384,6 +1386,31 @@ def test_pathology_zoo_invariants_red_twin(tmp_path: Path) -> None:
         check = _check(red, "pathology-zoo-invariants")
         assert check.status is OutcomeStatus.ERROR, member.invariant.condition
         assert member.member_id in check.evidence["failed_member_ids"]
+
+
+def test_pathology_zoo_candidate_check_uses_candidate_index_and_durable_source(tmp_path: Path) -> None:
+    zoo = build_pathology_zoo(tmp_path / "zoo")
+    candidate = tmp_path / "candidate-index.db"
+    shutil.copy2(zoo.archive_root / "index.db", candidate)
+
+    green = verify_archive(
+        zoo.archive_root,
+        checks=("pathology-zoo-invariants",),
+        index_path_override=candidate,
+    )
+    assert _check(green, "pathology-zoo-invariants").status is OutcomeStatus.OK
+
+    with _connect(candidate) as conn:
+        conn.execute("UPDATE sessions SET message_count = 47 WHERE session_id = ?", ("codex-session:zoo-whale",))
+
+    red = verify_archive(
+        zoo.archive_root,
+        checks=REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS,
+        index_path_override=candidate,
+    )
+    check = _check(red, "pathology-zoo-invariants")
+    assert check.status is OutcomeStatus.ERROR
+    assert "whale-component" in check.evidence["failed_member_ids"]
 
 
 def test_every_non_complexity_check_has_a_red_twin_test() -> None:

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -26,6 +26,7 @@ from polylogue.maintenance.archive_verification import (
 )
 from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS, initialize_active_archive_root
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from tests.infra.pathology_zoo import build_pathology_zoo
 from tests.infra.workload_artifacts import SeededArchiveArtifact
 
 
@@ -1290,7 +1291,7 @@ RED_TWIN_TESTS: dict[str, str] = {
     "excluded-cursor-vocabulary-honesty": "test_excluded_cursor_with_live_next_retry_at_trips_vocabulary_honesty",
     "stalled-append-cursor-freshness": "test_stalled_append_cursor_trips_freshness_check",
     "raw-quarantine-group-dedup": "test_fully_quarantined_duplicate_group_trips_raw_quarantine_group_dedup",
-    "corpus-absences": "test_corpus_absences_red_twin",
+    "corpus-absences": "test_pathology_zoo_corpus_absences_red_twin",
     "corpus-attachment-fidelity": "test_corpus_attachment_fidelity_red_twin",
     "corpus-revision-fidelity": "test_corpus_revision_fidelity_red_twin",
 }
@@ -1317,6 +1318,21 @@ def test_corpus_absences_red_twin(tmp_path: Path) -> None:
         )
     report = verify_archive(tmp_path, checks=("corpus-absences",))
     assert _check(report, "corpus-absences").status is OutcomeStatus.ERROR
+
+
+def test_pathology_zoo_corpus_absences_red_twin(tmp_path: Path) -> None:
+    """The zoo consumes t0m73's red-twin registry through a real two-wave archive."""
+    zoo = build_pathology_zoo(tmp_path / "zoo")
+    clean = verify_archive(zoo.archive_root, checks=("corpus-absences", "corpus-revision-fidelity"))
+    assert _check(clean, "corpus-absences").status is OutcomeStatus.OK
+    assert _check(clean, "corpus-revision-fidelity").status is OutcomeStatus.OK
+
+    with _connect(zoo.archive_root / "index.db") as conn:
+        conn.execute("DELETE FROM sessions WHERE session_id = ?", ("codex-session:zoo-append-self",))
+        conn.commit()
+
+    red = verify_archive(zoo.archive_root, checks=("corpus-absences",))
+    assert _check(red, "corpus-absences").status is OutcomeStatus.ERROR
 
 
 def test_corpus_attachment_fidelity_red_twin(tmp_path: Path) -> None:

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -1281,7 +1281,7 @@ RED_TWIN_TESTS: dict[str, str] = {
     "fts-parity": "test_deleted_fts_row_trips_message_fts_parity",
     "lineage-sanity": "test_dangling_resolved_dst_trips_lineage_sanity",
     "enum-superset-check": "test_missing_enum_value_trips_enum_superset_check",
-    "blob-refs-liveness": "test_blob_ref_with_no_referent_trips_blob_refs_liveness",
+    "blob-refs-liveness": "test_pathology_zoo_manifest_archive_verification_red_twin",
     "embeddings-refs-liveness": "test_orphaned_embedding_ref_trips_embeddings_refs_liveness",
     "session-lineage-acyclic": "test_parent_session_id_cycle_trips_session_lineage_acyclic",
     "message-count-projection": "test_drifted_message_count_trips_message_count_projection",
@@ -1291,7 +1291,7 @@ RED_TWIN_TESTS: dict[str, str] = {
     "excluded-cursor-vocabulary-honesty": "test_excluded_cursor_with_live_next_retry_at_trips_vocabulary_honesty",
     "stalled-append-cursor-freshness": "test_stalled_append_cursor_trips_freshness_check",
     "raw-quarantine-group-dedup": "test_fully_quarantined_duplicate_group_trips_raw_quarantine_group_dedup",
-    "corpus-absences": "test_pathology_zoo_corpus_absences_red_twin",
+    "corpus-absences": "test_pathology_zoo_manifest_archive_verification_red_twin",
     "corpus-attachment-fidelity": "test_corpus_attachment_fidelity_red_twin",
     "corpus-revision-fidelity": "test_corpus_revision_fidelity_red_twin",
 }
@@ -1320,12 +1320,12 @@ def test_corpus_absences_red_twin(tmp_path: Path) -> None:
     assert _check(report, "corpus-absences").status is OutcomeStatus.ERROR
 
 
-def test_pathology_zoo_corpus_absences_red_twin(tmp_path: Path) -> None:
-    """The zoo consumes t0m73's red-twin registry through a real two-wave archive."""
+def test_pathology_zoo_manifest_archive_verification_red_twin(tmp_path: Path) -> None:
+    """Manifest-declared checks are green on ingest, then trip on their real evidence mutations."""
     zoo = build_pathology_zoo(tmp_path / "zoo")
-    clean = verify_archive(zoo.archive_root, checks=("corpus-absences", "corpus-revision-fidelity"))
+    clean = verify_archive(zoo.archive_root, checks=zoo.archive_verification_checks)
     assert _check(clean, "corpus-absences").status is OutcomeStatus.OK
-    assert _check(clean, "corpus-revision-fidelity").status is OutcomeStatus.OK
+    assert _check(clean, "blob-refs-liveness").status is OutcomeStatus.OK
 
     with _connect(zoo.archive_root / "index.db") as conn:
         conn.execute("DELETE FROM sessions WHERE session_id = ?", ("codex-session:zoo-append-self",))
@@ -1333,6 +1333,42 @@ def test_pathology_zoo_corpus_absences_red_twin(tmp_path: Path) -> None:
 
     red = verify_archive(zoo.archive_root, checks=("corpus-absences",))
     assert _check(red, "corpus-absences").status is OutcomeStatus.ERROR
+
+    hook_zoo = build_pathology_zoo(tmp_path / "hook-zoo")
+    with _connect(hook_zoo.archive_root / "source.db") as conn:
+        conn.execute("DELETE FROM raw_hook_events WHERE hook_event_id = ?", ("hook:zoo-hook-event",))
+        conn.commit()
+    hook_red = verify_archive(hook_zoo.archive_root, checks=("blob-refs-liveness",))
+    assert _check(hook_red, "blob-refs-liveness").status is OutcomeStatus.ERROR
+
+
+def test_pathology_zoo_manifest_members_have_registered_check_and_red_twin_coverage(tmp_path: Path) -> None:
+    """A manifest addition must name an exercised archive verification consumer."""
+    zoo = build_pathology_zoo(tmp_path / "zoo")
+    registry = set(ARCHIVE_VERIFICATION_CHECK_NAMES)
+    module_globals = globals()
+
+    uncovered = {
+        member.member_id: tuple(
+            check
+            for check in member.archive_verification_checks
+            if check not in registry
+            or RED_TWIN_TESTS.get(check) != "test_pathology_zoo_manifest_archive_verification_red_twin"
+            or not callable(module_globals.get(RED_TWIN_TESTS.get(check, "")))
+        )
+        for member in zoo.manifest
+        if not member.archive_verification_checks
+        or any(
+            check not in registry
+            or RED_TWIN_TESTS.get(check) != "test_pathology_zoo_manifest_archive_verification_red_twin"
+            or not callable(module_globals.get(RED_TWIN_TESTS.get(check, "")))
+            for check in member.archive_verification_checks
+        )
+    }
+    assert not uncovered, f"manifest members without registry/red-twin coverage: {uncovered}"
+
+    report = verify_archive(zoo.archive_root, checks=zoo.archive_verification_checks)
+    assert all(check.status is OutcomeStatus.OK for check in report.checks)
 
 
 def test_corpus_attachment_fidelity_red_twin(tmp_path: Path) -> None:

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -26,7 +26,6 @@ from polylogue.maintenance.archive_verification import (
 )
 from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS, initialize_active_archive_root
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
-from tests.infra.pathology_zoo import build_pathology_zoo
 from tests.infra.workload_artifacts import SeededArchiveArtifact
 
 
@@ -1281,7 +1280,7 @@ RED_TWIN_TESTS: dict[str, str] = {
     "fts-parity": "test_deleted_fts_row_trips_message_fts_parity",
     "lineage-sanity": "test_dangling_resolved_dst_trips_lineage_sanity",
     "enum-superset-check": "test_missing_enum_value_trips_enum_superset_check",
-    "blob-refs-liveness": "test_pathology_zoo_manifest_archive_verification_red_twin",
+    "blob-refs-liveness": "test_blob_ref_with_no_referent_trips_blob_refs_liveness",
     "embeddings-refs-liveness": "test_orphaned_embedding_ref_trips_embeddings_refs_liveness",
     "session-lineage-acyclic": "test_parent_session_id_cycle_trips_session_lineage_acyclic",
     "message-count-projection": "test_drifted_message_count_trips_message_count_projection",
@@ -1291,7 +1290,7 @@ RED_TWIN_TESTS: dict[str, str] = {
     "excluded-cursor-vocabulary-honesty": "test_excluded_cursor_with_live_next_retry_at_trips_vocabulary_honesty",
     "stalled-append-cursor-freshness": "test_stalled_append_cursor_trips_freshness_check",
     "raw-quarantine-group-dedup": "test_fully_quarantined_duplicate_group_trips_raw_quarantine_group_dedup",
-    "corpus-absences": "test_pathology_zoo_manifest_archive_verification_red_twin",
+    "corpus-absences": "test_corpus_absences_red_twin",
     "corpus-attachment-fidelity": "test_corpus_attachment_fidelity_red_twin",
     "corpus-revision-fidelity": "test_corpus_revision_fidelity_red_twin",
 }
@@ -1318,57 +1317,6 @@ def test_corpus_absences_red_twin(tmp_path: Path) -> None:
         )
     report = verify_archive(tmp_path, checks=("corpus-absences",))
     assert _check(report, "corpus-absences").status is OutcomeStatus.ERROR
-
-
-def test_pathology_zoo_manifest_archive_verification_red_twin(tmp_path: Path) -> None:
-    """Manifest-declared checks are green on ingest, then trip on their real evidence mutations."""
-    zoo = build_pathology_zoo(tmp_path / "zoo")
-    clean = verify_archive(zoo.archive_root, checks=zoo.archive_verification_checks)
-    assert _check(clean, "corpus-absences").status is OutcomeStatus.OK
-    assert _check(clean, "blob-refs-liveness").status is OutcomeStatus.OK
-
-    with _connect(zoo.archive_root / "index.db") as conn:
-        conn.execute("DELETE FROM sessions WHERE session_id = ?", ("codex-session:zoo-append-self",))
-        conn.commit()
-
-    red = verify_archive(zoo.archive_root, checks=("corpus-absences",))
-    assert _check(red, "corpus-absences").status is OutcomeStatus.ERROR
-
-    hook_zoo = build_pathology_zoo(tmp_path / "hook-zoo")
-    with _connect(hook_zoo.archive_root / "source.db") as conn:
-        conn.execute("DELETE FROM raw_hook_events WHERE hook_event_id = ?", ("hook:zoo-hook-event",))
-        conn.commit()
-    hook_red = verify_archive(hook_zoo.archive_root, checks=("blob-refs-liveness",))
-    assert _check(hook_red, "blob-refs-liveness").status is OutcomeStatus.ERROR
-
-
-def test_pathology_zoo_manifest_members_have_registered_check_and_red_twin_coverage(tmp_path: Path) -> None:
-    """A manifest addition must name an exercised archive verification consumer."""
-    zoo = build_pathology_zoo(tmp_path / "zoo")
-    registry = set(ARCHIVE_VERIFICATION_CHECK_NAMES)
-    module_globals = globals()
-
-    uncovered = {
-        member.member_id: tuple(
-            check
-            for check in member.archive_verification_checks
-            if check not in registry
-            or RED_TWIN_TESTS.get(check) != "test_pathology_zoo_manifest_archive_verification_red_twin"
-            or not callable(module_globals.get(RED_TWIN_TESTS.get(check, "")))
-        )
-        for member in zoo.manifest
-        if not member.archive_verification_checks
-        or any(
-            check not in registry
-            or RED_TWIN_TESTS.get(check) != "test_pathology_zoo_manifest_archive_verification_red_twin"
-            or not callable(module_globals.get(RED_TWIN_TESTS.get(check, "")))
-            for check in member.archive_verification_checks
-        )
-    }
-    assert not uncovered, f"manifest members without registry/red-twin coverage: {uncovered}"
-
-    report = verify_archive(zoo.archive_root, checks=zoo.archive_verification_checks)
-    assert all(check.status is OutcomeStatus.OK for check in report.checks)
 
 
 def test_corpus_attachment_fidelity_red_twin(tmp_path: Path) -> None:

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -312,6 +312,44 @@ def test_selector_refuses_unknown_or_non_replayable_explicit_sessions(tmp_path: 
         select_canary_sessions(index, pathology_session_ids=("codex-session:alpha",))
 
 
+def test_run_reindex_canary_automatically_includes_production_pathology_sessions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The real canary runner supplements operator IDs from the production manifest."""
+    from polylogue.maintenance.pathology_zoo import pathology_zoo_session_ids
+
+    current = tmp_path / "current.db"
+    pathology_session_ids = pathology_zoo_session_ids()
+    native_ids = tuple(session_id.split(":", 1)[1] for session_id in pathology_session_ids)
+    origins = tuple(session_id.split(":", 1)[0] for session_id in pathology_session_ids)
+    _seed_index(current, sessions=native_ids, origins=origins)
+    captured: dict[str, tuple[str, ...]] = {}
+
+    class Receipt:
+        def to_dict(self) -> dict[str, object]:
+            return {"status": "replayed"}
+
+    def fake_rebuild(request: object) -> Receipt:
+        captured["raw_ids"] = tuple(request.raw_ids)  # type: ignore[attr-defined]
+        return Receipt()
+
+    def fake_compare(current_index: Path, candidate_index: Path, *, session_ids: tuple[str, ...]) -> CanaryDiffReport:
+        captured["session_ids"] = session_ids
+        return _empty_comparison(current_index, candidate_index, session_ids)
+
+    monkeypatch.setattr("polylogue.maintenance.rebuild_index.rebuild_index_from_source_sync", fake_rebuild)
+    monkeypatch.setattr(
+        "polylogue.maintenance.reindex_canary._validate_canary_candidate", lambda *args, **kwargs: current
+    )
+    monkeypatch.setattr("polylogue.maintenance.reindex_canary.compare_reindex_generations", fake_compare)
+
+    result = run_reindex_canary(tmp_path, input_index=current, sessions_per_origin=1, no_promote=True)
+
+    assert result.selection.pathology_session_ids == pathology_session_ids
+    assert set(pathology_session_ids) <= set(captured["session_ids"])
+    assert len(captured["raw_ids"]) == len(pathology_session_ids)
+
+
 def test_run_reindex_canary_compares_its_own_inactive_generation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -352,6 +352,62 @@ def test_run_reindex_canary_automatically_includes_production_pathology_sessions
     assert captured["acceptance_checks"] == ("pathology-zoo-invariants",)
 
 
+def test_run_reindex_canary_rejects_input_index_outside_archive_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "archive"
+    root.mkdir()
+    external_index = tmp_path / "external" / "index.db"
+    external_index.parent.mkdir()
+    external_index.touch()
+    monkeypatch.setattr("polylogue.config.resolve_archive_root", lambda: tmp_path / "configured-live")
+    selector_called = False
+
+    def unexpected_selector(*args: object, **kwargs: object) -> None:
+        nonlocal selector_called
+        selector_called = True
+        raise AssertionError("an outside-root input must be rejected before selection")
+
+    monkeypatch.setattr("polylogue.maintenance.reindex_canary.select_canary_sessions", unexpected_selector)
+
+    with pytest.raises(CanarySelectionError, match="inside or bound to the selected archive root"):
+        run_reindex_canary(root, input_index=external_index, no_promote=True)
+    assert not selector_called
+
+
+def test_run_reindex_canary_accepts_input_index_bound_by_active_pointer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "archive"
+    root.mkdir()
+    external_index = tmp_path / "external" / "index.db"
+    external_index.parent.mkdir()
+    external_index.touch()
+    (root / ".index-active-pointer").write_text(str(external_index), encoding="utf-8")
+    selection = _empty_selection(external_index)
+
+    class Receipt:
+        def to_dict(self) -> dict[str, object]:
+            return {"status": "replayed"}
+
+    monkeypatch.setattr(
+        "polylogue.maintenance.reindex_canary.select_canary_sessions", lambda *args, **kwargs: selection
+    )
+    monkeypatch.setattr("polylogue.maintenance.rebuild_index.rebuild_index_from_source_sync", lambda request: Receipt())
+    monkeypatch.setattr(
+        "polylogue.maintenance.reindex_canary._validate_canary_candidate", lambda *args, **kwargs: external_index
+    )
+    monkeypatch.setattr(
+        "polylogue.maintenance.reindex_canary.compare_reindex_generations",
+        lambda current, candidate, *, session_ids: _empty_comparison(current, candidate, session_ids),
+    )
+
+    result = run_reindex_canary(root, input_index=external_index, no_promote=True)
+
+    assert result.selection.index_path == external_index
+    assert result.comparison.current_index == external_index
+
+
 def test_run_reindex_canary_does_not_require_zoo_sessions_for_ordinary_archive(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -8,6 +8,7 @@ green, while the real blocks read model must report the changed row.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import shutil
@@ -566,6 +567,45 @@ def test_run_reindex_canary_refuses_the_configured_live_archive_root(
     with pytest.raises(CanarySelectionError, match="refuses the configured live archive root"):
         run_reindex_canary(tmp_path, no_promote=True)
     assert not rebuild_called
+
+
+def test_real_pathology_canary_rejects_cyclic_candidate_before_insight_repair(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A corrupt inactive lineage candidate is rejected without touching active data."""
+    from tests.infra.pathology_zoo import build_pathology_zoo
+
+    zoo = build_pathology_zoo(tmp_path / "zoo")
+    active_index = zoo.archive_root / "index.db"
+    active_digest = hashlib.sha256(active_index.read_bytes()).hexdigest()
+    from polylogue.maintenance import rebuild_index
+
+    real_repopulate = rebuild_index._repopulate_bulk_build_derived_state
+
+    def corrupt_candidate_after_replay(candidate_index: Path) -> dict[str, float]:
+        timings = real_repopulate(candidate_index)
+        with sqlite3.connect(candidate_index) as connection:
+            connection.execute(
+                "UPDATE sessions SET parent_session_id = ? WHERE session_id = ?",
+                ("codex-session:zoo-cycle-b", "codex-session:zoo-cycle-a"),
+            )
+            connection.execute(
+                "UPDATE sessions SET parent_session_id = ? WHERE session_id = ?",
+                ("codex-session:zoo-cycle-a", "codex-session:zoo-cycle-b"),
+            )
+            connection.commit()
+        return timings
+
+    def unexpected_insight_repair(*args: object, **kwargs: object) -> object:
+        raise AssertionError("invalid lineage candidate reached session insight materialization")
+
+    monkeypatch.setattr(rebuild_index, "_repopulate_bulk_build_derived_state", corrupt_candidate_after_replay)
+    monkeypatch.setattr("polylogue.storage.repair.repair_session_insights", unexpected_insight_repair)
+
+    with pytest.raises(RuntimeError, match="session-lineage-acyclic"):
+        run_reindex_canary(zoo.archive_root, sessions_per_origin=1, no_promote=True)
+
+    assert hashlib.sha256(active_index.read_bytes()).hexdigest() == active_digest
 
 
 def test_durable_report_refuses_unclassified_diffs(tmp_path: Path) -> None:

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import sqlite3
 import tempfile
 from pathlib import Path
@@ -34,6 +35,7 @@ from polylogue.maintenance.reindex_canary import (
 )
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from tests.infra.workload_artifacts import build_seeded_archive, clone_seeded_archive
 
 
 def _seed_index(
@@ -375,37 +377,53 @@ def test_run_reindex_canary_rejects_input_index_outside_archive_root(
     assert not selector_called
 
 
-def test_run_reindex_canary_accepts_input_index_bound_by_active_pointer(
+def test_run_reindex_canary_accepts_split_root_active_pointer_through_real_validator(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    root = tmp_path / "archive"
-    root.mkdir()
-    external_index = tmp_path / "external" / "index.db"
-    external_index.parent.mkdir()
-    external_index.touch()
+    artifact = build_seeded_archive(cache_root=tmp_path / "seeded-cache")
+    root = clone_seeded_archive(artifact, tmp_path / "archive").root
+    external_index_root = tmp_path / "external-index-root"
+    external_index_root.mkdir()
+    external_index = external_index_root / "index.db"
+    shutil.move(root / "index.db", external_index)
     (root / ".index-active-pointer").write_text(str(external_index), encoding="utf-8")
-    selection = _empty_selection(external_index)
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path / "configured-live"))
 
-    class Receipt:
-        def to_dict(self) -> dict[str, object]:
-            return {"status": "replayed"}
+    result = run_reindex_canary(root, input_index=external_index, sessions_per_origin=1, no_promote=True)
 
-    monkeypatch.setattr(
-        "polylogue.maintenance.reindex_canary.select_canary_sessions", lambda *args, **kwargs: selection
-    )
-    monkeypatch.setattr("polylogue.maintenance.rebuild_index.rebuild_index_from_source_sync", lambda request: Receipt())
-    monkeypatch.setattr(
-        "polylogue.maintenance.reindex_canary._validate_canary_candidate", lambda *args, **kwargs: external_index
-    )
-    monkeypatch.setattr(
-        "polylogue.maintenance.reindex_canary.compare_reindex_generations",
-        lambda current, candidate, *, session_ids: _empty_comparison(current, candidate, session_ids),
-    )
-
-    result = run_reindex_canary(root, input_index=external_index, no_promote=True)
-
+    receipt = result.rebuild_receipt
+    generation = receipt["generation"]
+    assert isinstance(generation, dict)
+    generation_id = generation["generation_id"]
+    owner_id = generation["owner_id"]
+    source_snapshot = generation["source_snapshot"]
+    candidate_path = Path(str(generation["index_path"]))
+    expected_candidate_path = external_index_root / ".index-generations" / str(generation_id) / "index.db"
     assert result.selection.index_path == external_index
-    assert result.comparison.current_index == external_index
+    assert result.comparison.current_index.resolve() == external_index.resolve()
+    assert result.comparison.candidate_index == candidate_path
+    assert candidate_path == expected_candidate_path.resolve()
+    assert candidate_path.is_file()
+    assert generation["archive_root"] == str(root.resolve())
+    assert generation["state"] == "inactive"
+    assert isinstance(owner_id, str) and owner_id
+    assert isinstance(source_snapshot, str) and source_snapshot
+    assert json.loads((candidate_path.parent / "generation.json").read_text(encoding="utf-8")) == generation
+
+    transaction = receipt["transaction"]
+    operation = receipt["operation"]
+    assert transaction is None
+    assert isinstance(operation, dict)
+    operation_owner = operation["owner"]
+    operation_generation = operation["generation"]
+    operation_delta = operation["delta"]
+    assert isinstance(operation_owner, dict)
+    assert isinstance(operation_generation, dict)
+    assert isinstance(operation_delta, dict)
+    assert operation_owner["generation_owner_id"] == owner_id
+    assert operation_generation == {"generation_id": generation_id, "state": "inactive"}
+    assert operation_delta["transaction_source_snapshot"] == source_snapshot
+    assert operation_delta["source_snapshot_matches"] is True
 
 
 def test_run_reindex_canary_does_not_require_zoo_sessions_for_ordinary_archive(

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -331,6 +331,7 @@ def test_run_reindex_canary_automatically_includes_production_pathology_sessions
 
     def fake_rebuild(request: object) -> Receipt:
         captured["raw_ids"] = tuple(request.raw_ids)  # type: ignore[attr-defined]
+        captured["acceptance_checks"] = tuple(request.candidate_acceptance_checks)  # type: ignore[attr-defined]
         return Receipt()
 
     def fake_compare(current_index: Path, candidate_index: Path, *, session_ids: tuple[str, ...]) -> CanaryDiffReport:
@@ -348,6 +349,53 @@ def test_run_reindex_canary_automatically_includes_production_pathology_sessions
     assert result.selection.pathology_session_ids == pathology_session_ids
     assert set(pathology_session_ids) <= set(captured["session_ids"])
     assert len(captured["raw_ids"]) == len(pathology_session_ids)
+    assert captured["acceptance_checks"] == ("pathology-zoo-invariants",)
+
+
+def test_run_reindex_canary_does_not_require_zoo_sessions_for_ordinary_archive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    current = tmp_path / "current.db"
+    _seed_index(current)
+    selection = CanarySelection(
+        index_path=current,
+        sessions_per_origin=1,
+        selected_session_ids=("codex-session:alpha",),
+        selected_raw_ids=("raw-alpha",),
+        sampled_session_ids=("codex-session:alpha",),
+        pathology_session_ids=(),
+        sample_session_ids=(),
+        origin_counts=(("codex-session", 1),),
+    )
+    captured: dict[str, tuple[str, ...]] = {}
+
+    class Receipt:
+        def to_dict(self) -> dict[str, object]:
+            return {"status": "replayed"}
+
+    def fake_rebuild(request: object) -> Receipt:
+        captured["raw_ids"] = tuple(request.raw_ids)  # type: ignore[attr-defined]
+        captured["acceptance_checks"] = tuple(request.candidate_acceptance_checks)  # type: ignore[attr-defined]
+        return Receipt()
+
+    def fake_compare(current_index: Path, candidate_index: Path, *, session_ids: tuple[str, ...]) -> CanaryDiffReport:
+        captured["session_ids"] = session_ids
+        return _empty_comparison(current_index, candidate_index, session_ids)
+
+    monkeypatch.setattr(
+        "polylogue.maintenance.reindex_canary.select_canary_sessions", lambda *args, **kwargs: selection
+    )
+    monkeypatch.setattr("polylogue.maintenance.rebuild_index.rebuild_index_from_source_sync", fake_rebuild)
+    monkeypatch.setattr(
+        "polylogue.maintenance.reindex_canary._validate_canary_candidate", lambda *args, **kwargs: current
+    )
+    monkeypatch.setattr("polylogue.maintenance.reindex_canary.compare_reindex_generations", fake_compare)
+
+    result = run_reindex_canary(tmp_path, input_index=current, no_promote=True)
+
+    assert result.selection.pathology_session_ids == ()
+    assert captured["raw_ids"] == ("raw-alpha",)
+    assert captured["acceptance_checks"] == ("pathology-zoo-invariants",)
 
 
 def test_run_reindex_canary_compares_its_own_inactive_generation(


### PR DESCRIPTION
## Summary

Rejects structurally invalid inactive reindex candidates before session-insight materialization.

## Problem

A cyclic parent lineage could make thread materialization fail before the candidate acceptance gate reported the actual invariant violation.

## Solution

Bounds all recursive session-thread walks and moves the existing candidate acceptance checks ahead of derived insight materialization. The pathology-zoo red twin performs a real inactive rebuild, corrupts only the candidate after replay, requires `session-lineage-acyclic` to reject it, and proves active index bytes are unchanged.

## Verification

`direnv exec . devtools test tests/unit/maintenance/test_reindex_canary.py::test_real_pathology_canary_rejects_cyclic_candidate_before_insight_repair`

1 passed.