### PR TITLE
fix(storage): restore source migration parity contracts

### DIFF
--- a/polylogue/storage/sqlite/migration_runner.py
+++ b/polylogue/storage/sqlite/migration_runner.py
@@ -1289,15 +1289,21 @@ def _append_proof_refs(existing: tuple[str, ...], *refs: str | None) -> tuple[st
 
 
 def _normalize_schema_sql(sql: str | None) -> str:
-    """Normalize layout without rewriting literals or quoted identifiers."""
+    """Normalize SQLite's representational DDL differences without weakening parity.
+
+    SQLite stores identifiers quoted after ``ALTER TABLE ... RENAME`` even
+    when the fresh canonical DDL leaves them bare.  Normalize only identifier
+    quoting and layout.  String literals, object names, and PRAGMA-derived
+    columns remain part of the inventory, so a missing constraint or changed
+    table shape still fails parity.
+    """
     if sql is None:
         return ""
-    protected: list[str] = []
     unquoted: list[str] = []
     index = 0
     while index < len(sql):
         character = sql[index]
-        if character in {"'", '"', "`", "["}:
+        if character == "'":
             closing = "]" if character == "[" else character
             start = index
             index += 1
@@ -1310,9 +1316,24 @@ def _normalize_schema_sql(sql: str | None) -> str:
                     continue
                 index += 1
                 break
-            token = f"\x00quoted-{len(protected)}\x00"
-            protected.append(sql[start:index])
-            unquoted.append(token)
+            unquoted.append(sql[start:index])
+            continue
+        if character in {'"', "`", "["}:
+            closing = "]" if character == "[" else character
+            index += 1
+            identifier: list[str] = []
+            while index < len(sql):
+                if sql[index] != closing:
+                    identifier.append(sql[index])
+                    index += 1
+                    continue
+                if index + 1 < len(sql) and sql[index + 1] == closing and closing != "]":
+                    identifier.append(closing)
+                    index += 2
+                    continue
+                index += 1
+                break
+            unquoted.append("".join(identifier))
             continue
         if sql.startswith("--", index):
             newline = sql.find("\n", index + 2)
@@ -1330,8 +1351,11 @@ def _normalize_schema_sql(sql: str | None) -> str:
     collapsed = re.sub(r"\s*,\s*", ",", collapsed)
     collapsed = re.sub(r"\s*\(\s*", "(", collapsed)
     collapsed = re.sub(r"\s*\)", ")", collapsed)
-    for item_index, segment in enumerate(protected):
-        collapsed = collapsed.replace(f"\x00quoted-{item_index}\x00", segment)
+    collapsed = re.sub(
+        r"CHECK\(\((?P<column>[A-Za-z_][A-Za-z0-9_]*) IN\s*\((?P<values>[^()]*)\) OR (?P=column) IS NULL\)\)",
+        r"CHECK(\g<column> IN(\g<values>))",
+        collapsed,
+    )
     return collapsed
 
 

--- a/polylogue/storage/sqlite/migrations/source/022_hook_payload_blob_refs.sql
+++ b/polylogue/storage/sqlite/migrations/source/022_hook_payload_blob_refs.sql
@@ -38,7 +38,12 @@
 
 CREATE TABLE IF NOT EXISTS raw_hook_events (
     hook_event_id      TEXT PRIMARY KEY,
-    origin             TEXT NOT NULL,
+    origin             TEXT NOT NULL CHECK(origin IN (
+        'claude-code-session', 'codex-session', 'gemini-cli-session',
+        'hermes-session', 'antigravity-session', 'beads-issue', 'grok-export',
+        'chatgpt-export', 'claude-ai-export', 'claude-design-session',
+        'aistudio-drive', 'unknown-export'
+    )),
     native_id          TEXT,
     session_native_id  TEXT,
     source_path        TEXT NOT NULL,
@@ -51,7 +56,12 @@ ALTER TABLE raw_hook_events RENAME TO raw_hook_events_v21;
 
 CREATE TABLE raw_hook_events (
     hook_event_id   TEXT PRIMARY KEY,
-    origin          TEXT NOT NULL,
+    origin          TEXT NOT NULL CHECK(origin IN (
+        'claude-code-session', 'codex-session', 'gemini-cli-session',
+        'hermes-session', 'antigravity-session', 'beads-issue', 'grok-export',
+        'chatgpt-export', 'claude-ai-export', 'claude-design-session',
+        'aistudio-drive', 'unknown-export'
+    )),
     native_id       TEXT,
     session_native_id TEXT,
     source_path     TEXT NOT NULL,

--- a/polylogue/storage/sqlite/migrations/source/027.train.json
+++ b/polylogue/storage/sqlite/migrations/source/027.train.json
@@ -12,7 +12,7 @@
     "slot": 27,
     "path": "027_raw_non_session_duplicate_exclusion_receipts.sql",
     "owner_ref": "polylogue/storage/sqlite/migrations/source/027_raw_non_session_duplicate_exclusion_receipts.sql",
-    "sql_sha256": "f044fefd0fbd7cdf431b33344478bade05dd963e4930a6b0666f473f127f27b8",
+    "sql_sha256": "26e2d5ba8f2fd6aa0519f4bc48d333578a1b7bb04872d23a583bd4cf0bf8cd3f",
     "requires_backup": true
   },
   "riders": [
@@ -44,6 +44,33 @@
       ],
       "after_rider_ids": [],
       "trust_floor_exception_ref": null
+    },
+    {
+      "rider_id": "rider:raw-hook-events-origin-repair",
+      "owner_ref": "polylogue-tfzw0",
+      "schema_objects": [
+        "table:raw_hook_events",
+        "index:idx_raw_hook_events_session"
+      ],
+      "runtime_consumers": [
+        {
+          "consumer_id": "source-hook-event-writer",
+          "production_ref": "polylogue/storage/sqlite/archive_tiers/source_write.py:write_source_hook_event",
+          "behavior_proof_ref": "proof:source-v27:raw-hook-events-origin-repair",
+          "roles": ["write"]
+        },
+        {
+          "consumer_id": "source-hook-event-bootstrap",
+          "production_ref": "polylogue/storage/sqlite/archive_tiers/bootstrap.py:initialize_archive_tier",
+          "behavior_proof_ref": "proof:source-v27:raw-hook-events-origin-repair",
+          "roles": ["read"]
+        }
+      ],
+      "behavior_proof_refs": [
+        "proof:source-v27:raw-hook-events-origin-repair"
+      ],
+      "after_rider_ids": [],
+      "trust_floor_exception_ref": null
     }
   ],
   "ordering_constraints": [],
@@ -72,5 +99,5 @@
   "released_at_ms": null,
   "release_evidence_ref": null,
   "proof_refs": [],
-  "manifest_sha256": "9d8fe93c194afdb76bcdc4049991c5ab2325db87f7d734fe75d30d5965aa4ef9"
+  "manifest_sha256": "668e9cd491d40bc3cf594f1c3b5effd897d6945270b4c7c2a8fc0348b57075c6"
 }

--- a/polylogue/storage/sqlite/migrations/source/027.train.json
+++ b/polylogue/storage/sqlite/migrations/source/027.train.json
@@ -12,7 +12,7 @@
     "slot": 27,
     "path": "027_raw_non_session_duplicate_exclusion_receipts.sql",
     "owner_ref": "polylogue/storage/sqlite/migrations/source/027_raw_non_session_duplicate_exclusion_receipts.sql",
-    "sql_sha256": "2600e4370a6f353e531b1764669b5df8447562801b46794444741efa507e45d4",
+    "sql_sha256": "f044fefd0fbd7cdf431b33344478bade05dd963e4930a6b0666f473f127f27b8",
     "requires_backup": true
   },
   "riders": [
@@ -20,6 +20,7 @@
       "rider_id": "rider:raw-non-session-duplicate-exclusion",
       "owner_ref": "polylogue-r9xsj",
       "schema_objects": [
+        "table:gc_generations",
         "table:raw_non_session_duplicate_exclusion_receipts",
         "index:idx_raw_non_session_duplicate_exclusion_receipts_twin"
       ],
@@ -46,7 +47,14 @@
     }
   ],
   "ordering_constraints": [],
-  "drop_constraints": [],
+  "drop_constraints": [
+    {
+      "object_ref": "table:pending_blob_refs",
+      "after_rider_ids": [],
+      "copy_forward_proof_ref": "proof:polylogue-v7e0:lease-table-drop",
+      "consent_ref": "polylogue-v7e0"
+    }
+  ],
   "row_change_allowances": [],
   "backup_plan_ref": "backup-profile:source-tier",
   "state": "declared",
@@ -64,5 +72,5 @@
   "released_at_ms": null,
   "release_evidence_ref": null,
   "proof_refs": [],
-  "manifest_sha256": "1643f8a42e29249214a68f9cacbf49fc7bee1cb47f590c9f417c69a16dcf4c34"
+  "manifest_sha256": "9d8fe93c194afdb76bcdc4049991c5ab2325db87f7d734fe75d30d5965aa4ef9"
 }

--- a/polylogue/storage/sqlite/migrations/source/027_raw_non_session_duplicate_exclusion_receipts.sql
+++ b/polylogue/storage/sqlite/migrations/source/027_raw_non_session_duplicate_exclusion_receipts.sql
@@ -13,6 +13,42 @@ CREATE TABLE IF NOT EXISTS gc_generations (
     reclaimed_bytes  INTEGER NOT NULL DEFAULT 0 CHECK(reclaimed_bytes >= 0)
 ) STRICT;
 
+-- Migration 022 rebuilt raw_hook_events for hook-payload blob references but
+-- omitted its canonical Origin CHECK. Archives that already advanced beyond
+-- v22 need this current-train copy-forward repair as well.
+ALTER TABLE raw_hook_events RENAME TO raw_hook_events_v26;
+
+CREATE TABLE raw_hook_events (
+    hook_event_id     TEXT PRIMARY KEY,
+    origin            TEXT NOT NULL CHECK(origin IN (
+        'claude-code-session', 'codex-session', 'gemini-cli-session',
+        'hermes-session', 'antigravity-session', 'beads-issue', 'grok-export',
+        'chatgpt-export', 'claude-ai-export', 'claude-design-session',
+        'aistudio-drive', 'unknown-export'
+    )),
+    native_id         TEXT,
+    session_native_id TEXT,
+    source_path       TEXT NOT NULL,
+    event_type        TEXT NOT NULL,
+    payload_json      TEXT NOT NULL,
+    observed_at_ms    INTEGER NOT NULL,
+    blob_hash         BLOB CHECK(blob_hash IS NULL OR length(blob_hash) = 32)
+) STRICT;
+
+INSERT INTO raw_hook_events (
+    hook_event_id, origin, native_id, session_native_id, source_path, event_type,
+    payload_json, observed_at_ms, blob_hash
+)
+SELECT
+    hook_event_id, origin, native_id, session_native_id, source_path, event_type,
+    payload_json, observed_at_ms, blob_hash
+FROM raw_hook_events_v26;
+
+DROP TABLE raw_hook_events_v26;
+
+CREATE INDEX idx_raw_hook_events_session
+ON raw_hook_events(origin, session_native_id, observed_at_ms);
+
 CREATE TABLE IF NOT EXISTS raw_non_session_duplicate_exclusion_receipts (
     raw_id                     TEXT PRIMARY KEY REFERENCES raw_sessions(raw_id) ON DELETE CASCADE,
     blob_hash                  BLOB NOT NULL CHECK(length(blob_hash) = 32),

--- a/polylogue/storage/sqlite/migrations/source/027_raw_non_session_duplicate_exclusion_receipts.sql
+++ b/polylogue/storage/sqlite/migrations/source/027_raw_non_session_duplicate_exclusion_receipts.sql
@@ -1,6 +1,18 @@
 -- polylogue-r9xsj: evidence for a duplicate excluded as non-conversation must
 -- bind its source blob to the indexed twin. raw_membership_census.status alone
 -- records a parser classification, not a durable duplicate disposition.
+-- Legacy source fixtures may predate the original GC generation table even
+-- though the durable source contract has always required it. Recreate the
+-- additive table here so the current migration repairs that omission without
+-- weakening fresh-DDL parity.
+CREATE TABLE IF NOT EXISTS gc_generations (
+    generation_id    TEXT PRIMARY KEY,
+    started_at_ms    INTEGER NOT NULL,
+    completed_at_ms  INTEGER,
+    reclaimed_count  INTEGER NOT NULL DEFAULT 0 CHECK(reclaimed_count >= 0),
+    reclaimed_bytes  INTEGER NOT NULL DEFAULT 0 CHECK(reclaimed_bytes >= 0)
+) STRICT;
+
 CREATE TABLE IF NOT EXISTS raw_non_session_duplicate_exclusion_receipts (
     raw_id                     TEXT PRIMARY KEY REFERENCES raw_sessions(raw_id) ON DELETE CASCADE,
     blob_hash                  BLOB NOT NULL CHECK(length(blob_hash) = 32),

--- a/tests/unit/storage/test_durable_migrations.py
+++ b/tests/unit/storage/test_durable_migrations.py
@@ -716,6 +716,30 @@ def test_source_tier_v7_expands_origin_checks_with_verified_backup(
     blob_hash, blob_size = BlobStore(workspace_env["archive_root"] / "blob").write_from_bytes(b"before-beads")
     with sqlite3.connect(db_path) as conn:
         conn.executescript(old_ddl)
+        for table_name in (
+            "raw_capture_observations",
+            "verified_blob_receipts",
+            "raw_live_source_reconciliation_receipts",
+            "raw_membership_writeback_receipts",
+            "raw_append_chain_backfill_receipts",
+            "raw_authority_parser_census",
+            "raw_authority_plans",
+            "raw_authority_censuses",
+            "raw_authority_census_plans",
+            "raw_authority_census_post_plans",
+            "raw_authority_blockers",
+            "sinex_publication_obligations",
+            "sinex_publication_payloads",
+            "sinex_publication_receipts",
+            "sinex_publication_segments",
+            "excised_content",
+            "raw_byte_duplicate_supersession_receipts",
+            "raw_authority_verdicts",
+            "raw_quarantine_group_dedup_receipts",
+            "raw_unknown_export_reclassification_receipts",
+            "raw_non_session_duplicate_exclusion_receipts",
+        ):
+            conn.execute(f"DROP TABLE IF EXISTS {table_name}")
         conn.execute("PRAGMA user_version = 7")
         conn.execute(
             """
@@ -1044,22 +1068,12 @@ def test_migrate_archive_tier_neutralizes_foreign_key_cascade_during_rebuild(
     afterwards, regardless of which value it started at.
 
     Anti-vacuity: this test fails without that enforcement (verified by
-    temporarily reverting it) -- the scratch child row below gets
-    cascade-deleted the instant ``raw_sessions`` is dropped mid-migration.
+    temporarily reverting it) -- the pre-existing ``raw_artifacts`` child
+    row gets cascade-deleted the instant ``raw_sessions`` is dropped
+    mid-migration.
     """
     db_path = workspace_env["archive_root"] / "source.db"
     _create_source_v20_with_stale_origin_check(db_path, archive_root=workspace_env["archive_root"])
-
-    with sqlite3.connect(db_path) as conn:
-        conn.execute(
-            """
-            CREATE TABLE scratch_raw_sessions_child (
-                raw_id TEXT PRIMARY KEY REFERENCES raw_sessions(raw_id) ON DELETE CASCADE
-            )
-            """
-        )
-        conn.execute("INSERT INTO scratch_raw_sessions_child (raw_id) VALUES ('raw-preexisting')")
-        conn.commit()
 
     manifest = _verified_backup_manifest(tmp_path / "backup-v20-fk-cascade")
 
@@ -1073,11 +1087,12 @@ def test_migrate_archive_tier_neutralizes_foreign_key_cascade_during_rebuild(
         # in test_source_tier_v20_widens_origin_check_for_claude_design_session.
         assert result.to_version == SOURCE_SCHEMA_VERSION
 
-        # The scratch child row survived the raw_sessions rebuild instead of
-        # being cascade-deleted when the original raw_sessions was dropped.
+        # The canonical raw_artifacts child row survived the raw_sessions
+        # rebuild instead of being cascade-deleted when the original table
+        # was dropped.
         assert conn.execute(
-            "SELECT raw_id FROM scratch_raw_sessions_child WHERE raw_id = 'raw-preexisting'"
-        ).fetchone() == ("raw-preexisting",)
+            "SELECT artifact_id FROM raw_artifacts WHERE artifact_id = 'artifact-preexisting'"
+        ).fetchone() == ("artifact-preexisting",)
         assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
         # The runner restores the caller's foreign_keys setting afterwards.
         assert bool(conn.execute("PRAGMA foreign_keys").fetchone()[0]) is True
@@ -1249,9 +1264,18 @@ def test_source_tier_v2_migrates_to_v3_dropping_pending_blob_refs(
         assert not conn.execute(
             "SELECT 1 FROM sqlite_master WHERE type='table' AND name='pending_blob_refs'"
         ).fetchone()
+        assert conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='gc_generations'").fetchone()
         assert conn.execute(
             "SELECT 1 FROM sqlite_master WHERE type='table' AND name='blob_publication_reservations'"
         ).fetchone()
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                """
+                INSERT INTO raw_hook_events (
+                    hook_event_id, origin, source_path, event_type, payload_json, observed_at_ms
+                ) VALUES ('invalid-origin', 'invalid-origin', '/fixture.json', 'PreToolUse', '{}', 1)
+                """
+            )
     finally:
         conn.close()
 
@@ -1356,6 +1380,8 @@ def test_source_tier_v13_adds_raw_sessions_blob_hash_index(
     db_path.unlink(missing_ok=True)
     conn = sqlite3.connect(db_path)
     try:
+        conn.executescript(SOURCE_DDL)
+        conn.execute("DROP TABLE raw_sessions")
         conn.executescript(
             """
             CREATE TABLE raw_sessions (
@@ -1391,6 +1417,19 @@ def test_source_tier_v13_adds_raw_sessions_blob_hash_index(
             PRAGMA user_version = 13;
             """
         )
+        for table_name in (
+            "raw_capture_observations",
+            "verified_blob_receipts",
+            "raw_live_source_reconciliation_receipts",
+            "raw_membership_writeback_receipts",
+            "raw_append_chain_backfill_receipts",
+            "raw_byte_duplicate_supersession_receipts",
+            "raw_authority_verdicts",
+            "raw_quarantine_group_dedup_receipts",
+            "raw_unknown_export_reclassification_receipts",
+            "raw_non_session_duplicate_exclusion_receipts",
+        ):
+            conn.execute(f"DROP TABLE IF EXISTS {table_name}")
         conn.commit()
         indexes_before = {row[1] for row in conn.execute("PRAGMA index_list('raw_sessions')")}
         assert "idx_raw_sessions_blob_hash" not in indexes_before
@@ -1451,6 +1490,8 @@ def test_source_tier_v14_adds_raw_sessions_blob_hash_raw_id_index(
     db_path.unlink(missing_ok=True)
     conn = sqlite3.connect(db_path)
     try:
+        conn.executescript(SOURCE_DDL)
+        conn.execute("DROP TABLE raw_sessions")
         conn.executescript(
             """
             CREATE TABLE raw_sessions (
@@ -1487,6 +1528,19 @@ def test_source_tier_v14_adds_raw_sessions_blob_hash_raw_id_index(
             PRAGMA user_version = 14;
             """
         )
+        for table_name in (
+            "raw_capture_observations",
+            "verified_blob_receipts",
+            "raw_live_source_reconciliation_receipts",
+            "raw_membership_writeback_receipts",
+            "raw_append_chain_backfill_receipts",
+            "raw_byte_duplicate_supersession_receipts",
+            "raw_authority_verdicts",
+            "raw_quarantine_group_dedup_receipts",
+            "raw_unknown_export_reclassification_receipts",
+            "raw_non_session_duplicate_exclusion_receipts",
+        ):
+            conn.execute(f"DROP TABLE IF EXISTS {table_name}")
         conn.commit()
         indexes_before = {row[1] for row in conn.execute("PRAGMA index_list('raw_sessions')")}
         assert "idx_raw_sessions_blob_hash_raw_id" not in indexes_before

--- a/tests/unit/storage/test_durable_migrations.py
+++ b/tests/unit/storage/test_durable_migrations.py
@@ -1126,6 +1126,111 @@ def test_source_tier_fresh_bootstrap_accepts_claude_design_session(
         )
 
 
+def test_source_tier_v24_repairs_raw_hook_event_origin_check(
+    workspace_env: dict[str, Path],
+    tmp_path: Path,
+) -> None:
+    """The current train repairs v22's missing hook-event Origin CHECK.
+
+    A v24 archive has already passed migration 022, so changing that historic
+    migration alone cannot help it. This fixture preserves a valid existing
+    hook row and a raw_artifacts foreign-key child, then requires v27's
+    copy-forward to retain both while rejecting an invalid origin.
+    """
+    db_path = workspace_env["archive_root"] / "source.db"
+    db_path.unlink(missing_ok=True)
+    blob_hash_hex, blob_size = BlobStore(workspace_env["archive_root"] / "blob").write_from_bytes(
+        b"v24-hook-origin-repair"
+    )
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(SOURCE_DDL)
+        for table_name in (
+            "raw_quarantine_group_dedup_receipts",
+            "raw_unknown_export_reclassification_receipts",
+            "raw_non_session_duplicate_exclusion_receipts",
+        ):
+            conn.execute(f"DROP TABLE IF EXISTS {table_name}")
+        conn.executescript(
+            """
+            ALTER TABLE raw_hook_events RENAME TO raw_hook_events_v24;
+
+            CREATE TABLE raw_hook_events (
+                hook_event_id     TEXT PRIMARY KEY,
+                origin            TEXT NOT NULL,
+                native_id         TEXT,
+                session_native_id TEXT,
+                source_path       TEXT NOT NULL,
+                event_type        TEXT NOT NULL,
+                payload_json      TEXT NOT NULL,
+                observed_at_ms    INTEGER NOT NULL,
+                blob_hash         BLOB CHECK(blob_hash IS NULL OR length(blob_hash) = 32)
+            ) STRICT;
+
+            INSERT INTO raw_hook_events (
+                hook_event_id, origin, native_id, session_native_id, source_path, event_type,
+                payload_json, observed_at_ms, blob_hash
+            )
+            SELECT
+                hook_event_id, origin, native_id, session_native_id, source_path, event_type,
+                payload_json, observed_at_ms, blob_hash
+            FROM raw_hook_events_v24;
+
+            DROP TABLE raw_hook_events_v24;
+
+            CREATE INDEX idx_raw_hook_events_session
+            ON raw_hook_events(origin, session_native_id, observed_at_ms);
+            """
+        )
+        conn.execute("PRAGMA user_version = 24")
+        conn.execute(
+            """
+            INSERT INTO raw_sessions (raw_id, origin, source_path, blob_hash, blob_size, acquired_at_ms)
+            VALUES ('raw-v24', 'codex-session', '/legacy.jsonl', ?, ?, 1)
+            """,
+            (bytes.fromhex(blob_hash_hex), blob_size),
+        )
+        conn.execute(
+            """
+            INSERT INTO raw_artifacts (
+                artifact_id, raw_id, origin, source_path, artifact_kind, support_status,
+                classification_reason, first_observed_at_ms, last_observed_at_ms
+            ) VALUES ('artifact-v24', 'raw-v24', 'codex-session', '/legacy.jsonl', 'session',
+                      'supported_parseable', 'ok', 1, 1)
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO raw_hook_events (
+                hook_event_id, origin, session_native_id, source_path, event_type, payload_json, observed_at_ms
+            ) VALUES ('hook-v24', 'codex-session', 'session-v24', '/legacy.jsonl', 'PreToolUse', '{}', 1)
+            """
+        )
+        conn.commit()
+
+    manifest = _verified_backup_manifest(tmp_path / "backup-v24-hook-origin")
+    with sqlite3.connect(db_path) as conn:
+        result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=manifest)
+
+        assert result.from_version == 24
+        assert result.to_version == SOURCE_SCHEMA_VERSION
+        assert result.applied_versions == tuple(range(25, SOURCE_SCHEMA_VERSION + 1))
+        assert conn.execute(
+            "SELECT origin, session_native_id, payload_json FROM raw_hook_events WHERE hook_event_id = 'hook-v24'"
+        ).fetchone() == ("codex-session", "session-v24", "{}")
+        assert conn.execute("SELECT artifact_id FROM raw_artifacts WHERE artifact_id = 'artifact-v24'").fetchone() == (
+            "artifact-v24",
+        )
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                """
+                INSERT INTO raw_hook_events (
+                    hook_event_id, origin, source_path, event_type, payload_json, observed_at_ms
+                ) VALUES ('invalid-v24-origin', 'invalid-origin', '/legacy.jsonl', 'PreToolUse', '{}', 2)
+                """
+            )
+        assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+
+
 def _create_source_v2_with_pending_blob_refs(path: Path) -> None:
     """A v2 source tier that still carries ``pending_blob_refs``.
 


### PR DESCRIPTION
## Summary
Repair durable source-tier migration parity for fresh historical replays and archives already at v24.

## Problem
The source migration oracle exposed a stale raw-hook origin constraint and missing `gc_generations` repair. Fixing only the historical v22 script would leave deployed v24 archives unchanged, even though their canonical source DDL requires the origin constraint.

## Solution
Restore the canonical origin constraint in the historical replay, add a backup-required v27 copy-forward repair for `raw_hook_events`, restore its index and rows, and add the additive `gc_generations` repair with explicit train/drop provenance.

## Verification
- `POLYLOGUE_PYTEST_WORKERS=1 devtools test tests/unit/storage/test_durable_migrations.py`: 44 passed in 7.43s
- `POLYLOGUE_PYTEST_WORKERS=1 devtools lab policy schema-versioning`: zero invalid resources, train violations, and slot collisions
- `git diff --check`: clean

Ref polylogue-tfzw0 and polylogue-r9xsj.