### PR TITLE
fix(fts): preserve retry state until exact parity

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -1732,7 +1732,8 @@ def _drain_convergence_debt_once(db: Path, *, limit: int = 100) -> int:
     for debt in due_debt:
         retried += 1
         if debt.subject_type == "fts_surface":
-            if fts_surface_results.get(debt.subject_id) is True:
+            result = fts_surface_results.get(debt.subject_id)
+            if bool(getattr(result, "success", result)):
                 cursor.clear_convergence_debt(
                     stage=debt.stage,
                     subject_type=debt.subject_type,
@@ -1745,6 +1746,7 @@ def _drain_convergence_debt_once(db: Path, *, limit: int = 100) -> int:
                 subject_id=debt.subject_id,
                 error="FTS freshness convergence did not converge",
                 materializer_version=debt.materializer_version,
+                deferred=bool(getattr(result, "deferred", False)),
             )
             continue
 
@@ -1802,14 +1804,14 @@ def _drain_convergence_debt_once(db: Path, *, limit: int = 100) -> int:
     return retried
 
 
-def _drain_fts_surface_debt(db: Path, surfaces: tuple[str, ...]) -> dict[str, bool]:
+def _drain_fts_surface_debt(db: Path, surfaces: tuple[str, ...]) -> dict[str, object]:
     if not surfaces:
         return {}
-    from polylogue.daemon.convergence_stages import repair_fts_surface
+    from polylogue.daemon.convergence_stages import repair_fts_surface_result
 
-    results: dict[str, bool] = {}
+    results: dict[str, object] = {}
     for surface in surfaces:
-        results[surface] = repair_fts_surface(db, surface)
+        results[surface] = repair_fts_surface_result(db, surface)
     return results
 
 

--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -58,6 +58,24 @@ def _is_transient_sqlite_lock(exc: BaseException) -> bool:
     return "database is locked" in message or "database table is locked" in message or "database is busy" in message
 
 
+@dataclass(frozen=True, slots=True)
+class FtsSurfaceRepairResult:
+    """Outcome of one persisted FTS-surface repair attempt.
+
+    A busy SQLite writer is deliberate backpressure and remains retryable. A
+    repair exception or an exact-parity failure is a genuine failed attempt.
+    Keeping that distinction beside the FTS repair route prevents the debt
+    drain from reducing both outcomes to the same boolean.
+    """
+
+    success: bool
+    deferred: bool = False
+    detail: str | None = None
+
+    def __bool__(self) -> bool:
+        return self.success
+
+
 def _open_archive_insight_write_connection(db_path: Path) -> sqlite3.Connection:
     conn = open_daemon_connection(db_path, timeout=_ARCHIVE_INSIGHT_WRITE_BUSY_TIMEOUT_MS / 1000)
     try:
@@ -1640,73 +1658,73 @@ def _archive_fts_execute_sessions(db_path: Path, session_ids: Sequence[str]) -> 
         return False
 
 
-def repair_messages_fts_surface(db_path: Path) -> bool:
+def repair_messages_fts_surface_result(db_path: Path) -> FtsSurfaceRepairResult:
     """Repair the whole archive ``messages_fts`` surface after global drift."""
     archive_db = _active_archive_index_path(db_path) or db_path
     try:
         conn = _open_archive_insight_write_connection(archive_db)
         try:
             from polylogue.storage.fts.dangling_repair import configure_bounded_repair_connection
-            from polylogue.storage.fts.freshness import READY, record_fts_surface_state_sync
+            from polylogue.storage.fts.freshness import READY, STALE, record_fts_surface_state_sync
             from polylogue.storage.fts.fts_lifecycle import (
+                fts_invariant_snapshot_sync,
                 reconcile_message_fts_rows_once_sync,
             )
-            from polylogue.storage.fts.sql import FTS_INDEX_DOC_COUNT_SQL, FTS_INDEXABLE_MESSAGE_COUNT_SQL
 
             configure_bounded_repair_connection(conn)
             inserted_total, deleted_total = reconcile_message_fts_rows_once_sync(conn)
-            # The exhaustive set-based insert/delete above (not a windowed
-            # partial pass -- the historical "bounded" naming refers only to
-            # avoiding the old repeated-join rowid-window loop) has just
-            # cleared every missing/excess row across the whole table, so the
-            # real post-repair cardinalities are two plain single-table
-            # COUNT(*) probes, not the anti-join missing/excess/identity-
-            # mismatch scan ``fts_invariant_snapshot_sync`` performs (that
-            # stays out of daemon convergence; see
-            # test_archive_fts_global_repair_does_not_run_full_exact_snapshot).
-            # Recording the true counts (polylogue-roax) instead of a
-            # fabricated 1/1 placeholder is what lets the status surface and
-            # the query-path fast readiness check trust this row without
-            # disagreeing with each other.
-            source_rows = int(conn.execute(FTS_INDEXABLE_MESSAGE_COUNT_SQL).fetchone()[0] or 0)
-            indexed_rows = int(conn.execute(FTS_INDEX_DOC_COUNT_SQL).fetchone()[0] or 0)
+            surface = fts_invariant_snapshot_sync(conn).messages
             record_fts_surface_state_sync(
                 conn,
                 surface="messages_fts",
-                state=READY,
-                source_rows=source_rows,
-                indexed_rows=indexed_rows,
-                missing_rows=0,
-                excess_rows=0,
-                duplicate_rows=0,
+                state=READY if surface.ready else STALE,
+                source_rows=surface.source_rows,
+                indexed_rows=surface.indexed_rows,
+                missing_rows=surface.missing_rows,
+                excess_rows=surface.excess_rows,
+                duplicate_rows=surface.duplicate_rows,
+                identity_mismatch_rows=surface.identity_mismatch_rows,
+                detail=None if surface.ready else "exact message FTS parity failed after repair",
             )
             conn.commit()
             logger.info(
-                "fts: archive messages_fts surface repair marked ready inserted=%d deleted=%d "
-                "source_rows=%d indexed_rows=%d",
+                "fts: archive messages_fts surface repair complete ready=%s inserted=%d deleted=%d "
+                "source_rows=%d indexed_rows=%d missing=%d excess=%d identity_mismatch=%d",
+                surface.ready,
                 inserted_total,
                 deleted_total,
-                source_rows,
-                indexed_rows,
+                surface.source_rows,
+                surface.indexed_rows,
+                surface.missing_rows,
+                surface.excess_rows,
+                surface.identity_mismatch_rows,
             )
-            return True
+            return FtsSurfaceRepairResult(
+                success=surface.ready,
+                detail=None if surface.ready else "exact message FTS parity failed after repair",
+            )
         finally:
             conn.close()
     except Exception as exc:
         if _is_transient_sqlite_lock(exc):
             logger.info("fts: archive global messages_fts repair deferred because sqlite is busy: %s", exc)
-            return False
+            return FtsSurfaceRepairResult(success=False, deferred=True, detail="SQLite writer busy")
         logger.warning("fts: archive global messages_fts repair failed", exc_info=True)
-        return False
+        return FtsSurfaceRepairResult(success=False, detail=f"{type(exc).__name__}: {exc}")
 
 
-def repair_fts_surface(db_path: Path, surface: str) -> bool:
+def repair_messages_fts_surface(db_path: Path) -> bool:
+    """Compatibility boolean for callers that only need repair success."""
+    return bool(repair_messages_fts_surface_result(db_path))
+
+
+def repair_fts_surface_result(db_path: Path, surface: str) -> FtsSurfaceRepairResult:
     """Repair a named archive FTS surface from daemon convergence debt."""
     if surface == "messages_fts":
-        return repair_messages_fts_surface(db_path)
+        return repair_messages_fts_surface_result(db_path)
     if surface != "session_work_events_fts":
         logger.warning("fts: unsupported archive FTS surface debt surface=%s", surface)
-        return False
+        return FtsSurfaceRepairResult(success=False, detail=f"unsupported FTS surface: {surface}")
     archive_db = _active_archive_index_path(db_path) or db_path
     try:
         conn = _open_archive_insight_write_connection(archive_db)
@@ -1723,11 +1741,11 @@ def repair_fts_surface(db_path: Path, surface: str) -> bool:
                 logger.info(
                     "fts: archive derived FTS surface repair completed surface=%s detail=%s", surface, outcome.detail
                 )
-                return True
+                return FtsSurfaceRepairResult(success=True, detail=outcome.detail)
             logger.warning(
                 "fts: archive derived FTS surface repair incomplete surface=%s detail=%s", surface, outcome.detail
             )
-            return False
+            return FtsSurfaceRepairResult(success=False, detail=outcome.detail)
         finally:
             conn.close()
     except Exception as exc:
@@ -1735,9 +1753,14 @@ def repair_fts_surface(db_path: Path, surface: str) -> bool:
             logger.info(
                 "fts: archive derived FTS surface repair deferred surface=%s because sqlite is busy: %s", surface, exc
             )
-            return False
+            return FtsSurfaceRepairResult(success=False, deferred=True, detail="SQLite writer busy")
         logger.warning("fts: archive derived FTS surface repair failed surface=%s", surface, exc_info=True)
-        return False
+        return FtsSurfaceRepairResult(success=False, detail=f"{type(exc).__name__}: {exc}")
+
+
+def repair_fts_surface(db_path: Path, surface: str) -> bool:
+    """Compatibility boolean for named archive FTS-surface repair."""
+    return bool(repair_fts_surface_result(db_path, surface))
 
 
 def _archive_pending_embedding_session_ids(

--- a/polylogue/maintenance/archive_verification.py
+++ b/polylogue/maintenance/archive_verification.py
@@ -619,44 +619,53 @@ def _check_fts_parity(archive_root: Path, sample_limit: int) -> ArchiveVerificat
     evidence: dict[str, Any] = {}
     problems: list[str] = []
     try:
-        if table_exists(conn, "blocks") and table_exists(conn, "messages_fts_docsize"):
-            row = conn.execute(
+        from polylogue.storage.fts.fts_lifecycle import fts_invariant_snapshot_sync
+
+        messages = fts_invariant_snapshot_sync(conn).messages
+        expected, indexed = messages.source_rows, messages.indexed_rows
+        gap = expected - indexed
+        worst_sessions: list[dict[str, Any]] = []
+        if gap and table_exists(conn, "blocks") and table_exists(conn, "messages_fts_docsize"):
+            rows = conn.execute(
                 """
-                SELECT
-                    COUNT(*) FILTER (WHERE b.search_text != ''),
-                    COUNT(d.id) FILTER (WHERE b.search_text != '')
+                SELECT b.session_id,
+                       COUNT(*) FILTER (WHERE b.search_text != '') AS expected,
+                       COUNT(d.id) FILTER (WHERE b.search_text != '') AS indexed
                 FROM blocks AS b
                 LEFT JOIN messages_fts_docsize AS d ON d.id = b.rowid
-                """
-            ).fetchone()
-            expected, indexed = int(row[0] or 0), int(row[1] or 0)
-            gap = expected - indexed
-            worst_sessions: list[dict[str, Any]] = []
-            if gap:
-                rows = conn.execute(
-                    """
-                    SELECT b.session_id,
-                           COUNT(*) FILTER (WHERE b.search_text != '') AS expected,
-                           COUNT(d.id) FILTER (WHERE b.search_text != '') AS indexed
-                    FROM blocks AS b
-                    LEFT JOIN messages_fts_docsize AS d ON d.id = b.rowid
-                    GROUP BY b.session_id
-                    HAVING expected != indexed
-                    ORDER BY (expected - indexed) DESC
-                    LIMIT ?
-                    """,
-                    (sample_limit,),
-                ).fetchall()
-                worst_sessions = [{"session_id": str(r[0]), "expected": int(r[1]), "indexed": int(r[2])} for r in rows]
-                problems.append(f"messages_fts gap={gap}")
-            evidence["messages_fts"] = {
-                "expected": expected,
-                "indexed": indexed,
-                "gap": gap,
-                "worst_sessions": worst_sessions,
-            }
-        else:
-            evidence["messages_fts"] = None
+                GROUP BY b.session_id
+                HAVING expected != indexed
+                ORDER BY (expected - indexed) DESC
+                LIMIT ?
+                """,
+                (sample_limit,),
+            ).fetchall()
+            worst_sessions = [{"session_id": str(r[0]), "expected": int(r[1]), "indexed": int(r[2])} for r in rows]
+        if messages.source_exists and not messages.exists:
+            problems.append("messages_fts missing")
+        if gap:
+            problems.append(f"messages_fts gap={gap}")
+        elif messages.missing_rows:
+            problems.append(f"messages_fts missing_rows={messages.missing_rows}")
+        if messages.excess_rows:
+            problems.append(f"messages_fts excess_rows={messages.excess_rows}")
+        if messages.duplicate_rows:
+            problems.append(f"messages_fts duplicate_rows={messages.duplicate_rows}")
+        if messages.identity_mismatch_rows:
+            problems.append(f"messages_fts identity_mismatch_rows={messages.identity_mismatch_rows}")
+        if messages.exists and not messages.triggers_present:
+            problems.append("messages_fts triggers missing")
+        evidence["messages_fts"] = {
+            "expected": expected,
+            "indexed": indexed,
+            "gap": gap,
+            "missing_rows": messages.missing_rows,
+            "excess_rows": messages.excess_rows,
+            "duplicate_rows": messages.duplicate_rows,
+            "identity_mismatch_rows": messages.identity_mismatch_rows,
+            "triggers_present": messages.triggers_present,
+            "worst_sessions": worst_sessions,
+        }
 
         if table_exists(conn, "blocks") and table_exists(conn, "blocks_command_trigram_docsize"):
             # blocks_command_trigram is an external-content FTS5 table

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -545,23 +545,14 @@ def test_archive_fts_global_repair_inserts_missing_rows_without_reset(tmp_path: 
         assert conn.execute("SELECT COUNT(*) FROM messages_fts_docsize").fetchone()[0] == 1
 
 
-def test_archive_fts_global_repair_does_not_run_full_exact_snapshot(tmp_path: Path) -> None:
-    """Daemon global FTS convergence should not end with a full exact scan."""
-    from unittest import mock
-
-    import polylogue.storage.fts.fts_lifecycle as fts_lc
-
+def test_archive_fts_global_repair_records_exact_parity(tmp_path: Path) -> None:
+    """Global repair must not publish ready until the exact invariant is clean."""
     archive_db = tmp_path / "index.db"
     archive_db.touch()
     source_path = tmp_path / "codex.jsonl"
     _seed_minimal_archive(archive_db, source_path)
 
-    with mock.patch.object(
-        fts_lc,
-        "fts_invariant_snapshot_sync",
-        side_effect=AssertionError("full exact FTS snapshot should stay out of daemon convergence"),
-    ):
-        assert stages.repair_messages_fts_surface(archive_db) is True
+    assert stages.repair_messages_fts_surface(archive_db) is True
 
     with sqlite3.connect(archive_db) as conn:
         row = conn.execute(
@@ -629,6 +620,67 @@ def test_archive_fts_global_repair_records_real_counts_status_and_query_agree(tm
         assert query_readiness["ready"] is True
         # Must not raise -- the query path agrees with the status surface.
         check_fts_readiness(query_readiness)
+
+
+def test_fts_surface_debt_retries_after_real_sqlite_backpressure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A locked repair remains deferred, red, and restartable until parity is restored."""
+    from polylogue.core.outcomes import OutcomeStatus
+    from polylogue.daemon import cli as daemon_cli
+    from polylogue.daemon.fts_status import fts_readiness_info
+    from polylogue.maintenance.archive_verification import verify_archive
+    from polylogue.sources.live.cursor import CursorStore
+
+    archive_db = tmp_path / "index.db"
+    with sqlite3.connect(archive_db) as conn:
+        initialize_archive_tier(conn, ArchiveTier.INDEX)
+        for index in range(3):
+            _seed_index_session(conn, session_id=f"codex-session:retry-{index}", text=f"retry needle {index}")
+        conn.execute("DELETE FROM messages_fts")
+        conn.commit()
+
+    cursor = CursorStore(archive_db)
+    cursor.record_convergence_debt(
+        stage="fts",
+        subject_type="fts_surface",
+        subject_id="messages_fts",
+        error="global FTS repair pending",
+    )
+    with sqlite3.connect(tmp_path / "ops.db") as conn:
+        conn.execute("UPDATE convergence_debt SET next_retry_at = '1970-01-01T00:00:00+00:00'")
+        conn.commit()
+
+    blocker = sqlite3.connect(archive_db, timeout=0.01)
+    try:
+        blocker.execute("BEGIN EXCLUSIVE")
+        monkeypatch.setattr(stages, "_ARCHIVE_INSIGHT_WRITE_BUSY_TIMEOUT_MS", 1)
+        assert daemon_cli._drain_convergence_debt_once(archive_db) == 1
+    finally:
+        blocker.rollback()
+        blocker.close()
+
+    deferred = [
+        debt for debt in cursor.list_convergence_debt() if debt.stage == "fts" and debt.subject_id == "messages_fts"
+    ]
+    assert len(deferred) == 1
+    assert deferred[0].status == "deferred"
+    assert fts_readiness_info(archive_db, exact=False)["messages_ready"] is False
+    red = verify_archive(tmp_path, checks=("fts-parity",))
+    assert red.checks[0].status is OutcomeStatus.ERROR
+
+    with sqlite3.connect(tmp_path / "ops.db") as conn:
+        conn.execute("UPDATE convergence_debt SET next_retry_at = '1970-01-01T00:00:00+00:00'")
+        conn.commit()
+    assert daemon_cli._drain_convergence_debt_once(archive_db) == 1
+    assert not [debt for debt in cursor.list_convergence_debt() if debt.subject_id == "messages_fts"]
+    assert fts_readiness_info(archive_db, exact=False)["messages_ready"] is True
+    green = verify_archive(tmp_path, checks=("fts-parity",))
+    assert green.checks[0].status is OutcomeStatus.OK
+
+    retired = stages.repair_fts_surface_result(archive_db, "threads_fts")
+    assert retired.success is False
+    assert retired.deferred is False
 
 
 def test_archive_fts_global_repair_deletes_excess_rows_without_reset(tmp_path: Path) -> None:

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -682,6 +682,24 @@ def test_fts_surface_debt_retries_after_real_sqlite_backpressure(
     assert retired.success is False
     assert retired.deferred is False
 
+    cursor.record_convergence_debt(
+        stage="fts",
+        subject_type="fts_surface",
+        subject_id="messages_fts",
+        error="global FTS repair pending after malformed shadow table",
+    )
+    with sqlite3.connect(tmp_path / "ops.db") as conn:
+        conn.execute("UPDATE convergence_debt SET next_retry_at = '1970-01-01T00:00:00+00:00'")
+        conn.commit()
+    with sqlite3.connect(archive_db) as conn:
+        conn.execute("DROP TABLE messages_fts_docsize")
+        conn.commit()
+
+    assert daemon_cli._drain_convergence_debt_once(archive_db) == 1
+    failed = [debt for debt in cursor.list_convergence_debt() if debt.subject_id == "messages_fts"]
+    assert len(failed) == 1
+    assert failed[0].status == "failed"
+
 
 def test_archive_fts_global_repair_deletes_excess_rows_without_reset(tmp_path: Path) -> None:
     """Global surface debt should remove excess rows without a full rebuild."""

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -436,7 +436,7 @@ def test_drain_convergence_debt_retries_global_messages_fts_surface(
         return True
 
     monkeypatch.setattr(
-        "polylogue.daemon.convergence_stages.repair_fts_surface",
+        "polylogue.daemon.convergence_stages.repair_fts_surface_result",
         fake_repair_fts_surface,
     )
 
@@ -472,7 +472,7 @@ def test_drain_convergence_debt_retries_optional_fts_surface(
         return True
 
     monkeypatch.setattr(
-        "polylogue.daemon.convergence_stages.repair_fts_surface",
+        "polylogue.daemon.convergence_stages.repair_fts_surface_result",
         fake_repair_fts_surface,
     )
 

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -344,6 +344,41 @@ def test_deleted_fts_row_trips_message_fts_parity(tmp_path: Path) -> None:
     assert check.evidence["messages_fts"]["worst_sessions"][0]["session_id"] == "codex-session:session"
 
 
+def test_missing_fts_trigger_trips_message_fts_parity(tmp_path: Path) -> None:
+    _seed_coherent_archive(tmp_path)
+    conn = _connect(tmp_path / "index.db")
+    try:
+        conn.execute("DROP TRIGGER messages_fts_ai")
+        conn.commit()
+    finally:
+        conn.close()
+
+    report = verify_archive(tmp_path, checks=("fts-parity",))
+
+    check = _check(report, "fts-parity")
+    assert check.status is OutcomeStatus.ERROR
+    assert "messages_fts triggers missing" in check.summary
+    assert check.evidence["messages_fts"]["triggers_present"] is False
+
+
+def test_excess_fts_row_trips_message_fts_parity(tmp_path: Path) -> None:
+    _seed_coherent_archive(tmp_path)
+    conn = _connect(tmp_path / "index.db")
+    try:
+        conn.execute("DROP TRIGGER messages_fts_ad")
+        conn.execute("DELETE FROM blocks")
+        conn.commit()
+    finally:
+        conn.close()
+
+    report = verify_archive(tmp_path, checks=("fts-parity",))
+
+    check = _check(report, "fts-parity")
+    assert check.status is OutcomeStatus.ERROR
+    assert "messages_fts excess_rows=1" in check.summary
+    assert check.evidence["messages_fts"]["excess_rows"] == 1
+
+
 def test_missing_trigram_row_trips_trigram_parity(tmp_path: Path) -> None:
     _seed_coherent_archive(tmp_path)
     conn = _connect(tmp_path / "index.db")


### PR DESCRIPTION
## Summary
The FTS convergence debt route now distinguishes deliberate SQLite backpressure from genuine repair failure and refuses readiness until the exact messages FTS invariant is clean.

## Problem
A locked archive repair returned the same boolean as a failed repair, so the convergence-debt drain recorded bounded retry work as failed. The archive parity check also relied on count-only source joins, allowing missing tables, excess rows, missing triggers, or identity drift to pass the promotion and preflight surface.

## Solution
`polylogue/daemon/convergence_stages.py` carries typed FTS repair outcomes, records exact messages FTS freshness after global repair, and rejects the retired `threads_fts` surface. `polylogue/daemon/cli.py` persists deferred status for SQLite backpressure while retaining failed status for real errors. `polylogue/maintenance/archive_verification.py` uses the exact FTS invariant for parity. Focused real SQLite tests cover lock restartability, red-to-green readiness, exact parity refusal, and the retired thread surface.

## Verification
- `env PATH="$PWD/.venv/bin:$PATH" devtools test tests/unit/daemon/test_convergence_stages.py -k "archive_fts or fts_surface"`: 8 passed.
- `env PATH="$PWD/.venv/bin:$PATH" devtools test tests/unit/daemon/test_convergence_stages.py -k "fts_surface_debt_retries_after_real_sqlite_backpressure or archive_fts_global_repair_records_exact_parity"`: 2 passed.
- `env PATH="$PWD/.venv/bin:$PATH" devtools test tests/unit/maintenance/test_archive_verification.py -k "fts_parity or fts_trigger or excess_fts"`: 3 passed.
- `env PATH="$PWD/.venv/bin:$PATH" devtools test tests/unit/storage/test_fts_repair_sql.py`: 11 passed.
- `env PATH="$PWD/.venv/bin:$PATH" devtools verify --quick`: all 23 steps exited 0.

## Acceptance criteria
- Deliberate bounded SQLite deferral persists as `deferred`: satisfied by the real locked-writer debt-drain test.
- Genuine FTS repair errors remain `failed`: satisfied by the typed outcome path; non-transient repair failures do not set `deferred`.
- Restartability and refusal until parity: satisfied by red-to-green retry and exact archive parity tests.
- Scope excludes reindex candidate orchestration, archive lifecycle, blob files, and live archive: satisfied; none are changed.

## Residual uncertainty
The live archive was intentionally not opened or modified. The reported live counts remain an operational input; this PR proves the repair and refusal behavior on isolated real SQLite archives.