### PR TITLE
test(storage): cover source blob liveness surfaces

### DIFF
--- a/tests/unit/maintenance/test_rebuild_index_ownership.py
+++ b/tests/unit/maintenance/test_rebuild_index_ownership.py
@@ -71,6 +71,33 @@ def test_rebuild_source_preflight_rejects_orphaned_blob_refs_before_generation_c
     assert not (root / ".index-generations").exists()
 
 
+def test_rebuild_preflight_exposes_unreconciled_source_ref_types(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _init_empty_source(root)
+    with sqlite3.connect(root / "source.db") as conn:
+        conn.executemany(
+            """
+            INSERT INTO blob_refs(blob_hash, ref_id, ref_type, size_bytes, acquired_at_ms)
+            VALUES (?, ?, ?, 10, 100)
+            """,
+            (
+                (b"r" * 32, "raw-gone", "raw_payload"),
+                (b"a" * 32, "attachment-gone", "attachment"),
+                (b"h" * 32, "hook-gone", "hook_payload"),
+            ),
+        )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root))
+
+    message = str(exc_info.value)
+    assert "reindex source preflight gate failed: blob-refs-liveness" in message
+    assert "raw_payload orphans=1" in message
+    assert "attachment orphans=1" in message
+    assert "hook_payload orphans=1" in message
+    assert not (root / ".index-generations").exists()
+
+
 def test_rebuild_releases_ownership_lock_after_completion(tmp_path: Path) -> None:
     """The ownership lock must not be left held after a rebuild returns, so a
     second rebuild (or any other maintenance/campaign writer) can acquire it.

--- a/tests/unit/storage/test_blob_gc_ref_type_liveness.py
+++ b/tests/unit/storage/test_blob_gc_ref_type_liveness.py
@@ -142,6 +142,81 @@ def test_hook_payload_ref_survives_gc_while_hook_event_row_exists_then_is_reclai
     assert not blob_store.exists(blob_hash)
 
 
+def test_gc_retains_live_raw_attachment_and_hook_references_together(tmp_path: Path) -> None:
+    """The real GC route protects every durable source reference surface.
+
+    Raw payload and attachment refs are keyed to source rows, while hook
+    payload refs join to ``raw_hook_events``.  Keeping all three in one pass
+    prevents a future change from preserving the already-tested hook path
+    while regressing one of the source-ref branches.
+    """
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+    blob_store = BlobStore(archive_root / "blob")
+    raw_hash, _ = blob_store.write_from_bytes(b"raw payload")
+    attachment_hash, _ = blob_store.write_from_bytes(b"attachment payload")
+    _write_hook_event(
+        archive_root,
+        hook_event_id="hook-batch",
+        source_path="/hooks/batch.jsonl",
+        payload=b'{"event":"PostToolUse","batch":true}',
+    )
+
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms
+            ) VALUES ('raw-live', 'codex-session', 'raw-live', '/raw.jsonl', ?, 11, 1)
+            """,
+            (bytes.fromhex(raw_hash),),
+        )
+        # Attachment refs use the parent raw session as their ref_id in the
+        # source tier. Its payload is deliberately a different, non-file hash
+        # so this assertion exercises the attachment ref join itself.
+        conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms
+            ) VALUES ('attachment-parent', 'codex-session', 'attachment-parent', '/parent.jsonl', ?, 1, 1)
+            """,
+            (b"p" * 32,),
+        )
+        conn.execute(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, 'raw-live', 'raw_payload', '/raw.jsonl', 11, 1)
+            """,
+            (bytes.fromhex(raw_hash),),
+        )
+        conn.execute(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, 'attachment-parent', 'attachment', '/parent.jsonl', 18, 1)
+            """,
+            (bytes.fromhex(attachment_hash),),
+        )
+
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        hook_hash = conn.execute("SELECT blob_hash FROM raw_hook_events WHERE hook_event_id = 'hook-batch'").fetchone()[
+            0
+        ]
+
+    for blob_hash in (raw_hash, attachment_hash, bytes(hook_hash).hex()):
+        _backdate(blob_store, blob_hash)
+
+    assert run_blob_gc(archive_root / "source.db", archive_root / "blob", max_batch=10) == 0
+    assert all(blob_store.exists(blob_hash) for blob_hash in (raw_hash, attachment_hash, bytes(hook_hash).hex()))
+
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        conn.execute("DELETE FROM blob_refs WHERE ref_id IN ('raw-live', 'attachment-parent')")
+        conn.execute("DELETE FROM raw_sessions WHERE raw_id IN ('raw-live', 'attachment-parent')")
+    assert _delete_hook_event(archive_root, hook_event_id="hook-batch") is True
+
+    assert run_blob_gc(archive_root / "source.db", archive_root / "blob", max_batch=10) == 3
+    assert not any(blob_store.exists(blob_hash) for blob_hash in (raw_hash, attachment_hash, bytes(hook_hash).hex()))
+
+
 def test_interrupted_hook_rekey_blocks_liveness_deletion_and_preserves_blob(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Extend blob-GC and reindex-preflight proof across every durable source-reference type.

## Problem

The production liveness paths join raw payload, attachment, and hook-event references, but focused coverage did not prove all three survive one real GC pass or that preflight exposes each unreconciled class.

## Solution

Add a combined archive GC regression and a reindex-preflight refusal assertion covering raw, attachment, and hook payload references.

## Verification

- `devtools test tests/unit/storage/test_blob_gc_ref_type_liveness.py tests/unit/maintenance/test_rebuild_index_ownership.py`: 11 passed
- `git diff --check`: passed
- Independent adversarial review: no legitimate gaps found

Ref polylogue-0v4tn and polylogue-tfzw0