### PR TITLE
fix(verification): persist origin-scoped ground-truth provenance

### DIFF
--- a/polylogue/maintenance/schema_inference_gate.py
+++ b/polylogue/maintenance/schema_inference_gate.py
@@ -39,6 +39,14 @@ _ALLOWED_RESIDUAL_EXPLANATIONS = frozenset(
     {"materialized", "superseded-duplicate", "legitimately-excluded-non-conversation"}
 )
 _CAUSE_EXPLANATIONS = {"byte-revision-governed": "superseded-duplicate"}
+_GROUND_TRUTH_DISPOSITIONS = frozenset(
+    {
+        "materialized",
+        "superseded-duplicate",
+        "legitimately-excluded-non-conversation",
+        "unreconciled-source-raw",
+    }
+)
 
 # Hooks and browser capture are the explicit no-external-ground-truth
 # exceptions from r9xsj. Every other origin present in source.db must receive
@@ -531,20 +539,116 @@ def _file_hash(path: Path) -> tuple[str, int]:
     return hasher.hexdigest(), size
 
 
+def _external_inventory(roots: Sequence[Path]) -> list[dict[str, object]]:
+    """Return a stable, relative-path inventory for declared external roots."""
+
+    inventory: list[dict[str, object]] = []
+    for root_index, root in enumerate(sorted({path.resolve() for path in roots}, key=str)):
+        for path in _iter_ground_truth_files(root):
+            resolved_path = path.resolve()
+            digest, size = _file_hash(resolved_path)
+            relative_path = resolved_path.name if root.is_file() else resolved_path.relative_to(root).as_posix()
+            inventory.append(
+                {
+                    "root_index": root_index,
+                    "relative_path": relative_path,
+                    "hash": digest,
+                    "size": size,
+                    "_path": resolved_path,
+                }
+            )
+    inventory.sort(key=lambda item: (str(item["relative_path"]), int(item["root_index"])))
+    return inventory
+
+
+def _raw_dispositions(
+    source: sqlite3.Connection,
+    *,
+    index_path: Path,
+) -> tuple[dict[str, str], dict[str, dict[str, object]]]:
+    """Classify raw rows using durable receipts and the indexed read model."""
+
+    source_rows = source.execute(
+        """
+        SELECT raw_id, origin, native_id, logical_source_key, source_path,
+               hex(blob_hash), blob_size, revision_authority
+        FROM raw_sessions
+        ORDER BY origin, raw_id
+        """
+    ).fetchall()
+    indexed_raw_ids: set[str] = set()
+    if index_path.exists():
+        with open_readonly_connection(index_path) as index:
+            if table_exists(index, "sessions"):
+                indexed_raw_ids = {
+                    str(row[0]) for row in index.execute("SELECT raw_id FROM sessions WHERE raw_id IS NOT NULL")
+                }
+
+    def receipt_ids(table: str) -> set[str]:
+        return (
+            {str(row[0]) for row in source.execute(f"SELECT raw_id FROM {table}")}
+            if table_exists(source, table)
+            else set()
+        )
+
+    superseded_ids = receipt_ids("raw_byte_duplicate_supersession_receipts")
+    superseded_ids.update(receipt_ids("raw_quarantine_group_dedup_receipts"))
+    excluded_ids = receipt_ids("raw_non_session_duplicate_exclusion_receipts")
+    excluded_ids.update(
+        str(row[0])
+        for row in source.execute("SELECT raw_id FROM raw_membership_census WHERE status = 'non_session'")
+        if str(row[0]) in excluded_ids
+    )
+
+    dispositions: dict[str, str] = {}
+    rows_by_origin: dict[str, list[dict[str, object]]] = {}
+    for row in source_rows:
+        raw_id = str(row[0])
+        if raw_id in indexed_raw_ids:
+            disposition = "materialized"
+        elif raw_id in superseded_ids:
+            disposition = "superseded-duplicate"
+        elif raw_id in excluded_ids:
+            disposition = "legitimately-excluded-non-conversation"
+        else:
+            disposition = "unreconciled-source-raw"
+        assert disposition in _GROUND_TRUTH_DISPOSITIONS
+        dispositions[raw_id] = disposition
+        rows_by_origin.setdefault(str(row[1]), []).append(
+            {
+                "raw_id": raw_id,
+                "origin": str(row[1]),
+                "native_id": row[2],
+                "logical_source_key": row[3],
+                "source_path": str(row[4]),
+                "blob_hash": str(row[5]).lower(),
+                "blob_size": int(row[6]),
+                "revision_authority": str(row[7]),
+                "disposition": disposition,
+            }
+        )
+    return dispositions, rows_by_origin
+
+
 def _ground_truth_evidence(
     archive_root: Path,
     *,
+    index_path: Path,
     source_counts: Mapping[str, Mapping[str, int]],
     roots: Mapping[str, Sequence[Path]] | None,
 ) -> dict[str, object]:
-    """Compare source raw blobs with the files actually present under declared roots."""
+    """Reconcile source raws and external files in both directions by origin."""
 
     root_map = roots or {}
     source_path = archive_root / ARCHIVE_TIER_SPECS[ArchiveTier.SOURCE].filename
     evidence: dict[str, object] = {}
     errors: list[str] = []
     with open_readonly_connection(source_path) as source:
-        for origin in sorted(source_counts):
+        _dispositions, rows_by_origin = _raw_dispositions(source, index_path=index_path)
+        origins = sorted(set(source_counts) | set(root_map))
+        external_claims: dict[Path, set[str]] = {}
+        inventories: dict[str, list[dict[str, object]]] = {}
+        for origin in origins:
             declared = GROUND_TRUTH_INPUTS.get(origin, {"exempt": False})
             if bool(declared.get("exempt")):
                 evidence[origin] = {"exempt": True, "reason": declared.get("reason")}
@@ -560,14 +664,8 @@ def _ground_truth_evidence(
                     "passed": False,
                 }
                 continue
-            files = [path for root in declared_roots for path in _iter_ground_truth_files(root)]
-            hashes: set[str] = set()
-            bytes_total = 0
             try:
-                for path in files:
-                    digest, size = _file_hash(path)
-                    hashes.add(digest)
-                    bytes_total += size
+                inventory = _external_inventory(declared_roots)
             except OSError as exc:
                 errors.append(f"ground truth for {origin} could not be fully scanned: {exc}")
                 evidence[origin] = {
@@ -576,23 +674,143 @@ def _ground_truth_evidence(
                     "passed": False,
                 }
                 continue
-            source_hashes = {
-                bytes(row[0]).hex()
-                for row in source.execute("SELECT DISTINCT blob_hash FROM raw_sessions WHERE origin = ?", (origin,))
-            }
-            missing = sorted(source_hashes - hashes)
-            if missing:
-                errors.append(f"ground truth for {origin} does not verify every source raw blob")
+            inventories[origin] = inventory
+            for item in inventory:
+                external_claims.setdefault(cast(Path, item["_path"]), set()).add(origin)
+
+        for path, claimed_origins in sorted(external_claims.items(), key=lambda item: str(item[0])):
+            if len(claimed_origins) > 1:
+                errors.append(
+                    "external ground-truth file is claimed by multiple origins: "
+                    f"{path.name} ({', '.join(sorted(claimed_origins))})"
+                )
+
+        source_key_origins: dict[tuple[str, int], set[str]] = {}
+        for origin, rows in rows_by_origin.items():
+            for row in rows:
+                source_key_origins.setdefault((str(row["blob_hash"]), int(row["blob_size"])), set()).add(origin)
+
+        for origin in origins:
+            declared = GROUND_TRUTH_INPUTS.get(origin, {"exempt": False})
+            if bool(declared.get("exempt")) or origin not in inventories:
+                continue
+            rows = rows_by_origin.get(origin, [])
+            inventory = inventories[origin]
+            by_key: dict[tuple[str, int], list[dict[str, object]]] = {}
+            for item in inventory:
+                by_key.setdefault((str(item["hash"]), int(item["size"])), []).append(item)
+            provenance: list[dict[str, object]] = []
+            matched_external_paths: set[tuple[int, str]] = set()
+            unmatched_raws: list[dict[str, object]] = []
+            for row in rows:
+                key = (str(row["blob_hash"]), int(row["blob_size"]))
+                matches = by_key.get(key, [])
+                match = matches[0] if matches else None
+                if match is None:
+                    disposition = "unreconciled-source-raw"
+                    unmatched_raws.append(
+                        {
+                            "raw_id": row["raw_id"],
+                            "blob_hash": row["blob_hash"],
+                            "blob_size": row["blob_size"],
+                            "disposition": disposition,
+                        }
+                    )
+                else:
+                    matched_external_paths.add((int(match["root_index"]), str(match["relative_path"])))
+                provenance.append(
+                    {
+                        "raw_id": row["raw_id"],
+                        "origin": row["origin"],
+                        "native_id": row["native_id"],
+                        "logical_source_key": row["logical_source_key"],
+                        "source_path": row["source_path"],
+                        "blob_hash": row["blob_hash"],
+                        "blob_size": row["blob_size"],
+                        "matched_external_relative_path": (str(match["relative_path"]) if match is not None else None),
+                        "matched_external_hash": str(match["hash"]) if match is not None else None,
+                        "matched_external_size": int(match["size"]) if match is not None else None,
+                        "disposition": str(row["disposition"]),
+                    }
+                )
+
+            unmatched_external_files = [
+                {
+                    "root_index": int(item["root_index"]),
+                    "relative_path": str(item["relative_path"]),
+                    "hash": str(item["hash"]),
+                    "size": int(item["size"]),
+                    "disposition": "unmatched-external-file",
+                }
+                for item in inventory
+                if (int(item["root_index"]), str(item["relative_path"])) not in matched_external_paths
+            ]
+            cross_origin_mismatches: list[dict[str, object]] = []
+            for item in unmatched_external_files:
+                other_origins = sorted(source_key_origins.get((str(item["hash"]), int(item["size"])), set()) - {origin})
+                if other_origins:
+                    item["disposition"] = "cross-origin-source"
+                    item["other_origins"] = other_origins
+                    cross_origin_mismatches.append(item)
+            for item in inventory:
+                claimed_origins = external_claims.get(cast(Path, item["_path"]), set()) - {origin}
+                if claimed_origins:
+                    cross_origin_mismatches.append(
+                        {
+                            "root_index": int(item["root_index"]),
+                            "relative_path": str(item["relative_path"]),
+                            "hash": str(item["hash"]),
+                            "size": int(item["size"]),
+                            "disposition": "cross-origin-source",
+                            "other_origins": sorted(claimed_origins),
+                        }
+                    )
+
+            source_keys = {(str(row["blob_hash"]), int(row["blob_size"])) for row in rows}
+            source_distinct_bytes = sum(size for _hash, size in source_keys)
+            external_bytes = sum(int(item["size"]) for item in inventory)
+            count_discrepancy = len(source_keys) != len(inventory)
+            byte_discrepancy = source_distinct_bytes != external_bytes
+            origin_errors: list[str] = []
+            if unmatched_raws:
+                origin_errors.append(f"{len(unmatched_raws)} source raw(s) have no external file match")
+            if unmatched_external_files:
+                origin_errors.append(f"{len(unmatched_external_files)} external file(s) have no source raw match")
+            if count_discrepancy:
+                origin_errors.append(
+                    f"source distinct blob count {len(source_keys)} disagrees with external file count {len(inventory)}"
+                )
+            if byte_discrepancy:
+                origin_errors.append(
+                    f"source distinct blob bytes {source_distinct_bytes} disagrees with external bytes {external_bytes}"
+                )
+            if cross_origin_mismatches:
+                origin_errors.append(f"{len(cross_origin_mismatches)} external file(s) match another origin")
+            if origin_errors:
+                errors.extend(f"ground truth for {origin}: {reason}" for reason in origin_errors)
+            hashes = {str(item["hash"]) for item in inventory}
+            missing = sorted(
+                source_keys_hash for source_keys_hash, _size in source_keys if source_keys_hash not in hashes
+            )
             evidence[origin] = {
                 "exempt": False,
                 "declared_roots": [str(path) for path in declared_roots],
-                "external_files": len(files),
-                "external_bytes": bytes_total,
+                "external_files": len(inventory),
+                "external_bytes": external_bytes,
                 "external_hashes": len(hashes),
-                "source_blob_hashes": len(source_hashes),
+                "source_raw_count": len(rows),
+                "source_raw_bytes": sum(int(row["blob_size"]) for row in rows),
+                "source_blob_hashes": len(source_keys),
+                "source_blob_bytes": source_distinct_bytes,
+                "count_discrepancy": count_discrepancy,
+                "byte_discrepancy": byte_discrepancy,
                 "unverified_source_blob_hashes": len(missing),
                 "unverified_samples": _sample(missing, DEFAULT_SAMPLE_LIMIT),
-                "passed": not missing,
+                "unmatched_source_raws": unmatched_raws[:DEFAULT_SAMPLE_LIMIT],
+                "unmatched_external_files": unmatched_external_files[:DEFAULT_SAMPLE_LIMIT],
+                "cross_origin_mismatches": cross_origin_mismatches[:DEFAULT_SAMPLE_LIMIT],
+                "provenance": provenance,
+                "passed": not origin_errors,
             }
     return {"passed": not errors, "origins": evidence, "reasons": errors}
 
@@ -791,6 +1009,7 @@ def run_schema_inference_gate(
     try:
         ground_truth = _ground_truth_evidence(
             root,
+            index_path=index_path,
             source_counts=cast(Mapping[str, Mapping[str, int]], source_gates.get("source_counts", {})),
             roots=ground_truth_roots,
         )

--- a/polylogue/maintenance/schema_inference_gate.py
+++ b/polylogue/maintenance/schema_inference_gate.py
@@ -19,7 +19,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Literal, NotRequired, TypeAlias, TypedDict, cast
 
 from polylogue.maintenance.archive_verification import CORPUS_FIDELITY_CHECKS, verify_archive
 from polylogue.storage.archive_identity import ArchiveIdentity, ArchiveLocation
@@ -39,14 +39,74 @@ _ALLOWED_RESIDUAL_EXPLANATIONS = frozenset(
     {"materialized", "superseded-duplicate", "legitimately-excluded-non-conversation"}
 )
 _CAUSE_EXPLANATIONS = {"byte-revision-governed": "superseded-duplicate"}
-_GROUND_TRUTH_DISPOSITIONS = frozenset(
-    {
-        "materialized",
-        "superseded-duplicate",
-        "legitimately-excluded-non-conversation",
-        "unreconciled-source-raw",
-    }
-)
+GroundTruthKey: TypeAlias = tuple[str, int]
+GroundTruthDisposition: TypeAlias = Literal[
+    "materialized",
+    "superseded-duplicate",
+    "legitimately-excluded-non-conversation",
+    "unreconciled-source-raw",
+]
+ExternalDisposition: TypeAlias = Literal["unmatched-external-file", "cross-origin-source"]
+
+
+@dataclass(frozen=True, slots=True)
+class _ExternalGroundTruthFile:
+    root_index: int
+    relative_path: str
+    content_hash: str
+    size: int
+    path: Path
+
+    @property
+    def key(self) -> GroundTruthKey:
+        return (self.content_hash, self.size)
+
+
+@dataclass(frozen=True, slots=True)
+class _SourceRawGroundTruth:
+    raw_id: str
+    origin: str
+    native_id: str | None
+    logical_source_key: str | None
+    source_path: str
+    blob_hash: str
+    blob_size: int
+    disposition: GroundTruthDisposition
+
+    @property
+    def key(self) -> GroundTruthKey:
+        return (self.blob_hash, self.blob_size)
+
+
+class _RawGroundTruthProvenance(TypedDict):
+    raw_id: str
+    origin: str
+    native_id: str | None
+    logical_source_key: str | None
+    source_path: str
+    blob_hash: str
+    blob_size: int
+    matched_external_relative_path: str | None
+    matched_external_hash: str | None
+    matched_external_size: int | None
+    disposition: GroundTruthDisposition
+
+
+class _ExternalGroundTruthReceipt(TypedDict):
+    root_index: int
+    relative_path: str
+    hash: str
+    size: int
+    disposition: ExternalDisposition
+    other_origins: NotRequired[list[str]]
+
+
+class _UnmatchedSourceRawReceipt(TypedDict):
+    raw_id: str
+    blob_hash: str
+    blob_size: int
+    disposition: Literal["unreconciled-source-raw"]
+
 
 # Hooks and browser capture are the explicit no-external-ground-truth
 # exceptions from r9xsj. Every other origin present in source.db must receive
@@ -539,39 +599,75 @@ def _file_hash(path: Path) -> tuple[str, int]:
     return hasher.hexdigest(), size
 
 
-def _external_inventory(roots: Sequence[Path]) -> list[dict[str, object]]:
+def _external_inventory(roots: Sequence[Path]) -> list[_ExternalGroundTruthFile]:
     """Return a stable, relative-path inventory for declared external roots."""
 
-    inventory: list[dict[str, object]] = []
+    inventory: list[_ExternalGroundTruthFile] = []
     for root_index, root in enumerate(sorted({path.resolve() for path in roots}, key=str)):
         for path in _iter_ground_truth_files(root):
             resolved_path = path.resolve()
             digest, size = _file_hash(resolved_path)
             relative_path = resolved_path.name if root.is_file() else resolved_path.relative_to(root).as_posix()
             inventory.append(
-                {
-                    "root_index": root_index,
-                    "relative_path": relative_path,
-                    "hash": digest,
-                    "size": size,
-                    "_path": resolved_path,
-                }
+                _ExternalGroundTruthFile(
+                    root_index=root_index,
+                    relative_path=relative_path,
+                    content_hash=digest,
+                    size=size,
+                    path=resolved_path,
+                )
             )
-    inventory.sort(key=lambda item: (str(item["relative_path"]), int(item["root_index"])))
+    inventory.sort(key=lambda item: (item.relative_path, item.root_index))
     return inventory
+
+
+def _external_receipt(
+    item: _ExternalGroundTruthFile,
+    disposition: ExternalDisposition,
+    *,
+    other_origins: list[str] | None = None,
+) -> _ExternalGroundTruthReceipt:
+    receipt: _ExternalGroundTruthReceipt = {
+        "root_index": item.root_index,
+        "relative_path": item.relative_path,
+        "hash": item.content_hash,
+        "size": item.size,
+        "disposition": disposition,
+    }
+    if other_origins:
+        receipt["other_origins"] = other_origins
+    return receipt
+
+
+def _raw_provenance(
+    raw: _SourceRawGroundTruth,
+    matched_external: _ExternalGroundTruthFile | None,
+) -> _RawGroundTruthProvenance:
+    return {
+        "raw_id": raw.raw_id,
+        "origin": raw.origin,
+        "native_id": raw.native_id,
+        "logical_source_key": raw.logical_source_key,
+        "source_path": raw.source_path,
+        "blob_hash": raw.blob_hash,
+        "blob_size": raw.blob_size,
+        "matched_external_relative_path": (matched_external.relative_path if matched_external is not None else None),
+        "matched_external_hash": matched_external.content_hash if matched_external is not None else None,
+        "matched_external_size": matched_external.size if matched_external is not None else None,
+        "disposition": raw.disposition,
+    }
 
 
 def _raw_dispositions(
     source: sqlite3.Connection,
     *,
     index_path: Path,
-) -> tuple[dict[str, str], dict[str, dict[str, object]]]:
+) -> dict[str, list[_SourceRawGroundTruth]]:
     """Classify raw rows using durable receipts and the indexed read model."""
 
     source_rows = source.execute(
         """
-        SELECT raw_id, origin, native_id, logical_source_key, source_path,
-               hex(blob_hash), blob_size, revision_authority
+        SELECT raw_id, origin, native_id, logical_source_key, source_path, hex(blob_hash), blob_size
         FROM raw_sessions
         ORDER BY origin, raw_id
         """
@@ -594,16 +690,11 @@ def _raw_dispositions(
     superseded_ids = receipt_ids("raw_byte_duplicate_supersession_receipts")
     superseded_ids.update(receipt_ids("raw_quarantine_group_dedup_receipts"))
     excluded_ids = receipt_ids("raw_non_session_duplicate_exclusion_receipts")
-    excluded_ids.update(
-        str(row[0])
-        for row in source.execute("SELECT raw_id FROM raw_membership_census WHERE status = 'non_session'")
-        if str(row[0]) in excluded_ids
-    )
 
-    dispositions: dict[str, str] = {}
-    rows_by_origin: dict[str, list[dict[str, object]]] = {}
+    rows_by_origin: dict[str, list[_SourceRawGroundTruth]] = {}
     for row in source_rows:
         raw_id = str(row[0])
+        disposition: GroundTruthDisposition
         if raw_id in indexed_raw_ids:
             disposition = "materialized"
         elif raw_id in superseded_ids:
@@ -612,22 +703,19 @@ def _raw_dispositions(
             disposition = "legitimately-excluded-non-conversation"
         else:
             disposition = "unreconciled-source-raw"
-        assert disposition in _GROUND_TRUTH_DISPOSITIONS
-        dispositions[raw_id] = disposition
         rows_by_origin.setdefault(str(row[1]), []).append(
-            {
-                "raw_id": raw_id,
-                "origin": str(row[1]),
-                "native_id": row[2],
-                "logical_source_key": row[3],
-                "source_path": str(row[4]),
-                "blob_hash": str(row[5]).lower(),
-                "blob_size": int(row[6]),
-                "revision_authority": str(row[7]),
-                "disposition": disposition,
-            }
+            _SourceRawGroundTruth(
+                raw_id=raw_id,
+                origin=str(row[1]),
+                native_id=None if row[2] is None else str(row[2]),
+                logical_source_key=None if row[3] is None else str(row[3]),
+                source_path=str(row[4]),
+                blob_hash=str(row[5]).lower(),
+                blob_size=int(row[6]),
+                disposition=disposition,
+            )
         )
-    return dispositions, rows_by_origin
+    return rows_by_origin
 
 
 def _ground_truth_evidence(
@@ -644,10 +732,11 @@ def _ground_truth_evidence(
     evidence: dict[str, object] = {}
     errors: list[str] = []
     with open_readonly_connection(source_path) as source:
-        _dispositions, rows_by_origin = _raw_dispositions(source, index_path=index_path)
+        rows_by_origin = _raw_dispositions(source, index_path=index_path)
         origins = sorted(set(source_counts) | set(root_map))
         external_claims: dict[Path, set[str]] = {}
-        inventories: dict[str, list[dict[str, object]]] = {}
+        inventories: dict[str, list[_ExternalGroundTruthFile]] = {}
+        declared_roots_by_origin: dict[str, tuple[Path, ...]] = {}
         for origin in origins:
             declared = GROUND_TRUTH_INPUTS.get(origin, {"exempt": False})
             if bool(declared.get("exempt")):
@@ -675,8 +764,9 @@ def _ground_truth_evidence(
                 }
                 continue
             inventories[origin] = inventory
+            declared_roots_by_origin[origin] = declared_roots
             for item in inventory:
-                external_claims.setdefault(cast(Path, item["_path"]), set()).add(origin)
+                external_claims.setdefault(item.path, set()).add(origin)
 
         for path, claimed_origins in sorted(external_claims.items(), key=lambda item: str(item[0])):
             if len(claimed_origins) > 1:
@@ -685,10 +775,10 @@ def _ground_truth_evidence(
                     f"{path.name} ({', '.join(sorted(claimed_origins))})"
                 )
 
-        source_key_origins: dict[tuple[str, int], set[str]] = {}
+        source_key_origins: dict[GroundTruthKey, set[str]] = {}
         for origin, rows in rows_by_origin.items():
             for row in rows:
-                source_key_origins.setdefault((str(row["blob_hash"]), int(row["blob_size"])), set()).add(origin)
+                source_key_origins.setdefault(row.key, set()).add(origin)
 
         for origin in origins:
             declared = GROUND_TRUTH_INPUTS.get(origin, {"exempt": False})
@@ -696,79 +786,52 @@ def _ground_truth_evidence(
                 continue
             rows = rows_by_origin.get(origin, [])
             inventory = inventories[origin]
-            by_key: dict[tuple[str, int], list[dict[str, object]]] = {}
+            declared_roots = declared_roots_by_origin[origin]
+            by_key: dict[GroundTruthKey, list[_ExternalGroundTruthFile]] = {}
             for item in inventory:
-                by_key.setdefault((str(item["hash"]), int(item["size"])), []).append(item)
-            provenance: list[dict[str, object]] = []
+                by_key.setdefault(item.key, []).append(item)
+            provenance: list[_RawGroundTruthProvenance] = []
             matched_external_paths: set[tuple[int, str]] = set()
-            unmatched_raws: list[dict[str, object]] = []
+            unmatched_raws: list[_UnmatchedSourceRawReceipt] = []
             for row in rows:
-                key = (str(row["blob_hash"]), int(row["blob_size"]))
-                matches = by_key.get(key, [])
+                matches = by_key.get(row.key, [])
                 match = matches[0] if matches else None
                 if match is None:
-                    disposition = "unreconciled-source-raw"
                     unmatched_raws.append(
                         {
-                            "raw_id": row["raw_id"],
-                            "blob_hash": row["blob_hash"],
-                            "blob_size": row["blob_size"],
-                            "disposition": disposition,
+                            "raw_id": row.raw_id,
+                            "blob_hash": row.blob_hash,
+                            "blob_size": row.blob_size,
+                            "disposition": "unreconciled-source-raw",
                         }
                     )
                 else:
-                    matched_external_paths.add((int(match["root_index"]), str(match["relative_path"])))
-                provenance.append(
-                    {
-                        "raw_id": row["raw_id"],
-                        "origin": row["origin"],
-                        "native_id": row["native_id"],
-                        "logical_source_key": row["logical_source_key"],
-                        "source_path": row["source_path"],
-                        "blob_hash": row["blob_hash"],
-                        "blob_size": row["blob_size"],
-                        "matched_external_relative_path": (str(match["relative_path"]) if match is not None else None),
-                        "matched_external_hash": str(match["hash"]) if match is not None else None,
-                        "matched_external_size": int(match["size"]) if match is not None else None,
-                        "disposition": str(row["disposition"]),
-                    }
-                )
+                    matched_external_paths.add((match.root_index, match.relative_path))
+                provenance.append(_raw_provenance(row, match))
 
-            unmatched_external_files = [
-                {
-                    "root_index": int(item["root_index"]),
-                    "relative_path": str(item["relative_path"]),
-                    "hash": str(item["hash"]),
-                    "size": int(item["size"]),
-                    "disposition": "unmatched-external-file",
-                }
-                for item in inventory
-                if (int(item["root_index"]), str(item["relative_path"])) not in matched_external_paths
+            unmatched_external = [
+                item for item in inventory if (item.root_index, item.relative_path) not in matched_external_paths
             ]
-            cross_origin_mismatches: list[dict[str, object]] = []
-            for item in unmatched_external_files:
-                other_origins = sorted(source_key_origins.get((str(item["hash"]), int(item["size"])), set()) - {origin})
+            unmatched_external_files: list[_ExternalGroundTruthReceipt] = []
+            cross_origin_mismatches: list[_ExternalGroundTruthReceipt] = []
+            for item in unmatched_external:
+                other_origins = sorted(source_key_origins.get(item.key, set()) - {origin})
                 if other_origins:
-                    item["disposition"] = "cross-origin-source"
-                    item["other_origins"] = other_origins
-                    cross_origin_mismatches.append(item)
+                    receipt = _external_receipt(item, "cross-origin-source", other_origins=other_origins)
+                    unmatched_external_files.append(receipt)
+                    cross_origin_mismatches.append(receipt)
+                else:
+                    unmatched_external_files.append(_external_receipt(item, "unmatched-external-file"))
             for item in inventory:
-                claimed_origins = external_claims.get(cast(Path, item["_path"]), set()) - {origin}
+                claimed_origins = external_claims.get(item.path, set()) - {origin}
                 if claimed_origins:
                     cross_origin_mismatches.append(
-                        {
-                            "root_index": int(item["root_index"]),
-                            "relative_path": str(item["relative_path"]),
-                            "hash": str(item["hash"]),
-                            "size": int(item["size"]),
-                            "disposition": "cross-origin-source",
-                            "other_origins": sorted(claimed_origins),
-                        }
+                        _external_receipt(item, "cross-origin-source", other_origins=sorted(claimed_origins))
                     )
 
-            source_keys = {(str(row["blob_hash"]), int(row["blob_size"])) for row in rows}
+            source_keys: set[GroundTruthKey] = {row.key for row in rows}
             source_distinct_bytes = sum(size for _hash, size in source_keys)
-            external_bytes = sum(int(item["size"]) for item in inventory)
+            external_bytes = sum(item.size for item in inventory)
             count_discrepancy = len(source_keys) != len(inventory)
             byte_discrepancy = source_distinct_bytes != external_bytes
             origin_errors: list[str] = []
@@ -788,7 +851,7 @@ def _ground_truth_evidence(
                 origin_errors.append(f"{len(cross_origin_mismatches)} external file(s) match another origin")
             if origin_errors:
                 errors.extend(f"ground truth for {origin}: {reason}" for reason in origin_errors)
-            hashes = {str(item["hash"]) for item in inventory}
+            hashes = {item.content_hash for item in inventory}
             missing = sorted(
                 source_keys_hash for source_keys_hash, _size in source_keys if source_keys_hash not in hashes
             )
@@ -799,7 +862,7 @@ def _ground_truth_evidence(
                 "external_bytes": external_bytes,
                 "external_hashes": len(hashes),
                 "source_raw_count": len(rows),
-                "source_raw_bytes": sum(int(row["blob_size"]) for row in rows),
+                "source_raw_bytes": sum(row.blob_size for row in rows),
                 "source_blob_hashes": len(source_keys),
                 "source_blob_bytes": source_distinct_bytes,
                 "count_discrepancy": count_discrepancy,

--- a/tests/unit/maintenance/test_schema_inference_gate.py
+++ b/tests/unit/maintenance/test_schema_inference_gate.py
@@ -76,12 +76,18 @@ def _seed_archive(root: Path) -> Path:
     return ground_truth
 
 
-def _run(root: Path, tmp_path: Path, *, ground_truth: Path | None = None) -> dict[str, Any]:
+def _run(
+    root: Path,
+    tmp_path: Path,
+    *,
+    ground_truth: Path | None = None,
+    ground_truth_roots: dict[str, tuple[Path, ...]] | None = None,
+) -> dict[str, Any]:
     external_root = ground_truth or root.parent / f"{root.name}-codex-ground-truth"
     result = run_schema_inference_gate(
         root,
         receipt_path=tmp_path / RECEIPT_FILENAME,
-        ground_truth_roots={"codex-session": (external_root,)},
+        ground_truth_roots=ground_truth_roots or {"codex-session": (external_root,)},
     )
     return cast(dict[str, Any], result.payload)
 
@@ -96,6 +102,23 @@ def test_clean_archive_runs_actual_blobstore_verifier_and_external_reconciliatio
     assert payload["verdict"] == "PASS"
     assert payload["ground_truth_inputs"]["origins"]["codex-session"]["external_files"] == 1
     assert payload["ground_truth_inputs"]["origins"]["codex-session"]["unverified_source_blob_hashes"] == 0
+    provenance = payload["ground_truth_inputs"]["origins"]["codex-session"]["provenance"]
+    expected_hash = hashlib.sha256(b"actual external codex raw").hexdigest()
+    assert provenance == [
+        {
+            "raw_id": "raw-1",
+            "origin": "codex-session",
+            "native_id": "session",
+            "logical_source_key": "codex:session",
+            "source_path": str(ground_truth / "session.jsonl"),
+            "blob_hash": expected_hash,
+            "blob_size": len(b"actual external codex raw"),
+            "matched_external_relative_path": "session.jsonl",
+            "matched_external_hash": expected_hash,
+            "matched_external_size": len(b"actual external codex raw"),
+            "disposition": "materialized",
+        }
+    ]
     full = payload["full_blob_hash_verification"]
     assert full["passed"] is True
     assert full["verifier"]["identity"] == "polylogue.storage.blob_store.BlobStore.verify_all"
@@ -140,6 +163,108 @@ def test_unavailable_or_unverified_external_ground_truth_is_a_hard_failure(tmp_p
     unverified = _run(root, tmp_path, ground_truth=wrong_root)
     assert unverified["verdict"] == "FAIL"
     assert unverified["ground_truth_inputs"]["origins"]["codex-session"]["unverified_source_blob_hashes"] == 1
+
+
+def test_extra_external_file_is_rejected_by_bidirectional_reconciliation(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    ground_truth = _seed_archive(root)
+    (ground_truth / "extra-session.jsonl").write_bytes(b"external-only")
+
+    payload = _run(root, tmp_path, ground_truth=ground_truth)
+
+    origin = payload["ground_truth_inputs"]["origins"]["codex-session"]
+    assert payload["verdict"] == "FAIL"
+    assert origin["unmatched_external_files"] == [
+        {
+            "root_index": 0,
+            "relative_path": "extra-session.jsonl",
+            "hash": hashlib.sha256(b"external-only").hexdigest(),
+            "size": len(b"external-only"),
+            "disposition": "unmatched-external-file",
+        }
+    ]
+    assert origin["count_discrepancy"] is True
+    assert origin["byte_discrepancy"] is True
+    assert any("external file(s) have no source raw match" in reason for reason in payload["pass_fail_reasons"])
+
+
+def test_cross_origin_external_source_is_rejected_and_recorded(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    ground_truth = _seed_archive(root)
+    with sqlite3.connect(root / "source.db") as conn:
+        blob_hash, blob_size = conn.execute(
+            "SELECT blob_hash, blob_size FROM raw_sessions WHERE raw_id = 'raw-1'"
+        ).fetchone()
+        conn.execute(
+            """
+            INSERT INTO raw_sessions(
+                raw_id, origin, native_id, source_path, blob_hash, blob_size,
+                acquired_at_ms, logical_source_key, revision_authority
+            ) VALUES ('raw-cross-origin', 'claude-code-session', 'session', ?, ?, ?, 101,
+                      'claude:session', 'byte_proven')
+            """,
+            (str(ground_truth / "session.jsonl"), blob_hash, blob_size),
+        )
+
+    payload = _run(
+        root,
+        tmp_path,
+        ground_truth_roots={
+            "codex-session": (ground_truth,),
+            "claude-code-session": (ground_truth,),
+        },
+    )
+
+    claude = payload["ground_truth_inputs"]["origins"]["claude-code-session"]
+    assert payload["verdict"] == "FAIL"
+    assert claude["cross_origin_mismatches"] == [
+        {
+            "root_index": 0,
+            "relative_path": "session.jsonl",
+            "hash": hashlib.sha256(b"actual external codex raw").hexdigest(),
+            "size": len(b"actual external codex raw"),
+            "disposition": "cross-origin-source",
+            "other_origins": ["codex-session"],
+        }
+    ]
+    assert any("claimed by multiple origins" in reason for reason in payload["pass_fail_reasons"])
+
+
+def test_stale_acquisition_path_is_preserved_while_content_matches_external_file(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    ground_truth = _seed_archive(root)
+    stale_path = "/retired/archive-root/session.jsonl"
+    with sqlite3.connect(root / "source.db") as conn:
+        conn.execute("UPDATE raw_sessions SET source_path = ? WHERE raw_id = 'raw-1'", (stale_path,))
+
+    payload = _run(root, tmp_path, ground_truth=ground_truth)
+    provenance = payload["ground_truth_inputs"]["origins"]["codex-session"]["provenance"][0]
+
+    assert payload["verdict"] == "PASS"
+    assert provenance["source_path"] == stale_path
+    assert provenance["matched_external_relative_path"] == "session.jsonl"
+    with sqlite3.connect(root / "source.db") as conn:
+        assert conn.execute("SELECT source_path FROM raw_sessions WHERE raw_id = 'raw-1'").fetchone()[0] == stale_path
+
+
+def test_receipt_rerun_keeps_deterministic_external_provenance(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    ground_truth = _seed_archive(root)
+    first = run_schema_inference_gate(
+        root,
+        receipt_path=tmp_path / "first" / RECEIPT_FILENAME,
+        ground_truth_roots={"codex-session": (ground_truth,)},
+    ).payload
+    second = run_schema_inference_gate(
+        root,
+        receipt_path=tmp_path / "second" / RECEIPT_FILENAME,
+        ground_truth_roots={"codex-session": (ground_truth,)},
+    ).payload
+
+    first_origin = first["ground_truth_inputs"]["origins"]["codex-session"]
+    second_origin = second["ground_truth_inputs"]["origins"]["codex-session"]
+    assert first_origin["provenance"] == second_origin["provenance"]
+    assert first_origin["unmatched_external_files"] == second_origin["unmatched_external_files"] == []
 
 
 def test_full_blob_hash_evidence_is_not_a_caller_claim(tmp_path: Path) -> None:

--- a/tests/unit/maintenance/test_schema_inference_gate.py
+++ b/tests/unit/maintenance/test_schema_inference_gate.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import sqlite3
 from pathlib import Path
-from typing import Any, cast
+from typing import TypedDict, cast
 
 import pytest
 
@@ -17,6 +17,59 @@ from polylogue.maintenance.schema_inference_gate import (
 )
 from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+
+class _RawGroundTruthProvenance(TypedDict):
+    source_path: str
+    matched_external_relative_path: str | None
+
+
+class _OriginGroundTruthReceipt(TypedDict):
+    external_files: int
+    unverified_source_blob_hashes: int
+    provenance: list[_RawGroundTruthProvenance]
+    unmatched_external_files: list[object]
+    cross_origin_mismatches: list[object]
+    count_discrepancy: bool
+    byte_discrepancy: bool
+
+
+class _GroundTruthInputs(TypedDict):
+    origins: dict[str, _OriginGroundTruthReceipt]
+
+
+class _BlobVerifier(TypedDict):
+    identity: str
+
+
+class _BlobSnapshot(TypedDict):
+    digest: str
+
+
+class _BlobFailure(TypedDict):
+    reason: str
+
+
+class _FullBlobHashVerification(TypedDict):
+    passed: bool
+    verifier: _BlobVerifier
+    before_snapshot: _BlobSnapshot
+    after_snapshot: _BlobSnapshot
+    failures: list[_BlobFailure]
+
+
+class _GateQueryResult(TypedDict):
+    passed: bool
+    invalid_receipt_count: int
+    resolved_by_rule: dict[str, int]
+
+
+class _GateReceipt(TypedDict):
+    verdict: str
+    ground_truth_inputs: _GroundTruthInputs
+    full_blob_hash_verification: _FullBlobHashVerification
+    query_results: dict[str, _GateQueryResult]
+    pass_fail_reasons: list[str]
 
 
 def _seed_archive(root: Path) -> Path:
@@ -82,14 +135,14 @@ def _run(
     *,
     ground_truth: Path | None = None,
     ground_truth_roots: dict[str, tuple[Path, ...]] | None = None,
-) -> dict[str, Any]:
+) -> _GateReceipt:
     external_root = ground_truth or root.parent / f"{root.name}-codex-ground-truth"
     result = run_schema_inference_gate(
         root,
         receipt_path=tmp_path / RECEIPT_FILENAME,
         ground_truth_roots=ground_truth_roots or {"codex-session": (external_root,)},
     )
-    return cast(dict[str, Any], result.payload)
+    return cast(_GateReceipt, result.payload)
 
 
 def test_clean_archive_runs_actual_blobstore_verifier_and_external_reconciliation(tmp_path: Path) -> None:
@@ -250,16 +303,22 @@ def test_stale_acquisition_path_is_preserved_while_content_matches_external_file
 def test_receipt_rerun_keeps_deterministic_external_provenance(tmp_path: Path) -> None:
     root = tmp_path / "archive"
     ground_truth = _seed_archive(root)
-    first = run_schema_inference_gate(
-        root,
-        receipt_path=tmp_path / "first" / RECEIPT_FILENAME,
-        ground_truth_roots={"codex-session": (ground_truth,)},
-    ).payload
-    second = run_schema_inference_gate(
-        root,
-        receipt_path=tmp_path / "second" / RECEIPT_FILENAME,
-        ground_truth_roots={"codex-session": (ground_truth,)},
-    ).payload
+    first = cast(
+        _GateReceipt,
+        run_schema_inference_gate(
+            root,
+            receipt_path=tmp_path / "first" / RECEIPT_FILENAME,
+            ground_truth_roots={"codex-session": (ground_truth,)},
+        ).payload,
+    )
+    second = cast(
+        _GateReceipt,
+        run_schema_inference_gate(
+            root,
+            receipt_path=tmp_path / "second" / RECEIPT_FILENAME,
+            ground_truth_roots={"codex-session": (ground_truth,)},
+        ).payload,
+    )
 
     first_origin = first["ground_truth_inputs"]["origins"]["codex-session"]
     second_origin = second["ground_truth_inputs"]["origins"]["codex-session"]


### PR DESCRIPTION
## Summary
Make the schema-inference gate retain a deterministic, bidirectional provenance receipt for every externally reconcilable source origin.

## Problem
The existing pristine-source gate compared hashes but discarded the raw-to-external mapping. It could not prove there were no external-only files, origin-crossing matches, or count and byte discrepancies, leaving the r9xsj prerequisite too weak for schema inference.

## Solution
Persist typed per-raw source identity, content hash and size, external relative-path match, and typed disposition in the gate receipt. Reconciliation now rejects unmatched source raws, external-only files, duplicate origin claims, cross-origin source matches, and count or byte discrepancies while retaining historical acquisition paths unchanged.

## Verification
- `mypy tests/unit/maintenance/test_schema_inference_gate.py polylogue/maintenance/schema_inference_gate.py`: success
- `POLYLOGUE_PYTEST_WORKERS=1 devtools test tests/unit/maintenance/test_schema_inference_gate.py`: 13 passed
- Pre-push quick verification: formatting, lint, mypy, generated checks, and policy checks passed

Ref polylogue-r9xsj and polylogue-f1vg.

Remaining r9xsj scope: wire the fresh PASS receipt as an explicit rebuild go/no-go consumer before live inference or rebuild.