### PR TITLE
test(storage): cover raw-authority verdict cache contract

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/source.py
+++ b/polylogue/storage/sqlite/archive_tiers/source.py
@@ -471,11 +471,13 @@ WHERE resolved_at_ms IS NULL;
 -- cohort's own (raw_id, revision_kind, blob_hash) rows, so any membership or
 -- content change to the logical_source_key cohort changes the fingerprint and
 -- the cached rows read as stale on the next lookup (see
--- polylogue.storage.raw_authority_verdict_cache). No write-side actuator
--- writes here yet -- polylogue.storage.raw_authority_verdict_cache's
--- get_or_compute_raw_authority_verdicts() populates it lazily on read;
--- DaemonConverger convergence-stage wiring to keep it warm proactively is
--- deferred, see polylogue-tw4ar.
+-- polylogue.storage.raw_authority_verdict_cache). The daemon's bounded
+-- raw_authority_verdict_cache convergence stage warms eligible full/unknown
+-- cohorts proactively; get_or_compute_raw_authority_verdicts() remains the
+-- read-through fallback for cold or invalidated cohorts. Cohorts containing
+-- append revisions are explicitly skipped because their authority uses a
+-- separate proof shape, so this cache is never the retention or rebuild
+-- authority for those source rows.
 CREATE TABLE IF NOT EXISTS raw_authority_verdicts (
     raw_id                TEXT PRIMARY KEY REFERENCES raw_sessions(raw_id) ON DELETE CASCADE,
     logical_source_key    TEXT NOT NULL,

--- a/polylogue/storage/sqlite/migrations/source/024_raw_authority_verdicts_cache.sql
+++ b/polylogue/storage/sqlite/migrations/source/024_raw_authority_verdicts_cache.sql
@@ -13,11 +13,14 @@
 -- fingerprint and the previously-cached rows read as stale on the next
 -- lookup rather than being trusted past their true validity window.
 --
--- No write-side actuator populates this table proactively yet --
--- get_or_compute_raw_authority_verdicts() (raw_authority_verdict_cache.py)
--- fills it lazily on first read. Wiring a DaemonConverger stage to keep it
--- warm ahead of reads is deferred to a follow-up within polylogue-tw4ar's own
--- scope, not attempted in this migration.
+-- The daemon's bounded raw_authority_verdict_cache convergence stage also
+-- warms eligible full/unknown cohorts ahead of reads. The read-through
+-- get_or_compute_raw_authority_verdicts() path remains the fallback for a
+-- cold or invalidated cohort. Cohorts containing append revisions are
+-- explicitly skipped because their authority has a separate proof shape;
+-- absence from this cache is not an assertion that the raw evidence is absent.
+-- This cache never controls raw retention or index rebuild selection; those
+-- decisions continue to use direct source-tier evidence and their own proofs.
 CREATE TABLE IF NOT EXISTS raw_authority_verdicts (
     raw_id                TEXT PRIMARY KEY REFERENCES raw_sessions(raw_id) ON DELETE CASCADE,
     logical_source_key    TEXT NOT NULL,

--- a/tests/unit/storage/test_raw_authority_verdict_cache.py
+++ b/tests/unit/storage/test_raw_authority_verdict_cache.py
@@ -18,6 +18,8 @@ from polylogue.archive.revision_authority import RawRevisionAuthority, RawRevisi
 from polylogue.core.enums import Provider, RawAuthorityVerdict
 from polylogue.storage import raw_authority_verdict_cache as cache_module
 from polylogue.storage.raw_authority_verdict_cache import (
+    RawAuthorityVerdictCacheWarmup,
+    RawAuthorityVerdictCacheWork,
     find_raw_authority_verdict_cache_work,
     get_or_compute_raw_authority_verdicts,
     read_cached_raw_authority_verdicts,
@@ -101,6 +103,39 @@ def test_new_revision_invalidates_the_cache(tmp_path: Path) -> None:
     }
 
 
+def test_changed_content_fingerprint_invalidates_the_cache(tmp_path: Path) -> None:
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        _bind_full(archive, raw_id="oldest", payload=b"one\n", logical_source_key="codex:s1")
+        _bind_full(archive, raw_id="newest", payload=b"one\ntwo\n", logical_source_key="codex:s1")
+        _bind_full(archive, raw_id="replacement", payload=b"diverged", logical_source_key="codex:replacement")
+
+        first = get_or_compute_raw_authority_verdicts(archive, "codex:s1", now_ms=1000)
+        assert first == {
+            "oldest": RawAuthorityVerdict.SUPERSEDED,
+            "newest": RawAuthorityVerdict.VERIFIED,
+        }
+
+        conn = archive._ensure_source_conn()
+        conn.execute(
+            """
+            UPDATE raw_sessions
+            SET blob_hash = (SELECT blob_hash FROM raw_sessions WHERE raw_id = 'replacement'),
+                blob_size = (SELECT blob_size FROM raw_sessions WHERE raw_id = 'replacement')
+            WHERE raw_id = 'newest'
+            """
+        )
+        conn.commit()
+
+        assert read_cached_raw_authority_verdicts(archive, "codex:s1") is None
+        second = get_or_compute_raw_authority_verdicts(archive, "codex:s1", now_ms=2000)
+
+    assert second == {
+        "oldest": RawAuthorityVerdict.DIVERGED,
+        "newest": RawAuthorityVerdict.DIVERGED,
+    }
+
+
 def test_write_requires_full_cohort_and_replaces_prior_rows(tmp_path: Path) -> None:
     """A rewrite must clear the cohort's whole prior row set, not accumulate."""
     initialize_active_archive_root(tmp_path)
@@ -145,13 +180,9 @@ def test_missing_cohort_returns_no_verdicts_and_no_cache_write(tmp_path: Path) -
 def test_warmup_is_bounded_and_skips_append_cohorts(tmp_path: Path) -> None:
     initialize_active_archive_root(tmp_path)
     with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
-        for index in range(2):
-            _bind_full(
-                archive,
-                raw_id=f"full-{index}",
-                payload=f"payload-{index}".encode(),
-                logical_source_key=f"codex:full-{index}",
-            )
+        _bind_full(archive, raw_id="full-oldest", payload=b"one\n", logical_source_key="codex:full")
+        _bind_full(archive, raw_id="full-newest", payload=b"one\ntwo\n", logical_source_key="codex:full")
+        _bind_full(archive, raw_id="full-single", payload=b"single", logical_source_key="codex:full-single")
         append_id = archive.write_raw_payload(
             provider=Provider.CODEX,
             payload=b"append-payload",
@@ -176,10 +207,12 @@ def test_warmup_is_bounded_and_skips_append_cohorts(tmp_path: Path) -> None:
         )
 
         work = find_raw_authority_verdict_cache_work(archive._ensure_source_conn(), max_cohorts=1)
-        assert work.pending_logical_source_keys == ("codex:full-0",)
+        assert isinstance(work, RawAuthorityVerdictCacheWork)
+        assert work.pending_logical_source_keys == ("codex:full",)
         assert work.skipped_append_cohorts == 1
 
         first = warm_raw_authority_verdict_cache(archive, max_cohorts=1, now_ms=1000)
+        assert isinstance(first, RawAuthorityVerdictCacheWarmup)
         assert first.warmed_cohorts == 1
         assert first.pending_cohorts is True
         assert first.skipped_append_cohorts == 1
@@ -195,8 +228,19 @@ def test_warmup_is_bounded_and_skips_append_cohorts(tmp_path: Path) -> None:
             .execute("SELECT logical_source_key FROM raw_authority_verdicts")
             .fetchall()
         }
+        cached_verdicts = {
+            key: read_cached_raw_authority_verdicts(archive, key) for key in ("codex:full", "codex:full-single")
+        }
+        assert read_cached_raw_authority_verdicts(archive, "codex:append") is None
 
-    assert cached_keys == {"codex:full-0", "codex:full-1"}
+    assert cached_keys == {"codex:full", "codex:full-single"}
+    assert cached_verdicts == {
+        "codex:full": {
+            "full-oldest": RawAuthorityVerdict.SUPERSEDED,
+            "full-newest": RawAuthorityVerdict.VERIFIED,
+        },
+        "codex:full-single": {"full-single": RawAuthorityVerdict.SOLE_COPY},
+    }
 
 
 def test_warmup_does_not_recompute_fresh_cohorts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Add the safe Phase-2 raw-authority verdict-cache contract coverage and update stale source-schema comments after daemon cache warming landed.

## Problem

The existing cache coverage proved read-through persistence and membership invalidation, but it did not prove that proactive warming persists every verdict in a multi-member full cohort or that a changed raw content fingerprint forces recomputation. Migration and canonical source-schema comments still described proactive warming as deferred.

## Solution

- Exercise the real `warm_raw_authority_verdict_cache` path with a two-member full cohort and a single-member full cohort, asserting every persisted verdict.
- Change authoritative `raw_sessions.blob_hash` and `blob_size` to an existing divergent blob and require stale-cache rejection plus recomputed `DIVERGED` results.
- Assert `RawAuthorityVerdictCacheWork` and `RawAuthorityVerdictCacheWarmup` are returned with an explicit append skip count, while append rows remain absent from the cache.
- Update migration 024 and canonical source DDL comments to describe daemon warming, read-through fallback, direct source-tier authority, and exclusion from retention/rebuild selection.

No schema implementation, cache implementation, daemon-stage, schema-inference gate, rebuild, retention, or fragmented reconciler code changed.

## Acceptance matrix

| Criterion | Status | Evidence |
| --- | --- | --- |
| Full cohorts warm and persist complete verdict sets | Satisfied | `tests/unit/storage/test_raw_authority_verdict_cache.py` warms a two-member full cohort and asserts both `SUPERSEDED` and `VERIFIED` rows, plus a single-member cohort. Existing convergence-stage coverage proves daemon delegation to the warmer. |
| Changed content fingerprint invalidates cache | Satisfied | The test mutates source-table blob evidence, asserts the cached read is stale, and verifies recomputed `DIVERGED` verdicts from the real blob-backed projection. |
| Append cohorts are explicitly skipped | Satisfied | Typed work and warmup objects expose `skipped_append_cohorts`; tests assert the count and append cache absence. Existing convergence-stage coverage asserts the skip log. |
| Cache remains subordinate to source truth | Satisfied | Both schema comments state read-through fallback, direct source/blob recomputation, and no retention or rebuild authority. |
| Scope remains within the assigned lane | Satisfied | Exactly three files changed: two schema/comment surfaces and one cache test file. |

## Verification

- `direnv exec . devtools test tests/unit/storage/test_raw_authority_verdict_cache.py tests/unit/storage/test_raw_authority_verdict_projection.py tests/unit/daemon/test_convergence_stages.py` -> `64 passed in 18.08s`
- `direnv exec . devtools verify --quick` -> `exit_code: 0`, all 23 steps passed
- Pre-push hook quick baseline -> `exit_code: 0`, all 23 steps passed
- `git diff --check` -> passed

## Anti-vacuity

The tests enter the production `ArchiveStore.write_raw_payload` and `bind_raw_revision` paths, the real source SQLite tables, the real blob publisher, `warm_raw_authority_verdict_cache`, `read_cached_raw_authority_verdicts`, and `project_raw_authority_verdicts`. Removing blob-backed projection reads, changing the cohort fingerprint inputs, truncating a multi-member verdict result, or dropping typed append-skip reporting makes the focused assertions fail. No toy store, fake DDL, or test-only validator is used.

## Adversarial review notes

Two independent cold-context review iterations were run. Iteration 1 found one real AC1 gap: the existing daemon-stage fixture used only single-member full cohorts. The cache contract test was updated to use a two-member cohort and assert both persisted verdicts. The reviewer also identified a documentation strengthening opportunity, so migration 024 now explicitly states that the cache does not control retention or index rebuild selection. Iteration 2 found no legitimate gaps across all five acceptance criteria.

## Residual uncertainty

The full repository test suite was not run. No live archive or daemon deployment was exercised. This lane intentionally leaves the existing daemon-stage implementation and append-authority proof unchanged.