### PR TITLE
feat(daemon): warm raw-authority verdict cache

### DIFF
--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -25,6 +25,11 @@ from polylogue.core.enums import Provider
 from polylogue.daemon.convergence import ConvergenceStage, StageExecuteReturn, StageExecutionResult
 from polylogue.daemon.convergence_standing_queries import make_standing_query_stage
 from polylogue.logging import get_logger
+from polylogue.operations.raw_authority_verdict_cache import (
+    RawAuthorityVerdictCacheWork,
+    find_raw_authority_verdict_cache_work,
+    warm_raw_authority_verdict_cache,
+)
 from polylogue.sources.origin_specs import artifact_rule_for_path
 from polylogue.storage.insights.session.runtime import session_profile_stale_predicate
 from polylogue.storage.introspection import table_exists as _table_exists
@@ -49,6 +54,7 @@ _DAEMON_EMBED_MAX_MESSAGES = 2_500
 _DAEMON_EMBED_STOP_AFTER_SECONDS = 30
 _DAEMON_EMBED_MAX_ERRORS = 3
 _ARCHIVE_INSIGHT_WRITE_BUSY_TIMEOUT_MS = 120_000
+_DAEMON_RAW_AUTHORITY_CACHE_MAX_COHORTS = 8
 
 
 def _is_transient_sqlite_lock(exc: BaseException) -> bool:
@@ -957,6 +963,75 @@ def make_raw_parse_recovery_stage(db_path: Path) -> ConvergenceStage:
     )
 
 
+def make_raw_authority_verdict_cache_stage(db_path: Path) -> ConvergenceStage:
+    """Warm the content-keyed raw-authority verdict cache in bounded cohorts."""
+
+    def work() -> RawAuthorityVerdictCacheWork | None:
+        return find_raw_authority_verdict_cache_work(db_path.parent)
+
+    def log_skipped_append_cohorts(discovered: RawAuthorityVerdictCacheWork) -> None:
+        if discovered.skipped_append_cohorts:
+            logger.info(
+                "raw_authority_verdict_cache: skipped append cohorts=%d; append authority uses a separate proof",
+                discovered.skipped_append_cohorts,
+            )
+
+    def check(_path: Path) -> bool:
+        try:
+            discovered = work()
+        except Exception:
+            logger.warning("raw_authority_verdict_cache: readiness probe failed", exc_info=True)
+            return True
+        if discovered is None:
+            return False
+        log_skipped_append_cohorts(discovered)
+        return bool(discovered.pending_logical_source_keys)
+
+    def check_many(paths: Sequence[Path]) -> set[Path]:
+        if not paths:
+            return set()
+        try:
+            discovered = work()
+        except Exception:
+            logger.warning("raw_authority_verdict_cache: batch readiness probe failed", exc_info=True)
+            return set(paths)
+        if discovered is None:
+            return set()
+        log_skipped_append_cohorts(discovered)
+        return set(paths) if discovered.pending_logical_source_keys else set()
+
+    def execute(_path: Path) -> StageExecuteReturn:
+        return execute_many((_path,))
+
+    def execute_many(_paths: Sequence[Path]) -> StageExecuteReturn:
+        try:
+            outcome = warm_raw_authority_verdict_cache(
+                db_path.parent,
+                max_cohorts=_DAEMON_RAW_AUTHORITY_CACHE_MAX_COHORTS,
+                now_ms=int(time.time() * 1000),
+            )
+        except Exception:
+            logger.warning("raw_authority_verdict_cache: bounded warmup failed", exc_info=True)
+            return False
+        logger.info(
+            "raw_authority_verdict_cache: warmed cohorts=%d skipped_append=%d pending=%s",
+            outcome.warmed_cohorts,
+            outcome.skipped_append_cohorts,
+            outcome.pending_cohorts,
+        )
+        return not outcome.pending_cohorts
+
+    return ConvergenceStage(
+        name="raw_authority_verdict_cache",
+        description="Warm content-keyed raw-authority verdicts for full/unknown cohorts",
+        check=check,
+        execute=execute,
+        check_many=check_many,
+        execute_many=execute_many,
+        false_means_pending=True,
+    )
+
+
 def make_default_convergence_stages(
     db_path: Path,
     *,
@@ -988,6 +1063,7 @@ def make_default_convergence_stages(
     stages.extend(
         (
             make_raw_parse_recovery_stage(db_path),
+            make_raw_authority_verdict_cache_stage(db_path),
             make_fts_stage(db_path),
             make_embed_stage(db_path, defer=embed_defer),
             make_claude_workflow_stage(db_path),
@@ -2238,6 +2314,7 @@ __all__ = [
     "make_embed_stage",
     "make_fts_stage",
     "make_insights_stage",
+    "make_raw_authority_verdict_cache_stage",
     "make_raw_parse_recovery_stage",
     "make_sinex_publication_stage",
     "make_standing_query_stage",

--- a/polylogue/operations/raw_authority_verdict_cache.py
+++ b/polylogue/operations/raw_authority_verdict_cache.py
@@ -1,0 +1,47 @@
+"""Daemon-facing adapter for raw-authority verdict cache convergence."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from polylogue.storage.raw_authority_verdict_cache import (
+    RawAuthorityVerdictCacheWarmup,
+    RawAuthorityVerdictCacheWork,
+)
+
+
+def find_raw_authority_verdict_cache_work(archive_root: Path) -> RawAuthorityVerdictCacheWork | None:
+    """Inspect source-tier cache readiness without opening writable archive state."""
+    source_db = archive_root / "source.db"
+    if not source_db.exists():
+        return None
+    conn = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True, timeout=5.0)
+    try:
+        from polylogue.storage.introspection import table_exists
+        from polylogue.storage.raw_authority_verdict_cache import find_raw_authority_verdict_cache_work as find_work
+
+        if not table_exists(conn, "raw_sessions") or not table_exists(conn, "raw_authority_verdicts"):
+            return None
+        return find_work(conn, max_cohorts=1)
+    finally:
+        conn.close()
+
+
+def warm_raw_authority_verdict_cache(
+    archive_root: Path, *, max_cohorts: int, now_ms: int
+) -> RawAuthorityVerdictCacheWarmup:
+    """Warm source-tier verdicts through the source-only archive writer."""
+    from polylogue.storage.raw_authority_verdict_cache import warm_raw_authority_verdict_cache as warm_cache
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+    with ArchiveStore.open_source_tier_acquisition(archive_root) as archive:
+        return warm_cache(archive, max_cohorts=max_cohorts, now_ms=now_ms)
+
+
+__all__ = [
+    "RawAuthorityVerdictCacheWarmup",
+    "RawAuthorityVerdictCacheWork",
+    "find_raw_authority_verdict_cache_work",
+    "warm_raw_authority_verdict_cache",
+]

--- a/polylogue/storage/raw_authority_verdict_cache.py
+++ b/polylogue/storage/raw_authority_verdict_cache.py
@@ -18,16 +18,18 @@ cache impossible to observe returning a verdict that disagrees with what
 ``project_raw_authority_verdicts`` would compute right now for the same
 cohort shape.
 
-This module only fills the cache lazily on read
-(:func:`get_or_compute_raw_authority_verdicts`). Wiring a ``DaemonConverger``
-stage to keep it warm proactively ahead of reads is deliberately deferred --
-see polylogue-tw4ar's own notes for why that needs its own careful staging
-rather than landing bundled with the cache table itself.
+The read-through entry point remains available for consumers, while the
+daemon's bounded ``raw_authority_verdict_cache`` stage calls
+:func:`warm_raw_authority_verdict_cache` proactively ahead of reads. Both
+paths share the same content-keyed freshness check, so a warm cohort never
+re-enters the byte-proof projection.
 """
 
 from __future__ import annotations
 
 import hashlib
+import sqlite3
+from dataclasses import dataclass
 
 from polylogue.core.enums import RawAuthorityVerdict
 from polylogue.storage.raw_authority_verdict_projection import (
@@ -36,11 +38,26 @@ from polylogue.storage.raw_authority_verdict_projection import (
 )
 
 
-def _current_cohort_rows(
-    store: RawAuthorityVerdictProjectionHost, logical_source_key: str
+@dataclass(frozen=True, slots=True)
+class RawAuthorityVerdictCacheWork:
+    """Bounded cache-warming work discovered from one source-tier snapshot."""
+
+    pending_logical_source_keys: tuple[str, ...]
+    skipped_append_cohorts: int
+
+
+@dataclass(frozen=True, slots=True)
+class RawAuthorityVerdictCacheWarmup:
+    """Outcome of one bounded proactive cache-warming pass."""
+
+    warmed_cohorts: int
+    skipped_append_cohorts: int
+    pending_cohorts: bool
+
+
+def _current_cohort_rows_from_connection(
+    conn: sqlite3.Connection, logical_source_key: str
 ) -> list[tuple[str, str, str]]:
-    """Return every ``(raw_id, revision_kind, blob_hash_hex)`` row for a cohort."""
-    conn = store._ensure_source_conn()
     rows = conn.execute(
         """
         SELECT raw_id, revision_kind, lower(hex(blob_hash))
@@ -50,6 +67,71 @@ def _current_cohort_rows(
         (logical_source_key,),
     ).fetchall()
     return [(str(row[0]), str(row[1]), str(row[2])) for row in rows]
+
+
+def _read_cached_raw_authority_verdicts_from_connection(
+    conn: sqlite3.Connection, logical_source_key: str
+) -> dict[str, RawAuthorityVerdict] | None:
+    current_rows = _current_cohort_rows_from_connection(conn, logical_source_key)
+    if not current_rows:
+        return None
+    fingerprint = _cohort_fingerprint(current_rows)
+    cached_rows = conn.execute(
+        "SELECT raw_id, verdict, cohort_fingerprint FROM raw_authority_verdicts WHERE logical_source_key = ?",
+        (logical_source_key,),
+    ).fetchall()
+    if not cached_rows or len(cached_rows) != len(current_rows):
+        return None
+
+    verdicts: dict[str, RawAuthorityVerdict] = {}
+    for raw_id, verdict, cached_fingerprint in cached_rows:
+        if bytes(cached_fingerprint) != fingerprint:
+            return None
+        verdicts[str(raw_id)] = RawAuthorityVerdict(str(verdict))
+    return verdicts
+
+
+def find_raw_authority_verdict_cache_work(
+    conn: sqlite3.Connection, *, max_cohorts: int | None = None
+) -> RawAuthorityVerdictCacheWork:
+    """Find stale full/unknown cohorts without reading blob payloads.
+
+    Append cohorts are deliberately excluded because the Phase 2 projection
+    has a different proof shape for contiguous append authority. They are
+    counted so the daemon can report that they were intentionally skipped.
+    ``max_cohorts`` bounds returned work, while the skip count still covers
+    the complete source-tier snapshot.
+    """
+    rows = conn.execute(
+        """
+        SELECT logical_source_key,
+               MAX(CASE WHEN revision_kind = 'append' THEN 1 ELSE 0 END) AS has_append
+        FROM raw_sessions
+        WHERE logical_source_key IS NOT NULL
+          AND logical_source_key != ''
+        GROUP BY logical_source_key
+        ORDER BY logical_source_key
+        """
+    ).fetchall()
+    pending: list[str] = []
+    skipped_append_cohorts = 0
+    for logical_source_key, has_append in rows:
+        key = str(logical_source_key)
+        if bool(has_append):
+            skipped_append_cohorts += 1
+            continue
+        if _read_cached_raw_authority_verdicts_from_connection(conn, key) is not None:
+            continue
+        if max_cohorts is None or len(pending) < max_cohorts:
+            pending.append(key)
+    return RawAuthorityVerdictCacheWork(tuple(pending), skipped_append_cohorts)
+
+
+def _current_cohort_rows(
+    store: RawAuthorityVerdictProjectionHost, logical_source_key: str
+) -> list[tuple[str, str, str]]:
+    """Return every ``(raw_id, revision_kind, blob_hash_hex)`` row for a cohort."""
+    return _current_cohort_rows_from_connection(store._ensure_source_conn(), logical_source_key)
 
 
 def _cohort_fingerprint(rows: list[tuple[str, str, str]]) -> bytes:
@@ -83,25 +165,7 @@ def read_cached_raw_authority_verdicts(
     (or just call :func:`get_or_compute_raw_authority_verdicts`, which does
     exactly that and persists the result).
     """
-    current_rows = _current_cohort_rows(store, logical_source_key)
-    if not current_rows:
-        return None
-    fingerprint = _cohort_fingerprint(current_rows)
-
-    conn = store._ensure_source_conn()
-    cached_rows = conn.execute(
-        "SELECT raw_id, verdict, cohort_fingerprint FROM raw_authority_verdicts WHERE logical_source_key = ?",
-        (logical_source_key,),
-    ).fetchall()
-    if not cached_rows or len(cached_rows) != len(current_rows):
-        return None
-
-    verdicts: dict[str, RawAuthorityVerdict] = {}
-    for raw_id, verdict, cached_fingerprint in cached_rows:
-        if bytes(cached_fingerprint) != fingerprint:
-            return None
-        verdicts[str(raw_id)] = RawAuthorityVerdict(str(verdict))
-    return verdicts
+    return _read_cached_raw_authority_verdicts_from_connection(store._ensure_source_conn(), logical_source_key)
 
 
 def write_raw_authority_verdict_cache(
@@ -165,8 +229,35 @@ def get_or_compute_raw_authority_verdicts(
     return verdicts
 
 
+def warm_raw_authority_verdict_cache(
+    store: RawAuthorityVerdictProjectionHost,
+    *,
+    max_cohorts: int,
+    now_ms: int,
+) -> RawAuthorityVerdictCacheWarmup:
+    """Warm at most ``max_cohorts`` stale eligible cohorts, then report residue."""
+    if max_cohorts <= 0:
+        raise ValueError("max_cohorts must be positive")
+
+    conn = store._ensure_source_conn()
+    work = find_raw_authority_verdict_cache_work(conn, max_cohorts=max_cohorts)
+    for logical_source_key in work.pending_logical_source_keys:
+        get_or_compute_raw_authority_verdicts(store, logical_source_key, now_ms=now_ms)
+
+    remaining = find_raw_authority_verdict_cache_work(conn, max_cohorts=1)
+    return RawAuthorityVerdictCacheWarmup(
+        warmed_cohorts=len(work.pending_logical_source_keys),
+        skipped_append_cohorts=work.skipped_append_cohorts,
+        pending_cohorts=bool(remaining.pending_logical_source_keys),
+    )
+
+
 __all__ = [
+    "RawAuthorityVerdictCacheWarmup",
+    "RawAuthorityVerdictCacheWork",
+    "find_raw_authority_verdict_cache_work",
     "get_or_compute_raw_authority_verdicts",
     "read_cached_raw_authority_verdicts",
+    "warm_raw_authority_verdict_cache",
     "write_raw_authority_verdict_cache",
 ]

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -15,6 +15,7 @@ import pytest
 
 import polylogue.daemon.convergence_stages as stages
 from polylogue.archive.message.roles import Role
+from polylogue.archive.revision_authority import RawRevisionEnvelope, RawRevisionKind
 from polylogue.core.enums import BlockType, Provider
 from polylogue.daemon.convergence import StageExecutionResult
 from polylogue.daemon.convergence_stages import (
@@ -22,6 +23,7 @@ from polylogue.daemon.convergence_stages import (
     make_embed_stage,
     make_fts_stage,
     make_insights_stage,
+    make_raw_authority_verdict_cache_stage,
 )
 from polylogue.scenarios import (
     WorkloadPhaseObservation,
@@ -33,7 +35,8 @@ from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, Pa
 from polylogue.storage.insights.session import storage as session_storage
 from polylogue.storage.insights.session.runtime import SessionInsightCounts
 from polylogue.storage.runtime import SESSION_INSIGHT_MATERIALIZER_VERSION
-from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root, initialize_archive_tier
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
 from polylogue.storage.sqlite.connection import open_connection
@@ -67,6 +70,75 @@ def test_default_convergence_stages_retry_bounded_false_results(tmp_path: Path) 
     assert stages_by_name["fts"].false_means_pending is True
     assert stages_by_name["embed"].false_means_pending is True
     assert stages_by_name["insights"].false_means_pending is True
+
+
+def test_raw_authority_verdict_cache_stage_warms_in_bounded_batches_and_reports_readiness(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        for index in range(stages._DAEMON_RAW_AUTHORITY_CACHE_MAX_COHORTS + 1):
+            raw_id = f"full-{index}"
+            written_id = archive.write_raw_payload(
+                provider=Provider.CODEX,
+                payload=f"payload-{index}".encode(),
+                source_path="session.jsonl",
+                acquired_at_ms=1,
+                raw_id=raw_id,
+            )
+            archive.bind_raw_revision(
+                written_id,
+                RawRevisionEnvelope(f"codex:full-{index}", RawRevisionKind.FULL, f"revision-{raw_id}", 0),
+            )
+        append_id = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=b"append-payload",
+            source_path="session.jsonl",
+            acquired_at_ms=1,
+            raw_id="append-only",
+        )
+        archive.bind_raw_revision(
+            append_id,
+            RawRevisionEnvelope(
+                "codex:append",
+                RawRevisionKind.APPEND,
+                "revision-append",
+                0,
+                predecessor_source_revision="revision-base",
+                predecessor_raw_id="base",
+                baseline_raw_id="base",
+                append_start_offset=0,
+                append_end_offset=1,
+            ),
+        )
+
+    stage = make_raw_authority_verdict_cache_stage(tmp_path / "index.db")
+    assert stage.check_many is not None
+    assert stage.execute_many is not None
+    assert stage.false_means_pending is True
+    path = tmp_path / "source.jsonl"
+    with caplog.at_level("INFO"):
+        assert stage.check(path) is True
+        assert stage.execute_many((path,)) is False
+        assert stage.check(path) is True
+        assert stage.execute_many((path,)) is True
+        assert stage.check(path) is False
+
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        cached_cohorts = {
+            str(row[0]) for row in conn.execute("SELECT DISTINCT logical_source_key FROM raw_authority_verdicts")
+        }
+    assert len(cached_cohorts) == stages._DAEMON_RAW_AUTHORITY_CACHE_MAX_COHORTS + 1
+    assert "codex:append" not in cached_cohorts
+    assert "skipped append cohorts=1" in caplog.text
+
+    import polylogue.storage.raw_authority_verdict_cache as cache_module
+
+    def _fail_projection(*args: object, **kwargs: object) -> dict[str, object]:
+        raise AssertionError("warm cache was recomputed")
+
+    monkeypatch.setattr(cache_module, "project_raw_authority_verdicts", _fail_projection)
+    assert stage.execute_many((path,)) is True
 
 
 def test_sinex_stage_uses_configured_source_tier_not_active_index_parent(
@@ -1153,6 +1225,7 @@ def test_default_convergence_stages_always_register_embed_stage(
 
     assert stage_names == [
         "raw_parse_recovery",
+        "raw_authority_verdict_cache",
         "fts",
         "embed",
         "claude_workflow",

--- a/tests/unit/storage/test_blob_gc_raw_authority_verdict_invariant.py
+++ b/tests/unit/storage/test_blob_gc_raw_authority_verdict_invariant.py
@@ -20,7 +20,7 @@ row would project to.
 
 Anti-vacuity: every scenario binds real cohorts through the production writer
 (``ArchiveStore.write_raw_payload`` / ``bind_raw_revision``), projects real
-verdicts via ``project_raw_authority_verdicts`` (the same Phase 2 machinery
+verdicts via ``get_or_compute_raw_authority_verdicts`` (the same Phase 2 machinery
 ``tests/unit/storage/test_raw_authority_verdict_projection.py`` exercises),
 and then runs the real ``run_blob_gc_report`` against the resulting
 ``source.db`` + on-disk blob store -- not a mock reference check.
@@ -40,7 +40,7 @@ from polylogue.archive.revision_authority import (
 )
 from polylogue.core.enums import Provider, RawAuthorityVerdict
 from polylogue.storage.blob_gc import run_blob_gc_report
-from polylogue.storage.raw_authority_verdict_projection import project_raw_authority_verdicts
+from polylogue.storage.raw_authority_verdict_cache import get_or_compute_raw_authority_verdicts
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
 
@@ -106,10 +106,10 @@ def test_blob_gc_protects_every_verdict_value_while_the_raw_row_survives(tmp_pat
         )
 
         verdicts = {
-            **project_raw_authority_verdicts(archive, "codex:chain"),
-            **project_raw_authority_verdicts(archive, "codex:fork"),
-            **project_raw_authority_verdicts(archive, "codex:solo"),
-            **project_raw_authority_verdicts(archive, "codex:pending"),
+            **get_or_compute_raw_authority_verdicts(archive, "codex:chain", now_ms=1000),
+            **get_or_compute_raw_authority_verdicts(archive, "codex:fork", now_ms=1000),
+            **get_or_compute_raw_authority_verdicts(archive, "codex:solo", now_ms=1000),
+            **get_or_compute_raw_authority_verdicts(archive, "codex:pending", now_ms=1000),
         }
 
         source_db_path = archive.source_db_path
@@ -158,7 +158,7 @@ def test_blob_gc_reclaims_only_after_the_verdict_owning_row_is_actually_gone(tmp
         _bind_full(archive, raw_id="chain-old", payload=b"one\n", logical_source_key="codex:chain")
         _bind_full(archive, raw_id="chain-new", payload=b"one\ntwo\n", logical_source_key="codex:chain")
 
-        verdicts = project_raw_authority_verdicts(archive, "codex:chain")
+        verdicts = get_or_compute_raw_authority_verdicts(archive, "codex:chain", now_ms=1000)
         assert verdicts["chain-old"] is RawAuthorityVerdict.SUPERSEDED
 
         source_db_path = archive.source_db_path

--- a/tests/unit/storage/test_raw_authority_verdict_cache.py
+++ b/tests/unit/storage/test_raw_authority_verdict_cache.py
@@ -14,12 +14,14 @@ from pathlib import Path
 
 import pytest
 
-from polylogue.archive.revision_authority import RawRevisionEnvelope, RawRevisionKind
+from polylogue.archive.revision_authority import RawRevisionAuthority, RawRevisionEnvelope, RawRevisionKind
 from polylogue.core.enums import Provider, RawAuthorityVerdict
 from polylogue.storage import raw_authority_verdict_cache as cache_module
 from polylogue.storage.raw_authority_verdict_cache import (
+    find_raw_authority_verdict_cache_work,
     get_or_compute_raw_authority_verdicts,
     read_cached_raw_authority_verdicts,
+    warm_raw_authority_verdict_cache,
     write_raw_authority_verdict_cache,
 )
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -138,3 +140,77 @@ def test_missing_cohort_returns_no_verdicts_and_no_cache_write(tmp_path: Path) -
 
     assert verdicts == {}
     assert rows[0][0] == 0
+
+
+def test_warmup_is_bounded_and_skips_append_cohorts(tmp_path: Path) -> None:
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        for index in range(2):
+            _bind_full(
+                archive,
+                raw_id=f"full-{index}",
+                payload=f"payload-{index}".encode(),
+                logical_source_key=f"codex:full-{index}",
+            )
+        append_id = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=b"append-payload",
+            source_path="session.jsonl",
+            acquired_at_ms=1,
+            raw_id="append-only",
+        )
+        archive.bind_raw_revision(
+            append_id,
+            RawRevisionEnvelope(
+                "codex:append",
+                RawRevisionKind.APPEND,
+                "revision-append",
+                0,
+                predecessor_source_revision="revision-base",
+                predecessor_raw_id="base",
+                baseline_raw_id="base",
+                append_start_offset=0,
+                append_end_offset=1,
+                authority=RawRevisionAuthority.ASSERTED,
+            ),
+        )
+
+        work = find_raw_authority_verdict_cache_work(archive._ensure_source_conn(), max_cohorts=1)
+        assert work.pending_logical_source_keys == ("codex:full-0",)
+        assert work.skipped_append_cohorts == 1
+
+        first = warm_raw_authority_verdict_cache(archive, max_cohorts=1, now_ms=1000)
+        assert first.warmed_cohorts == 1
+        assert first.pending_cohorts is True
+        assert first.skipped_append_cohorts == 1
+
+        second = warm_raw_authority_verdict_cache(archive, max_cohorts=1, now_ms=2000)
+        assert second.warmed_cohorts == 1
+        assert second.pending_cohorts is False
+        assert second.skipped_append_cohorts == 1
+
+        cached_keys = {
+            str(row[0])
+            for row in archive._ensure_source_conn()
+            .execute("SELECT logical_source_key FROM raw_authority_verdicts")
+            .fetchall()
+        }
+
+    assert cached_keys == {"codex:full-0", "codex:full-1"}
+
+
+def test_warmup_does_not_recompute_fresh_cohorts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        _bind_full(archive, raw_id="only", payload=b"payload", logical_source_key="codex:s1")
+        warm_raw_authority_verdict_cache(archive, max_cohorts=1, now_ms=1000)
+
+        def _fail(*args: object, **kwargs: object) -> dict[str, RawAuthorityVerdict]:
+            raise AssertionError("a fresh cohort must not invoke the projection")
+
+        monkeypatch.setattr(cache_module, "project_raw_authority_verdicts", _fail)
+
+        outcome = warm_raw_authority_verdict_cache(archive, max_cohorts=1, now_ms=2000)
+
+    assert outcome.warmed_cohorts == 0
+    assert outcome.pending_cohorts is False


### PR DESCRIPTION
## Summary
Add a bounded daemon convergence stage that proactively warms content-keyed raw-authority verdicts before blob-GC consumers need them.

## Problem
Raw-authority verification was only read-through. A GC or reconciliation pass could therefore trigger repeated expensive cohort projection at the point where source-tier authority is already load-bearing.

## Solution
Add a source-tier operations adapter and a default convergence stage that discovers at most eight stale full or unknown cohorts per pass. Cache freshness remains content-fingerprint based, append cohorts remain explicitly excluded for their separate proof path, and the blob-GC invariant now consumes the cache-backed route.

## Verification
- Focused cache, convergence, and blob-GC selectors: 58 passed in 18.76s
- `POLYLOGUE_PYTEST_WORKERS=1 devtools verify --quick`: passed
- `git diff --check`: clean

Ref polylogue-tw4ar and polylogue-ds4b4.