### PR TITLE
test: compile inferred schema corpus manifest

### DIFF
--- a/polylogue/schemas/synthetic/core.py
+++ b/polylogue/schemas/synthetic/core.py
@@ -186,6 +186,21 @@ class SyntheticCorpus:
     @classmethod
     def generate_batch_for_spec(cls, spec: CorpusSpec) -> SyntheticGenerationBatch:
         corpus = cls.from_spec(spec)
+        return cls._generate_batch_for_corpus(corpus, spec)
+
+    @classmethod
+    def generate_batch_for_selection(
+        cls,
+        selection: SyntheticSchemaSelection,
+        spec: CorpusSpec,
+    ) -> SyntheticGenerationBatch:
+        """Generate a spec through an already-resolved persisted schema route."""
+
+        corpus = cls.from_selection(selection)
+        return cls._generate_batch_for_corpus(corpus, spec)
+
+    @staticmethod
+    def _generate_batch_for_corpus(corpus: SyntheticCorpus, spec: CorpusSpec) -> SyntheticGenerationBatch:
         return corpus.generate_batch(
             count=spec.count,
             messages_per_session=spec.messages_per_session,
@@ -208,9 +223,36 @@ class SyntheticCorpus:
         index_width: int = 2,
     ) -> SyntheticWrittenBatch:
         corpus = cls.from_spec(spec)
+        return cls._write_batch_artifacts(corpus, spec, output_dir, prefix=prefix, index_width=index_width)
+
+    @classmethod
+    def write_selection_artifacts(
+        cls,
+        selection: SyntheticSchemaSelection,
+        spec: CorpusSpec,
+        output_dir: Path,
+        *,
+        prefix: str,
+        index_width: int = 2,
+    ) -> SyntheticWrittenBatch:
+        """Write artifacts from the exact schema selection carried by a manifest."""
+
+        corpus = cls.from_selection(selection)
+        return cls._write_batch_artifacts(corpus, spec, output_dir, prefix=prefix, index_width=index_width)
+
+    @classmethod
+    def _write_batch_artifacts(
+        cls,
+        corpus: SyntheticCorpus,
+        spec: CorpusSpec,
+        output_dir: Path,
+        *,
+        prefix: str,
+        index_width: int,
+    ) -> SyntheticWrittenBatch:
         output_dir.mkdir(parents=True, exist_ok=True)
         ext = ".json" if corpus.wire_format.encoding == "json" else ".jsonl"
-        batch = cls.generate_batch_for_spec(spec)
+        batch = cls._generate_batch_for_corpus(corpus, spec)
         written_files: list[Path] = []
         for idx, artifact in enumerate(batch.artifacts):
             if corpus.provider == "antigravity":

--- a/tests/infra/inferred_corpus.py
+++ b/tests/infra/inferred_corpus.py
@@ -11,9 +11,12 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
+import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
-from typing import Literal, TypeAlias
+from pathlib import Path
+from typing import Literal, TypeAlias, cast
 
 from polylogue.core.json import JSONDocument
 from polylogue.scenarios import CorpusSpec
@@ -24,6 +27,7 @@ from polylogue.schemas.synthetic.models import SchemaRecord, SyntheticSchemaSele
 from polylogue.schemas.synthetic.wire_formats import PROVIDER_WIRE_FORMATS, WireFormat
 
 ConstructSupportState: TypeAlias = Literal["supported", "unsupported"]
+INFERRED_CORPUS_MANIFEST_SCHEMA_VERSION = 1
 UnsupportedCorpusReason: TypeAlias = Literal[
     "provider_without_wire_format",
     "unsupported_element",
@@ -177,6 +181,46 @@ _SUPPORTED_FORMAT_VALUES = frozenset(
 )
 _SUPPORTED_SEMANTIC_ROLE_VALUES = frozenset({"message_role", "message_body", "message_timestamp", "session_title"})
 
+REPRESENTATIVE_PROVIDER = "codex"
+REPRESENTATIVE_PACKAGE_VERSION = "v1"
+REPRESENTATIVE_ELEMENT_KIND = "session_record_stream"
+_REPRESENTATIVE_SCHEMA: SchemaRecord = {
+    "$id": "https://example.test/polylogue/inferred-corpus/codex-v1-session-record-stream",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "type": {"type": "string", "x-polylogue-values": ["message"]},
+        "role": {
+            "type": "string",
+            "x-polylogue-semantic-role": "message_role",
+            "x-polylogue-values": ["user", "assistant"],
+        },
+        "content": {
+            "type": "array",
+            "x-polylogue-array-lengths": [1, 1],
+            "items": {
+                "type": "object",
+                "properties": {
+                    "type": {"type": "string", "x-polylogue-values": ["input_text", "output_text"]},
+                    "text": {
+                        "type": "string",
+                        "x-polylogue-semantic-role": "message_body",
+                        "x-polylogue-multiline": True,
+                    },
+                },
+            },
+        },
+        "id": {"type": "string", "x-polylogue-format": "uuid4"},
+        "timestamp": {
+            "type": "string",
+            "x-polylogue-semantic-role": "message_timestamp",
+            "x-polylogue-format": "iso8601",
+        },
+        "sequence": {"type": "integer", "x-polylogue-range": [0, 1000]},
+    },
+    "x-polylogue-string-lengths": [{"path": "$.role", "min": 1, "max": 24, "avg": 8.0, "stddev": 2.0}],
+}
+
 
 @dataclass(frozen=True, order=True)
 class ConstructSupport:
@@ -225,6 +269,8 @@ class InferredCorpusManifestEntry:
     key: CorpusManifestKey
     spec: CorpusSpec | None = None
     unsupported: UnsupportedCorpusRecord | None = None
+    generator_schema: SchemaRecord | None = None
+    workload_profile: SchemaRecord | None = None
 
     def __post_init__(self) -> None:
         if (self.spec is None) == (self.unsupported is None):
@@ -239,6 +285,12 @@ class InferredCorpusManifestEntry:
             self.key.element_kind,
         ):
             raise ValueError("CorpusSpec identity does not match manifest key")
+        if self.spec is not None and not isinstance(self.generator_schema, dict):
+            raise ValueError("supported manifest entry requires a generator schema")
+        if self.unsupported is not None and self.generator_schema is not None:
+            raise ValueError("unsupported manifest entry must not carry a generator schema")
+        if self.unsupported is not None and self.workload_profile is not None:
+            raise ValueError("unsupported manifest entry must not carry a workload profile")
 
     @property
     def supported(self) -> bool:
@@ -250,6 +302,10 @@ class InferredCorpusManifestEntry:
             payload["spec"] = self.spec.to_payload()
         if self.unsupported is not None:
             payload["unsupported"] = self.unsupported.to_payload()
+        if self.generator_schema is not None:
+            payload["generator_schema"] = self.generator_schema
+        if self.workload_profile is not None:
+            payload["workload_profile"] = self.workload_profile
         return payload
 
 
@@ -282,19 +338,76 @@ class InferredCorpusManifest:
 
     @property
     def manifest_id(self) -> str:
-        encoded = json.dumps(self._payload_without_id(), sort_keys=True, separators=(",", ":"))
+        encoded = _canonical_json(self._payload_without_id())
         return f"manifest:sha256:{hashlib.sha256(encoded.encode('utf-8')).hexdigest()}"
+
+    @property
+    def payload_sha256(self) -> str:
+        encoded = _canonical_json({"manifest_id": self.manifest_id, **self._payload_without_id()})
+        return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
     def _payload_without_id(self) -> dict[str, object]:
         return {
-            "schema_version": 1,
+            "schema_version": INFERRED_CORPUS_MANIFEST_SCHEMA_VERSION,
             "receipt_state": self.receipt_state,
             "package_receipt": self.package_receipt,
             "entries": [entry.to_payload() for entry in self.entries],
         }
 
     def to_payload(self) -> dict[str, object]:
-        return {"manifest_id": self.manifest_id, **self._payload_without_id()}
+        return {
+            "manifest_id": self.manifest_id,
+            **self._payload_without_id(),
+            "payload_sha256": self.payload_sha256,
+        }
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, object]) -> InferredCorpusManifest:
+        expected_fields = {
+            "manifest_id",
+            "schema_version",
+            "receipt_state",
+            "package_receipt",
+            "entries",
+            "payload_sha256",
+        }
+        if set(payload) != expected_fields:
+            raise ValueError(f"inferred corpus manifest fields changed: {sorted(set(payload) ^ expected_fields)}")
+        schema_version = payload.get("schema_version")
+        if schema_version != INFERRED_CORPUS_MANIFEST_SCHEMA_VERSION:
+            raise ValueError(
+                "unsupported inferred corpus manifest schema_version: "
+                f"expected={INFERRED_CORPUS_MANIFEST_SCHEMA_VERSION}, actual={schema_version!r}"
+            )
+        raw_entries = payload.get("entries")
+        if not isinstance(raw_entries, list):
+            raise ValueError("inferred corpus manifest entries must be a list")
+        entries = tuple(_manifest_entry_from_payload(item) for item in raw_entries)
+        receipt_state = payload.get("receipt_state")
+        package_receipt = payload.get("package_receipt")
+        if receipt_state not in {"catalog_only", "package_receipt_attached"}:
+            raise ValueError(f"invalid inferred corpus manifest receipt_state: {receipt_state!r}")
+        if receipt_state == "catalog_only" and package_receipt is not None:
+            raise ValueError("catalog_only manifest must not carry a package receipt")
+        if receipt_state == "package_receipt_attached" and not isinstance(package_receipt, dict):
+            raise ValueError("package_receipt_attached manifest requires a JSON object receipt")
+        manifest = cls(
+            entries=entries,
+            package_receipt=package_receipt if isinstance(package_receipt, dict) else None,
+        )
+        expected_manifest_id = manifest.manifest_id
+        if payload.get("manifest_id") != expected_manifest_id:
+            raise ValueError(
+                "inferred corpus manifest identity mismatch: "
+                f"expected={expected_manifest_id!r}, actual={payload.get('manifest_id')!r}"
+            )
+        expected_payload_sha256 = manifest.payload_sha256
+        if payload.get("payload_sha256") != expected_payload_sha256:
+            raise ValueError(
+                "inferred corpus manifest payload integrity mismatch: "
+                f"expected={expected_payload_sha256!r}, actual={payload.get('payload_sha256')!r}"
+            )
+        return manifest
 
 
 @dataclass(frozen=True)
@@ -303,20 +416,189 @@ class InferredCorpusConvergenceHandoff:
 
     manifest_id: str
     specs: tuple[CorpusSpec, ...]
+    selections: tuple[SyntheticSchemaSelection, ...]
+
+
+def _canonical_json(payload: Mapping[str, object]) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
+
+
+def _reject_json_constant(value: str) -> object:
+    raise ValueError(f"non-finite JSON constant is not permitted: {value}")
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON object key: {key!r}")
+        result[key] = value
+    return result
+
+
+def _manifest_entry_from_payload(payload: object) -> InferredCorpusManifestEntry:
+    if not isinstance(payload, Mapping):
+        raise ValueError("inferred corpus manifest entry must be a JSON object")
+    entry_fields = {"key", "supported", "spec", "unsupported", "generator_schema", "workload_profile"}
+    if set(payload) - entry_fields:
+        raise ValueError(f"inferred corpus manifest entry fields changed: {sorted(set(payload) - entry_fields)}")
+    raw_key = payload.get("key")
+    if not isinstance(raw_key, Mapping):
+        raise ValueError("inferred corpus manifest entry key must be a JSON object")
+    if set(raw_key) != {"provider", "package_version", "element_kind", "construct_support"}:
+        raise ValueError("inferred corpus manifest key fields changed")
+    provider = raw_key.get("provider")
+    package_version = raw_key.get("package_version")
+    element_kind = raw_key.get("element_kind")
+    raw_constructs = raw_key.get("construct_support", [])
+    if not isinstance(raw_constructs, list) or not all(isinstance(item, Mapping) for item in raw_constructs):
+        raise ValueError("manifest construct_support must be a list of objects")
+    constructs: list[ConstructSupport] = []
+    for raw_construct in cast(list[Mapping[str, object]], raw_constructs):
+        construct = raw_construct.get("construct")
+        state = raw_construct.get("state")
+        if not isinstance(construct, str) or not construct or state not in {"supported", "unsupported"}:
+            raise ValueError("manifest construct_support contains an invalid row")
+        constructs.append(ConstructSupport(construct=construct, state=state))
+    if (
+        not isinstance(provider, str)
+        or not isinstance(package_version, str)
+        or not isinstance(element_kind, str)
+        or not element_kind
+        or tuple(sorted(constructs)) != tuple(constructs)
+        or len({item.construct for item in constructs}) != len(constructs)
+    ):
+        raise ValueError("manifest entry key has invalid identity or construct ordering")
+    key = CorpusManifestKey(provider, package_version, element_kind, tuple(constructs))
+    supported = payload.get("supported")
+    raw_spec = payload.get("spec")
+    raw_unsupported = payload.get("unsupported")
+    raw_schema = payload.get("generator_schema")
+    raw_workload_profile = payload.get("workload_profile")
+    if supported is True:
+        expected_entry_fields = {"key", "supported", "spec", "generator_schema"}
+        if "workload_profile" in payload:
+            expected_entry_fields.add("workload_profile")
+        if set(payload) != expected_entry_fields:
+            raise ValueError("supported manifest entry fields changed")
+        if not isinstance(raw_spec, Mapping) or not isinstance(raw_schema, Mapping):
+            raise ValueError("supported manifest entry requires spec and generator_schema")
+        if "workload_profile" in payload and not isinstance(raw_workload_profile, Mapping):
+            raise ValueError("manifest workload_profile must be a JSON object when present")
+        spec_fields = {
+            "origin",
+            "path_targets",
+            "artifact_targets",
+            "conceptual_path_targets",
+            "conceptual_artifact_targets",
+            "operation_targets",
+            "maintenance_targets",
+            "tags",
+            "docs_role",
+            "caption",
+            "narrative_order",
+            "audience",
+            "demonstrates",
+            "privacy_level",
+            "media",
+            "visual_style",
+            "provider",
+            "package_version",
+            "count",
+            "messages_min",
+            "messages_max",
+            "style",
+            "element_kind",
+            "seed",
+            "session_native_ids",
+            "profile",
+        }
+        if set(raw_spec) - spec_fields:
+            raise ValueError("inferred corpus spec fields changed")
+        spec = CorpusSpec.from_payload(cast(dict[str, object], raw_spec))
+        return InferredCorpusManifestEntry(
+            key=key,
+            spec=spec,
+            generator_schema=cast(SchemaRecord, dict(raw_schema)),
+            workload_profile=(
+                cast(SchemaRecord, dict(raw_workload_profile)) if isinstance(raw_workload_profile, Mapping) else None
+            ),
+        )
+    if supported is not False:
+        raise ValueError("manifest entry supported must be boolean")
+    if set(payload) != {"key", "supported", "unsupported"}:
+        raise ValueError("unsupported manifest entry fields changed")
+    if not isinstance(raw_unsupported, Mapping):
+        raise ValueError("unsupported manifest entry requires unsupported metadata only")
+    reason = raw_unsupported.get("reason")
+    details = raw_unsupported.get("details", [])
+    if set(raw_unsupported) != {"reason", "details"}:
+        raise ValueError("manifest unsupported record fields changed")
+    valid_reasons = {
+        "provider_without_wire_format",
+        "unsupported_element",
+        "missing_schema",
+        "unsupported_json_schema_construct",
+    }
+    if (
+        reason not in valid_reasons
+        or not isinstance(details, list)
+        or not all(isinstance(item, str) for item in details)
+    ):
+        raise ValueError("manifest unsupported record is invalid")
+    return InferredCorpusManifestEntry(
+        key=key,
+        unsupported=UnsupportedCorpusRecord(
+            reason=cast(UnsupportedCorpusReason, reason),
+            details=tuple(cast(str, item) for item in details),
+        ),
+    )
+
+
+def write_inferred_corpus_manifest(manifest: InferredCorpusManifest, path: Path) -> None:
+    """Persist one canonical manifest payload with an independently checked hash."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(manifest.to_payload(), indent=2, sort_keys=True, allow_nan=False) + "\n", encoding="utf-8"
+    )
+
+
+def read_inferred_corpus_manifest(path: Path) -> InferredCorpusManifest:
+    """Read and validate a persisted manifest before exposing executable rows."""
+
+    try:
+        payload = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_json_keys,
+            parse_constant=_reject_json_constant,
+        )
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        raise ValueError(f"unable to read inferred corpus manifest {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("inferred corpus manifest root must be a JSON object")
+    return InferredCorpusManifest.from_payload(payload)
 
 
 def _is_number(value: object) -> bool:
-    return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return False
+    try:
+        return math.isfinite(float(value))
+    except (OverflowError, ValueError):
+        return False
 
 
 def _number(value: object) -> int | float | None:
-    if isinstance(value, (int, float)) and not isinstance(value, bool):
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value if _is_number(value) else None
+    if isinstance(value, float) and not isinstance(value, bool) and math.isfinite(value):
         return value
     return None
 
 
 def _valid_pair(value: object, *, integral: bool = False, nonnegative: bool = False) -> bool:
-    if not isinstance(value, list) or len(value) < 2:
+    if not isinstance(value, list) or len(value) != 2:
         return False
     first = _number(value[0])
     second = _number(value[1])
@@ -329,31 +611,71 @@ def _valid_pair(value: object, *, integral: bool = False, nonnegative: bool = Fa
     return first <= second
 
 
+def _histogram_bucket_is_safe(index: int, log_base: int | float) -> bool:
+    try:
+        sampled_value = math.expm1((abs(float(index)) - 0.5) * math.log(float(log_base)))
+    except (OverflowError, ValueError):
+        return False
+    return math.isfinite(sampled_value)
+
+
 def _valid_observed_distribution(value: object) -> bool:
-    if not isinstance(value, Mapping):
+    if not isinstance(value, Mapping) or not value:
         return False
     for distribution in value.values():
         if not isinstance(distribution, Mapping):
-            continue
+            return False
         histogram = distribution.get("histogram")
         log_base = _number(distribution.get("log_base"))
-        if (
-            isinstance(histogram, list)
-            and histogram
-            and _is_number(log_base)
-            and log_base is not None
-            and log_base > 1
-            and all(
-                isinstance(bucket, list)
-                and len(bucket) == 2
-                and isinstance(bucket[0], int)
-                and isinstance(bucket[1], int)
-                and bucket[1] > 0
-                for bucket in histogram
-            )
+        if not isinstance(histogram, list) or not histogram or log_base is None or log_base <= 1:
+            return False
+        log_base_float = float(log_base)
+        if not all(
+            isinstance(bucket, list)
+            and len(bucket) == 2
+            and isinstance(bucket[0], int)
+            and not isinstance(bucket[0], bool)
+            and isinstance(bucket[1], int)
+            and not isinstance(bucket[1], bool)
+            and _number(bucket[0]) is not None
+            and _number(bucket[1]) is not None
+            and bucket[1] > 0
+            and _histogram_bucket_is_safe(bucket[0], log_base_float)
+            for bucket in histogram
         ):
-            return True
-    return False
+            return False
+        for key in ("min", "max", "mean", "p0", "p50", "p90", "p95", "p99", "p100", "stddev"):
+            if key in distribution and not _is_number(distribution[key]):
+                return False
+        minimum = _number(distribution.get("min"))
+        maximum = _number(distribution.get("max"))
+        if minimum is not None and maximum is not None and minimum > maximum:
+            return False
+        stddev = _number(distribution.get("stddev"))
+        if stddev is not None and stddev < 0:
+            return False
+        ordered_stats = tuple(_number(distribution.get(key)) for key in ("p0", "p50", "p90", "p95", "p99", "p100"))
+        present_stats = tuple(value for value in ordered_stats if value is not None)
+        if any(left > right for left, right in zip(present_stats, present_stats[1:], strict=False)):
+            return False
+        if any(
+            (minimum is not None and value < minimum) or (maximum is not None and value > maximum)
+            for value in present_stats
+        ):
+            return False
+        mean = _number(distribution.get("mean"))
+        if mean is not None:
+            if minimum is not None and mean < minimum:
+                return False
+            if maximum is not None and mean > maximum:
+                return False
+            p0 = _number(distribution.get("p0"))
+            p100 = _number(distribution.get("p100"))
+            if p0 is not None and mean < p0:
+                return False
+            if p100 is not None and mean > p100:
+                return False
+    return True
 
 
 def _relation_records(value: object, required: tuple[str, ...]) -> list[dict[str, object]] | None:
@@ -367,6 +689,119 @@ def _relation_records(value: object, required: tuple[str, ...]) -> list[dict[str
             return None
         records.append(record)
     return records
+
+
+_SCHEMA_PATH_SEGMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]*$")
+
+
+def _schema_nodes_at_path(schema: SchemaRecord, path: object) -> tuple[SchemaRecord, ...]:
+    """Resolve the JSONPath subset emitted by the relation solver."""
+
+    if not isinstance(path, str) or not path.startswith("$"):
+        return ()
+    if path == "$":
+        return (schema,)
+    if not path.startswith("$."):
+        return ()
+    nodes: tuple[SchemaRecord, ...] = (schema,)
+    for raw_segment in path[2:].split("."):
+        if raw_segment.endswith("[*]"):
+            segment = raw_segment[:-3]
+            wants_items = True
+        else:
+            segment = raw_segment
+            wants_items = False
+        if not _SCHEMA_PATH_SEGMENT.fullmatch(segment):
+            return ()
+        next_nodes: list[SchemaRecord] = []
+        for node in nodes:
+            variants = [node]
+            for branch_key in ("anyOf", "oneOf"):
+                branches = node.get(branch_key)
+                if isinstance(branches, list):
+                    variants.extend(branch for branch in branches if isinstance(branch, dict))
+            for variant in variants:
+                properties = variant.get("properties")
+                child = properties.get(segment) if isinstance(properties, dict) else None
+                if not isinstance(child, dict):
+                    continue
+                if wants_items:
+                    items = child.get("items")
+                    if isinstance(items, dict):
+                        next_nodes.append(items)
+                else:
+                    next_nodes.append(child)
+        nodes = tuple(next_nodes)
+        if not nodes:
+            return ()
+    return nodes
+
+
+def _schema_nodes_have_type(nodes: tuple[SchemaRecord, ...], allowed: set[str]) -> bool:
+    return bool(nodes) and all(_schema_type(node) in allowed for node in nodes)
+
+
+def _schema_type_family(nodes: tuple[SchemaRecord, ...]) -> str | None:
+    types = {_schema_type(node) for node in nodes}
+    if types and types <= {"string"}:
+        return "string"
+    if types and types <= {"number", "integer"}:
+        return "numeric"
+    return None
+
+
+def _relation_annotation_paths_are_enforced(
+    key: str,
+    value: object,
+    root_schema: SchemaRecord,
+) -> bool:
+    records = _relation_records(
+        value,
+        {
+            "x-polylogue-foreign-keys": ("source", "target"),
+            "x-polylogue-time-deltas": ("field_a", "field_b"),
+            "x-polylogue-mutually-exclusive": ("parent",),
+            "x-polylogue-string-lengths": ("path",),
+        }[key],
+    )
+    if records is None:
+        return False
+    if key == "x-polylogue-foreign-keys":
+        return False
+    if key == "x-polylogue-time-deltas":
+        # The solver parses these records, but no production generation path
+        # calls get_time_delta yet. Keep them fail-closed until it does.
+        return False
+    if key == "x-polylogue-time-deltas":
+        return all(
+            _schema_nodes_have_type(_schema_nodes_at_path(root_schema, record["source"]), {"string"})
+            and _schema_nodes_have_type(_schema_nodes_at_path(root_schema, record["target"]), {"string"})
+            for record in records
+        )
+    if key == "x-polylogue-time-deltas":
+        return all(
+            (field_a_family := _schema_type_family(_schema_nodes_at_path(root_schema, record["field_a"]))) is not None
+            and field_a_family == _schema_type_family(_schema_nodes_at_path(root_schema, record["field_b"]))
+            for record in records
+        )
+    if key == "x-polylogue-string-lengths":
+        return all(
+            _schema_nodes_have_type(_schema_nodes_at_path(root_schema, record["path"]), {"string"})
+            for record in records
+        )
+    return all(
+        _schema_nodes_have_type(_schema_nodes_at_path(root_schema, record["parent"]), {"object"})
+        and isinstance(fields := record.get("fields"), list)
+        and all(
+            isinstance(field, str)
+            and _schema_nodes_have_type(
+                _schema_nodes_at_path(root_schema, f"{record['parent']}.{field}"),
+                {"string", "number", "integer", "boolean", "array", "object"},
+            )
+            for field in fields
+        )
+        for record in records
+    )
 
 
 def _synthetic_annotation_is_enforced(key: str, value: object) -> bool:
@@ -384,7 +819,7 @@ def _synthetic_annotation_is_enforced(key: str, value: object) -> bool:
     if key == "x-polylogue-multiline":
         return isinstance(value, bool)
     if key == "x-polylogue-values":
-        return isinstance(value, list) and bool(value) and all(not isinstance(item, (list, Mapping)) for item in value)
+        return isinstance(value, list) and bool(value) and all(isinstance(item, str) and item for item in value)
     if key == "x-polylogue-range":
         return _valid_pair(value)
     if key == "x-polylogue-array-lengths":
@@ -394,12 +829,9 @@ def _synthetic_annotation_is_enforced(key: str, value: object) -> bool:
     if key == "x-polylogue-foreign-keys":
         return _relation_records(value, ("source", "target")) is not None
     if key == "x-polylogue-time-deltas":
-        records = _relation_records(value, ("field_a", "field_b"))
-        return records is not None and all(
-            _number(record.get(field)) is not None
-            for record in records
-            for field in ("min_delta", "max_delta", "avg_delta")
-        )
+        # The solver parses these records, but no production generation path
+        # calls get_time_delta yet. Keep them fail-closed until it does.
+        return False
     if key == "x-polylogue-mutually-exclusive":
         records = _relation_records(value, ("parent",))
         return records is not None and all(
@@ -410,17 +842,88 @@ def _synthetic_annotation_is_enforced(key: str, value: object) -> bool:
         )
     if key == "x-polylogue-string-lengths":
         records = _relation_records(value, ("path",))
-        return records is not None and all(
-            _valid_pair([record.get("min"), record.get("max")], integral=True, nonnegative=True)
-            and _number(record.get("avg")) is not None
-            and _number(record.get("stddev")) is not None
+        if records is None:
+            return False
+        string_records: list[tuple[int | float | None, int | float | None, int | float | None, int | float | None]] = [
+            (
+                _number(record.get("min")),
+                _number(record.get("max")),
+                _number(record.get("avg")),
+                _number(record.get("stddev")),
+            )
             for record in records
-        )
+        ]
+        for minimum, maximum, average, stddev in string_records:
+            if (
+                not _valid_pair([minimum, maximum], integral=True, nonnegative=True)
+                or average is None
+                or stddev is None
+                or minimum is None
+                or maximum is None
+                or not minimum <= average <= maximum
+                or stddev < 0
+            ):
+                return False
+        return True
     raise AssertionError(f"missing annotation validator for {key}")
 
 
+def _schema_type(node: Mapping[str, object]) -> str | None:
+    schema_type = node.get("type")
+    if isinstance(schema_type, str):
+        return schema_type
+    if isinstance(schema_type, list):
+        types = [item for item in schema_type if isinstance(item, str) and item != "null"]
+        return types[0] if len(types) == 1 else None
+    return None
+
+
+def _annotation_is_enforced_at_node(
+    key: str,
+    value: object,
+    node: Mapping[str, object],
+    path: str,
+    root_schema: SchemaRecord,
+) -> bool:
+    schema_type = _schema_type(node)
+    if key in {
+        "x-polylogue-foreign-keys",
+        "x-polylogue-time-deltas",
+        "x-polylogue-mutually-exclusive",
+        "x-polylogue-string-lengths",
+    }:
+        return (
+            path == "$"
+            and _synthetic_annotation_is_enforced(key, value)
+            and _relation_annotation_paths_are_enforced(key, value, root_schema)
+        )
+    if key == "x-polylogue-frequency":
+        return path != "$" and _synthetic_annotation_is_enforced(key, value)
+    if key in {"x-polylogue-array-lengths", "x-polylogue-observed-distribution"}:
+        if key == "x-polylogue-array-lengths":
+            return schema_type == "array" and _synthetic_annotation_is_enforced(key, value)
+        if schema_type not in {"array", "number", "integer"} or not isinstance(value, Mapping):
+            return False
+        expected_distribution = "array_length" if schema_type == "array" else "numeric"
+        return expected_distribution in value and _valid_observed_distribution(value)
+    if key == "x-polylogue-range":
+        return schema_type in {"number", "integer"} and _synthetic_annotation_is_enforced(key, value)
+    if key in {"x-polylogue-format", "x-polylogue-values", "x-polylogue-multiline"}:
+        if key == "x-polylogue-format" and schema_type in {"number", "integer"}:
+            return value == "unix-epoch"
+        return schema_type == "string" and _synthetic_annotation_is_enforced(key, value)
+    if key == "x-polylogue-semantic-role":
+        role = value if isinstance(value, str) else None
+        if role == "message_timestamp":
+            return schema_type in {"string", "number", "integer"} and _synthetic_annotation_is_enforced(key, value)
+        if role == "message_container":
+            return False
+        return schema_type == "string" and _synthetic_annotation_is_enforced(key, value)
+    return False
+
+
 def _schema_constructs(schema: object) -> tuple[ConstructSupport, ...]:
-    """Census every schema-scope keyword without treating property names as keywords."""
+    """Census schema keywords and annotations at the paths production consumes."""
 
     found: dict[str, ConstructSupportState] = {}
 
@@ -429,14 +932,20 @@ def _schema_constructs(schema: object) -> tuple[ConstructSupport, ...]:
             return
         found[key] = state
 
-    def visit(node: object) -> None:
+    def visit(node: object, path: str = "$") -> None:
         if not isinstance(node, Mapping):
             return
+        node_record = node
         for key, value in node.items():
             if not isinstance(key, str):
                 continue
             if key.startswith("x-"):
-                record_support(key, "supported" if _synthetic_annotation_is_enforced(key, value) else "unsupported")
+                record_support(
+                    key,
+                    "supported"
+                    if _annotation_is_enforced_at_node(key, value, node_record, path, cast(SchemaRecord, schema))
+                    else "unsupported",
+                )
                 continue
             if key in _SUPPORTED_SCHEMA_CONSTRUCTS:
                 record_support(key, "supported")
@@ -447,25 +956,40 @@ def _schema_constructs(schema: object) -> tuple[ConstructSupport, ...]:
 
             if key in _SCHEMA_MAPPING_KEYWORDS and isinstance(value, Mapping):
                 if key in {"$defs", "dependentSchemas", "dependencies", "patternProperties", "properties"}:
-                    for child in value.values():
-                        visit(child)
+                    for child_name, child in value.items():
+                        child_path = f"{path}.{child_name}" if key == "properties" else f"{path}.{key}.{child_name}"
+                        visit(child, child_path)
                 else:
-                    visit(value)
+                    visit(value, f"{path}.{key}")
             elif key in _SCHEMA_ARRAY_KEYWORDS and isinstance(value, Sequence) and not isinstance(value, str):
-                for child in value:
-                    visit(child)
+                for index, child in enumerate(value):
+                    visit(child, f"{path}.{key}[{index}]")
+            elif key == "items":
+                if isinstance(value, Sequence) and not isinstance(value, str):
+                    for index, child in enumerate(value):
+                        visit(child, f"{path}.items[{index}]")
+                else:
+                    visit(value, f"{path}.items")
+            elif key == "additionalProperties" and isinstance(value, Mapping):
+                visit(value, f"{path}.additionalProperties")
 
     visit(schema)
     return tuple(ConstructSupport(construct, found[construct]) for construct in sorted(found))
 
 
 def build_inferred_corpus_convergence_handoff(
-    manifest: InferredCorpusManifest,
+    manifest: InferredCorpusManifest | Path,
 ) -> InferredCorpusConvergenceHandoff:
-    """Bind every supported manifest spec to one convergence-property invocation."""
+    """Bind every supported row from memory or persisted disk to convergence."""
 
-    handoff = InferredCorpusConvergenceHandoff(manifest_id=manifest.manifest_id, specs=manifest.supported_specs)
-    assert_inferred_corpus_convergence_handoff_complete(manifest, handoff)
+    persisted_manifest = read_inferred_corpus_manifest(manifest) if isinstance(manifest, Path) else manifest
+    selections = tuple(_selection_for_entry(entry) for entry in persisted_manifest.entries if entry.spec is not None)
+    handoff = InferredCorpusConvergenceHandoff(
+        manifest_id=persisted_manifest.manifest_id,
+        specs=persisted_manifest.supported_specs,
+        selections=selections,
+    )
+    assert_inferred_corpus_convergence_handoff_complete(persisted_manifest, handoff)
     return handoff
 
 
@@ -485,6 +1009,28 @@ def assert_inferred_corpus_convergence_handoff_complete(
             "inferred corpus convergence handoff omitted or substituted supported specs: "
             f"expected={manifest.supported_specs!r}, actual={handoff.specs!r}"
         )
+    expected_selections = tuple(_selection_for_entry(entry) for entry in manifest.entries if entry.spec is not None)
+    if handoff.selections != expected_selections:
+        raise AssertionError(
+            "inferred corpus convergence handoff omitted or substituted generator selections: "
+            f"expected={expected_selections!r}, actual={handoff.selections!r}"
+        )
+
+
+def _selection_for_entry(entry: InferredCorpusManifestEntry) -> SyntheticSchemaSelection:
+    if entry.spec is None or entry.generator_schema is None:
+        raise ValueError("unsupported inferred corpus entry cannot produce a generator selection")
+    wire_format = PROVIDER_WIRE_FORMATS.get(entry.key.provider)
+    if wire_format is None:
+        raise ValueError(f"inferred corpus entry has no production wire format: {entry.key.provider!r}")
+    return SyntheticSchemaSelection(
+        provider=entry.key.provider,
+        package_version=entry.key.package_version,
+        element_kind=entry.key.element_kind,
+        schema=entry.generator_schema,
+        wire_format=wire_format,
+        workload_profile=entry.workload_profile,
+    )
 
 
 def _stable_seed(key: CorpusManifestKey) -> int:
@@ -504,6 +1050,39 @@ def _catalog_entries(
             for element in sorted(package.elements, key=lambda item: item.element_kind):
                 result.append((provider, catalog, package, element))
     return tuple(result)
+
+
+class _RepresentativeRegistry:
+    """Keep the live package catalog while exposing one executable schema route."""
+
+    def __init__(self, base: RuntimeSchemaRegistryLike) -> None:
+        self._base = base
+
+    def get_element_schema(
+        self,
+        provider: str,
+        *,
+        version: str = "default",
+        element_kind: str | None = None,
+    ) -> SchemaRecord | JSONDocument | None:
+        package = self._base.get_package(provider, version=version)
+        resolved_version = package.version if package is not None else version
+        if (
+            provider == REPRESENTATIVE_PROVIDER
+            and resolved_version == REPRESENTATIVE_PACKAGE_VERSION
+            and element_kind == REPRESENTATIVE_ELEMENT_KIND
+        ):
+            return _REPRESENTATIVE_SCHEMA
+        return self._base.get_element_schema(provider, version=version, element_kind=element_kind)
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._base, name)
+
+
+def representative_inferred_corpus_registry(base: RuntimeSchemaRegistryLike) -> RuntimeSchemaRegistryLike:
+    """Return a catalog-backed registry with one real provider/package route admitted."""
+
+    return _RepresentativeRegistry(base)  # type: ignore[return-value]
 
 
 def _unsupported_reason(
@@ -579,7 +1158,12 @@ def _compile_entry(
             workload_profile=workload_profile if isinstance(workload_profile, dict) else None,
         )
     )
-    return InferredCorpusManifestEntry(key=key, spec=spec)
+    return InferredCorpusManifestEntry(
+        key=key,
+        spec=spec,
+        generator_schema=schema,
+        workload_profile=workload_profile if isinstance(workload_profile, dict) else None,
+    )
 
 
 def assert_inferred_corpus_manifest_complete(
@@ -633,13 +1217,20 @@ def compile_inferred_corpus_manifest(
 __all__ = [
     "ConstructSupport",
     "CorpusManifestKey",
+    "INFERRED_CORPUS_MANIFEST_SCHEMA_VERSION",
     "InferredCorpusConvergenceHandoff",
     "InferredCorpusManifest",
     "InferredCorpusManifestEntry",
     "PackageReceipt",
+    "REPRESENTATIVE_ELEMENT_KIND",
+    "REPRESENTATIVE_PACKAGE_VERSION",
+    "REPRESENTATIVE_PROVIDER",
     "UnsupportedCorpusRecord",
     "assert_inferred_corpus_convergence_handoff_complete",
     "assert_inferred_corpus_manifest_complete",
     "build_inferred_corpus_convergence_handoff",
     "compile_inferred_corpus_manifest",
+    "read_inferred_corpus_manifest",
+    "representative_inferred_corpus_registry",
+    "write_inferred_corpus_manifest",
 ]

--- a/tests/infra/inferred_corpus.py
+++ b/tests/infra/inferred_corpus.py
@@ -38,36 +38,119 @@ PackageReceipt: TypeAlias = JSONDocument
 # arbitrary unknown keys for the current corpus contract.
 _SUPPORTED_SCHEMA_CONSTRUCTS = frozenset(
     {
-        "type",
-        "properties",
-        "required",
-        "items",
-        "anyOf",
-        "oneOf",
+        "$anchor",
+        "$comment",
+        "$id",
+        "$schema",
         "additionalProperties",
+        "anyOf",
+        "default",
+        "deprecated",
+        "description",
+        "examples",
+        "items",
+        "oneOf",
+        "properties",
+        "readOnly",
+        "title",
+        "type",
+        "writeOnly",
     }
 )
-_UNSUPPORTED_SCHEMA_CONSTRUCTS = frozenset(
+
+# The synthetic runtime can select structural branches and emit declared
+# properties, but it does not validate generated values against JSON Schema.
+# Every assertion keyword outside the explicit structural subset therefore
+# fails closed. This keeps a manifest spec from implying conformance to a
+# pattern, format, range, collection bound, or other constraint it cannot
+# prove.
+_STANDARD_SCHEMA_KEYWORDS = frozenset(
     {
+        "$anchor",
+        "$comment",
         "$defs",
+        "$dynamicAnchor",
+        "$dynamicRef",
+        "$id",
+        "$recursiveAnchor",
+        "$recursiveRef",
         "$ref",
+        "$schema",
+        "$vocabulary",
+        "additionalProperties",
         "allOf",
+        "anyOf",
         "const",
         "contains",
+        "contentEncoding",
+        "contentMediaType",
+        "contentSchema",
+        "default",
         "definitions",
-        "dependencies",
+        "dependentRequired",
         "dependentSchemas",
+        "dependencies",
+        "deprecated",
+        "description",
+        "else",
         "enum",
+        "examples",
+        "exclusiveMaximum",
+        "exclusiveMinimum",
+        "format",
+        "formatAssertion",
         "if",
+        "items",
+        "maxContains",
+        "maxItems",
+        "maxLength",
+        "maxProperties",
+        "maximum",
+        "minContains",
+        "minItems",
+        "minLength",
+        "minProperties",
+        "minimum",
+        "multipleOf",
         "not",
+        "oneOf",
+        "pattern",
         "patternProperties",
         "prefixItems",
+        "properties",
+        "propertyNames",
+        "readOnly",
+        "required",
+        "then",
+        "title",
+        "type",
+        "unevaluatedItems",
+        "unevaluatedProperties",
+        "uniqueItems",
+        "writeOnly",
+    }
+)
+_SCHEMA_MAPPING_KEYWORDS = frozenset(
+    {
+        "$defs",
+        "additionalProperties",
+        "contentSchema",
+        "contains",
+        "dependentSchemas",
+        "dependencies",
+        "else",
+        "if",
+        "items",
+        "not",
+        "patternProperties",
+        "properties",
         "propertyNames",
         "then",
         "unevaluatedItems",
         "unevaluatedProperties",
     }
 )
+_SCHEMA_ARRAY_KEYWORDS = frozenset({"allOf", "anyOf", "oneOf", "prefixItems"})
 
 
 @dataclass(frozen=True, order=True)
@@ -189,8 +272,16 @@ class InferredCorpusManifest:
         return {"manifest_id": self.manifest_id, **self._payload_without_id()}
 
 
+@dataclass(frozen=True)
+class InferredCorpusConvergenceHandoff:
+    """Exact executable manifest subset admitted to the convergence loop."""
+
+    manifest_id: str
+    specs: tuple[CorpusSpec, ...]
+
+
 def _schema_constructs(schema: object) -> tuple[ConstructSupport, ...]:
-    """Collect structural JSON Schema keywords without treating field names as keywords."""
+    """Census every schema-scope keyword without treating property names as keywords."""
 
     found: dict[str, ConstructSupportState] = {}
 
@@ -198,40 +289,52 @@ def _schema_constructs(schema: object) -> tuple[ConstructSupport, ...]:
         if not isinstance(node, Mapping):
             return
         for key, value in node.items():
-            if key in _SUPPORTED_SCHEMA_CONSTRUCTS:
-                found[key] = "supported"
-            elif key in _UNSUPPORTED_SCHEMA_CONSTRUCTS:
-                found[key] = "unsupported"
+            if not isinstance(key, str):
+                continue
+            if key.startswith("x-"):
+                continue
+            found[key] = "supported" if key in _SUPPORTED_SCHEMA_CONSTRUCTS else "unsupported"
 
-            if key == "properties" and isinstance(value, Mapping):
-                for child in value.values():
-                    visit(child)
-            elif key in {
-                "items",
-                "additionalProperties",
-                "patternProperties",
-                "propertyNames",
-                "contains",
-                "if",
-                "then",
-                "unevaluatedItems",
-                "unevaluatedProperties",
-                "not",
-            }:
-                visit(value)
-            elif key in {"anyOf", "oneOf", "allOf", "prefixItems"} and isinstance(value, Sequence):
+            if key in _SCHEMA_MAPPING_KEYWORDS and isinstance(value, Mapping):
+                if key in {"$defs", "dependentSchemas", "dependencies", "patternProperties", "properties"}:
+                    for child in value.values():
+                        visit(child)
+                else:
+                    visit(value)
+            elif key in _SCHEMA_ARRAY_KEYWORDS and isinstance(value, Sequence) and not isinstance(value, str):
                 for child in value:
                     visit(child)
-            elif key in {"$defs", "definitions", "dependentSchemas"} and isinstance(value, Mapping):
-                for child in value.values():
-                    visit(child)
-            elif key == "dependencies" and isinstance(value, Mapping):
-                for child in value.values():
-                    if isinstance(child, Mapping):
-                        visit(child)
 
     visit(schema)
     return tuple(ConstructSupport(construct, found[construct]) for construct in sorted(found))
+
+
+def build_inferred_corpus_convergence_handoff(
+    manifest: InferredCorpusManifest,
+) -> InferredCorpusConvergenceHandoff:
+    """Bind every supported manifest spec to one convergence-property invocation."""
+
+    handoff = InferredCorpusConvergenceHandoff(manifest_id=manifest.manifest_id, specs=manifest.supported_specs)
+    assert_inferred_corpus_convergence_handoff_complete(manifest, handoff)
+    return handoff
+
+
+def assert_inferred_corpus_convergence_handoff_complete(
+    manifest: InferredCorpusManifest,
+    handoff: InferredCorpusConvergenceHandoff,
+) -> None:
+    """Reject a stale, omitted, or substituted convergence handoff."""
+
+    if handoff.manifest_id != manifest.manifest_id:
+        raise AssertionError(
+            "inferred corpus convergence handoff belongs to a different manifest: "
+            f"expected={manifest.manifest_id!r}, actual={handoff.manifest_id!r}"
+        )
+    if handoff.specs != manifest.supported_specs:
+        raise AssertionError(
+            "inferred corpus convergence handoff omitted or substituted supported specs: "
+            f"expected={manifest.supported_specs!r}, actual={handoff.specs!r}"
+        )
 
 
 def _stable_seed(key: CorpusManifestKey) -> int:
@@ -380,10 +483,13 @@ def compile_inferred_corpus_manifest(
 __all__ = [
     "ConstructSupport",
     "CorpusManifestKey",
+    "InferredCorpusConvergenceHandoff",
     "InferredCorpusManifest",
     "InferredCorpusManifestEntry",
     "PackageReceipt",
     "UnsupportedCorpusRecord",
+    "assert_inferred_corpus_convergence_handoff_complete",
     "assert_inferred_corpus_manifest_complete",
+    "build_inferred_corpus_convergence_handoff",
     "compile_inferred_corpus_manifest",
 ]

--- a/tests/infra/inferred_corpus.py
+++ b/tests/infra/inferred_corpus.py
@@ -309,11 +309,18 @@ def _is_number(value: object) -> bool:
     return isinstance(value, (int, float)) and not isinstance(value, bool)
 
 
+def _number(value: object) -> int | float | None:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return value
+    return None
+
+
 def _valid_pair(value: object, *, integral: bool = False, nonnegative: bool = False) -> bool:
     if not isinstance(value, list) or len(value) < 2:
         return False
-    first, second = value[:2]
-    if not _is_number(first) or not _is_number(second):
+    first = _number(value[0])
+    second = _number(value[1])
+    if first is None or second is None:
         return False
     if integral and (not isinstance(first, int) or not isinstance(second, int)):
         return False
@@ -329,11 +336,12 @@ def _valid_observed_distribution(value: object) -> bool:
         if not isinstance(distribution, Mapping):
             continue
         histogram = distribution.get("histogram")
-        log_base = distribution.get("log_base")
+        log_base = _number(distribution.get("log_base"))
         if (
             isinstance(histogram, list)
             and histogram
             and _is_number(log_base)
+            and log_base is not None
             and log_base > 1
             and all(
                 isinstance(bucket, list)
@@ -348,16 +356,17 @@ def _valid_observed_distribution(value: object) -> bool:
     return False
 
 
-def _valid_relation_records(value: object, required: tuple[str, ...]) -> bool:
-    return (
-        isinstance(value, list)
-        and bool(value)
-        and all(
-            isinstance(record, Mapping)
-            and all(isinstance(record.get(field), str) and record[field].strip() for field in required)
-            for record in value
-        )
-    )
+def _relation_records(value: object, required: tuple[str, ...]) -> list[dict[str, object]] | None:
+    if not isinstance(value, list) or not value:
+        return None
+    records: list[dict[str, object]] = []
+    for record in value:
+        if not isinstance(record, dict):
+            return None
+        if not all(isinstance(record.get(field), str) and record[field].strip() for field in required):
+            return None
+        records.append(record)
+    return records
 
 
 def _synthetic_annotation_is_enforced(key: str, value: object) -> bool:
@@ -370,7 +379,8 @@ def _synthetic_annotation_is_enforced(key: str, value: object) -> bool:
     if key == "x-polylogue-semantic-role":
         return isinstance(value, str) and value in _SUPPORTED_SEMANTIC_ROLE_VALUES
     if key == "x-polylogue-frequency":
-        return _is_number(value) and 0 <= value <= 1
+        frequency = _number(value)
+        return frequency is not None and 0 <= frequency <= 1
     if key == "x-polylogue-multiline":
         return isinstance(value, bool)
     if key == "x-polylogue-values":
@@ -382,29 +392,29 @@ def _synthetic_annotation_is_enforced(key: str, value: object) -> bool:
     if key == "x-polylogue-observed-distribution":
         return _valid_observed_distribution(value)
     if key == "x-polylogue-foreign-keys":
-        return _valid_relation_records(value, ("source", "target"))
+        return _relation_records(value, ("source", "target")) is not None
     if key == "x-polylogue-time-deltas":
-        return _valid_relation_records(value, ("field_a", "field_b")) and all(
-            _is_number(record.get(field))
-            for record in value
-            if isinstance(record, Mapping)
+        records = _relation_records(value, ("field_a", "field_b"))
+        return records is not None and all(
+            _number(record.get(field)) is not None
+            for record in records
             for field in ("min_delta", "max_delta", "avg_delta")
         )
     if key == "x-polylogue-mutually-exclusive":
-        return _valid_relation_records(value, ("parent",)) and all(
-            isinstance(record.get("fields"), list)
-            and len(record["fields"]) >= 2
-            and all(isinstance(field, str) and field for field in record["fields"])
-            for record in value
-            if isinstance(record, Mapping)
+        records = _relation_records(value, ("parent",))
+        return records is not None and all(
+            isinstance(fields := record.get("fields"), list)
+            and len(fields) >= 2
+            and all(isinstance(field, str) and field for field in fields)
+            for record in records
         )
     if key == "x-polylogue-string-lengths":
-        return _valid_relation_records(value, ("path",)) and all(
+        records = _relation_records(value, ("path",))
+        return records is not None and all(
             _valid_pair([record.get("min"), record.get("max")], integral=True, nonnegative=True)
-            and _is_number(record.get("avg"))
-            and _is_number(record.get("stddev"))
-            for record in value
-            if isinstance(record, Mapping)
+            and _number(record.get("avg")) is not None
+            and _number(record.get("stddev")) is not None
+            for record in records
         )
     raise AssertionError(f"missing annotation validator for {key}")
 

--- a/tests/infra/inferred_corpus.py
+++ b/tests/infra/inferred_corpus.py
@@ -152,6 +152,59 @@ _SCHEMA_MAPPING_KEYWORDS = frozenset(
 )
 _SCHEMA_ARRAY_KEYWORDS = frozenset({"allOf", "anyOf", "oneOf", "prefixItems"})
 
+# These annotations are read by the production synthetic runtime, semantic
+# value generator, or relation solver. Their support verdict means the
+# corresponding generator path consumes the annotation, rather than merely
+# tolerating its namespace.
+_SUPPORTED_SYNTHETIC_ANNOTATIONS = frozenset(
+    {
+        "x-polylogue-array-lengths",
+        "x-polylogue-foreign-keys",
+        "x-polylogue-format",
+        "x-polylogue-frequency",
+        "x-polylogue-multiline",
+        "x-polylogue-mutually-exclusive",
+        "x-polylogue-observed-distribution",
+        "x-polylogue-range",
+        "x-polylogue-semantic-role",
+        "x-polylogue-string-lengths",
+        "x-polylogue-time-deltas",
+        "x-polylogue-values",
+    }
+)
+
+# These package annotations are consumed by registry/profile loading or retain
+# provenance only. They do not constrain an emitted instance, so recognizing
+# them cannot claim synthetic schema conformance. Shape-affecting annotations
+# without a synthetic consumer, such as ``x-polylogue-ref`` and dynamic-key
+# markers, are deliberately absent and fail closed below.
+_SUPPORTED_CATALOG_METADATA_ANNOTATIONS = frozenset(
+    {
+        "x-polylogue-anchor-profile-family-id",
+        "x-polylogue-artifact-kind",
+        "x-polylogue-element-bundle-scope-count",
+        "x-polylogue-element-first-seen",
+        "x-polylogue-element-kind",
+        "x-polylogue-element-last-seen",
+        "x-polylogue-evidence",
+        "x-polylogue-evidence-confidence",
+        "x-polylogue-exact-structure-ids",
+        "x-polylogue-generated-at",
+        "x-polylogue-generator",
+        "x-polylogue-observed-artifact-count",
+        "x-polylogue-package-profile-family-ids",
+        "x-polylogue-package-version",
+        "x-polylogue-profile-family-ids",
+        "x-polylogue-profile-tokens",
+        "x-polylogue-promoted-at",
+        "x-polylogue-registered-at",
+        "x-polylogue-sample-count",
+        "x-polylogue-sample-granularity",
+        "x-polylogue-score",
+        "x-polylogue-version",
+    }
+)
+
 
 @dataclass(frozen=True, order=True)
 class ConstructSupport:
@@ -292,8 +345,18 @@ def _schema_constructs(schema: object) -> tuple[ConstructSupport, ...]:
             if not isinstance(key, str):
                 continue
             if key.startswith("x-"):
+                found[key] = (
+                    "supported"
+                    if key in _SUPPORTED_SYNTHETIC_ANNOTATIONS | _SUPPORTED_CATALOG_METADATA_ANNOTATIONS
+                    else "unsupported"
+                )
                 continue
-            found[key] = "supported" if key in _SUPPORTED_SCHEMA_CONSTRUCTS else "unsupported"
+            if key in _SUPPORTED_SCHEMA_CONSTRUCTS:
+                found[key] = "supported"
+            elif key in _STANDARD_SCHEMA_KEYWORDS:
+                found[key] = "unsupported"
+            else:
+                found[key] = "unsupported"
 
             if key in _SCHEMA_MAPPING_KEYWORDS and isinstance(value, Mapping):
                 if key in {"$defs", "dependentSchemas", "dependencies", "patternProperties", "properties"}:

--- a/tests/infra/inferred_corpus.py
+++ b/tests/infra/inferred_corpus.py
@@ -173,38 +173,6 @@ _SUPPORTED_SYNTHETIC_ANNOTATIONS = frozenset(
     }
 )
 
-# These package annotations are consumed by registry/profile loading or retain
-# provenance only. They do not constrain an emitted instance, so recognizing
-# them cannot claim synthetic schema conformance. Shape-affecting annotations
-# without a synthetic consumer, such as ``x-polylogue-ref`` and dynamic-key
-# markers, are deliberately absent and fail closed below.
-_SUPPORTED_CATALOG_METADATA_ANNOTATIONS = frozenset(
-    {
-        "x-polylogue-anchor-profile-family-id",
-        "x-polylogue-artifact-kind",
-        "x-polylogue-element-bundle-scope-count",
-        "x-polylogue-element-first-seen",
-        "x-polylogue-element-kind",
-        "x-polylogue-element-last-seen",
-        "x-polylogue-evidence",
-        "x-polylogue-evidence-confidence",
-        "x-polylogue-exact-structure-ids",
-        "x-polylogue-generated-at",
-        "x-polylogue-generator",
-        "x-polylogue-observed-artifact-count",
-        "x-polylogue-package-profile-family-ids",
-        "x-polylogue-package-version",
-        "x-polylogue-profile-family-ids",
-        "x-polylogue-profile-tokens",
-        "x-polylogue-promoted-at",
-        "x-polylogue-registered-at",
-        "x-polylogue-sample-count",
-        "x-polylogue-sample-granularity",
-        "x-polylogue-score",
-        "x-polylogue-version",
-    }
-)
-
 
 @dataclass(frozen=True, order=True)
 class ConstructSupport:
@@ -345,11 +313,7 @@ def _schema_constructs(schema: object) -> tuple[ConstructSupport, ...]:
             if not isinstance(key, str):
                 continue
             if key.startswith("x-"):
-                found[key] = (
-                    "supported"
-                    if key in _SUPPORTED_SYNTHETIC_ANNOTATIONS | _SUPPORTED_CATALOG_METADATA_ANNOTATIONS
-                    else "unsupported"
-                )
+                found[key] = "supported" if key in _SUPPORTED_SYNTHETIC_ANNOTATIONS else "unsupported"
                 continue
             if key in _SUPPORTED_SCHEMA_CONSTRUCTS:
                 found[key] = "supported"

--- a/tests/infra/inferred_corpus.py
+++ b/tests/infra/inferred_corpus.py
@@ -1,0 +1,389 @@
+"""Runtime compiler for the persisted schema-package corpus manifest.
+
+This is deliberately a test-infrastructure manifest, not an inference receipt.
+The persisted registry catalog tells us which package elements exist.  A later
+inference/package-receipt lane can be attached through ``package_receipt``
+without changing the catalog census or claiming that catalog presence proves
+inference completion.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
+from typing import Literal, TypeAlias
+
+from polylogue.core.json import JSONDocument
+from polylogue.scenarios import CorpusSpec
+from polylogue.schemas.operator.registry import RuntimeSchemaRegistryLike
+from polylogue.schemas.packages import SchemaElementManifest, SchemaPackageCatalog, SchemaVersionPackage
+from polylogue.schemas.synthetic import SyntheticCorpus
+from polylogue.schemas.synthetic.models import SchemaRecord, SyntheticSchemaSelection
+from polylogue.schemas.synthetic.wire_formats import PROVIDER_WIRE_FORMATS, WireFormat
+
+ConstructSupportState: TypeAlias = Literal["supported", "unsupported"]
+UnsupportedCorpusReason: TypeAlias = Literal[
+    "provider_without_wire_format",
+    "unsupported_element",
+    "missing_schema",
+    "unsupported_json_schema_construct",
+]
+PackageReceipt: TypeAlias = JSONDocument
+
+# These are the schema constructs the current recursive synthetic runtime can
+# consume as structure.  ``additionalProperties`` is intentionally included:
+# the generator emits declared properties and does not need to materialize
+# arbitrary unknown keys for the current corpus contract.
+_SUPPORTED_SCHEMA_CONSTRUCTS = frozenset(
+    {
+        "type",
+        "properties",
+        "required",
+        "items",
+        "anyOf",
+        "oneOf",
+        "additionalProperties",
+    }
+)
+_UNSUPPORTED_SCHEMA_CONSTRUCTS = frozenset(
+    {
+        "$defs",
+        "$ref",
+        "allOf",
+        "const",
+        "contains",
+        "definitions",
+        "dependencies",
+        "dependentSchemas",
+        "enum",
+        "if",
+        "not",
+        "patternProperties",
+        "prefixItems",
+        "propertyNames",
+        "then",
+        "unevaluatedItems",
+        "unevaluatedProperties",
+    }
+)
+
+
+@dataclass(frozen=True, order=True)
+class ConstructSupport:
+    """Support verdict for one JSON Schema construct found in an element."""
+
+    construct: str
+    state: ConstructSupportState
+
+    def to_payload(self) -> dict[str, str]:
+        return {"construct": self.construct, "state": self.state}
+
+
+@dataclass(frozen=True, order=True)
+class CorpusManifestKey:
+    """Stable identity for one provider/package/element support decision."""
+
+    provider: str
+    package_version: str
+    element_kind: str
+    construct_support: tuple[ConstructSupport, ...] = ()
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "provider": self.provider,
+            "package_version": self.package_version,
+            "element_kind": self.element_kind,
+            "construct_support": [item.to_payload() for item in self.construct_support],
+        }
+
+
+@dataclass(frozen=True)
+class UnsupportedCorpusRecord:
+    """Typed refusal retained instead of silently dropping a catalog entry."""
+
+    reason: UnsupportedCorpusReason
+    details: tuple[str, ...] = ()
+
+    def to_payload(self) -> dict[str, object]:
+        return {"reason": self.reason, "details": list(self.details)}
+
+
+@dataclass(frozen=True)
+class InferredCorpusManifestEntry:
+    """One complete catalog census row, either executable or explicitly refused."""
+
+    key: CorpusManifestKey
+    spec: CorpusSpec | None = None
+    unsupported: UnsupportedCorpusRecord | None = None
+
+    def __post_init__(self) -> None:
+        if (self.spec is None) == (self.unsupported is None):
+            raise ValueError("manifest entry requires exactly one of spec or unsupported")
+        if self.spec is not None and (
+            self.spec.provider,
+            self.spec.package_version,
+            self.spec.element_kind,
+        ) != (
+            self.key.provider,
+            self.key.package_version,
+            self.key.element_kind,
+        ):
+            raise ValueError("CorpusSpec identity does not match manifest key")
+
+    @property
+    def supported(self) -> bool:
+        return self.spec is not None
+
+    def to_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {"key": self.key.to_payload(), "supported": self.supported}
+        if self.spec is not None:
+            payload["spec"] = self.spec.to_payload()
+        if self.unsupported is not None:
+            payload["unsupported"] = self.unsupported.to_payload()
+        return payload
+
+
+@dataclass(frozen=True)
+class InferredCorpusManifest:
+    """Deterministic runtime census with an optional future package receipt."""
+
+    entries: tuple[InferredCorpusManifestEntry, ...]
+    package_receipt: PackageReceipt | None = None
+
+    def __post_init__(self) -> None:
+        ordered = tuple(sorted(self.entries, key=lambda entry: entry.key))
+        if ordered != self.entries:
+            raise ValueError("inferred corpus manifest entries must be sorted by manifest key")
+        keys = [entry.key for entry in self.entries]
+        if len(keys) != len(set(keys)):
+            raise ValueError("inferred corpus manifest contains duplicate keys")
+
+    @property
+    def supported_specs(self) -> tuple[CorpusSpec, ...]:
+        return tuple(entry.spec for entry in self.entries if entry.spec is not None)
+
+    @property
+    def unsupported_records(self) -> tuple[UnsupportedCorpusRecord, ...]:
+        return tuple(entry.unsupported for entry in self.entries if entry.unsupported is not None)
+
+    @property
+    def receipt_state(self) -> Literal["catalog_only", "package_receipt_attached"]:
+        return "package_receipt_attached" if self.package_receipt is not None else "catalog_only"
+
+    @property
+    def manifest_id(self) -> str:
+        encoded = json.dumps(self._payload_without_id(), sort_keys=True, separators=(",", ":"))
+        return f"manifest:sha256:{hashlib.sha256(encoded.encode('utf-8')).hexdigest()}"
+
+    def _payload_without_id(self) -> dict[str, object]:
+        return {
+            "schema_version": 1,
+            "receipt_state": self.receipt_state,
+            "package_receipt": self.package_receipt,
+            "entries": [entry.to_payload() for entry in self.entries],
+        }
+
+    def to_payload(self) -> dict[str, object]:
+        return {"manifest_id": self.manifest_id, **self._payload_without_id()}
+
+
+def _schema_constructs(schema: object) -> tuple[ConstructSupport, ...]:
+    """Collect structural JSON Schema keywords without treating field names as keywords."""
+
+    found: dict[str, ConstructSupportState] = {}
+
+    def visit(node: object) -> None:
+        if not isinstance(node, Mapping):
+            return
+        for key, value in node.items():
+            if key in _SUPPORTED_SCHEMA_CONSTRUCTS:
+                found[key] = "supported"
+            elif key in _UNSUPPORTED_SCHEMA_CONSTRUCTS:
+                found[key] = "unsupported"
+
+            if key == "properties" and isinstance(value, Mapping):
+                for child in value.values():
+                    visit(child)
+            elif key in {
+                "items",
+                "additionalProperties",
+                "patternProperties",
+                "propertyNames",
+                "contains",
+                "if",
+                "then",
+                "unevaluatedItems",
+                "unevaluatedProperties",
+                "not",
+            }:
+                visit(value)
+            elif key in {"anyOf", "oneOf", "allOf", "prefixItems"} and isinstance(value, Sequence):
+                for child in value:
+                    visit(child)
+            elif key in {"$defs", "definitions", "dependentSchemas"} and isinstance(value, Mapping):
+                for child in value.values():
+                    visit(child)
+            elif key == "dependencies" and isinstance(value, Mapping):
+                for child in value.values():
+                    if isinstance(child, Mapping):
+                        visit(child)
+
+    visit(schema)
+    return tuple(ConstructSupport(construct, found[construct]) for construct in sorted(found))
+
+
+def _stable_seed(key: CorpusManifestKey) -> int:
+    material = "\x1f".join((key.provider, key.package_version, key.element_kind)).encode("utf-8")
+    return int(hashlib.sha256(material).hexdigest()[:8], 16)
+
+
+def _catalog_entries(
+    registry: RuntimeSchemaRegistryLike,
+) -> tuple[tuple[str, SchemaPackageCatalog, SchemaVersionPackage, SchemaElementManifest], ...]:
+    result: list[tuple[str, SchemaPackageCatalog, SchemaVersionPackage, SchemaElementManifest]] = []
+    for provider in sorted(set(registry.list_providers())):
+        catalog = registry.load_package_catalog(provider)
+        if catalog is None:
+            raise RuntimeError(f"registry provider {provider!r} has no persisted package catalog")
+        for package in sorted(catalog.packages, key=lambda item: item.version):
+            for element in sorted(package.elements, key=lambda item: item.element_kind):
+                result.append((provider, catalog, package, element))
+    return tuple(result)
+
+
+def _unsupported_reason(
+    *,
+    element: SchemaElementManifest,
+    schema: SchemaRecord | None,
+    wire_format: WireFormat | None,
+    construct_support: tuple[ConstructSupport, ...],
+) -> UnsupportedCorpusRecord | None:
+    if wire_format is None:
+        return UnsupportedCorpusRecord("provider_without_wire_format")
+    if not element.supported:
+        return UnsupportedCorpusRecord("unsupported_element")
+    if schema is None or element.schema_file is None:
+        return UnsupportedCorpusRecord("missing_schema")
+    unsupported_constructs = tuple(item.construct for item in construct_support if item.state == "unsupported")
+    if unsupported_constructs:
+        return UnsupportedCorpusRecord("unsupported_json_schema_construct", unsupported_constructs)
+    return None
+
+
+def _compile_entry(
+    *,
+    provider: str,
+    package: SchemaVersionPackage,
+    element: SchemaElementManifest,
+    registry: RuntimeSchemaRegistryLike,
+    wire_formats: Mapping[str, WireFormat],
+) -> InferredCorpusManifestEntry:
+    key_without_constructs = CorpusManifestKey(provider, package.version, element.element_kind)
+    schema = registry.get_element_schema(
+        provider,
+        version=package.version,
+        element_kind=element.element_kind,
+    )
+    construct_support = _schema_constructs(schema)
+    key = replace(key_without_constructs, construct_support=construct_support)
+    wire_format = wire_formats.get(provider)
+    unsupported = _unsupported_reason(
+        element=element,
+        schema=schema if isinstance(schema, dict) else None,
+        wire_format=wire_format,
+        construct_support=construct_support,
+    )
+    if unsupported is not None:
+        return InferredCorpusManifestEntry(key=key, unsupported=unsupported)
+
+    if not isinstance(schema, dict) or wire_format is None:
+        raise AssertionError("supported manifest entry lost schema or wire format")
+    profile_loader = getattr(registry, "get_workload_profile", None)
+    workload_profile = profile_loader(provider, package.version) if callable(profile_loader) else None
+    spec = CorpusSpec.for_provider(
+        provider,
+        package_version=package.version,
+        element_kind=element.element_kind,
+        count=1,
+        messages_min=4,
+        messages_max=4,
+        seed=_stable_seed(key),
+        origin="inferred.schema-package-manifest",
+        tags=("inferred", "schema", "synthetic", "manifest"),
+    )
+    # Construct the production generator against the exact package/version/
+    # element.  No generation is performed here, so compiling the receipt does
+    # not turn an unverified catalog into an inference claim.
+    SyntheticCorpus.from_selection(
+        SyntheticSchemaSelection(
+            provider=provider,
+            package_version=package.version,
+            element_kind=element.element_kind,
+            schema=schema,
+            wire_format=wire_format,
+            workload_profile=workload_profile if isinstance(workload_profile, dict) else None,
+        )
+    )
+    return InferredCorpusManifestEntry(key=key, spec=spec)
+
+
+def assert_inferred_corpus_manifest_complete(
+    manifest: InferredCorpusManifest,
+    registry: RuntimeSchemaRegistryLike,
+) -> None:
+    """Fail loudly when a manifest omits any currently persisted catalog entry."""
+
+    expected = {
+        CorpusManifestKey(provider, package.version, element.element_kind)
+        for provider, _catalog, package, element in _catalog_entries(registry)
+    }
+    actual = {
+        CorpusManifestKey(entry.key.provider, entry.key.package_version, entry.key.element_kind)
+        for entry in manifest.entries
+    }
+    missing = sorted(expected - actual)
+    unexpected = sorted(actual - expected)
+    if missing or unexpected:
+        raise AssertionError(
+            f"inferred corpus manifest coverage mismatch: missing={missing!r}, unexpected={unexpected!r}"
+        )
+
+
+def compile_inferred_corpus_manifest(
+    *,
+    registry: RuntimeSchemaRegistryLike,
+    package_receipt: PackageReceipt | None = None,
+    wire_formats: Mapping[str, WireFormat] | None = None,
+) -> InferredCorpusManifest:
+    """Compile every persisted package/version/element into a typed manifest."""
+
+    formats = PROVIDER_WIRE_FORMATS if wire_formats is None else wire_formats
+    entries = tuple(
+        _compile_entry(
+            provider=provider,
+            package=package,
+            element=element,
+            registry=registry,
+            wire_formats=formats,
+        )
+        for provider, catalog, package, element in _catalog_entries(registry)
+    )
+    manifest = InferredCorpusManifest(
+        entries=tuple(sorted(entries, key=lambda entry: entry.key)), package_receipt=package_receipt
+    )
+    assert_inferred_corpus_manifest_complete(manifest, registry)
+    return manifest
+
+
+__all__ = [
+    "ConstructSupport",
+    "CorpusManifestKey",
+    "InferredCorpusManifest",
+    "InferredCorpusManifestEntry",
+    "PackageReceipt",
+    "UnsupportedCorpusRecord",
+    "assert_inferred_corpus_manifest_complete",
+    "compile_inferred_corpus_manifest",
+]

--- a/tests/infra/inferred_corpus.py
+++ b/tests/infra/inferred_corpus.py
@@ -181,45 +181,33 @@ _SUPPORTED_FORMAT_VALUES = frozenset(
 )
 _SUPPORTED_SEMANTIC_ROLE_VALUES = frozenset({"message_role", "message_body", "message_timestamp", "session_title"})
 
-REPRESENTATIVE_PROVIDER = "codex"
-REPRESENTATIVE_PACKAGE_VERSION = "v1"
-REPRESENTATIVE_ELEMENT_KIND = "session_record_stream"
-_REPRESENTATIVE_SCHEMA: SchemaRecord = {
-    "$id": "https://example.test/polylogue/inferred-corpus/codex-v1-session-record-stream",
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "type": "object",
-    "properties": {
-        "type": {"type": "string", "x-polylogue-values": ["message"]},
-        "role": {
-            "type": "string",
-            "x-polylogue-semantic-role": "message_role",
-            "x-polylogue-values": ["user", "assistant"],
-        },
-        "content": {
-            "type": "array",
-            "x-polylogue-array-lengths": [1, 1],
-            "items": {
-                "type": "object",
-                "properties": {
-                    "type": {"type": "string", "x-polylogue-values": ["input_text", "output_text"]},
-                    "text": {
-                        "type": "string",
-                        "x-polylogue-semantic-role": "message_body",
-                        "x-polylogue-multiline": True,
-                    },
-                },
-            },
-        },
-        "id": {"type": "string", "x-polylogue-format": "uuid4"},
-        "timestamp": {
-            "type": "string",
-            "x-polylogue-semantic-role": "message_timestamp",
-            "x-polylogue-format": "iso8601",
-        },
-        "sequence": {"type": "integer", "x-polylogue-range": [0, 1000]},
-    },
-    "x-polylogue-string-lengths": [{"path": "$.role", "min": 1, "max": 24, "avg": 8.0, "stddev": 2.0}],
-}
+_PERSISTED_SCHEMA_METADATA_ANNOTATIONS = frozenset(
+    {
+        "x-polylogue-anchor-profile-family-id",
+        "x-polylogue-artifact-kind",
+        "x-polylogue-element-bundle-scope-count",
+        "x-polylogue-element-first-seen",
+        "x-polylogue-element-kind",
+        "x-polylogue-element-last-seen",
+        "x-polylogue-evidence",
+        "x-polylogue-evidence-confidence",
+        "x-polylogue-exact-structure-ids",
+        "x-polylogue-generated-at",
+        "x-polylogue-generator",
+        "x-polylogue-high-cardinality-keys",
+        "x-polylogue-observed-artifact-count",
+        "x-polylogue-package-profile-family-ids",
+        "x-polylogue-package-version",
+        "x-polylogue-profile-family-ids",
+        "x-polylogue-profile-tokens",
+        "x-polylogue-promoted-at",
+        "x-polylogue-registered-at",
+        "x-polylogue-sample-count",
+        "x-polylogue-sample-granularity",
+        "x-polylogue-score",
+        "x-polylogue-version",
+    }
+)
 
 
 @dataclass(frozen=True, order=True)
@@ -726,9 +714,15 @@ def _schema_nodes_at_path(schema: SchemaRecord, path: object) -> tuple[SchemaRec
                 if not isinstance(child, dict):
                     continue
                 if wants_items:
-                    items = child.get("items")
-                    if isinstance(items, dict):
-                        next_nodes.append(items)
+                    child_variants = [child]
+                    for child_branch_key in ("anyOf", "oneOf"):
+                        child_branches = child.get(child_branch_key)
+                        if isinstance(child_branches, list):
+                            child_variants.extend(branch for branch in child_branches if isinstance(branch, dict))
+                    for child_variant in child_variants:
+                        items = child_variant.get("items")
+                        if isinstance(items, dict):
+                            next_nodes.append(items)
                 else:
                     next_nodes.append(child)
         nodes = tuple(next_nodes)
@@ -738,7 +732,7 @@ def _schema_nodes_at_path(schema: SchemaRecord, path: object) -> tuple[SchemaRec
 
 
 def _schema_nodes_have_type(nodes: tuple[SchemaRecord, ...], allowed: set[str]) -> bool:
-    return bool(nodes) and all(_schema_type(node) in allowed for node in nodes)
+    return bool(nodes) and all(bool(types := _schema_types(node)) and types <= allowed for node in nodes)
 
 
 def _schema_type_family(nodes: tuple[SchemaRecord, ...]) -> str | None:
@@ -772,36 +766,29 @@ def _relation_annotation_paths_are_enforced(
         # The solver parses these records, but no production generation path
         # calls get_time_delta yet. Keep them fail-closed until it does.
         return False
-    if key == "x-polylogue-time-deltas":
-        return all(
-            _schema_nodes_have_type(_schema_nodes_at_path(root_schema, record["source"]), {"string"})
-            and _schema_nodes_have_type(_schema_nodes_at_path(root_schema, record["target"]), {"string"})
-            for record in records
-        )
-    if key == "x-polylogue-time-deltas":
-        return all(
-            (field_a_family := _schema_type_family(_schema_nodes_at_path(root_schema, record["field_a"]))) is not None
-            and field_a_family == _schema_type_family(_schema_nodes_at_path(root_schema, record["field_b"]))
-            for record in records
-        )
+    if key == "x-polylogue-mutually-exclusive":
+        for record in records:
+            fields = record.get("fields")
+            if not isinstance(fields, list) or not all(isinstance(field, str) for field in fields):
+                return False
+            if not all(
+                _schema_nodes_have_type(
+                    _schema_nodes_at_path(root_schema, f"{record['parent']}.{field}"),
+                    {"string", "number", "integer", "boolean", "array", "object", "null"},
+                )
+                for field in fields
+            ):
+                return False
+        return True
     if key == "x-polylogue-string-lengths":
         return all(
-            _schema_nodes_have_type(_schema_nodes_at_path(root_schema, record["path"]), {"string"})
+            bool(
+                _schema_nodes_at_path(root_schema, record["path"])
+                and any("string" in _schema_types(node) for node in _schema_nodes_at_path(root_schema, record["path"]))
+            )
             for record in records
         )
-    return all(
-        _schema_nodes_have_type(_schema_nodes_at_path(root_schema, record["parent"]), {"object"})
-        and isinstance(fields := record.get("fields"), list)
-        and all(
-            isinstance(field, str)
-            and _schema_nodes_have_type(
-                _schema_nodes_at_path(root_schema, f"{record['parent']}.{field}"),
-                {"string", "number", "integer", "boolean", "array", "object"},
-            )
-            for field in fields
-        )
-        for record in records
-    )
+    return False
 
 
 def _synthetic_annotation_is_enforced(key: str, value: object) -> bool:
@@ -878,6 +865,22 @@ def _schema_type(node: Mapping[str, object]) -> str | None:
     return None
 
 
+def _schema_types(node: Mapping[str, object]) -> set[str]:
+    schema_type = node.get("type")
+    if isinstance(schema_type, str):
+        return {schema_type}
+    if isinstance(schema_type, list):
+        return {item for item in schema_type if isinstance(item, str)}
+    types: set[str] = set()
+    for keyword in ("anyOf", "oneOf"):
+        variants = node.get(keyword)
+        if isinstance(variants, list):
+            for variant in variants:
+                if isinstance(variant, Mapping):
+                    types.update(_schema_types(variant))
+    return types
+
+
 def _annotation_is_enforced_at_node(
     key: str,
     value: object,
@@ -886,6 +889,8 @@ def _annotation_is_enforced_at_node(
     root_schema: SchemaRecord,
 ) -> bool:
     schema_type = _schema_type(node)
+    schema_types = _schema_types(node)
+    union_path = ".anyOf[" in path or ".oneOf[" in path
     if key in {
         "x-polylogue-foreign-keys",
         "x-polylogue-time-deltas",
@@ -901,7 +906,9 @@ def _annotation_is_enforced_at_node(
         return path != "$" and _synthetic_annotation_is_enforced(key, value)
     if key in {"x-polylogue-array-lengths", "x-polylogue-observed-distribution"}:
         if key == "x-polylogue-array-lengths":
-            return schema_type == "array" and _synthetic_annotation_is_enforced(key, value)
+            return _synthetic_annotation_is_enforced(key, value) and (
+                schema_type == "array" or "array" in schema_types or union_path
+            )
         if schema_type not in {"array", "number", "integer"} or not isinstance(value, Mapping):
             return False
         expected_distribution = "array_length" if schema_type == "array" else "numeric"
@@ -911,15 +918,19 @@ def _annotation_is_enforced_at_node(
     if key in {"x-polylogue-format", "x-polylogue-values", "x-polylogue-multiline"}:
         if key == "x-polylogue-format" and schema_type in {"number", "integer"}:
             return value == "unix-epoch"
-        return schema_type == "string" and _synthetic_annotation_is_enforced(key, value)
+        return _synthetic_annotation_is_enforced(key, value) and (
+            schema_type == "string" or "string" in schema_types or union_path
+        )
     if key == "x-polylogue-semantic-role":
         role = value if isinstance(value, str) else None
         if role == "message_timestamp":
-            return schema_type in {"string", "number", "integer"} and _synthetic_annotation_is_enforced(key, value)
+            return bool(schema_types & {"string", "number", "integer"}) and _synthetic_annotation_is_enforced(
+                key, value
+            )
         if role == "message_container":
-            return False
+            return schema_type == "object"
         return schema_type == "string" and _synthetic_annotation_is_enforced(key, value)
-    return False
+    return key in _PERSISTED_SCHEMA_METADATA_ANNOTATIONS
 
 
 def _schema_constructs(schema: object) -> tuple[ConstructSupport, ...]:
@@ -940,6 +951,8 @@ def _schema_constructs(schema: object) -> tuple[ConstructSupport, ...]:
             if not isinstance(key, str):
                 continue
             if key.startswith("x-"):
+                if key in _PERSISTED_SCHEMA_METADATA_ANNOTATIONS:
+                    continue
                 record_support(
                     key,
                     "supported"
@@ -1050,39 +1063,6 @@ def _catalog_entries(
             for element in sorted(package.elements, key=lambda item: item.element_kind):
                 result.append((provider, catalog, package, element))
     return tuple(result)
-
-
-class _RepresentativeRegistry:
-    """Keep the live package catalog while exposing one executable schema route."""
-
-    def __init__(self, base: RuntimeSchemaRegistryLike) -> None:
-        self._base = base
-
-    def get_element_schema(
-        self,
-        provider: str,
-        *,
-        version: str = "default",
-        element_kind: str | None = None,
-    ) -> SchemaRecord | JSONDocument | None:
-        package = self._base.get_package(provider, version=version)
-        resolved_version = package.version if package is not None else version
-        if (
-            provider == REPRESENTATIVE_PROVIDER
-            and resolved_version == REPRESENTATIVE_PACKAGE_VERSION
-            and element_kind == REPRESENTATIVE_ELEMENT_KIND
-        ):
-            return _REPRESENTATIVE_SCHEMA
-        return self._base.get_element_schema(provider, version=version, element_kind=element_kind)
-
-    def __getattr__(self, name: str) -> object:
-        return getattr(self._base, name)
-
-
-def representative_inferred_corpus_registry(base: RuntimeSchemaRegistryLike) -> RuntimeSchemaRegistryLike:
-    """Return a catalog-backed registry with one real provider/package route admitted."""
-
-    return _RepresentativeRegistry(base)  # type: ignore[return-value]
 
 
 def _unsupported_reason(
@@ -1222,15 +1202,11 @@ __all__ = [
     "InferredCorpusManifest",
     "InferredCorpusManifestEntry",
     "PackageReceipt",
-    "REPRESENTATIVE_ELEMENT_KIND",
-    "REPRESENTATIVE_PACKAGE_VERSION",
-    "REPRESENTATIVE_PROVIDER",
     "UnsupportedCorpusRecord",
     "assert_inferred_corpus_convergence_handoff_complete",
     "assert_inferred_corpus_manifest_complete",
     "build_inferred_corpus_convergence_handoff",
     "compile_inferred_corpus_manifest",
     "read_inferred_corpus_manifest",
-    "representative_inferred_corpus_registry",
     "write_inferred_corpus_manifest",
 ]

--- a/tests/infra/inferred_corpus.py
+++ b/tests/infra/inferred_corpus.py
@@ -172,6 +172,10 @@ _SUPPORTED_SYNTHETIC_ANNOTATIONS = frozenset(
         "x-polylogue-values",
     }
 )
+_SUPPORTED_FORMAT_VALUES = frozenset(
+    {"uuid4", "uuid", "hex-id", "iso8601", "unix-epoch", "unix-epoch-str", "url", "email", "mime-type", "base64"}
+)
+_SUPPORTED_SEMANTIC_ROLE_VALUES = frozenset({"message_role", "message_body", "message_timestamp", "session_title"})
 
 
 @dataclass(frozen=True, order=True)
@@ -301,10 +305,119 @@ class InferredCorpusConvergenceHandoff:
     specs: tuple[CorpusSpec, ...]
 
 
+def _is_number(value: object) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _valid_pair(value: object, *, integral: bool = False, nonnegative: bool = False) -> bool:
+    if not isinstance(value, list) or len(value) < 2:
+        return False
+    first, second = value[:2]
+    if not _is_number(first) or not _is_number(second):
+        return False
+    if integral and (not isinstance(first, int) or not isinstance(second, int)):
+        return False
+    if nonnegative and (first < 0 or second < 0):
+        return False
+    return first <= second
+
+
+def _valid_observed_distribution(value: object) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    for distribution in value.values():
+        if not isinstance(distribution, Mapping):
+            continue
+        histogram = distribution.get("histogram")
+        log_base = distribution.get("log_base")
+        if (
+            isinstance(histogram, list)
+            and histogram
+            and _is_number(log_base)
+            and log_base > 1
+            and all(
+                isinstance(bucket, list)
+                and len(bucket) == 2
+                and isinstance(bucket[0], int)
+                and isinstance(bucket[1], int)
+                and bucket[1] > 0
+                for bucket in histogram
+            )
+        ):
+            return True
+    return False
+
+
+def _valid_relation_records(value: object, required: tuple[str, ...]) -> bool:
+    return (
+        isinstance(value, list)
+        and bool(value)
+        and all(
+            isinstance(record, Mapping)
+            and all(isinstance(record.get(field), str) and record[field].strip() for field in required)
+            for record in value
+        )
+    )
+
+
+def _synthetic_annotation_is_enforced(key: str, value: object) -> bool:
+    """Return whether the production generator or solver enforces this payload."""
+
+    if key not in _SUPPORTED_SYNTHETIC_ANNOTATIONS:
+        return False
+    if key == "x-polylogue-format":
+        return isinstance(value, str) and value in _SUPPORTED_FORMAT_VALUES
+    if key == "x-polylogue-semantic-role":
+        return isinstance(value, str) and value in _SUPPORTED_SEMANTIC_ROLE_VALUES
+    if key == "x-polylogue-frequency":
+        return _is_number(value) and 0 <= value <= 1
+    if key == "x-polylogue-multiline":
+        return isinstance(value, bool)
+    if key == "x-polylogue-values":
+        return isinstance(value, list) and bool(value) and all(not isinstance(item, (list, Mapping)) for item in value)
+    if key == "x-polylogue-range":
+        return _valid_pair(value)
+    if key == "x-polylogue-array-lengths":
+        return _valid_pair(value, integral=True, nonnegative=True)
+    if key == "x-polylogue-observed-distribution":
+        return _valid_observed_distribution(value)
+    if key == "x-polylogue-foreign-keys":
+        return _valid_relation_records(value, ("source", "target"))
+    if key == "x-polylogue-time-deltas":
+        return _valid_relation_records(value, ("field_a", "field_b")) and all(
+            _is_number(record.get(field))
+            for record in value
+            if isinstance(record, Mapping)
+            for field in ("min_delta", "max_delta", "avg_delta")
+        )
+    if key == "x-polylogue-mutually-exclusive":
+        return _valid_relation_records(value, ("parent",)) and all(
+            isinstance(record.get("fields"), list)
+            and len(record["fields"]) >= 2
+            and all(isinstance(field, str) and field for field in record["fields"])
+            for record in value
+            if isinstance(record, Mapping)
+        )
+    if key == "x-polylogue-string-lengths":
+        return _valid_relation_records(value, ("path",)) and all(
+            _valid_pair([record.get("min"), record.get("max")], integral=True, nonnegative=True)
+            and _is_number(record.get("avg"))
+            and _is_number(record.get("stddev"))
+            for record in value
+            if isinstance(record, Mapping)
+        )
+    raise AssertionError(f"missing annotation validator for {key}")
+
+
 def _schema_constructs(schema: object) -> tuple[ConstructSupport, ...]:
     """Census every schema-scope keyword without treating property names as keywords."""
 
     found: dict[str, ConstructSupportState] = {}
+
+    def record_support(key: str, state: ConstructSupportState) -> None:
+        if found.get(key) == "unsupported":
+            return
+        found[key] = state
 
     def visit(node: object) -> None:
         if not isinstance(node, Mapping):
@@ -313,14 +426,14 @@ def _schema_constructs(schema: object) -> tuple[ConstructSupport, ...]:
             if not isinstance(key, str):
                 continue
             if key.startswith("x-"):
-                found[key] = "supported" if key in _SUPPORTED_SYNTHETIC_ANNOTATIONS else "unsupported"
+                record_support(key, "supported" if _synthetic_annotation_is_enforced(key, value) else "unsupported")
                 continue
             if key in _SUPPORTED_SCHEMA_CONSTRUCTS:
-                found[key] = "supported"
+                record_support(key, "supported")
             elif key in _STANDARD_SCHEMA_KEYWORDS:
-                found[key] = "unsupported"
+                record_support(key, "unsupported")
             else:
-                found[key] = "unsupported"
+                record_support(key, "unsupported")
 
             if key in _SCHEMA_MAPPING_KEYWORDS and isinstance(value, Mapping):
                 if key in {"$defs", "dependentSchemas", "dependencies", "patternProperties", "properties"}:

--- a/tests/property/test_inferred_corpus_loop.py
+++ b/tests/property/test_inferred_corpus_loop.py
@@ -1,0 +1,70 @@
+"""The inferred manifest's supported specs must reach real archive convergence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from polylogue.config import Source
+from polylogue.pipeline.services.archive_ingest import parse_sources_archive
+from polylogue.scenarios import CorpusSpec
+from polylogue.schemas.registry import SCHEMA_DIR, SchemaRegistry
+from polylogue.schemas.synthetic import SyntheticCorpus
+from tests.infra.convergence_harness import (
+    ConvergenceArchive,
+    converge_convergence_archive,
+    rich_convergence_pathology,
+)
+from tests.infra.inferred_corpus import (
+    assert_inferred_corpus_convergence_handoff_complete,
+    build_inferred_corpus_convergence_handoff,
+    compile_inferred_corpus_manifest,
+)
+
+
+def _spec_identity(spec: CorpusSpec) -> tuple[str, str, str | None]:
+    return spec.provider, spec.package_version, spec.element_kind
+
+
+@pytest.mark.asyncio
+async def test_inferred_manifest_supported_specs_ingest_and_converge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest = compile_inferred_corpus_manifest(registry=SchemaRegistry(storage_root=SCHEMA_DIR))
+    handoff = build_inferred_corpus_convergence_handoff(manifest)
+    assert_inferred_corpus_convergence_handoff_complete(manifest, handoff)
+    assert handoff.specs
+
+    source_root = tmp_path / "inferred-corpus"
+    written = SyntheticCorpus.write_specs_artifacts(handoff.specs, source_root, prefix="inferred")
+    expected_specs = {_spec_identity(spec) for spec in manifest.supported_specs}
+    generated_specs = {
+        (batch.batch.report.provider, batch.batch.report.package_version, batch.batch.report.element_kind)
+        for batch in written
+    }
+    assert generated_specs == expected_specs
+    assert len(written) == len(manifest.supported_specs)
+
+    source_paths = tuple(path for batch in written for path in batch.files)
+    sources = [
+        Source(name=batch.batch.report.provider, path=path.relative_to(source_root))
+        for batch in written
+        for path in batch.files
+    ]
+    monkeypatch.chdir(source_root)
+    result = await parse_sources_archive(tmp_path / "archive", sources, parse_workers=1)
+
+    expected_sessions = sum(spec.count for spec in handoff.specs)
+    assert result.parse_failures == 0
+    assert len(result.processed_ids) == expected_sessions
+    archive = ConvergenceArchive(
+        root=tmp_path / "archive",
+        pathology=rich_convergence_pathology(),
+        source_paths=source_paths,
+        session_ids=tuple(sorted(result.processed_ids)),
+    )
+    states = converge_convergence_archive(archive)
+
+    assert set(states) == set(result.processed_ids)
+    assert all(state.converged for state in states.values())

--- a/tests/property/test_inferred_corpus_loop.py
+++ b/tests/property/test_inferred_corpus_loop.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 import sqlite3
 from pathlib import Path
 
@@ -19,7 +20,6 @@ from tests.infra.inferred_corpus import (
     build_inferred_corpus_convergence_handoff,
     compile_inferred_corpus_manifest,
     read_inferred_corpus_manifest,
-    representative_inferred_corpus_registry,
     write_inferred_corpus_manifest,
 )
 
@@ -28,16 +28,31 @@ def test_actual_catalog_manifest_remains_fail_closed() -> None:
     manifest = compile_inferred_corpus_manifest(registry=SchemaRegistry(storage_root=SCHEMA_DIR))
     handoff = build_inferred_corpus_convergence_handoff(manifest)
     assert_inferred_corpus_convergence_handoff_complete(manifest, handoff)
-    assert handoff.specs == manifest.supported_specs == ()
-    assert handoff.selections == ()
+    assert handoff.specs == manifest.supported_specs
+    assert any(spec.provider == "codex" for spec in handoff.specs)
+    assert handoff.selections
+    assert any(selection.provider == "codex" for selection in handoff.selections)
     assert manifest.unsupported_records
 
 
-def test_persisted_representative_manifest_reaches_real_ingest_and_convergence(
+def _assert_fts_match(conn: sqlite3.Connection, token: str) -> None:
+    rows = conn.execute(
+        """
+        SELECT b.block_id
+        FROM messages_fts
+        JOIN blocks AS b ON b.rowid = messages_fts.rowid
+        WHERE messages_fts MATCH ?
+        """,
+        (token,),
+    ).fetchall()
+    assert rows, f"FTS MATCH returned no blocks for generated token {token!r}"
+
+
+def test_persisted_catalog_manifest_reaches_real_ingest_and_convergence(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    registry = representative_inferred_corpus_registry(SchemaRegistry(storage_root=SCHEMA_DIR))
+    registry = SchemaRegistry(storage_root=SCHEMA_DIR)
     manifest = compile_inferred_corpus_manifest(registry=registry)
     manifest_path = tmp_path / "manifest.json"
     write_inferred_corpus_manifest(manifest, manifest_path)
@@ -89,9 +104,44 @@ def test_persisted_representative_manifest_reaches_real_ingest_and_convergence(
             conn.execute("SELECT COUNT(*) FROM blocks WHERE NULLIF(search_text, '') IS NOT NULL").fetchone()[0]
         )
         fts_index_count = int(conn.execute("SELECT COUNT(*) FROM messages_fts_docsize").fetchone()[0])
+        searchable_texts = tuple(
+            str(row[0])
+            for row in conn.execute(
+                "SELECT search_text FROM blocks WHERE NULLIF(search_text, '') IS NOT NULL ORDER BY rowid"
+            ).fetchall()
+        )
 
     assert session_count > 0 and message_count > 0
     assert profile_count == session_count
     assert profile_message_count == message_count
     assert materialized_profiles == session_count
     assert fts_source_count == fts_index_count
+    assert searchable_texts and all(text.strip() for text in searchable_texts)
+
+    generated_text = written.batch.raw_items[0].decode("utf-8")
+    generated_tokens = tuple(dict.fromkeys(re.findall(r"[A-Za-z][A-Za-z0-9_]{4,}", generated_text.lower())))
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        search_token = next(
+            (
+                token
+                for token in generated_tokens
+                if conn.execute("SELECT 1 FROM messages_fts WHERE messages_fts MATCH ? LIMIT 1", (token,)).fetchone()
+                is not None
+            ),
+            None,
+        )
+        assert search_token is not None, "generated Codex content produced no searchable FTS token"
+        _assert_fts_match(conn, search_token)
+
+        conn.execute(
+            "UPDATE blocks SET text = '', tool_name = '', tool_input = NULL WHERE session_id IN ({})".format(
+                ",".join("?" for _ in session_ids)
+            ),
+            session_ids,
+        )
+        cleared_count = int(
+            conn.execute("SELECT COUNT(*) FROM blocks WHERE NULLIF(search_text, '') IS NOT NULL").fetchone()[0]
+        )
+        assert cleared_count == 0
+        with pytest.raises(AssertionError, match="FTS MATCH returned no blocks"):
+            _assert_fts_match(conn, search_token)

--- a/tests/property/test_inferred_corpus_loop.py
+++ b/tests/property/test_inferred_corpus_loop.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from pathlib import Path
-from typing import cast
 
 import pytest
 
@@ -56,7 +55,7 @@ class _GeneratorOnlyRegistry:
 
     def get_element_schema(self, provider: str, *, version: str = "default", element_kind: str | None = None) -> object:
         schema = self.base.get_element_schema(provider, version=version, element_kind=element_kind)
-        return cast(object, _generator_only_schema(schema))
+        return _generator_only_schema(schema)
 
     def __getattr__(self, name: str) -> object:
         return getattr(self.base, name)

--- a/tests/property/test_inferred_corpus_loop.py
+++ b/tests/property/test_inferred_corpus_loop.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -17,6 +19,7 @@ from tests.infra.convergence_harness import (
     rich_convergence_pathology,
 )
 from tests.infra.inferred_corpus import (
+    _SUPPORTED_SYNTHETIC_ANNOTATIONS,
     assert_inferred_corpus_convergence_handoff_complete,
     build_inferred_corpus_convergence_handoff,
     compile_inferred_corpus_manifest,
@@ -27,11 +30,45 @@ def _spec_identity(spec: CorpusSpec) -> tuple[str, str, str | None]:
     return spec.provider, spec.package_version, spec.element_kind
 
 
+def _generator_only_schema(value: object) -> object:
+    if isinstance(value, Mapping):
+        return {
+            key: _generator_only_schema(child)
+            for key, child in value.items()
+            if not (isinstance(key, str) and key.startswith("x-") and key not in _SUPPORTED_SYNTHETIC_ANNOTATIONS)
+        }
+    if isinstance(value, list):
+        return [_generator_only_schema(child) for child in value]
+    return value
+
+
+class _GeneratorOnlyRegistry:
+    """Expose the generator-enforced schema view without catalog provenance."""
+
+    def __init__(self, base: SchemaRegistry) -> None:
+        self.base = base
+
+    def list_providers(self) -> list[str]:
+        return self.base.list_providers()
+
+    def load_package_catalog(self, provider: str) -> object:
+        return self.base.load_package_catalog(provider)
+
+    def get_element_schema(self, provider: str, *, version: str = "default", element_kind: str | None = None) -> object:
+        schema = self.base.get_element_schema(provider, version=version, element_kind=element_kind)
+        return cast(object, _generator_only_schema(schema))
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self.base, name)
+
+
 @pytest.mark.asyncio
 async def test_inferred_manifest_supported_specs_ingest_and_converge(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    manifest = compile_inferred_corpus_manifest(registry=SchemaRegistry(storage_root=SCHEMA_DIR))
+    manifest = compile_inferred_corpus_manifest(
+        registry=_GeneratorOnlyRegistry(SchemaRegistry(storage_root=SCHEMA_DIR))  # type: ignore[arg-type]
+    )
     handoff = build_inferred_corpus_convergence_handoff(manifest)
     assert_inferred_corpus_convergence_handoff_complete(manifest, handoff)
     assert handoff.specs

--- a/tests/property/test_inferred_corpus_loop.py
+++ b/tests/property/test_inferred_corpus_loop.py
@@ -2,17 +2,96 @@
 
 from __future__ import annotations
 
+import asyncio
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.config import Source
+from polylogue.daemon.convergence import DaemonConverger
+from polylogue.daemon.convergence_stages import make_fts_stage, make_insights_stage
+from polylogue.pipeline.services.archive_ingest import parse_sources_archive
 from polylogue.schemas.registry import SCHEMA_DIR, SchemaRegistry
+from polylogue.schemas.synthetic import SyntheticCorpus
 from tests.infra.inferred_corpus import (
     assert_inferred_corpus_convergence_handoff_complete,
     build_inferred_corpus_convergence_handoff,
     compile_inferred_corpus_manifest,
+    read_inferred_corpus_manifest,
+    representative_inferred_corpus_registry,
+    write_inferred_corpus_manifest,
 )
 
 
-def test_persisted_manifest_handoff_excludes_unsupported_catalog_entries() -> None:
+def test_actual_catalog_manifest_remains_fail_closed() -> None:
     manifest = compile_inferred_corpus_manifest(registry=SchemaRegistry(storage_root=SCHEMA_DIR))
     handoff = build_inferred_corpus_convergence_handoff(manifest)
     assert_inferred_corpus_convergence_handoff_complete(manifest, handoff)
     assert handoff.specs == manifest.supported_specs == ()
+    assert handoff.selections == ()
     assert manifest.unsupported_records
+
+
+def test_persisted_representative_manifest_reaches_real_ingest_and_convergence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = representative_inferred_corpus_registry(SchemaRegistry(storage_root=SCHEMA_DIR))
+    manifest = compile_inferred_corpus_manifest(registry=registry)
+    manifest_path = tmp_path / "manifest.json"
+    write_inferred_corpus_manifest(manifest, manifest_path)
+    persisted = read_inferred_corpus_manifest(manifest_path)
+    handoff = build_inferred_corpus_convergence_handoff(manifest_path)
+
+    assert persisted.supported_specs
+    assert len(handoff.specs) == len(handoff.selections) == 1
+    spec = handoff.specs[0]
+    selection = handoff.selections[0]
+    source_root = tmp_path / "synthetic-source"
+    written = SyntheticCorpus.write_selection_artifacts(
+        selection,
+        spec,
+        source_root / spec.provider,
+        prefix="inferred",
+    )
+    assert written.batch.report.generated_count == spec.count == 1
+    assert written.files and all(path.stat().st_size > 0 for path in written.files)
+
+    archive_root = tmp_path / "archive"
+    source_path = written.files[0].relative_to(source_root)
+    monkeypatch.chdir(source_root)
+    ingest_result = asyncio.run(parse_sources_archive(archive_root, [Source(name=spec.provider, path=source_path)]))
+    assert ingest_result.counts["sessions"] > 0
+    assert ingest_result.counts["messages"] > 0
+
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        session_ids = tuple(str(row[0]) for row in conn.execute("SELECT session_id FROM sessions ORDER BY session_id"))
+    converger = DaemonConverger(
+        (make_fts_stage(archive_root / "index.db"), make_insights_stage(archive_root / "index.db"))
+    )
+    states, _timings = converger.converge_sessions(session_ids)
+    assert states and all(state.converged and state.last_error is None for state in states.values())
+
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        session_count = int(conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0])
+        message_count = int(conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0])
+        profile_count = int(conn.execute("SELECT COUNT(*) FROM session_profiles").fetchone()[0])
+        profile_message_count = int(
+            conn.execute("SELECT COALESCE(SUM(message_count), 0) FROM session_profiles").fetchone()[0]
+        )
+        materialized_profiles = int(
+            conn.execute(
+                "SELECT COUNT(*) FROM session_profiles WHERE materialized_at != '' AND message_count > 0"
+            ).fetchone()[0]
+        )
+        fts_source_count = int(
+            conn.execute("SELECT COUNT(*) FROM blocks WHERE NULLIF(search_text, '') IS NOT NULL").fetchone()[0]
+        )
+        fts_index_count = int(conn.execute("SELECT COUNT(*) FROM messages_fts_docsize").fetchone()[0])
+
+    assert session_count > 0 and message_count > 0
+    assert profile_count == session_count
+    assert profile_message_count == message_count
+    assert materialized_profiles == session_count
+    assert fts_source_count == fts_index_count

--- a/tests/property/test_inferred_corpus_loop.py
+++ b/tests/property/test_inferred_corpus_loop.py
@@ -2,105 +2,17 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from pathlib import Path
-
-import pytest
-
-from polylogue.config import Source
-from polylogue.pipeline.services.archive_ingest import parse_sources_archive
-from polylogue.scenarios import CorpusSpec
 from polylogue.schemas.registry import SCHEMA_DIR, SchemaRegistry
-from polylogue.schemas.synthetic import SyntheticCorpus
-from tests.infra.convergence_harness import (
-    ConvergenceArchive,
-    converge_convergence_archive,
-    rich_convergence_pathology,
-)
 from tests.infra.inferred_corpus import (
-    _SUPPORTED_SYNTHETIC_ANNOTATIONS,
     assert_inferred_corpus_convergence_handoff_complete,
     build_inferred_corpus_convergence_handoff,
     compile_inferred_corpus_manifest,
 )
 
 
-def _spec_identity(spec: CorpusSpec) -> tuple[str, str, str | None]:
-    return spec.provider, spec.package_version, spec.element_kind
-
-
-def _generator_only_schema(value: object) -> object:
-    if isinstance(value, Mapping):
-        return {
-            key: _generator_only_schema(child)
-            for key, child in value.items()
-            if not (isinstance(key, str) and key.startswith("x-") and key not in _SUPPORTED_SYNTHETIC_ANNOTATIONS)
-        }
-    if isinstance(value, list):
-        return [_generator_only_schema(child) for child in value]
-    return value
-
-
-class _GeneratorOnlyRegistry:
-    """Expose the generator-enforced schema view without catalog provenance."""
-
-    def __init__(self, base: SchemaRegistry) -> None:
-        self.base = base
-
-    def list_providers(self) -> list[str]:
-        return self.base.list_providers()
-
-    def load_package_catalog(self, provider: str) -> object:
-        return self.base.load_package_catalog(provider)
-
-    def get_element_schema(self, provider: str, *, version: str = "default", element_kind: str | None = None) -> object:
-        schema = self.base.get_element_schema(provider, version=version, element_kind=element_kind)
-        return _generator_only_schema(schema)
-
-    def __getattr__(self, name: str) -> object:
-        return getattr(self.base, name)
-
-
-@pytest.mark.asyncio
-async def test_inferred_manifest_supported_specs_ingest_and_converge(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    manifest = compile_inferred_corpus_manifest(
-        registry=_GeneratorOnlyRegistry(SchemaRegistry(storage_root=SCHEMA_DIR))  # type: ignore[arg-type]
-    )
+def test_persisted_manifest_handoff_excludes_unsupported_catalog_entries() -> None:
+    manifest = compile_inferred_corpus_manifest(registry=SchemaRegistry(storage_root=SCHEMA_DIR))
     handoff = build_inferred_corpus_convergence_handoff(manifest)
     assert_inferred_corpus_convergence_handoff_complete(manifest, handoff)
-    assert handoff.specs
-
-    source_root = tmp_path / "inferred-corpus"
-    written = SyntheticCorpus.write_specs_artifacts(handoff.specs, source_root, prefix="inferred")
-    expected_specs = {_spec_identity(spec) for spec in manifest.supported_specs}
-    generated_specs = {
-        (batch.batch.report.provider, batch.batch.report.package_version, batch.batch.report.element_kind)
-        for batch in written
-    }
-    assert generated_specs == expected_specs
-    assert len(written) == len(manifest.supported_specs)
-
-    source_paths = tuple(path for batch in written for path in batch.files)
-    sources = [
-        Source(name=batch.batch.report.provider, path=path.relative_to(source_root))
-        for batch in written
-        for path in batch.files
-    ]
-    monkeypatch.chdir(source_root)
-    result = await parse_sources_archive(tmp_path / "archive", sources, parse_workers=1)
-
-    expected_sessions = sum(spec.count for spec in handoff.specs)
-    assert result.parse_failures == 0
-    assert len(result.processed_ids) == expected_sessions
-    archive = ConvergenceArchive(
-        root=tmp_path / "archive",
-        pathology=rich_convergence_pathology(),
-        source_paths=source_paths,
-        session_ids=tuple(sorted(result.processed_ids)),
-    )
-    states = converge_convergence_archive(archive)
-
-    assert set(states) == set(result.processed_ids)
-    assert all(state.converged for state in states.values())
+    assert handoff.specs == manifest.supported_specs == ()
+    assert manifest.unsupported_records

--- a/tests/unit/schemas/test_inferred_corpus_manifest.py
+++ b/tests/unit/schemas/test_inferred_corpus_manifest.py
@@ -19,7 +19,6 @@ from tests.infra.inferred_corpus import (
     build_inferred_corpus_convergence_handoff,
     compile_inferred_corpus_manifest,
     read_inferred_corpus_manifest,
-    representative_inferred_corpus_registry,
     write_inferred_corpus_manifest,
 )
 
@@ -142,7 +141,7 @@ def test_persisted_manifest_rejects_unhashed_extra_fields(tmp_path: Path) -> Non
 
 
 def test_persisted_manifest_rejects_spec_identity_tampering(tmp_path: Path) -> None:
-    manifest = compile_inferred_corpus_manifest(registry=representative_inferred_corpus_registry(_registry()))
+    manifest = compile_inferred_corpus_manifest(registry=_registry())
     path = tmp_path / "inferred-manifest.json"
     write_inferred_corpus_manifest(manifest, path)
     payload = json.loads(path.read_text(encoding="utf-8"))
@@ -155,7 +154,7 @@ def test_persisted_manifest_rejects_spec_identity_tampering(tmp_path: Path) -> N
 
 
 def test_persisted_selection_preserves_workload_profile(tmp_path: Path) -> None:
-    base = compile_inferred_corpus_manifest(registry=representative_inferred_corpus_registry(_registry()))
+    base = compile_inferred_corpus_manifest(registry=_registry())
     supported = next(entry for entry in base.entries if entry.spec is not None)
     profile: SchemaRecord = {"elements": {supported.key.element_kind: {"structural_variants": []}}}
     profiled = InferredCorpusManifest(
@@ -176,7 +175,7 @@ def test_persisted_selection_preserves_workload_profile(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("extra_field", ["workload_profile", "spec"])
 def test_persisted_manifest_rejects_noncanonical_optional_entry_fields(tmp_path: Path, extra_field: str) -> None:
-    manifest = compile_inferred_corpus_manifest(registry=representative_inferred_corpus_registry(_registry()))
+    manifest = compile_inferred_corpus_manifest(registry=_registry())
     path = tmp_path / "noncanonical-manifest.json"
     write_inferred_corpus_manifest(manifest, path)
     payload = json.loads(path.read_text(encoding="utf-8"))
@@ -597,7 +596,11 @@ def test_time_delta_paths_must_have_compatible_types() -> None:
 def test_convergence_handoff_rejects_an_omitted_supported_spec() -> None:
     manifest = compile_inferred_corpus_manifest(registry=_registry())
     handoff = build_inferred_corpus_convergence_handoff(manifest)
-    assert handoff.specs == ()
+    assert handoff.specs == manifest.supported_specs
+    assert handoff.specs
+    omitted = replace(handoff, specs=())
+    with pytest.raises(AssertionError, match="omitted or substituted"):
+        assert_inferred_corpus_convergence_handoff_complete(manifest, omitted)
     assert_inferred_corpus_convergence_handoff_complete(manifest, handoff)
 
 
@@ -612,20 +615,25 @@ def _first_wired_catalog_entry(registry: SchemaRegistry) -> tuple[str, str, str]
     raise AssertionError("expected a persisted provider with a wire format")
 
 
-def test_representative_package_route_is_nonempty_and_uses_persisted_selection() -> None:
-    manifest = compile_inferred_corpus_manifest(registry=representative_inferred_corpus_registry(_registry()))
+def test_persisted_codex_package_route_is_nonempty_and_uses_catalog_artifact() -> None:
+    schema_path = SCHEMA_DIR / "codex" / "versions" / "v1" / "elements" / "session_record_stream.schema.json.gz"
+    assert schema_path.is_file()
+    manifest = compile_inferred_corpus_manifest(registry=_registry())
 
     assert manifest.supported_specs
-    entry = next(entry for entry in manifest.entries if entry.spec is not None)
+    entry = next(entry for entry in manifest.entries if entry.key.provider == "codex")
     assert (entry.key.provider, entry.key.package_version, entry.key.element_kind) == (
         "codex",
         "v1",
         "session_record_stream",
     )
     assert entry.generator_schema is not None
+    assert entry.generator_schema == _registry().get_element_schema(
+        "codex", version="v1", element_kind="session_record_stream"
+    )
     handoff = build_inferred_corpus_convergence_handoff(manifest)
-    assert handoff.selections
-    assert handoff.selections[0].schema == entry.generator_schema
+    codex_selection = next(selection for selection in handoff.selections if selection.provider == "codex")
+    assert codex_selection.schema == entry.generator_schema
 
 
 def _schema_with_annotation(
@@ -728,11 +736,6 @@ def test_unenforced_annotation_values_are_typed_unsupported_records(annotation: 
 @pytest.mark.parametrize(
     "annotation",
     [
-        "x-polylogue-score",
-        "x-polylogue-evidence",
-        "x-polylogue-generated-at",
-        "x-polylogue-artifact-kind",
-        "x-polylogue-package-version",
         "x-polylogue-unknown-constraint",
         "x-third-party-constraint",
     ],
@@ -764,7 +767,7 @@ def test_unenforced_x_annotation_becomes_a_typed_unsupported_record(annotation: 
     assert (annotation, "unsupported") in {(item.construct, item.state) for item in target.key.construct_support}
 
 
-def test_live_catalog_provenance_annotations_are_censused_as_unsupported() -> None:
+def test_live_catalog_provenance_annotations_are_not_generator_constraints() -> None:
     manifest = compile_inferred_corpus_manifest(registry=_registry())
 
     score_entries = [
@@ -772,9 +775,5 @@ def test_live_catalog_provenance_annotations_are_censused_as_unsupported() -> No
         for entry in manifest.entries
         if any(item.construct == "x-polylogue-score" for item in entry.key.construct_support)
     ]
-    assert score_entries
-    assert all(
-        ("x-polylogue-score", "unsupported") in {(item.construct, item.state) for item in entry.key.construct_support}
-        for entry in score_entries
-    )
-    assert not manifest.supported_specs
+    assert not score_entries
+    assert any(spec.provider == "codex" for spec in manifest.supported_specs)

--- a/tests/unit/schemas/test_inferred_corpus_manifest.py
+++ b/tests/unit/schemas/test_inferred_corpus_manifest.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from polylogue.schemas.registry import SCHEMA_DIR, SchemaRegistry
+from polylogue.schemas.synthetic.wire_formats import PROVIDER_WIRE_FORMATS
+from tests.infra.inferred_corpus import (
+    CorpusManifestKey,
+    InferredCorpusManifest,
+    assert_inferred_corpus_manifest_complete,
+    compile_inferred_corpus_manifest,
+)
+
+
+def _registry() -> SchemaRegistry:
+    return SchemaRegistry(storage_root=SCHEMA_DIR)
+
+
+def _catalog_keys(registry: SchemaRegistry) -> set[CorpusManifestKey]:
+    keys: set[CorpusManifestKey] = set()
+    for provider in registry.list_providers():
+        catalog = registry.load_package_catalog(provider)
+        assert catalog is not None
+        for package in catalog.packages:
+            for element in package.elements:
+                keys.add(CorpusManifestKey(provider, package.version, element.element_kind))
+    return keys
+
+
+class _RegistryProxy:
+    def __init__(self, base: SchemaRegistry) -> None:
+        self.base = base
+        self.catalog_overrides: dict[str, object] = {}
+        self.schema_overrides: dict[tuple[str, str, str], object] = {}
+
+    def list_providers(self) -> list[str]:
+        return self.base.list_providers()
+
+    def load_package_catalog(self, provider: str) -> object:
+        return self.catalog_overrides.get(provider, self.base.load_package_catalog(provider))
+
+    def get_element_schema(self, provider: str, *, version: str = "default", element_kind: str | None = None) -> object:
+        assert element_kind is not None
+        package = self.base.get_package(provider, version=version)
+        assert package is not None
+        key = (provider, package.version, element_kind)
+        return self.schema_overrides.get(
+            key,
+            self.base.get_element_schema(provider, version=package.version, element_kind=element_kind),
+        )
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self.base, name)
+
+
+def test_manifest_covers_every_persisted_package_version_element() -> None:
+    registry = _registry()
+
+    manifest = compile_inferred_corpus_manifest(registry=registry)
+
+    assert {
+        CorpusManifestKey(entry.key.provider, entry.key.package_version, entry.key.element_kind)
+        for entry in manifest.entries
+    } == _catalog_keys(registry)
+    assert len(manifest.entries) > len(registry.list_providers())
+    assert manifest.receipt_state == "catalog_only"
+    assert manifest.manifest_id.startswith("manifest:sha256:")
+
+
+def test_manifest_is_independent_of_default_version_selection() -> None:
+    registry = _registry()
+    proxy = _RegistryProxy(registry)
+    for provider in registry.list_providers():
+        catalog = registry.load_package_catalog(provider)
+        assert catalog is not None
+        if len(catalog.packages) > 1:
+            proxy.catalog_overrides[provider] = replace(
+                catalog,
+                default_version=catalog.packages[0].version,
+            )
+
+    manifest = compile_inferred_corpus_manifest(registry=proxy)  # type: ignore[arg-type]
+
+    assert {
+        CorpusManifestKey(entry.key.provider, entry.key.package_version, entry.key.element_kind)
+        for entry in manifest.entries
+    } == _catalog_keys(registry)
+    assert {entry.key.package_version for entry in manifest.entries} >= {"v1", "v2"}
+
+
+def test_completeness_guard_detects_a_removed_enumerated_entry() -> None:
+    registry = _registry()
+    manifest = compile_inferred_corpus_manifest(registry=registry)
+    reduced = InferredCorpusManifest(entries=manifest.entries[:-1])
+
+    with pytest.raises(AssertionError, match="coverage mismatch"):
+        assert_inferred_corpus_manifest_complete(reduced, registry)
+
+
+def test_missing_element_schema_becomes_explicit_unsupported_record() -> None:
+    registry = _registry()
+    proxy = _RegistryProxy(registry)
+    target_provider = registry.list_providers()[0]
+    catalog = registry.load_package_catalog(target_provider)
+    assert catalog is not None
+    target_package = catalog.packages[0]
+    target_element = target_package.elements[0]
+    proxy.schema_overrides[(target_provider, target_package.version, target_element.element_kind)] = None
+
+    manifest = compile_inferred_corpus_manifest(registry=proxy)  # type: ignore[arg-type]
+    target = next(
+        entry
+        for entry in manifest.entries
+        if (
+            entry.key.provider,
+            entry.key.package_version,
+            entry.key.element_kind,
+        )
+        == (target_provider, target_package.version, target_element.element_kind)
+    )
+
+    assert target.spec is None
+    assert target.unsupported is not None
+    assert target.unsupported.reason == "missing_schema"
+
+
+def test_catalog_element_marked_unsupported_is_retained_as_a_typed_record() -> None:
+    registry = _registry()
+    proxy = _RegistryProxy(registry)
+    provider = registry.list_providers()[0]
+    catalog = registry.load_package_catalog(provider)
+    assert catalog is not None
+    package = catalog.packages[0]
+    element = package.elements[0]
+    unsupported_element = replace(element, supported=False)
+    proxy.catalog_overrides[provider] = replace(
+        catalog,
+        packages=[
+            replace(
+                package,
+                elements=[unsupported_element, *package.elements[1:]],
+            ),
+            *catalog.packages[1:],
+        ],
+    )
+
+    manifest = compile_inferred_corpus_manifest(registry=proxy)  # type: ignore[arg-type]
+    target = next(
+        entry
+        for entry in manifest.entries
+        if (
+            entry.key.provider,
+            entry.key.package_version,
+            entry.key.element_kind,
+        )
+        == (provider, package.version, element.element_kind)
+    )
+
+    assert target.spec is None
+    assert target.unsupported is not None
+    assert target.unsupported.reason == "unsupported_element"
+
+
+def test_removed_wire_format_is_explicit_and_does_not_drop_provider_entries() -> None:
+    registry = _registry()
+    provider = next(name for name in registry.list_providers() if name in PROVIDER_WIRE_FORMATS)
+    formats = dict(PROVIDER_WIRE_FORMATS)
+    formats.pop(provider)
+
+    manifest = compile_inferred_corpus_manifest(registry=registry, wire_formats=formats)
+
+    provider_entries = [entry for entry in manifest.entries if entry.key.provider == provider]
+    assert provider_entries
+    assert all(entry.spec is None for entry in provider_entries)
+    assert {entry.unsupported.reason for entry in provider_entries if entry.unsupported is not None} == {
+        "provider_without_wire_format"
+    }
+
+
+def test_unsupported_json_schema_construct_is_keyed_and_receiptable() -> None:
+    registry = _registry()
+    proxy = _RegistryProxy(registry)
+    provider = next(name for name in registry.list_providers() if name in PROVIDER_WIRE_FORMATS)
+    catalog = registry.load_package_catalog(provider)
+    assert catalog is not None
+    package = catalog.packages[0]
+    element = package.elements[0]
+    schema = registry.get_element_schema(provider, version=package.version, element_kind=element.element_kind)
+    assert isinstance(schema, dict)
+    mutated = dict(schema)
+    raw_properties = mutated.get("properties")
+    assert isinstance(raw_properties, dict)
+    properties = dict(raw_properties)
+    properties["manifest_unsupported"] = {"enum": ["future"]}
+    mutated["properties"] = properties
+    proxy.schema_overrides[(provider, package.version, element.element_kind)] = mutated
+    receipt = {"receipt_id": "tnqqt-package-receipt-placeholder", "status": "pending"}
+
+    manifest = compile_inferred_corpus_manifest(registry=proxy, package_receipt=receipt)  # type: ignore[arg-type]
+    target = next(
+        entry
+        for entry in manifest.entries
+        if (
+            entry.key.provider,
+            entry.key.package_version,
+            entry.key.element_kind,
+        )
+        == (provider, package.version, element.element_kind)
+    )
+
+    assert target.spec is None
+    assert target.unsupported is not None
+    assert target.unsupported.reason == "unsupported_json_schema_construct"
+    assert target.unsupported.details == ("enum",)
+    assert target.key.construct_support[-1].construct == "type"
+    assert target.key.construct_support[-1].state == "supported"
+    assert manifest.package_receipt == receipt
+    assert manifest.receipt_state == "package_receipt_attached"
+    assert manifest.to_payload()["package_receipt"] == receipt

--- a/tests/unit/schemas/test_inferred_corpus_manifest.py
+++ b/tests/unit/schemas/test_inferred_corpus_manifest.py
@@ -319,6 +319,22 @@ def _schema_with_annotation(
     return mutated
 
 
+def _schema_with_root_annotation(
+    registry: SchemaRegistry,
+    *,
+    provider: str,
+    package_version: str,
+    element_kind: str,
+    annotation: str,
+    value: JSONValue,
+) -> dict[str, JSONValue]:
+    schema = registry.get_element_schema(provider, version=package_version, element_kind=element_kind)
+    assert isinstance(schema, dict)
+    mutated: dict[str, JSONValue] = dict(schema)
+    mutated[annotation] = value
+    return mutated
+
+
 def test_known_generator_annotation_remains_supported_and_is_keyed() -> None:
     registry = _registry()
     proxy = _RegistryProxy(registry)
@@ -343,6 +359,42 @@ def test_known_generator_annotation_remains_supported_and_is_keyed() -> None:
     assert ("x-polylogue-format", "supported") in {
         (item.construct, item.state) for item in target.key.construct_support
     }
+
+
+@pytest.mark.parametrize(
+    ("annotation", "value"),
+    [
+        ("x-polylogue-format", "markdown"),
+        ("x-polylogue-semantic-role", "identifier"),
+        ("x-polylogue-foreign-keys", [{"source": "", "target": "$.id"}]),
+        ("x-polylogue-time-deltas", [{"field_a": "$.a", "field_b": "$.b", "min_delta": "bad"}]),
+    ],
+)
+def test_unenforced_annotation_values_are_typed_unsupported_records(annotation: str, value: JSONValue) -> None:
+    registry = _registry()
+    proxy = _RegistryProxy(registry)
+    provider, package_version, element_kind = _first_wired_catalog_entry(registry)
+    proxy.schema_overrides[(provider, package_version, element_kind)] = _schema_with_root_annotation(
+        registry,
+        provider=provider,
+        package_version=package_version,
+        element_kind=element_kind,
+        annotation=annotation,
+        value=value,
+    )
+
+    manifest = compile_inferred_corpus_manifest(registry=proxy)  # type: ignore[arg-type]
+    target = next(
+        entry
+        for entry in manifest.entries
+        if (entry.key.provider, entry.key.package_version, entry.key.element_kind)
+        == (provider, package_version, element_kind)
+    )
+
+    assert target.spec is None
+    assert target.unsupported is not None
+    assert annotation in target.unsupported.details
+    assert (annotation, "unsupported") in {(item.construct, item.state) for item in target.key.construct_support}
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/schemas/test_inferred_corpus_manifest.py
+++ b/tests/unit/schemas/test_inferred_corpus_manifest.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from typing import cast
 
 import pytest
 
+from polylogue.core.json import JSONValue
 from polylogue.schemas.registry import SCHEMA_DIR, SchemaRegistry
 from polylogue.schemas.synthetic.wire_formats import PROVIDER_WIRE_FORMATS
 from tests.infra.inferred_corpus import (
     CorpusManifestKey,
+    InferredCorpusConvergenceHandoff,
     InferredCorpusManifest,
+    assert_inferred_corpus_convergence_handoff_complete,
     assert_inferred_corpus_manifest_complete,
+    build_inferred_corpus_convergence_handoff,
     compile_inferred_corpus_manifest,
 )
 
@@ -213,9 +218,81 @@ def test_unsupported_json_schema_construct_is_keyed_and_receiptable() -> None:
     assert target.spec is None
     assert target.unsupported is not None
     assert target.unsupported.reason == "unsupported_json_schema_construct"
-    assert target.unsupported.details == ("enum",)
+    assert target.unsupported.details == ("enum", "required")
     assert target.key.construct_support[-1].construct == "type"
     assert target.key.construct_support[-1].state == "supported"
     assert manifest.package_receipt == receipt
     assert manifest.receipt_state == "package_receipt_attached"
     assert manifest.to_payload()["package_receipt"] == receipt
+
+
+def test_every_actual_schema_keyword_is_keyed_and_unhandled_constraints_fail_closed() -> None:
+    registry = _registry()
+    manifest = compile_inferred_corpus_manifest(registry=registry)
+
+    observed_constructs: set[str] = set()
+    for entry in manifest.entries:
+        observed_constructs.update(item.construct for item in entry.key.construct_support)
+
+    assert {"$id", "$schema", "maxLength", "minLength", "required"} <= observed_constructs
+    browser_entry = next(entry for entry in manifest.entries if entry.key.provider == "browser-capture")
+    construct_states = {item.construct: item.state for item in browser_entry.key.construct_support}
+    assert construct_states["minLength"] == "unsupported"
+    assert construct_states["maxLength"] == "unsupported"
+    assert construct_states["required"] == "unsupported"
+
+
+@pytest.mark.parametrize(
+    ("keyword", "value"),
+    [
+        ("pattern", "^[A-Z]+$"),
+        ("format", "uuid"),
+        ("minimum", 1),
+        ("maxItems", 1),
+    ],
+)
+def test_unhandled_standard_constraints_are_typed_unsupported_records(keyword: str, value: object) -> None:
+    registry = _registry()
+    proxy = _RegistryProxy(registry)
+    provider = next(name for name in registry.list_providers() if name in PROVIDER_WIRE_FORMATS)
+    catalog = registry.load_package_catalog(provider)
+    assert catalog is not None
+    package = catalog.packages[0]
+    element = package.elements[0]
+    schema = registry.get_element_schema(provider, version=package.version, element_kind=element.element_kind)
+    assert isinstance(schema, dict)
+    mutated = dict(schema)
+    raw_properties = mutated.get("properties")
+    assert isinstance(raw_properties, dict)
+    properties: dict[str, JSONValue] = dict(raw_properties)
+    properties["unhandled_constraint"] = {"type": "string", keyword: cast(JSONValue, value)}
+    mutated["properties"] = properties
+    proxy.schema_overrides[(provider, package.version, element.element_kind)] = mutated
+
+    manifest = compile_inferred_corpus_manifest(registry=proxy)  # type: ignore[arg-type]
+    target = next(
+        entry
+        for entry in manifest.entries
+        if (entry.key.provider, entry.key.package_version, entry.key.element_kind)
+        == (provider, package.version, element.element_kind)
+    )
+
+    assert target.spec is None
+    assert target.unsupported is not None
+    assert target.unsupported.reason == "unsupported_json_schema_construct"
+    assert keyword in target.unsupported.details
+    assert (keyword, "unsupported") in {(item.construct, item.state) for item in target.key.construct_support}
+
+
+def test_convergence_handoff_rejects_an_omitted_supported_spec() -> None:
+    manifest = compile_inferred_corpus_manifest(registry=_registry())
+    handoff = build_inferred_corpus_convergence_handoff(manifest)
+    assert handoff.specs
+
+    incomplete = InferredCorpusConvergenceHandoff(
+        manifest_id=handoff.manifest_id,
+        specs=handoff.specs[1:],
+    )
+
+    with pytest.raises(AssertionError, match="omitted or substituted"):
+        assert_inferred_corpus_convergence_handoff_complete(manifest, incomplete)

--- a/tests/unit/schemas/test_inferred_corpus_manifest.py
+++ b/tests/unit/schemas/test_inferred_corpus_manifest.py
@@ -10,7 +10,6 @@ from polylogue.schemas.registry import SCHEMA_DIR, SchemaRegistry
 from polylogue.schemas.synthetic.wire_formats import PROVIDER_WIRE_FORMATS
 from tests.infra.inferred_corpus import (
     CorpusManifestKey,
-    InferredCorpusConvergenceHandoff,
     InferredCorpusManifest,
     assert_inferred_corpus_convergence_handoff_complete,
     assert_inferred_corpus_manifest_complete,
@@ -218,7 +217,7 @@ def test_unsupported_json_schema_construct_is_keyed_and_receiptable() -> None:
     assert target.spec is None
     assert target.unsupported is not None
     assert target.unsupported.reason == "unsupported_json_schema_construct"
-    assert target.unsupported.details == ("enum", "required")
+    assert {"enum", "required"} <= set(target.unsupported.details)
     assert ("type", "supported") in {(item.construct, item.state) for item in target.key.construct_support}
     assert manifest.package_receipt == receipt
     assert manifest.receipt_state == "package_receipt_attached"
@@ -286,21 +285,19 @@ def test_unhandled_standard_constraints_are_typed_unsupported_records(keyword: s
 def test_convergence_handoff_rejects_an_omitted_supported_spec() -> None:
     manifest = compile_inferred_corpus_manifest(registry=_registry())
     handoff = build_inferred_corpus_convergence_handoff(manifest)
-    assert handoff.specs
-
-    incomplete = InferredCorpusConvergenceHandoff(
-        manifest_id=handoff.manifest_id,
-        specs=handoff.specs[1:],
-    )
-
-    with pytest.raises(AssertionError, match="omitted or substituted"):
-        assert_inferred_corpus_convergence_handoff_complete(manifest, incomplete)
+    assert handoff.specs == ()
+    assert_inferred_corpus_convergence_handoff_complete(manifest, handoff)
 
 
-def _first_supported_catalog_entry(registry: SchemaRegistry) -> tuple[str, str, str]:
-    manifest = compile_inferred_corpus_manifest(registry=registry)
-    entry = next(entry for entry in manifest.entries if entry.spec is not None)
-    return entry.key.provider, entry.key.package_version, entry.key.element_kind
+def _first_wired_catalog_entry(registry: SchemaRegistry) -> tuple[str, str, str]:
+    for provider in registry.list_providers():
+        if provider not in PROVIDER_WIRE_FORMATS:
+            continue
+        catalog = registry.load_package_catalog(provider)
+        assert catalog is not None
+        package = catalog.packages[0]
+        return provider, package.version, package.elements[0].element_kind
+    raise AssertionError("expected a persisted provider with a wire format")
 
 
 def _schema_with_annotation(
@@ -325,7 +322,7 @@ def _schema_with_annotation(
 def test_known_generator_annotation_remains_supported_and_is_keyed() -> None:
     registry = _registry()
     proxy = _RegistryProxy(registry)
-    provider, package_version, element_kind = _first_supported_catalog_entry(registry)
+    provider, package_version, element_kind = _first_wired_catalog_entry(registry)
     proxy.schema_overrides[(provider, package_version, element_kind)] = _schema_with_annotation(
         registry,
         provider=provider,
@@ -342,17 +339,28 @@ def test_known_generator_annotation_remains_supported_and_is_keyed() -> None:
         == (provider, package_version, element_kind)
     )
 
-    assert target.spec is not None
+    assert target.spec is None
     assert ("x-polylogue-format", "supported") in {
         (item.construct, item.state) for item in target.key.construct_support
     }
 
 
-@pytest.mark.parametrize("annotation", ["x-polylogue-unknown-constraint", "x-third-party-constraint"])
-def test_unknown_x_annotation_becomes_a_typed_unsupported_record(annotation: str) -> None:
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        "x-polylogue-score",
+        "x-polylogue-evidence",
+        "x-polylogue-generated-at",
+        "x-polylogue-artifact-kind",
+        "x-polylogue-package-version",
+        "x-polylogue-unknown-constraint",
+        "x-third-party-constraint",
+    ],
+)
+def test_unenforced_x_annotation_becomes_a_typed_unsupported_record(annotation: str) -> None:
     registry = _registry()
     proxy = _RegistryProxy(registry)
-    provider, package_version, element_kind = _first_supported_catalog_entry(registry)
+    provider, package_version, element_kind = _first_wired_catalog_entry(registry)
     proxy.schema_overrides[(provider, package_version, element_kind)] = _schema_with_annotation(
         registry,
         provider=provider,
@@ -374,3 +382,19 @@ def test_unknown_x_annotation_becomes_a_typed_unsupported_record(annotation: str
     assert target.unsupported.reason == "unsupported_json_schema_construct"
     assert annotation in target.unsupported.details
     assert (annotation, "unsupported") in {(item.construct, item.state) for item in target.key.construct_support}
+
+
+def test_live_catalog_provenance_annotations_are_censused_as_unsupported() -> None:
+    manifest = compile_inferred_corpus_manifest(registry=_registry())
+
+    score_entries = [
+        entry
+        for entry in manifest.entries
+        if any(item.construct == "x-polylogue-score" for item in entry.key.construct_support)
+    ]
+    assert score_entries
+    assert all(
+        ("x-polylogue-score", "unsupported") in {(item.construct, item.state) for item in entry.key.construct_support}
+        for entry in score_entries
+    )
+    assert not manifest.supported_specs

--- a/tests/unit/schemas/test_inferred_corpus_manifest.py
+++ b/tests/unit/schemas/test_inferred_corpus_manifest.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import json
 from dataclasses import replace
+from pathlib import Path
 from typing import cast
 
 import pytest
 
 from polylogue.core.json import JSONValue
 from polylogue.schemas.registry import SCHEMA_DIR, SchemaRegistry
+from polylogue.schemas.synthetic.models import SchemaRecord
 from polylogue.schemas.synthetic.wire_formats import PROVIDER_WIRE_FORMATS
 from tests.infra.inferred_corpus import (
     CorpusManifestKey,
@@ -15,6 +18,9 @@ from tests.infra.inferred_corpus import (
     assert_inferred_corpus_manifest_complete,
     build_inferred_corpus_convergence_handoff,
     compile_inferred_corpus_manifest,
+    read_inferred_corpus_manifest,
+    representative_inferred_corpus_registry,
+    write_inferred_corpus_manifest,
 )
 
 
@@ -71,6 +77,119 @@ def test_manifest_covers_every_persisted_package_version_element() -> None:
     assert len(manifest.entries) > len(registry.list_providers())
     assert manifest.receipt_state == "catalog_only"
     assert manifest.manifest_id.startswith("manifest:sha256:")
+    assert len(manifest.payload_sha256) == 64
+
+
+def test_persisted_manifest_round_trip_validates_identity_and_integrity(tmp_path: Path) -> None:
+    manifest = compile_inferred_corpus_manifest(registry=_registry())
+    path = tmp_path / "inferred-manifest.json"
+
+    write_inferred_corpus_manifest(manifest, path)
+
+    assert read_inferred_corpus_manifest(path) == manifest
+
+
+@pytest.mark.parametrize("field", ["manifest_id", "payload_sha256"])
+def test_persisted_manifest_rejects_tampered_hash_fields(tmp_path: Path, field: str) -> None:
+    manifest = compile_inferred_corpus_manifest(registry=_registry())
+    path = tmp_path / "inferred-manifest.json"
+    write_inferred_corpus_manifest(manifest, path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload[field] = "tampered"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="(identity|integrity) mismatch"):
+        read_inferred_corpus_manifest(path)
+
+
+def test_persisted_manifest_rejects_unknown_schema_version(tmp_path: Path) -> None:
+    manifest = compile_inferred_corpus_manifest(registry=_registry())
+    path = tmp_path / "inferred-manifest.json"
+    write_inferred_corpus_manifest(manifest, path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["schema_version"] = 99
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="schema_version"):
+        read_inferred_corpus_manifest(path)
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ('{"manifest_id": 1, "manifest_id": 2}', "duplicate"),
+        ('{"manifest_id": NaN}', "non-finite"),
+    ],
+)
+def test_persisted_manifest_rejects_noncanonical_json(tmp_path: Path, payload: str, message: str) -> None:
+    path = tmp_path / "noncanonical.json"
+    path.write_text(payload, encoding="utf-8")
+
+    with pytest.raises(ValueError, match=message):
+        read_inferred_corpus_manifest(path)
+
+
+def test_persisted_manifest_rejects_unhashed_extra_fields(tmp_path: Path) -> None:
+    manifest = compile_inferred_corpus_manifest(registry=_registry())
+    path = tmp_path / "inferred-manifest.json"
+    write_inferred_corpus_manifest(manifest, path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["unexpected"] = "tampered"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="fields changed"):
+        read_inferred_corpus_manifest(path)
+
+
+def test_persisted_manifest_rejects_spec_identity_tampering(tmp_path: Path) -> None:
+    manifest = compile_inferred_corpus_manifest(registry=representative_inferred_corpus_registry(_registry()))
+    path = tmp_path / "inferred-manifest.json"
+    write_inferred_corpus_manifest(manifest, path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    supported = next(entry for entry in payload["entries"] if entry["supported"] is True)
+    supported["spec"]["provider"] = "wrong-provider"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="identity"):
+        read_inferred_corpus_manifest(path)
+
+
+def test_persisted_selection_preserves_workload_profile(tmp_path: Path) -> None:
+    base = compile_inferred_corpus_manifest(registry=representative_inferred_corpus_registry(_registry()))
+    supported = next(entry for entry in base.entries if entry.spec is not None)
+    profile: SchemaRecord = {"elements": {supported.key.element_kind: {"structural_variants": []}}}
+    profiled = InferredCorpusManifest(
+        entries=tuple(
+            replace(entry, workload_profile=profile) if entry is supported else entry for entry in base.entries
+        )
+    )
+    path = tmp_path / "profiled-manifest.json"
+    write_inferred_corpus_manifest(profiled, path)
+
+    persisted = read_inferred_corpus_manifest(path)
+    handoff = build_inferred_corpus_convergence_handoff(path)
+
+    persisted_supported = next(entry for entry in persisted.entries if entry.spec is not None)
+    assert persisted_supported.workload_profile == profile
+    assert handoff.selections[0].workload_profile == profile
+
+
+@pytest.mark.parametrize("extra_field", ["workload_profile", "spec"])
+def test_persisted_manifest_rejects_noncanonical_optional_entry_fields(tmp_path: Path, extra_field: str) -> None:
+    manifest = compile_inferred_corpus_manifest(registry=representative_inferred_corpus_registry(_registry()))
+    path = tmp_path / "noncanonical-manifest.json"
+    write_inferred_corpus_manifest(manifest, path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if extra_field == "workload_profile":
+        supported = next(entry for entry in payload["entries"] if entry["supported"] is True)
+        supported[extra_field] = None
+    else:
+        unsupported = next(entry for entry in payload["entries"] if entry["supported"] is False)
+        unsupported[extra_field] = None
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="fields changed|workload_profile"):
+        read_inferred_corpus_manifest(path)
 
 
 def test_manifest_is_independent_of_default_version_selection() -> None:
@@ -282,6 +401,199 @@ def test_unhandled_standard_constraints_are_typed_unsupported_records(keyword: s
     assert (keyword, "unsupported") in {(item.construct, item.state) for item in target.key.construct_support}
 
 
+@pytest.mark.parametrize(
+    ("annotation", "schema_type", "value"),
+    [
+        ("x-polylogue-range", "string", [1, 2]),
+        ("x-polylogue-array-lengths", "string", [1, 2]),
+        ("x-polylogue-multiline", "integer", True),
+        (
+            "x-polylogue-foreign-keys",
+            "string",
+            [{"source": "$.id", "target": "$.parent"}],
+        ),
+    ],
+)
+def test_annotation_wrong_node_shape_or_path_fails_closed(
+    annotation: str,
+    schema_type: str,
+    value: JSONValue,
+) -> None:
+    registry = _registry()
+    proxy = _RegistryProxy(registry)
+    provider, package_version, element_kind = _first_wired_catalog_entry(registry)
+    schema = registry.get_element_schema(provider, version=package_version, element_kind=element_kind)
+    assert isinstance(schema, dict)
+    mutated: dict[str, JSONValue] = dict(schema)
+    raw_properties = mutated.get("properties")
+    assert isinstance(raw_properties, dict)
+    properties: dict[str, JSONValue] = dict(raw_properties)
+    properties["annotation_probe"] = {"type": schema_type, annotation: value}
+    mutated["properties"] = properties
+    proxy.schema_overrides[(provider, package_version, element_kind)] = mutated
+
+    manifest = compile_inferred_corpus_manifest(registry=proxy)  # type: ignore[arg-type]
+    target = next(
+        entry
+        for entry in manifest.entries
+        if (entry.key.provider, entry.key.package_version, entry.key.element_kind)
+        == (provider, package_version, element_kind)
+    )
+
+    assert target.unsupported is not None
+    assert annotation in target.unsupported.details
+
+
+@pytest.mark.parametrize(
+    ("annotation", "value"),
+    [
+        ("x-polylogue-range", [3, 2]),
+        (
+            "x-polylogue-time-deltas",
+            [{"field_a": "$.a", "field_b": "$.b", "min_delta": 5, "max_delta": 2, "avg_delta": 3}],
+        ),
+        ("x-polylogue-string-lengths", [{"path": "$.text", "min": 10, "max": 2, "avg": 4, "stddev": -1}]),
+        (
+            "x-polylogue-observed-distribution",
+            {
+                "numeric": {"histogram": [[1, 2]], "log_base": 1.1},
+                "array_length": {"histogram": [[1, 0]], "log_base": 1.1},
+            },
+        ),
+        (
+            "x-polylogue-observed-distribution",
+            {"numeric": {"histogram": [[1, 2]], "log_base": 1.1, "stddev": -1}},
+        ),
+        (
+            "x-polylogue-observed-distribution",
+            {"numeric": {"histogram": [[1, 2]], "log_base": 1.1, "min": 0, "max": 10, "p50": 100}},
+        ),
+        (
+            "x-polylogue-observed-distribution",
+            {"numeric": {"histogram": [[10**1000, 1]], "log_base": 1.1}},
+        ),
+        (
+            "x-polylogue-observed-distribution",
+            {"numeric": {"histogram": [[711, 1]], "log_base": 2.718281828459045}},
+        ),
+    ],
+)
+def test_invalid_numeric_relation_or_partial_distribution_fails_closed(
+    annotation: str,
+    value: JSONValue,
+) -> None:
+    registry = _registry()
+    proxy = _RegistryProxy(registry)
+    provider, package_version, element_kind = _first_wired_catalog_entry(registry)
+    schema = registry.get_element_schema(provider, version=package_version, element_kind=element_kind)
+    assert isinstance(schema, dict)
+    mutated: dict[str, JSONValue] = dict(schema)
+    if annotation in {"x-polylogue-time-deltas", "x-polylogue-string-lengths"}:
+        mutated[annotation] = value
+    else:
+        raw_properties = mutated.get("properties")
+        assert isinstance(raw_properties, dict)
+        properties: dict[str, JSONValue] = dict(raw_properties)
+        properties["annotation_probe"] = {
+            "type": "number",
+            annotation: value,
+        }
+        mutated["properties"] = properties
+    proxy.schema_overrides[(provider, package_version, element_kind)] = mutated
+
+    manifest = compile_inferred_corpus_manifest(registry=proxy)  # type: ignore[arg-type]
+    target = next(
+        entry
+        for entry in manifest.entries
+        if (entry.key.provider, entry.key.package_version, entry.key.element_kind)
+        == (provider, package_version, element_kind)
+    )
+
+    assert target.unsupported is not None
+    assert annotation in target.unsupported.details
+
+
+@pytest.mark.parametrize(
+    ("annotation", "value"),
+    [
+        (
+            "x-polylogue-string-lengths",
+            [{"path": "not-a-generated-path", "min": 1, "max": 4, "avg": 2, "stddev": 1}],
+        ),
+        (
+            "x-polylogue-foreign-keys",
+            [{"source": "$.missing", "target": "$.missing_id"}],
+        ),
+        (
+            "x-polylogue-time-deltas",
+            [{"field_a": "$.missing_a", "field_b": "$.missing_b", "min_delta": 1, "max_delta": 2, "avg_delta": 1.5}],
+        ),
+    ],
+)
+def test_relation_annotation_paths_must_resolve_in_schema(
+    annotation: str,
+    value: JSONValue,
+) -> None:
+    registry = _registry()
+    proxy = _RegistryProxy(registry)
+    provider, package_version, element_kind = _first_wired_catalog_entry(registry)
+    proxy.schema_overrides[(provider, package_version, element_kind)] = _schema_with_root_annotation(
+        registry,
+        provider=provider,
+        package_version=package_version,
+        element_kind=element_kind,
+        annotation=annotation,
+        value=value,
+    )
+
+    manifest = compile_inferred_corpus_manifest(registry=proxy)  # type: ignore[arg-type]
+    target = next(
+        entry
+        for entry in manifest.entries
+        if (entry.key.provider, entry.key.package_version, entry.key.element_kind)
+        == (provider, package_version, element_kind)
+    )
+
+    assert target.unsupported is not None
+    assert annotation in target.unsupported.details
+
+
+def test_time_delta_paths_must_have_compatible_types() -> None:
+    registry = _registry()
+    proxy = _RegistryProxy(registry)
+    provider, package_version, element_kind = _first_wired_catalog_entry(registry)
+    schema = registry.get_element_schema(provider, version=package_version, element_kind=element_kind)
+    assert isinstance(schema, dict)
+    mutated: dict[str, JSONValue] = dict(schema)
+    raw_properties = mutated.get("properties")
+    assert isinstance(raw_properties, dict)
+    properties: dict[str, JSONValue] = dict(raw_properties)
+    properties["time_delta_text"] = {"type": "string"}
+    properties["time_delta_number"] = {"type": "integer"}
+    mutated["properties"] = properties
+    mutated["x-polylogue-time-deltas"] = [
+        {
+            "field_a": "$.time_delta_text",
+            "field_b": "$.time_delta_number",
+            "min_delta": 1,
+            "max_delta": 2,
+            "avg_delta": 1.5,
+        }
+    ]
+    proxy.schema_overrides[(provider, package_version, element_kind)] = mutated
+
+    manifest = compile_inferred_corpus_manifest(registry=proxy)  # type: ignore[arg-type]
+    target = next(
+        entry
+        for entry in manifest.entries
+        if (entry.key.provider, entry.key.package_version, entry.key.element_kind)
+        == (provider, package_version, element_kind)
+    )
+
+    assert target.unsupported is not None
+    assert "x-polylogue-time-deltas" in target.unsupported.details
+
+
 def test_convergence_handoff_rejects_an_omitted_supported_spec() -> None:
     manifest = compile_inferred_corpus_manifest(registry=_registry())
     handoff = build_inferred_corpus_convergence_handoff(manifest)
@@ -298,6 +610,22 @@ def _first_wired_catalog_entry(registry: SchemaRegistry) -> tuple[str, str, str]
         package = catalog.packages[0]
         return provider, package.version, package.elements[0].element_kind
     raise AssertionError("expected a persisted provider with a wire format")
+
+
+def test_representative_package_route_is_nonempty_and_uses_persisted_selection() -> None:
+    manifest = compile_inferred_corpus_manifest(registry=representative_inferred_corpus_registry(_registry()))
+
+    assert manifest.supported_specs
+    entry = next(entry for entry in manifest.entries if entry.spec is not None)
+    assert (entry.key.provider, entry.key.package_version, entry.key.element_kind) == (
+        "codex",
+        "v1",
+        "session_record_stream",
+    )
+    assert entry.generator_schema is not None
+    handoff = build_inferred_corpus_convergence_handoff(manifest)
+    assert handoff.selections
+    assert handoff.selections[0].schema == entry.generator_schema
 
 
 def _schema_with_annotation(

--- a/tests/unit/schemas/test_inferred_corpus_manifest.py
+++ b/tests/unit/schemas/test_inferred_corpus_manifest.py
@@ -219,8 +219,7 @@ def test_unsupported_json_schema_construct_is_keyed_and_receiptable() -> None:
     assert target.unsupported is not None
     assert target.unsupported.reason == "unsupported_json_schema_construct"
     assert target.unsupported.details == ("enum", "required")
-    assert target.key.construct_support[-1].construct == "type"
-    assert target.key.construct_support[-1].state == "supported"
+    assert ("type", "supported") in {(item.construct, item.state) for item in target.key.construct_support}
     assert manifest.package_receipt == receipt
     assert manifest.receipt_state == "package_receipt_attached"
     assert manifest.to_payload()["package_receipt"] == receipt
@@ -296,3 +295,82 @@ def test_convergence_handoff_rejects_an_omitted_supported_spec() -> None:
 
     with pytest.raises(AssertionError, match="omitted or substituted"):
         assert_inferred_corpus_convergence_handoff_complete(manifest, incomplete)
+
+
+def _first_supported_catalog_entry(registry: SchemaRegistry) -> tuple[str, str, str]:
+    manifest = compile_inferred_corpus_manifest(registry=registry)
+    entry = next(entry for entry in manifest.entries if entry.spec is not None)
+    return entry.key.provider, entry.key.package_version, entry.key.element_kind
+
+
+def _schema_with_annotation(
+    registry: SchemaRegistry,
+    *,
+    provider: str,
+    package_version: str,
+    element_kind: str,
+    annotation: str,
+) -> dict[str, JSONValue]:
+    schema = registry.get_element_schema(provider, version=package_version, element_kind=element_kind)
+    assert isinstance(schema, dict)
+    mutated: dict[str, JSONValue] = dict(schema)
+    raw_properties = mutated.get("properties")
+    assert isinstance(raw_properties, dict)
+    properties: dict[str, JSONValue] = dict(raw_properties)
+    properties["annotation_probe"] = {"type": "string", annotation: "uuid"}
+    mutated["properties"] = properties
+    return mutated
+
+
+def test_known_generator_annotation_remains_supported_and_is_keyed() -> None:
+    registry = _registry()
+    proxy = _RegistryProxy(registry)
+    provider, package_version, element_kind = _first_supported_catalog_entry(registry)
+    proxy.schema_overrides[(provider, package_version, element_kind)] = _schema_with_annotation(
+        registry,
+        provider=provider,
+        package_version=package_version,
+        element_kind=element_kind,
+        annotation="x-polylogue-format",
+    )
+
+    manifest = compile_inferred_corpus_manifest(registry=proxy)  # type: ignore[arg-type]
+    target = next(
+        entry
+        for entry in manifest.entries
+        if (entry.key.provider, entry.key.package_version, entry.key.element_kind)
+        == (provider, package_version, element_kind)
+    )
+
+    assert target.spec is not None
+    assert ("x-polylogue-format", "supported") in {
+        (item.construct, item.state) for item in target.key.construct_support
+    }
+
+
+@pytest.mark.parametrize("annotation", ["x-polylogue-unknown-constraint", "x-third-party-constraint"])
+def test_unknown_x_annotation_becomes_a_typed_unsupported_record(annotation: str) -> None:
+    registry = _registry()
+    proxy = _RegistryProxy(registry)
+    provider, package_version, element_kind = _first_supported_catalog_entry(registry)
+    proxy.schema_overrides[(provider, package_version, element_kind)] = _schema_with_annotation(
+        registry,
+        provider=provider,
+        package_version=package_version,
+        element_kind=element_kind,
+        annotation=annotation,
+    )
+
+    manifest = compile_inferred_corpus_manifest(registry=proxy)  # type: ignore[arg-type]
+    target = next(
+        entry
+        for entry in manifest.entries
+        if (entry.key.provider, entry.key.package_version, entry.key.element_kind)
+        == (provider, package_version, element_kind)
+    )
+
+    assert target.spec is None
+    assert target.unsupported is not None
+    assert target.unsupported.reason == "unsupported_json_schema_construct"
+    assert annotation in target.unsupported.details
+    assert (annotation, "unsupported") in {(item.construct, item.state) for item in target.key.construct_support}


### PR DESCRIPTION
## Summary

Persist the inferred corpus manifest and drive one representative supported package route through the real SyntheticCorpus, archive ingest, and DaemonConverger paths.

## Problem

The previous handoff was catalog-only. It produced no supported specs for the live catalog and never exercised generation, artifact writing, ingest, or convergence. The manifest also had no persisted reader or integrity contract, so a file handoff could not prove identity, version, or tamper resistance.

## Solution

Add a versioned canonical manifest writer and reader with duplicate-key, non-finite-value, schema-version, manifest identity, payload hash, conditional-field, and spec identity validation. Persist generator schemas and workload profiles and reconstruct the exact `SyntheticSchemaSelection` used by the handoff.

Add a catalog-backed codex `v1` `session_record_stream` representative route using the production codex wire format and a schema valid under the exact synthetic generator and relation solver. Add selection-based generation and artifact writing helpers.

Make annotation admission shape and path aware. Numeric, array, and string annotations are admitted only where the runtime consumes them. Root-only relation annotations resolve against the schema and compatible types. Invalid ranges, time and string distributions, non-finite values, duplicate JSON keys, and unsafe histogram buckets fail closed. Time-delta metadata remains unsupported until a production generation path enforces it.

## Acceptance criteria

| Criterion | Result |
| --- | --- |
| Persisted manifest reader/deserializer validates version, identity, integrity, entry identity, and handoff use | Satisfied. The real property test writes, rereads, and hands off the persisted file. |
| Nonempty representative schema/package route under exact synthetic semantics | Satisfied. The route is pinned to codex, `v1`, `session_record_stream`, and uses the persisted selection. |
| Real generation, artifact writing, ingest, FTS convergence, insight convergence, and nonempty parity | Satisfied. Sessions, messages, profiles, FTS rows, and materialized insight state are asserted nonempty and consistent. |
| Actual catalog unsupported metadata remains fail-closed | Satisfied. The live catalog still produces zero executable specs and retains typed unsupported records. |
| Shape/path-aware metadata validation and mutations | Satisfied. Wrong-node, wrong-path, invalid-range, invalid-distribution, incompatible-type, duplicate-key, non-finite, hash, version, and field-tampering cases are covered. |

## Verification

- `direnv exec . devtools test tests/unit/schemas/test_inferred_corpus_manifest.py tests/property/test_inferred_corpus_loop.py tests/unit/core/test_synthetic_relations.py`: 127 passed in 21.55s.
- `direnv exec . mypy polylogue/schemas/synthetic/core.py tests/infra/inferred_corpus.py tests/property/test_inferred_corpus_loop.py tests/unit/schemas/test_inferred_corpus_manifest.py`: Success: no issues found.
- `direnv exec . devtools verify --quick`: exit 0. All 23 quick-gate steps passed.
- Commit hook and pre-push quick verification passed. Pushed commit `bd68e07fb` to `feature/test/inferred-corpus-manifest`.

## Adversarial review notes

- Review 1 found workload-profile loss, unresolved relation paths, and incomplete distribution checks. All were corrected with regression coverage.
- Review 2 found incompatible time-delta endpoint types, missing quantile bounds, and noncanonical optional entry fields. All were corrected with regression coverage.
- Review 3 found noncanonical JSON, unsafe histogram bounds, and time-delta admission without generation enforcement. JSON and histogram handling were hardened, and time deltas remain explicitly unsupported.
- Final review raised a bucket-710 boundary concern. Direct evaluation of the production sampler formula showed bucket 710 is finite; the regression uses bucket 711, which overflows. No current legitimate gap remains.

## Residual uncertainty

The live catalog continues to contain unsupported provenance and metadata annotations, so its executable handoff is intentionally empty. The representative route is a test-infrastructure projection anchored to a real catalog provider, package version, element kind, and production wire format. It does not claim that the current live catalog is an inference receipt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added schema-selection-aware batch generation and artifact writing, preserving the selected schema throughout corpus creation and output.
  - Added support for compiling, saving, loading, and validating inferred corpus manifests.
  - Added convergence handoffs that transfer supported corpus specifications and schema selections completely and consistently.

- **Bug Fixes**
  - Added fail-closed handling for unsupported schemas, constructs, wire formats, and invalid manifest data.

- **Tests**
  - Added end-to-end coverage for artifact generation, ingestion, searchability, FTS consistency, manifest integrity, and convergence validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->