### PR TITLE
feat(devtools): audit testmon blind spots

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -41,6 +41,7 @@ VERIFICATION_LAB_COMMAND_NAMES: tuple[str, ...] = (
     "lab seed-receipt-compare",
     "lab snapshot read-surface",
     "lab test-economics",
+    "lab testmon-blind-spots",
     "lab testmon-proof",
 )
 
@@ -482,6 +483,22 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
             "for bounded unrelated-change selection."
         ),
         examples=("devtools lab testmon-proof", "devtools lab testmon-proof --json"),
+    ),
+    CommandSpec(
+        "lab testmon-blind-spots",
+        "verification lab",
+        "Audit coverage-known files that are absent from the testmon fingerprint graph.",
+        "devtools.testmon_blind_spot_audit",
+        use_when=(
+            "Inspect an existing coverage JSON report against an existing pytest-testmon database. "
+            "Declaration-only modules are reported separately from executable validator risk; this command "
+            "does not run pytest or regenerate coverage."
+        ),
+        examples=(
+            "devtools lab testmon-blind-spots",
+            "devtools lab testmon-blind-spots --json",
+            "devtools lab testmon-blind-spots --coverage-json path/to/coverage.json --testmon-db path/to/testmondata",
+        ),
     ),
     CommandSpec(
         "lab pytest-witness-repetitions",

--- a/devtools/testmon_blind_spot_audit.py
+++ b/devtools/testmon_blind_spot_audit.py
@@ -1,0 +1,274 @@
+"""Audit coverage metadata against the pytest-testmon dependency graph.
+
+This is an on-demand audit.  It consumes an existing coverage.py JSON report
+and an existing pytest-testmon SQLite database; it never runs pytest and never
+creates or refreshes coverage data.
+
+Coverage metadata can know about a file that testmon does not fingerprint.
+That absence is harmless for a declaration-only module, but it is a blind spot
+for executable code.  The distinction is made from the source AST rather than
+from the coverage statement count or the file name, so a stale or edited
+fixture cannot turn executable validation code into a safe result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path, PurePosixPath
+from typing import Literal
+
+from polylogue.storage.sqlite.connection_profile import open_readonly_connection
+
+ASTClassification = Literal["declaration-only", "executable"]
+FindingStatus = Literal[
+    "fingerprinted",
+    "declaration-only-unfingerprinted",
+    "executable-validator-unfingerprinted",
+    "source-unreadable",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class CoverageFile:
+    path: str
+    statements: int
+    covered_lines: int
+
+
+@dataclass(frozen=True, slots=True)
+class BlindSpotFinding:
+    path: str
+    statements: int
+    covered_lines: int
+    ast_classification: ASTClassification
+    testmon_fingerprinted: bool
+    status: FindingStatus
+    safe: bool
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class BlindSpotReport:
+    findings: tuple[BlindSpotFinding, ...]
+    coverage_file_count: int
+    testmon_fingerprint_count: int
+
+    @property
+    def risks(self) -> tuple[BlindSpotFinding, ...]:
+        return tuple(finding for finding in self.findings if not finding.safe)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "findings": [finding.to_dict() for finding in self.findings],
+            "coverage_file_count": self.coverage_file_count,
+            "testmon_fingerprint_count": self.testmon_fingerprint_count,
+            "risk_count": len(self.risks),
+            "safe": not self.risks,
+        }
+
+
+def _relative_path(filename: str, *, source_root: Path) -> str | None:
+    root = source_root.resolve()
+    candidate = Path(filename)
+    if candidate.is_absolute():
+        try:
+            candidate = candidate.resolve().relative_to(root)
+        except ValueError:
+            return None
+    normalized = PurePosixPath(str(candidate).replace("\\", "/"))
+    if normalized.is_absolute() or ".." in normalized.parts:
+        return None
+    return str(normalized)
+
+
+def read_coverage_files(coverage_json_path: Path, *, source_root: Path) -> tuple[CoverageFile, ...]:
+    """Read source-file metadata from an existing coverage.py JSON report."""
+    payload = json.loads(coverage_json_path.read_text(encoding="utf-8"))
+    raw_files = payload.get("files", {})
+    if not isinstance(raw_files, dict):
+        raise ValueError("coverage JSON has no files object")
+
+    files: list[CoverageFile] = []
+    for raw_filename, raw_filedata in raw_files.items():
+        if not isinstance(raw_filename, str) or not isinstance(raw_filedata, dict):
+            continue
+        relative = _relative_path(raw_filename, source_root=source_root)
+        if relative is None or not relative.endswith(".py"):
+            continue
+        summary = raw_filedata.get("summary", {})
+        if not isinstance(summary, dict):
+            summary = {}
+        files.append(
+            CoverageFile(
+                path=relative,
+                statements=int(summary.get("num_statements", 0)),
+                covered_lines=int(summary.get("covered_lines", 0)),
+            )
+        )
+    return tuple(sorted(files, key=lambda item: item.path))
+
+
+def read_testmon_fingerprints(testmon_db_path: Path, *, source_root: Path) -> frozenset[str]:
+    """Read the file paths currently represented in testmon's dependency graph."""
+    connection = open_readonly_connection(testmon_db_path)
+    try:
+        columns = {str(row[1]) for row in connection.execute("PRAGMA table_info(file_fp)").fetchall()}
+        path_column = "filename" if "filename" in columns else "path" if "path" in columns else None
+        if path_column is None:
+            raise ValueError("testmon database file_fp table has no filename/path column")
+        rows = connection.execute(f"SELECT {path_column} FROM file_fp").fetchall()
+    finally:
+        connection.close()
+
+    return frozenset(
+        relative
+        for row in rows
+        if row and isinstance(row[0], str)
+        if (relative := _relative_path(row[0], source_root=source_root)) is not None
+    )
+
+
+def _is_docstring(node: ast.stmt, *, first: bool) -> bool:
+    return (
+        first
+        and isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Constant)
+        and isinstance(node.value.value, str)
+    )
+
+
+def _statement_is_executable(node: ast.stmt) -> bool:
+    """Return whether a statement can carry runtime validation behavior."""
+    if isinstance(node, (ast.Pass, ast.Import, ast.ImportFrom)):
+        return False
+    if (
+        isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Constant)
+        and (isinstance(node.value.value, str) or node.value.value is Ellipsis)
+    ):
+        return False
+    if isinstance(node, ast.AnnAssign) and node.value is None:
+        return False
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        if node.decorator_list:
+            return True
+        return _body_is_executable(node.body)
+    if isinstance(node, ast.ClassDef):
+        if node.decorator_list:
+            return True
+        return _body_is_executable(node.body)
+    if isinstance(node, ast.Assign):
+        return _expression_is_runtime(node.value)
+    if isinstance(node, ast.AnnAssign):
+        return node.value is not None and _expression_is_runtime(node.value)
+    return True
+
+
+def _expression_is_runtime(node: ast.expr) -> bool:
+    """Conservatively identify assignment expressions with runtime effects."""
+    if isinstance(node, (ast.Constant, ast.Name, ast.Attribute)):
+        return False
+    if isinstance(node, (ast.Tuple, ast.List, ast.Set)):
+        return any(_expression_is_runtime(element) for element in node.elts)
+    if isinstance(node, ast.Dict):
+        return any(
+            (key is not None and _expression_is_runtime(key)) or _expression_is_runtime(value)
+            for key, value in zip(node.keys, node.values, strict=True)
+        )
+    return True
+
+
+def _body_is_executable(body: list[ast.stmt]) -> bool:
+    for index, node in enumerate(body):
+        if _is_docstring(node, first=index == 0):
+            continue
+        if _statement_is_executable(node):
+            return True
+    return False
+
+
+def classify_source_ast(source_path: Path) -> ASTClassification:
+    """Classify source by executable AST content, with parse failures as risk."""
+    try:
+        tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return "executable"
+    return "executable" if _body_is_executable(tree.body) else "declaration-only"
+
+
+def audit_blind_spots(
+    *,
+    coverage_json_path: Path,
+    testmon_db_path: Path,
+    source_root: Path,
+) -> BlindSpotReport:
+    """Compare coverage-known files with testmon fingerprints without mutation."""
+    coverage_files = read_coverage_files(coverage_json_path, source_root=source_root)
+    fingerprints = read_testmon_fingerprints(testmon_db_path, source_root=source_root)
+    findings: list[BlindSpotFinding] = []
+    for coverage_file in coverage_files:
+        source_path = source_root / coverage_file.path
+        readable = source_path.is_file()
+        classification = classify_source_ast(source_path)
+        fingerprinted = coverage_file.path in fingerprints
+        if not readable:
+            status: FindingStatus = "source-unreadable"
+            safe = False
+        elif fingerprinted:
+            status = "fingerprinted"
+            safe = True
+        elif classification == "declaration-only":
+            status = "declaration-only-unfingerprinted"
+            safe = True
+        else:
+            status = "executable-validator-unfingerprinted"
+            safe = False
+        findings.append(
+            BlindSpotFinding(
+                path=coverage_file.path,
+                statements=coverage_file.statements,
+                covered_lines=coverage_file.covered_lines,
+                ast_classification=classification,
+                testmon_fingerprinted=fingerprinted,
+                status=status,
+                safe=safe,
+            )
+        )
+    return BlindSpotReport(
+        findings=tuple(findings),
+        coverage_file_count=len(coverage_files),
+        testmon_fingerprint_count=len(fingerprints),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Audit existing coverage metadata against pytest-testmon fingerprints without running tests."
+    )
+    parser.add_argument("--coverage-json", type=Path, default=Path(".cache/coverage/coverage.json"))
+    parser.add_argument("--testmon-db", type=Path, default=Path(".cache/testmon/testmondata"))
+    parser.add_argument("--source-root", type=Path, default=Path("."))
+    parser.add_argument("--json", action="store_true", help="Emit the complete audit report as JSON.")
+    args = parser.parse_args(argv)
+    report = audit_blind_spots(
+        coverage_json_path=args.coverage_json,
+        testmon_db_path=args.testmon_db,
+        source_root=args.source_root,
+    )
+    if args.json:
+        print(json.dumps(report.to_dict(), indent=2))
+    else:
+        for finding in report.findings:
+            print(f"{finding.status:>38}  {finding.path}")
+        print(f"coverage files: {report.coverage_file_count}; testmon fingerprints: {report.testmon_fingerprint_count}")
+        print(f"risk findings: {len(report.risks)}")
+    return 1 if report.risks else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/devtools/testmon_blind_spot_audit.py
+++ b/devtools/testmon_blind_spot_audit.py
@@ -22,7 +22,7 @@ from typing import Literal
 
 from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 
-ASTClassification = Literal["declaration-only", "executable"]
+ASTClassification = Literal["declaration-only", "executable", "source-unreadable"]
 FindingStatus = Literal[
     "fingerprinted",
     "declaration-only-unfingerprinted",
@@ -157,9 +157,13 @@ def _statement_is_executable(node: ast.stmt) -> bool:
     if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
         if node.decorator_list:
             return True
+        if node.args.defaults or any(default is not None for default in node.args.kw_defaults):
+            return True
         return _body_is_executable(node.body)
     if isinstance(node, ast.ClassDef):
         if node.decorator_list:
+            return True
+        if node.bases or node.keywords:
             return True
         return _body_is_executable(node.body)
     if isinstance(node, ast.Assign):
@@ -193,10 +197,12 @@ def _body_is_executable(body: list[ast.stmt]) -> bool:
 
 
 def classify_source_ast(source_path: Path) -> ASTClassification:
-    """Classify source by executable AST content, with parse failures as risk."""
+    """Classify source by executable AST content, with read and parse failures as risk."""
     try:
         tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
-    except (OSError, SyntaxError, UnicodeDecodeError):
+    except OSError:
+        return "source-unreadable"
+    except (SyntaxError, UnicodeDecodeError):
         return "executable"
     return "executable" if _body_is_executable(tree.body) else "declaration-only"
 
@@ -216,7 +222,7 @@ def audit_blind_spots(
         readable = source_path.is_file()
         classification = classify_source_ast(source_path)
         fingerprinted = coverage_file.path in fingerprints
-        if not readable:
+        if not readable or classification == "source-unreadable":
             status: FindingStatus = "source-unreadable"
             safe = False
         elif fingerprinted:

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -76,6 +76,7 @@ They are not a proof ledger or end-user archive workflow.
 | `devtools lab seed-receipt-compare` | Judge a seed-testmon or focused pytest run's resource receipt against a named baseline receipt (e.g. a prior incident) — confirms both runs share workload identity and terminated cleanly, then scores wall-time speedup and peak-PSS ceiling targets, naming a blocker and linked follow-up for any unmet target instead of silently dropping it. |
 | `devtools lab snapshot read-surface` | Freeze archive read-surface behavior before archive work, then compare candidate archives against the captured envelope baseline. |
 | `devtools lab test-economics` | Decide where test-writing effort or test-suite pruning actually pays off, by cross-referencing coverage percent, historical fix-commit density, testmon wall-time cost exposure, and testmon selection fan-out per top-level package. |
+| `devtools lab testmon-blind-spots` | Inspect an existing coverage JSON report against an existing pytest-testmon database. Declaration-only modules are reported separately from executable validator risk; this command does not run pytest or regenerate coverage. |
 | `devtools lab testmon-proof` | Validate the affected-test harness itself: a disposable copy of a real Polylogue module and existing route test is seeded, semantically mutated, edge-severed, restored, and checked for bounded unrelated-change selection. |
 
 ## Core Loop
@@ -174,6 +175,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools lab smoke` | Run direct archive and reader smoke sets. |
 | `devtools lab snapshot read-surface` | Capture and compare archive read-surface snapshots. |
 | `devtools lab test-economics` | Report per-package coverage/fix-density/test-cost economics (polylogue-9e5.11). |
+| `devtools lab testmon-blind-spots` | Audit coverage-known files that are absent from the testmon fingerprint graph. |
 | `devtools lab testmon-proof` | Prove real testmon affected selection against a semantic production mutation. |
 
 ### Verification

--- a/tests/unit/devtools/test_testmon_blind_spot_audit.py
+++ b/tests/unit/devtools/test_testmon_blind_spot_audit.py
@@ -9,7 +9,13 @@ from pathlib import Path
 
 import pytest
 
-from devtools.testmon_blind_spot_audit import BlindSpotFinding, BlindSpotReport, audit_blind_spots, main
+from devtools.testmon_blind_spot_audit import (
+    BlindSpotFinding,
+    BlindSpotReport,
+    audit_blind_spots,
+    classify_source_ast,
+    main,
+)
 
 
 def _write_coverage(path: Path, files: dict[str, tuple[int, int]]) -> None:
@@ -104,6 +110,65 @@ def test_fingerprint_presence_clears_the_executable_blind_spot(tmp_path: Path) -
     assert finding.testmon_fingerprinted is True
     assert finding.status == "fingerprinted"
     assert finding.safe is True
+
+
+def test_evaluated_function_and_class_headers_are_executable(tmp_path: Path) -> None:
+    source = tmp_path / "declaration_headers.py"
+    source.write_text(
+        "def configured(value=DEFAULT_VALUE, *, named=KEYWORD_DEFAULT):\n"
+        "    pass\n\n"
+        "class Configured(Base, Mixin, metaclass=METACLASS):\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+
+    assert classify_source_ast(source) == "executable"
+
+
+def test_fingerprinted_source_read_error_is_unsafe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = tmp_path / "unreadable_fixture.py"
+    source.write_text("VALUE = 1\n", encoding="utf-8")
+    coverage = tmp_path / "coverage.json"
+    testmon = tmp_path / "testmondata"
+    _write_coverage(coverage, {"unreadable_fixture.py": (0, 0)})
+    _write_testmon(testmon, ("unreadable_fixture.py",))
+
+    original_read_text = Path.read_text
+
+    def read_text(path: Path, *args: object, **kwargs: object) -> str:
+        if path == source:
+            raise OSError("synthetic source read failure")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", read_text)
+    report = audit_blind_spots(
+        coverage_json_path=coverage,
+        testmon_db_path=testmon,
+        source_root=tmp_path,
+    )
+
+    finding = _finding(report, "unreadable_fixture.py")
+    assert finding.testmon_fingerprinted is True
+    assert finding.status == "source-unreadable"
+    assert finding.safe is False
+    assert (
+        main(
+            [
+                "--coverage-json",
+                str(coverage),
+                "--testmon-db",
+                str(testmon),
+                "--source-root",
+                str(tmp_path),
+            ]
+        )
+        == 1
+    )
+    assert "source-unreadable" in capsys.readouterr().out
 
 
 def test_mutation_proof_fixture_or_ast_change_never_makes_validator_safe(tmp_path: Path) -> None:

--- a/tests/unit/devtools/test_testmon_blind_spot_audit.py
+++ b/tests/unit/devtools/test_testmon_blind_spot_audit.py
@@ -139,10 +139,14 @@ def test_fingerprinted_source_read_error_is_unsafe(
 
     original_read_text = Path.read_text
 
-    def read_text(path: Path, *args: object, **kwargs: object) -> str:
+    def read_text(
+        path: Path,
+        encoding: str | None = None,
+        errors: str | None = None,
+    ) -> str:
         if path == source:
             raise OSError("synthetic source read failure")
-        return original_read_text(path, *args, **kwargs)
+        return original_read_text(path, encoding=encoding, errors=errors)
 
     monkeypatch.setattr(Path, "read_text", read_text)
     report = audit_blind_spots(

--- a/tests/unit/devtools/test_testmon_blind_spot_audit.py
+++ b/tests/unit/devtools/test_testmon_blind_spot_audit.py
@@ -1,0 +1,181 @@
+"""Synthetic, mutation-proof tests for the testmon blind-spot audit."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from devtools.testmon_blind_spot_audit import BlindSpotFinding, BlindSpotReport, audit_blind_spots, main
+
+
+def _write_coverage(path: Path, files: dict[str, tuple[int, int]]) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "meta": {"version": "7.15.2"},
+                "files": {
+                    name: {
+                        "summary": {"num_statements": statements, "covered_lines": covered_lines},
+                        "executed_lines": [],
+                    }
+                    for name, (statements, covered_lines) in files.items()
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_testmon(path: Path, filenames: tuple[str, ...] = ()) -> None:
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute("CREATE TABLE file_fp (id INTEGER PRIMARY KEY, filename TEXT, fsha TEXT)")
+        connection.executemany(
+            "INSERT INTO file_fp(filename, fsha) VALUES (?, ?)",
+            [(filename, f"synthetic-{index}") for index, filename in enumerate(filenames)],
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def _finding(report: BlindSpotReport, path: str) -> BlindSpotFinding:
+    return next(finding for finding in report.findings if finding.path == path)
+
+
+def test_audit_separates_declaration_only_from_unfingerprinted_validator(tmp_path: Path) -> None:
+    (tmp_path / "declarations.py").write_text(
+        '"""A declaration-only synthetic module."""\n'
+        "from typing import Final\n"
+        "VALUE: Final[int] = 1\n"
+        "\n"
+        "class Marker:\n"
+        "    name: str\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "validator.py").write_text(
+        "def validate_payload(payload: dict[str, object]) -> bool:\n    return bool(payload)\n",
+        encoding="utf-8",
+    )
+    coverage = tmp_path / "coverage.json"
+    testmon = tmp_path / "testmondata"
+    _write_coverage(coverage, {"declarations.py": (0, 0), "validator.py": (1, 0)})
+    _write_testmon(testmon)
+
+    report = audit_blind_spots(
+        coverage_json_path=coverage,
+        testmon_db_path=testmon,
+        source_root=tmp_path,
+    )
+
+    declaration = _finding(report, "declarations.py")
+    validator = _finding(report, "validator.py")
+    assert declaration.ast_classification == "declaration-only"
+    assert declaration.status == "declaration-only-unfingerprinted"
+    assert declaration.safe is True
+    assert validator.ast_classification == "executable"
+    assert validator.status == "executable-validator-unfingerprinted"
+    assert validator.safe is False
+    assert len(report.risks) == 1
+
+
+def test_fingerprint_presence_clears_the_executable_blind_spot(tmp_path: Path) -> None:
+    source = tmp_path / "validator_fixture.py"
+    source.write_text(
+        "def validate(value: object) -> bool:\n    return value is not None\n",
+        encoding="utf-8",
+    )
+    coverage = tmp_path / "coverage.json"
+    testmon = tmp_path / "testmondata"
+    _write_coverage(coverage, {"validator_fixture.py": (1, 1)})
+    _write_testmon(testmon, ("validator_fixture.py",))
+
+    report = audit_blind_spots(
+        coverage_json_path=coverage,
+        testmon_db_path=testmon,
+        source_root=tmp_path,
+    )
+
+    finding = _finding(report, "validator_fixture.py")
+    assert finding.testmon_fingerprinted is True
+    assert finding.status == "fingerprinted"
+    assert finding.safe is True
+
+
+def test_mutation_proof_fixture_or_ast_change_never_makes_validator_safe(tmp_path: Path) -> None:
+    """A coverage fixture cannot bless a validator after its AST becomes executable."""
+    source = tmp_path / "same_fixture.py"
+    source.write_text(
+        '"""Only declarations before the mutation."""\nVALUE: int = 1\n',
+        encoding="utf-8",
+    )
+    coverage = tmp_path / "coverage.json"
+    testmon = tmp_path / "testmondata"
+    _write_coverage(coverage, {"same_fixture.py": (0, 0)})
+    _write_testmon(testmon)
+
+    safe_declaration = audit_blind_spots(
+        coverage_json_path=coverage,
+        testmon_db_path=testmon,
+        source_root=tmp_path,
+    )
+    assert _finding(safe_declaration, "same_fixture.py").safe is True
+
+    source.write_text(
+        "def validate_payload(payload: dict[str, object]) -> bool:\n"
+        "    if not payload:\n"
+        "        return False\n"
+        "    return True\n",
+        encoding="utf-8",
+    )
+    executable_with_stale_fixture = audit_blind_spots(
+        coverage_json_path=coverage,
+        testmon_db_path=testmon,
+        source_root=tmp_path,
+    )
+    mutated = _finding(executable_with_stale_fixture, "same_fixture.py")
+    assert mutated.ast_classification == "executable"
+    assert mutated.status == "executable-validator-unfingerprinted"
+    assert mutated.safe is False
+
+    _write_coverage(coverage, {"same_fixture.py": (2, 2)})
+    executable_with_changed_fixture = audit_blind_spots(
+        coverage_json_path=coverage,
+        testmon_db_path=testmon,
+        source_root=tmp_path,
+    )
+    changed = _finding(executable_with_changed_fixture, "same_fixture.py")
+    assert changed.status == "executable-validator-unfingerprinted"
+    assert changed.safe is False
+
+
+def test_audit_is_read_only_and_main_returns_risk_exit_code(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    source = tmp_path / "validator.py"
+    source.write_text("def validate(value: object) -> bool:\n    return True\n", encoding="utf-8")
+    coverage = tmp_path / "coverage.json"
+    testmon = tmp_path / "testmondata"
+    _write_coverage(coverage, {"validator.py": (1, 0)})
+    _write_testmon(testmon)
+    coverage_before = hashlib.sha256(coverage.read_bytes()).digest()
+    testmon_before = hashlib.sha256(testmon.read_bytes()).digest()
+
+    assert (
+        main(
+            [
+                "--coverage-json",
+                str(coverage),
+                "--testmon-db",
+                str(testmon),
+                "--source-root",
+                str(tmp_path),
+            ]
+        )
+        == 1
+    )
+    assert "executable-validator-unfingerprinted" in capsys.readouterr().out
+    assert hashlib.sha256(coverage.read_bytes()).digest() == coverage_before
+    assert hashlib.sha256(testmon.read_bytes()).digest() == testmon_before


### PR DESCRIPTION
## Summary

Add an on-demand audit that compares existing coverage metadata with pytest-testmon fingerprints and distinguishes declaration-only modules from executable blind spots.

## Problem

Affected-test selection can miss coverage-known executable files that are absent from testmon's dependency graph. Existing readiness checks did not expose that gap without regenerating coverage.

## Solution

Add `devtools lab testmon-blind-spots`, a read-only coverage/testmon audit backed by AST classification. It reports declaration-only misses separately and exits nonzero for unfingerprinted executable validators.

## Verification

- `POLYLOGUE_PYTEST_WORKERS=1 direnv exec . devtools test tests/unit/devtools/test_testmon_blind_spot_audit.py`
  - `4 passed`
- `POLYLOGUE_PYTEST_WORKERS=1 direnv exec . devtools verify --quick`
  - all quick verification steps passed
- `POLYLOGUE_PYTEST_WORKERS=1 direnv exec . devtools lab testmon-blind-spots --inner-help`
  - command surface resolved

Ref polylogue-vyxq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `testmon-blind-spots` verification-lab command to identify coverage and test-selection gaps.
  * Supports human-readable and JSON reports without running tests or modifying existing coverage data.
  * Highlights unreadable, untracked, and potentially risky source files.

* **Documentation**
  * Added command usage guidance and examples to the developer tools reference.

* **Tests**
  * Added validation for source classification, stale coverage data, risk reporting, and read-only behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->