### PR TITLE
fix(sources): require Antigravity conversation evidence

### DIFF
--- a/polylogue/sources/source_parsing.py
+++ b/polylogue/sources/source_parsing.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from polylogue.archive.artifact_taxonomy import classify_artifact_path
 from polylogue.config import Source
 from polylogue.core.enums import Provider
-from polylogue.core.json import loads
 from polylogue.logging import get_logger
 from polylogue.sources.assembly import SidecarData
 from polylogue.storage.blob_store import BlobStore
@@ -61,14 +60,12 @@ def iter_antigravity_language_server_sessions(
     the whole ``conversations/`` corpus -- used by the daemon's periodic
     reconciliation loop to convert only not-yet-acquired cascades.
 
-    Falls back to walking ``brain/**/*.md.metadata.json`` directly
-    (``_iter_antigravity_brain_metadata_fallback``) only when there is
-    nothing to export via the language server: no ``conversations/``
-    directory, no language server binary, or a connection failure before any
-    session was obtained. A mid-export *abort* (some sessions obtained, the
-    rest lost) is deliberately NOT fallback-eligible — that is real data
-    loss and must surface loudly rather than being silently backfilled with
-    degraded per-artifact fragments.
+    Brain ``*.md.metadata.json`` files are artifacts, never a fallback
+    transcript source. If the exporter or its ``conversations/`` directory is
+    unavailable, this yields no sessions and logs the resulting coverage gap.
+    A mid-export *abort* (some sessions obtained, the rest lost) is likewise
+    surfaced loudly rather than being silently backfilled with degraded
+    per-artifact fragments.
     """
     if not source.path:
         return
@@ -77,55 +74,51 @@ def iter_antigravity_language_server_sessions(
         return
 
     conversations_dir = source.path / "conversations"
-    exported_any = False
-    should_fallback = not conversations_dir.is_dir()
+    if not conversations_dir.is_dir():
+        logger.warning(
+            "Antigravity conversation export unavailable for %s: no conversations directory; "
+            "brain metadata remains artifact-only and this source has no session coverage",
+            source.path,
+        )
+        return
 
-    if conversations_dir.is_dir():
-        try:
-            for session in antigravity.iter_language_server_exports(source.path, only_cascade_ids=only_cascade_ids):
-                exported_any = True
-                raw_data = _antigravity_raw_snapshot(
-                    source.path,
-                    session,
-                    capture_raw=capture_raw,
-                    blob_root=blob_root,
-                    blob_store=blob_store,
-                )
-                yield (raw_data, session)
-        except antigravity.AntigravityBinaryUnavailableError as exc:
-            # Benign: Antigravity is simply not installed. Fall back to the
-            # brain-artifact walk at INFO — this is not data loss.
-            logger.info(
-                "Antigravity language server unavailable for %s; using brain-metadata fallback: %s",
+    try:
+        for session in antigravity.iter_language_server_exports(source.path, only_cascade_ids=only_cascade_ids):
+            raw_data = _antigravity_raw_snapshot(
                 source.path,
-                exc,
+                session,
+                capture_raw=capture_raw,
+                blob_root=blob_root,
+                blob_store=blob_store,
             )
-            should_fallback = True
-        except antigravity.AntigravityPartialExportError as exc:
-            # Mid-export failure: some sessions were obtained before the
-            # abort and the remainder is dropped. Surface obtained-vs-expected
-            # loudly instead of conflating it with a benign fallback.
-            logger.error(
-                "Antigravity language-server export of %s truncated mid-iteration: "
-                "obtained %d of %d sessions; %d lost — NOT backfilling with the "
-                "degraded metadata fallback: %s",
-                source.path,
-                exc.obtained,
-                exc.expected,
-                max(exc.expected - exc.obtained, 0),
-                exc,
-            )
-        except antigravity.AntigravityExportError as exc:
-            # Connection/protocol failure before any session was obtained.
-            logger.warning(
-                "Antigravity language-server export failed for %s; using brain-metadata fallback: %s",
-                source.path,
-                exc,
-            )
-            should_fallback = True
-
-    if not exported_any and should_fallback:
-        yield from _iter_antigravity_brain_metadata_fallback(source.path)
+            yield (raw_data, session)
+    except antigravity.AntigravityBinaryUnavailableError as exc:
+        logger.warning(
+            "Antigravity conversation export unavailable for %s; brain metadata remains artifact-only "
+            "and this source has no session coverage: %s",
+            source.path,
+            exc,
+        )
+    except antigravity.AntigravityPartialExportError as exc:
+        # Mid-export failure: some sessions were obtained before the abort.
+        # Surface obtained-vs-expected loudly instead of replacing the lost
+        # conversations with unrelated per-artifact fragments.
+        logger.error(
+            "Antigravity language-server export of %s truncated mid-iteration: "
+            "obtained %d of %d sessions; %d remain uncovered; brain metadata remains artifact-only: %s",
+            source.path,
+            exc.obtained,
+            exc.expected,
+            max(exc.expected - exc.obtained, 0),
+            exc,
+        )
+    except antigravity.AntigravityExportError as exc:
+        logger.warning(
+            "Antigravity conversation export failed for %s; brain metadata remains artifact-only "
+            "and this source has no session coverage: %s",
+            source.path,
+            exc,
+        )
 
 
 def _antigravity_raw_snapshot(
@@ -163,35 +156,6 @@ def _antigravity_raw_snapshot(
         blob_size=blob_size,
         blob_publication_receipt_id=receipt_id,
     )
-
-
-def _iter_antigravity_brain_metadata_fallback(root: Path) -> Iterable[tuple[None, ParsedSession]]:
-    """Degraded fallback: parse per-artifact brain metadata directly.
-
-    Only reached when the language-server export route acquired nothing for
-    this source (see ``iter_antigravity_language_server_sessions``). Walks
-    ``brain/**/*.md.metadata.json`` directly rather than going through the
-    generic per-file walk, because that walk now classifies these paths as
-    non-session sidecars (``polylogue-eo81`` — they are noise once the real
-    conversation is available, so they must not be a session by default).
-    Each match still becomes a single-message session tagged
-    ``BRAIN_METADATA_FRAGMENT_FLAG`` so downstream consumers can rank/exclude
-    it, exactly as before this fix (GH #1764).
-    """
-    brain_dir = root / "brain"
-    if not brain_dir.is_dir():
-        return
-    for metadata_path in sorted(brain_dir.glob("*/*.metadata.json")):
-        try:
-            payload = loads(metadata_path.read_bytes())
-        except (OSError, ValueError):
-            continue
-        if not isinstance(payload, dict):
-            continue
-        json_payload = {str(key): value for key, value in payload.items()}
-        if not antigravity.looks_like_brain_metadata(json_payload, metadata_path):
-            continue
-        yield (None, antigravity.parse_brain_metadata(json_payload, metadata_path, metadata_path.stem))
 
 
 def parse_one_source_path(

--- a/tests/unit/daemon/test_antigravity_conversation_acquisition.py
+++ b/tests/unit/daemon/test_antigravity_conversation_acquisition.py
@@ -102,6 +102,12 @@ def test_acquires_real_pb_conversations_not_yet_in_raw_sessions(
 ) -> None:
     antigravity_root = tmp_path / "antigravity"
     _touch_conversation_pb(antigravity_root, "cascade-0", "cascade-1")
+    sidecar = antigravity_root / "brain" / "work-session" / "plan.md.metadata.json"
+    sidecar.parent.mkdir(parents=True)
+    sidecar.write_text(
+        '{"artifactType":"ARTIFACT_TYPE_OTHER","summary":"Plan","updatedAt":"2026-08-04T08:00:00Z"}',
+        encoding="utf-8",
+    )
     monkeypatch.setattr("polylogue.paths.antigravity_path", lambda: antigravity_root)
 
     archive_root = workspace_env["archive_root"]
@@ -118,6 +124,7 @@ def test_acquires_real_pb_conversations_not_yet_in_raw_sessions(
     assert {
         source_path: blob_store.read_all(blob_hash) for source_path, blob_hash in raw_blobs.items()
     } == expected_payloads
+    assert str(sidecar) not in raw_blobs
 
 
 def test_rerun_after_full_acquisition_is_a_noop(

--- a/tests/unit/sources/test_antigravity_source_acquisition.py
+++ b/tests/unit/sources/test_antigravity_source_acquisition.py
@@ -1,0 +1,57 @@
+"""Antigravity source-level acquisition contracts.
+
+The periodic daemon reconciler covers a working language-server export. These
+tests exercise the shared source iterator when that supported export surface
+is unavailable, which is where brain metadata used to bypass artifact
+classification and become synthetic conversation sessions.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from polylogue.config import Source
+from polylogue.sources.parsers.antigravity import AntigravityBinaryUnavailableError
+from polylogue.sources.source_parsing import iter_antigravity_language_server_sessions
+
+
+def _write_brain_sidecar(root: Path) -> Path:
+    metadata_path = root / "brain" / "work-session" / "plan.md.metadata.json"
+    metadata_path.parent.mkdir(parents=True)
+    metadata_path.with_name("plan.md").write_text("# Plan\n\nInspect the archive.\n", encoding="utf-8")
+    metadata_path.write_text(
+        '{"artifactType":"ARTIFACT_TYPE_OTHER","summary":"Plan","updatedAt":"2026-08-04T08:00:00Z"}',
+        encoding="utf-8",
+    )
+    return metadata_path
+
+
+def test_unavailable_language_server_never_promotes_brain_sidecars_to_sessions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A missing exporter leaves the conversation coverage gap visible.
+
+    This enters the real Antigravity source iterator that batch import uses.
+    Metadata is an artifact, so it cannot substitute for a conversation
+    trajectory when the language-server export is unavailable.
+    """
+    root = tmp_path / "antigravity"
+    (root / "conversations").mkdir(parents=True)
+    _write_brain_sidecar(root)
+
+    def unavailable_export(*_args: object, **_kwargs: object) -> object:
+        raise AntigravityBinaryUnavailableError("test language server unavailable")
+
+    monkeypatch.setattr(
+        "polylogue.sources.source_parsing.antigravity.iter_language_server_exports",
+        unavailable_export,
+    )
+    caplog.set_level(logging.WARNING, logger="polylogue.sources.source_parsing")
+
+    sessions = list(iter_antigravity_language_server_sessions(Source(name="antigravity", path=root)))
+
+    assert sessions == []
+    assert "no session coverage" in caplog.messages[-1]

--- a/tests/unit/sources/test_parsers_local_agent.py
+++ b/tests/unit/sources/test_parsers_local_agent.py
@@ -995,10 +995,9 @@ def test_antigravity_brain_artifact_metadata_parses_sibling_markdown(tmp_path: P
     assert classification.parse_as_session is False
     assert classification.kind is ArtifactKind.AGENT_SIDECAR_META
 
-    # ``parse_brain_metadata`` itself remains usable directly -- it backs the
-    # explicit degraded fallback wired in
-    # ``source_parsing._iter_antigravity_brain_metadata_fallback`` for when
-    # the language server truly cannot be reached.
+    # ``parse_brain_metadata`` itself remains usable directly as a parser
+    # compatibility helper, but source acquisition never promotes this
+    # sidecar to a session.
     [session] = parse_payload(
         Provider.ANTIGRAVITY,
         payload,
@@ -1092,7 +1091,7 @@ def test_antigravity_source_walk_prefers_language_server_exports(
     assert sessions[0].messages[0].text == "hello"
 
 
-def test_antigravity_source_walk_ingests_metadata_not_config(tmp_path: Path) -> None:
+def test_antigravity_source_walk_leaves_metadata_artifact_only_without_conversations(tmp_path: Path) -> None:
     session_dir = tmp_path / "brain" / "session-1"
     session_dir.mkdir(parents=True)
     (session_dir / "task.md").write_text("Task artifact", encoding="utf-8")
@@ -1104,5 +1103,4 @@ def test_antigravity_source_walk_ingests_metadata_not_config(tmp_path: Path) -> 
 
     sessions = list(iter_source_sessions(Source(name="antigravity", path=tmp_path)))
 
-    assert len(sessions) == 1
-    assert sessions[0].source_name is Provider.ANTIGRAVITY
+    assert sessions == []


### PR DESCRIPTION
## Summary

Require real Antigravity conversation-export evidence before source acquisition creates a session.

## Problem

Brain metadata sidecars could enter the fallback path and be presented as conversation coverage when the language-server export was unavailable.

## Solution

Remove metadata fallback from source acquisition, retain parser compatibility only, report the coverage gap, and add real source/daemon-route regressions proving only conversation `.pb` bytes become raw sessions.

## Verification

- `devtools test tests/unit/sources/test_antigravity_source_acquisition.py tests/unit/sources/test_parsers_local_agent.py tests/unit/daemon/test_antigravity_conversation_acquisition.py`: 10 passed, 25 deselected
- `devtools verify --quick`: passed, including source identity, demo-tour, schema-promotion, and raw-authority checks

Ref polylogue-3m3de