### PR TITLE
test: restore provider-shaped synthetic corpus members

### DIFF
--- a/polylogue/schemas/synthetic/build_batch.py
+++ b/polylogue/schemas/synthetic/build_batch.py
@@ -598,9 +598,9 @@ def _pin_session_native_id(provider: str, data: JSONValue, native_id: str) -> JS
         for index, record in enumerate(data):
             if not isinstance(record, dict) or record.get("type") != "message":
                 continue
-            payload = dict(record)
-            payload["type"] = "message"
-            data[index] = {"type": "response_item", "payload": payload}
+            response_payload = dict(record)
+            response_payload["type"] = "message"
+            data[index] = {"type": "response_item", "payload": response_payload}
         for record in data:
             if not isinstance(record, dict) or record.get("type") != "session_meta":
                 continue

--- a/polylogue/schemas/synthetic/build_batch.py
+++ b/polylogue/schemas/synthetic/build_batch.py
@@ -604,8 +604,10 @@ def _pin_session_native_id(provider: str, data: JSONValue, native_id: str) -> JS
         for record in data:
             if not isinstance(record, dict) or record.get("type") != "session_meta":
                 continue
-            payload = record.get("payload")
-            if not isinstance(payload, dict):
+            payload_value = record.get("payload")
+            if isinstance(payload_value, dict):
+                payload: dict[str, JSONValue] = payload_value
+            else:
                 payload = {}
                 record["payload"] = payload
             payload["id"] = native_id

--- a/polylogue/schemas/synthetic/build_batch.py
+++ b/polylogue/schemas/synthetic/build_batch.py
@@ -582,12 +582,25 @@ def _pin_session_native_id(provider: str, data: JSONValue, native_id: str) -> JS
     if provider == "gemini" and isinstance(data, dict):
         data["id"] = native_id
         return data
+    if provider == "antigravity" and isinstance(data, dict):
+        data["cascadeId"] = native_id
+        return data
     if provider == "claude-code" and isinstance(data, list):
         for record in data:
             if isinstance(record, dict):
                 record["sessionId"] = native_id
         return data
     if provider == "codex" and isinstance(data, list):
+        # A native id is only authoritative in Codex's session_meta envelope.
+        # Convert generated flat messages before adding that header so the
+        # result remains one supported stream shape instead of mixing direct
+        # messages with envelope records, which the parser rejects.
+        for index, record in enumerate(data):
+            if not isinstance(record, dict) or record.get("type") != "message":
+                continue
+            payload = dict(record)
+            payload["type"] = "message"
+            data[index] = {"type": "response_item", "payload": payload}
         for record in data:
             if not isinstance(record, dict) or record.get("type") != "session_meta":
                 continue

--- a/polylogue/schemas/synthetic/build_batch.py
+++ b/polylogue/schemas/synthetic/build_batch.py
@@ -604,9 +604,10 @@ def _pin_session_native_id(provider: str, data: JSONValue, native_id: str) -> JS
         for record in data:
             if not isinstance(record, dict) or record.get("type") != "session_meta":
                 continue
+            payload: dict[str, JSONValue]
             payload_value = record.get("payload")
             if isinstance(payload_value, dict):
-                payload: dict[str, JSONValue] = payload_value
+                payload = payload_value
             else:
                 payload = {}
                 record["payload"] = payload

--- a/polylogue/schemas/synthetic/core.py
+++ b/polylogue/schemas/synthetic/core.py
@@ -8,7 +8,6 @@ from collections import Counter
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from polylogue.core.json import json_document, loads
 from polylogue.scenarios import CorpusSpec
 from polylogue.schemas.runtime_registry import SchemaRegistry, canonical_schema_provider
 from polylogue.schemas.synthetic import builders as synthetic_builders
@@ -215,24 +214,21 @@ class SyntheticCorpus:
         written_files: list[Path] = []
         for idx, artifact in enumerate(batch.artifacts):
             if corpus.provider == "antigravity":
-                # The real acquisition path (iter_antigravity_language_server_sessions /
-                # its brain-metadata fallback, polylogue-eo81) requires a rooted
-                # directory layout: root/brain/<session-dir>/<name>.md.metadata.json,
-                # session identity derived from the immediate parent directory name.
-                # A flat root/<name>.md.metadata.json layout is refused by the
-                # generic per-file walk (deliberately, so real conversations aren't
-                # double-counted as sidecar fragments) and never reaches a parser.
-                session_dir = output_dir / "brain" / f"{prefix}-{idx:0{index_width}d}"
-                session_dir.mkdir(parents=True, exist_ok=True)
-                file_path = session_dir / f"{prefix}-{idx:0{index_width}d}.md.metadata.json"
-                markdown_path = session_dir / f"{prefix}-{idx:0{index_width}d}.md"
-                payload = json_document(loads(artifact.raw_bytes))
-                markdown_path.write_text(
-                    str(payload.get("summary") or "Synthetic Antigravity artifact"), encoding="utf-8"
+                # Sidecars describe artifacts and are intentionally not sessions.
+                # Synthetic conversations must use the same rooted trajectory shape
+                # as the real acquisition path: conversations/<cascade_id>.pb.
+                conversations_dir = output_dir / "conversations"
+                conversations_dir.mkdir(parents=True, exist_ok=True)
+                cascade_id = (
+                    spec.session_native_ids[idx]
+                    if idx < len(spec.session_native_ids)
+                    else f"{prefix}-{idx:0{index_width}d}"
                 )
+                file_path = conversations_dir / f"{cascade_id}.pb"
+                file_path.write_bytes(b"fake-protobuf-bytes-" + cascade_id.encode("utf-8"))
             else:
                 file_path = output_dir / f"{prefix}-{idx:0{index_width}d}{ext}"
-            file_path.write_bytes(artifact.raw_bytes)
+                file_path.write_bytes(artifact.raw_bytes)
             written_files.append(file_path)
         return SyntheticWrittenBatch(batch=batch, files=tuple(written_files))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1114,7 +1114,10 @@ def raw_synthetic_samples() -> list[RawSessionRecord]:
 
 
 @pytest.fixture
-def synthetic_source(tmp_path: Path) -> Callable[[str, int, range, int], Source]:
+def synthetic_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Callable[[str, int, range, int], Source]:
     """Factory fixture that generates synthetic Source objects for any provider.
 
     Writes SyntheticCorpus output to temp files, returning Source objects that
@@ -1133,6 +1136,7 @@ def synthetic_source(tmp_path: Path) -> Callable[[str, int, range, int], Source]
     """
     from polylogue.config import Source
     from polylogue.schemas.synthetic import SyntheticCorpus
+    from tests.infra.source_builders import SyntheticAntigravityLanguageServerClient
 
     def _factory(
         provider: str,
@@ -1153,12 +1157,10 @@ def synthetic_source(tmp_path: Path) -> Callable[[str, int, range, int], Source]
         written = SyntheticCorpus.write_spec_artifacts(spec, provider_dir, prefix="synth")
 
         if provider == "antigravity":
-            # The real acquisition path roots itself at a directory holding
-            # brain/ (and conversations/), not a single file -- see
-            # SyntheticCorpus.write_spec_artifacts's antigravity branch. It
-            # also resolves source.name via Provider.from_string, so the name
-            # must be exactly "antigravity", not "antigravity-test" like
-            # every other provider's synthetic source name.
+            monkeypatch.setattr(
+                "polylogue.sources.parsers.antigravity.AntigravityLanguageServerClient",
+                SyntheticAntigravityLanguageServerClient,
+            )
             return Source(name=provider, path=provider_dir)
 
         if count == 1:

--- a/tests/infra/pathology_zoo.py
+++ b/tests/infra/pathology_zoo.py
@@ -14,6 +14,7 @@ import sqlite3
 from collections.abc import Iterable
 from dataclasses import dataclass, replace
 from pathlib import Path
+from unittest.mock import patch
 
 from polylogue.config import Source
 from polylogue.maintenance.pathology_zoo import (
@@ -29,6 +30,7 @@ from polylogue.pipeline.services.archive_ingest import parse_sources_archive
 from polylogue.scenarios import CorpusSpec
 from polylogue.schemas.synthetic import SyntheticCorpus
 from polylogue.sources.hooks import drain_hook_event_spool, enqueue_hook_event
+from tests.infra.source_builders import SyntheticAntigravityLanguageServerClient
 
 
 @dataclass(frozen=True, slots=True)
@@ -385,6 +387,7 @@ def _write_generated_members(root: Path, *, indexes: tuple[int, ...] | None = No
             messages_min=2,
             messages_max=2,
             seed=37,
+            session_native_ids=("zoo-06-00:zoo-06-00.md",),
             origin="test.pathology-zoo",
             tags=("pathology-zoo",),
         ),
@@ -404,6 +407,8 @@ def _bind_durable_paths(
             member,
             durable_paths=(str(hook_event_path),)
             if member.member_id == "hook-event"
+            else (str(wire_root / "generated" / "conversations" / "zoo-06-00:zoo-06-00.md.pb"),)
+            if member.member_id == "non-stream-safe"
             else tuple(str(wire_root / raw_path) for raw_path in member.raw_paths),
         )
         for member in manifest
@@ -439,13 +444,21 @@ def build_pathology_zoo(archive_root: Path) -> PathologyZoo:
     _write_generated_members(wire_root, indexes=(0, 1, 3, 5, 6))
     _write_manual_members(wire_root)
     sources = [Source(name="pathology-zoo", path=wire_root), Source(name="antigravity", path=wire_root / "generated")]
-    asyncio.run(parse_sources_archive(archive_root, sources, parse_workers=1))
+    with patch(
+        "polylogue.sources.parsers.antigravity.AntigravityLanguageServerClient",
+        SyntheticAntigravityLanguageServerClient,
+    ):
+        asyncio.run(parse_sources_archive(archive_root, sources, parse_workers=1))
     _write_generated_members(wire_root, indexes=(2, 4))
     _write_jsonl(
         wire_root / "manual" / "lineage-cycle-z-a-update.jsonl",
         _codex_records("zoo-cycle-a", ("cycle A", "cycle A revised"), parent="zoo-cycle-b", subagent=True),
     )
-    asyncio.run(parse_sources_archive(archive_root, sources, parse_workers=1))
+    with patch(
+        "polylogue.sources.parsers.antigravity.AntigravityLanguageServerClient",
+        SyntheticAntigravityLanguageServerClient,
+    ):
+        asyncio.run(parse_sources_archive(archive_root, sources, parse_workers=1))
     hook_event_path = enqueue_hook_event(
         event_id="zoo-hook-event",
         provider="claude-code",

--- a/tests/infra/source_builders.py
+++ b/tests/infra/source_builders.py
@@ -2,11 +2,46 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TypeAlias
 
+from polylogue.sources.parsers.antigravity import AntigravitySessionSummary
+
 JsonObject: TypeAlias = dict[str, object]
 JsonObjectList: TypeAlias = list[JsonObject]
+
+
+@dataclass
+class SyntheticAntigravityLanguageServerClient:
+    """Test-only language-server boundary for real synthetic conversation files."""
+
+    root: Path
+
+    def start(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+    def search_sessions(self, *, limit: int = 10000, query: str = "") -> list[AntigravitySessionSummary]:
+        del limit, query
+        return [
+            AntigravitySessionSummary(
+                cascade_id=path.stem,
+                title=f"Synthetic Antigravity {path.stem}",
+                last_modified_time="2026-01-01T00:00:00Z",
+            )
+            for path in sorted((self.root / "conversations").glob("*.pb"))
+        ]
+
+    def export_markdown(self, cascade_id: str) -> str:
+        return (
+            "### User Input\n\n"
+            f"Synthetic prompt for {cascade_id}\n\n"
+            "### Planner Response\n\n"
+            f"Synthetic response for {cascade_id}\n"
+        )
 
 
 def make_chatgpt_node(

--- a/tests/infra/workload_artifacts.py
+++ b/tests/infra/workload_artifacts.py
@@ -23,6 +23,7 @@ import uuid
 from collections.abc import Iterable, Iterator
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from unittest.mock import patch
 
 from polylogue.config import Config, Source
 from polylogue.pipeline.services.archive_ingest import parse_sources_archive
@@ -38,6 +39,7 @@ from polylogue.schemas.synthetic import SyntheticCorpus
 from polylogue.schemas.synthetic.models import SyntheticArtifactFacts
 from polylogue.storage.archive_readiness import raw_materialization_readiness_snapshot, raw_materialization_ready
 from polylogue.storage.raw_reconciler import inspect_raw_authority_frontier
+from tests.infra.source_builders import SyntheticAntigravityLanguageServerClient
 
 _ARTIFACT_PROTOCOL_VERSION = 1
 _CACHE_ROOT = Path("/realm/tmp/polylogue-seeded-artifacts")
@@ -434,13 +436,18 @@ def build_seeded_archive(
                 SyntheticCorpus.write_spec_artifacts(spec, corpus_root / spec.provider, prefix=f"seed-{index:02d}")
                 for index, spec in enumerate(selected_specs)
             )
-            sources = [
-                Source(name=spec.provider, path=path)
-                for spec, written in zip(selected_specs, written_batches, strict=True)
-                for path in written.files
-            ]
+            sources = []
+            for spec, written in zip(selected_specs, written_batches, strict=True):
+                if spec.provider == "antigravity":
+                    sources.append(Source(name=spec.provider, path=written.files[0].parent.parent))
+                else:
+                    sources.extend(Source(name=spec.provider, path=path) for path in written.files)
             with _configured_archive_root(staging):
-                asyncio.run(parse_sources_archive(staging, sources))
+                with patch(
+                    "polylogue.sources.parsers.antigravity.AntigravityLanguageServerClient",
+                    SyntheticAntigravityLanguageServerClient,
+                ):
+                    asyncio.run(parse_sources_archive(staging, sources))
             inspect_raw_authority_frontier(
                 Config(
                     archive_root=staging,


### PR DESCRIPTION
## Summary
Restore provider-shaped synthetic corpus members so generated Antigravity and Codex artifacts enter the archive through their production parser routes.

## Problem
The previous synthetic Antigravity shape wrote metadata sidecars, which the acquisition contract correctly rejects as non-session artifacts. Codex native-ID pinning also mixed direct message records with envelope records, which the Codex parser correctly refuses. Those fixture defects made the pathology corpus unable to prove representative provider ingestion.

## Solution
Generate Antigravity conversations under `conversations/<cascade_id>.pb`, preserve sidecars as non-session evidence, and normalize pinned Codex messages into `response_item` envelopes before adding `session_meta`. The pathology zoo discovers files from disk and exercises parse-and-archive ingestion with an Antigravity language-server test boundary.

## Verification
- `POLYLOGUE_PYTEST_WORKERS=1 devtools test ...`: 237 passed in 64.45s
- Pathology-zoo selectors: 6 passed
- Codex native-ID selectors: 5 passed
- `mypy polylogue/schemas/synthetic/build_batch.py`: Success

Ref polylogue-ujitw, polylogue-59qy, polylogue-rrxe4.1.