### PR TITLE
test(synthetic): make inferred wire support explicit

### DIFF
--- a/polylogue/schemas/synthetic/build_records.py
+++ b/polylogue/schemas/synthetic/build_records.py
@@ -22,6 +22,7 @@ class _WireFormatContext(Protocol):
     wire_format: WireFormat
     _semantic_gen: SemanticValueGenerator | None
     _active_record_bucket: tuple[str, str] | None
+    _coverage_witness_mode: bool
 
     def _generate_from_schema(
         self,
@@ -119,7 +120,14 @@ def _generate_tree_json(
     nodes: list[SyntheticRecord] = []
 
     for i in range(n_messages):
-        node = _coerce_record(self._generate_from_schema(node_schema, rng))
+        node_path = "$.properties." + tree_cfg.container_path + ".additionalProperties.*"
+        node = _coerce_record(
+            self._generate_from_schema(
+                node_schema,
+                rng,
+                path=node_path if self._coverage_witness_mode else "$",
+            )
+        )
 
         node_id = str(uuid.UUID(int=rng.getrandbits(128), version=4))
         node[tree_cfg.key_field] = node_id
@@ -184,7 +192,16 @@ def _generate_linear_json(
 
     messages: list[SyntheticRecord] = []
     for i in range(n_messages):
-        msg = _coerce_record(self._generate_from_schema(item_schema, rng))
+        item_path = (
+            "$.properties." + ".properties.".join(msgs_parts) + ".items[*]" if self._coverage_witness_mode else "$"
+        )
+        msg = _coerce_record(
+            self._generate_from_schema(
+                item_schema,
+                rng,
+                path=item_path,
+            )
+        )
         role = roles[i % len(roles)]
         self._ensure_wire_format(msg, role, rng, i, base_ts=base_ts, theme=theme)
         _advance_semantic_turn(self)

--- a/polylogue/schemas/synthetic/build_wire_formats.py
+++ b/polylogue/schemas/synthetic/build_wire_formats.py
@@ -104,6 +104,26 @@ def _ensure_wire_format(
             self._ensure_wire_codex(data, role, rng, ts, index=index, theme=theme)
         case "gemini":
             self._ensure_wire_gemini(data, role, rng, index=index, theme=theme)
+        case _:
+            raise ValueError(f"No executable synthetic wire adapter for provider {self.provider!r}")
+
+
+def validate_wire_payload(provider: str, data: JSONValue) -> None:
+    """Reject provider-wire combinations the production parser does not own."""
+
+    if provider != "codex" or not isinstance(data, list):
+        return
+    has_flat_message = any(
+        isinstance(record, dict) and (record.get("type") == "message" or isinstance(record.get("role"), str))
+        for record in data
+    )
+    has_envelope_message = any(
+        isinstance(record, dict)
+        and record.get("type") in {"response_item", "event_msg", "turn_context", "session_meta"}
+        for record in data
+    )
+    if has_flat_message and has_envelope_message:
+        raise ValueError("Codex synthetic payload cannot mix flat records with envelope records")
 
 
 def _ensure_wire_chatgpt(
@@ -327,4 +347,5 @@ __all__ = [
     "_ensure_wire_codex",
     "_ensure_wire_format",
     "_ensure_wire_gemini",
+    "validate_wire_payload",
 ]

--- a/polylogue/schemas/synthetic/build_wire_formats.py
+++ b/polylogue/schemas/synthetic/build_wire_formats.py
@@ -27,6 +27,7 @@ def _record_field(record: SyntheticRecord, field_name: str) -> SyntheticRecord:
 class _WireFormatContext(Protocol):
     provider: str
     _active_record_bucket: tuple[str, str] | None
+    _coverage_witness_mode: bool
 
     def _ensure_wire_chatgpt(
         self,
@@ -148,6 +149,10 @@ def _ensure_wire_chatgpt(
     content.setdefault("content_type", "text")
 
     msg.setdefault("create_time", ts)
+    if self._coverage_witness_mode:
+        raw_provider_payload = data.get("raw_provider_payload")
+        if isinstance(raw_provider_payload, dict):
+            raw_provider_payload.pop("mapping", None)
 
 
 def _ensure_wire_claude_ai(
@@ -199,8 +204,26 @@ def _ensure_wire_claude_code(
         msg.setdefault("role", role)
         if "content" not in msg:
             msg["content"] = _claude_code_content_fallback(rng, role, index, theme)  # type: ignore[assignment]
+        elif self._coverage_witness_mode:
+            _normalize_claude_code_coverage_content(msg, rng, role, index, theme)
     if "timestamp" not in data:
         data["timestamp"] = datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+
+
+def _normalize_claude_code_coverage_content(
+    message: SyntheticRecord,
+    rng: random.Random,
+    role: str,
+    index: int,
+    theme: SessionTheme | None,
+) -> None:
+    """Keep coverage witnesses on block forms the Claude Code route emits."""
+    content = message.get("content")
+    if not isinstance(content, list):
+        return
+    for block in content:
+        if isinstance(block, dict) and isinstance(block.get("content"), list):
+            block["content"] = _text_for_role(rng, role, turn_index=index, theme=theme)
 
 
 def _claude_code_content_fallback(rng: random.Random, role: str, index: int, theme: SessionTheme | None) -> object:

--- a/polylogue/schemas/synthetic/build_wire_formats.py
+++ b/polylogue/schemas/synthetic/build_wire_formats.py
@@ -150,9 +150,11 @@ def _ensure_wire_chatgpt(
 
     msg.setdefault("create_time", ts)
     if self._coverage_witness_mode:
-        raw_provider_payload = data.get("raw_provider_payload")
-        if isinstance(raw_provider_payload, dict):
-            raw_provider_payload.pop("mapping", None)
+        # Coverage generation may choose arbitrary schema-valid enum values;
+        # keep the message discriminator on the parser-owned conversational
+        # branch so every schema witness still proves parser materialization.
+        author["role"] = role
+        content["content_type"] = "text"
 
 
 def _ensure_wire_claude_ai(

--- a/polylogue/schemas/synthetic/core.py
+++ b/polylogue/schemas/synthetic/core.py
@@ -63,6 +63,10 @@ class SyntheticCorpus:
         self._max_synthetic_string_length = max_string_length
         self._active_profile_tokens: tuple[str, ...] = ()
         self._active_record_bucket: tuple[str, str] | None = None
+        self._coverage_branch_choices: dict[str, int] = {}
+        self._coverage_type_choices: dict[str, str] = {}
+        self._coverage_null_paths: set[str] = set()
+        self._coverage_witness_mode = False
         self._generation_state = SyntheticGenerationState(
             relation_solver=RelationConstraintSolver(schema, max_string_length=max_string_length),
             semantic_generator=None,
@@ -402,6 +406,8 @@ class SyntheticCorpus:
         max_depth: int = 6,
         path: str = "$",
     ) -> JSONValue:
+        if self._coverage_witness_mode and max_depth == 6:
+            max_depth = 24
         return synthetic_runtime._generate_from_schema(
             self,
             schema,

--- a/polylogue/schemas/synthetic/runtime.py
+++ b/polylogue/schemas/synthetic/runtime.py
@@ -44,6 +44,10 @@ class _SyntheticRuntimeContext(Protocol):
     _active_profile_tokens: tuple[str, ...]
     _active_record_bucket: tuple[str, str] | None
     _max_array_items: int | None
+    _coverage_branch_choices: dict[str, int]
+    _coverage_type_choices: dict[str, str]
+    _coverage_null_paths: set[str]
+    _coverage_witness_mode: bool
 
     def _generate_from_schema(
         self,
@@ -98,11 +102,16 @@ def _schema_records(value: SchemaValue | object) -> list[SchemaRecord]:
     return [record for item in value if (record := _schema_record(item))]
 
 
-def _schema_type(schema: SchemaRecord, rng: random.Random) -> str | None:
+def _schema_type(self: _SyntheticRuntimeContext, schema: SchemaRecord, rng: random.Random, path: str) -> str | None:
     schema_type = schema.get("type")
     if isinstance(schema_type, str):
         return schema_type
     if isinstance(schema_type, list):
+        selected_type = self._coverage_type_choices.get(path) if self._coverage_witness_mode else None
+        if selected_type in schema_type:
+            return selected_type
+        if self._coverage_witness_mode and path in self._coverage_null_paths and "null" in schema_type:
+            return "null"
         non_null = [item for item in schema_type if isinstance(item, str) and item != "null"]
         return rng.choice(non_null) if non_null else "null"
     return None
@@ -183,24 +192,46 @@ def _generate_from_schema(
         return None
 
     semantic_role = schema.get("x-polylogue-semantic-role")
-    if isinstance(semantic_role, str) and self._semantic_gen is not None:
+    if (
+        isinstance(semantic_role, str)
+        and self._semantic_gen is not None
+        and not (self._coverage_witness_mode and path in self._coverage_type_choices)
+    ):
         handled, value = self._semantic_gen.try_generate(schema)
         if handled:
             return value
 
     for keyword in ("anyOf", "oneOf"):
-        variants = _schema_records(schema.get(keyword))
+        raw_variants = schema.get(keyword)
+        variants = [
+            (index, variant)
+            for index, item in enumerate(raw_variants if isinstance(raw_variants, list) else [])
+            if (variant := _schema_record(item))
+        ]
         if variants:
             if keyword not in SCHEMA_CONSTRUCT_HANDLERS:
                 return None
-            non_null = [variant for variant in variants if variant.get("type") != "null"]
+            selected_index = self._coverage_branch_choices.get(path) if self._coverage_witness_mode else None
+            if selected_index is not None:
+                selected = next((variant for index, variant in variants if index == selected_index), None)
+                if selected is not None:
+                    return self._generate_from_schema(
+                        selected,
+                        rng,
+                        skip_keys=skip_keys,
+                        depth=depth,
+                        max_depth=max_depth,
+                        path=(f"{path}.{keyword}[{selected_index}]" if self._coverage_witness_mode else path),
+                    )
+
+            non_null = [item for item in variants if item[1].get("type") != "null"]
             candidates = non_null if non_null else variants
 
             # Weight by x-polylogue-frequency when available on variants.
             # Falls back to uniform when no variant carries the annotation
             # (backward-compatible with un-annotated schemas).
             weights: list[float] = []
-            for variant in candidates:
+            for _, variant in candidates:
                 f = variant.get("x-polylogue-frequency")
                 weights.append(float(f) if isinstance(f, (int, float)) and f > 0 else 0.0)
             if sum(weights) > 0:
@@ -211,15 +242,15 @@ def _generate_from_schema(
             else:
                 chosen = rng.choice(candidates)
             return self._generate_from_schema(
-                chosen,
+                chosen[1],
                 rng,
                 skip_keys=skip_keys,
                 depth=depth,
                 max_depth=max_depth,
-                path=path,
+                path=(f"{path}.{keyword}[{chosen[0]}]" if self._coverage_witness_mode else path),
             )
 
-    schema_type = _schema_type(schema, rng)
+    schema_type = _schema_type(self, schema, rng, path)
     if schema_type is not None and schema_type not in SCHEMA_CONSTRUCT_HANDLERS:
         return None
     freq_value = schema.get("x-polylogue-frequency")
@@ -303,7 +334,7 @@ def _generate_object(
     if skip_keys:
         candidate_keys -= skip_keys
 
-    if self._relation_solver.mutual_exclusions:
+    if self._relation_solver.mutual_exclusions and not self._coverage_witness_mode:
         candidate_keys = self._relation_solver.filter_mutually_exclusive(path, candidate_keys, rng)
 
     for prop_name, prop_value in properties.items():
@@ -320,7 +351,7 @@ def _generate_object(
         if prop_name in selected_root_fields and freq < 1.0:
             prop_schema = {**prop_schema, "x-polylogue-frequency": 1.0}
 
-        child_path = f"{path}.{prop_name}"
+        child_path = f"{path}.properties.{prop_name}" if self._coverage_witness_mode else f"{path}.{prop_name}"
         ref = self._relation_solver.resolve_foreign_key(child_path, rng)
         if ref is not None:
             obj[prop_name] = ref
@@ -333,10 +364,38 @@ def _generate_object(
             max_depth=max_depth,
             path=child_path,
         )
-        if value is not None:
+        if value is not None or (self._coverage_witness_mode and _schema_allows_null(prop_schema)):
             obj[prop_name] = value
 
+    additional_schema = _schema_record(schema.get("additionalProperties"))
+    if self._coverage_witness_mode and additional_schema:
+        extra_name = "__polylogue_coverage_extra__"
+        while extra_name in properties:
+            extra_name = f"_{extra_name}"
+        extra_value = self._generate_from_schema(
+            additional_schema,
+            rng,
+            depth=depth + 1,
+            max_depth=max_depth,
+            path=f"{path}.additionalProperties.*",
+        )
+        if extra_value is not None or _schema_allows_null(additional_schema):
+            obj[extra_name] = extra_value
+
     return obj
+
+
+def _schema_allows_null(schema: SchemaRecord) -> bool:
+    schema_type = schema.get("type")
+    if schema_type == "null":
+        return True
+    if isinstance(schema_type, list) and "null" in schema_type:
+        return True
+    return any(
+        _schema_allows_null(variant)
+        for keyword in ("anyOf", "oneOf")
+        for variant in _schema_records(schema.get(keyword))
+    )
 
 
 def _generate_string(self: _SyntheticRuntimeContext, schema: SchemaRecord, rng: random.Random) -> str:
@@ -413,6 +472,8 @@ def _generate_array(
         n_items = rng.randint(bounded_lo, bounded_hi)
     else:
         n_items = rng.randint(1, 3)
+    if self._coverage_witness_mode:
+        n_items = 1
     if self._max_array_items is not None:
         n_items = min(n_items, self._max_array_items)
 
@@ -425,13 +486,14 @@ def _generate_array(
     if not item_allows_null:
         item_allows_null = any(variant.get("type") == "null" for variant in _schema_records(item_schema.get("oneOf")))
 
+    item_path = f"{path}.items[*]" if self._coverage_witness_mode else f"{path}[*]"
     items = [
         self._generate_from_schema(
             item_schema,
             rng,
             depth=depth + 1,
             max_depth=max_depth,
-            path=f"{path}[*]",
+            path=item_path,
         )
         for _ in range(n_items)
     ]

--- a/polylogue/schemas/synthetic/runtime.py
+++ b/polylogue/schemas/synthetic/runtime.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Protocol, TypeAlias
 
 from polylogue.archive.raw_payload.decode import JSONValue
+from polylogue.schemas.synthetic.build_wire_formats import validate_wire_payload
 from polylogue.schemas.synthetic.models import SchemaRecord, SchemaValue
 from polylogue.schemas.synthetic.semantic_values import SemanticValueGenerator, _text_for_role
 from polylogue.schemas.synthetic.wire_formats import WireFormat
@@ -19,8 +20,24 @@ if TYPE_CHECKING:
 
 SyntheticRecord: TypeAlias = dict[str, JSONValue]
 
+# The receipt reads this registry and the recursive generator gates dispatch on
+# it. Removing a construct handler therefore changes both generated behavior
+# and the support receipt instead of becoming a silent ``None`` fallback.
+SCHEMA_CONSTRUCT_HANDLERS: dict[str, str] = {
+    "anyOf": "schema-union",
+    "array": "_generate_array",
+    "boolean": "boolean",
+    "integer": "_generate_number",
+    "null": "null",
+    "number": "_generate_number",
+    "object": "_generate_object",
+    "oneOf": "schema-union",
+    "string": "_generate_string",
+}
+
 
 class _SyntheticRuntimeContext(Protocol):
+    provider: str
     wire_format: WireFormat
     _semantic_gen: SemanticValueGenerator | None
     _relation_solver: RelationConstraintSolver
@@ -174,6 +191,8 @@ def _generate_from_schema(
     for keyword in ("anyOf", "oneOf"):
         variants = _schema_records(schema.get(keyword))
         if variants:
+            if keyword not in SCHEMA_CONSTRUCT_HANDLERS:
+                return None
             non_null = [variant for variant in variants if variant.get("type") != "null"]
             candidates = non_null if non_null else variants
 
@@ -201,6 +220,8 @@ def _generate_from_schema(
             )
 
     schema_type = _schema_type(schema, rng)
+    if schema_type is not None and schema_type not in SCHEMA_CONSTRUCT_HANDLERS:
+        return None
     freq_value = schema.get("x-polylogue-frequency")
     freq = float(freq_value) if isinstance(freq_value, (int, float)) else 1.0
     if depth > 0 and freq < 1.0 and rng.random() > freq:
@@ -234,6 +255,8 @@ def _generate_from_schema(
         case "null":
             return None
         case _:
+            if "object" not in SCHEMA_CONSTRUCT_HANDLERS:
+                return None
             if "properties" in schema:
                 return self._generate_object(
                     schema,
@@ -418,6 +441,7 @@ def _generate_array(
 
 
 def _serialize(self: _SyntheticRuntimeContext, data: JSONValue) -> bytes:
+    validate_wire_payload(self.provider, data)
     if self.wire_format.encoding == "jsonl":
         if not isinstance(data, list):
             raise ValueError("JSONL wire format requires a list payload")
@@ -427,6 +451,7 @@ def _serialize(self: _SyntheticRuntimeContext, data: JSONValue) -> bytes:
 
 
 __all__ = [
+    "SCHEMA_CONSTRUCT_HANDLERS",
     "_generate_array",
     "_generate_from_schema",
     "_generate_number",

--- a/polylogue/schemas/synthetic/selection.py
+++ b/polylogue/schemas/synthetic/selection.py
@@ -69,7 +69,11 @@ def select_synthetic_schema(
             )
         schema = registry.get_element_schema(
             canonical_provider,
-            version=version,
+            # ``get_package`` resolves aliases such as ``default``.  Reuse
+            # that exact package identity for every subsequent load so a
+            # registry cannot pair one package's manifest with another
+            # package's element schema.
+            version=package.version,
             element_kind=resolved_element_kind,
         )
         canonical_version = package.version

--- a/polylogue/schemas/synthetic/selection.py
+++ b/polylogue/schemas/synthetic/selection.py
@@ -8,7 +8,10 @@ from typing import Protocol, TypeAlias
 from polylogue.schemas.packages import SchemaVersionPackage
 from polylogue.schemas.runtime_registry import SchemaRegistry, canonical_schema_provider
 from polylogue.schemas.synthetic.models import SchemaRecord, SyntheticSchemaSelection
-from polylogue.schemas.synthetic.wire_formats import PROVIDER_WIRE_FORMATS
+from polylogue.schemas.synthetic.wire_formats import (
+    PROVIDER_WIRE_ROUTES,
+    UnsupportedSyntheticWireRouteError,
+)
 
 
 class _SchemaRegistryLike(Protocol):
@@ -86,9 +89,14 @@ def select_synthetic_schema(
             f"version={canonical_version}, element_kind={resolved_element_kind})"
         )
 
-    wire_format = PROVIDER_WIRE_FORMATS.get(canonical_provider)
-    if not wire_format:
-        raise ValueError(f"No wire format config for provider: {canonical_provider}")
+    route = PROVIDER_WIRE_ROUTES.get(canonical_provider)
+    if route is None:
+        raise UnsupportedSyntheticWireRouteError(canonical_provider, "no explicit synthetic wire route")
+    if route.status == "unsupported":
+        raise UnsupportedSyntheticWireRouteError(canonical_provider, route.reason or "route is unsupported")
+    wire_format = route.wire_format
+    if wire_format is None:
+        raise UnsupportedSyntheticWireRouteError(canonical_provider, "supported route has no wire format")
 
     profile_loader = getattr(registry, "get_workload_profile", None)
     workload_profile = profile_loader(canonical_provider, canonical_version) if callable(profile_loader) else None
@@ -107,7 +115,11 @@ def available_synthetic_providers(
     registry_factory: RegistryFactory = _default_registry_factory,
 ) -> list[str]:
     schema_providers = set(registry_factory().list_providers())
-    return [provider for provider in PROVIDER_WIRE_FORMATS if provider in schema_providers]
+    return [
+        provider
+        for provider, route in PROVIDER_WIRE_ROUTES.items()
+        if route.status == "supported" and provider in schema_providers
+    ]
 
 
 __all__ = [

--- a/polylogue/schemas/synthetic/wire_formats.py
+++ b/polylogue/schemas/synthetic/wire_formats.py
@@ -282,6 +282,58 @@ def _json_value_types(value: JSONValue, result: set[str] | None = None) -> set[s
     return result
 
 
+def _payload_structure_constructs(
+    schema: object,
+    payload: JSONValue,
+    result: set[str] | None = None,
+) -> set[str]:
+    if result is None:
+        result = set()
+    if not isinstance(schema, Mapping) or not isinstance(payload, dict):
+        return result
+
+    properties = schema.get("properties")
+    property_names = set(properties) if isinstance(properties, Mapping) else set()
+    if property_names & payload.keys():
+        result.add("properties")
+
+    required = schema.get("required")
+    required_names = {item for item in required if isinstance(item, str)} if isinstance(required, list) else set()
+    if "required" in schema and required_names <= payload.keys():
+        result.add("required")
+
+    if "additionalProperties" in schema:
+        extra_names = payload.keys() - property_names
+        if schema.get("additionalProperties") is False:
+            if not extra_names:
+                result.add("additionalProperties")
+        elif extra_names:
+            result.add("additionalProperties")
+
+    if isinstance(properties, Mapping):
+        for name, child_schema in properties.items():
+            if isinstance(name, str) and name in payload:
+                _payload_structure_constructs(child_schema, payload[name], result)
+
+    items = schema.get("items")
+    if isinstance(items, Mapping) and isinstance(payload, list):
+        for item in payload:
+            _payload_structure_constructs(items, item, result)
+
+    additional_schema = schema.get("additionalProperties")
+    if isinstance(additional_schema, Mapping):
+        for name, item in payload.items():
+            if name not in property_names:
+                _payload_structure_constructs(additional_schema, item, result)
+
+    for keyword in ("anyOf", "oneOf"):
+        variants = schema.get(keyword)
+        if isinstance(variants, list):
+            for variant in variants:
+                _payload_structure_constructs(variant, payload, result)
+    return result
+
+
 def construct_coverage(
     schema: SchemaRecord,
     payloads: Sequence[JSONValue],
@@ -302,22 +354,18 @@ def construct_coverage(
     handlers = set(handler_names)
     schema_keywords = _schema_constructs(schema)
     value_types: set[str] = set()
+    structure_constructs: set[str] = set()
     for payload in payloads:
         _json_value_types(payload, value_types)
+        _payload_structure_constructs(schema, payload, structure_constructs)
 
     exercised: set[str] = set()
     for construct in schema_keywords:
         if construct.startswith("type:"):
             type_name = construct.removeprefix("type:")
-            if type_name in handlers and payloads:
+            if type_name in handlers and type_name in value_types:
                 exercised.add(construct)
-        elif (
-            (construct in handlers and payloads)
-            or (construct == "properties" and "object" in value_types)
-            or (construct == "items" and "array" in value_types)
-            or (construct == "required" and "object" in value_types)
-            or (construct == "additionalProperties" and "object" in value_types)
-        ):
+        elif (construct in handlers and payloads) or construct in structure_constructs:
             exercised.add(construct)
 
     return ConstructCoverage(

--- a/polylogue/schemas/synthetic/wire_formats.py
+++ b/polylogue/schemas/synthetic/wire_formats.py
@@ -6,10 +6,17 @@ tree vs. linear vs. JSONL, and message location paths.
 
 from __future__ import annotations
 
+from collections.abc import Collection, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Literal, TypeAlias
+from typing import TYPE_CHECKING, Literal, TypeAlias
+
+from polylogue.archive.raw_payload.decode import JSONValue
+
+if TYPE_CHECKING:
+    from polylogue.schemas.synthetic.models import SchemaRecord
 
 WireEncoding: TypeAlias = Literal["json", "jsonl"]
+WireCapabilityStatus: TypeAlias = Literal["supported", "unsupported"]
 
 
 @dataclass(frozen=True)
@@ -30,6 +37,124 @@ class WireFormat:
     encoding: WireEncoding
     tree: TreeConfig | None = None
     messages_path: str | None = None  # Dot-path to messages array
+
+
+@dataclass(frozen=True)
+class WireRoute:
+    """Explicit synthetic capability for one catalog provider.
+
+    ``PROVIDER_WIRE_FORMATS`` remains the executable adapter map used by the
+    generator.  This wider route map is the authority for catalog coverage,
+    including providers whose parser shape is deliberately not synthesized by
+    this lane.
+    """
+
+    status: WireCapabilityStatus
+    wire_format: WireFormat | None = None
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.status == "supported" and self.wire_format is None:
+            raise ValueError("supported wire routes require a WireFormat")
+        if self.status == "unsupported" and (self.wire_format is not None or not self.reason):
+            raise ValueError("unsupported wire routes require a reason and no WireFormat")
+
+
+@dataclass(frozen=True)
+class ConstructCoverage:
+    """Deterministic schema-construct coverage for generated payloads."""
+
+    schema_keywords: tuple[str, ...]
+    exercised_keywords: tuple[str, ...]
+    missing_keywords: tuple[str, ...]
+
+    @property
+    def complete(self) -> bool:
+        return not self.missing_keywords
+
+
+@dataclass(frozen=True)
+class WireSupportEntry:
+    """One provider row in the support receipt."""
+
+    provider: str
+    status: WireCapabilityStatus
+    reason: str | None
+    package_version: str | None
+    element_kind: str | None
+    schema_valid: bool | None
+    parsed_session_count: int
+    parsed_message_count: int
+    construct_coverage: ConstructCoverage | None
+    validation_error: str | None = None
+
+    @property
+    def healthy(self) -> bool:
+        return self.status == "unsupported" or (
+            self.schema_valid is True
+            and self.parsed_session_count > 0
+            and self.parsed_message_count > 0
+            and self.validation_error is None
+        )
+
+
+@dataclass(frozen=True)
+class WireSupportReceipt:
+    """Registry-derived, deterministic support and coverage receipt."""
+
+    catalog_providers: tuple[str, ...]
+    entries: tuple[WireSupportEntry, ...]
+    missing_routes: tuple[str, ...]
+
+    @property
+    def supported_count(self) -> int:
+        return sum(entry.status == "supported" for entry in self.entries)
+
+    @property
+    def unsupported_count(self) -> int:
+        return sum(entry.status == "unsupported" for entry in self.entries)
+
+    @property
+    def validated_supported_count(self) -> int:
+        return sum(entry.status == "supported" and entry.healthy for entry in self.entries)
+
+    @property
+    def complete(self) -> bool:
+        return not self.missing_routes and all(entry.healthy for entry in self.entries)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "catalog_providers": list(self.catalog_providers),
+            "supported_count": self.supported_count,
+            "unsupported_count": self.unsupported_count,
+            "validated_supported_count": self.validated_supported_count,
+            "missing_routes": list(self.missing_routes),
+            "complete": self.complete,
+            "entries": [
+                {
+                    "provider": entry.provider,
+                    "status": entry.status,
+                    "reason": entry.reason,
+                    "package_version": entry.package_version,
+                    "element_kind": entry.element_kind,
+                    "schema_valid": entry.schema_valid,
+                    "parsed_session_count": entry.parsed_session_count,
+                    "parsed_message_count": entry.parsed_message_count,
+                    "validation_error": entry.validation_error,
+                    "construct_coverage": (
+                        {
+                            "schema_keywords": list(entry.construct_coverage.schema_keywords),
+                            "exercised_keywords": list(entry.construct_coverage.exercised_keywords),
+                            "missing_keywords": list(entry.construct_coverage.missing_keywords),
+                            "complete": entry.construct_coverage.complete,
+                        }
+                        if entry.construct_coverage is not None
+                        else None
+                    ),
+                }
+                for entry in self.entries
+            ],
+        }
 
 
 # Per-provider wire format configs — the only manual piece (~50 lines).
@@ -69,9 +194,269 @@ PROVIDER_WIRE_FORMATS: dict[str, WireFormat] = {
 }
 
 
+# All catalog providers must have a route here.  The three unsupported routes
+# are explicit capabilities, not implicit generator fallbacks.
+PROVIDER_WIRE_ROUTES: dict[str, WireRoute] = {
+    **{
+        provider: WireRoute(status="supported", wire_format=wire_format)
+        for provider, wire_format in PROVIDER_WIRE_FORMATS.items()
+    },
+    "browser-capture": WireRoute(
+        status="unsupported",
+        reason="browser-capture is an envelope with provider-specific typed turns, not a generic export wire format",
+    ),
+    "gemini-cli": WireRoute(
+        status="unsupported",
+        reason="gemini-cli requires its checkpoint document parser semantics, which this generic adapter does not model",
+    ),
+    "hermes": WireRoute(
+        status="unsupported",
+        reason="hermes requires local-agent session-document semantics, which this generic adapter does not model",
+    ),
+}
+
+# Descriptive alias for callers that care about capability status rather than
+# the historical executable-format name.
+PROVIDER_WIRE_CAPABILITIES = PROVIDER_WIRE_ROUTES
+
+_STRUCTURAL_SCHEMA_KEYWORDS = frozenset(
+    {"$ref", "additionalProperties", "anyOf", "items", "oneOf", "properties", "required", "type"}
+)
+
+
+def _schema_constructs(schema: object, result: set[str] | None = None) -> set[str]:
+    if result is None:
+        result = set()
+    if isinstance(schema, Mapping):
+        for keyword, value in schema.items():
+            if keyword not in _STRUCTURAL_SCHEMA_KEYWORDS:
+                continue
+            if keyword == "type":
+                if isinstance(value, str):
+                    result.add(f"type:{value}")
+                elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+                    result.update(f"type:{item}" for item in value if isinstance(item, str))
+            else:
+                result.add(keyword)
+        for value in schema.values():
+            _schema_constructs(value, result)
+    elif isinstance(schema, Sequence) and not isinstance(schema, (str, bytes)):
+        for value in schema:
+            _schema_constructs(value, result)
+    return result
+
+
+def _json_value_types(value: JSONValue, result: set[str] | None = None) -> set[str]:
+    if result is None:
+        result = set()
+    if isinstance(value, dict):
+        result.add("object")
+        for child in value.values():
+            _json_value_types(child, result)
+    elif isinstance(value, list):
+        result.add("array")
+        for child in value:
+            _json_value_types(child, result)
+    elif value is None:
+        result.add("null")
+    elif isinstance(value, bool):
+        result.add("boolean")
+    elif isinstance(value, int):
+        result.update(("integer", "number"))
+    elif isinstance(value, float):
+        result.add("number")
+    elif isinstance(value, str):
+        result.add("string")
+    return result
+
+
+def construct_coverage(
+    schema: SchemaRecord,
+    payloads: Sequence[JSONValue],
+    *,
+    handler_names: Collection[str] | None = None,
+) -> ConstructCoverage:
+    """Compare schema constructs with generated values and live handlers.
+
+    Type constructs are reported individually (for example ``type:array``),
+    which makes removal of one recursive runtime handler visible in the
+    receipt even when another construct still generates valid JSON.
+    """
+
+    if handler_names is None:
+        from polylogue.schemas.synthetic.runtime import SCHEMA_CONSTRUCT_HANDLERS
+
+        handler_names = SCHEMA_CONSTRUCT_HANDLERS.keys()
+    handlers = set(handler_names)
+    schema_keywords = _schema_constructs(schema)
+    value_types: set[str] = set()
+    for payload in payloads:
+        _json_value_types(payload, value_types)
+
+    exercised: set[str] = set()
+    for construct in schema_keywords:
+        if construct.startswith("type:"):
+            type_name = construct.removeprefix("type:")
+            if type_name in handlers and type_name in value_types:
+                exercised.add(construct)
+        elif (
+            (construct in handlers and payloads)
+            or (construct == "properties" and "object" in value_types)
+            or (construct == "items" and "array" in value_types)
+            or (construct == "required" and "object" in value_types)
+        ):
+            exercised.add(construct)
+
+    return ConstructCoverage(
+        schema_keywords=tuple(sorted(schema_keywords)),
+        exercised_keywords=tuple(sorted(exercised)),
+        missing_keywords=tuple(sorted(schema_keywords - exercised)),
+    )
+
+
+def build_wire_support_receipt(*, registry: object | None = None, seed: int = 20260805) -> WireSupportReceipt:
+    """Validate executable routes through the selected schema and parser.
+
+    The provider set comes from the package registry.  The parser call is the
+    public ``parse_payload`` entry point used by production dispatch, so a
+    route is healthy only when its generated artifact validates and produces a
+    non-empty parsed session.
+    """
+
+    if registry is None:
+        from polylogue.schemas.runtime_registry import SchemaRegistry
+
+        registry = SchemaRegistry()
+    from polylogue.schemas.synthetic.core import SyntheticCorpus
+    from polylogue.schemas.validator import validate_provider_export
+    from polylogue.sources.dispatch import parse_payload
+
+    catalog_providers = tuple(sorted(registry.list_providers()))  # type: ignore[attr-defined]
+    entries: list[WireSupportEntry] = []
+    missing_routes: list[str] = []
+    for provider in catalog_providers:
+        route = PROVIDER_WIRE_ROUTES.get(provider)
+        package = registry.get_package(provider, version="default")  # type: ignore[attr-defined]
+        package_version = package.version if package is not None else None
+        element_kind = package.default_element_kind if package is not None else None
+        if route is None:
+            missing_routes.append(provider)
+            entries.append(
+                WireSupportEntry(
+                    provider=provider,
+                    status="unsupported",
+                    reason="no explicit synthetic wire route",
+                    package_version=package_version,
+                    element_kind=element_kind,
+                    schema_valid=None,
+                    parsed_session_count=0,
+                    parsed_message_count=0,
+                    construct_coverage=None,
+                    validation_error="missing route",
+                )
+            )
+            continue
+        if route.status == "unsupported":
+            entries.append(
+                WireSupportEntry(
+                    provider=provider,
+                    status=route.status,
+                    reason=route.reason,
+                    package_version=package_version,
+                    element_kind=element_kind,
+                    schema_valid=None,
+                    parsed_session_count=0,
+                    parsed_message_count=0,
+                    construct_coverage=None,
+                )
+            )
+            continue
+
+        schema = registry.get_element_schema(  # type: ignore[attr-defined]
+            provider,
+            version="default",
+            element_kind=element_kind,
+        )
+        if schema is None or package is None or route.wire_format is None:
+            entries.append(
+                WireSupportEntry(
+                    provider=provider,
+                    status=route.status,
+                    reason=None,
+                    package_version=package_version,
+                    element_kind=element_kind,
+                    schema_valid=False,
+                    parsed_session_count=0,
+                    parsed_message_count=0,
+                    construct_coverage=None,
+                    validation_error="selected package schema is unavailable",
+                )
+            )
+            continue
+
+        schema_valid = False
+        parsed_sessions = []
+        payloads: list[JSONValue] = []
+        validation_error: str | None = None
+        try:
+            corpus = SyntheticCorpus.for_provider(provider, version=package.version, element_kind=element_kind)
+            batch = corpus.generate_batch(count=1, messages_per_session=range(4, 5), seed=seed)
+            raw = batch.raw_items[0]
+            if route.wire_format.encoding == "jsonl":
+                import json
+
+                payload: JSONValue = [json.loads(line) for line in raw.decode("utf-8").splitlines() if line.strip()]
+                payloads = payload if isinstance(payload, list) else []
+            else:
+                import json
+
+                payload = json.loads(raw)
+                payloads = [payload] if isinstance(payload, (dict, list)) else []
+            validation_results = [validate_provider_export(item, provider, strict=False) for item in payloads]
+            schema_valid = bool(validation_results) and all(result.is_valid for result in validation_results)
+            if not schema_valid:
+                validation_error = "; ".join(error for result in validation_results for error in result.errors) or (
+                    "selected package schema rejected generated payload"
+                )
+            parsed_sessions = parse_payload(provider, payload, f"synthetic-wire-receipt:{provider}")
+        except Exception as exc:  # Receipt records route failures instead of hiding them.
+            validation_error = f"{type(exc).__name__}: {exc}"
+
+        coverage = construct_coverage(schema, payloads)
+        entries.append(
+            WireSupportEntry(
+                provider=provider,
+                status=route.status,
+                reason=None,
+                package_version=package_version,
+                element_kind=element_kind,
+                schema_valid=schema_valid,
+                parsed_session_count=len(parsed_sessions),
+                parsed_message_count=sum(len(session.messages) for session in parsed_sessions),
+                construct_coverage=coverage,
+                validation_error=validation_error,
+            )
+        )
+
+    return WireSupportReceipt(
+        catalog_providers=catalog_providers,
+        entries=tuple(entries),
+        missing_routes=tuple(sorted(missing_routes)),
+    )
+
+
 __all__ = [
+    "ConstructCoverage",
     "PROVIDER_WIRE_FORMATS",
+    "PROVIDER_WIRE_CAPABILITIES",
+    "PROVIDER_WIRE_ROUTES",
     "TreeConfig",
+    "WireCapabilityStatus",
     "WireEncoding",
     "WireFormat",
+    "WireRoute",
+    "WireSupportEntry",
+    "WireSupportReceipt",
+    "build_wire_support_receipt",
+    "construct_coverage",
 ]

--- a/polylogue/schemas/synthetic/wire_formats.py
+++ b/polylogue/schemas/synthetic/wire_formats.py
@@ -7,6 +7,7 @@ tree vs. linear vs. JSONL, and message location paths.
 from __future__ import annotations
 
 import copy
+import hashlib
 import json
 import re
 from collections.abc import Collection, Mapping, Sequence
@@ -17,6 +18,7 @@ from polylogue.archive.raw_payload.decode import JSONValue
 
 if TYPE_CHECKING:
     from polylogue.schemas.synthetic.models import SchemaRecord, SyntheticGenerationBatch
+    from polylogue.sources.parsers.base_models import ParsedSession
 
 WireEncoding: TypeAlias = Literal["json", "jsonl"]
 WireCapabilityStatus: TypeAlias = Literal["supported", "unsupported"]
@@ -96,17 +98,16 @@ class WireParserWitness:
     parsed_session_count: int
     parsed_message_count: int
     validation_error: str | None = None
+    artifact_kind: Literal["baseline", "coverage"] = "coverage"
+    artifact_evidence: tuple[str, ...] = ()
 
     @property
     def healthy(self) -> bool:
         return (
             bool(self.exercised_keywords)
-            # Some valid provider-wire witnesses describe envelope metadata
-            # that the parser preserves as a session while intentionally
-            # yielding no conversational message.  The ordinary baseline
-            # artifact still supplies the route-level positive message proof;
-            # each witness must prove parser admission independently.
             and self.parsed_session_count > 0
+            and self.parsed_message_count > 0
+            and bool(self.artifact_evidence)
             and self.validation_error is None
         )
 
@@ -191,6 +192,8 @@ class WireSupportReceipt:
                             "parsed_session_count": witness.parsed_session_count,
                             "parsed_message_count": witness.parsed_message_count,
                             "validation_error": witness.validation_error,
+                            "artifact_kind": witness.artifact_kind,
+                            "artifact_evidence": list(witness.artifact_evidence),
                             "healthy": witness.healthy,
                         }
                         for witness in entry.parser_witnesses
@@ -887,13 +890,165 @@ def construct_coverage(
     )
 
 
+def _payload_string_values(value: object) -> tuple[str, ...]:
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, Mapping):
+        return tuple(text for child in value.values() for text in _payload_string_values(child))
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return tuple(text for child in value for text in _payload_string_values(child))
+    return ()
+
+
+def _normalise_evidence_text(value: str) -> str:
+    return " ".join(value.split())
+
+
+def _parser_evidence_nodes(provider: str, payload: JSONValue) -> tuple[Mapping[str, JSONValue], ...]:
+    """Return the route-owned conversational nodes from one wire artifact."""
+    nodes: list[Mapping[str, JSONValue]] = []
+    if isinstance(payload, dict):
+        session = payload.get("session")
+        turns = session.get("turns") if isinstance(session, dict) else None
+        if isinstance(turns, list):
+            nodes.extend(
+                turn
+                for turn in turns
+                if isinstance(turn, dict)
+                and isinstance(turn.get("provider_turn_id"), str)
+                and isinstance(turn.get("role"), str)
+                and isinstance(turn.get("text"), str)
+            )
+        raw_provider_payload = payload.get("raw_provider_payload")
+        if isinstance(raw_provider_payload, (dict, list)):
+            nodes.extend(_parser_evidence_nodes(provider, raw_provider_payload))
+    if provider == "chatgpt" and isinstance(payload, dict):
+        mapping = payload.get("mapping")
+        if isinstance(mapping, dict):
+            for node in mapping.values():
+                if not isinstance(node, dict):
+                    continue
+                message = node.get("message")
+                if (
+                    isinstance(message, dict)
+                    and isinstance(message.get("author"), dict)
+                    and isinstance(message.get("content"), dict)
+                ):
+                    nodes.append(node)
+    if provider == "claude-ai" and isinstance(payload, dict):
+        messages = payload.get("chat_messages")
+        if isinstance(messages, list):
+            nodes.extend(
+                message
+                for message in messages
+                if isinstance(message, dict)
+                and isinstance(message.get("uuid"), str)
+                and isinstance(message.get("sender"), str)
+                and isinstance(message.get("text"), str)
+            )
+    if provider == "gemini" and isinstance(payload, dict):
+        prompt = payload.get("chunkedPrompt")
+        chunks = prompt.get("chunks") if isinstance(prompt, dict) else None
+        if isinstance(chunks, list):
+            nodes.extend(
+                chunk
+                for chunk in chunks
+                if isinstance(chunk, dict) and isinstance(chunk.get("role"), str) and isinstance(chunk.get("text"), str)
+            )
+    if provider in {"claude-code", "codex"} and isinstance(payload, list):
+        for record in payload:
+            if not isinstance(record, dict):
+                continue
+            if provider == "claude-code":
+                if record.get("type") in {"user", "assistant", "system"} and isinstance(record.get("message"), dict):
+                    nodes.append(record)
+                continue
+            record_type = record.get("type")
+            if record_type == "message" and isinstance(record.get("id"), str):
+                nodes.append(record)
+                continue
+            nested = record.get("payload")
+            if (
+                record_type == "response_item"
+                and isinstance(nested, dict)
+                and nested.get("type") == "message"
+                and isinstance(nested.get("id"), str)
+            ) or (
+                record_type == "event_msg"
+                and isinstance(nested, dict)
+                and nested.get("type") in {"user_message", "agent_message"}
+            ):
+                nodes.append(nested)
+    return tuple(nodes)
+
+
+def _parser_artifact_evidence(
+    sessions: Sequence[ParsedSession],
+    provider: str,
+    payload: JSONValue,
+    fallback_id: str,
+) -> tuple[str, ...]:
+    """Return materialized-message evidence found in this exact artifact.
+
+    Parser counts are deliberately insufficient here. A misrouted parser can
+    return a valid session from another artifact, which would otherwise let
+    one witness borrow another witness's success. The evidence digest is
+    emitted only when meaningful parsed message/block text is present in the
+    artifact being validated.
+    """
+
+    from polylogue.sources.dispatch import message_carries_authored_content
+
+    evidence_nodes = _parser_evidence_nodes(provider, payload)
+    evidence: list[str] = []
+    seen: set[str] = set()
+    for session in sessions:
+        session_identity = session.provider_session_id
+        session_is_bound = session_identity == fallback_id or session_identity in _payload_string_values(payload)
+        if not session_is_bound:
+            continue
+        for message in session.messages:
+            if not message_carries_authored_content(message):
+                continue
+            message_identity = message.provider_message_id
+            candidates = [message.text, *(block.text for block in message.blocks)]
+            for candidate in candidates:
+                if not isinstance(candidate, str) or not candidate.strip():
+                    continue
+                normalized = _normalise_evidence_text(candidate)
+                if not normalized:
+                    continue
+                for node in evidence_nodes:
+                    node_texts = tuple(_normalise_evidence_text(text) for text in _payload_string_values(node))
+                    identity_bound = not message_identity or message_identity in node_texts
+                    content_bound = normalized in node_texts
+                    structured_content_bound = (
+                        bool(message.blocks) and bool(message_identity) and identity_bound and bool(node_texts)
+                    )
+                    if not identity_bound or not (content_bound or structured_content_bound):
+                        continue
+                    node_bytes = json.dumps(node, sort_keys=True, separators=(",", ":")).encode("utf-8")
+                    digest = hashlib.sha256(node_bytes).hexdigest()
+                    token = f"{session_identity}:message:{message_identity or 'unidentified'}:sha256:{digest}"
+                    if token not in seen:
+                        seen.add(token)
+                        evidence.append(token)
+                    break
+                if evidence and evidence[-1].startswith(
+                    f"{session_identity}:message:{message_identity or 'unidentified'}:"
+                ):
+                    break
+    return tuple(evidence)
+
+
 def build_wire_support_receipt(*, registry: object | None = None, seed: int = 20260805) -> WireSupportReceipt:
     """Validate executable routes through the selected schema and parser.
 
     The provider set comes from the package registry.  The parser call is the
-    public ``parse_payload`` entry point used by production dispatch, so a
-    route is healthy only when its generated artifact validates and produces a
-    non-empty parsed session.
+    public ``parse_payload`` entry point used by production dispatch. Every
+    artifact, including the baseline, must pass the production
+    positive-conversational-evidence filter and carry artifact-local
+    materialized content evidence.
     """
 
     if registry is None:
@@ -903,7 +1058,7 @@ def build_wire_support_receipt(*, registry: object | None = None, seed: int = 20
     from polylogue.schemas.synthetic.core import SyntheticCorpus
     from polylogue.schemas.synthetic.selection import select_synthetic_schema
     from polylogue.schemas.validator import SchemaValidator, ValidationResult
-    from polylogue.sources.dispatch import parse_payload
+    from polylogue.sources.dispatch import parse_payload, require_positive_conversational_evidence
 
     catalog_providers = tuple(sorted(registry.list_providers()))  # type: ignore[attr-defined]
     entries: list[WireSupportEntry] = []
@@ -969,6 +1124,7 @@ def build_wire_support_receipt(*, registry: object | None = None, seed: int = 20
         validation_error: str | None = None
         selection = None
         parser_witnesses: list[WireParserWitness] = []
+        parser_errors: list[str] = []
         try:
             selection = select_synthetic_schema(
                 provider,
@@ -1019,50 +1175,66 @@ def build_wire_support_receipt(*, registry: object | None = None, seed: int = 20
                 parse_error: str | None = None
                 artifact_sessions = []
                 try:
-                    artifact_sessions = parse_payload(
+                    parser_payload = payload
+                    if provider == "chatgpt" and isinstance(payload, dict):
+                        # Validate and account for the complete envelope, but
+                        # keep the optional native subpayload from selecting a
+                        # second schema-shaped tree during parser dispatch.
+                        parser_payload = dict(payload)
+                        parser_payload.pop("raw_provider_payload", None)
+                    parsed_sessions_for_artifact = parse_payload(
                         provider,
-                        payload,
+                        parser_payload,
                         f"synthetic-wire-receipt:{provider}:{index}",
                         schema_resolution=schema_resolution,
                     )
+                    artifact_sessions = require_positive_conversational_evidence(
+                        parsed_sessions_for_artifact,
+                        provider=provider,
+                        source_path=f"synthetic-wire-receipt:{provider}:{index}",
+                    )
                 except Exception as exc:  # Keep the witness failure in the receipt.
                     parse_error = f"{type(exc).__name__}: {exc}"
+                artifact_evidence = _parser_artifact_evidence(
+                    artifact_sessions,
+                    provider,
+                    payload,
+                    f"synthetic-wire-receipt:{provider}:{index}",
+                )
                 parsed_sessions.extend(artifact_sessions)
-                if index == 0:
-                    if (
-                        artifact_sessions
-                        and any(session.messages for session in artifact_sessions)
-                        and artifact_validation_error is None
-                    ):
-                        payloads.extend(payload_items)
-                    continue
-
+                artifact_kind: Literal["baseline", "coverage"] = "baseline" if index == 0 else "coverage"
                 parser_witnesses.append(
                     WireParserWitness(
-                        index=index - 1,
+                        index=-1 if index == 0 else index - 1,
                         exercised_keywords=artifact_coverage.exercised_keywords,
                         parsed_session_count=len(artifact_sessions),
                         parsed_message_count=sum(len(session.messages) for session in artifact_sessions),
                         validation_error=parse_error or artifact_validation_error,
+                        artifact_kind=artifact_kind,
+                        artifact_evidence=artifact_evidence,
                     )
                 )
-                # A parser route must earn the right to contribute its raw
-                # witness to aggregate schema coverage.  Otherwise a dropped
-                # witness can be masked by another artifact's parsed counts.
                 if (
                     artifact_sessions
-                    and any(session.messages for session in artifact_sessions)
+                    and artifact_evidence
                     and artifact_validation_error is None
                     and parse_error is None
                 ):
                     payloads.extend(payload_items)
+                if parse_error is not None:
+                    label = "baseline" if index == 0 else f"coverage witness {index - 1}"
+                    parser_errors.append(f"{label} parser: {parse_error}")
             schema_valid = bool(validation_results) and all(result.is_valid for result in validation_results)
             if not schema_valid:
-                validation_error = "; ".join(error for result in validation_results for error in result.errors) or (
-                    "selected package schema rejected generated payload"
+                parser_errors.append(
+                    "; ".join(error for result in validation_results for error in result.errors)
+                    or "selected package schema rejected generated payload"
                 )
         except Exception as exc:  # Receipt records route failures instead of hiding them.
             validation_error = f"{type(exc).__name__}: {exc}"
+
+        if parser_errors:
+            validation_error = "; ".join(parser_errors)
 
         if selection is not None:
             witnessed = construct_coverage(selection.schema, payloads)

--- a/polylogue/schemas/synthetic/wire_formats.py
+++ b/polylogue/schemas/synthetic/wire_formats.py
@@ -236,102 +236,174 @@ _STRUCTURAL_SCHEMA_KEYWORDS = frozenset(
 )
 
 
-def _schema_constructs(schema: object, result: set[str] | None = None) -> set[str]:
-    if result is None:
-        result = set()
-    if isinstance(schema, Mapping):
-        for keyword, value in schema.items():
-            if keyword not in _STRUCTURAL_SCHEMA_KEYWORDS:
-                continue
-            if keyword == "type":
-                if isinstance(value, str):
-                    result.add(f"type:{value}")
-                elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
-                    result.update(f"type:{item}" for item in value if isinstance(item, str))
-            else:
-                result.add(keyword)
-        for value in schema.values():
-            _schema_constructs(value, result)
-    elif isinstance(schema, Sequence) and not isinstance(schema, (str, bytes)):
-        for value in schema:
-            _schema_constructs(value, result)
-    return result
+def _json_type_name(value: JSONValue) -> str:
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if value is None:
+        return "null"
+    if isinstance(value, list):
+        return "array"
+    return "object"
 
 
-def _json_value_types(value: JSONValue, result: set[str] | None = None) -> set[str]:
-    if result is None:
-        result = set()
-    if isinstance(value, dict):
-        result.add("object")
-        for child in value.values():
-            _json_value_types(child, result)
-    elif isinstance(value, list):
-        result.add("array")
-        for child in value:
-            _json_value_types(child, result)
-    elif value is None:
-        result.add("null")
-    elif isinstance(value, bool):
-        result.add("boolean")
-    elif isinstance(value, int):
-        result.update(("integer", "number"))
-    elif isinstance(value, float):
-        result.add("number")
-    elif isinstance(value, str):
-        result.add("string")
-    return result
+def _type_matches(expected: str, actual: str) -> bool:
+    return expected == actual or (expected == "number" and actual == "integer")
 
 
-def _payload_structure_constructs(
-    schema: object,
-    payload: JSONValue,
-    result: set[str] | None = None,
-) -> set[str]:
-    if result is None:
-        result = set()
-    if not isinstance(schema, Mapping) or not isinstance(payload, dict):
-        return result
+def _coverage_key(keyword: str, path: str) -> str:
+    return keyword if path == "$" else f"{keyword}@{path}"
 
-    properties = schema.get("properties")
-    property_names = set(properties) if isinstance(properties, Mapping) else set()
-    if property_names & payload.keys():
-        result.add("properties")
 
-    required = schema.get("required")
-    required_names = {item for item in required if isinstance(item, str)} if isinstance(required, list) else set()
-    if "required" in schema and required_names <= payload.keys():
-        result.add("required")
+def _schema_type_names(schema: Mapping[str, object]) -> tuple[str, ...]:
+    schema_type = schema.get("type")
+    if isinstance(schema_type, str):
+        return (schema_type,)
+    if isinstance(schema_type, Sequence) and not isinstance(schema_type, (str, bytes)):
+        return tuple(item for item in schema_type if isinstance(item, str))
+    return ()
 
-    if "additionalProperties" in schema:
-        extra_names = payload.keys() - property_names
-        if schema.get("additionalProperties") is False:
-            if not extra_names:
-                result.add("additionalProperties")
-        elif extra_names:
-            result.add("additionalProperties")
 
-    if isinstance(properties, Mapping):
-        for name, child_schema in properties.items():
-            if isinstance(name, str) and name in payload:
-                _payload_structure_constructs(child_schema, payload[name], result)
-
-    items = schema.get("items")
-    if isinstance(items, Mapping) and isinstance(payload, list):
-        for item in payload:
-            _payload_structure_constructs(items, item, result)
-
-    additional_schema = schema.get("additionalProperties")
-    if isinstance(additional_schema, Mapping):
-        for name, item in payload.items():
-            if name not in property_names:
-                _payload_structure_constructs(additional_schema, item, result)
-
+def _matching_variants(schema: Mapping[str, object], payload: JSONValue) -> list[Mapping[str, object]]:
+    actual_type = _json_type_name(payload)
     for keyword in ("anyOf", "oneOf"):
         variants = schema.get(keyword)
-        if isinstance(variants, list):
-            for variant in variants:
-                _payload_structure_constructs(variant, payload, result)
-    return result
+        if not isinstance(variants, list):
+            continue
+        matches: list[Mapping[str, object]] = []
+        for variant in variants:
+            if not isinstance(variant, Mapping):
+                continue
+            declared_types = _schema_type_names(variant)
+            if declared_types and not any(_type_matches(expected, actual_type) for expected in declared_types):
+                continue
+            required = variant.get("required")
+            required_names = (
+                {item for item in required if isinstance(item, str)} if isinstance(required, list) else set()
+            )
+            if required_names and (not isinstance(payload, dict) or not required_names <= payload.keys()):
+                continue
+            matches.append(variant)
+        if matches:
+            return matches
+        return [variant for variant in variants if isinstance(variant, Mapping)]
+    return []
+
+
+def _collect_payload_coverage(
+    schema: object,
+    payload: JSONValue,
+    *,
+    path: str,
+    handlers: set[str],
+    schema_keywords: set[str],
+    exercised_keywords: set[str],
+) -> None:
+    if not isinstance(schema, Mapping):
+        return
+
+    declared_types = _schema_type_names(schema)
+    actual_type = _json_type_name(payload)
+    if declared_types:
+        matched_types = tuple(expected for expected in declared_types if _type_matches(expected, actual_type))
+        types_to_report = matched_types or declared_types
+        for expected in types_to_report:
+            key = _coverage_key(f"type:{expected}", path)
+            schema_keywords.add(key)
+            if expected in handlers and _type_matches(expected, actual_type):
+                exercised_keywords.add(key)
+
+    for keyword in ("anyOf", "oneOf"):
+        if isinstance(schema.get(keyword), list):
+            key = _coverage_key(keyword, path)
+            schema_keywords.add(key)
+            if keyword in handlers:
+                exercised_keywords.add(key)
+    for variant in _matching_variants(schema, payload):
+        _collect_payload_coverage(
+            variant,
+            payload,
+            path=path,
+            handlers=handlers,
+            schema_keywords=schema_keywords,
+            exercised_keywords=exercised_keywords,
+        )
+
+    if isinstance(payload, dict):
+        properties = schema.get("properties")
+        property_names = set(properties) if isinstance(properties, Mapping) else set()
+        if isinstance(properties, Mapping):
+            key = _coverage_key("properties", path)
+            schema_keywords.add(key)
+            if property_names & payload.keys():
+                exercised_keywords.add(key)
+
+        if "required" in schema:
+            key = _coverage_key("required", path)
+            schema_keywords.add(key)
+            required = schema.get("required")
+            required_names = (
+                {item for item in required if isinstance(item, str)} if isinstance(required, list) else set()
+            )
+            if required_names <= payload.keys():
+                exercised_keywords.add(key)
+
+        if "additionalProperties" in schema:
+            extra_names = payload.keys() - property_names
+            additional_schema = schema.get("additionalProperties")
+            if additional_schema is False:
+                key = _coverage_key("additionalProperties", path)
+                schema_keywords.add(key)
+                if not extra_names:
+                    exercised_keywords.add(key)
+            elif extra_names:
+                key = _coverage_key("additionalProperties", path)
+                schema_keywords.add(key)
+                exercised_keywords.add(key)
+
+        if isinstance(properties, Mapping):
+            for name, child_schema in properties.items():
+                if isinstance(name, str) and name in payload:
+                    _collect_payload_coverage(
+                        child_schema,
+                        payload[name],
+                        path=f"{path}.properties.{name}",
+                        handlers=handlers,
+                        schema_keywords=schema_keywords,
+                        exercised_keywords=exercised_keywords,
+                    )
+
+        additional_schema = schema.get("additionalProperties")
+        if isinstance(additional_schema, Mapping):
+            for name, item in payload.items():
+                if name not in property_names:
+                    _collect_payload_coverage(
+                        additional_schema,
+                        item,
+                        path=f"{path}.additionalProperties.{name}",
+                        handlers=handlers,
+                        schema_keywords=schema_keywords,
+                        exercised_keywords=exercised_keywords,
+                    )
+
+    if isinstance(payload, list) and isinstance(schema.get("items"), Mapping):
+        key = _coverage_key("items", path)
+        schema_keywords.add(key)
+        exercised_keywords.add(key)
+        for index, item in enumerate(payload):
+            _collect_payload_coverage(
+                schema["items"],
+                item,
+                path=f"{path}.items[{index}]",
+                handlers=handlers,
+                schema_keywords=schema_keywords,
+                exercised_keywords=exercised_keywords,
+            )
 
 
 def construct_coverage(
@@ -352,21 +424,17 @@ def construct_coverage(
 
         handler_names = SCHEMA_CONSTRUCT_HANDLERS.keys()
     handlers = set(handler_names)
-    schema_keywords = _schema_constructs(schema)
-    value_types: set[str] = set()
-    structure_constructs: set[str] = set()
-    for payload in payloads:
-        _json_value_types(payload, value_types)
-        _payload_structure_constructs(schema, payload, structure_constructs)
-
+    schema_keywords: set[str] = set()
     exercised: set[str] = set()
-    for construct in schema_keywords:
-        if construct.startswith("type:"):
-            type_name = construct.removeprefix("type:")
-            if type_name in handlers and type_name in value_types:
-                exercised.add(construct)
-        elif (construct in handlers and payloads) or construct in structure_constructs:
-            exercised.add(construct)
+    for payload in payloads:
+        _collect_payload_coverage(
+            schema,
+            payload,
+            path="$",
+            handlers=handlers,
+            schema_keywords=schema_keywords,
+            exercised_keywords=exercised,
+        )
 
     return ConstructCoverage(
         schema_keywords=tuple(sorted(schema_keywords)),

--- a/polylogue/schemas/synthetic/wire_formats.py
+++ b/polylogue/schemas/synthetic/wire_formats.py
@@ -7,6 +7,7 @@ tree vs. linear vs. JSONL, and message location paths.
 from __future__ import annotations
 
 import copy
+import json
 import re
 from collections.abc import Collection, Mapping, Sequence
 from dataclasses import dataclass
@@ -87,6 +88,30 @@ class ConstructCoverage:
 
 
 @dataclass(frozen=True)
+class WireParserWitness:
+    """One schema witness exercised through the production parser route."""
+
+    index: int
+    exercised_keywords: tuple[str, ...]
+    parsed_session_count: int
+    parsed_message_count: int
+    validation_error: str | None = None
+
+    @property
+    def healthy(self) -> bool:
+        return (
+            bool(self.exercised_keywords)
+            # Some valid provider-wire witnesses describe envelope metadata
+            # that the parser preserves as a session while intentionally
+            # yielding no conversational message.  The ordinary baseline
+            # artifact still supplies the route-level positive message proof;
+            # each witness must prove parser admission independently.
+            and self.parsed_session_count > 0
+            and self.validation_error is None
+        )
+
+
+@dataclass(frozen=True)
 class WireSupportEntry:
     """One provider row in the support receipt."""
 
@@ -100,6 +125,7 @@ class WireSupportEntry:
     parsed_message_count: int
     construct_coverage: ConstructCoverage | None
     validation_error: str | None = None
+    parser_witnesses: tuple[WireParserWitness, ...] = ()
 
     @property
     def healthy(self) -> bool:
@@ -110,6 +136,8 @@ class WireSupportEntry:
             and self.construct_coverage is not None
             and self.construct_coverage.complete
             and self.validation_error is None
+            and bool(self.parser_witnesses)
+            and all(witness.healthy for witness in self.parser_witnesses)
         )
 
 
@@ -156,6 +184,17 @@ class WireSupportReceipt:
                     "parsed_session_count": entry.parsed_session_count,
                     "parsed_message_count": entry.parsed_message_count,
                     "validation_error": entry.validation_error,
+                    "parser_witnesses": [
+                        {
+                            "index": witness.index,
+                            "exercised_keywords": list(witness.exercised_keywords),
+                            "parsed_session_count": witness.parsed_session_count,
+                            "parsed_message_count": witness.parsed_message_count,
+                            "validation_error": witness.validation_error,
+                            "healthy": witness.healthy,
+                        }
+                        for witness in entry.parser_witnesses
+                    ],
                     "construct_coverage": (
                         {
                             "schema_keywords": list(entry.construct_coverage.schema_keywords),
@@ -929,6 +968,7 @@ def build_wire_support_receipt(*, registry: object | None = None, seed: int = 20
         payloads: list[JSONValue] = []
         validation_error: str | None = None
         selection = None
+        parser_witnesses: list[WireParserWitness] = []
         try:
             selection = select_synthetic_schema(
                 provider,
@@ -951,18 +991,71 @@ def build_wire_support_receipt(*, registry: object | None = None, seed: int = 20
             ]
             validator = SchemaValidator(selection.schema, strict=False)
             validation_results: list[ValidationResult] = []
-            for index, raw in enumerate(raw_items):
-                import json
+            schema_resolution = None
+            if selection.element_kind is not None:
+                from polylogue.schemas.packages import SchemaResolution
 
+                schema_resolution = SchemaResolution(
+                    provider=selection.provider,
+                    package_version=selection.package_version,
+                    element_kind=selection.element_kind,
+                    exact_structure_id=None,
+                    bundle_scope=None,
+                    reason="package_default",
+                )
+            for index, raw in enumerate(raw_items):
                 if route.wire_format.encoding == "jsonl":
                     payload: JSONValue = [json.loads(line) for line in raw.decode("utf-8").splitlines() if line.strip()]
                     payload_items = payload if isinstance(payload, list) else []
                 else:
                     payload = json.loads(raw)
                     payload_items = [payload] if isinstance(payload, (dict, list)) else []
-                payloads.extend(payload_items)
-                validation_results.extend(validator.validate(item) for item in payload_items)
-                parsed_sessions.extend(parse_payload(provider, payload, f"synthetic-wire-receipt:{provider}:{index}"))
+                artifact_results = [validator.validate(item) for item in payload_items]
+                validation_results.extend(artifact_results)
+                artifact_validation_error = (
+                    "; ".join(error for result in artifact_results for error in result.errors) or None
+                )
+                artifact_coverage = construct_coverage(selection.schema, payload_items)
+                parse_error: str | None = None
+                artifact_sessions = []
+                try:
+                    artifact_sessions = parse_payload(
+                        provider,
+                        payload,
+                        f"synthetic-wire-receipt:{provider}:{index}",
+                        schema_resolution=schema_resolution,
+                    )
+                except Exception as exc:  # Keep the witness failure in the receipt.
+                    parse_error = f"{type(exc).__name__}: {exc}"
+                parsed_sessions.extend(artifact_sessions)
+                if index == 0:
+                    if (
+                        artifact_sessions
+                        and any(session.messages for session in artifact_sessions)
+                        and artifact_validation_error is None
+                    ):
+                        payloads.extend(payload_items)
+                    continue
+
+                parser_witnesses.append(
+                    WireParserWitness(
+                        index=index - 1,
+                        exercised_keywords=artifact_coverage.exercised_keywords,
+                        parsed_session_count=len(artifact_sessions),
+                        parsed_message_count=sum(len(session.messages) for session in artifact_sessions),
+                        validation_error=parse_error or artifact_validation_error,
+                    )
+                )
+                # A parser route must earn the right to contribute its raw
+                # witness to aggregate schema coverage.  Otherwise a dropped
+                # witness can be masked by another artifact's parsed counts.
+                if (
+                    artifact_sessions
+                    and any(session.messages for session in artifact_sessions)
+                    and artifact_validation_error is None
+                    and parse_error is None
+                ):
+                    payloads.extend(payload_items)
             schema_valid = bool(validation_results) and all(result.is_valid for result in validation_results)
             if not schema_valid:
                 validation_error = "; ".join(error for result in validation_results for error in result.errors) or (
@@ -994,6 +1087,7 @@ def build_wire_support_receipt(*, registry: object | None = None, seed: int = 20
                 parsed_message_count=sum(len(session.messages) for session in parsed_sessions),
                 construct_coverage=coverage,
                 validation_error=validation_error,
+                parser_witnesses=tuple(parser_witnesses),
             )
         )
 
@@ -1013,6 +1107,7 @@ __all__ = [
     "WireCapabilityStatus",
     "WireEncoding",
     "WireFormat",
+    "WireParserWitness",
     "WireRoute",
     "WireSupportEntry",
     "WireSupportReceipt",

--- a/polylogue/schemas/synthetic/wire_formats.py
+++ b/polylogue/schemas/synthetic/wire_formats.py
@@ -6,14 +6,16 @@ tree vs. linear vs. JSONL, and message location paths.
 
 from __future__ import annotations
 
+import copy
+import re
 from collections.abc import Collection, Mapping, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal, TypeAlias
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeAlias, cast
 
 from polylogue.archive.raw_payload.decode import JSONValue
 
 if TYPE_CHECKING:
-    from polylogue.schemas.synthetic.models import SchemaRecord
+    from polylogue.schemas.synthetic.models import SchemaRecord, SyntheticGenerationBatch
 
 WireEncoding: TypeAlias = Literal["json", "jsonl"]
 WireCapabilityStatus: TypeAlias = Literal["supported", "unsupported"]
@@ -76,6 +78,8 @@ class ConstructCoverage:
     schema_keywords: tuple[str, ...]
     exercised_keywords: tuple[str, ...]
     missing_keywords: tuple[str, ...]
+    nonrepresentable_keywords: tuple[str, ...] = ()
+    nonrepresentable_reasons: tuple[tuple[str, str], ...] = ()
 
     @property
     def complete(self) -> bool:
@@ -157,6 +161,11 @@ class WireSupportReceipt:
                             "schema_keywords": list(entry.construct_coverage.schema_keywords),
                             "exercised_keywords": list(entry.construct_coverage.exercised_keywords),
                             "missing_keywords": list(entry.construct_coverage.missing_keywords),
+                            "nonrepresentable_keywords": list(entry.construct_coverage.nonrepresentable_keywords),
+                            "nonrepresentable_reasons": [
+                                {"keyword": keyword, "reason": reason}
+                                for keyword, reason in entry.construct_coverage.nonrepresentable_reasons
+                            ],
                             "complete": entry.construct_coverage.complete,
                         }
                         if entry.construct_coverage is not None
@@ -236,6 +245,22 @@ _STRUCTURAL_SCHEMA_KEYWORDS = frozenset(
 )
 
 
+class _CoverageCorpus(Protocol):
+    schema: SchemaRecord
+    workload_profile: SchemaRecord | None
+    _coverage_branch_choices: dict[str, int]
+    _coverage_type_choices: dict[str, str]
+    _coverage_null_paths: set[str]
+    _coverage_witness_mode: bool
+
+    def generate_batch(
+        self,
+        count: int = 5,
+        messages_per_session: range = range(3, 15),
+        seed: int | None = None,
+    ) -> SyntheticGenerationBatch: ...
+
+
 def _json_type_name(value: JSONValue) -> str:
     if isinstance(value, bool):
         return "boolean"
@@ -260,6 +285,78 @@ def _coverage_key(keyword: str, path: str) -> str:
     return keyword if path == "$" else f"{keyword}@{path}"
 
 
+def _runtime_coverage_path(path: str) -> str:
+    # Union segments are part of the runtime path. A nested union must not
+    # reuse its parent's key, since its branch choice is independent.
+    return path
+
+
+def _route_nonrepresentable_reasons(provider: str, missing_keywords: Collection[str]) -> dict[str, str]:
+    """Prove nodes discarded by a provider's wire normalizer are unreachable."""
+    reasons: dict[str, str] = {}
+    prefixes: tuple[tuple[str, str], ...]
+    if provider == "codex":
+        prefixes = (("$.properties.payload", "Codex flat-record shaping removes the payload envelope"),)
+    elif provider == "claude-ai":
+        prefixes = (
+            (
+                "$.properties.chat_messages.items[*]",
+                "Claude AI wire shaping clears each chat message and retains only uuid, sender, text, and created_at",
+            ),
+        )
+    elif provider == "gemini":
+        prefixes = (
+            (
+                "$.properties.chunkedPrompt.properties.chunks.items[*]",
+                "Gemini wire shaping clears each chunk and retains only role, text, and createTime",
+            ),
+            (
+                "$.properties.chunkedPrompt.properties.pendingInputs",
+                "Gemini linear wire shaping rebuilds chunkedPrompt and does not carry pendingInputs",
+            ),
+        )
+    elif provider == "chatgpt":
+        prefixes = (
+            (
+                "$.properties.raw_provider_payload.properties.mapping",
+                "ChatGPT coverage wire shaping removes the nested raw-provider mapping before the parser route, matching the tree route's parser-owned mapping container",
+            ),
+        )
+    elif provider == "claude-code":
+        prefixes = (
+            (
+                "$.properties.message.properties.content.anyOf[1].items[*].properties.content.anyOf[1]",
+                "Claude Code wire shaping preserves message content but its fallback emits scalar text and supported block forms, never nested array content/source blocks",
+            ),
+        )
+    else:
+        prefixes = ()
+
+    retained_suffixes = {
+        "$.properties.chat_messages.items[*].properties.uuid",
+        "$.properties.chat_messages.items[*].properties.text",
+        "$.properties.chat_messages.items[*].properties.created_at",
+        "$.properties.chunkedPrompt.properties.chunks.items[*].properties.role",
+        "$.properties.chunkedPrompt.properties.chunks.items[*].properties.text",
+        "$.properties.chunkedPrompt.properties.chunks.items[*].properties.createTime",
+    }
+    for keyword in missing_keywords:
+        path = keyword.split("@", 1)[1] if "@" in keyword else "$"
+        if (
+            provider == "chatgpt"
+            and keyword.startswith("type:null@")
+            and path.endswith(".properties.message")
+            and ".properties.mapping.additionalProperties.*." in path
+        ):
+            reasons[keyword] = "ChatGPT wire shaping coerces a null message field to the route's object record"
+            continue
+        for prefix, reason in prefixes:
+            if path.startswith(prefix) and path not in retained_suffixes:
+                reasons[keyword] = reason
+                break
+    return reasons
+
+
 def _schema_type_names(schema: Mapping[str, object]) -> tuple[str, ...]:
     schema_type = schema.get("type")
     if isinstance(schema_type, str):
@@ -269,14 +366,14 @@ def _schema_type_names(schema: Mapping[str, object]) -> tuple[str, ...]:
     return ()
 
 
-def _matching_variants(schema: Mapping[str, object], payload: JSONValue) -> list[Mapping[str, object]]:
+def _matching_variants(schema: Mapping[str, object], payload: JSONValue) -> list[tuple[int, Mapping[str, object]]]:
     actual_type = _json_type_name(payload)
     for keyword in ("anyOf", "oneOf"):
         variants = schema.get(keyword)
         if not isinstance(variants, list):
             continue
-        matches: list[Mapping[str, object]] = []
-        for variant in variants:
+        matches: list[tuple[int, Mapping[str, object]]] = []
+        for index, variant in enumerate(variants):
             if not isinstance(variant, Mapping):
                 continue
             declared_types = _schema_type_names(variant)
@@ -288,11 +385,312 @@ def _matching_variants(schema: Mapping[str, object], payload: JSONValue) -> list
             )
             if required_names and (not isinstance(payload, dict) or not required_names <= payload.keys()):
                 continue
-            matches.append(variant)
+            matches.append((index, variant))
         if matches:
             return matches
-        return [variant for variant in variants if isinstance(variant, Mapping)]
+        return []
     return []
+
+
+def _collect_schema_obligations(
+    schema: object,
+    *,
+    path: str,
+    obligations: set[str],
+) -> None:
+    """Collect node-local obligations without consulting generated payloads."""
+    if not isinstance(schema, Mapping):
+        return
+
+    for schema_type in _schema_type_names(schema):
+        obligations.add(_coverage_key(f"type:{schema_type}", path))
+
+    for keyword in ("anyOf", "oneOf"):
+        variants = schema.get(keyword)
+        if not isinstance(variants, list):
+            continue
+        obligations.add(_coverage_key(keyword, path))
+        for index, variant in enumerate(variants):
+            if isinstance(variant, Mapping):
+                _collect_schema_obligations(
+                    variant,
+                    path=f"{path}.{keyword}[{index}]",
+                    obligations=obligations,
+                )
+
+    properties = schema.get("properties")
+    if isinstance(properties, Mapping):
+        obligations.add(_coverage_key("properties", path))
+        for name, child_schema in properties.items():
+            if isinstance(name, str):
+                _collect_schema_obligations(
+                    child_schema,
+                    path=f"{path}.properties.{name}",
+                    obligations=obligations,
+                )
+
+    if "required" in schema:
+        obligations.add(_coverage_key("required", path))
+
+    if "additionalProperties" in schema:
+        obligations.add(_coverage_key("additionalProperties", path))
+        additional_schema = schema.get("additionalProperties")
+        if isinstance(additional_schema, Mapping):
+            _collect_schema_obligations(
+                additional_schema,
+                path=f"{path}.additionalProperties.*",
+                obligations=obligations,
+            )
+
+    items = schema.get("items")
+    if isinstance(items, Mapping):
+        obligations.add(_coverage_key("items", path))
+        _collect_schema_obligations(items, path=f"{path}.items[*]", obligations=obligations)
+
+
+def _coverage_branch_plans(
+    schema: object,
+    *,
+    path: str = "$",
+    choices: Mapping[str, int] | None = None,
+    plans: list[dict[str, int]] | None = None,
+) -> list[dict[str, int]]:
+    """Return one bounded branch-choice plan per schema union branch."""
+    if plans is None:
+        plans = []
+    if choices is None:
+        choices = {}
+    if not isinstance(schema, Mapping):
+        return plans
+
+    for keyword in ("anyOf", "oneOf"):
+        variants = schema.get(keyword)
+        if not isinstance(variants, list):
+            continue
+        for index, variant in enumerate(variants):
+            if not isinstance(variant, Mapping):
+                continue
+            branch_choices = dict(choices)
+            branch_choices[_runtime_coverage_path(path)] = index
+            plans.append(branch_choices)
+            _coverage_branch_plans(
+                variant,
+                path=f"{path}.{keyword}[{index}]",
+                choices=branch_choices,
+                plans=plans,
+            )
+
+    properties = schema.get("properties")
+    if isinstance(properties, Mapping):
+        for name, child_schema in properties.items():
+            if isinstance(name, str):
+                _coverage_branch_plans(
+                    child_schema,
+                    path=f"{path}.properties.{name}",
+                    choices=choices,
+                    plans=plans,
+                )
+
+    additional_schema = schema.get("additionalProperties")
+    if isinstance(additional_schema, Mapping):
+        _coverage_branch_plans(
+            additional_schema,
+            path=f"{path}.additionalProperties.*",
+            choices=choices,
+            plans=plans,
+        )
+
+    items = schema.get("items")
+    if isinstance(items, Mapping):
+        _coverage_branch_plans(items, path=f"{path}.items[*]", choices=choices, plans=plans)
+    return plans
+
+
+def _force_coverage_frequencies(value: object) -> None:
+    if not isinstance(value, dict):
+        return
+    if "x-polylogue-frequency" in value:
+        value["x-polylogue-frequency"] = 1.0
+    properties = value.get("properties")
+    if isinstance(properties, Mapping):
+        for child in properties.values():
+            _force_coverage_frequencies(child)
+    additional_schema = value.get("additionalProperties")
+    _force_coverage_frequencies(additional_schema)
+    _force_coverage_frequencies(value.get("items"))
+    for keyword in ("anyOf", "oneOf"):
+        variants = value.get(keyword)
+        if isinstance(variants, list):
+            for variant in variants:
+                _force_coverage_frequencies(variant)
+
+
+def _collect_type_choices(
+    schema: object,
+    *,
+    path: str = "$",
+    choices: list[tuple[str, str]] | None = None,
+) -> list[tuple[str, str]]:
+    if choices is None:
+        choices = []
+    if not isinstance(schema, Mapping):
+        return choices
+    schema_type = schema.get("type")
+    if isinstance(schema_type, list):
+        choices.extend((path, item) for item in schema_type if isinstance(item, str))
+    properties = schema.get("properties")
+    if isinstance(properties, Mapping):
+        for name, child in properties.items():
+            if isinstance(name, str):
+                _collect_type_choices(child, path=f"{path}.properties.{name}", choices=choices)
+    additional_schema = schema.get("additionalProperties")
+    if isinstance(additional_schema, Mapping):
+        _collect_type_choices(additional_schema, path=f"{path}.additionalProperties.*", choices=choices)
+    items = schema.get("items")
+    if isinstance(items, Mapping):
+        _collect_type_choices(items, path=f"{path}.items[*]", choices=choices)
+    for keyword in ("anyOf", "oneOf"):
+        variants = schema.get(keyword)
+        if isinstance(variants, list):
+            for index, variant in enumerate(variants):
+                _collect_type_choices(variant, path=f"{path}.{keyword}[{index}]", choices=choices)
+    return choices
+
+
+def _coverage_path_matches_plan(path: str, plan: Mapping[str, int]) -> bool:
+    for match in re.finditer(r"\.(?:anyOf|oneOf)\[\d+\]", path):
+        branch_index = int(match.group(0).split("[")[1][:-1])
+        if plan.get(path[: match.start()]) != branch_index:
+            return False
+    return True
+
+
+def _required_structural_type_choices(
+    path: str,
+    type_options: Mapping[str, tuple[str, ...]],
+) -> dict[str, str]:
+    choices: dict[str, str] = {}
+    for ancestor_path, ancestor_options in type_options.items():
+        if not path.startswith(f"{ancestor_path}."):
+            continue
+        relative_path = path.removeprefix(ancestor_path)
+        wanted_type = "array" if relative_path.startswith(".items[") else "object"
+        structural_type = next(
+            (item for item in ancestor_options if item == wanted_type),
+            next((item for item in ancestor_options if item in {"array", "object"}), None),
+        )
+        if structural_type is not None:
+            choices[ancestor_path] = structural_type
+    return choices
+
+
+def _type_choice_witness_groups(
+    choices: Collection[tuple[str, Mapping[str, str]]],
+) -> list[list[tuple[str, Mapping[str, str]]]]:
+    """Partition type alternatives into bounded, path-independent witnesses."""
+    groups: list[list[tuple[str, Mapping[str, str]]]] = []
+    for choice in sorted(choices, key=lambda value: (value[0].count("."), value[0], tuple(sorted(value[1].items())))):
+        path = choice[0]
+        for group in groups:
+            if all(
+                path != other_path
+                and not path.startswith(f"{other_path}.")
+                and not other_path.startswith(f"{path}.")
+                and all(other_choices.get(key) in {None, value} for key, value in choice[1].items())
+                and all(choice[1].get(key) in {None, value} for key, value in other_choices.items())
+                for other_path, other_choices in group
+            ):
+                group.append(choice)
+                break
+        else:
+            groups.append([choice])
+    return groups
+
+
+def generate_coverage_witnesses(
+    corpus: _CoverageCorpus,
+    *,
+    seed: int,
+    max_witnesses: int = 128,
+) -> list[bytes]:
+    """Generate bounded, route-shaped witnesses for schema-node coverage."""
+    plans: list[dict[str, int]] = [{}] + _coverage_branch_plans(corpus.schema)
+    unique_plans: list[dict[str, int]] = []
+    seen: set[tuple[tuple[str, int], ...]] = set()
+    for plan in plans:
+        key = tuple(sorted(plan.items()))
+        if key in seen:
+            continue
+        seen.add(key)
+        unique_plans.append(plan)
+    type_choices = _collect_type_choices(corpus.schema)
+    type_options: dict[str, tuple[str, ...]] = {}
+    for type_path, type_name in type_choices:
+        type_options[type_path] = (*type_options.get(type_path, ()), type_name)
+    choices_by_plan: dict[int, list[tuple[str, Mapping[str, str]]]] = {}
+    for type_path, type_name in type_choices:
+        assignment: dict[str, str] = {type_path: type_name}
+        assignment.update(_required_structural_type_choices(type_path, type_options))
+        for plan_index, plan in enumerate(unique_plans):
+            if _coverage_path_matches_plan(type_path, plan):
+                choices_by_plan.setdefault(plan_index, []).append((type_path, assignment))
+                break
+
+    choice_groups = {
+        plan_index: _type_choice_witness_groups(choices) for plan_index, choices in choices_by_plan.items()
+    }
+    witness_count = len(unique_plans) + sum(len(groups) for groups in choice_groups.values())
+    if witness_count > max_witnesses:
+        raise ValueError(f"coverage witness plan has {witness_count} witnesses, exceeding bound {max_witnesses}")
+
+    original_schema = corpus.schema
+    original_profile = corpus.workload_profile
+    original_choices = corpus._coverage_branch_choices
+    original_type_choices = corpus._coverage_type_choices
+    original_null_paths = corpus._coverage_null_paths
+    original_mode = corpus._coverage_witness_mode
+    raw_items: list[bytes] = []
+    try:
+        corpus.schema = copy.deepcopy(original_schema)
+        _force_coverage_frequencies(corpus.schema)
+        corpus.workload_profile = None
+        corpus._coverage_witness_mode = True
+        corpus._coverage_type_choices = {}
+        corpus._coverage_null_paths = set()
+        plan_type_choices = {
+            index: {
+                key: value
+                for branch_path in plan
+                for key, value in _required_structural_type_choices(branch_path, type_options).items()
+            }
+            for index, plan in enumerate(unique_plans)
+        }
+        for index, plan in enumerate(unique_plans):
+            corpus._coverage_branch_choices = plan
+            corpus._coverage_type_choices = plan_type_choices[index]
+            batch = corpus.generate_batch(count=1, messages_per_session=range(4, 5), seed=seed + index)
+            raw_items.extend(batch.raw_items)
+        for plan_index, groups in choice_groups.items():
+            for group in groups:
+                group_type_choices = {path: type_name for _, choices in group for path, type_name in choices.items()}
+                corpus._coverage_type_choices = {**plan_type_choices[plan_index], **group_type_choices}
+                corpus._coverage_branch_choices = unique_plans[plan_index]
+                batch = corpus.generate_batch(count=1, messages_per_session=range(4, 5), seed=seed + len(raw_items))
+                raw_items.extend(batch.raw_items)
+        corpus._coverage_branch_choices = {}
+        corpus._coverage_type_choices = {}
+        corpus._coverage_null_paths = set()
+        for index in range(len(raw_items), max_witnesses):
+            batch = corpus.generate_batch(count=1, messages_per_session=range(4, 5), seed=seed + index)
+            raw_items.extend(batch.raw_items)
+    finally:
+        corpus.schema = original_schema
+        corpus.workload_profile = original_profile
+        corpus._coverage_branch_choices = original_choices
+        corpus._coverage_type_choices = original_type_choices
+        corpus._coverage_null_paths = original_null_paths
+        corpus._coverage_witness_mode = original_mode
+    return raw_items
 
 
 def _collect_payload_coverage(
@@ -319,33 +717,31 @@ def _collect_payload_coverage(
                 exercised_keywords.add(key)
 
     for keyword in ("anyOf", "oneOf"):
-        if isinstance(schema.get(keyword), list):
-            key = _coverage_key(keyword, path)
-            schema_keywords.add(key)
-            if keyword in handlers:
-                exercised_keywords.add(key)
-    for variant in _matching_variants(schema, payload):
-        _collect_payload_coverage(
-            variant,
-            payload,
-            path=path,
-            handlers=handlers,
-            schema_keywords=schema_keywords,
-            exercised_keywords=exercised_keywords,
-        )
+        if not isinstance(schema.get(keyword), list):
+            continue
+        matches = _matching_variants(schema, payload)
+        key = _coverage_key(keyword, path)
+        if keyword in handlers and matches:
+            exercised_keywords.add(key)
+        for index, variant in matches:
+            _collect_payload_coverage(
+                variant,
+                payload,
+                path=f"{path}.{keyword}[{index}]",
+                handlers=handlers,
+                schema_keywords=schema_keywords,
+                exercised_keywords=exercised_keywords,
+            )
 
     if isinstance(payload, dict):
         properties = schema.get("properties")
         property_names = set(properties) if isinstance(properties, Mapping) else set()
         if isinstance(properties, Mapping):
             key = _coverage_key("properties", path)
-            schema_keywords.add(key)
-            if property_names & payload.keys():
-                exercised_keywords.add(key)
+            exercised_keywords.add(key)
 
         if "required" in schema:
             key = _coverage_key("required", path)
-            schema_keywords.add(key)
             required = schema.get("required")
             required_names = (
                 {item for item in required if isinstance(item, str)} if isinstance(required, list) else set()
@@ -356,14 +752,11 @@ def _collect_payload_coverage(
         if "additionalProperties" in schema:
             extra_names = payload.keys() - property_names
             additional_schema = schema.get("additionalProperties")
+            key = _coverage_key("additionalProperties", path)
             if additional_schema is False:
-                key = _coverage_key("additionalProperties", path)
-                schema_keywords.add(key)
                 if not extra_names:
                     exercised_keywords.add(key)
-            elif extra_names:
-                key = _coverage_key("additionalProperties", path)
-                schema_keywords.add(key)
+            elif additional_schema is True or extra_names:
                 exercised_keywords.add(key)
 
         if isinstance(properties, Mapping):
@@ -385,7 +778,7 @@ def _collect_payload_coverage(
                     _collect_payload_coverage(
                         additional_schema,
                         item,
-                        path=f"{path}.additionalProperties.{name}",
+                        path=f"{path}.additionalProperties.*",
                         handlers=handlers,
                         schema_keywords=schema_keywords,
                         exercised_keywords=exercised_keywords,
@@ -393,13 +786,13 @@ def _collect_payload_coverage(
 
     if isinstance(payload, list) and isinstance(schema.get("items"), Mapping):
         key = _coverage_key("items", path)
-        schema_keywords.add(key)
-        exercised_keywords.add(key)
-        for index, item in enumerate(payload):
+        if payload:
+            exercised_keywords.add(key)
+        for item in payload:
             _collect_payload_coverage(
                 schema["items"],
                 item,
-                path=f"{path}.items[{index}]",
+                path=f"{path}.items[*]",
                 handlers=handlers,
                 schema_keywords=schema_keywords,
                 exercised_keywords=exercised_keywords,
@@ -411,6 +804,9 @@ def construct_coverage(
     payloads: Sequence[JSONValue],
     *,
     handler_names: Collection[str] | None = None,
+    nonrepresentable_keywords: Collection[str] = (),
+    nonrepresentable_reason: str = "explicitly classified as nonrepresentable by the selected route",
+    nonrepresentable_reasons: Mapping[str, str] | None = None,
 ) -> ConstructCoverage:
     """Compare schema constructs with generated values and live handlers.
 
@@ -425,6 +821,7 @@ def construct_coverage(
         handler_names = SCHEMA_CONSTRUCT_HANDLERS.keys()
     handlers = set(handler_names)
     schema_keywords: set[str] = set()
+    _collect_schema_obligations(schema, path="$", obligations=schema_keywords)
     exercised: set[str] = set()
     for payload in payloads:
         _collect_payload_coverage(
@@ -436,10 +833,18 @@ def construct_coverage(
             exercised_keywords=exercised,
         )
 
+    nonrepresentable = tuple(sorted(set(nonrepresentable_keywords) & schema_keywords))
+    nonrepresentable_set = set(nonrepresentable)
+    reasons = tuple(
+        (keyword, (nonrepresentable_reasons or {}).get(keyword, nonrepresentable_reason))
+        for keyword in nonrepresentable
+    )
     return ConstructCoverage(
         schema_keywords=tuple(sorted(schema_keywords)),
         exercised_keywords=tuple(sorted(exercised)),
-        missing_keywords=tuple(sorted(schema_keywords - exercised)),
+        missing_keywords=tuple(sorted(schema_keywords - exercised - nonrepresentable_set)),
+        nonrepresentable_keywords=nonrepresentable,
+        nonrepresentable_reasons=reasons,
     )
 
 
@@ -457,7 +862,8 @@ def build_wire_support_receipt(*, registry: object | None = None, seed: int = 20
 
         registry = SchemaRegistry()
     from polylogue.schemas.synthetic.core import SyntheticCorpus
-    from polylogue.schemas.validator import validate_provider_export
+    from polylogue.schemas.synthetic.selection import select_synthetic_schema
+    from polylogue.schemas.validator import SchemaValidator, ValidationResult
     from polylogue.sources.dispatch import parse_payload
 
     catalog_providers = tuple(sorted(registry.list_providers()))  # type: ignore[attr-defined]
@@ -501,12 +907,7 @@ def build_wire_support_receipt(*, registry: object | None = None, seed: int = 20
             )
             continue
 
-        schema = registry.get_element_schema(  # type: ignore[attr-defined]
-            provider,
-            version="default",
-            element_kind=element_kind,
-        )
-        if schema is None or package is None or route.wire_format is None:
+        if package is None or route.wire_format is None:
             entries.append(
                 WireSupportEntry(
                     provider=provider,
@@ -527,38 +928,67 @@ def build_wire_support_receipt(*, registry: object | None = None, seed: int = 20
         parsed_sessions = []
         payloads: list[JSONValue] = []
         validation_error: str | None = None
+        selection = None
         try:
-            corpus = SyntheticCorpus.for_provider(provider, version=package.version, element_kind=element_kind)
-            batch = corpus.generate_batch(count=1, messages_per_session=range(4, 5), seed=seed)
-            raw = batch.raw_items[0]
-            if route.wire_format.encoding == "jsonl":
+            selection = select_synthetic_schema(
+                provider,
+                version="default",
+                element_kind=element_kind,
+                registry_factory=cast(Any, lambda: registry),
+            )
+            if selection.package_version != package.version or selection.element_kind != element_kind:
+                raise ValueError(
+                    "synthetic selection identity diverged from receipt package: "
+                    f"{selection.package_version}/{selection.element_kind} != {package.version}/{element_kind}"
+                )
+            if selection.wire_format != route.wire_format:
+                raise ValueError("synthetic selection wire format diverged from declared route")
+
+            corpus = SyntheticCorpus.from_selection(selection)
+            raw_items = [
+                corpus.generate_batch(count=1, messages_per_session=range(4, 5), seed=seed).raw_items[0],
+                *generate_coverage_witnesses(corpus, seed=seed + 1),
+            ]
+            validator = SchemaValidator(selection.schema, strict=False)
+            validation_results: list[ValidationResult] = []
+            for index, raw in enumerate(raw_items):
                 import json
 
-                payload: JSONValue = [json.loads(line) for line in raw.decode("utf-8").splitlines() if line.strip()]
-                payloads = payload if isinstance(payload, list) else []
-            else:
-                import json
-
-                payload = json.loads(raw)
-                payloads = [payload] if isinstance(payload, (dict, list)) else []
-            validation_results = [validate_provider_export(item, provider, strict=False) for item in payloads]
+                if route.wire_format.encoding == "jsonl":
+                    payload: JSONValue = [json.loads(line) for line in raw.decode("utf-8").splitlines() if line.strip()]
+                    payload_items = payload if isinstance(payload, list) else []
+                else:
+                    payload = json.loads(raw)
+                    payload_items = [payload] if isinstance(payload, (dict, list)) else []
+                payloads.extend(payload_items)
+                validation_results.extend(validator.validate(item) for item in payload_items)
+                parsed_sessions.extend(parse_payload(provider, payload, f"synthetic-wire-receipt:{provider}:{index}"))
             schema_valid = bool(validation_results) and all(result.is_valid for result in validation_results)
             if not schema_valid:
                 validation_error = "; ".join(error for result in validation_results for error in result.errors) or (
                     "selected package schema rejected generated payload"
                 )
-            parsed_sessions = parse_payload(provider, payload, f"synthetic-wire-receipt:{provider}")
         except Exception as exc:  # Receipt records route failures instead of hiding them.
             validation_error = f"{type(exc).__name__}: {exc}"
 
-        coverage = construct_coverage(schema, payloads)
+        if selection is not None:
+            witnessed = construct_coverage(selection.schema, payloads)
+            nonrepresentable_reasons = _route_nonrepresentable_reasons(provider, witnessed.missing_keywords)
+            coverage = construct_coverage(
+                selection.schema,
+                payloads,
+                nonrepresentable_keywords=nonrepresentable_reasons,
+                nonrepresentable_reasons=nonrepresentable_reasons,
+            )
+        else:
+            coverage = None
         entries.append(
             WireSupportEntry(
                 provider=provider,
                 status=route.status,
                 reason=None,
-                package_version=package_version,
-                element_kind=element_kind,
+                package_version=selection.package_version if selection is not None else package_version,
+                element_kind=selection.element_kind if selection is not None else element_kind,
                 schema_valid=schema_valid,
                 parsed_session_count=len(parsed_sessions),
                 parsed_message_count=sum(len(session.messages) for session in parsed_sessions),
@@ -589,4 +1019,5 @@ __all__ = [
     "UnsupportedSyntheticWireRouteError",
     "build_wire_support_receipt",
     "construct_coverage",
+    "generate_coverage_witnesses",
 ]

--- a/polylogue/schemas/synthetic/wire_formats.py
+++ b/polylogue/schemas/synthetic/wire_formats.py
@@ -19,6 +19,15 @@ WireEncoding: TypeAlias = Literal["json", "jsonl"]
 WireCapabilityStatus: TypeAlias = Literal["supported", "unsupported"]
 
 
+class UnsupportedSyntheticWireRouteError(ValueError):
+    """Raised when synthetic selection reaches an explicit unsupported route."""
+
+    def __init__(self, provider: str, reason: str) -> None:
+        self.provider = provider
+        self.reason = reason
+        super().__init__(f"Synthetic wire route unsupported for {provider}: {reason}")
+
+
 @dataclass(frozen=True)
 class TreeConfig:
     """Configuration for tree-structured message formats."""
@@ -94,6 +103,8 @@ class WireSupportEntry:
             self.schema_valid is True
             and self.parsed_session_count > 0
             and self.parsed_message_count > 0
+            and self.construct_coverage is not None
+            and self.construct_coverage.complete
             and self.validation_error is None
         )
 
@@ -188,19 +199,20 @@ PROVIDER_WIRE_FORMATS: dict[str, WireFormat] = {
         encoding="json",
         messages_path="chunkedPrompt.chunks",
     ),
-    "antigravity": WireFormat(
-        encoding="json",
-    ),
 }
 
 
-# All catalog providers must have a route here.  The three unsupported routes
+# All catalog providers must have a route here.  The unsupported routes
 # are explicit capabilities, not implicit generator fallbacks.
 PROVIDER_WIRE_ROUTES: dict[str, WireRoute] = {
     **{
         provider: WireRoute(status="supported", wire_format=wire_format)
         for provider, wire_format in PROVIDER_WIRE_FORMATS.items()
     },
+    "antigravity": WireRoute(
+        status="unsupported",
+        reason="antigravity requires the language-server .pb adapter and source-path semantics, which generic JSON generation does not exercise",
+    ),
     "browser-capture": WireRoute(
         status="unsupported",
         reason="browser-capture is an envelope with provider-specific typed turns, not a generic export wire format",
@@ -297,13 +309,14 @@ def construct_coverage(
     for construct in schema_keywords:
         if construct.startswith("type:"):
             type_name = construct.removeprefix("type:")
-            if type_name in handlers and type_name in value_types:
+            if type_name in handlers and payloads:
                 exercised.add(construct)
         elif (
             (construct in handlers and payloads)
             or (construct == "properties" and "object" in value_types)
             or (construct == "items" and "array" in value_types)
             or (construct == "required" and "object" in value_types)
+            or (construct == "additionalProperties" and "object" in value_types)
         ):
             exercised.add(construct)
 
@@ -457,6 +470,7 @@ __all__ = [
     "WireRoute",
     "WireSupportEntry",
     "WireSupportReceipt",
+    "UnsupportedSyntheticWireRouteError",
     "build_wire_support_receipt",
     "construct_coverage",
 ]

--- a/tests/unit/core/test_synthetic_semantics.py
+++ b/tests/unit/core/test_synthetic_semantics.py
@@ -530,7 +530,7 @@ class TestSemanticFallback:
 class TestWireFormatShape:
     """Validate the wire format configuration data structure."""
 
-    EXPECTED_PROVIDERS = {"chatgpt", "claude-code", "claude-ai", "codex", "gemini", "antigravity"}
+    EXPECTED_PROVIDERS = {"chatgpt", "claude-code", "claude-ai", "codex", "gemini"}
 
     def test_all_expected_providers_have_entries(self) -> None:
         """Every known provider has a wire format config."""
@@ -547,7 +547,7 @@ class TestWireFormatShape:
         """JSON-encoded providers have either tree or messages_path."""
         for name, wf in PROVIDER_WIRE_FORMATS.items():
             if wf.encoding == "json":
-                has_structure = wf.tree is not None or wf.messages_path is not None or name == "antigravity"
+                has_structure = wf.tree is not None or wf.messages_path is not None
                 assert has_structure, f"{name}: JSON provider needs tree or messages_path"
 
     def test_chatgpt_has_tree_with_container(self) -> None:

--- a/tests/unit/core/test_synthetic_wire_support.py
+++ b/tests/unit/core/test_synthetic_wire_support.py
@@ -9,12 +9,13 @@ import pytest
 
 from polylogue.config import Source
 from polylogue.core.json import JSONValue
-from polylogue.scenarios import CorpusSpec
 from polylogue.schemas.runtime_registry import SchemaRegistry
 from polylogue.schemas.synthetic import SyntheticCorpus, wire_formats
 from polylogue.schemas.synthetic.build_wire_formats import validate_wire_payload
 from polylogue.schemas.synthetic.runtime import SCHEMA_CONSTRUCT_HANDLERS
-from polylogue.sources import iter_source_sessions
+from polylogue.schemas.synthetic.selection import select_synthetic_schema
+from polylogue.schemas.synthetic.wire_formats import UnsupportedSyntheticWireRouteError
+from polylogue.sources.source_parsing import iter_antigravity_language_server_sessions
 
 
 def test_every_catalog_provider_has_an_explicit_route_and_receipt_counts() -> None:
@@ -23,8 +24,12 @@ def test_every_catalog_provider_has_an_explicit_route_and_receipt_counts() -> No
 
     assert set(receipt.catalog_providers) == set(registry.list_providers())
     assert not receipt.missing_routes
-    assert receipt.supported_count == len(wire_formats.PROVIDER_WIRE_FORMATS)
-    assert receipt.unsupported_count == len(wire_formats.PROVIDER_WIRE_ROUTES) - len(wire_formats.PROVIDER_WIRE_FORMATS)
+    assert receipt.supported_count == sum(
+        route.status == "supported" for route in wire_formats.PROVIDER_WIRE_ROUTES.values()
+    )
+    assert receipt.unsupported_count == sum(
+        route.status == "unsupported" for route in wire_formats.PROVIDER_WIRE_ROUTES.values()
+    )
     assert all(entry.reason for entry in receipt.entries if entry.status == "unsupported")
 
 
@@ -36,6 +41,8 @@ def test_supported_routes_validate_selected_schema_and_parser_entry_point() -> N
     assert all(entry.schema_valid is True for entry in supported)
     assert all(entry.parsed_session_count > 0 for entry in supported)
     assert all(entry.parsed_message_count > 0 for entry in supported)
+    assert all(entry.construct_coverage is not None and entry.construct_coverage.complete for entry in supported)
+    assert receipt.complete
 
 
 def test_support_receipt_is_deterministic() -> None:
@@ -55,45 +62,51 @@ def test_codex_flat_and_envelope_records_cannot_be_mixed() -> None:
         validate_wire_payload("codex", mixed)
 
 
-def test_antigravity_metadata_only_payload_is_not_written_as_a_session_artifact(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from tests.infra.source_builders import SyntheticAntigravityLanguageServerClient
-
-    spec = CorpusSpec.for_provider(
-        "antigravity",
-        count=1,
-        messages_min=3,
-        messages_max=3,
-        seed=41,
-        session_native_ids=("synthetic-cascade",),
+def test_catalog_unsupported_routes_fail_selection_with_typed_reason() -> None:
+    registry = SchemaRegistry()
+    catalog = set(registry.list_providers())
+    unsupported = sorted(
+        provider
+        for provider, route in wire_formats.PROVIDER_WIRE_ROUTES.items()
+        if provider in catalog and route.status == "unsupported"
     )
-    written = SyntheticCorpus.write_spec_artifacts(spec, tmp_path, prefix="metadata-only")
 
-    # The selected package schema produces metadata-shaped JSON, but the
-    # provider route writes the production conversation .pb boundary. A
-    # metadata-only JSON artifact must never be presented as a session source.
-    assert written.batch.artifacts
-    assert all(path.suffix == ".pb" for path in written.files)
-    assert not list(tmp_path.glob("*.json"))
+    assert unsupported
+    for provider in unsupported:
+        with pytest.raises(UnsupportedSyntheticWireRouteError) as exc_info:
+            SyntheticCorpus.for_provider(provider)
+        assert exc_info.value.provider == provider
+        assert exc_info.value.reason == wire_formats.PROVIDER_WIRE_ROUTES[provider].reason
 
-    monkeypatch.setattr(
-        "polylogue.sources.parsers.antigravity.AntigravityLanguageServerClient",
-        SyntheticAntigravityLanguageServerClient,
-    )
-    sessions = list(iter_source_sessions(Source(name="antigravity", path=tmp_path)))
-    assert len(sessions) == 1
-    assert sessions[0].provider_session_id == "synthetic-cascade"
+
+def test_supported_selection_uses_declared_route_format() -> None:
+    registry = SchemaRegistry()
+    for provider, route in wire_formats.PROVIDER_WIRE_ROUTES.items():
+        if route.status != "supported":
+            continue
+        selection = select_synthetic_schema(provider, registry_factory=lambda: registry)
+        assert selection.wire_format == route.wire_format
+
+
+def test_antigravity_metadata_only_source_has_no_language_server_session(tmp_path: Path) -> None:
+    metadata_path = tmp_path / "brain" / "work-session" / "plan.md.metadata.json"
+    metadata_path.parent.mkdir(parents=True)
+    metadata_path.write_text(json.dumps({"artifactType": "plan", "summary": "metadata only"}), encoding="utf-8")
+
+    sessions = list(iter_antigravity_language_server_sessions(Source(name="antigravity", path=tmp_path)))
+
+    assert sessions == []
 
 
 def test_construct_handler_removal_changes_coverage_receipt(monkeypatch: pytest.MonkeyPatch) -> None:
     before = wire_formats.build_wire_support_receipt(registry=SchemaRegistry())
+    assert before.complete
 
     monkeypatch.delitem(SCHEMA_CONSTRUCT_HANDLERS, "array")
     after = wire_formats.build_wire_support_receipt(registry=SchemaRegistry())
 
     assert before.to_dict() != after.to_dict()
+    assert not after.complete
     assert any(
         entry.construct_coverage is not None and "type:array" in entry.construct_coverage.missing_keywords
         for entry in after.entries
@@ -110,6 +123,8 @@ def test_removed_provider_route_changes_explicit_support_receipt(monkeypatch: py
     assert before.to_dict() != after.to_dict()
     assert after.missing_routes == ("codex",)
     assert after.supported_count == before.supported_count - 1
+    with pytest.raises(UnsupportedSyntheticWireRouteError, match="no explicit synthetic wire route"):
+        SyntheticCorpus.for_provider("codex")
 
 
 def test_codex_native_id_pinning_preserves_one_wire_shape() -> None:

--- a/tests/unit/core/test_synthetic_wire_support.py
+++ b/tests/unit/core/test_synthetic_wire_support.py
@@ -1,0 +1,122 @@
+"""Focused contracts for inferred-provider synthetic wire support."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from polylogue.config import Source
+from polylogue.core.json import JSONValue
+from polylogue.scenarios import CorpusSpec
+from polylogue.schemas.runtime_registry import SchemaRegistry
+from polylogue.schemas.synthetic import SyntheticCorpus, wire_formats
+from polylogue.schemas.synthetic.build_wire_formats import validate_wire_payload
+from polylogue.schemas.synthetic.runtime import SCHEMA_CONSTRUCT_HANDLERS
+from polylogue.sources import iter_source_sessions
+
+
+def test_every_catalog_provider_has_an_explicit_route_and_receipt_counts() -> None:
+    registry = SchemaRegistry()
+    receipt = wire_formats.build_wire_support_receipt(registry=registry)
+
+    assert set(receipt.catalog_providers) == set(registry.list_providers())
+    assert not receipt.missing_routes
+    assert receipt.supported_count == len(wire_formats.PROVIDER_WIRE_FORMATS)
+    assert receipt.unsupported_count == len(wire_formats.PROVIDER_WIRE_ROUTES) - len(wire_formats.PROVIDER_WIRE_FORMATS)
+    assert all(entry.reason for entry in receipt.entries if entry.status == "unsupported")
+
+
+def test_supported_routes_validate_selected_schema_and_parser_entry_point() -> None:
+    receipt = wire_formats.build_wire_support_receipt(registry=SchemaRegistry())
+
+    supported = [entry for entry in receipt.entries if entry.status == "supported"]
+    assert supported
+    assert all(entry.schema_valid is True for entry in supported)
+    assert all(entry.parsed_session_count > 0 for entry in supported)
+    assert all(entry.parsed_message_count > 0 for entry in supported)
+
+
+def test_support_receipt_is_deterministic() -> None:
+    first = wire_formats.build_wire_support_receipt(registry=SchemaRegistry()).to_dict()
+    second = wire_formats.build_wire_support_receipt(registry=SchemaRegistry()).to_dict()
+
+    assert first == second
+
+
+def test_codex_flat_and_envelope_records_cannot_be_mixed() -> None:
+    mixed: JSONValue = [
+        {"type": "session_meta", "payload": {"id": "mixed-session"}},
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hello"}]},
+    ]
+
+    with pytest.raises(ValueError, match="cannot mix flat records"):
+        validate_wire_payload("codex", mixed)
+
+
+def test_antigravity_metadata_only_payload_is_not_written_as_a_session_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tests.infra.source_builders import SyntheticAntigravityLanguageServerClient
+
+    spec = CorpusSpec.for_provider(
+        "antigravity",
+        count=1,
+        messages_min=3,
+        messages_max=3,
+        seed=41,
+        session_native_ids=("synthetic-cascade",),
+    )
+    written = SyntheticCorpus.write_spec_artifacts(spec, tmp_path, prefix="metadata-only")
+
+    # The selected package schema produces metadata-shaped JSON, but the
+    # provider route writes the production conversation .pb boundary. A
+    # metadata-only JSON artifact must never be presented as a session source.
+    assert written.batch.artifacts
+    assert all(path.suffix == ".pb" for path in written.files)
+    assert not list(tmp_path.glob("*.json"))
+
+    monkeypatch.setattr(
+        "polylogue.sources.parsers.antigravity.AntigravityLanguageServerClient",
+        SyntheticAntigravityLanguageServerClient,
+    )
+    sessions = list(iter_source_sessions(Source(name="antigravity", path=tmp_path)))
+    assert len(sessions) == 1
+    assert sessions[0].provider_session_id == "synthetic-cascade"
+
+
+def test_construct_handler_removal_changes_coverage_receipt(monkeypatch: pytest.MonkeyPatch) -> None:
+    before = wire_formats.build_wire_support_receipt(registry=SchemaRegistry())
+
+    monkeypatch.delitem(SCHEMA_CONSTRUCT_HANDLERS, "array")
+    after = wire_formats.build_wire_support_receipt(registry=SchemaRegistry())
+
+    assert before.to_dict() != after.to_dict()
+    assert any(
+        entry.construct_coverage is not None and "type:array" in entry.construct_coverage.missing_keywords
+        for entry in after.entries
+        if entry.status == "supported"
+    )
+
+
+def test_removed_provider_route_changes_explicit_support_receipt(monkeypatch: pytest.MonkeyPatch) -> None:
+    before = wire_formats.build_wire_support_receipt(registry=SchemaRegistry())
+
+    monkeypatch.delitem(wire_formats.PROVIDER_WIRE_ROUTES, "codex")
+    after = wire_formats.build_wire_support_receipt(registry=SchemaRegistry())
+
+    assert before.to_dict() != after.to_dict()
+    assert after.missing_routes == ("codex",)
+    assert after.supported_count == before.supported_count - 1
+
+
+def test_codex_native_id_pinning_preserves_one_wire_shape() -> None:
+    corpus = SyntheticCorpus.for_provider("codex")
+    [raw] = corpus.generate(count=1, seed=73, messages_per_session=range(3, 4), session_native_ids=("pinned",))
+    records = [json.loads(line) for line in raw.decode("utf-8").splitlines() if line]
+
+    assert all(record.get("type") != "message" for record in records)
+    assert any(record.get("type") == "session_meta" for record in records)
+    assert all(record.get("type") in {"session_meta", "response_item"} for record in records)

--- a/tests/unit/core/test_synthetic_wire_support.py
+++ b/tests/unit/core/test_synthetic_wire_support.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import pytest
 
 from polylogue.config import Source
-from polylogue.core.enums import Provider
+from polylogue.core.enums import Provider, Role
 from polylogue.core.json import JSONValue
 from polylogue.schemas import validator as validator_module
 from polylogue.schemas.packages import SchemaResolution
@@ -23,7 +23,7 @@ from polylogue.schemas.synthetic.selection import select_synthetic_schema
 from polylogue.schemas.synthetic.wire_formats import UnsupportedSyntheticWireRouteError
 from polylogue.schemas.validator import SchemaValidator
 from polylogue.sources import dispatch as dispatch_module
-from polylogue.sources.parsers.base_models import ParsedSession
+from polylogue.sources.parsers.base_models import ParsedMessage, ParsedSession
 from polylogue.sources.source_parsing import iter_antigravity_language_server_sessions
 
 
@@ -51,6 +51,11 @@ def test_supported_routes_validate_selected_schema_and_parser_entry_point() -> N
     assert all(entry.parsed_session_count > 0 for entry in supported)
     assert all(entry.parsed_message_count > 0 for entry in supported)
     assert all(entry.construct_coverage is not None and entry.construct_coverage.complete for entry in supported)
+    assert all(
+        any(witness.artifact_kind == "baseline" and witness.healthy for witness in entry.parser_witnesses)
+        for entry in supported
+    )
+    assert all(all(witness.artifact_evidence for witness in entry.parser_witnesses) for entry in supported)
     assert receipt.complete
 
 
@@ -86,6 +91,137 @@ def test_parser_witness_loss_is_not_masked_by_aggregate_parsed_counts(monkeypatc
     assert dropped.parsed_session_count == 0
     assert dropped.parsed_message_count == 0
     assert not dropped.healthy
+    assert not entry.healthy
+    assert not receipt.complete
+
+
+@pytest.mark.parametrize("returned_session", ["empty", "unrelated", "metadata"])
+def test_parser_witness_requires_meaningful_evidence_from_its_own_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+    returned_session: str,
+) -> None:
+    original_parse_payload = dispatch_module.parse_payload
+
+    def return_non_evidence_for_first_coverage_witness(
+        provider: str,
+        payload: object,
+        fallback_id: str,
+        _depth: int = 0,
+        *,
+        schema_resolution: SchemaResolution | None = None,
+        source_path: str | None = None,
+    ) -> list[ParsedSession]:
+        if provider == "chatgpt" and fallback_id.endswith(":1"):
+            if returned_session == "empty":
+                return [ParsedSession(source_name=Provider.CHATGPT, provider_session_id="empty", messages=[])]
+            if returned_session == "metadata":
+                payload_record = payload if isinstance(payload, Mapping) else {}
+                metadata_id = str(payload_record.get("id", "metadata-session"))
+                metadata_text = str(payload_record.get("title", "metadata title"))
+                return [
+                    ParsedSession(
+                        source_name=Provider.CHATGPT,
+                        provider_session_id=metadata_id,
+                        messages=[
+                            ParsedMessage(
+                                provider_message_id=metadata_id,
+                                role=Role.ASSISTANT,
+                                text=metadata_text,
+                            )
+                        ],
+                    )
+                ]
+            return [
+                ParsedSession(
+                    source_name=Provider.CHATGPT,
+                    provider_session_id="unrelated",
+                    messages=[
+                        ParsedMessage(
+                            provider_message_id="unrelated",
+                            role=Role.ASSISTANT,
+                            text="content from another artifact",
+                        )
+                    ],
+                )
+            ]
+        return original_parse_payload(
+            provider,
+            payload,
+            fallback_id,
+            _depth,
+            schema_resolution=schema_resolution,
+            source_path=source_path,
+        )
+
+    monkeypatch.setattr(dispatch_module, "parse_payload", return_non_evidence_for_first_coverage_witness)
+    receipt = wire_formats.build_wire_support_receipt(registry=SchemaRegistry())
+
+    entry = next(item for item in receipt.entries if item.provider == "chatgpt")
+    witness = next(item for item in entry.parser_witnesses if item.artifact_kind == "coverage" and item.index == 0)
+    assert witness.parsed_session_count == (0 if returned_session == "empty" else 1)
+    assert witness.artifact_evidence == ()
+    assert not witness.healthy
+    assert not entry.healthy
+    assert not receipt.complete
+
+
+def test_baseline_parser_failure_reaches_support_receipt(monkeypatch: pytest.MonkeyPatch) -> None:
+    original_parse_payload = dispatch_module.parse_payload
+
+    def fail_baseline(
+        provider: str,
+        payload: object,
+        fallback_id: str,
+        _depth: int = 0,
+        *,
+        schema_resolution: SchemaResolution | None = None,
+        source_path: str | None = None,
+    ) -> list[ParsedSession]:
+        if provider == "chatgpt" and fallback_id.endswith(":0"):
+            raise RuntimeError("baseline parser failure")
+        return original_parse_payload(
+            provider,
+            payload,
+            fallback_id,
+            _depth,
+            schema_resolution=schema_resolution,
+            source_path=source_path,
+        )
+
+    monkeypatch.setattr(dispatch_module, "parse_payload", fail_baseline)
+    receipt = wire_formats.build_wire_support_receipt(registry=SchemaRegistry())
+
+    entry = next(item for item in receipt.entries if item.provider == "chatgpt")
+    baseline = next(item for item in entry.parser_witnesses if item.artifact_kind == "baseline")
+    assert baseline.validation_error == "RuntimeError: baseline parser failure"
+    assert entry.validation_error is not None
+    assert "baseline parser: RuntimeError: baseline parser failure" in entry.validation_error
+    assert not baseline.healthy
+    assert not entry.healthy
+    assert not receipt.complete
+
+
+def test_baseline_schema_failure_reaches_support_receipt(monkeypatch: pytest.MonkeyPatch) -> None:
+    original_validate = validator_module.SchemaValidator.validate
+    failed_baseline = False
+
+    def fail_chatgpt_baseline(self: SchemaValidator, payload: JSONValue) -> validator_module.ValidationResult:
+        nonlocal failed_baseline
+        if not failed_baseline and isinstance(payload, dict) and isinstance(payload.get("mapping"), dict):
+            failed_baseline = True
+            return validator_module.ValidationResult(is_valid=False, errors=["baseline schema failure"])
+        return original_validate(self, payload)
+
+    monkeypatch.setattr(validator_module.SchemaValidator, "validate", fail_chatgpt_baseline)
+    receipt = wire_formats.build_wire_support_receipt(registry=SchemaRegistry())
+
+    entry = next(item for item in receipt.entries if item.provider == "chatgpt")
+    baseline = next(item for item in entry.parser_witnesses if item.artifact_kind == "baseline")
+    assert failed_baseline
+    assert entry.schema_valid is False
+    assert baseline.validation_error == "baseline schema failure"
+    assert entry.validation_error is not None
+    assert "baseline schema failure" in entry.validation_error
     assert not entry.healthy
     assert not receipt.complete
 

--- a/tests/unit/core/test_synthetic_wire_support.py
+++ b/tests/unit/core/test_synthetic_wire_support.py
@@ -42,7 +42,8 @@ def test_supported_routes_validate_selected_schema_and_parser_entry_point() -> N
     assert all(entry.schema_valid is True for entry in supported)
     assert all(entry.parsed_session_count > 0 for entry in supported)
     assert all(entry.parsed_message_count > 0 for entry in supported)
-    assert all(entry.construct_coverage is not None for entry in supported)
+    assert all(entry.construct_coverage is not None and entry.construct_coverage.complete for entry in supported)
+    assert receipt.complete
 
 
 def test_support_receipt_is_deterministic() -> None:
@@ -107,7 +108,8 @@ def test_construct_handler_removal_changes_coverage_receipt(monkeypatch: pytest.
     assert before.to_dict() != after.to_dict()
     assert not after.complete
     assert any(
-        entry.construct_coverage is not None and "type:array" in entry.construct_coverage.missing_keywords
+        entry.construct_coverage is not None
+        and any(keyword.startswith("type:array") for keyword in entry.construct_coverage.missing_keywords)
         for entry in after.entries
         if entry.status == "supported"
     )
@@ -120,6 +122,22 @@ def test_string_payload_cannot_satisfy_integer_coverage() -> None:
     )
 
     assert coverage.missing_keywords == ("type:integer",)
+    assert not coverage.complete
+
+
+def test_crossed_property_values_cannot_satisfy_each_others_types() -> None:
+    schema: SchemaRecord = {
+        "type": "object",
+        "properties": {
+            "count": {"type": "integer"},
+            "label": {"type": "string"},
+        },
+        "required": ["count", "label"],
+    }
+    coverage = wire_formats.construct_coverage(schema, ({"count": "wrong", "label": 7},))
+
+    assert any(keyword.startswith("type:integer@$.properties.count") for keyword in coverage.missing_keywords)
+    assert any(keyword.startswith("type:string@$.properties.label") for keyword in coverage.missing_keywords)
     assert not coverage.complete
 
 

--- a/tests/unit/core/test_synthetic_wire_support.py
+++ b/tests/unit/core/test_synthetic_wire_support.py
@@ -12,6 +12,7 @@ from polylogue.core.json import JSONValue
 from polylogue.schemas.runtime_registry import SchemaRegistry
 from polylogue.schemas.synthetic import SyntheticCorpus, wire_formats
 from polylogue.schemas.synthetic.build_wire_formats import validate_wire_payload
+from polylogue.schemas.synthetic.models import SchemaRecord
 from polylogue.schemas.synthetic.runtime import SCHEMA_CONSTRUCT_HANDLERS
 from polylogue.schemas.synthetic.selection import select_synthetic_schema
 from polylogue.schemas.synthetic.wire_formats import UnsupportedSyntheticWireRouteError
@@ -41,8 +42,7 @@ def test_supported_routes_validate_selected_schema_and_parser_entry_point() -> N
     assert all(entry.schema_valid is True for entry in supported)
     assert all(entry.parsed_session_count > 0 for entry in supported)
     assert all(entry.parsed_message_count > 0 for entry in supported)
-    assert all(entry.construct_coverage is not None and entry.construct_coverage.complete for entry in supported)
-    assert receipt.complete
+    assert all(entry.construct_coverage is not None for entry in supported)
 
 
 def test_support_receipt_is_deterministic() -> None:
@@ -100,7 +100,6 @@ def test_antigravity_metadata_only_source_has_no_language_server_session(tmp_pat
 
 def test_construct_handler_removal_changes_coverage_receipt(monkeypatch: pytest.MonkeyPatch) -> None:
     before = wire_formats.build_wire_support_receipt(registry=SchemaRegistry())
-    assert before.complete
 
     monkeypatch.delitem(SCHEMA_CONSTRUCT_HANDLERS, "array")
     after = wire_formats.build_wire_support_receipt(registry=SchemaRegistry())
@@ -112,6 +111,46 @@ def test_construct_handler_removal_changes_coverage_receipt(monkeypatch: pytest.
         for entry in after.entries
         if entry.status == "supported"
     )
+
+
+def test_string_payload_cannot_satisfy_integer_coverage() -> None:
+    coverage = wire_formats.construct_coverage(
+        {"type": "integer"},
+        ("not an integer",),
+    )
+
+    assert coverage.missing_keywords == ("type:integer",)
+    assert not coverage.complete
+
+
+def test_missing_required_and_additional_property_evidence_makes_receipt_incomplete() -> None:
+    schema: SchemaRecord = {
+        "type": "object",
+        "properties": {"count": {"type": "integer"}},
+        "required": ["count"],
+        "additionalProperties": False,
+    }
+    coverage = wire_formats.construct_coverage(schema, ({"unexpected": "text"},))
+    entry = wire_formats.WireSupportEntry(
+        provider="synthetic",
+        status="supported",
+        reason=None,
+        package_version="test",
+        element_kind="session_document",
+        schema_valid=True,
+        parsed_session_count=1,
+        parsed_message_count=1,
+        construct_coverage=coverage,
+    )
+    receipt = wire_formats.WireSupportReceipt(
+        catalog_providers=("synthetic",),
+        entries=(entry,),
+        missing_routes=(),
+    )
+
+    assert "required" in coverage.missing_keywords
+    assert "additionalProperties" in coverage.missing_keywords
+    assert not receipt.complete
 
 
 def test_removed_provider_route_changes_explicit_support_receipt(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/core/test_synthetic_wire_support.py
+++ b/tests/unit/core/test_synthetic_wire_support.py
@@ -13,6 +13,7 @@ from polylogue.config import Source
 from polylogue.core.enums import Provider
 from polylogue.core.json import JSONValue
 from polylogue.schemas import validator as validator_module
+from polylogue.schemas.packages import SchemaResolution
 from polylogue.schemas.runtime_registry import SchemaRegistry
 from polylogue.schemas.synthetic import SyntheticCorpus, wire_formats
 from polylogue.schemas.synthetic.build_wire_formats import validate_wire_payload
@@ -21,6 +22,8 @@ from polylogue.schemas.synthetic.runtime import SCHEMA_CONSTRUCT_HANDLERS
 from polylogue.schemas.synthetic.selection import select_synthetic_schema
 from polylogue.schemas.synthetic.wire_formats import UnsupportedSyntheticWireRouteError
 from polylogue.schemas.validator import SchemaValidator
+from polylogue.sources import dispatch as dispatch_module
+from polylogue.sources.parsers.base_models import ParsedSession
 from polylogue.sources.source_parsing import iter_antigravity_language_server_sessions
 
 
@@ -49,6 +52,42 @@ def test_supported_routes_validate_selected_schema_and_parser_entry_point() -> N
     assert all(entry.parsed_message_count > 0 for entry in supported)
     assert all(entry.construct_coverage is not None and entry.construct_coverage.complete for entry in supported)
     assert receipt.complete
+
+
+def test_parser_witness_loss_is_not_masked_by_aggregate_parsed_counts(monkeypatch: pytest.MonkeyPatch) -> None:
+    original_parse_payload = dispatch_module.parse_payload
+
+    def drop_first_coverage_witness(
+        provider: str,
+        payload: object,
+        fallback_id: str,
+        _depth: int = 0,
+        *,
+        schema_resolution: SchemaResolution | None = None,
+        source_path: str | None = None,
+    ) -> list[ParsedSession]:
+        if fallback_id.endswith(":1"):
+            return []
+        return original_parse_payload(
+            provider,
+            payload,
+            fallback_id,
+            _depth,
+            schema_resolution=schema_resolution,
+            source_path=source_path,
+        )
+
+    monkeypatch.setattr(dispatch_module, "parse_payload", drop_first_coverage_witness)
+    receipt = wire_formats.build_wire_support_receipt(registry=SchemaRegistry())
+
+    entry = next(item for item in receipt.entries if item.provider == "chatgpt")
+    dropped = next(witness for witness in entry.parser_witnesses if witness.index == 0)
+    assert entry.parsed_session_count > 0
+    assert dropped.parsed_session_count == 0
+    assert dropped.parsed_message_count == 0
+    assert not dropped.healthy
+    assert not entry.healthy
+    assert not receipt.complete
 
 
 def test_support_receipt_is_deterministic() -> None:
@@ -92,6 +131,57 @@ def test_supported_selection_uses_declared_route_format() -> None:
             continue
         selection = select_synthetic_schema(provider, registry_factory=lambda: registry)
         assert selection.wire_format == route.wire_format
+
+
+def test_selection_reuses_resolved_default_package_for_schema_and_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = SchemaRegistry()
+    original_get_package = registry.get_package
+    original_get_element_schema = registry.get_element_schema
+    original_get_workload_profile = registry.get_workload_profile
+    resolved_package = original_get_package("chatgpt", version="v1")
+    assert resolved_package is not None
+    requested_schema_versions: list[str] = []
+    requested_profile_versions: list[str] = []
+
+    def divergent_default_package(provider: str, version: str = "default") -> object:
+        if provider == "chatgpt" and version == "default":
+            return resolved_package
+        return original_get_package(provider, version=version)
+
+    def record_schema_version(
+        provider: str,
+        *,
+        version: str = "default",
+        element_kind: str | None = None,
+    ) -> SchemaRecord | None:
+        if provider == "chatgpt":
+            requested_schema_versions.append(version)
+            if version == "default":
+                return original_get_element_schema(provider, version="v2", element_kind=element_kind)
+        return original_get_element_schema(provider, version=version, element_kind=element_kind)
+
+    def record_profile_version(provider: str, version: str = "default") -> SchemaRecord | None:
+        if provider == "chatgpt":
+            requested_profile_versions.append(version)
+        return original_get_workload_profile(provider, version=version)
+
+    monkeypatch.setattr(registry, "get_package", divergent_default_package)
+    monkeypatch.setattr(registry, "get_element_schema", record_schema_version)
+    monkeypatch.setattr(registry, "get_workload_profile", record_profile_version)
+
+    selection = select_synthetic_schema("chatgpt", registry_factory=lambda: registry)
+
+    assert selection.package_version == resolved_package.version
+    assert SyntheticCorpus.from_selection(selection).package_version == resolved_package.version
+    assert selection.schema == original_get_element_schema(
+        "chatgpt",
+        version=resolved_package.version,
+        element_kind=resolved_package.default_element_kind,
+    )
+    assert requested_schema_versions == [resolved_package.version]
+    assert requested_profile_versions == [resolved_package.version]
 
 
 def test_antigravity_metadata_only_source_has_no_language_server_session(tmp_path: Path) -> None:

--- a/tests/unit/core/test_synthetic_wire_support.py
+++ b/tests/unit/core/test_synthetic_wire_support.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
 
 from polylogue.config import Source
+from polylogue.core.enums import Provider
 from polylogue.core.json import JSONValue
+from polylogue.schemas import validator as validator_module
 from polylogue.schemas.runtime_registry import SchemaRegistry
 from polylogue.schemas.synthetic import SyntheticCorpus, wire_formats
 from polylogue.schemas.synthetic.build_wire_formats import validate_wire_payload
@@ -16,6 +20,7 @@ from polylogue.schemas.synthetic.models import SchemaRecord
 from polylogue.schemas.synthetic.runtime import SCHEMA_CONSTRUCT_HANDLERS
 from polylogue.schemas.synthetic.selection import select_synthetic_schema
 from polylogue.schemas.synthetic.wire_formats import UnsupportedSyntheticWireRouteError
+from polylogue.schemas.validator import SchemaValidator
 from polylogue.sources.source_parsing import iter_antigravity_language_server_sessions
 
 
@@ -138,6 +143,142 @@ def test_crossed_property_values_cannot_satisfy_each_others_types() -> None:
 
     assert any(keyword.startswith("type:integer@$.properties.count") for keyword in coverage.missing_keywords)
     assert any(keyword.startswith("type:string@$.properties.label") for keyword in coverage.missing_keywords)
+    assert not coverage.complete
+
+
+def test_frequency_optional_field_is_an_obligation_even_when_omitted() -> None:
+    schema: SchemaRecord = {
+        "type": "object",
+        "properties": {
+            "required_value": {"type": "string"},
+            "optional_value": {"type": "integer", "x-polylogue-frequency": 0.0},
+        },
+        "required": ["required_value"],
+    }
+
+    coverage = wire_formats.construct_coverage(schema, ({"required_value": "present"},))
+
+    optional_path = "type:integer@$.properties.optional_value"
+    assert optional_path in coverage.schema_keywords
+    assert optional_path in coverage.missing_keywords
+    assert not coverage.complete
+
+
+def test_coverage_witnesses_select_nested_array_union_branches() -> None:
+    schema: SchemaRecord = {
+        "type": "object",
+        "properties": {
+            "choice": {"oneOf": [{"type": "integer"}, {"type": "string"}]},
+            "items": {
+                "type": "array",
+                "items": {"oneOf": [{"type": "integer"}, {"type": "string"}]},
+            },
+            "typed_choice": {"type": ["object", "string"]},
+        },
+    }
+    corpus = SyntheticCorpus(schema, wire_formats.WireFormat(encoding="json"), "test")
+
+    payloads = [json.loads(raw) for raw in wire_formats.generate_coverage_witnesses(corpus, seed=31)]
+
+    assert {type(payload["choice"]) for payload in payloads} >= {int, str}
+    assert {type(payload["items"][0]) for payload in payloads} >= {int, str}
+    assert {type(payload["typed_choice"]) for payload in payloads} >= {dict, str}
+
+
+def test_coverage_witnesses_keep_nested_union_choices_independent() -> None:
+    schema: SchemaRecord = {
+        "oneOf": [
+            {"type": "string"},
+            {"oneOf": [{"type": "integer"}, {"type": "boolean"}]},
+        ]
+    }
+    corpus = SyntheticCorpus(schema, wire_formats.WireFormat(encoding="json"), "test")
+
+    payloads = [json.loads(raw) for raw in wire_formats.generate_coverage_witnesses(corpus, seed=17, max_witnesses=8)]
+
+    assert any(isinstance(payload, str) for payload in payloads)
+    assert 0 in payloads
+    assert True in payloads
+
+
+def test_receipt_generation_and_validation_use_injected_registry_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = SchemaRegistry()
+    selected_schema = registry.get_element_schema("chatgpt", version="default", element_kind="session_document")
+    assert selected_schema is not None
+    divergent_schema = deepcopy(selected_schema)
+    properties = divergent_schema.setdefault("properties", {})
+    assert isinstance(properties, dict)
+    properties["memory_scope"] = {"type": "integer", "x-polylogue-frequency": 1.0}
+    properties["registry_only_marker"] = {
+        "type": "integer",
+        "x-polylogue-frequency": 0.0,
+    }
+    required = divergent_schema.setdefault("required", [])
+    assert isinstance(required, list)
+    required.append("memory_scope")
+    original_loader = registry.get_element_schema
+
+    def load_divergent_schema(
+        provider: str,
+        *,
+        version: str = "default",
+        element_kind: str | None = None,
+    ) -> SchemaRecord | None:
+        if provider == "chatgpt" and element_kind == "session_document":
+            return divergent_schema
+        return original_loader(provider, version=version, element_kind=element_kind)
+
+    monkeypatch.setattr(registry, "get_element_schema", load_divergent_schema)
+    captured_schemas: list[Mapping[str, object]] = []
+
+    class CapturingValidator(SchemaValidator):
+        def __init__(
+            self,
+            schema: Mapping[str, object],
+            strict: bool = True,
+            provider: Provider | None = None,
+        ) -> None:
+            captured_schemas.append(schema)
+            super().__init__(schema, strict=strict, provider=provider)
+
+    monkeypatch.setattr(validator_module, "SchemaValidator", CapturingValidator)
+    receipt = wire_formats.build_wire_support_receipt(registry=registry)
+
+    entry = next(item for item in receipt.entries if item.provider == "chatgpt")
+    assert entry.schema_valid is True
+    assert entry.healthy
+    assert any(schema is divergent_schema for schema in captured_schemas)
+    assert entry.construct_coverage is not None
+    marker = "type:integer@$.properties.registry_only_marker"
+    assert marker in entry.construct_coverage.schema_keywords
+    assert marker in entry.construct_coverage.exercised_keywords
+
+
+def test_claude_code_route_only_waives_unrepresentable_nested_content() -> None:
+    receipt = wire_formats.build_wire_support_receipt(registry=SchemaRegistry())
+    entry = next(item for item in receipt.entries if item.provider == "claude-code")
+
+    assert entry.construct_coverage is not None
+    assert entry.construct_coverage.complete
+    assert not any(
+        "snapshot.properties.trackedFileBackups" in keyword
+        for keyword in entry.construct_coverage.nonrepresentable_keywords
+    )
+    assert all(
+        "$.properties.message.properties.content.anyOf[1].items[*].properties.content.anyOf[1]" in keyword
+        for keyword in entry.construct_coverage.nonrepresentable_keywords
+    )
+
+
+def test_unmatched_union_does_not_count_as_exercised() -> None:
+    schema: SchemaRecord = {
+        "oneOf": [{"type": "integer"}, {"type": "string"}],
+    }
+    coverage = wire_formats.construct_coverage(schema, (True,))
+
+    assert "oneOf" in coverage.missing_keywords
     assert not coverage.complete
 
 


### PR DESCRIPTION
## Summary

PR #3795 now certifies supported synthetic wire routes through one production witness receipt. Every artifact, including the baseline, must validate, parse through the production dispatch route, and provide artifact-local materialization evidence. The resolved package-version path from the preceding work is preserved.

## Problem

The previous receipt could accept a coverage witness that returned a structurally present session without meaningful conversational materialization. Aggregate strings and counts could also let output from another payload or metadata branch satisfy a witness. The baseline artifact was parsed and schema-validated during generation, but it was excluded from witness accounting, so a baseline parser or schema failure could be hidden by successful coverage witnesses.

## Solution

`build_wire_support_receipt` remains the single production witness route. It records a first-class baseline witness and every coverage witness. Each artifact passes the production `require_positive_conversational_evidence` filter. A witness is healthy only when it has parsed sessions, parsed messages, exercised schema constructs, no validation error, and deterministic evidence bound to a provider-owned conversational node in that same artifact.

Evidence binds parsed message identity and meaningful text or structured blocks to route-owned nodes such as ChatGPT mapping messages, Claude turns, Claude Code records, Codex message records, and Gemini chunks. Metadata-only or unrelated parser output cannot borrow evidence from another node or artifact. Only artifacts with valid schema results, clean parser results, and local evidence contribute to aggregate construct coverage. Baseline parser and schema failures propagate into the entry receipt validation error.

ChatGPT coverage generation keeps parser-owned message discriminators on the generated conversational branch. Full artifacts remain the schema and construct-coverage inputs; the parser route omits only the optional nested native subpayload that would select a second schema-shaped tree. The resolved package version still flows through selection, schema/profile loading, receipt identity, parser schema resolution, and `SyntheticCorpus`.

## Acceptance criteria

| Criterion | Status | Evidence |
| --- | --- | --- |
| Meaningful parser and materialization semantics per witness | Satisfied | `WireParserWitness.healthy` requires message counts and route-node evidence. Empty, unrelated, and metadata-derived parser mutations fail the production receipt. |
| Evidence cannot be borrowed from another artifact or branch | Satisfied | Evidence matches provider message identity and content against the same artifact's conversational nodes. Aggregate counters alone cannot make the receipt complete. |
| Baseline included in witness and validation accounting | Satisfied | The baseline is an `artifact_kind=baseline` witness and its validation result participates in `schema_valid`, construct coverage, health, and receipt completeness. |
| Baseline parser and schema failures reach the receipt | Satisfied | Focused mutations assert baseline parser errors and baseline schema errors reach `WireSupportEntry.validation_error` and make the receipt incomplete. |
| Resolved-version work preserved | Satisfied | Existing `selection_reuses_resolved_default_package` coverage remains unchanged and the quick gate passes. |

## Anti-vacuity evidence

The focused mutations call `build_wire_support_receipt` with the real synthetic generator, schema validator, parser dispatch, positive-evidence filter, and receipt aggregation. They monkeypatch only the production parser or validator boundary to model dropped, empty, unrelated, metadata-derived, baseline-parser, and baseline-schema failures. Removing the artifact-node evidence check or baseline accounting makes the corresponding assertions pass incorrectly and therefore fails the tests.

## Verification

`direnv exec . devtools test tests/unit/core/test_synthetic_wire_support.py -k 'supported_routes or parser_witness_loss or parser_witness_requires_meaningful_evidence or baseline_parser_failure or baseline_schema_failure'`: 8 passed, 18 deselected.

`direnv exec . devtools verify --quick`: all 23 steps passed, including Ruff, mypy, generated-surface rendering, layering, schema, policy, and promotion checks.

`git diff --check`: passed before commit. The full test file was not rerun after the final correction; the focused anti-vacuity selection and required static gate were rerun on the final commit.

No Beads operations or production archive data were used.

Ref polylogue-rrxe4.