### PR TITLE
fix(storage): add source v27 migration train sidecar

### DIFF
--- a/polylogue/storage/sqlite/migrations/source/027.train.json
+++ b/polylogue/storage/sqlite/migrations/source/027.train.json
@@ -1,0 +1,68 @@
+{
+  "manifest_format": "polylogue.durable-change-train.v1",
+  "train_id": "train:source:v27",
+  "tier": "source",
+  "current_version": 26,
+  "target_version": 27,
+  "slot": 27,
+  "owner_ref": "polylogue-r9xsj",
+  "migration": {
+    "tier": "source",
+    "target_version": 27,
+    "slot": 27,
+    "path": "027_raw_non_session_duplicate_exclusion_receipts.sql",
+    "owner_ref": "polylogue/storage/sqlite/migrations/source/027_raw_non_session_duplicate_exclusion_receipts.sql",
+    "sql_sha256": "2600e4370a6f353e531b1764669b5df8447562801b46794444741efa507e45d4",
+    "requires_backup": true
+  },
+  "riders": [
+    {
+      "rider_id": "rider:raw-non-session-duplicate-exclusion",
+      "owner_ref": "polylogue-r9xsj",
+      "schema_objects": [
+        "table:raw_non_session_duplicate_exclusion_receipts",
+        "index:idx_raw_non_session_duplicate_exclusion_receipts_twin"
+      ],
+      "runtime_consumers": [
+        {
+          "consumer_id": "source-archive-bootstrap",
+          "production_ref": "polylogue/storage/sqlite/archive_tiers/bootstrap.py:initialize_archive_database",
+          "behavior_proof_ref": "proof:source-v27:archive-bootstrap",
+          "roles": ["write"]
+        },
+        {
+          "consumer_id": "source-tier-bootstrap",
+          "production_ref": "polylogue/storage/sqlite/archive_tiers/bootstrap.py:initialize_archive_tier",
+          "behavior_proof_ref": "proof:source-v27:tier-bootstrap",
+          "roles": ["write", "read"]
+        }
+      ],
+      "behavior_proof_refs": [
+        "proof:source-v27:archive-bootstrap",
+        "proof:source-v27:tier-bootstrap"
+      ],
+      "after_rider_ids": [],
+      "trust_floor_exception_ref": null
+    }
+  ],
+  "ordering_constraints": [],
+  "drop_constraints": [],
+  "row_change_allowances": [],
+  "backup_plan_ref": "backup-profile:source-tier",
+  "state": "declared",
+  "revision": 0,
+  "declared_at_ms": 1785876509000,
+  "admitted_at_ms": null,
+  "admission_evidence_ref": null,
+  "fresh_ddl_parity": null,
+  "reservation": null,
+  "backup_authorization": null,
+  "pre_apply_evidence": null,
+  "apply_evidence": null,
+  "proof": null,
+  "failure": null,
+  "released_at_ms": null,
+  "release_evidence_ref": null,
+  "proof_refs": [],
+  "manifest_sha256": "bff53ffaddc8f94a8cbf5e26dd82946e5cbca7720a252be674687fd40252f1ab"
+}

--- a/polylogue/storage/sqlite/migrations/source/027.train.json
+++ b/polylogue/storage/sqlite/migrations/source/027.train.json
@@ -34,7 +34,7 @@
           "consumer_id": "source-tier-bootstrap",
           "production_ref": "polylogue/storage/sqlite/archive_tiers/bootstrap.py:initialize_archive_tier",
           "behavior_proof_ref": "proof:source-v27:tier-bootstrap",
-          "roles": ["write", "read"]
+          "roles": ["read"]
         }
       ],
       "behavior_proof_refs": [
@@ -64,5 +64,5 @@
   "released_at_ms": null,
   "release_evidence_ref": null,
   "proof_refs": [],
-  "manifest_sha256": "bff53ffaddc8f94a8cbf5e26dd82946e5cbca7720a252be674687fd40252f1ab"
+  "manifest_sha256": "1643f8a42e29249214a68f9cacbf49fc7bee1cb47f590c9f417c69a16dcf4c34"
 }

--- a/tests/unit/storage/test_durable_change_train.py
+++ b/tests/unit/storage/test_durable_change_train.py
@@ -224,6 +224,10 @@ def _install_synthetic_migration(
     monkeypatch.setattr(
         migration_runner, "_migration_package", lambda observed_tier: f"{package_name}.{observed_tier.value}"
     )
+    monkeypatch.setattr(
+        "polylogue.storage.sqlite.durable_change_train._migration_package",
+        lambda observed_tier: f"{package_name}.{observed_tier.value}",
+    )
 
 
 def _reserve_and_authorize(


### PR DESCRIPTION
## Summary

Complete durable source migration v27 with its declared change-train sidecar.

## Problem

The durable migration policy correctly rejected current master because source migration 027 had no train manifest. Synthetic migration tests also discovered shipped sidecars instead of their synthetic package.

## Solution

Add the v27 manifest with its SQL digest, backup plan, provenance, and bootstrap consumer role. Align the synthetic resolver with its test package.

## Verification

- `devtools lab policy schema-versioning`: passed
- `devtools test tests/unit/storage/test_durable_change_train.py`: 35 passed
- `devtools verify --quick`: passed

Ref polylogue-r9xsj