### PR TITLE
fix(sources): preserve Codex append replay authority

### DIFF
--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -13,7 +13,6 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from hashlib import sha256
 from io import BytesIO
-from itertools import islice
 from json import dumps as json_dumps
 from json import loads as json_loads
 from pathlib import Path
@@ -2147,16 +2146,9 @@ class LiveBatchProcessor:
                     fallback_id = Path(record.source_path).stem
                     blob_hash = record.blob_hash or record.raw_id
                     acquired_at_ms = _iso_to_epoch_ms(record.acquired_at)
-                    artifact_sample: list[object] = []
-                    if payload is not None and Path(record.source_path).suffix.lower() in {".jsonl", ".ndjson"}:
-                        try:
-                            artifact_sample = list(islice(_iter_json_stream(BytesIO(payload), source_name), 64))
-                        except Exception:
-                            artifact_sample = []
                     artifact_classification = _declared_non_session_artifact_classification(
                         provider,
                         record.source_path,
-                        sample=artifact_sample,
                     )
                     if artifact_classification is not None:
                         explicit_raw_id = record.raw_id if record.blob_hash is not None else None

--- a/polylogue/sources/parsers/codex.py
+++ b/polylogue/sources/parsers/codex.py
@@ -2301,7 +2301,10 @@ def is_supported_session_stream(payload: Sequence[object]) -> bool:
             return False
         record_type = _record_type(record)
         if record_type in supported_envelope_types:
-            has_envelope_record = True
+            # ``session_meta`` is the shared header for both the envelope
+            # stream and the legacy direct-message stream. It must not make a
+            # valid header-plus-direct stream look like mixed generations.
+            has_envelope_record = has_envelope_record or record_type != "session_meta"
             if not _is_envelope(record):
                 return False
             session_meta = _session_meta_record(record)
@@ -2328,11 +2331,10 @@ def is_supported_session_stream(payload: Sequence[object]) -> bool:
         # The parser supports these wire formats independently, but their
         # records cannot be combined into one trustworthy session stream.
         return False
-    # The legacy direct-message format has no session header. Its parser uses
-    # the acquisition fallback id, so a complete stream of direct records is
-    # still materializable. Header-bearing streams must prove their header;
-    # this keeps bare or truncated envelope prefixes ineligible.
-    return has_session_header or (has_direct_record and not has_envelope_record)
+    # Legacy direct-message streams and headerless envelope append deltas use
+    # the acquisition fallback id. A bare header remains ineligible because
+    # ``has_message`` is false above.
+    return has_session_header or has_direct_record or has_envelope_record
 
 
 def _parse_records(records: Iterable[object], fallback_id: str) -> ParsedSession:

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -21,7 +21,7 @@ from types import TracebackType
 from typing import BinaryIO, Final, Literal, cast
 
 from polylogue import logging as _polylogue_logging
-from polylogue.archive.artifact_taxonomy.models import ArtifactClassification
+from polylogue.archive.artifact_taxonomy.models import ArtifactClassification, ArtifactKind
 from polylogue.archive.ingest_flags import (
     COMPACT_BROWSER_CAPTURE_INGEST_FLAG,
     DOM_FALLBACK_INGEST_FLAG,
@@ -2516,6 +2516,16 @@ def _declared_non_session_artifact_classification(
     # same decoded-JSON shape ijson/json.loads ever produce, so the cast is
     # a type-identity bridge, not a real behavior narrowing.
     classification = classify_artifact(cast(list[JSONValue], list(sample)), provider=provider, source_path=source_path)
+    # ``UNKNOWN`` means the taxonomy cannot decide, not that the payload is
+    # a proved sidecar.  Codex append deltas intentionally omit the
+    # session_meta header and become materializable only after the live
+    # revision layer supplies its recorded native-id hint.  Treating that
+    # undecided partial stream as an artifact skips revision binding and
+    # silently loses its append frontier.  Keep the raw evidence on the
+    # normal parser path, which either uses the hint or records a typed parse
+    # failure; only a positive non-session cohort may bypass session parsing.
+    if classification.kind is ArtifactKind.UNKNOWN:
+        return None
     return classification if not classification.parse_as_session else None
 
 

--- a/tests/unit/pipeline/test_resilience.py
+++ b/tests/unit/pipeline/test_resilience.py
@@ -918,6 +918,28 @@ def test_ingest_record_streams_detected_codex_jsonl_without_full_envelope_decode
     assert result.sessions[0].parsed_session.source_name == "codex"
 
 
+def test_ingest_record_streams_headerless_codex_append_with_fallback_identity(tmp_path: Path) -> None:
+    from polylogue.pipeline.services.ingest_worker import ingest_record
+
+    content = (
+        b'{"type":"response_item","payload":{"type":"message","role":"user",'
+        b'"content":[{"type":"input_text","text":"append delta"}]}}\n'
+    )
+    record = _make_raw_record("codex-append", "unknown", content, "/exports/rollout-append.jsonl")
+
+    with patch(
+        "polylogue.archive.raw_payload.build_raw_payload_envelope",
+        side_effect=AssertionError("headerless Codex append must use stream parsing"),
+    ):
+        result = ingest_record(record, str(tmp_path / "archive"), "advisory")
+
+    assert result.error is None
+    assert len(result.sessions) == 1
+    parsed = result.sessions[0].parsed_session
+    assert parsed.source_name == "codex"
+    assert parsed.provider_session_id == "rollout-append"
+
+
 def test_ingest_record_stream_plan_trusts_known_provider(tmp_path: Path) -> None:
     from polylogue.pipeline.services.ingest_worker import ingest_record
 

--- a/tests/unit/sources/test_artifact_taxonomy.py
+++ b/tests/unit/sources/test_artifact_taxonomy.py
@@ -476,6 +476,25 @@ def test_chatgpt_codex_cloud_task_classifies_as_session_document() -> None:
     assert artifact.parse_as_session is True
 
 
+def test_headerless_codex_append_delta_is_a_session_record_stream() -> None:
+    records: list[JSONValue] = [
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "append delta"}],
+            },
+        }
+    ]
+
+    artifact = classify_artifact(records, provider="codex", source_path="/exports/rollout.jsonl")
+
+    assert artifact.kind is ArtifactKind.SESSION_RECORD_STREAM
+    assert artifact.parse_as_session is True
+    assert artifact.schema_eligible is True
+
+
 def test_chatgpt_library_files_entry_is_not_a_session() -> None:
     entry: JSONValue = {"file_id": "file_abc", "file_name": "notes.md", "mime_type": "text/markdown"}
 

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -170,7 +170,7 @@ def _seed_live_append_plan(
     path = root / f"{native_id}.jsonl"
     baseline = (
         f'{{"type":"session_meta","payload":{{"id":"{native_id}",'
-        '"timestamp":"2026-06-02T00:00:00Z"}}}\n'
+        '"timestamp":"2026-06-02T00:00:00Z"}}\n'
         '{"type":"response_item","payload":{"type":"message","id":"message-0",'
         '"role":"user","content":[{"type":"input_text","text":"zero"}]}}\n'
     ).encode()
@@ -4055,7 +4055,11 @@ def test_full_archive_lock_propagates_for_watcher_retry(
     root = tmp_path / "sessions"
     root.mkdir()
     source = root / "full-locked.jsonl"
-    source.write_bytes(b'{"type":"session_meta","payload":{"id":"full-locked"}}\n')
+    source.write_bytes(
+        b'{"type":"session_meta","payload":{"id":"full-locked"}}\n'
+        b'{"type":"response_item","payload":{"type":"message","id":"message-0",'
+        b'"role":"user","content":[{"type":"input_text","text":"zero"}]}}\n'
+    )
     index_db = tmp_path / "index.db"
     processor = LiveBatchProcessor(
         cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=index_db))),

--- a/tests/unit/sources/test_parsers_codex.py
+++ b/tests/unit/sources/test_parsers_codex.py
@@ -83,6 +83,26 @@ class TestLooksLike:
 
 
 class TestSessionStreamContract:
+    def test_headerless_envelope_append_delta_uses_fallback_identity(self) -> None:
+        from polylogue.sources.dispatch import parse_stream_payload
+
+        payload = [
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "append delta"}],
+                },
+            }
+        ]
+
+        assert is_supported_session_stream(payload)
+        sessions = parse_stream_payload("codex", iter(payload), "rollout-fallback", source_path="/tmp/append.jsonl")
+
+        assert [session.provider_session_id for session in sessions] == ["rollout-fallback"]
+        assert len(sessions[0].messages) == 1
+
     def test_real_wire_stream_parses_and_passes_materialization_evidence_gate(self) -> None:
         from polylogue.sources.dispatch import parse_stream_payload, require_positive_conversational_evidence
 
@@ -106,6 +126,26 @@ class TestSessionStreamContract:
             require_positive_conversational_evidence(sessions, provider="codex", source_path="/tmp/real-stream.jsonl")
             == sessions
         )
+
+    def test_session_header_plus_direct_messages_is_admitted_and_parsed(self) -> None:
+        from polylogue.sources.dispatch import parse_stream_payload
+
+        payload = [
+            {"type": "session_meta", "payload": {"id": "legacy-stream"}},
+            {
+                "type": "message",
+                "id": "legacy-user",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "header plus direct"}],
+            },
+        ]
+
+        assert is_supported_session_stream(payload)
+        sessions = parse_stream_payload("codex", iter(payload), "fallback", source_path="/tmp/header-direct.jsonl")
+
+        assert [session.provider_session_id for session in sessions] == ["legacy-stream"]
+        assert len(sessions[0].messages) == 1
+        assert sessions[0].messages[0].provider_message_id == "legacy-user"
 
     def test_legacy_direct_stream_uses_fallback_identity_and_passes_contract(self) -> None:
         from polylogue.sources.dispatch import parse_stream_payload, require_positive_conversational_evidence

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -248,6 +248,32 @@ def test_parse_stream_refuses_non_conversational_content_with_no_path_rule(tmp_p
     assert sessions == []
 
 
+def test_parse_stream_keeps_unheadered_codex_append_for_hint_materialization(tmp_path: Path) -> None:
+    """A Codex append delta is undecided by taxonomy, not a proved artifact.
+
+    The live revision path provides the archived session identity as the
+    fallback, so this real append envelope must reach the parser.  Returning
+    ``[]`` here causes live admission to classify the range as a sidecar and
+    drops byte-authoritative revisions before they can update the session.
+    """
+    source_path = tmp_path / "sessions" / "append.jsonl"
+    payload = BytesIO(
+        b'{"type":"response_item","payload":{"type":"message","id":"message-1",'
+        b'"role":"assistant","content":[{"type":"output_text","text":"one"}]}}\n'
+    )
+
+    sessions = revision_backfill._parse_stream(
+        Provider.CODEX,
+        payload,
+        str(source_path),
+        fallback_id_override="append-owner",
+    )
+
+    assert len(sessions) == 1
+    assert sessions[0].provider_session_id == "append-owner"
+    assert [message.text for message in sessions[0].messages] == ["one"]
+
+
 def test_parse_one_still_replays_real_claude_code_sessions_with_no_path_rule(tmp_path: Path) -> None:
     """Guard against the regression-direction failure mode: the content gate
     added for polylogue-9ykn must not start refusing genuine Claude Code


### PR DESCRIPTION
## Summary
Preserve Codex append-session authority from artifact classification through production stream ingest, including valid legacy header-plus-direct-message streams.

## Problem
Codex append deltas and valid header-plus-direct streams could be classified as non-session or rejected as mixed record generations. The archive then missed representative workload sessions and treated replay input as unknown rather than materializable source evidence.

## Solution
Treat `session_meta` as a shared header rather than an envelope-generation discriminator, admit headerless envelope append deltas with the acquisition fallback identity, and preserve Codex append replay authority across the live batch path.

## Verification
- Combined source-route proof: 230 passed in 152.71s
- Focused parser, ingest, strict malformed-stream, and artifact selectors: 11 passed
- Sidecar refusal selectors: 5 passed
- `git diff --check`: clean

Ref polylogue-1fijp and polylogue-dyica.