### PR TITLE
fix(devtools): report preflight census gaps by origin

### DIFF
--- a/devtools/daemon_workload_probe.py
+++ b/devtools/daemon_workload_probe.py
@@ -21,6 +21,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from devtools.preflight_ledger import build_preflight_ledger
 from polylogue.config import Config
 from polylogue.paths import archive_root
 from polylogue.storage.archive_identity import resolve_active_index_path
@@ -32,7 +33,7 @@ from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 
 # Bumped when the JSON shape gains new top-level keys or changes a field type.
 # The compare path uses this to refuse incompatible inputs loudly.
-REPORT_VERSION = 19  # v19 removes dead OTLP ops-tier table inventory.
+REPORT_VERSION = 20  # v20 adds the opt-in read-only preflight ledger.
 UNKNOWN_TABLE_COUNT = -2
 
 _EXPECTED_FTS_TRIGGERS: tuple[str, ...] = ("messages_fts_ai", "messages_fts_ad", "messages_fts_au")
@@ -2355,6 +2356,7 @@ def probe(
     exact_derived_counts: bool = False,
     exact_table_counts: bool = False,
     blob_reference_debt: bool = False,
+    preflight: bool = False,
 ) -> dict[str, Any]:
     ops_db = db.with_name("ops.db")
     index_db = db.with_name("index.db")
@@ -2418,6 +2420,11 @@ def probe(
             "convergence_debt": convergence_debt,
             "cursor_lag_baselines": _cursor_lag_baselines(conn, ops_db=ops_db),
             "query_plans": _query_plans(conn, db=db),
+            "preflight_ledger": (
+                build_preflight_ledger(db.parent, limit=limit)
+                if preflight
+                else {"requested": False, "read_only": True, "state": "not_requested", "mutation_operations": []}
+            ),
         }
     finally:
         conn.close()
@@ -2982,6 +2989,11 @@ def _parser() -> argparse.ArgumentParser:
         help="Count missing referenced blob files exactly (can stat many blob paths on large archives)",
     )
     parser.add_argument(
+        "--preflight",
+        action="store_true",
+        help="Add the strict read-only deployed-status preflight ledger (exact source/FTS/frontier reads)",
+    )
+    parser.add_argument(
         "--compare",
         nargs=2,
         metavar=("BEFORE", "AFTER"),
@@ -3016,6 +3028,7 @@ def main(argv: list[str] | None = None) -> int:
         exact_derived_counts=args.exact_derived_counts,
         exact_table_counts=args.exact_table_counts,
         blob_reference_debt=args.blob_reference_debt,
+        preflight=args.preflight,
     )
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
@@ -3026,6 +3039,32 @@ def main(argv: list[str] | None = None) -> int:
     if not payload.get("ok"):
         print(f"  error: {payload.get('error')}")
         return 1
+    preflight = payload.get("preflight_ledger") or {}
+    if preflight.get("requested") is not False:
+        print(
+            "  preflight: "
+            f"{preflight.get('state')} "
+            f"(blocking={len(preflight.get('blocking_checks') or [])}, "
+            f"warnings={len(preflight.get('warning_checks') or [])})"
+        )
+        source = (preflight.get("checks") or {}).get("source") or {}
+        totals = source.get("totals") or {}
+        if totals:
+            print(
+                "    source raw: "
+                f"{totals.get('raw_count', 0)} total, "
+                f"{totals.get('quarantined_count', 0)} quarantined, "
+                f"{totals.get('missing_census_count', 0)} missing census"
+            )
+            for item in source.get("by_origin") or []:
+                quarantine = item.get("quarantine") or {}
+                census = item.get("census_coverage") or {}
+                print(
+                    f"      {item.get('origin')}: quarantine={quarantine.get('count', 0)} "
+                    f"({(quarantine.get('size') or {}).get('display', '0.0GiB')}), "
+                    f"census={census.get('missing_count', 0)} missing "
+                    f"({(census.get('missing_size') or {}).get('display', '0.0GiB')})"
+                )
     counts = payload["attempt_counts"]
     print(f"  attempts: {counts['total']} total, {counts['running']} running, {counts['failed']} failed")
     print(f"  stale cursor writes: {counts.get('stale_cursor_writes', 0)}")

--- a/devtools/preflight_ledger.py
+++ b/devtools/preflight_ledger.py
@@ -1,0 +1,532 @@
+"""Read-only live-archive preflight ledger.
+
+This module is deliberately a projection, not a repair command. It reads the
+durable relations used by deployed status and keeps terminal census verdicts,
+actionable parser failures, and absent census coverage distinct.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+from polylogue.config import Config
+from polylogue.storage.archive_readiness import probe_archive_tier, raw_materialization_readiness_snapshot
+from polylogue.storage.fts.fts_lifecycle import fts_invariant_snapshot_sync
+from polylogue.storage.raw_retention import raw_frontier_integrity_projection
+from polylogue.storage.repair import raw_materialization_replay_backlog
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.connection_profile import open_readonly_connection
+
+PREFLIGHT_REPORT_VERSION = 1
+_REQUIRED_RAW_COLUMNS = frozenset(
+    {"raw_id", "origin", "blob_size", "parse_error", "validation_status", "revision_authority"}
+)
+_REQUIRED_CENSUS_COLUMNS = frozenset({"raw_id", "status", "member_count"})
+_REQUIRED_CURSOR_COLUMNS = frozenset(
+    {"source_path", "origin", "stat_size", "byte_offset", "failure_count", "next_retry_at", "excluded"}
+)
+_VALID_DEBT_STATUSES = frozenset({"failed", "deferred"})
+
+
+def _gib(size_bytes: int) -> float:
+    return round(size_bytes / (1024**3), 3)
+
+
+def _count(value: object) -> int:
+    return 0 if value is None else int(str(value))
+
+
+def _size_evidence(size_bytes: int) -> dict[str, object]:
+    gib = _gib(size_bytes)
+    return {"bytes": size_bytes, "gib": gib, "display": f"{gib:.1f}GiB"}
+
+
+def _status(*, state: str, reason: str | None = None, **evidence: object) -> dict[str, object]:
+    payload: dict[str, object] = {"state": state}
+    if reason is not None:
+        payload["reason"] = reason
+    payload.update(evidence)
+    return payload
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> frozenset[str]:
+    rows = conn.execute("SELECT name FROM pragma_table_info(?)", (table,)).fetchall()
+    return frozenset(str(row[0]) for row in rows)
+
+
+def _relation_error(relation: str, exc: Exception) -> dict[str, object]:
+    return _status(state="unknown", reason=f"{relation} unavailable: {exc}", available=False)
+
+
+def _schema_preflight(root: Path) -> dict[str, object]:
+    tiers: dict[str, object] = {}
+    blocking: list[str] = []
+    for tier in ArchiveTier:
+        probe = probe_archive_tier(tier, root / f"{tier.value}.db")
+        tiers[tier.value] = {
+            "exists": probe.exists,
+            "user_version": probe.user_version,
+            "expected_user_version": probe.expected_user_version,
+            "version_status": probe.version_status,
+        }
+        if not probe.exists or probe.version_status != "ok":
+            blocking.append(tier.value)
+    return _status(
+        state="pass" if not blocking else "fail",
+        reason=None if not blocking else "archive tier schema is missing or mismatched",
+        available=True,
+        schema_mismatches=blocking,
+        tiers=tiers,
+    )
+
+
+def _source_distribution(root: Path) -> dict[str, object]:
+    source_db = root / "source.db"
+    if not source_db.exists():
+        return _relation_error("source.db", FileNotFoundError(source_db))
+    try:
+        conn = open_readonly_connection(source_db)
+        try:
+            raw_columns = _table_columns(conn, "raw_sessions")
+            census_columns = _table_columns(conn, "raw_membership_census")
+            missing_raw = sorted(_REQUIRED_RAW_COLUMNS - raw_columns)
+            missing_census_columns = sorted(_REQUIRED_CENSUS_COLUMNS - census_columns)
+            if missing_raw or missing_census_columns:
+                missing = ", ".join(
+                    [
+                        *(f"raw_sessions.{column}" for column in missing_raw),
+                        *(f"raw_membership_census.{column}" for column in missing_census_columns),
+                    ]
+                )
+                return _status(
+                    state="unknown",
+                    reason=f"required source relation columns missing: {missing}",
+                    available=False,
+                )
+            rows = conn.execute(
+                """
+                WITH classified AS (
+                    SELECT r.origin, r.blob_size, r.revision_authority, r.parse_error,
+                           LOWER(COALESCE(r.validation_status, '')) AS validation_status,
+                           c.status AS census_status,
+                           CASE WHEN c.raw_id IS NULL THEN 1 ELSE 0 END AS coverage_unknown,
+                           CASE WHEN c.status IN ('failed', 'non_session') THEN 1 ELSE 0 END AS terminal,
+                           CASE WHEN r.parse_error IS NOT NULL
+                                  OR LOWER(COALESCE(r.validation_status, '')) = 'failed'
+                                THEN 1 ELSE 0 END AS failure,
+                           CASE WHEN c.status = 'complete' AND c.member_count > 0 THEN 1 ELSE 0 END AS census_eligible
+                    FROM raw_sessions AS r
+                    LEFT JOIN raw_membership_census AS c ON c.raw_id = r.raw_id
+                )
+                SELECT origin, COUNT(*), COALESCE(SUM(blob_size), 0),
+                       COALESCE(SUM(parse_error IS NOT NULL), 0),
+                       COALESCE(SUM(validation_status = 'failed'), 0),
+                       COALESCE(SUM(revision_authority = 'quarantined'), 0),
+                       COALESCE(SUM(CASE WHEN revision_authority = 'quarantined' THEN blob_size ELSE 0 END), 0),
+                       COALESCE(SUM(coverage_unknown), 0),
+                       COALESCE(SUM(CASE WHEN coverage_unknown = 1 THEN blob_size ELSE 0 END), 0),
+                       COALESCE(SUM(CASE WHEN coverage_unknown = 0 AND terminal = 1 THEN 1 ELSE 0 END), 0),
+                       COALESCE(SUM(CASE WHEN coverage_unknown = 0 AND terminal = 1 THEN blob_size ELSE 0 END), 0),
+                       COALESCE(SUM(CASE WHEN coverage_unknown = 0 AND terminal = 0 AND failure = 1 THEN 1 ELSE 0 END), 0),
+                       COALESCE(SUM(CASE WHEN coverage_unknown = 0 AND terminal = 0 AND failure = 1 THEN blob_size ELSE 0 END), 0),
+                       COALESCE(SUM(CASE WHEN coverage_unknown = 0 AND terminal = 0 AND failure = 0
+                                          AND revision_authority = 'quarantined' THEN 1 ELSE 0 END), 0),
+                       COALESCE(SUM(CASE WHEN coverage_unknown = 0 AND terminal = 0 AND failure = 0
+                                          AND revision_authority = 'quarantined' THEN blob_size ELSE 0 END), 0),
+                       COALESCE(SUM(CASE WHEN coverage_unknown = 0 AND terminal = 0 AND failure = 0
+                                          AND revision_authority != 'quarantined' AND census_eligible = 1 THEN 1 ELSE 0 END), 0),
+                       COALESCE(SUM(CASE WHEN coverage_unknown = 0 AND terminal = 0 AND failure = 0
+                                          AND revision_authority != 'quarantined' AND census_eligible = 1
+                                         THEN blob_size ELSE 0 END), 0)
+                FROM classified
+                GROUP BY origin
+                ORDER BY COUNT(*) DESC, origin
+                """
+            ).fetchall()
+            totals = conn.execute(
+                """
+                SELECT COUNT(*), COALESCE(SUM(blob_size), 0),
+                       COALESCE(SUM(parse_error IS NOT NULL), 0),
+                       COALESCE(SUM(LOWER(COALESCE(validation_status, '')) = 'failed'), 0),
+                       COALESCE(SUM(revision_authority = 'quarantined'), 0),
+                       COALESCE(SUM(CASE WHEN revision_authority = 'quarantined' THEN blob_size ELSE 0 END), 0),
+                       COALESCE(SUM(CASE WHEN c.raw_id IS NULL THEN 1 ELSE 0 END), 0),
+                       COALESCE(SUM(CASE WHEN c.raw_id IS NULL THEN r.blob_size ELSE 0 END), 0)
+                FROM raw_sessions AS r
+                LEFT JOIN raw_membership_census AS c ON c.raw_id = r.raw_id
+                """
+            ).fetchone()
+        finally:
+            conn.close()
+    except Exception as exc:
+        return _relation_error("source raw/census relations", exc)
+
+    distribution: list[dict[str, object]] = []
+    for row in rows:
+        distribution.append(
+            {
+                "origin": str(row[0]),
+                "raw_count": int(row[1] or 0),
+                "blob": _size_evidence(int(row[2] or 0)),
+                "parse_failures": int(row[3] or 0),
+                "validation_failures": int(row[4] or 0),
+                "quarantine": {"count": int(row[5] or 0), "size": _size_evidence(int(row[6] or 0))},
+                "census_coverage": {
+                    "status": "missing" if int(row[7] or 0) else "present",
+                    "missing_count": int(row[7] or 0),
+                    "missing_size": _size_evidence(int(row[8] or 0)),
+                },
+                "eligibility": {
+                    "terminal_count": int(row[9] or 0),
+                    "terminal_size": _size_evidence(int(row[10] or 0)),
+                    "actionable_count": int(row[11] or 0),
+                    "actionable_size": _size_evidence(int(row[12] or 0)),
+                    "authority_pending_count": int(row[13] or 0),
+                    "authority_pending_size": _size_evidence(int(row[14] or 0)),
+                    "eligible_count": int(row[15] or 0),
+                    "eligible_size": _size_evidence(int(row[16] or 0)),
+                },
+            }
+        )
+    (
+        raw_count,
+        raw_bytes,
+        parse_failures,
+        validation_failures,
+        quarantined,
+        quarantined_bytes,
+        missing_census,
+        missing_census_bytes,
+    ) = tuple(_count(value) for value in totals)
+    eligibility_rows = [item["eligibility"] for item in distribution]
+    actionable = sum(int(item["actionable_count"]) for item in eligibility_rows if isinstance(item, dict))
+    terminal = sum(int(item["terminal_count"]) for item in eligibility_rows if isinstance(item, dict))
+    authority_pending = sum(int(item["authority_pending_count"]) for item in eligibility_rows if isinstance(item, dict))
+    state = (
+        "fail" if actionable else "unknown" if missing_census else "warn" if terminal or authority_pending else "pass"
+    )
+    return _status(
+        state=state,
+        reason=(
+            "source coverage is incomplete"
+            if missing_census
+            else "actionable parse/validation failures remain"
+            if actionable
+            else "known terminal or authority-pending raw evidence"
+            if terminal or authority_pending
+            else None
+        ),
+        available=True,
+        totals={
+            "raw_count": raw_count,
+            "raw_size": _size_evidence(raw_bytes),
+            "parse_failures": parse_failures,
+            "validation_failures": validation_failures,
+            "quarantined_count": quarantined,
+            "quarantined_size": _size_evidence(quarantined_bytes),
+            "missing_census_count": missing_census,
+            "missing_census_size": _size_evidence(missing_census_bytes),
+            "terminal_count": terminal,
+            "actionable_count": actionable,
+            "authority_pending_count": authority_pending,
+        },
+        by_origin=distribution,
+        semantics={
+            "quarantine": "authority_pending, not automatically bad",
+            "missing_census": "coverage_unknown, never terminal or actionable without a census verdict",
+            "terminal": "census status failed or non_session",
+            "actionable": "parse/validation failure with present non-terminal census evidence",
+        },
+    )
+
+
+def _index_profiles(root: Path) -> dict[str, object]:
+    index_db = root / "index.db"
+    if not index_db.exists():
+        return _relation_error("index.db", FileNotFoundError(index_db))
+    try:
+        conn = open_readonly_connection(index_db)
+        try:
+            required = {"sessions", "session_profiles"}
+            missing = sorted(
+                table
+                for table in required
+                if not conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)).fetchone()
+            )
+            if missing:
+                return _status(
+                    state="unknown", reason=f"required index relation(s) missing: {', '.join(missing)}", available=False
+                )
+            sessions = int(conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] or 0)
+            missing_profiles = int(
+                conn.execute(
+                    "SELECT COUNT(*) FROM sessions AS s WHERE NOT EXISTS (SELECT 1 FROM session_profiles AS p WHERE p.session_id = s.session_id)"
+                ).fetchone()[0]
+                or 0
+            )
+        finally:
+            conn.close()
+    except Exception as exc:
+        return _relation_error("index sessions/profile relations", exc)
+    return _status(
+        state="fail" if missing_profiles else "pass",
+        reason="session profile rows are missing" if missing_profiles else None,
+        available=True,
+        sessions_count=sessions,
+        missing_profile_count=missing_profiles,
+    )
+
+
+def _fts_preflight(root: Path) -> dict[str, object]:
+    index_db = root / "index.db"
+    if not index_db.exists():
+        return _relation_error("index.db FTS relations", FileNotFoundError(index_db))
+    try:
+        conn = open_readonly_connection(index_db)
+        try:
+            snapshot = fts_invariant_snapshot_sync(conn)
+        finally:
+            conn.close()
+    except Exception as exc:
+        return _relation_error("FTS readiness", exc)
+    surfaces = {
+        surface.name: {
+            "source_exists": surface.source_exists,
+            "exists": surface.exists,
+            "source_rows": surface.source_rows,
+            "indexed_rows": surface.indexed_rows,
+            "triggers_present": surface.triggers_present,
+            "missing_rows": surface.missing_rows,
+            "excess_rows": surface.excess_rows,
+            "duplicate_rows": surface.duplicate_rows,
+            "identity_mismatch_rows": surface.identity_mismatch_rows,
+            "ready": surface.ready,
+        }
+        for surface in snapshot.surfaces
+    }
+    debt = 0
+    for surface in surfaces.values():
+        debt += sum(
+            int(surface.get(key) or 0)
+            for key in ("missing_rows", "excess_rows", "duplicate_rows", "identity_mismatch_rows")
+        )
+    ready = snapshot.ready
+    return _status(
+        state="pass" if ready and debt == 0 else "fail",
+        reason=None if ready and debt == 0 else "FTS debt or invariant failure is present",
+        available=True,
+        debt_count=debt,
+        coverage_pct=(
+            round(snapshot.messages.indexed_rows / snapshot.messages.source_rows * 100, 1)
+            if snapshot.messages.source_rows
+            else None
+        ),
+        coverage_exact=True,
+        surfaces=surfaces,
+    )
+
+
+def _frontier_preflight(root: Path) -> dict[str, object]:
+    try:
+        readiness = raw_materialization_readiness_snapshot(root, classify_gaps=True)
+        projection = raw_frontier_integrity_projection(root, readiness)
+        payload = projection.to_dict()
+    except Exception as exc:
+        return _relation_error("raw frontier relations", exc)
+    overall = str(payload.get("overall_status") or "unknown")
+    state = "pass" if overall == "healthy" else "fail" if overall == "violated" else "unknown"
+    return _status(
+        state=state,
+        reason=None
+        if state == "pass"
+        else str(payload.get("missing_source_raw_reason") or "raw frontier is not healthy"),
+        available=bool(payload.get("available")),
+        evidence=payload,
+    )
+
+
+def _replay_preflight(root: Path, *, limit: int) -> dict[str, object]:
+    try:
+        payload = raw_materialization_replay_backlog(
+            Config(archive_root=root, render_root=root / "render", sources=[], db_path=root / "index.db"),
+            limit=limit,
+        )
+    except Exception as exc:
+        return _relation_error("raw replay relations", exc)
+    if payload.get("available") is not True:
+        return _status(
+            state="unknown",
+            reason=str(payload.get("reason") or "raw replay backlog unavailable"),
+            available=False,
+            evidence=payload,
+        )
+    candidate_count = _count(payload.get("candidate_count"))
+    blocked_count = _count(payload.get("blocked_candidate_count"))
+    state = "fail" if candidate_count > blocked_count else "warn" if blocked_count else "pass"
+    return _status(
+        state=state,
+        reason=(
+            "executable raw replay candidates remain"
+            if state == "fail"
+            else "raw replay candidates are authority/resource blocked"
+            if state == "warn"
+            else None
+        ),
+        available=True,
+        candidate_count=candidate_count,
+        blocked_candidate_count=blocked_count,
+        authority_quarantined_count=_count(payload.get("authority_quarantined_count")),
+        evidence=payload,
+    )
+
+
+def _cursor_preflight(root: Path, *, now: datetime | None = None, limit: int) -> dict[str, object]:
+    ops_db = root / "ops.db"
+    if not ops_db.exists():
+        return _relation_error("ops.db cursor relation", FileNotFoundError(ops_db))
+    try:
+        conn = open_readonly_connection(ops_db)
+        try:
+            columns = _table_columns(conn, "ingest_cursor")
+            missing = sorted(_REQUIRED_CURSOR_COLUMNS - columns)
+            if missing:
+                return _status(
+                    state="unknown", reason=f"ingest_cursor columns missing: {', '.join(missing)}", available=False
+                )
+            rows = conn.execute(
+                "SELECT source_path, origin, failure_count, next_retry_at, excluded FROM ingest_cursor ORDER BY source_path"
+            ).fetchall()
+            totals = conn.execute(
+                """
+                SELECT COUNT(*), COALESCE(SUM(failure_count > 0), 0),
+                       COALESCE(SUM(excluded = 1), 0),
+                       COALESCE(SUM(failure_count > 0 AND excluded = 0), 0)
+                FROM ingest_cursor
+                """
+            ).fetchone()
+        finally:
+            conn.close()
+    except Exception as exc:
+        return _relation_error("ops.db ingest_cursor", exc)
+    resolved_now = now or datetime.now(UTC)
+    failed = int(totals[1] or 0)
+    excluded = int(totals[2] or 0)
+    retry_due = 0
+    for row in rows:
+        if int(row[2] or 0) <= 0 or bool(row[4]):
+            continue
+        retry_at = row[3]
+        if retry_at is None:
+            retry_due += 1
+            continue
+        try:
+            if datetime.fromisoformat(str(retry_at)) <= resolved_now:
+                retry_due += 1
+        except ValueError:
+            return _status(
+                state="unknown", reason=f"ingest_cursor has malformed retry timestamp: {retry_at!r}", available=False
+            )
+    state = "fail" if failed else "warn" if excluded else "pass"
+    return _status(
+        state=state,
+        reason="cursor failures remain"
+        if failed
+        else "excluded cursors are parked until source identity changes"
+        if excluded
+        else None,
+        available=True,
+        tracked_count=int(totals[0] or 0),
+        failed_count=failed,
+        excluded_count=excluded,
+        retry_due_count=retry_due,
+        sample=[
+            {"source_path": str(row[0]), "origin": row[1], "failure_count": int(row[2] or 0), "excluded": bool(row[4])}
+            for row in rows[:limit]
+        ],
+    )
+
+
+def _convergence_preflight(root: Path) -> dict[str, object]:
+    ops_db = root / "ops.db"
+    if not ops_db.exists():
+        return _relation_error("ops.db convergence_debt relation", FileNotFoundError(ops_db))
+    try:
+        conn = open_readonly_connection(ops_db)
+        try:
+            columns = _table_columns(conn, "convergence_debt")
+            missing = sorted({"stage", "status", "target_type", "target_id", "updated_at_ms"} - columns)
+            if missing:
+                return _status(
+                    state="unknown", reason=f"convergence_debt columns missing: {', '.join(missing)}", available=False
+                )
+            rows = conn.execute(
+                "SELECT stage, status, target_type, target_id FROM convergence_debt ORDER BY updated_at_ms DESC LIMIT 16"
+            ).fetchall()
+            counts = conn.execute("SELECT status, COUNT(*) FROM convergence_debt GROUP BY status").fetchall()
+        finally:
+            conn.close()
+    except Exception as exc:
+        return _relation_error("ops.db convergence_debt", exc)
+    unknown = sorted(str(row[0]) for row in counts if str(row[0]) not in _VALID_DEBT_STATUSES)
+    if unknown:
+        return _status(
+            state="unknown",
+            reason=f"convergence_debt has unknown status value(s): {', '.join(unknown)}",
+            available=False,
+        )
+    failed = sum(int(row[1] or 0) for row in counts if str(row[0]) == "failed")
+    deferred = sum(int(row[1] or 0) for row in counts if str(row[0]) == "deferred")
+    return _status(
+        state="fail" if failed else "warn" if deferred else "pass",
+        reason="failed convergence debt rows remain"
+        if failed
+        else "deferred convergence debt remains"
+        if deferred
+        else None,
+        available=True,
+        failed_count=failed,
+        deferred_count=deferred,
+        row_count=failed + deferred,
+        sample=[
+            {"stage": str(row[0]), "status": str(row[1]), "target_type": str(row[2]), "target_id": str(row[3])}
+            for row in rows
+        ],
+    )
+
+
+def build_preflight_ledger(root: Path, *, limit: int = 10, now: datetime | None = None) -> dict[str, object]:
+    """Build a read-only preflight ledger from the deployed archive relations."""
+    checks = {
+        "schema": _schema_preflight(root),
+        "source": _source_distribution(root),
+        "index_profiles": _index_profiles(root),
+        "fts": _fts_preflight(root),
+        "source_frontier": _frontier_preflight(root),
+        "replay_backlog": _replay_preflight(root, limit=limit),
+        "cursor_failures": _cursor_preflight(root, now=now, limit=limit),
+        "convergence_debt": _convergence_preflight(root),
+    }
+    states = [str(value.get("state")) for value in checks.values()]
+    blocking = [name for name, value in checks.items() if value.get("state") in {"fail", "unknown"}]
+    warnings = [name for name, value in checks.items() if value.get("state") == "warn"]
+    gate = "blocked" if blocking else "ready_with_warnings" if warnings else "ready"
+    return {
+        "report_version": PREFLIGHT_REPORT_VERSION,
+        "read_only": True,
+        "mutation_operations": [],
+        "state": gate,
+        "ok": not blocking,
+        "blocking_checks": blocking,
+        "warning_checks": warnings,
+        "checks": checks,
+        "evidence": {
+            "source": "deployed archive status relations",
+            "states_observed": states,
+            "denominator_policy": "counts and bytes are exact SQL aggregates; cursor samples are bounded",
+        },
+    }
+
+
+__all__ = ["PREFLIGHT_REPORT_VERSION", "build_preflight_ledger"]

--- a/devtools/preflight_ledger.py
+++ b/devtools/preflight_ledger.py
@@ -113,7 +113,7 @@ def _source_distribution(root: Path) -> dict[str, object]:
                            c.status AS census_status,
                            CASE WHEN c.raw_id IS NULL THEN 1 ELSE 0 END AS coverage_unknown,
                            CASE WHEN c.status IN ('failed', 'non_session') THEN 1 ELSE 0 END AS terminal,
-                           CASE WHEN r.parse_error IS NOT NULL
+                           CASE WHEN (r.parse_error IS NOT NULL AND TRIM(r.parse_error) != '')
                                   OR LOWER(COALESCE(r.validation_status, '')) = 'failed'
                                 THEN 1 ELSE 0 END AS failure,
                            CASE WHEN c.status = 'complete' AND c.member_count > 0 THEN 1 ELSE 0 END AS census_eligible
@@ -121,7 +121,7 @@ def _source_distribution(root: Path) -> dict[str, object]:
                     LEFT JOIN raw_membership_census AS c ON c.raw_id = r.raw_id
                 )
                 SELECT origin, COUNT(*), COALESCE(SUM(blob_size), 0),
-                       COALESCE(SUM(parse_error IS NOT NULL), 0),
+                       COALESCE(SUM(parse_error IS NOT NULL AND TRIM(parse_error) != ''), 0),
                        COALESCE(SUM(validation_status = 'failed'), 0),
                        COALESCE(SUM(revision_authority = 'quarantined'), 0),
                        COALESCE(SUM(CASE WHEN revision_authority = 'quarantined' THEN blob_size ELSE 0 END), 0),
@@ -148,7 +148,7 @@ def _source_distribution(root: Path) -> dict[str, object]:
             totals = conn.execute(
                 """
                 SELECT COUNT(*), COALESCE(SUM(blob_size), 0),
-                       COALESCE(SUM(parse_error IS NOT NULL), 0),
+                       COALESCE(SUM(parse_error IS NOT NULL AND TRIM(parse_error) != ''), 0),
                        COALESCE(SUM(LOWER(COALESCE(validation_status, '')) = 'failed'), 0),
                        COALESCE(SUM(revision_authority = 'quarantined'), 0),
                        COALESCE(SUM(CASE WHEN revision_authority = 'quarantined' THEN blob_size ELSE 0 END), 0),
@@ -364,7 +364,7 @@ def _replay_preflight(root: Path, *, limit: int) -> dict[str, object]:
         )
     candidate_count = _count(payload.get("candidate_count"))
     blocked_count = _count(payload.get("blocked_candidate_count"))
-    state = "fail" if candidate_count > blocked_count else "warn" if blocked_count else "pass"
+    state = "fail" if candidate_count else "warn" if blocked_count else "pass"
     return _status(
         state=state,
         reason=(

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -477,6 +477,22 @@ strings. `polylogue ops doctor` reports a `messages_fts` discrepancy.
 `polylogue ops diagnostics workload`
 shows non-empty `fts_trigger_state.missing` or `regressed` triggers.
 
+For a deployment-bound, read-only gate that checks schema versions, exact FTS
+debt, raw frontier integrity, replay candidates, cursor failures, and
+convergence debt, add `--preflight`:
+
+```bash
+polylogue ops diagnostics workload --preflight --json > preflight.json
+jq '.preflight_ledger | {state, blocking_checks, warning_checks}' preflight.json
+```
+
+The preflight reports quarantined raw bytes and missing
+`raw_membership_census` rows by origin. Quarantine is authority-pending
+evidence, not an automatic failure. Missing census is `coverage_unknown` and
+blocks the gate until a verdict exists. Only source rows with present,
+non-terminal census evidence are classified as actionable parse/validation
+debt.
+
 **Root cause.** `messages_fts` is a contentless FTS5 table
 (`content=''`, `contentless_delete=1`) indexing `blocks.search_text`,
 kept in sync by three rowid-keyed triggers on `blocks`

--- a/polylogue/cli/commands/diagnostics.py
+++ b/polylogue/cli/commands/diagnostics.py
@@ -39,6 +39,11 @@ def diagnostics_group() -> None:
     help="Count missing referenced blob files exactly. This can stat many blob paths on large archives.",
 )
 @click.option(
+    "--preflight",
+    is_flag=True,
+    help="Add the strict read-only deployed-status preflight ledger.",
+)
+@click.option(
     "--compare",
     nargs=2,
     type=click.Path(path_type=Path),
@@ -53,6 +58,7 @@ def workload_command(
     integrity_check: bool,
     exact_derived_counts: bool,
     blob_reference_debt: bool,
+    preflight: bool,
     compare: tuple[Path, Path] | None,
 ) -> None:
     """Inspect daemon ingest workload, convergence debt, and hot query plans."""
@@ -70,6 +76,8 @@ def workload_command(
         argv.append("--exact-derived-counts")
     if blob_reference_debt:
         argv.append("--blob-reference-debt")
+    if preflight:
+        argv.append("--preflight")
     if compare is not None:
         before, after = compare
         argv.extend(("--compare", str(before), str(after)))

--- a/tests/unit/devtools/test_preflight_ledger.py
+++ b/tests/unit/devtools/test_preflight_ledger.py
@@ -7,6 +7,7 @@ from typing import cast
 
 import pytest
 
+from devtools import preflight_ledger
 from devtools.preflight_ledger import build_preflight_ledger
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.ops_write import add_convergence_debt
@@ -21,6 +22,10 @@ def _mapping(value: object) -> dict[str, object]:
 def _list(value: object) -> list[object]:
     assert isinstance(value, list)
     return cast(list[object], value)
+
+
+def _mixed_replay_backlog(*_args: object, **_kwargs: object) -> dict[str, object]:
+    return {"available": True, "candidate_count": 2, "blocked_candidate_count": 5}
 
 
 def _initialize_all_tiers(root: Path) -> None:
@@ -174,6 +179,54 @@ def test_preflight_fails_closed_on_missing_census_relation(tmp_path: Path) -> No
     reason = source["reason"]
     assert isinstance(reason, str)
     assert "raw_membership_census" in reason
+
+
+def test_preflight_fails_when_executable_replay_candidates_coexist_with_blocked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(preflight_ledger, "raw_materialization_replay_backlog", _mixed_replay_backlog)
+
+    replay = preflight_ledger._replay_preflight(tmp_path, limit=10)
+
+    assert replay["state"] == "fail"
+    assert replay["candidate_count"] == 2
+    assert replay["blocked_candidate_count"] == 5
+
+
+def test_preflight_ignores_blank_parse_errors_in_origin_and_totals(tmp_path: Path) -> None:
+    _initialize_all_tiers(tmp_path)
+    _insert_raws(
+        tmp_path,
+        origin="codex-session",
+        quarantined_count=4,
+        missing_census=0,
+        missing_quarantine_count=0,
+        quarantined_bytes=4,
+        missing_census_bytes=0,
+    )
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        conn.execute("UPDATE raw_sessions SET revision_authority = 'byte_proven'")
+        conn.executemany(
+            "UPDATE raw_sessions SET parse_error = ? WHERE raw_id = ?",
+            [
+                (None, "codex-session-raw-0"),
+                ("", "codex-session-raw-1"),
+                ("   ", "codex-session-raw-2"),
+                ("parse failed", "codex-session-raw-3"),
+            ],
+        )
+        conn.commit()
+
+    report = build_preflight_ledger(tmp_path)
+
+    source = _mapping(_mapping(report["checks"])["source"])
+    totals = _mapping(source["totals"])
+    by_origin = {str(item["origin"]): item for item in (_mapping(value) for value in _list(source["by_origin"]))}
+    origin = by_origin["codex-session"]
+    eligibility = _mapping(origin["eligibility"])
+    assert totals["parse_failures"] == 1
+    assert origin["parse_failures"] == 1
+    assert eligibility["actionable_count"] == 1
 
 
 def test_preflight_exposes_schema_and_convergence_failures_without_writing(tmp_path: Path) -> None:

--- a/tests/unit/devtools/test_preflight_ledger.py
+++ b/tests/unit/devtools/test_preflight_ledger.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -10,6 +11,16 @@ from devtools.preflight_ledger import build_preflight_ledger
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.ops_write import add_convergence_debt
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+
+def _mapping(value: object) -> dict[str, object]:
+    assert isinstance(value, dict)
+    return cast(dict[str, object], value)
+
+
+def _list(value: object) -> list[object]:
+    assert isinstance(value, list)
+    return cast(list[object], value)
 
 
 def _initialize_all_tiers(root: Path) -> None:
@@ -114,33 +125,38 @@ def test_preflight_reports_quarantine_and_missing_census_by_origin(tmp_path: Pat
     )
 
     report = build_preflight_ledger(tmp_path, limit=4, now=datetime(2026, 8, 5, tzinfo=UTC))
-    source = report["checks"]["source"]
-    by_origin = {item["origin"]: item for item in source["by_origin"]}
+    source = _mapping(_mapping(report["checks"])["source"])
+    totals = _mapping(source["totals"])
+    by_origin = {str(item["origin"]): item for item in (_mapping(value) for value in _list(source["by_origin"]))}
+    codex = by_origin["codex-session"]
+    codex_quarantine = _mapping(codex["quarantine"])
+    codex_census = _mapping(codex["census_coverage"])
+    claude = by_origin["claude-code-session"]
+    claude_quarantine = _mapping(claude["quarantine"])
+    claude_census = _mapping(claude["census_coverage"])
+    semantics = _mapping(source["semantics"])
 
     assert report["read_only"] is True
     assert report["mutation_operations"] == []
     assert report["state"] == "blocked"
     assert source["state"] == "unknown"
-    assert source["totals"]["raw_count"] == 14_489
-    assert source["totals"]["quarantined_count"] == 9_032
-    assert source["totals"]["missing_census_count"] == 7_301
-    assert source["totals"]["quarantined_size"]["bytes"] == round((46.8 + 7.9) * gib)
-    assert source["totals"]["missing_census_size"]["bytes"] == round((9.602 + 2.275) * gib)
-    assert by_origin["codex-session"]["quarantine"]["count"] == 5_203
-    assert by_origin["codex-session"]["quarantine"]["size"]["gib"] == pytest.approx(46.8, abs=0.001)
-    assert by_origin["codex-session"]["census_coverage"]["missing_count"] == 922
-    assert by_origin["codex-session"]["census_coverage"]["missing_size"]["bytes"] == round(9.602 * gib)
-    assert by_origin["codex-session"]["census_coverage"]["missing_size"]["gib"] == pytest.approx(9.602, abs=0.001)
-    assert by_origin["claude-code-session"]["quarantine"]["count"] == 3_829
-    assert by_origin["claude-code-session"]["quarantine"]["size"]["gib"] == pytest.approx(7.9, abs=0.001)
-    assert by_origin["claude-code-session"]["census_coverage"]["missing_count"] == 6_379
-    assert by_origin["claude-code-session"]["census_coverage"]["missing_size"]["bytes"] == round(2.275 * gib)
-    assert by_origin["claude-code-session"]["census_coverage"]["missing_size"]["gib"] == pytest.approx(2.275, abs=0.001)
-    assert source["semantics"]["quarantine"] == "authority_pending, not automatically bad"
-    assert (
-        source["semantics"]["missing_census"]
-        == "coverage_unknown, never terminal or actionable without a census verdict"
-    )
+    assert totals["raw_count"] == 14_489
+    assert totals["quarantined_count"] == 9_032
+    assert totals["missing_census_count"] == 7_301
+    assert _mapping(totals["quarantined_size"])["bytes"] == round((46.8 + 7.9) * gib)
+    assert _mapping(totals["missing_census_size"])["bytes"] == round((9.602 + 2.275) * gib)
+    assert codex_quarantine["count"] == 5_203
+    assert _mapping(codex_quarantine["size"])["gib"] == pytest.approx(46.8, abs=0.001)
+    assert codex_census["missing_count"] == 922
+    assert _mapping(codex_census["missing_size"])["bytes"] == round(9.602 * gib)
+    assert _mapping(codex_census["missing_size"])["gib"] == pytest.approx(9.602, abs=0.001)
+    assert claude_quarantine["count"] == 3_829
+    assert _mapping(claude_quarantine["size"])["gib"] == pytest.approx(7.9, abs=0.001)
+    assert claude_census["missing_count"] == 6_379
+    assert _mapping(claude_census["missing_size"])["bytes"] == round(2.275 * gib)
+    assert _mapping(claude_census["missing_size"])["gib"] == pytest.approx(2.275, abs=0.001)
+    assert semantics["quarantine"] == "authority_pending, not automatically bad"
+    assert semantics["missing_census"] == "coverage_unknown, never terminal or actionable without a census verdict"
 
 
 def test_preflight_fails_closed_on_missing_census_relation(tmp_path: Path) -> None:
@@ -151,10 +167,10 @@ def test_preflight_fails_closed_on_missing_census_relation(tmp_path: Path) -> No
 
     report = build_preflight_ledger(tmp_path)
 
-    source = report["checks"]["source"]
+    source = _mapping(_mapping(report["checks"])["source"])
     assert source["state"] == "unknown"
     assert report["ok"] is False
-    assert "source" in report["blocking_checks"]
+    assert "source" in _list(report["blocking_checks"])
     assert "raw_membership_census" in source["reason"]
 
 
@@ -181,8 +197,11 @@ def test_preflight_exposes_schema_and_convergence_failures_without_writing(tmp_p
     report = build_preflight_ledger(tmp_path)
 
     after = {path.name: path.read_bytes() for path in tmp_path.glob("*.db")}
-    assert report["checks"]["schema"]["state"] == "fail"
-    assert "source" in report["checks"]["schema"]["schema_mismatches"]
-    assert report["checks"]["convergence_debt"]["failed_count"] == 3
-    assert report["checks"]["convergence_debt"]["state"] == "fail"
+    checks = _mapping(report["checks"])
+    schema = _mapping(checks["schema"])
+    convergence_debt = _mapping(checks["convergence_debt"])
+    assert schema["state"] == "fail"
+    assert "source" in _list(schema["schema_mismatches"])
+    assert convergence_debt["failed_count"] == 3
+    assert convergence_debt["state"] == "fail"
     assert before == after

--- a/tests/unit/devtools/test_preflight_ledger.py
+++ b/tests/unit/devtools/test_preflight_ledger.py
@@ -171,7 +171,9 @@ def test_preflight_fails_closed_on_missing_census_relation(tmp_path: Path) -> No
     assert source["state"] == "unknown"
     assert report["ok"] is False
     assert "source" in _list(report["blocking_checks"])
-    assert "raw_membership_census" in source["reason"]
+    reason = source["reason"]
+    assert isinstance(reason, str)
+    assert "raw_membership_census" in reason
 
 
 def test_preflight_exposes_schema_and_convergence_failures_without_writing(tmp_path: Path) -> None:

--- a/tests/unit/devtools/test_preflight_ledger.py
+++ b/tests/unit/devtools/test_preflight_ledger.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from devtools.preflight_ledger import build_preflight_ledger
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+from polylogue.storage.sqlite.archive_tiers.ops_write import add_convergence_debt
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+
+def _initialize_all_tiers(root: Path) -> None:
+    for tier in ArchiveTier:
+        initialize_archive_database(root / f"{tier.value}.db", tier)
+
+
+def _insert_raws(
+    root: Path,
+    *,
+    origin: str,
+    quarantined_count: int,
+    missing_census: int,
+    missing_quarantine_count: int,
+    quarantined_bytes: int,
+    missing_census_bytes: int,
+) -> None:
+    source_db = root / "source.db"
+    count = missing_census + quarantined_count - missing_quarantine_count
+    missing_quarantined_count = missing_quarantine_count
+    regular_count = quarantined_count - missing_quarantined_count
+    regular_bytes = quarantined_bytes - missing_census_bytes
+
+    def sizes(total: int, rows: int) -> list[int]:
+        if rows == 0:
+            assert total == 0
+            return []
+        quotient, remainder = divmod(total, rows)
+        return [quotient + (index < remainder) for index in range(rows)]
+
+    missing_sizes = sizes(missing_census_bytes, missing_quarantined_count) + [0] * (
+        missing_census - missing_quarantined_count
+    )
+    regular_sizes = sizes(regular_bytes, regular_count)
+    all_sizes = missing_sizes + regular_sizes
+    with sqlite3.connect(source_db) as conn:
+        conn.executemany(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, blob_hash, blob_size,
+                acquired_at_ms, revision_authority
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, 'quarantined')
+            """,
+            [
+                (
+                    f"{origin}-raw-{index}",
+                    origin,
+                    f"{origin}-native-{index}",
+                    f"/{origin}/{index}.jsonl",
+                    (f"{origin}-{index}".encode() + b"x" * 32)[:32],
+                    all_sizes[index],
+                    index + 1,
+                )
+                for index in range(count)
+            ],
+        )
+        conn.executemany(
+            """
+            INSERT INTO raw_membership_census (
+                raw_id, parser_fingerprint, status, member_count, censused_at_ms
+            ) VALUES (?, 'test', 'complete', 1, 1)
+            """,
+            [(f"{origin}-raw-{index}",) for index in range(missing_census, count)],
+        )
+        conn.execute(
+            """
+            UPDATE raw_sessions SET revision_authority = 'byte_proven'
+            WHERE origin = ?
+              AND CAST(substr(raw_id, instr(raw_id, 'raw-') + 4) AS INTEGER) >= ?
+              AND CAST(substr(raw_id, instr(raw_id, 'raw-') + 4) AS INTEGER) < ?
+            """,
+            (origin, missing_quarantined_count, missing_census),
+        )
+        conn.commit()
+    assert sum(missing_sizes[:missing_quarantined_count]) + sum(regular_sizes) == quarantined_bytes
+    assert sum(all_sizes[:missing_census]) == missing_census_bytes
+    assert regular_count == quarantined_count - missing_quarantined_count
+    assert regular_bytes == quarantined_bytes - missing_census_bytes
+
+
+@pytest.mark.integration
+def test_preflight_reports_quarantine_and_missing_census_by_origin(tmp_path: Path) -> None:
+    _initialize_all_tiers(tmp_path)
+    gib = 1024**3
+    _insert_raws(
+        tmp_path,
+        origin="codex-session",
+        quarantined_count=5_203,
+        missing_census=922,
+        missing_quarantine_count=922,
+        quarantined_bytes=round(46.8 * gib),
+        missing_census_bytes=round(9.602 * gib),
+    )
+    _insert_raws(
+        tmp_path,
+        origin="claude-code-session",
+        quarantined_count=3_829,
+        missing_census=6_379,
+        missing_quarantine_count=922,
+        quarantined_bytes=round(7.9 * gib),
+        missing_census_bytes=round(2.275 * gib),
+    )
+
+    report = build_preflight_ledger(tmp_path, limit=4, now=datetime(2026, 8, 5, tzinfo=UTC))
+    source = report["checks"]["source"]
+    by_origin = {item["origin"]: item for item in source["by_origin"]}
+
+    assert report["read_only"] is True
+    assert report["mutation_operations"] == []
+    assert report["state"] == "blocked"
+    assert source["state"] == "unknown"
+    assert source["totals"]["raw_count"] == 14_489
+    assert source["totals"]["quarantined_count"] == 9_032
+    assert source["totals"]["missing_census_count"] == 7_301
+    assert source["totals"]["quarantined_size"]["bytes"] == round((46.8 + 7.9) * gib)
+    assert source["totals"]["missing_census_size"]["bytes"] == round((9.602 + 2.275) * gib)
+    assert by_origin["codex-session"]["quarantine"]["count"] == 5_203
+    assert by_origin["codex-session"]["quarantine"]["size"]["gib"] == pytest.approx(46.8, abs=0.001)
+    assert by_origin["codex-session"]["census_coverage"]["missing_count"] == 922
+    assert by_origin["codex-session"]["census_coverage"]["missing_size"]["bytes"] == round(9.602 * gib)
+    assert by_origin["codex-session"]["census_coverage"]["missing_size"]["gib"] == pytest.approx(9.602, abs=0.001)
+    assert by_origin["claude-code-session"]["quarantine"]["count"] == 3_829
+    assert by_origin["claude-code-session"]["quarantine"]["size"]["gib"] == pytest.approx(7.9, abs=0.001)
+    assert by_origin["claude-code-session"]["census_coverage"]["missing_count"] == 6_379
+    assert by_origin["claude-code-session"]["census_coverage"]["missing_size"]["bytes"] == round(2.275 * gib)
+    assert by_origin["claude-code-session"]["census_coverage"]["missing_size"]["gib"] == pytest.approx(2.275, abs=0.001)
+    assert source["semantics"]["quarantine"] == "authority_pending, not automatically bad"
+    assert (
+        source["semantics"]["missing_census"]
+        == "coverage_unknown, never terminal or actionable without a census verdict"
+    )
+
+
+def test_preflight_fails_closed_on_missing_census_relation(tmp_path: Path) -> None:
+    _initialize_all_tiers(tmp_path)
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        conn.execute("DROP TABLE raw_membership_census")
+        conn.commit()
+
+    report = build_preflight_ledger(tmp_path)
+
+    source = report["checks"]["source"]
+    assert source["state"] == "unknown"
+    assert report["ok"] is False
+    assert "source" in report["blocking_checks"]
+    assert "raw_membership_census" in source["reason"]
+
+
+def test_preflight_exposes_schema_and_convergence_failures_without_writing(tmp_path: Path) -> None:
+    _initialize_all_tiers(tmp_path)
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        conn.execute("PRAGMA user_version = 24")
+        conn.commit()
+    with sqlite3.connect(tmp_path / "ops.db") as conn:
+        for index in range(3):
+            add_convergence_debt(
+                conn,
+                stage="fts",
+                target_type="session_id",
+                target_id=f"session-{index}",
+                status="failed",
+                attempts=1,
+                created_at_ms=1,
+                updated_at_ms=1,
+            )
+        conn.commit()
+    before = {path.name: path.read_bytes() for path in tmp_path.glob("*.db")}
+
+    report = build_preflight_ledger(tmp_path)
+
+    after = {path.name: path.read_bytes() for path in tmp_path.glob("*.db")}
+    assert report["checks"]["schema"]["state"] == "fail"
+    assert "source" in report["checks"]["schema"]["schema_mismatches"]
+    assert report["checks"]["convergence_debt"]["failed_count"] == 3
+    assert report["checks"]["convergence_debt"]["state"] == "fail"
+    assert before == after


### PR DESCRIPTION
## Summary

Add a strict, read-only deployment preflight ledger that gives the reindex campaign exact source-coverage evidence by origin.

## Problem

The live archive contains overlapping quarantined and missing-census cohorts. Existing status could report the raw figures but did not distinguish terminal, unknown-coverage, actionable, and authority-pending evidence in one deployable gate; its test fixture also encoded impossible byte totals.

## Solution

Add the preflight ledger to workload diagnostics. It reads schema, source/census distributions, profiles, FTS, raw frontier, replay backlog, cursor state, and convergence debt without mutation, and fails closed on unknown or failed relations.

## Verification

- Focused regression: `tests/unit/devtools/test_preflight_ledger.py::test_preflight_reports_quarantine_and_missing_census_by_origin` passed
- `devtools verify --quick`: passed
- Independent review in progress before merge

Ref polylogue-818fy and polylogue-r9xsj