### PR TITLE
feat: add rebuild work observability

### DIFF
--- a/polylogue/core/enums.py
+++ b/polylogue/core/enums.py
@@ -26,6 +26,15 @@ class OperationStatus(PolylogueStrEnum):
     INTERRUPTED = "interrupted"
 
 
+class SloSampleLabel(PolylogueStrEnum):
+    """Closed labels for optional daemon steady-state telemetry."""
+
+    BACKLOG = "backlog"
+    OFFERED_WORK = "offered_work"
+    DRAIN_RATE = "drain_rate"
+    INGEST_LATENCY = "ingest_latency"
+
+
 OPERATION_LIFECYCLE_STATUSES: tuple[OperationStatus, ...] = (
     OperationStatus.RUNNING,
     OperationStatus.COMPLETED,

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -2038,12 +2038,15 @@ async def run_live_watcher(
     sources: tuple[WatchSource, ...],
     debounce_s: float,
 ) -> None:
+    from polylogue.daemon.events import emit_catch_up_cycle
+
     async with Polylogue() as polylogue:
         watcher = LiveWatcher(
             polylogue,
             sources,
             debounce_s=debounce_s,
             event_emitter=_emit_live_batch_event,
+            catch_up_event_emitter=emit_catch_up_cycle,
             write_coordinator=daemon_write_coordinator(),
         )
         try:
@@ -2511,6 +2514,8 @@ async def run_daemon_services(
         # convergence coupling (polylogue-gbs02).
         try:
             if enable_watch and not watcher_creation_blocked:
+                from polylogue.daemon.events import emit_catch_up_cycle
+
                 async with Polylogue() as polylogue:
                     watcher = LiveWatcher(
                         polylogue,
@@ -2518,6 +2523,7 @@ async def run_daemon_services(
                         debounce_s=debounce_s,
                         converger=converger,
                         event_emitter=_emit_live_batch_event,
+                        catch_up_event_emitter=emit_catch_up_cycle,
                         write_coordinator=write_coordinator,
                     )
                     watcher_catch_up_complete = getattr(watcher, "catch_up_complete", None)

--- a/polylogue/daemon/events.py
+++ b/polylogue/daemon/events.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from polylogue.paths import archive_root
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
@@ -27,6 +28,8 @@ CREATE TABLE IF NOT EXISTS daemon_events (
  ) STRICT;
 CREATE INDEX IF NOT EXISTS idx_daemon_events_kind ON daemon_events(kind);
 CREATE INDEX IF NOT EXISTS idx_daemon_events_ts ON daemon_events(ts_ms);
+CREATE INDEX IF NOT EXISTS idx_daemon_events_kind_id ON daemon_events(kind, id DESC);
+CREATE INDEX IF NOT EXISTS idx_daemon_events_lifecycle ON daemon_events(kind, operation_id, id DESC);
 """
 
 
@@ -86,6 +89,14 @@ class CatchUpCycleTerminalOutcome(StrEnum):
     FAILURE = "failure"
     CANCELLED = "cancelled"
     STOPPED = "stopped"
+
+
+@dataclass(frozen=True)
+class CatchUpLifecycleHistory:
+    """Bounded catch-up evidence with an explicit completeness result."""
+
+    events: tuple[dict[str, object], ...]
+    incomplete: bool
 
 
 def _iso_from_ms(value: object) -> str:
@@ -158,58 +169,74 @@ def query_daemon_events(
         conn.close()
 
 
-def query_recent_catch_up_lifecycles(*, limit: int = 20) -> Sequence[dict[str, object]]:
-    """Return complete event histories for the most recent catch-up operations.
+def query_recent_catch_up_lifecycles(*, limit: int = 32) -> CatchUpLifecycleHistory:
+    """Return bounded, complete histories for recent catch-up identities.
 
-    The bound applies to lifecycle identities, rather than arbitrary ledger
-    rows. Each selected operation returns every persisted start, end, and
-    terminal boundary so SLO projection can verify its own pairing even when
-    unrelated daemon traffic is busy. The newest bulk-import marker is included
-    as the other event source that changes the catch-up verdict.
+    A valid lifecycle writes at most start, end, and terminal receipts. The
+    indexed seed query therefore reads at most ``limit * 3 + 1`` catch-up
+    rows, then each selected identity receives at most four indexed receipts:
+    three valid boundaries plus one overflow detector. Any older tail, excess
+    identity, malformed operation id, or repeated identity receipt marks the
+    result incomplete so status cannot hide it behind a newer healthy cycle.
     """
     if limit < 1:
         raise ValueError("catch-up lifecycle limit must be positive")
     conn = _open_events_reader()
     if conn is None:
-        return []
+        return CatchUpLifecycleHistory(events=(), incomplete=False)
     try:
-        rows = conn.execute(
-            """
-            WITH recent_operations AS (
-                SELECT operation_id, MAX(id) AS latest_id
-                FROM daemon_events
-                WHERE kind = 'catch_up_cycle' AND operation_id IS NOT NULL
-                GROUP BY operation_id
-                ORDER BY latest_id DESC
-                LIMIT ?
-            ), latest_bulk_import_marker AS (
-                SELECT id, ts_ms, kind, operation_id, payload_json
-                FROM daemon_events
-                WHERE kind IN ('bulk_import_started', 'bulk_import_opened', 'bulk_import_completed', 'bulk_import_closed')
-                ORDER BY id DESC
-                LIMIT 1
-            )
-            SELECT event.id, event.ts_ms, event.kind, event.operation_id, event.payload_json
-            FROM daemon_events AS event
-            JOIN recent_operations AS recent USING (operation_id)
-            WHERE event.kind = 'catch_up_cycle'
-            UNION ALL
-            SELECT id, ts_ms, kind, operation_id, payload_json
-            FROM latest_bulk_import_marker
-            ORDER BY id DESC
-            """,
-            (limit,),
+        seed_limit = limit * 3
+        seed_rows = conn.execute(
+            "SELECT id, ts_ms, kind, operation_id, payload_json "
+            "FROM daemon_events WHERE kind = 'catch_up_cycle' "
+            "ORDER BY id DESC LIMIT ?",
+            (seed_limit + 1,),
         ).fetchall()
-        return [
-            {
-                "id": row[0],
-                "ts": _iso_from_ms(row[1]),
-                "kind": row[2],
-                "operation_id": row[3],
-                "payload": json.loads(row[4]),
-            }
-            for row in rows
-        ]
+        incomplete = len(seed_rows) > seed_limit
+        operation_ids: list[str] = []
+        for row in seed_rows[:seed_limit]:
+            operation_id = row[3]
+            if not isinstance(operation_id, str):
+                incomplete = True
+            elif operation_id not in operation_ids:
+                if len(operation_ids) == limit:
+                    incomplete = True
+                else:
+                    operation_ids.append(operation_id)
+
+        lifecycle_rows: list[tuple[object, ...]] = []
+        for operation_id in operation_ids:
+            rows = conn.execute(
+                "SELECT id, ts_ms, kind, operation_id, payload_json "
+                "FROM daemon_events WHERE kind = 'catch_up_cycle' AND operation_id = ? "
+                "ORDER BY id DESC LIMIT 4",
+                (operation_id,),
+            ).fetchall()
+            lifecycle_rows.extend(rows)
+            if len(rows) == 4:
+                incomplete = True
+
+        marker = conn.execute(
+            "SELECT id, ts_ms, kind, operation_id, payload_json FROM daemon_events "
+            "WHERE kind IN ('bulk_import_started', 'bulk_import_opened', 'bulk_import_completed', 'bulk_import_closed') "
+            "ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+        if marker is not None:
+            lifecycle_rows.append(marker)
+        lifecycle_rows.sort(key=lambda row: int(cast(int | str | bytes | bytearray, row[0])), reverse=True)
+        return CatchUpLifecycleHistory(
+            events=tuple(
+                {
+                    "id": row[0],
+                    "ts": _iso_from_ms(row[1]),
+                    "kind": row[2],
+                    "operation_id": row[3],
+                    "payload": json.loads(cast(str | bytes | bytearray, row[4])),
+                }
+                for row in lifecycle_rows
+            ),
+            incomplete=incomplete,
+        )
     finally:
         conn.close()
 
@@ -468,6 +495,7 @@ def get_daemon_event_counts() -> dict[str, int]:
 
 
 __all__ = [
+    "CatchUpLifecycleHistory",
     "CatchUpCycleTerminalOutcome",
     "EVENT_SESSION_APPENDED",
     "EVENT_SESSION_UPDATED",

--- a/polylogue/daemon/events.py
+++ b/polylogue/daemon/events.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from datetime import UTC, datetime
+from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -74,8 +75,17 @@ def _open_events_reader() -> sqlite3.Connection | None:
     return conn
 
 
-def _now_ms() -> int:
+def current_epoch_ms() -> int:
     return int(datetime.now(UTC).timestamp() * 1000)
+
+
+class CatchUpCycleTerminalOutcome(StrEnum):
+    """Typed terminal outcomes for a catch-up lifecycle."""
+
+    SUCCESS = "success"
+    FAILURE = "failure"
+    CANCELLED = "cancelled"
+    STOPPED = "stopped"
 
 
 def _iso_from_ms(value: object) -> str:
@@ -100,7 +110,7 @@ def emit_daemon_event(
         conn.execute(
             "INSERT INTO daemon_events (ts_ms, kind, operation_id, payload_json) VALUES (?, ?, ?, ?)",
             (
-                _now_ms(),
+                current_epoch_ms(),
                 kind,
                 operation_id,
                 json.dumps(payload or {}),
@@ -235,6 +245,7 @@ def emit_catch_up_cycle(
     duration_ms: float,
     stage_timings_s: Mapping[str, float] | None,
     repair: Mapping[str, object] | None,
+    terminal_outcome: CatchUpCycleTerminalOutcome | str | None = None,
 ) -> None:
     """Emit one catch-up convergence cycle envelope.
 
@@ -242,9 +253,20 @@ def emit_catch_up_cycle(
     attempts taxonomy, errors, queue/backlog, repair state, per-stage timings)
     so downstream tooling can read durable evidence without scraping logs.
 
-    ``phase`` is ``"start"`` or ``"end"``; the same ``operation_id`` ties them
-    together. End events carry the realized counts and timings.
+    ``phase`` is ``"start"``, ``"end"``, or ``"terminal"``. Terminal events
+    require a typed outcome. The same ``operation_id`` ties every boundary
+    together, while an end event remains the realized backlog measurement.
     """
+    if phase not in {"start", "end", "terminal"}:
+        raise ValueError(f"unsupported catch-up cycle phase: {phase!r}")
+    if phase == "terminal":
+        if terminal_outcome is None:
+            raise ValueError("terminal catch-up cycle events require an outcome")
+        resolved_terminal_outcome = CatchUpCycleTerminalOutcome(terminal_outcome)
+    elif terminal_outcome is not None:
+        raise ValueError("only terminal catch-up cycle events may carry an outcome")
+    else:
+        resolved_terminal_outcome = None
     payload: dict[str, object] = {
         "phase": phase,
         "backlog_start": backlog_start,
@@ -262,6 +284,7 @@ def emit_catch_up_cycle(
             {key: round(float(value), 6) for key, value in stage_timings_s.items()} if stage_timings_s else {}
         ),
         "repair": dict(repair) if repair is not None else None,
+        "terminal_outcome": (resolved_terminal_outcome.value if resolved_terminal_outcome is not None else None),
     }
     emit_daemon_event("catch_up_cycle", operation_id=operation_id, payload=payload)
 
@@ -389,6 +412,7 @@ def get_daemon_event_counts() -> dict[str, int]:
 
 
 __all__ = [
+    "CatchUpCycleTerminalOutcome",
     "EVENT_SESSION_APPENDED",
     "EVENT_SESSION_UPDATED",
     "EVENT_MESSAGE_APPENDED",
@@ -402,6 +426,7 @@ __all__ = [
     "get_last_ingestion_batch",
     "get_latest_event_id",
     "get_recent_operations",
+    "current_epoch_ms",
     "query_daemon_events",
     "query_events_since",
 ]

--- a/polylogue/daemon/events.py
+++ b/polylogue/daemon/events.py
@@ -158,6 +158,62 @@ def query_daemon_events(
         conn.close()
 
 
+def query_recent_catch_up_lifecycles(*, limit: int = 20) -> Sequence[dict[str, object]]:
+    """Return complete event histories for the most recent catch-up operations.
+
+    The bound applies to lifecycle identities, rather than arbitrary ledger
+    rows. Each selected operation returns every persisted start, end, and
+    terminal boundary so SLO projection can verify its own pairing even when
+    unrelated daemon traffic is busy. The newest bulk-import marker is included
+    as the other event source that changes the catch-up verdict.
+    """
+    if limit < 1:
+        raise ValueError("catch-up lifecycle limit must be positive")
+    conn = _open_events_reader()
+    if conn is None:
+        return []
+    try:
+        rows = conn.execute(
+            """
+            WITH recent_operations AS (
+                SELECT operation_id, MAX(id) AS latest_id
+                FROM daemon_events
+                WHERE kind = 'catch_up_cycle' AND operation_id IS NOT NULL
+                GROUP BY operation_id
+                ORDER BY latest_id DESC
+                LIMIT ?
+            ), latest_bulk_import_marker AS (
+                SELECT id, ts_ms, kind, operation_id, payload_json
+                FROM daemon_events
+                WHERE kind IN ('bulk_import_started', 'bulk_import_opened', 'bulk_import_completed', 'bulk_import_closed')
+                ORDER BY id DESC
+                LIMIT 1
+            )
+            SELECT event.id, event.ts_ms, event.kind, event.operation_id, event.payload_json
+            FROM daemon_events AS event
+            JOIN recent_operations AS recent USING (operation_id)
+            WHERE event.kind = 'catch_up_cycle'
+            UNION ALL
+            SELECT id, ts_ms, kind, operation_id, payload_json
+            FROM latest_bulk_import_marker
+            ORDER BY id DESC
+            """,
+            (limit,),
+        ).fetchall()
+        return [
+            {
+                "id": row[0],
+                "ts": _iso_from_ms(row[1]),
+                "kind": row[2],
+                "operation_id": row[3],
+                "payload": json.loads(row[4]),
+            }
+            for row in rows
+        ]
+    finally:
+        conn.close()
+
+
 def query_events_since(
     last_id: int,
     *,
@@ -429,4 +485,5 @@ __all__ = [
     "current_epoch_ms",
     "query_daemon_events",
     "query_events_since",
+    "query_recent_catch_up_lifecycles",
 ]

--- a/polylogue/daemon/events.py
+++ b/polylogue/daemon/events.py
@@ -26,10 +26,6 @@ CREATE TABLE IF NOT EXISTS daemon_events (
     operation_id TEXT,
     payload_json TEXT NOT NULL
  ) STRICT;
-CREATE INDEX IF NOT EXISTS idx_daemon_events_kind ON daemon_events(kind);
-CREATE INDEX IF NOT EXISTS idx_daemon_events_ts ON daemon_events(ts_ms);
-CREATE INDEX IF NOT EXISTS idx_daemon_events_kind_id ON daemon_events(kind, id DESC);
-CREATE INDEX IF NOT EXISTS idx_daemon_events_lifecycle ON daemon_events(kind, operation_id, id DESC);
 """
 
 
@@ -97,6 +93,11 @@ class CatchUpLifecycleHistory:
 
     events: tuple[dict[str, object], ...]
     incomplete: bool
+
+
+_CATCH_UP_LIFECYCLE_IDENTITY_LIMIT = 32
+_CATCH_UP_LIFECYCLE_RECEIPT_LIMIT = 4
+CATCH_UP_LIFECYCLE_RETURN_LIMIT = _CATCH_UP_LIFECYCLE_IDENTITY_LIMIT * _CATCH_UP_LIFECYCLE_RECEIPT_LIMIT + 1
 
 
 def _iso_from_ms(value: object) -> str:
@@ -169,23 +170,21 @@ def query_daemon_events(
         conn.close()
 
 
-def query_recent_catch_up_lifecycles(*, limit: int = 32) -> CatchUpLifecycleHistory:
+def query_recent_catch_up_lifecycles() -> CatchUpLifecycleHistory:
     """Return bounded, complete histories for recent catch-up identities.
 
     A valid lifecycle writes at most start, end, and terminal receipts. The
-    indexed seed query therefore reads at most ``limit * 3 + 1`` catch-up
+    indexed seed query therefore reads at most ``32 * 3 + 1`` catch-up
     rows, then each selected identity receives at most four indexed receipts:
     three valid boundaries plus one overflow detector. Any older tail, excess
     identity, malformed operation id, or repeated identity receipt marks the
     result incomplete so status cannot hide it behind a newer healthy cycle.
     """
-    if limit < 1:
-        raise ValueError("catch-up lifecycle limit must be positive")
     conn = _open_events_reader()
     if conn is None:
         return CatchUpLifecycleHistory(events=(), incomplete=False)
     try:
-        seed_limit = limit * 3
+        seed_limit = _CATCH_UP_LIFECYCLE_IDENTITY_LIMIT * 3
         seed_rows = conn.execute(
             "SELECT id, ts_ms, kind, operation_id, payload_json "
             "FROM daemon_events WHERE kind = 'catch_up_cycle' "
@@ -199,7 +198,7 @@ def query_recent_catch_up_lifecycles(*, limit: int = 32) -> CatchUpLifecycleHist
             if not isinstance(operation_id, str):
                 incomplete = True
             elif operation_id not in operation_ids:
-                if len(operation_ids) == limit:
+                if len(operation_ids) == _CATCH_UP_LIFECYCLE_IDENTITY_LIMIT:
                     incomplete = True
                 else:
                     operation_ids.append(operation_id)
@@ -209,11 +208,11 @@ def query_recent_catch_up_lifecycles(*, limit: int = 32) -> CatchUpLifecycleHist
             rows = conn.execute(
                 "SELECT id, ts_ms, kind, operation_id, payload_json "
                 "FROM daemon_events WHERE kind = 'catch_up_cycle' AND operation_id = ? "
-                "ORDER BY id DESC LIMIT 4",
-                (operation_id,),
+                "ORDER BY id DESC LIMIT ?",
+                (operation_id, _CATCH_UP_LIFECYCLE_RECEIPT_LIMIT),
             ).fetchall()
             lifecycle_rows.extend(rows)
-            if len(rows) == 4:
+            if len(rows) == _CATCH_UP_LIFECYCLE_RECEIPT_LIMIT:
                 incomplete = True
 
         marker = conn.execute(
@@ -224,19 +223,19 @@ def query_recent_catch_up_lifecycles(*, limit: int = 32) -> CatchUpLifecycleHist
         if marker is not None:
             lifecycle_rows.append(marker)
         lifecycle_rows.sort(key=lambda row: int(cast(int | str | bytes | bytearray, row[0])), reverse=True)
-        return CatchUpLifecycleHistory(
-            events=tuple(
-                {
-                    "id": row[0],
-                    "ts": _iso_from_ms(row[1]),
-                    "kind": row[2],
-                    "operation_id": row[3],
-                    "payload": json.loads(cast(str | bytes | bytearray, row[4])),
-                }
-                for row in lifecycle_rows
-            ),
-            incomplete=incomplete,
+        events = tuple(
+            {
+                "id": row[0],
+                "ts": _iso_from_ms(row[1]),
+                "kind": row[2],
+                "operation_id": row[3],
+                "payload": json.loads(cast(str | bytes | bytearray, row[4])),
+            }
+            for row in lifecycle_rows
         )
+        if len(events) > CATCH_UP_LIFECYCLE_RETURN_LIMIT:
+            raise RuntimeError("catch-up lifecycle query exceeded its fixed return bound")
+        return CatchUpLifecycleHistory(events=events, incomplete=incomplete)
     finally:
         conn.close()
 
@@ -495,6 +494,7 @@ def get_daemon_event_counts() -> dict[str, int]:
 
 
 __all__ = [
+    "CATCH_UP_LIFECYCLE_RETURN_LIMIT",
     "CatchUpLifecycleHistory",
     "CatchUpCycleTerminalOutcome",
     "EVENT_SESSION_APPENDED",

--- a/polylogue/daemon/slo.py
+++ b/polylogue/daemon/slo.py
@@ -76,6 +76,12 @@ class BacklogWindow(BaseModel):
     bulk_import_suppressed: bool = False
 
 
+# Cancellation and a cooperative stop both leave the requested catch-up cycle
+# without a successful drain measurement. They share FAILED intentionally: the
+# operator action is the same as an execution failure, inspect and redrive the
+# outstanding backlog rather than treat the cycle as healthy or merely idle.
+
+
 class IngestSloStatus(BaseModel):
     """Status/readiness projection for the live ingest SLO."""
 
@@ -90,6 +96,7 @@ class IngestSloStatus(BaseModel):
     cursor_lag_stuck_file_count: int = 0
     cursor_lag_degraded_file_count: int = 0
     bulk_import_suppressed: bool = False
+    lifecycle_history_incomplete: bool = False
     latest_window: BacklogWindow | None = None
     reductions: dict[str, SloReduction] = Field(default_factory=dict)
 
@@ -122,10 +129,9 @@ def _event_observed_at_ms(event: Mapping[str, object]) -> int | None:
     return int(timestamp.timestamp() * 1000)
 
 
-def _event_order_key(index: int, event: Mapping[str, object]) -> tuple[int, int, int]:
-    """Order event projections by their persisted timestamp, then event id."""
-    observed_at_ms = _event_observed_at_ms(event)
-    return (observed_at_ms if observed_at_ms is not None else -1, _int(event, "id"), index)
+def _event_order_key(index: int, event: Mapping[str, object]) -> tuple[int, int]:
+    """Order lifecycle transitions by SQLite insertion identity, then input order."""
+    return (_int(event, "id"), index)
 
 
 def _events_newest_first(events: Sequence[Mapping[str, object]]) -> list[Mapping[str, object]]:
@@ -228,9 +234,9 @@ def project_backlog_windows(
 ) -> tuple[BacklogWindow, ...]:
     """Return bounded windows from the existing event stream, newest first."""
     suppressed = bulk_import_is_open(events) if bulk_import_suppressed is None else bulk_import_suppressed
-    completed: list[tuple[tuple[int, int, int], BacklogWindow]] = []
+    completed: list[tuple[tuple[int, int], BacklogWindow]] = []
     completed_lifecycles: set[str] = set()
-    active: dict[str, tuple[tuple[int, int, int], BacklogWindow]] = {}
+    active: dict[str, tuple[tuple[int, int], BacklogWindow]] = {}
     for index, event in sorted(enumerate(events), key=lambda item: _event_order_key(*item)):
         window = backlog_window_from_event(event, bulk_import_suppressed=suppressed)
         if window is None:
@@ -383,7 +389,14 @@ def slo_status_info(
     now_ms: int | None = None,
 ) -> IngestSloStatus:
     """Build status from existing event and cursor-lag sources only."""
-    resolved_events = list(events) if events is not None else list(query_recent_catch_up_lifecycles())
+    resolved_events: list[Mapping[str, object]]
+    if events is None:
+        history = query_recent_catch_up_lifecycles()
+        resolved_events = list(history.events)
+        history_incomplete = history.incomplete
+    else:
+        resolved_events = list(events)
+        history_incomplete = False
     suppressed = bulk_import_is_open(resolved_events)
     windows = project_backlog_windows(
         resolved_events,
@@ -391,6 +404,17 @@ def slo_status_info(
         now_ms=current_epoch_ms() if now_ms is None else now_ms,
     )
     latest = windows[0] if windows else None
+    if history_incomplete:
+        return IngestSloStatus(
+            available=latest is not None,
+            verdict=SloVerdict.UNKNOWN,
+            reason="catch-up lifecycle history is incomplete",
+            cursor_lag_stuck_file_count=cursor_lag.stuck_file_count,
+            cursor_lag_degraded_file_count=cursor_lag.degraded_file_count,
+            bulk_import_suppressed=suppressed,
+            lifecycle_history_incomplete=True,
+            latest_window=latest,
+        )
     if latest is None:
         return IngestSloStatus(
             cursor_lag_stuck_file_count=cursor_lag.stuck_file_count,
@@ -408,6 +432,7 @@ def slo_status_info(
         cursor_lag_stuck_file_count=cursor_lag.stuck_file_count,
         cursor_lag_degraded_file_count=cursor_lag.degraded_file_count,
         bulk_import_suppressed=latest.bulk_import_suppressed,
+        lifecycle_history_incomplete=False,
         latest_window=latest,
     )
 

--- a/polylogue/daemon/slo.py
+++ b/polylogue/daemon/slo.py
@@ -1,0 +1,294 @@
+"""Steady-state ingest SLO projection over existing daemon evidence.
+
+The daemon event ledger and cursor-lag projection remain the sources of truth.
+This module adds only a bounded reducer and optional numeric samples. It never
+recounts source files or creates a second backlog ledger.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from polylogue.core.enums import SloSampleLabel
+from polylogue.core.stats import percentile
+from polylogue.daemon.cursor_lag_status import CursorLagSummary
+from polylogue.daemon.events import query_daemon_events
+from polylogue.operations.slo import (
+    ArchiveSloSample,
+    list_slo_samples,
+    record_slo_sample,
+)
+
+
+class SloVerdict(StrEnum):
+    UNKNOWN = "unknown"
+    HEALTHY = "healthy"
+    IDLE = "idle"
+    DRAINING = "draining"
+    STALLED = "stalled"
+    SUPPRESSED = "suppressed"
+
+
+class SloReduction(BaseModel):
+    """Reducer output for one label, honest about cold-start fields."""
+
+    label: str
+    sample_count: int = 0
+    level: float | None = None
+    p50: float | None = None
+    p95: float | None = None
+    slope_per_s: float | None = None
+    eta_s: float | None = None
+    burn_rate: float | None = None
+    confident: bool = False
+
+
+class BacklogWindow(BaseModel):
+    """One bounded catch-up window derived from a catch-up cycle end event."""
+
+    operation_id: str | None = None
+    observed_at_ms: int = 0
+    duration_s: float = 0.0
+    backlog_start: int = 0
+    backlog_end: int = 0
+    offered_work: int = 0
+    drained_work: int = 0
+    drain_rate_per_s: float = 0.0
+    offered_rate_per_s: float = 0.0
+    verdict: SloVerdict = SloVerdict.UNKNOWN
+    reason: str = "no catch-up cycle evidence"
+    bulk_import_suppressed: bool = False
+
+
+class IngestSloStatus(BaseModel):
+    """Status/readiness projection for the live ingest SLO."""
+
+    available: bool = False
+    verdict: SloVerdict = SloVerdict.UNKNOWN
+    reason: str = "cold start: no catch-up cycle evidence"
+    backlog: int = 0
+    offered_work: int = 0
+    drained_work: int = 0
+    drain_rate_per_s: float = 0.0
+    offered_rate_per_s: float = 0.0
+    cursor_lag_stuck_file_count: int = 0
+    cursor_lag_degraded_file_count: int = 0
+    bulk_import_suppressed: bool = False
+    latest_window: BacklogWindow | None = None
+    reductions: dict[str, SloReduction] = Field(default_factory=dict)
+
+
+_BULK_IMPORT_START_KINDS = frozenset({"bulk_import_started", "bulk_import_opened"})
+_BULK_IMPORT_END_KINDS = frozenset({"bulk_import_completed", "bulk_import_closed"})
+
+
+def _int(payload: Mapping[str, object], key: str) -> int:
+    value = payload.get(key, 0)
+    return max(0, int(value)) if isinstance(value, int | float | str) and not isinstance(value, bool) else 0
+
+
+def _float(payload: Mapping[str, object], key: str) -> float:
+    value = payload.get(key, 0.0)
+    return max(0.0, float(value)) if isinstance(value, int | float | str) and not isinstance(value, bool) else 0.0
+
+
+def bulk_import_is_open(events: Sequence[Mapping[str, object]]) -> bool:
+    """Return whether the newest explicit bulk-import marker is still open."""
+    for event in events:
+        kind = event.get("kind")
+        if not isinstance(kind, str):
+            continue
+        if kind in _BULK_IMPORT_START_KINDS:
+            return True
+        if kind in _BULK_IMPORT_END_KINDS:
+            return False
+    return False
+
+
+def backlog_window_from_event(
+    event: Mapping[str, object],
+    *,
+    bulk_import_suppressed: bool = False,
+) -> BacklogWindow | None:
+    """Project one existing ``catch_up_cycle`` end event into a verdict."""
+    if event.get("kind") != "catch_up_cycle":
+        return None
+    payload = event.get("payload")
+    if not isinstance(payload, Mapping) or payload.get("phase") != "end":
+        return None
+    duration_s = _float(payload, "duration_ms") / 1000.0
+    backlog_start = _int(payload, "backlog_start")
+    backlog_end = _int(payload, "backlog_end")
+    offered_work = _int(payload, "discovered")
+    drained_work = min(
+        backlog_start, _int(payload, "ingested") + _int(payload, "quarantine_count") + _int(payload, "skipped")
+    )
+    drain_rate = drained_work / duration_s if duration_s > 0 else 0.0
+    offered_rate = offered_work / duration_s if duration_s > 0 else 0.0
+    if bulk_import_suppressed:
+        verdict = SloVerdict.SUPPRESSED
+        reason = "bulk-import marker is open"
+    elif backlog_end <= 0:
+        verdict = SloVerdict.HEALTHY
+        reason = "backlog drained"
+    elif offered_work <= 0:
+        verdict = SloVerdict.IDLE
+        reason = "backlog exists but no work was offered in this window"
+    elif drained_work <= 0:
+        verdict = SloVerdict.STALLED
+        reason = "work was offered but no backlog unit drained"
+    else:
+        verdict = SloVerdict.DRAINING
+        reason = "offered work is draining the backlog"
+    observed_at_ms = _int(event, "ts_ms")
+    if observed_at_ms == 0:
+        observed_at_ms = _int(payload, "observed_at_ms")
+    operation_id = event.get("operation_id")
+    return BacklogWindow(
+        operation_id=operation_id if isinstance(operation_id, str) else None,
+        observed_at_ms=observed_at_ms,
+        duration_s=round(duration_s, 6),
+        backlog_start=backlog_start,
+        backlog_end=backlog_end,
+        offered_work=offered_work,
+        drained_work=drained_work,
+        drain_rate_per_s=round(drain_rate, 6),
+        offered_rate_per_s=round(offered_rate, 6),
+        verdict=verdict,
+        reason=reason,
+        bulk_import_suppressed=bulk_import_suppressed,
+    )
+
+
+def project_backlog_windows(
+    events: Sequence[Mapping[str, object]],
+    *,
+    bulk_import_suppressed: bool | None = None,
+) -> tuple[BacklogWindow, ...]:
+    """Return bounded windows from the existing event stream, newest first."""
+    suppressed = bulk_import_is_open(events) if bulk_import_suppressed is None else bulk_import_suppressed
+    windows = [
+        window
+        for event in events
+        if (window := backlog_window_from_event(event, bulk_import_suppressed=suppressed)) is not None
+    ]
+    return tuple(windows[:20])
+
+
+def reduce_slo_samples(
+    samples: Sequence[ArchiveSloSample],
+    *,
+    target_rate: float | None = None,
+) -> SloReduction:
+    """Compute level, quantiles, slope, ETA, and optional burn rate."""
+    if not samples:
+        return SloReduction(label="unknown")
+    ordered = sorted(samples, key=lambda sample: sample.observed_at_ms)
+    values = [float(sample.value) for sample in ordered]
+    label = ordered[-1].label
+    first, latest = ordered[0], ordered[-1]
+    delta_s = (latest.observed_at_ms - first.observed_at_ms) / 1000.0
+    slope = (latest.value - first.value) / delta_s if len(ordered) > 1 and delta_s > 0 else None
+    eta_s = None
+    if label == SloSampleLabel.BACKLOG.value and slope is not None and slope < 0 and latest.value > 0:
+        eta_s = latest.value / -slope
+    burn_rate = None
+    if target_rate is not None and target_rate > 0:
+        burn_rate = latest.value / target_rate
+    return SloReduction(
+        label=label,
+        sample_count=len(ordered),
+        level=round(latest.value, 6),
+        p50=round(percentile(values, 0.50), 6),
+        p95=round(percentile(values, 0.95), 6),
+        slope_per_s=round(slope, 6) if slope is not None else None,
+        eta_s=round(eta_s, 3) if eta_s is not None and math.isfinite(eta_s) else None,
+        burn_rate=round(burn_rate, 6) if burn_rate is not None else None,
+        confident=len(ordered) >= 2,
+    )
+
+
+def record_backlog_window_sample(ops_db: Path, window: BacklogWindow) -> tuple[str, ...]:
+    """Persist numeric samples from one derived window in disposable ops state."""
+    observed_at_ms = window.observed_at_ms or int(datetime.now(UTC).timestamp() * 1000)
+    values = (
+        (SloSampleLabel.BACKLOG, float(window.backlog_end)),
+        (SloSampleLabel.OFFERED_WORK, float(window.offered_work)),
+        (SloSampleLabel.DRAIN_RATE, float(window.drain_rate_per_s)),
+    )
+    return tuple(
+        record_slo_sample(
+            ops_db,
+            label=label,
+            value=value,
+            observed_at_ms=observed_at_ms,
+            window_start_ms=observed_at_ms - round(window.duration_s * 1000),
+            window_end_ms=observed_at_ms,
+            metadata={"verdict": window.verdict.value},
+        )
+        for label, value in (
+            (*values, (SloSampleLabel.INGEST_LATENCY, float(window.duration_s)))
+            if not window.bulk_import_suppressed
+            else values
+        )
+    )
+
+
+def load_slo_reductions(ops_db: Path, *, since_ms: int | None = None) -> dict[str, SloReduction]:
+    """Read and reduce the optional sample history; cold start stays explicit."""
+    grouped: dict[str, list[ArchiveSloSample]] = {}
+    for sample in list_slo_samples(ops_db, since_ms=since_ms, limit=2000):
+        grouped.setdefault(sample.label, []).append(sample)
+    return {label: reduce_slo_samples(samples) for label, samples in sorted(grouped.items())}
+
+
+def slo_status_info(
+    *,
+    cursor_lag: CursorLagSummary,
+    events: Sequence[Mapping[str, object]] | None = None,
+) -> IngestSloStatus:
+    """Build status from existing event and cursor-lag sources only."""
+    resolved_events = list(events) if events is not None else list(query_daemon_events(limit=50))
+    suppressed = bulk_import_is_open(resolved_events)
+    windows = project_backlog_windows(resolved_events, bulk_import_suppressed=suppressed)
+    latest = windows[0] if windows else None
+    if latest is None:
+        return IngestSloStatus(
+            cursor_lag_stuck_file_count=cursor_lag.stuck_file_count,
+            cursor_lag_degraded_file_count=cursor_lag.degraded_file_count,
+        )
+    return IngestSloStatus(
+        available=True,
+        verdict=latest.verdict,
+        reason=latest.reason,
+        backlog=latest.backlog_end,
+        offered_work=latest.offered_work,
+        drained_work=latest.drained_work,
+        drain_rate_per_s=latest.drain_rate_per_s,
+        offered_rate_per_s=latest.offered_rate_per_s,
+        cursor_lag_stuck_file_count=cursor_lag.stuck_file_count,
+        cursor_lag_degraded_file_count=cursor_lag.degraded_file_count,
+        bulk_import_suppressed=latest.bulk_import_suppressed,
+        latest_window=latest,
+    )
+
+
+__all__ = [
+    "BacklogWindow",
+    "IngestSloStatus",
+    "SloReduction",
+    "SloVerdict",
+    "backlog_window_from_event",
+    "bulk_import_is_open",
+    "load_slo_reductions",
+    "project_backlog_windows",
+    "record_backlog_window_sample",
+    "reduce_slo_samples",
+    "slo_status_info",
+]

--- a/polylogue/daemon/slo.py
+++ b/polylogue/daemon/slo.py
@@ -233,66 +233,109 @@ def project_backlog_windows(
     now_ms: int | None = None,
 ) -> tuple[BacklogWindow, ...]:
     """Return bounded windows from the existing event stream, newest first."""
+    windows, _invalid = _project_backlog_windows(
+        events,
+        bulk_import_suppressed=bulk_import_suppressed,
+        now_ms=now_ms,
+    )
+    return windows
+
+
+def _project_backlog_windows(
+    events: Sequence[Mapping[str, object]],
+    *,
+    bulk_import_suppressed: bool | None = None,
+    now_ms: int | None = None,
+) -> tuple[tuple[BacklogWindow, ...], bool]:
+    """Project windows and report whether any lifecycle violated the receipt grammar.
+
+    Valid identities are ``start → end [→ terminal(success)]`` or
+    ``start → terminal(failure|cancelled|stopped)``. Historical ``start → end``
+    remains valid for compatibility with receipts written before terminals.
+    """
     suppressed = bulk_import_is_open(events) if bulk_import_suppressed is None else bulk_import_suppressed
     completed: list[tuple[tuple[int, int], BacklogWindow]] = []
-    completed_lifecycles: set[str] = set()
     active: dict[str, tuple[tuple[int, int], BacklogWindow]] = {}
+    states: dict[str, str] = {}
+    invalid_operations: set[str] = set()
+    invalid_metadata = False
+
+    def invalid_window(window: BacklogWindow) -> BacklogWindow:
+        return window.model_copy(
+            update={
+                "verdict": SloVerdict.UNKNOWN,
+                "reason": "catch-up lifecycle grammar is invalid",
+                "in_progress": False,
+            }
+        )
+
     for index, event in sorted(enumerate(events), key=lambda item: _event_order_key(*item)):
+        if event.get("kind") != "catch_up_cycle":
+            continue
         window = backlog_window_from_event(event, bulk_import_suppressed=suppressed)
         if window is None:
+            invalid_metadata = True
             continue
-        key = window.operation_id or f"event:{_int(event, 'id')}:{index}"
+        if window.operation_id is None:
+            invalid_metadata = True
+            continue
+        key = window.operation_id
         order_key = _event_order_key(index, event)
+        state = states.get(key)
         if window.in_progress:
+            if state is not None:
+                invalid_operations.add(key)
+                completed.append((order_key, invalid_window(window)))
+                continue
             active[key] = (order_key, window)
+            states[key] = "started"
         elif window.phase == "end":
-            if active.pop(key, None) is None:
-                completed.append(
-                    (
-                        order_key,
-                        window.model_copy(
-                            update={
-                                "verdict": SloVerdict.UNKNOWN,
-                                "reason": "catch-up cycle end has no matching start",
-                            }
-                        ),
-                    )
-                )
-            else:
-                completed.append((order_key, window))
-                completed_lifecycles.add(key)
+            if state != "started" or active.pop(key, None) is None:
+                invalid_operations.add(key)
+                completed.append((order_key, invalid_window(window)))
+                continue
+            completed.append((order_key, window))
+            states[key] = "ended"
         elif window.terminal_outcome is CatchUpCycleTerminalOutcome.SUCCESS:
-            if active.pop(key, None) is not None:
-                completed.append((order_key, window))
-                completed_lifecycles.add(key)
-            elif key not in completed_lifecycles:
-                completed.append(
-                    (
-                        order_key,
-                        window.model_copy(
-                            update={
-                                "verdict": SloVerdict.UNKNOWN,
-                                "reason": "catch-up cycle terminal receipt has no matching start",
-                            }
-                        ),
-                    )
-                )
+            if state != "ended":
+                invalid_operations.add(key)
+                completed.append((order_key, invalid_window(window)))
+                continue
+            states[key] = "terminal"
         else:
-            if active.pop(key, None) is None:
-                completed.append(
-                    (
-                        order_key,
-                        window.model_copy(
-                            update={
-                                "verdict": SloVerdict.UNKNOWN,
-                                "reason": "catch-up cycle terminal receipt has no matching start",
-                            }
-                        ),
-                    )
+            if state != "started" or active.pop(key, None) is None:
+                invalid_operations.add(key)
+                completed.append((order_key, invalid_window(window)))
+                continue
+            completed.append((order_key, window))
+            states[key] = "terminal"
+    if invalid_operations:
+        completed = [
+            (
+                order_key,
+                window.model_copy(
+                    update={
+                        "verdict": SloVerdict.UNKNOWN,
+                        "reason": "catch-up lifecycle grammar is invalid",
+                    }
                 )
-            else:
-                completed.append((order_key, window))
-                completed_lifecycles.add(key)
+                if window.operation_id in invalid_operations
+                else window,
+            )
+            for order_key, window in completed
+        ]
+        active = {
+            key: (
+                order_key,
+                window.model_copy(
+                    update={
+                        "verdict": SloVerdict.UNKNOWN,
+                        "reason": "catch-up lifecycle grammar is invalid",
+                    }
+                ),
+            )
+            for key, (order_key, window) in active.items()
+        }
     if now_ms is not None:
         for key, (order_key, window) in tuple(active.items()):
             if window.observed_at_ms is not None and now_ms - window.observed_at_ms >= CATCH_UP_ACTIVE_STALE_AFTER_MS:
@@ -310,7 +353,9 @@ def project_backlog_windows(
                     )
                 )
     windows = completed + list(active.values())
-    return tuple(window for _key, window in sorted(windows, reverse=True)[:20])
+    return tuple(window for _key, window in sorted(windows, reverse=True)[:20]), (
+        bool(invalid_operations) or invalid_metadata
+    )
 
 
 def reduce_slo_samples(
@@ -398,21 +443,25 @@ def slo_status_info(
         resolved_events = list(events)
         history_incomplete = False
     suppressed = bulk_import_is_open(resolved_events)
-    windows = project_backlog_windows(
+    windows, grammar_invalid = _project_backlog_windows(
         resolved_events,
         bulk_import_suppressed=suppressed,
         now_ms=current_epoch_ms() if now_ms is None else now_ms,
     )
     latest = windows[0] if windows else None
-    if history_incomplete:
+    if history_incomplete or grammar_invalid:
         return IngestSloStatus(
             available=latest is not None,
             verdict=SloVerdict.UNKNOWN,
-            reason="catch-up lifecycle history is incomplete",
+            reason=(
+                "catch-up lifecycle history is incomplete"
+                if history_incomplete
+                else "catch-up lifecycle grammar is invalid"
+            ),
             cursor_lag_stuck_file_count=cursor_lag.stuck_file_count,
             cursor_lag_degraded_file_count=cursor_lag.degraded_file_count,
             bulk_import_suppressed=suppressed,
-            lifecycle_history_incomplete=True,
+            lifecycle_history_incomplete=history_incomplete or grammar_invalid,
             latest_window=latest,
         )
     if latest is None:

--- a/polylogue/daemon/slo.py
+++ b/polylogue/daemon/slo.py
@@ -18,7 +18,8 @@ from pydantic import BaseModel, Field
 from polylogue.core.enums import SloSampleLabel
 from polylogue.core.stats import percentile
 from polylogue.daemon.cursor_lag_status import CursorLagSummary
-from polylogue.daemon.events import query_daemon_events
+from polylogue.daemon.events import CatchUpCycleTerminalOutcome, current_epoch_ms, query_daemon_events
+from polylogue.daemon.lifecycle import DAEMON_HEARTBEAT_STALE_AFTER_SECONDS
 from polylogue.operations.slo import (
     ArchiveSloSample,
     list_slo_samples,
@@ -33,6 +34,8 @@ class SloVerdict(StrEnum):
     IDLE = "idle"
     DRAINING = "draining"
     STALLED = "stalled"
+    FAILED = "failed"
+    STALE = "stale"
     SUPPRESSED = "suppressed"
 
 
@@ -50,13 +53,17 @@ class SloReduction(BaseModel):
     confident: bool = False
 
 
+CATCH_UP_ACTIVE_STALE_AFTER_MS = DAEMON_HEARTBEAT_STALE_AFTER_SECONDS * 1000
+
+
 class BacklogWindow(BaseModel):
-    """One bounded catch-up window derived from a catch-up cycle end event."""
+    """One bounded catch-up window derived from the lifecycle event stream."""
 
     operation_id: str | None = None
     observed_at_ms: int | None = None
     phase: str = "end"
     in_progress: bool = False
+    terminal_outcome: CatchUpCycleTerminalOutcome | None = None
     duration_s: float = 0.0
     backlog_start: int = 0
     backlog_end: int = 0
@@ -152,7 +159,7 @@ def backlog_window_from_event(
     if not isinstance(payload, Mapping):
         return None
     phase = payload.get("phase")
-    if phase not in {"start", "end"}:
+    if phase not in {"start", "end", "terminal"}:
         return None
     duration_s = _float(payload, "duration_ms") / 1000.0
     backlog_start = _int(payload, "backlog_start")
@@ -163,12 +170,24 @@ def backlog_window_from_event(
     )
     drain_rate = drained_work / duration_s if duration_s > 0 else 0.0
     offered_rate = offered_work / duration_s if duration_s > 0 else 0.0
+    terminal_outcome: CatchUpCycleTerminalOutcome | None = None
+    if phase == "terminal":
+        raw_terminal_outcome = payload.get("terminal_outcome")
+        if not isinstance(raw_terminal_outcome, str):
+            return None
+        try:
+            terminal_outcome = CatchUpCycleTerminalOutcome(raw_terminal_outcome)
+        except ValueError:
+            return None
     if bulk_import_suppressed:
         verdict = SloVerdict.SUPPRESSED
         reason = "bulk-import marker is open"
     elif phase == "start":
         verdict = SloVerdict.ACTIVE
         reason = "catch-up cycle is in progress"
+    elif terminal_outcome is not None and terminal_outcome is not CatchUpCycleTerminalOutcome.SUCCESS:
+        verdict = SloVerdict.FAILED
+        reason = f"catch-up cycle terminated: {terminal_outcome.value}"
     elif backlog_end <= 0:
         verdict = SloVerdict.HEALTHY
         reason = "backlog drained"
@@ -187,6 +206,7 @@ def backlog_window_from_event(
         observed_at_ms=_event_observed_at_ms(event),
         phase=phase,
         in_progress=phase == "start",
+        terminal_outcome=terminal_outcome,
         duration_s=round(duration_s, 6),
         backlog_start=backlog_start,
         backlog_end=backlog_end,
@@ -204,10 +224,12 @@ def project_backlog_windows(
     events: Sequence[Mapping[str, object]],
     *,
     bulk_import_suppressed: bool | None = None,
+    now_ms: int | None = None,
 ) -> tuple[BacklogWindow, ...]:
     """Return bounded windows from the existing event stream, newest first."""
     suppressed = bulk_import_is_open(events) if bulk_import_suppressed is None else bulk_import_suppressed
     completed: list[tuple[tuple[int, int, int], BacklogWindow]] = []
+    completed_operations: set[str] = set()
     active: dict[str, tuple[tuple[int, int, int], BacklogWindow]] = {}
     for index, event in sorted(enumerate(events), key=lambda item: _event_order_key(*item)):
         window = backlog_window_from_event(event, bulk_import_suppressed=suppressed)
@@ -217,9 +239,35 @@ def project_backlog_windows(
         order_key = _event_order_key(index, event)
         if window.in_progress:
             active[key] = (order_key, window)
+        elif window.phase == "end":
+            active.pop(key, None)
+            completed.append((order_key, window))
+            completed_operations.add(key)
+        elif window.terminal_outcome is CatchUpCycleTerminalOutcome.SUCCESS:
+            active.pop(key, None)
+            if key not in completed_operations:
+                completed.append((order_key, window))
+                completed_operations.add(key)
         else:
             active.pop(key, None)
             completed.append((order_key, window))
+            completed_operations.add(key)
+    if now_ms is not None:
+        for key, (order_key, window) in tuple(active.items()):
+            if window.observed_at_ms is not None and now_ms - window.observed_at_ms >= CATCH_UP_ACTIVE_STALE_AFTER_MS:
+                active.pop(key)
+                completed.append(
+                    (
+                        order_key,
+                        window.model_copy(
+                            update={
+                                "verdict": SloVerdict.STALE,
+                                "reason": "catch-up cycle start exceeded the active timeout",
+                                "in_progress": False,
+                            }
+                        ),
+                    )
+                )
     windows = completed + list(active.values())
     return tuple(window for _key, window in sorted(windows, reverse=True)[:20])
 
@@ -297,11 +345,16 @@ def slo_status_info(
     *,
     cursor_lag: CursorLagSummary,
     events: Sequence[Mapping[str, object]] | None = None,
+    now_ms: int | None = None,
 ) -> IngestSloStatus:
     """Build status from existing event and cursor-lag sources only."""
     resolved_events = list(events) if events is not None else list(query_daemon_events(limit=50))
     suppressed = bulk_import_is_open(resolved_events)
-    windows = project_backlog_windows(resolved_events, bulk_import_suppressed=suppressed)
+    windows = project_backlog_windows(
+        resolved_events,
+        bulk_import_suppressed=suppressed,
+        now_ms=current_epoch_ms() if now_ms is None else now_ms,
+    )
     latest = windows[0] if windows else None
     if latest is None:
         return IngestSloStatus(
@@ -326,6 +379,7 @@ def slo_status_info(
 
 __all__ = [
     "BacklogWindow",
+    "CATCH_UP_ACTIVE_STALE_AFTER_MS",
     "IngestSloStatus",
     "SloReduction",
     "SloVerdict",

--- a/polylogue/daemon/slo.py
+++ b/polylogue/daemon/slo.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel, Field
 from polylogue.core.enums import SloSampleLabel
 from polylogue.core.stats import percentile
 from polylogue.daemon.cursor_lag_status import CursorLagSummary
-from polylogue.daemon.events import CatchUpCycleTerminalOutcome, current_epoch_ms, query_daemon_events
+from polylogue.daemon.events import CatchUpCycleTerminalOutcome, current_epoch_ms, query_recent_catch_up_lifecycles
 from polylogue.daemon.lifecycle import DAEMON_HEARTBEAT_STALE_AFTER_SECONDS
 from polylogue.operations.slo import (
     ArchiveSloSample,
@@ -229,7 +229,7 @@ def project_backlog_windows(
     """Return bounded windows from the existing event stream, newest first."""
     suppressed = bulk_import_is_open(events) if bulk_import_suppressed is None else bulk_import_suppressed
     completed: list[tuple[tuple[int, int, int], BacklogWindow]] = []
-    completed_operations: set[str] = set()
+    completed_lifecycles: set[str] = set()
     active: dict[str, tuple[tuple[int, int, int], BacklogWindow]] = {}
     for index, event in sorted(enumerate(events), key=lambda item: _event_order_key(*item)):
         window = backlog_window_from_event(event, bulk_import_suppressed=suppressed)
@@ -240,18 +240,53 @@ def project_backlog_windows(
         if window.in_progress:
             active[key] = (order_key, window)
         elif window.phase == "end":
-            active.pop(key, None)
-            completed.append((order_key, window))
-            completed_operations.add(key)
-        elif window.terminal_outcome is CatchUpCycleTerminalOutcome.SUCCESS:
-            active.pop(key, None)
-            if key not in completed_operations:
+            if active.pop(key, None) is None:
+                completed.append(
+                    (
+                        order_key,
+                        window.model_copy(
+                            update={
+                                "verdict": SloVerdict.UNKNOWN,
+                                "reason": "catch-up cycle end has no matching start",
+                            }
+                        ),
+                    )
+                )
+            else:
                 completed.append((order_key, window))
-                completed_operations.add(key)
+                completed_lifecycles.add(key)
+        elif window.terminal_outcome is CatchUpCycleTerminalOutcome.SUCCESS:
+            if active.pop(key, None) is not None:
+                completed.append((order_key, window))
+                completed_lifecycles.add(key)
+            elif key not in completed_lifecycles:
+                completed.append(
+                    (
+                        order_key,
+                        window.model_copy(
+                            update={
+                                "verdict": SloVerdict.UNKNOWN,
+                                "reason": "catch-up cycle terminal receipt has no matching start",
+                            }
+                        ),
+                    )
+                )
         else:
-            active.pop(key, None)
-            completed.append((order_key, window))
-            completed_operations.add(key)
+            if active.pop(key, None) is None:
+                completed.append(
+                    (
+                        order_key,
+                        window.model_copy(
+                            update={
+                                "verdict": SloVerdict.UNKNOWN,
+                                "reason": "catch-up cycle terminal receipt has no matching start",
+                            }
+                        ),
+                    )
+                )
+            else:
+                completed.append((order_key, window))
+                completed_lifecycles.add(key)
     if now_ms is not None:
         for key, (order_key, window) in tuple(active.items()):
             if window.observed_at_ms is not None and now_ms - window.observed_at_ms >= CATCH_UP_ACTIVE_STALE_AFTER_MS:
@@ -348,7 +383,7 @@ def slo_status_info(
     now_ms: int | None = None,
 ) -> IngestSloStatus:
     """Build status from existing event and cursor-lag sources only."""
-    resolved_events = list(events) if events is not None else list(query_daemon_events(limit=50))
+    resolved_events = list(events) if events is not None else list(query_recent_catch_up_lifecycles())
     suppressed = bulk_import_is_open(resolved_events)
     windows = project_backlog_windows(
         resolved_events,

--- a/polylogue/daemon/slo.py
+++ b/polylogue/daemon/slo.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Mapping, Sequence
-from datetime import UTC, datetime
+from datetime import datetime
 from enum import StrEnum
 from pathlib import Path
 
@@ -28,6 +28,7 @@ from polylogue.operations.slo import (
 
 class SloVerdict(StrEnum):
     UNKNOWN = "unknown"
+    ACTIVE = "active"
     HEALTHY = "healthy"
     IDLE = "idle"
     DRAINING = "draining"
@@ -53,7 +54,9 @@ class BacklogWindow(BaseModel):
     """One bounded catch-up window derived from a catch-up cycle end event."""
 
     operation_id: str | None = None
-    observed_at_ms: int = 0
+    observed_at_ms: int | None = None
+    phase: str = "end"
+    in_progress: bool = False
     duration_s: float = 0.0
     backlog_start: int = 0
     backlog_end: int = 0
@@ -98,9 +101,35 @@ def _float(payload: Mapping[str, object], key: str) -> float:
     return max(0.0, float(value)) if isinstance(value, int | float | str) and not isinstance(value, bool) else 0.0
 
 
+def _event_observed_at_ms(event: Mapping[str, object]) -> int | None:
+    """Decode the daemon event reader's canonical ISO ``ts`` field."""
+    value = event.get("ts")
+    if not isinstance(value, str):
+        return None
+    try:
+        timestamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if timestamp.tzinfo is None:
+        return None
+    return int(timestamp.timestamp() * 1000)
+
+
+def _event_order_key(index: int, event: Mapping[str, object]) -> tuple[int, int, int]:
+    """Order event projections by their persisted timestamp, then event id."""
+    observed_at_ms = _event_observed_at_ms(event)
+    return (observed_at_ms if observed_at_ms is not None else -1, _int(event, "id"), index)
+
+
+def _events_newest_first(events: Sequence[Mapping[str, object]]) -> list[Mapping[str, object]]:
+    return [
+        event for _index, event in sorted(enumerate(events), key=lambda item: _event_order_key(*item), reverse=True)
+    ]
+
+
 def bulk_import_is_open(events: Sequence[Mapping[str, object]]) -> bool:
     """Return whether the newest explicit bulk-import marker is still open."""
-    for event in events:
+    for event in _events_newest_first(events):
         kind = event.get("kind")
         if not isinstance(kind, str):
             continue
@@ -120,7 +149,10 @@ def backlog_window_from_event(
     if event.get("kind") != "catch_up_cycle":
         return None
     payload = event.get("payload")
-    if not isinstance(payload, Mapping) or payload.get("phase") != "end":
+    if not isinstance(payload, Mapping):
+        return None
+    phase = payload.get("phase")
+    if phase not in {"start", "end"}:
         return None
     duration_s = _float(payload, "duration_ms") / 1000.0
     backlog_start = _int(payload, "backlog_start")
@@ -134,6 +166,9 @@ def backlog_window_from_event(
     if bulk_import_suppressed:
         verdict = SloVerdict.SUPPRESSED
         reason = "bulk-import marker is open"
+    elif phase == "start":
+        verdict = SloVerdict.ACTIVE
+        reason = "catch-up cycle is in progress"
     elif backlog_end <= 0:
         verdict = SloVerdict.HEALTHY
         reason = "backlog drained"
@@ -146,13 +181,12 @@ def backlog_window_from_event(
     else:
         verdict = SloVerdict.DRAINING
         reason = "offered work is draining the backlog"
-    observed_at_ms = _int(event, "ts_ms")
-    if observed_at_ms == 0:
-        observed_at_ms = _int(payload, "observed_at_ms")
     operation_id = event.get("operation_id")
     return BacklogWindow(
         operation_id=operation_id if isinstance(operation_id, str) else None,
-        observed_at_ms=observed_at_ms,
+        observed_at_ms=_event_observed_at_ms(event),
+        phase=phase,
+        in_progress=phase == "start",
         duration_s=round(duration_s, 6),
         backlog_start=backlog_start,
         backlog_end=backlog_end,
@@ -173,12 +207,21 @@ def project_backlog_windows(
 ) -> tuple[BacklogWindow, ...]:
     """Return bounded windows from the existing event stream, newest first."""
     suppressed = bulk_import_is_open(events) if bulk_import_suppressed is None else bulk_import_suppressed
-    windows = [
-        window
-        for event in events
-        if (window := backlog_window_from_event(event, bulk_import_suppressed=suppressed)) is not None
-    ]
-    return tuple(windows[:20])
+    completed: list[tuple[tuple[int, int, int], BacklogWindow]] = []
+    active: dict[str, tuple[tuple[int, int, int], BacklogWindow]] = {}
+    for index, event in sorted(enumerate(events), key=lambda item: _event_order_key(*item)):
+        window = backlog_window_from_event(event, bulk_import_suppressed=suppressed)
+        if window is None:
+            continue
+        key = window.operation_id or f"event:{_int(event, 'id')}:{index}"
+        order_key = _event_order_key(index, event)
+        if window.in_progress:
+            active[key] = (order_key, window)
+        else:
+            active.pop(key, None)
+            completed.append((order_key, window))
+    windows = completed + list(active.values())
+    return tuple(window for _key, window in sorted(windows, reverse=True)[:20])
 
 
 def reduce_slo_samples(
@@ -216,7 +259,9 @@ def reduce_slo_samples(
 
 def record_backlog_window_sample(ops_db: Path, window: BacklogWindow) -> tuple[str, ...]:
     """Persist numeric samples from one derived window in disposable ops state."""
-    observed_at_ms = window.observed_at_ms or int(datetime.now(UTC).timestamp() * 1000)
+    if window.observed_at_ms is None:
+        return ()
+    observed_at_ms = window.observed_at_ms
     values = (
         (SloSampleLabel.BACKLOG, float(window.backlog_end)),
         (SloSampleLabel.OFFERED_WORK, float(window.offered_work)),

--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -63,6 +63,7 @@ from polylogue.daemon.live_ingest_attempt_workload import (
     latest_stage_events,
     workload_fields,
 )
+from polylogue.daemon.slo import IngestSloStatus, slo_status_info
 from polylogue.logging import get_logger
 from polylogue.operations.status_protocol import ComponentSnapshot, StatusComponentRegistry, StatusComponentSpec
 from polylogue.paths import archive_root, index_db_path
@@ -470,6 +471,7 @@ class DaemonStatus(BaseModel):
     catchup: CatchupStatus = Field(default_factory=CatchupStatus)
     convergence: ConvergenceDebtSummary = Field(default_factory=ConvergenceDebtSummary)
     cursor_lag: CursorLagSummary = Field(default_factory=CursorLagSummary)
+    ingest_slo: IngestSloStatus = Field(default_factory=IngestSloStatus)
     db_size_bytes: int = 0
     wal_size_bytes: int = 0
     blob_dir_size_bytes: int = 0
@@ -2686,6 +2688,7 @@ def build_daemon_status(
     live_ingest_attempts = _v("live_ingest_attempts", LiveIngestAttemptSummary())
     convergence = _convergence_debt_from_snapshot(snapshots["convergence"])
     cursor_lag = _v("cursor_lag", CursorLagSummary())
+    ingest_slo = slo_status_info(cursor_lag=cursor_lag)
     catchup = catchup_status_info(
         active_db,
         latest_attempt=live_ingest_attempts.recent[0] if live_ingest_attempts.recent else None,
@@ -2802,6 +2805,7 @@ def build_daemon_status(
         catchup=catchup,
         convergence=convergence,
         cursor_lag=cursor_lag,
+        ingest_slo=ingest_slo,
         db_size_bytes=_safe_int(db_info.get("db_size_bytes", 0)),
         wal_size_bytes=_safe_int(db_info.get("wal_size_bytes", 0)),
         blob_dir_size_bytes=_v("blob_size", 0),

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -330,6 +330,15 @@ class RebuildPassCost:
     #: held a single session, with nothing durable recording where that time
     #: went.
     selection_s: float = 0.0
+    #: Time spent classifying byte and membership authority cohorts. This is
+    #: a diagnostic rollup over the replay stage ledger, retained separately
+    #: from the parse/apply split for phase-level receipts.
+    cohort_s: float = 0.0
+    #: Terminal insight materialization time. Deferred/paused passes carry
+    #: the explicit zero because they have not reached terminal stages.
+    insight_s: float = 0.0
+    #: Sum of terminal stages after replay, excluding raw selection.
+    terminal_s: float = 0.0
 
     @property
     def mib_per_s(self) -> float:
@@ -354,9 +363,12 @@ class RebuildPassCost:
         eta = self.eta_s
         return {
             "selection_s": round(self.selection_s, 3),
+            "cohort_s": round(self.cohort_s, 3),
             "replay_s": round(self.replay_s, 3),
             "parse_s": round(self.parse_s, 3),
             "apply_s": round(self.apply_s, 3),
+            "insight_s": round(self.insight_s, 3),
+            "terminal_s": round(self.terminal_s, 3),
             "checkpoint_s": round(self.checkpoint_s, 3),
             "pass_s": round(self.pass_s, 3),
             "raws": self.raws,
@@ -372,6 +384,51 @@ class RebuildPassCost:
             "free_threaded": self.free_threaded,
             "parse_workers": self.parse_workers,
         }
+
+
+_COHORT_TIMING_PREFIXES = ("replay.classify_cohort", "replay.adoptable_check", "membership.")
+
+
+def _cohort_seconds(stage_timings_s: object) -> float:
+    """Roll up the durable replay timing keys that decide authority cohorts."""
+    if not isinstance(stage_timings_s, dict):
+        return 0.0
+    return sum(
+        float(value)
+        for key, value in stage_timings_s.items()
+        if isinstance(key, str)
+        and key.startswith(_COHORT_TIMING_PREFIXES)
+        and isinstance(value, int | float)
+        and not isinstance(value, bool)
+    )
+
+
+def _receipt_timings(
+    *,
+    selection_s: float,
+    replay: dict[str, object],
+    terminal_timings_s: dict[str, float],
+) -> dict[str, float]:
+    """Build one stable phase vocabulary plus existing granular timings."""
+    stage_timings_s = replay.get("stage_timings_s", {})
+    parse_s = replay.get("parse_s", 0.0)
+    apply_s = replay.get("apply_s", 0.0)
+    resolved_parse_s = float(parse_s) if isinstance(parse_s, int | float) else 0.0
+    resolved_apply_s = float(apply_s) if isinstance(apply_s, int | float) else 0.0
+    insight_s = float(terminal_timings_s.get("terminal.session_insights", 0.0))
+    terminal_s = sum(float(value) for key, value in terminal_timings_s.items() if key != "selection_s")
+    rollups = {
+        "selection_s": float(selection_s),
+        "cohort_s": _cohort_seconds(stage_timings_s),
+        "parse_s": resolved_parse_s,
+        "apply_s": resolved_apply_s,
+        "insight_s": insight_s,
+        "terminal_s": terminal_s,
+    }
+    return {
+        **{key: round(value, 3) for key, value in rollups.items()},
+        **{key: round(float(value), 3) for key, value in terminal_timings_s.items()},
+    }
 
 
 @dataclass(frozen=True, slots=True)
@@ -890,6 +947,7 @@ async def _rebuild_index_from_source_owned(
 
                     pass_cost = RebuildPassCost(
                         selection_s=selection_elapsed_s,
+                        cohort_s=0.0,
                         replay_s=pass_elapsed_s,
                         checkpoint_s=0.0,
                         pass_s=time.perf_counter() - pass_started_at_s,
@@ -990,6 +1048,7 @@ async def _rebuild_index_from_source_owned(
 
                     pass_cost = RebuildPassCost(
                         selection_s=selection_elapsed_s,
+                        cohort_s=_cohort_seconds(replay.get("stage_timings_s", {})),
                         replay_s=pass_elapsed_s,
                         checkpoint_s=0.0,
                         pass_s=time.perf_counter() - pass_started_at_s,
@@ -1199,7 +1258,11 @@ async def _rebuild_index_from_source_owned(
             transaction=transaction,
             recovery_state="promoted" if request.promote else "ready",
         ),
-        timings_s={key: round(value, 3) for key, value in terminal_timings_s.items()},
+        timings_s=_receipt_timings(
+            selection_s=selection_elapsed_s,
+            replay=replay,
+            terminal_timings_s=terminal_timings_s,
+        ),
     )
     if transaction is not None:
         generation_store.save_pass_receipt(transaction.operation_id, final_receipt.to_dict())

--- a/polylogue/operations/slo.py
+++ b/polylogue/operations/slo.py
@@ -1,0 +1,163 @@
+"""Optional steady-state ingest SLO samples in the disposable ops tier."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+from polylogue.core.enums import SloSampleLabel
+from polylogue.storage.sqlite.archive_tiers.ops import SLO_SAMPLES_DDL
+from polylogue.storage.sqlite.connection_profile import open_daemon_connection, open_readonly_connection
+
+SLO_SAMPLE_RETENTION_MS = 30 * 24 * 60 * 60 * 1000
+SLO_SAMPLE_ROW_CAP = 20_000
+
+
+@dataclass(frozen=True, slots=True)
+class ArchiveSloSample:
+    """One bounded optional steady-state telemetry sample."""
+
+    sample_id: str
+    label: str
+    scope: str
+    value: float
+    observed_at_ms: int
+    window_start_ms: int | None
+    window_end_ms: int | None
+    metadata: dict[str, object]
+
+
+def _ensure_slo_samples_table(conn: sqlite3.Connection) -> None:
+    """Self-heal the optional SLO table without changing OPS_SCHEMA_VERSION."""
+    conn.executescript(SLO_SAMPLES_DDL)
+
+
+def _prune_slo_samples(conn: sqlite3.Connection, *, now_ms: int) -> None:
+    conn.execute("DELETE FROM slo_samples WHERE observed_at_ms < ?", (now_ms - SLO_SAMPLE_RETENTION_MS,))
+    row_count = int(conn.execute("SELECT COUNT(*) FROM slo_samples").fetchone()[0])
+    if row_count > SLO_SAMPLE_ROW_CAP:
+        conn.execute(
+            """
+            DELETE FROM slo_samples WHERE sample_id IN (
+                SELECT sample_id FROM slo_samples
+                ORDER BY observed_at_ms ASC LIMIT ?
+            )
+            """,
+            (row_count - SLO_SAMPLE_ROW_CAP,),
+        )
+
+
+def record_slo_sample(
+    ops_db: Path,
+    *,
+    label: SloSampleLabel | str,
+    value: float,
+    observed_at_ms: int,
+    scope: str = "archive",
+    window_start_ms: int | None = None,
+    window_end_ms: int | None = None,
+    metadata: dict[str, object] | None = None,
+    sample_id: str | None = None,
+) -> str:
+    """Append one SLO sample, pruning by age and a hard row cap."""
+    resolved_label = label if isinstance(label, SloSampleLabel) else SloSampleLabel(label)
+    sample_id = sample_id or str(uuid.uuid4())
+    with open_daemon_connection(ops_db) as conn:
+        _ensure_slo_samples_table(conn)
+        with conn:
+            conn.execute(
+                """
+                INSERT INTO slo_samples(
+                    sample_id, label, scope, value, observed_at_ms,
+                    window_start_ms, window_end_ms, metadata_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    sample_id,
+                    resolved_label.value,
+                    scope,
+                    float(value),
+                    int(observed_at_ms),
+                    window_start_ms,
+                    window_end_ms,
+                    json.dumps(metadata or {}, sort_keys=True),
+                ),
+            )
+            _prune_slo_samples(conn, now_ms=observed_at_ms)
+    return sample_id
+
+
+def list_slo_samples(
+    ops_db: Path,
+    *,
+    label: SloSampleLabel | str | None = None,
+    scope: str | None = None,
+    since_ms: int | None = None,
+    limit: int = 1000,
+) -> tuple[ArchiveSloSample, ...]:
+    """Read optional SLO samples newest-first, returning an empty cold start."""
+    with open_readonly_connection(ops_db) as conn:
+        exists = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'slo_samples' LIMIT 1"
+        ).fetchone()
+        if exists is None:
+            return ()
+        clauses: list[str] = []
+        params: list[object] = []
+        if label is not None:
+            resolved_label = label if isinstance(label, SloSampleLabel) else SloSampleLabel(label)
+            clauses.append("label = ?")
+            params.append(resolved_label.value)
+        if scope is not None:
+            clauses.append("scope = ?")
+            params.append(scope)
+        if since_ms is not None:
+            clauses.append("observed_at_ms >= ?")
+            params.append(int(since_ms))
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        rows = conn.execute(
+            f"""
+            SELECT sample_id, label, scope, value, observed_at_ms,
+                   window_start_ms, window_end_ms, metadata_json
+            FROM slo_samples {where}
+            ORDER BY observed_at_ms DESC, sample_id DESC LIMIT ?
+            """,
+            (*params, max(0, int(limit))),
+        ).fetchall()
+    return tuple(
+        ArchiveSloSample(
+            sample_id=str(row[0]),
+            label=str(row[1]),
+            scope=str(row[2]),
+            value=float(row[3]),
+            observed_at_ms=int(row[4]),
+            window_start_ms=int(row[5]) if row[5] is not None else None,
+            window_end_ms=int(row[6]) if row[6] is not None else None,
+            metadata=json.loads(str(row[7])) if isinstance(row[7], str) else {},
+        )
+        for row in rows
+    )
+
+
+def gc_slo_samples(ops_db: Path, *, now_ms: int) -> int:
+    """Apply retention and return the number of removed samples."""
+    with open_daemon_connection(ops_db) as conn:
+        _ensure_slo_samples_table(conn)
+        with conn:
+            before = int(conn.execute("SELECT COUNT(*) FROM slo_samples").fetchone()[0])
+            _prune_slo_samples(conn, now_ms=now_ms)
+            remaining = int(conn.execute("SELECT COUNT(*) FROM slo_samples").fetchone()[0])
+    return before - remaining
+
+
+__all__ = [
+    "ArchiveSloSample",
+    "SLO_SAMPLE_RETENTION_MS",
+    "SLO_SAMPLE_ROW_CAP",
+    "gc_slo_samples",
+    "list_slo_samples",
+    "record_slo_sample",
+]

--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -18,7 +18,7 @@ import sqlite3
 import stat as stat_module
 import time
 import uuid
-from collections.abc import Awaitable, Callable, Iterable, Iterator
+from collections.abc import Awaitable, Callable, Iterable, Iterator, Mapping
 from contextlib import closing, contextmanager, suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -441,7 +441,7 @@ class LiveWatcher:
             return
         operation_id = f"watcher-catch-up:{uuid.uuid4()}"
         cycle_started = time.perf_counter()
-        self._emit_catch_up_cycle(
+        await self._emit_catch_up_cycle(
             operation_id=operation_id,
             phase="start",
             backlog_start=len(plan.candidates),
@@ -471,65 +471,85 @@ class LiveWatcher:
             plan.skipped_file_count,
             len(chunks),
         )
-        for index, chunk in enumerate(chunks, start=1):
-            if self._stop.is_set():
-                break
-            chunk_bytes = sum(candidate_by_path[path].stat.st_size for path in chunk)
-            logger.info(
-                "live.watcher: catch-up chunk %d/%d ingesting %d file(s) (%.1f MB)",
-                index,
-                len(chunks),
-                len(chunk),
-                chunk_bytes / 1e6,
-            )
-            chunk_index = index
-            chunk_paths = list(chunk)
-
-            async def ingest_chunk(
-                chunk_index: int = chunk_index,
-                chunk_paths: list[Path] = chunk_paths,
-            ) -> None:
-                nonlocal attempted, ingested, failed
-                metrics = await self._ingest_files(
-                    chunk_paths,
-                    queued_file_count=len(plan.candidates) if chunk_index == 1 else len(chunk_paths),
-                    skipped_file_count=plan.skipped_file_count if chunk_index == 1 else 0,
+        try:
+            for index, chunk in enumerate(chunks, start=1):
+                if self._stop.is_set():
+                    await self._emit_catch_up_terminal(
+                        operation_id, "stopped", plan, attempted, ingested, failed, stage_timings_s, cycle_started
+                    )
+                    return
+                chunk_bytes = sum(candidate_by_path[path].stat.st_size for path in chunk)
+                logger.info(
+                    "live.watcher: catch-up chunk %d/%d ingesting %d file(s) (%.1f MB)",
+                    index,
+                    len(chunks),
+                    len(chunk),
+                    chunk_bytes / 1e6,
                 )
-                if metrics is not None:
-                    _log_ingest_metrics(f"live.watcher: catch-up chunk {chunk_index}/{len(chunks)}", metrics)
-                    attempted += metrics.needed_file_count
-                    ingested += metrics.succeeded_file_count
-                    failed += metrics.failed_file_count
-                    for stage, elapsed_s in metrics.stage_timings_s.items():
-                        stage_timings_s[stage] = stage_timings_s.get(stage, 0.0) + elapsed_s
-                    if (
-                        getattr(metrics, "succeeded_file_count", 0) == 0
-                        and getattr(metrics, "failed_file_count", 0) == 0
-                    ):
-                        self._defer_unaccounted_failed_retries(chunk_paths)
+                chunk_index = index
+                chunk_paths = list(chunk)
 
-            await self._run_coordinated("watcher.catch_up.chunk", ingest_chunk)
-        if self._stop.is_set():
-            return
-        backlog_end = max(0, len(plan.candidates) - plan.skipped_file_count - ingested)
-        self._emit_catch_up_cycle(
-            operation_id=operation_id,
-            phase="end",
-            backlog_start=len(plan.candidates),
-            backlog_end=backlog_end,
-            discovered=len(plan.candidates),
-            attempted=attempted,
-            skipped=plan.skipped_file_count,
-            ingested=ingested,
-            quarantine_count=0,
-            errors_by_kind={"ingest_failed": failed} if failed else {},
-            cursor_before=None,
-            cursor_after=None,
-            duration_ms=(time.perf_counter() - cycle_started) * 1000.0,
-            stage_timings_s=stage_timings_s,
-            repair={"required": failed, "performed": 0, "remaining": backlog_end},
-        )
-        self._schedule_failed_retry_scan()
+                async def ingest_chunk(
+                    chunk_index: int = chunk_index,
+                    chunk_paths: list[Path] = chunk_paths,
+                ) -> None:
+                    nonlocal attempted, ingested, failed
+                    metrics = await self._ingest_files(
+                        chunk_paths,
+                        queued_file_count=len(plan.candidates) if chunk_index == 1 else len(chunk_paths),
+                        skipped_file_count=plan.skipped_file_count if chunk_index == 1 else 0,
+                    )
+                    if metrics is not None:
+                        _log_ingest_metrics(f"live.watcher: catch-up chunk {chunk_index}/{len(chunks)}", metrics)
+                        attempted += metrics.needed_file_count
+                        ingested += metrics.succeeded_file_count
+                        failed += metrics.failed_file_count
+                        for stage, elapsed_s in metrics.stage_timings_s.items():
+                            stage_timings_s[stage] = stage_timings_s.get(stage, 0.0) + elapsed_s
+                        if (
+                            getattr(metrics, "succeeded_file_count", 0) == 0
+                            and getattr(metrics, "failed_file_count", 0) == 0
+                        ):
+                            self._defer_unaccounted_failed_retries(chunk_paths)
+
+                await self._run_coordinated("watcher.catch_up.chunk", ingest_chunk)
+            if self._stop.is_set():
+                await self._emit_catch_up_terminal(
+                    operation_id, "stopped", plan, attempted, ingested, failed, stage_timings_s, cycle_started
+                )
+                return
+            backlog_end = max(0, len(plan.candidates) - plan.skipped_file_count - ingested)
+            await self._emit_catch_up_cycle(
+                operation_id=operation_id,
+                phase="end",
+                backlog_start=len(plan.candidates),
+                backlog_end=backlog_end,
+                discovered=len(plan.candidates),
+                attempted=attempted,
+                skipped=plan.skipped_file_count,
+                ingested=ingested,
+                quarantine_count=0,
+                errors_by_kind={"ingest_failed": failed} if failed else {},
+                cursor_before=None,
+                cursor_after=None,
+                duration_ms=(time.perf_counter() - cycle_started) * 1000.0,
+                stage_timings_s=stage_timings_s,
+                repair={"required": failed, "performed": 0, "remaining": backlog_end},
+            )
+            await self._emit_catch_up_terminal(
+                operation_id, "success", plan, attempted, ingested, failed, stage_timings_s, cycle_started, backlog_end
+            )
+            self._schedule_failed_retry_scan()
+        except asyncio.CancelledError:
+            await self._emit_catch_up_terminal(
+                operation_id, "cancelled", plan, attempted, ingested, failed, stage_timings_s, cycle_started
+            )
+            raise
+        except BaseException:
+            await self._emit_catch_up_terminal(
+                operation_id, "failure", plan, attempted, ingested, failed, stage_timings_s, cycle_started
+            )
+            raise
 
     async def _drain_hook_spool(self) -> None:
         """Acknowledge hook envelopes only after their source-tier write commits.
@@ -1403,10 +1423,48 @@ class LiveWatcher:
             metrics = await run("watcher.live_ingest", ingest) if callable(run) else await ingest()
         return metrics
 
-    def _emit_catch_up_cycle(self, **kwargs: object) -> None:
-        """Forward watcher lifecycle facts to the daemon-owned event ledger."""
+    async def _emit_catch_up_terminal(
+        self,
+        operation_id: str,
+        outcome: str,
+        plan: CatchUpPlan,
+        attempted: int,
+        ingested: int,
+        failed: int,
+        stage_timings_s: Mapping[str, float],
+        cycle_started: float,
+        backlog_end: int | None = None,
+    ) -> None:
+        resolved_backlog_end = (
+            max(0, len(plan.candidates) - plan.skipped_file_count - ingested) if backlog_end is None else backlog_end
+        )
+        await self._emit_catch_up_cycle(
+            operation_id=operation_id,
+            phase="terminal",
+            backlog_start=len(plan.candidates),
+            backlog_end=resolved_backlog_end,
+            discovered=len(plan.candidates),
+            attempted=attempted,
+            skipped=plan.skipped_file_count,
+            ingested=ingested,
+            quarantine_count=0,
+            errors_by_kind={"ingest_failed": failed} if failed else {},
+            cursor_before=None,
+            cursor_after=None,
+            duration_ms=(time.perf_counter() - cycle_started) * 1000.0,
+            stage_timings_s=stage_timings_s,
+            repair={"required": failed, "performed": 0, "remaining": resolved_backlog_end},
+            terminal_outcome=outcome,
+        )
+
+    async def _emit_catch_up_cycle(self, **kwargs: object) -> None:
+        """Persist lifecycle facts through the daemon's write coordinator."""
         if self._catch_up_event_emitter is not None:
-            self._catch_up_event_emitter(**kwargs)
+            await self._run_writer_sync(
+                "watcher.catch_up.event",
+                self._catch_up_event_emitter,
+                **kwargs,
+            )
 
     async def _run_coordinated(self, actor: str, operation: Callable[[], Awaitable[None]]) -> None:
         """Run a complete watcher write batch under the injected coordinator."""

--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -17,6 +17,7 @@ import os
 import sqlite3
 import stat as stat_module
 import time
+import uuid
 from collections.abc import Awaitable, Callable, Iterable, Iterator
 from contextlib import closing, contextmanager, suppress
 from dataclasses import dataclass
@@ -224,6 +225,7 @@ class LiveWatcher:
         max_workers: int | None = None,
         converger: object | None = None,  # DaemonConverger | None — avoids circular import
         event_emitter: LiveBatchEventEmitter | None = None,
+        catch_up_event_emitter: Callable[..., None] | None = None,
         write_coordinator: object | None = None,
         parse_stage: LiveParseStage | None = None,
     ) -> None:
@@ -238,6 +240,7 @@ class LiveWatcher:
         self._max_workers = max_workers
         self._converger = converger
         self._write_coordinator = write_coordinator
+        self._catch_up_event_emitter = catch_up_event_emitter
         # polylogue-wf8a: always on -- pre-parsing runs entirely BEFORE the
         # write coordinator is ever asked for the writer hold
         # (``LiveBatchProcessor._ingest_full_paths``), so it never contends
@@ -436,8 +439,31 @@ class LiveWatcher:
         plan = plan_holder[0]
         if not plan.needed:
             return
+        operation_id = f"watcher-catch-up:{uuid.uuid4()}"
+        cycle_started = time.perf_counter()
+        self._emit_catch_up_cycle(
+            operation_id=operation_id,
+            phase="start",
+            backlog_start=len(plan.candidates),
+            backlog_end=len(plan.candidates),
+            discovered=len(plan.candidates),
+            attempted=0,
+            skipped=0,
+            ingested=0,
+            quarantine_count=0,
+            errors_by_kind={},
+            cursor_before=None,
+            cursor_after=None,
+            duration_ms=0.0,
+            stage_timings_s={},
+            repair=None,
+        )
         candidate_by_path = {candidate.path: candidate for candidate in plan.candidates}
         chunks = tuple(self._chunk_catch_up_paths(plan.needed, candidate_by_path))
+        attempted = 0
+        ingested = 0
+        failed = 0
+        stage_timings_s: dict[str, float] = {}
         logger.info(
             "live.watcher: catch-up ingesting %d file(s) (%.1f MB), skipped=%d, chunks=%d",
             len(plan.needed),
@@ -463,6 +489,7 @@ class LiveWatcher:
                 chunk_index: int = chunk_index,
                 chunk_paths: list[Path] = chunk_paths,
             ) -> None:
+                nonlocal attempted, ingested, failed
                 metrics = await self._ingest_files(
                     chunk_paths,
                     queued_file_count=len(plan.candidates) if chunk_index == 1 else len(chunk_paths),
@@ -470,6 +497,11 @@ class LiveWatcher:
                 )
                 if metrics is not None:
                     _log_ingest_metrics(f"live.watcher: catch-up chunk {chunk_index}/{len(chunks)}", metrics)
+                    attempted += metrics.needed_file_count
+                    ingested += metrics.succeeded_file_count
+                    failed += metrics.failed_file_count
+                    for stage, elapsed_s in metrics.stage_timings_s.items():
+                        stage_timings_s[stage] = stage_timings_s.get(stage, 0.0) + elapsed_s
                     if (
                         getattr(metrics, "succeeded_file_count", 0) == 0
                         and getattr(metrics, "failed_file_count", 0) == 0
@@ -477,6 +509,26 @@ class LiveWatcher:
                         self._defer_unaccounted_failed_retries(chunk_paths)
 
             await self._run_coordinated("watcher.catch_up.chunk", ingest_chunk)
+        if self._stop.is_set():
+            return
+        backlog_end = max(0, len(plan.candidates) - plan.skipped_file_count - ingested)
+        self._emit_catch_up_cycle(
+            operation_id=operation_id,
+            phase="end",
+            backlog_start=len(plan.candidates),
+            backlog_end=backlog_end,
+            discovered=len(plan.candidates),
+            attempted=attempted,
+            skipped=plan.skipped_file_count,
+            ingested=ingested,
+            quarantine_count=0,
+            errors_by_kind={"ingest_failed": failed} if failed else {},
+            cursor_before=None,
+            cursor_after=None,
+            duration_ms=(time.perf_counter() - cycle_started) * 1000.0,
+            stage_timings_s=stage_timings_s,
+            repair={"required": failed, "performed": 0, "remaining": backlog_end},
+        )
         self._schedule_failed_retry_scan()
 
     async def _drain_hook_spool(self) -> None:
@@ -1350,6 +1402,11 @@ class LiveWatcher:
             run = getattr(self._write_coordinator, "run", None)
             metrics = await run("watcher.live_ingest", ingest) if callable(run) else await ingest()
         return metrics
+
+    def _emit_catch_up_cycle(self, **kwargs: object) -> None:
+        """Forward watcher lifecycle facts to the daemon-owned event ledger."""
+        if self._catch_up_event_emitter is not None:
+            self._catch_up_event_emitter(**kwargs)
 
     async def _run_coordinated(self, actor: str, operation: Callable[[], Awaitable[None]]) -> None:
         """Run a complete watcher write batch under the injected coordinator."""

--- a/polylogue/storage/sqlite/archive_tiers/bootstrap.py
+++ b/polylogue/storage/sqlite/archive_tiers/bootstrap.py
@@ -101,6 +101,7 @@ def initialize_archive_tier(conn: sqlite3.Connection, tier: ArchiveTier) -> None
         ensure_embedding_catchup_run_outcome_columns(conn)
         ensure_ops_status_checks(conn)
         _ensure_schema_drift_samples_check(conn)
+        _apply_ops_benign_ddl_convergence(conn)
     if tier is ArchiveTier.INDEX:
         # Fresh init never had a registered drop's target table, and any
         # additive registry entry lands identically to canonical DDL -- this
@@ -139,6 +140,14 @@ def _ensure_schema_drift_samples_check(conn: sqlite3.Connection) -> None:
 
     conn.execute("DROP TABLE IF EXISTS schema_drift_samples")
     conn.executescript(SCHEMA_DRIFT_SAMPLES_DDL)
+
+
+def _apply_ops_benign_ddl_convergence(conn: sqlite3.Connection) -> None:
+    """Apply the declared idempotent OPS same-version fast-forward plan."""
+    from polylogue.storage.sqlite.archive_tiers.ops import OPS_BENIGN_DDL_CONVERGENCE_PLAN
+
+    for statement in OPS_BENIGN_DDL_CONVERGENCE_PLAN:
+        conn.execute(statement)
 
 
 def _ensure_user_annotation_schemas(conn: sqlite3.Connection) -> None:

--- a/polylogue/storage/sqlite/archive_tiers/ops.py
+++ b/polylogue/storage/sqlite/archive_tiers/ops.py
@@ -212,6 +212,8 @@ CREATE TABLE IF NOT EXISTS daemon_events (
 
 CREATE INDEX IF NOT EXISTS idx_daemon_events_kind ON daemon_events(kind);
 CREATE INDEX IF NOT EXISTS idx_daemon_events_ts ON daemon_events(ts_ms);
+CREATE INDEX IF NOT EXISTS idx_daemon_events_kind_id ON daemon_events(kind, id DESC);
+CREATE INDEX IF NOT EXISTS idx_daemon_events_lifecycle ON daemon_events(kind, operation_id, id DESC);
 
 CREATE TABLE IF NOT EXISTS daemon_lifecycle (
     run_id               TEXT PRIMARY KEY,
@@ -374,4 +376,21 @@ ON fts_drift_samples(surface, sampled_at_ms DESC);
 -- drift apart from each other.
 {SCHEMA_DRIFT_SAMPLES_DDL}"""
 
-__all__ = ["OPS_DDL", "OPS_SCHEMA_VERSION", "SCHEMA_DRIFT_SAMPLES_DDL", "SLO_SAMPLES_DDL"]
+OPS_BENIGN_DDL_CONVERGENCE_PLAN: tuple[str, ...] = (
+    "CREATE INDEX IF NOT EXISTS idx_daemon_events_kind_id ON daemon_events(kind, id DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_daemon_events_lifecycle ON daemon_events(kind, operation_id, id DESC)",
+)
+"""Idempotent same-version OPS fast-forward statements.
+
+The ops tier is disposable and intentionally has no migration chain. Bootstrap
+applies this plan to existing generations after canonical DDL reapplication,
+so the lifecycle query indexes converge without an emitter-local schema write.
+"""
+
+__all__ = [
+    "OPS_BENIGN_DDL_CONVERGENCE_PLAN",
+    "OPS_DDL",
+    "OPS_SCHEMA_VERSION",
+    "SCHEMA_DRIFT_SAMPLES_DDL",
+    "SLO_SAMPLES_DDL",
+]

--- a/polylogue/storage/sqlite/archive_tiers/ops.py
+++ b/polylogue/storage/sqlite/archive_tiers/ops.py
@@ -4,12 +4,29 @@ from __future__ import annotations
 
 from typing import get_args
 
-from polylogue.core.enums import OPERATION_LIFECYCLE_STATUSES, IngestOutcome, Origin
+from polylogue.core.enums import OPERATION_LIFECYCLE_STATUSES, IngestOutcome, Origin, SloSampleLabel
 from polylogue.schemas.drift_sentinel import DriftClassification
 from polylogue.storage.sqlite.archive_tiers.common import check, literal_check, nullable_check
 
 OPS_SCHEMA_VERSION = 1
 _OPS_RUN_STATUS_CHECK = literal_check("status", *(status.value for status in OPERATION_LIFECYCLE_STATUSES))
+_SLO_SAMPLE_LABEL_CHECK = check("label", SloSampleLabel)
+
+SLO_SAMPLES_DDL = f"""
+CREATE TABLE IF NOT EXISTS slo_samples (
+    sample_id       TEXT PRIMARY KEY,
+    label           TEXT NOT NULL CHECK ({_SLO_SAMPLE_LABEL_CHECK}),
+    scope           TEXT NOT NULL DEFAULT 'archive',
+    value           REAL NOT NULL,
+    observed_at_ms  INTEGER NOT NULL,
+    window_start_ms INTEGER,
+    window_end_ms   INTEGER,
+    metadata_json   TEXT NOT NULL DEFAULT '{{}}'
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_slo_samples_label_time
+ON slo_samples(label, observed_at_ms DESC);
+"""
 
 # Split out of OPS_DDL (polylogue-sd9s) so the ops-bootstrap convergence step
 # that repairs a stale live CHECK (``_ensure_schema_drift_samples_check`` in
@@ -166,6 +183,12 @@ CREATE TABLE IF NOT EXISTS cursor_lag_samples (
 
 CREATE INDEX IF NOT EXISTS idx_cursor_lag_samples_family_time
 ON cursor_lag_samples(family, sampled_at_ms DESC);
+
+-- Optional steady-state telemetry. This table is disposable and deliberately
+-- self-healing through the idempotent OPS_DDL reapply path. It records only
+-- bounded numeric samples; the source events and cursor tables remain the
+-- authoritative evidence for the projection that produces them.
+{SLO_SAMPLES_DDL}
 
 CREATE TABLE IF NOT EXISTS daemon_stage_events (
     event_id       TEXT PRIMARY KEY,
@@ -351,4 +374,4 @@ ON fts_drift_samples(surface, sampled_at_ms DESC);
 -- drift apart from each other.
 {SCHEMA_DRIFT_SAMPLES_DDL}"""
 
-__all__ = ["OPS_DDL", "OPS_SCHEMA_VERSION", "SCHEMA_DRIFT_SAMPLES_DDL"]
+__all__ = ["OPS_DDL", "OPS_SCHEMA_VERSION", "SCHEMA_DRIFT_SAMPLES_DDL", "SLO_SAMPLES_DDL"]

--- a/polylogue/storage/sqlite/archive_tiers/ops_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/ops_write.py
@@ -10,7 +10,12 @@ import sqlite3
 import uuid
 from dataclasses import dataclass
 
-from polylogue.core.enums import IngestOutcome, OperationStatus, Origin, require_operation_lifecycle_status
+from polylogue.core.enums import (
+    IngestOutcome,
+    OperationStatus,
+    Origin,
+    require_operation_lifecycle_status,
+)
 from polylogue.pipeline.ingest_outcomes import IngestAttemptDisposition
 
 MCP_CALL_LOG_RETENTION_MS = 90 * 24 * 60 * 60 * 1000

--- a/tests/unit/daemon/test_slo_observability.py
+++ b/tests/unit/daemon/test_slo_observability.py
@@ -21,6 +21,7 @@ from polylogue.daemon.events import (
     emit_catch_up_cycle,
     emit_daemon_event,
     query_daemon_events,
+    query_recent_catch_up_lifecycles,
 )
 from polylogue.daemon.slo import (
     CATCH_UP_ACTIVE_STALE_AFTER_MS,
@@ -51,10 +52,12 @@ def _cycle(
     operation_id: str = "cycle-1",
     phase: str = "end",
     timestamp_ms: int = 1_000,
+    event_id: int | None = None,
     terminal_outcome: str | None = None,
 ) -> dict[str, object]:
     return {
         "kind": "catch_up_cycle",
+        "id": timestamp_ms if event_id is None else event_id,
         "operation_id": operation_id,
         "ts": datetime.fromtimestamp(timestamp_ms / 1000, tz=UTC).isoformat(),
         "payload": {
@@ -70,6 +73,33 @@ def _cycle(
             "terminal_outcome": terminal_outcome,
         },
     }
+
+
+def _emit_persisted_cycle(
+    operation_id: str,
+    *,
+    phase: str,
+    backlog_end: int,
+    terminal_outcome: str | None = None,
+) -> None:
+    emit_catch_up_cycle(
+        operation_id=operation_id,
+        phase=phase,
+        backlog_start=1,
+        backlog_end=backlog_end,
+        discovered=1,
+        attempted=1 if phase != "start" else 0,
+        skipped=0,
+        ingested=1 if backlog_end == 0 and phase != "start" else 0,
+        quarantine_count=0,
+        errors_by_kind={},
+        cursor_before=None,
+        cursor_after=None,
+        duration_ms=10.0,
+        stage_timings_s={},
+        repair=None,
+        terminal_outcome=terminal_outcome,
+    )
 
 
 def test_idle_backlog_is_not_reported_as_stalled() -> None:
@@ -121,6 +151,57 @@ def test_unmatched_terminal_receipt_is_unknown() -> None:
 
     assert windows[0].verdict is SloVerdict.UNKNOWN
     assert windows[0].reason == "catch-up cycle terminal receipt has no matching start"
+
+
+@pytest.mark.parametrize("outcome", ["cancelled", "stopped"])
+def test_cancelled_and_stopped_cycles_are_failed_until_redriven(outcome: str) -> None:
+    status = slo_status_info(
+        cursor_lag=CursorLagSummary(),
+        events=[
+            _cycle(backlog_start=3, backlog_end=3, discovered=3, phase="start", event_id=10),
+            _cycle(
+                backlog_start=3,
+                backlog_end=3,
+                discovered=3,
+                phase="terminal",
+                terminal_outcome=outcome,
+                event_id=11,
+            ),
+        ],
+        now_ms=2_000,
+    )
+
+    assert status.verdict is SloVerdict.FAILED
+    assert status.reason == f"catch-up cycle terminated: {outcome}"
+
+
+def test_lifecycle_pairing_uses_insertion_id_when_timestamps_rollback() -> None:
+    status = slo_status_info(
+        cursor_lag=CursorLagSummary(),
+        events=[
+            _cycle(
+                backlog_start=2,
+                backlog_end=0,
+                discovered=2,
+                ingested=2,
+                timestamp_ms=1_000,
+                event_id=12,
+            ),
+            _cycle(
+                backlog_start=2,
+                backlog_end=2,
+                discovered=2,
+                phase="start",
+                timestamp_ms=10_000,
+                event_id=11,
+            ),
+        ],
+        now_ms=10_500,
+    )
+
+    assert status.verdict is SloVerdict.HEALTHY
+    assert status.latest_window is not None
+    assert status.latest_window.observed_at_ms == 1_000
 
 
 def test_status_reuses_event_and_cursor_lag_sources() -> None:
@@ -374,6 +455,41 @@ def test_persisted_lifecycle_pair_survives_unrelated_event_traffic(workspace_env
     assert status.verdict is SloVerdict.HEALTHY
     assert status.latest_window is not None
     assert status.latest_window.operation_id == "paired-through-traffic"
+
+
+def test_bounded_history_fails_closed_when_older_active_cycle_is_outside_window(
+    workspace_env: dict[str, Path],
+) -> None:
+    del workspace_env
+    _emit_persisted_cycle("older-active", phase="start", backlog_end=1)
+    for index in range(33):
+        operation_id = f"recent-{index}"
+        _emit_persisted_cycle(operation_id, phase="start", backlog_end=1)
+        _emit_persisted_cycle(operation_id, phase="end", backlog_end=0)
+
+    history = query_recent_catch_up_lifecycles()
+    status = slo_status_info(cursor_lag=CursorLagSummary())
+
+    assert len(history.events) <= 32 * 4
+    assert history.incomplete is True
+    assert "older-active" not in {event["operation_id"] for event in history.events}
+    assert status.verdict is SloVerdict.UNKNOWN
+    assert status.lifecycle_history_incomplete is True
+    assert status.reason == "catch-up lifecycle history is incomplete"
+
+
+def test_repeated_operation_identity_makes_persisted_history_incomplete(workspace_env: dict[str, Path]) -> None:
+    del workspace_env
+    for phase, backlog_end in (("start", 1), ("end", 0), ("start", 1), ("end", 0)):
+        _emit_persisted_cycle("repeated", phase=phase, backlog_end=backlog_end)
+
+    history = query_recent_catch_up_lifecycles()
+    status = slo_status_info(cursor_lag=CursorLagSummary())
+
+    assert len(history.events) == 4
+    assert history.incomplete is True
+    assert status.verdict is SloVerdict.UNKNOWN
+    assert status.lifecycle_history_incomplete is True
 
 
 def test_live_tail_sampling_adds_latency_but_bulk_sampling_does_not(tmp_path: Path) -> None:

--- a/tests/unit/daemon/test_slo_observability.py
+++ b/tests/unit/daemon/test_slo_observability.py
@@ -1,0 +1,185 @@
+"""Hermetic steady-state SLO projection tests (polylogue-8jg9.3).
+
+The mutation-proof cases exercise the real projection over existing
+``catch_up_cycle`` event envelopes and cursor-lag models. Removing the event
+source reuse or changing the idle/stalled predicate makes these tests fail.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import polylogue.operations.slo as slo_storage
+from polylogue.core.enums import SloSampleLabel
+from polylogue.daemon.cursor_lag_status import CursorLagSummary
+from polylogue.daemon.slo import (
+    SloVerdict,
+    backlog_window_from_event,
+    project_backlog_windows,
+    record_backlog_window_sample,
+    reduce_slo_samples,
+    slo_status_info,
+)
+from polylogue.operations.slo import (
+    ArchiveSloSample,
+    list_slo_samples,
+    record_slo_sample,
+)
+
+
+def _cycle(
+    *,
+    backlog_start: int,
+    backlog_end: int,
+    discovered: int,
+    attempted: int = 0,
+    ingested: int = 0,
+    skipped: int = 0,
+    quarantine_count: int = 0,
+    duration_ms: float = 1000.0,
+    operation_id: str = "cycle-1",
+) -> dict[str, object]:
+    return {
+        "kind": "catch_up_cycle",
+        "operation_id": operation_id,
+        "ts_ms": 1_000,
+        "payload": {
+            "phase": "end",
+            "backlog_start": backlog_start,
+            "backlog_end": backlog_end,
+            "discovered": discovered,
+            "attempted": attempted,
+            "ingested": ingested,
+            "skipped": skipped,
+            "quarantine_count": quarantine_count,
+            "duration_ms": duration_ms,
+        },
+    }
+
+
+def test_idle_backlog_is_not_reported_as_stalled() -> None:
+    windows = project_backlog_windows([_cycle(backlog_start=7, backlog_end=7, discovered=0)])
+
+    assert len(windows) == 1
+    assert windows[0].verdict is SloVerdict.IDLE
+    assert windows[0].offered_work == 0
+    assert windows[0].drain_rate_per_s == 0.0
+
+
+def test_offered_work_without_drain_is_stalled() -> None:
+    windows = project_backlog_windows([_cycle(backlog_start=7, backlog_end=7, discovered=3, attempted=3)])
+
+    assert windows[0].verdict is SloVerdict.STALLED
+    assert windows[0].offered_work == 3
+    assert windows[0].drained_work == 0
+
+
+def test_status_reuses_event_and_cursor_lag_sources() -> None:
+    status = slo_status_info(
+        cursor_lag=CursorLagSummary(stuck_file_count=2, degraded_file_count=1),
+        events=[_cycle(backlog_start=5, backlog_end=3, discovered=2, attempted=2, ingested=2)],
+    )
+
+    assert status.verdict is SloVerdict.DRAINING
+    assert status.backlog == 3
+    assert status.offered_work == 2
+    assert status.drained_work == 2
+    assert status.cursor_lag_stuck_file_count == 2
+    assert status.cursor_lag_degraded_file_count == 1
+
+
+def test_bulk_import_marker_suppresses_ingest_slo() -> None:
+    events: list[dict[str, object]] = [
+        {"kind": "bulk_import_started", "payload": {}},
+        _cycle(backlog_start=4, backlog_end=4, discovered=4, attempted=4),
+    ]
+
+    windows = project_backlog_windows(events)
+    assert windows[0].verdict is SloVerdict.SUPPRESSED
+    assert windows[0].bulk_import_suppressed is True
+
+
+def test_live_tail_sampling_adds_latency_but_bulk_sampling_does_not(tmp_path: Path) -> None:
+    db = tmp_path / "ops.db"
+    live = backlog_window_from_event(_cycle(backlog_start=3, backlog_end=2, discovered=1, ingested=1))
+    suppressed = backlog_window_from_event(
+        _cycle(backlog_start=3, backlog_end=2, discovered=1, ingested=1),
+        bulk_import_suppressed=True,
+    )
+    assert live is not None and suppressed is not None
+
+    live_ids = record_backlog_window_sample(db, live)
+    suppressed_ids = record_backlog_window_sample(db, suppressed)
+
+    with sqlite3.connect(db) as conn:
+        labels = [row[0] for row in conn.execute("SELECT label FROM slo_samples ORDER BY rowid")]
+    assert len(live_ids) == 4
+    assert len(suppressed_ids) == 3
+    assert labels.count(SloSampleLabel.INGEST_LATENCY.value) == 1
+
+
+def test_reducer_is_level_only_on_cold_start_and_derives_trend_fields() -> None:
+    cold = reduce_slo_samples(
+        [ArchiveSloSample("cold", SloSampleLabel.BACKLOG.value, "archive", 8.0, 1_000, None, None, {})]
+    )
+    assert cold.level == 8.0
+    assert cold.p95 == 8.0
+    assert cold.confident is False
+    assert cold.slope_per_s is None
+    assert cold.eta_s is None
+
+    samples = tuple(
+        ArchiveSloSample(
+            f"sample-{index}",
+            SloSampleLabel.BACKLOG.value,
+            "archive",
+            float(value),
+            1_000 + index * 1_000,
+            None,
+            None,
+            {},
+        )
+        for index, value in enumerate((10, 6, 2))
+    )
+    reduction = reduce_slo_samples(samples, target_rate=2.0)
+    assert reduction.confident is True
+    assert reduction.level == 2.0
+    assert reduction.slope_per_s == -4.0
+    assert reduction.eta_s == 0.5
+    assert reduction.burn_rate == 1.0
+    assert reduction.p50 == 6.0
+    assert reduction.p95 == 2.4
+
+
+def test_slo_samples_self_heal_and_retention_bound(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = tmp_path / "ops.db"
+    monkeypatch.setattr(slo_storage, "SLO_SAMPLE_ROW_CAP", 2)
+    record_slo_sample(
+        db,
+        label=SloSampleLabel.BACKLOG,
+        value=9,
+        observed_at_ms=1_000,
+        sample_id="old",
+    )
+    record_slo_sample(
+        db,
+        label=SloSampleLabel.BACKLOG,
+        value=3,
+        observed_at_ms=30 * 24 * 60 * 60 * 1000 + 2_000,
+        sample_id="new-1",
+    )
+    record_slo_sample(
+        db,
+        label=SloSampleLabel.BACKLOG,
+        value=2,
+        observed_at_ms=30 * 24 * 60 * 60 * 1000 + 3_000,
+        sample_id="new-2",
+    )
+    with sqlite3.connect(db) as conn:
+        assert conn.execute("SELECT 1 FROM sqlite_master WHERE name = 'slo_samples'").fetchone() is not None
+    rows = list_slo_samples(db, label=SloSampleLabel.BACKLOG)
+
+    assert [row.sample_id for row in rows] == ["new-2", "new-1"]

--- a/tests/unit/daemon/test_slo_observability.py
+++ b/tests/unit/daemon/test_slo_observability.py
@@ -8,6 +8,7 @@ source reuse or changing the idle/stalled predicate makes these tests fail.
 from __future__ import annotations
 
 import sqlite3
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -15,6 +16,7 @@ import pytest
 import polylogue.operations.slo as slo_storage
 from polylogue.core.enums import SloSampleLabel
 from polylogue.daemon.cursor_lag_status import CursorLagSummary
+from polylogue.daemon.events import emit_catch_up_cycle, query_daemon_events
 from polylogue.daemon.slo import (
     SloVerdict,
     backlog_window_from_event,
@@ -41,13 +43,15 @@ def _cycle(
     quarantine_count: int = 0,
     duration_ms: float = 1000.0,
     operation_id: str = "cycle-1",
+    phase: str = "end",
+    timestamp_ms: int = 1_000,
 ) -> dict[str, object]:
     return {
         "kind": "catch_up_cycle",
         "operation_id": operation_id,
-        "ts_ms": 1_000,
+        "ts": datetime.fromtimestamp(timestamp_ms / 1000, tz=UTC).isoformat(),
         "payload": {
-            "phase": "end",
+            "phase": phase,
             "backlog_start": backlog_start,
             "backlog_end": backlog_end,
             "discovered": discovered,
@@ -100,6 +104,86 @@ def test_bulk_import_marker_suppresses_ingest_slo() -> None:
     windows = project_backlog_windows(events)
     assert windows[0].verdict is SloVerdict.SUPPRESSED
     assert windows[0].bulk_import_suppressed is True
+
+
+def test_newer_start_cycle_overrides_stale_completed_verdict() -> None:
+    events = [
+        _cycle(backlog_start=3, backlog_end=0, discovered=3, ingested=3, operation_id="old", timestamp_ms=1_000),
+        _cycle(
+            backlog_start=5,
+            backlog_end=5,
+            discovered=5,
+            operation_id="current",
+            phase="start",
+            timestamp_ms=2_000,
+        ),
+    ]
+
+    status = slo_status_info(cursor_lag=CursorLagSummary(), events=list(reversed(events)))
+
+    assert status.verdict is SloVerdict.ACTIVE
+    assert status.latest_window is not None
+    assert status.latest_window.operation_id == "current"
+    assert status.latest_window.in_progress is True
+    assert status.latest_window.observed_at_ms == 2_000
+
+
+def test_newer_end_cycle_closes_its_matching_start_before_status_projection() -> None:
+    events = [
+        _cycle(
+            backlog_start=4,
+            backlog_end=4,
+            discovered=4,
+            operation_id="completed",
+            phase="start",
+            timestamp_ms=1_000,
+        ),
+        _cycle(
+            backlog_start=4,
+            backlog_end=0,
+            discovered=4,
+            ingested=4,
+            operation_id="completed",
+            timestamp_ms=2_000,
+        ),
+    ]
+
+    status = slo_status_info(cursor_lag=CursorLagSummary(), events=list(reversed(events)))
+
+    assert status.verdict is SloVerdict.HEALTHY
+    assert status.latest_window is not None
+    assert status.latest_window.operation_id == "completed"
+    assert status.latest_window.in_progress is False
+    assert status.latest_window.observed_at_ms == 2_000
+
+
+def test_event_reader_timestamp_is_preserved_without_wall_clock_fallback(workspace_env: dict[str, Path]) -> None:
+    del workspace_env
+    emit_catch_up_cycle(
+        operation_id="timestamped",
+        phase="end",
+        backlog_start=2,
+        backlog_end=1,
+        discovered=1,
+        attempted=1,
+        skipped=0,
+        ingested=1,
+        quarantine_count=0,
+        errors_by_kind={},
+        cursor_before=None,
+        cursor_after=None,
+        duration_ms=10.0,
+        stage_timings_s={},
+        repair=None,
+    )
+
+    event = query_daemon_events(kind="catch_up_cycle", limit=1)[0]
+    window = backlog_window_from_event(event)
+
+    assert window is not None
+    assert isinstance(event["ts"], str)
+    expected_ms = int(datetime.fromisoformat(event["ts"].replace("Z", "+00:00")).timestamp() * 1000)
+    assert window.observed_at_ms == expected_ms
 
 
 def test_live_tail_sampling_adds_latency_but_bulk_sampling_does_not(tmp_path: Path) -> None:

--- a/tests/unit/daemon/test_slo_observability.py
+++ b/tests/unit/daemon/test_slo_observability.py
@@ -16,7 +16,12 @@ import pytest
 import polylogue.operations.slo as slo_storage
 from polylogue.core.enums import SloSampleLabel
 from polylogue.daemon.cursor_lag_status import CursorLagSummary
-from polylogue.daemon.events import CatchUpCycleTerminalOutcome, emit_catch_up_cycle, query_daemon_events
+from polylogue.daemon.events import (
+    CatchUpCycleTerminalOutcome,
+    emit_catch_up_cycle,
+    emit_daemon_event,
+    query_daemon_events,
+)
 from polylogue.daemon.slo import (
     CATCH_UP_ACTIVE_STALE_AFTER_MS,
     SloVerdict,
@@ -68,7 +73,12 @@ def _cycle(
 
 
 def test_idle_backlog_is_not_reported_as_stalled() -> None:
-    windows = project_backlog_windows([_cycle(backlog_start=7, backlog_end=7, discovered=0)])
+    windows = project_backlog_windows(
+        [
+            _cycle(backlog_start=7, backlog_end=7, discovered=0, phase="start"),
+            _cycle(backlog_start=7, backlog_end=7, discovered=0),
+        ]
+    )
 
     assert len(windows) == 1
     assert windows[0].verdict is SloVerdict.IDLE
@@ -77,17 +87,49 @@ def test_idle_backlog_is_not_reported_as_stalled() -> None:
 
 
 def test_offered_work_without_drain_is_stalled() -> None:
-    windows = project_backlog_windows([_cycle(backlog_start=7, backlog_end=7, discovered=3, attempted=3)])
+    windows = project_backlog_windows(
+        [
+            _cycle(backlog_start=7, backlog_end=7, discovered=3, phase="start"),
+            _cycle(backlog_start=7, backlog_end=7, discovered=3, attempted=3),
+        ]
+    )
 
     assert windows[0].verdict is SloVerdict.STALLED
     assert windows[0].offered_work == 3
     assert windows[0].drained_work == 0
 
 
+def test_unmatched_end_is_unknown_not_healthy() -> None:
+    windows = project_backlog_windows([_cycle(backlog_start=3, backlog_end=0, discovered=3, ingested=3)])
+
+    assert windows[0].verdict is SloVerdict.UNKNOWN
+    assert windows[0].reason == "catch-up cycle end has no matching start"
+
+
+def test_unmatched_terminal_receipt_is_unknown() -> None:
+    windows = project_backlog_windows(
+        [
+            _cycle(
+                backlog_start=3,
+                backlog_end=3,
+                discovered=3,
+                phase="terminal",
+                terminal_outcome="cancelled",
+            )
+        ]
+    )
+
+    assert windows[0].verdict is SloVerdict.UNKNOWN
+    assert windows[0].reason == "catch-up cycle terminal receipt has no matching start"
+
+
 def test_status_reuses_event_and_cursor_lag_sources() -> None:
     status = slo_status_info(
         cursor_lag=CursorLagSummary(stuck_file_count=2, degraded_file_count=1),
-        events=[_cycle(backlog_start=5, backlog_end=3, discovered=2, attempted=2, ingested=2)],
+        events=[
+            _cycle(backlog_start=5, backlog_end=5, discovered=2, phase="start", timestamp_ms=500),
+            _cycle(backlog_start=5, backlog_end=3, discovered=2, attempted=2, ingested=2),
+        ],
         now_ms=1_500,
     )
 
@@ -102,6 +144,7 @@ def test_status_reuses_event_and_cursor_lag_sources() -> None:
 def test_bulk_import_marker_suppresses_ingest_slo() -> None:
     events: list[dict[str, object]] = [
         {"kind": "bulk_import_started", "payload": {}},
+        _cycle(backlog_start=4, backlog_end=4, discovered=4, phase="start"),
         _cycle(backlog_start=4, backlog_end=4, discovered=4, attempted=4),
     ]
 
@@ -259,6 +302,78 @@ def test_event_reader_timestamp_is_preserved_without_wall_clock_fallback(workspa
     assert isinstance(event["ts"], str)
     expected_ms = int(datetime.fromisoformat(event["ts"].replace("Z", "+00:00")).timestamp() * 1000)
     assert window.observed_at_ms == expected_ms
+
+
+def test_persisted_unmatched_end_fails_closed_in_status(workspace_env: dict[str, Path]) -> None:
+    del workspace_env
+    emit_catch_up_cycle(
+        operation_id="unmatched-end",
+        phase="end",
+        backlog_start=2,
+        backlog_end=0,
+        discovered=2,
+        attempted=2,
+        skipped=0,
+        ingested=2,
+        quarantine_count=0,
+        errors_by_kind={},
+        cursor_before=None,
+        cursor_after=None,
+        duration_ms=10.0,
+        stage_timings_s={},
+        repair=None,
+    )
+
+    status = slo_status_info(cursor_lag=CursorLagSummary())
+
+    assert status.verdict is SloVerdict.UNKNOWN
+    assert status.reason == "catch-up cycle end has no matching start"
+
+
+def test_persisted_lifecycle_pair_survives_unrelated_event_traffic(workspace_env: dict[str, Path]) -> None:
+    del workspace_env
+    emit_catch_up_cycle(
+        operation_id="paired-through-traffic",
+        phase="start",
+        backlog_start=2,
+        backlog_end=2,
+        discovered=2,
+        attempted=0,
+        skipped=0,
+        ingested=0,
+        quarantine_count=0,
+        errors_by_kind={},
+        cursor_before=None,
+        cursor_after=None,
+        duration_ms=0.0,
+        stage_timings_s={},
+        repair=None,
+    )
+    for index in range(60):
+        emit_daemon_event("unrelated", operation_id=f"unrelated-{index}")
+    emit_catch_up_cycle(
+        operation_id="paired-through-traffic",
+        phase="end",
+        backlog_start=2,
+        backlog_end=0,
+        discovered=2,
+        attempted=2,
+        skipped=0,
+        ingested=2,
+        quarantine_count=0,
+        errors_by_kind={},
+        cursor_before=None,
+        cursor_after=None,
+        duration_ms=10.0,
+        stage_timings_s={},
+        repair=None,
+    )
+
+    status = slo_status_info(cursor_lag=CursorLagSummary())
+
+    assert status.verdict is SloVerdict.HEALTHY
+    assert status.latest_window is not None
+    assert status.latest_window.operation_id == "paired-through-traffic"
 
 
 def test_live_tail_sampling_adds_latency_but_bulk_sampling_does_not(tmp_path: Path) -> None:

--- a/tests/unit/daemon/test_slo_observability.py
+++ b/tests/unit/daemon/test_slo_observability.py
@@ -17,6 +17,7 @@ import polylogue.operations.slo as slo_storage
 from polylogue.core.enums import SloSampleLabel
 from polylogue.daemon.cursor_lag_status import CursorLagSummary
 from polylogue.daemon.events import (
+    CATCH_UP_LIFECYCLE_RETURN_LIMIT,
     CatchUpCycleTerminalOutcome,
     emit_catch_up_cycle,
     emit_daemon_event,
@@ -133,7 +134,7 @@ def test_unmatched_end_is_unknown_not_healthy() -> None:
     windows = project_backlog_windows([_cycle(backlog_start=3, backlog_end=0, discovered=3, ingested=3)])
 
     assert windows[0].verdict is SloVerdict.UNKNOWN
-    assert windows[0].reason == "catch-up cycle end has no matching start"
+    assert windows[0].reason == "catch-up lifecycle grammar is invalid"
 
 
 def test_unmatched_terminal_receipt_is_unknown() -> None:
@@ -150,7 +151,7 @@ def test_unmatched_terminal_receipt_is_unknown() -> None:
     )
 
     assert windows[0].verdict is SloVerdict.UNKNOWN
-    assert windows[0].reason == "catch-up cycle terminal receipt has no matching start"
+    assert windows[0].reason == "catch-up lifecycle grammar is invalid"
 
 
 @pytest.mark.parametrize("outcome", ["cancelled", "stopped"])
@@ -204,6 +205,72 @@ def test_lifecycle_pairing_uses_insertion_id_when_timestamps_rollback() -> None:
     assert status.latest_window.observed_at_ms == 1_000
 
 
+def test_persisted_repeated_start_then_end_is_unknown(workspace_env: dict[str, Path]) -> None:
+    del workspace_env
+    _emit_persisted_cycle("repeated-start", phase="start", backlog_end=1)
+    _emit_persisted_cycle("repeated-start", phase="start", backlog_end=1)
+    _emit_persisted_cycle("repeated-start", phase="end", backlog_end=0)
+
+    status = slo_status_info(cursor_lag=CursorLagSummary())
+
+    assert status.verdict is SloVerdict.UNKNOWN
+    assert status.lifecycle_history_incomplete is True
+    assert status.reason == "catch-up lifecycle grammar is invalid"
+
+
+def test_persisted_multiple_end_receipts_are_unknown(workspace_env: dict[str, Path]) -> None:
+    del workspace_env
+    _emit_persisted_cycle("multiple-end", phase="start", backlog_end=1)
+    _emit_persisted_cycle("multiple-end", phase="end", backlog_end=0)
+    _emit_persisted_cycle("multiple-end", phase="end", backlog_end=0)
+
+    status = slo_status_info(cursor_lag=CursorLagSummary())
+
+    assert status.verdict is SloVerdict.UNKNOWN
+    assert status.lifecycle_history_incomplete is True
+    assert status.reason == "catch-up lifecycle grammar is invalid"
+
+
+def test_persisted_multiple_terminal_receipts_are_unknown(workspace_env: dict[str, Path]) -> None:
+    del workspace_env
+    _emit_persisted_cycle("multiple-terminal", phase="start", backlog_end=1)
+    _emit_persisted_cycle(
+        "multiple-terminal",
+        phase="terminal",
+        backlog_end=1,
+        terminal_outcome="cancelled",
+    )
+    _emit_persisted_cycle(
+        "multiple-terminal",
+        phase="terminal",
+        backlog_end=1,
+        terminal_outcome="stopped",
+    )
+
+    status = slo_status_info(cursor_lag=CursorLagSummary())
+
+    assert status.verdict is SloVerdict.UNKNOWN
+    assert status.lifecycle_history_incomplete is True
+    assert status.reason == "catch-up lifecycle grammar is invalid"
+
+
+def test_persisted_unsupported_phase_invalidates_a_coexisting_valid_pair(workspace_env: dict[str, Path]) -> None:
+    del workspace_env
+    _emit_persisted_cycle("malformed-phase", phase="start", backlog_end=1)
+    _emit_persisted_cycle("malformed-phase", phase="end", backlog_end=0)
+    emit_daemon_event(
+        "catch_up_cycle",
+        operation_id="malformed-phase",
+        payload={"phase": "ignored-by-projection"},
+    )
+
+    status = slo_status_info(cursor_lag=CursorLagSummary())
+
+    assert status.verdict is SloVerdict.UNKNOWN
+    assert status.lifecycle_history_incomplete is True
+    assert status.reason == "catch-up lifecycle grammar is invalid"
+
+
 def test_status_reuses_event_and_cursor_lag_sources() -> None:
     status = slo_status_info(
         cursor_lag=CursorLagSummary(stuck_file_count=2, degraded_file_count=1),
@@ -236,6 +303,14 @@ def test_bulk_import_marker_suppresses_ingest_slo() -> None:
 
 def test_newer_start_cycle_overrides_stale_completed_verdict() -> None:
     events = [
+        _cycle(
+            backlog_start=3,
+            backlog_end=3,
+            discovered=3,
+            operation_id="old",
+            phase="start",
+            timestamp_ms=500,
+        ),
         _cycle(backlog_start=3, backlog_end=0, discovered=3, ingested=3, operation_id="old", timestamp_ms=1_000),
         _cycle(
             backlog_start=5,
@@ -408,7 +483,7 @@ def test_persisted_unmatched_end_fails_closed_in_status(workspace_env: dict[str,
     status = slo_status_info(cursor_lag=CursorLagSummary())
 
     assert status.verdict is SloVerdict.UNKNOWN
-    assert status.reason == "catch-up cycle end has no matching start"
+    assert status.reason == "catch-up lifecycle grammar is invalid"
 
 
 def test_persisted_lifecycle_pair_survives_unrelated_event_traffic(workspace_env: dict[str, Path]) -> None:
@@ -476,6 +551,20 @@ def test_bounded_history_fails_closed_when_older_active_cycle_is_outside_window(
     assert status.verdict is SloVerdict.UNKNOWN
     assert status.lifecycle_history_incomplete is True
     assert status.reason == "catch-up lifecycle history is incomplete"
+
+
+def test_lifecycle_history_return_count_includes_the_bulk_marker_bound(workspace_env: dict[str, Path]) -> None:
+    del workspace_env
+    for _receipt in range(4):
+        for index in range(32):
+            _emit_persisted_cycle(f"bounded-{index}", phase="start", backlog_end=1)
+    emit_daemon_event("bulk_import_started")
+
+    history = query_recent_catch_up_lifecycles()
+
+    assert CATCH_UP_LIFECYCLE_RETURN_LIMIT == 129
+    assert len(history.events) == CATCH_UP_LIFECYCLE_RETURN_LIMIT
+    assert history.incomplete is True
 
 
 def test_repeated_operation_identity_makes_persisted_history_incomplete(workspace_env: dict[str, Path]) -> None:

--- a/tests/unit/daemon/test_slo_observability.py
+++ b/tests/unit/daemon/test_slo_observability.py
@@ -16,8 +16,9 @@ import pytest
 import polylogue.operations.slo as slo_storage
 from polylogue.core.enums import SloSampleLabel
 from polylogue.daemon.cursor_lag_status import CursorLagSummary
-from polylogue.daemon.events import emit_catch_up_cycle, query_daemon_events
+from polylogue.daemon.events import CatchUpCycleTerminalOutcome, emit_catch_up_cycle, query_daemon_events
 from polylogue.daemon.slo import (
+    CATCH_UP_ACTIVE_STALE_AFTER_MS,
     SloVerdict,
     backlog_window_from_event,
     project_backlog_windows,
@@ -45,6 +46,7 @@ def _cycle(
     operation_id: str = "cycle-1",
     phase: str = "end",
     timestamp_ms: int = 1_000,
+    terminal_outcome: str | None = None,
 ) -> dict[str, object]:
     return {
         "kind": "catch_up_cycle",
@@ -60,6 +62,7 @@ def _cycle(
             "skipped": skipped,
             "quarantine_count": quarantine_count,
             "duration_ms": duration_ms,
+            "terminal_outcome": terminal_outcome,
         },
     }
 
@@ -85,6 +88,7 @@ def test_status_reuses_event_and_cursor_lag_sources() -> None:
     status = slo_status_info(
         cursor_lag=CursorLagSummary(stuck_file_count=2, degraded_file_count=1),
         events=[_cycle(backlog_start=5, backlog_end=3, discovered=2, attempted=2, ingested=2)],
+        now_ms=1_500,
     )
 
     assert status.verdict is SloVerdict.DRAINING
@@ -119,7 +123,7 @@ def test_newer_start_cycle_overrides_stale_completed_verdict() -> None:
         ),
     ]
 
-    status = slo_status_info(cursor_lag=CursorLagSummary(), events=list(reversed(events)))
+    status = slo_status_info(cursor_lag=CursorLagSummary(), events=list(reversed(events)), now_ms=2_500)
 
     assert status.verdict is SloVerdict.ACTIVE
     assert status.latest_window is not None
@@ -148,13 +152,84 @@ def test_newer_end_cycle_closes_its_matching_start_before_status_projection() ->
         ),
     ]
 
-    status = slo_status_info(cursor_lag=CursorLagSummary(), events=list(reversed(events)))
+    status = slo_status_info(cursor_lag=CursorLagSummary(), events=list(reversed(events)), now_ms=2_500)
 
     assert status.verdict is SloVerdict.HEALTHY
     assert status.latest_window is not None
     assert status.latest_window.operation_id == "completed"
     assert status.latest_window.in_progress is False
     assert status.latest_window.observed_at_ms == 2_000
+
+
+def test_terminal_failure_closes_matching_start_with_typed_failed_verdict() -> None:
+    events = [
+        _cycle(backlog_start=4, backlog_end=4, discovered=4, operation_id="failed", phase="start", timestamp_ms=1_000),
+        _cycle(
+            backlog_start=4,
+            backlog_end=4,
+            discovered=4,
+            operation_id="failed",
+            phase="terminal",
+            terminal_outcome="failure",
+            timestamp_ms=2_000,
+        ),
+    ]
+
+    status = slo_status_info(cursor_lag=CursorLagSummary(), events=events, now_ms=2_500)
+
+    assert status.verdict is SloVerdict.FAILED
+    assert status.latest_window is not None
+    assert status.latest_window.in_progress is False
+    assert status.latest_window.terminal_outcome is CatchUpCycleTerminalOutcome.FAILURE
+
+
+def test_terminal_success_preserves_the_matching_end_measurement() -> None:
+    events = [
+        _cycle(
+            backlog_start=4, backlog_end=4, discovered=4, operation_id="complete", phase="start", timestamp_ms=1_000
+        ),
+        _cycle(
+            backlog_start=4,
+            backlog_end=0,
+            discovered=4,
+            ingested=4,
+            operation_id="complete",
+            timestamp_ms=2_000,
+        ),
+        _cycle(
+            backlog_start=4,
+            backlog_end=0,
+            discovered=4,
+            ingested=4,
+            operation_id="complete",
+            phase="terminal",
+            terminal_outcome="success",
+            timestamp_ms=3_000,
+        ),
+    ]
+
+    status = slo_status_info(cursor_lag=CursorLagSummary(), events=events, now_ms=3_500)
+
+    assert status.verdict is SloVerdict.HEALTHY
+    assert status.latest_window is not None
+    assert status.latest_window.phase == "end"
+    assert status.latest_window.observed_at_ms == 2_000
+
+
+def test_unmatched_start_becomes_stale_from_its_persisted_timestamp() -> None:
+    start = _cycle(backlog_start=3, backlog_end=3, discovered=3, phase="start", timestamp_ms=1_000)
+
+    active = slo_status_info(cursor_lag=CursorLagSummary(), events=[start], now_ms=1_000)
+    stale = slo_status_info(
+        cursor_lag=CursorLagSummary(),
+        events=[start],
+        now_ms=1_000 + CATCH_UP_ACTIVE_STALE_AFTER_MS,
+    )
+
+    assert active.verdict is SloVerdict.ACTIVE
+    assert stale.verdict is SloVerdict.STALE
+    assert stale.latest_window is not None
+    assert stale.latest_window.in_progress is False
 
 
 def test_event_reader_timestamp_is_preserved_without_wall_clock_fallback(workspace_env: dict[str, Path]) -> None:

--- a/tests/unit/maintenance/test_rebuild_index_phase_timing.py
+++ b/tests/unit/maintenance/test_rebuild_index_phase_timing.py
@@ -96,6 +96,81 @@ def test_replayed_receipt_carries_selection_phase_timing(tmp_path: Path, monkeyp
         assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 2
 
 
+def test_real_receipt_accounts_for_all_rebuild_phases(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The production receipt carries one stable rollup for every rebuild phase.
+
+    This is deliberately a real source-to-index rebuild. The assertions bind
+    the rollups to the existing replay stage ledger and terminal-stage receipt,
+    so a test-only timing fixture cannot make the contract pass.
+    """
+    root = tmp_path / "archive"
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
+    _seed_distinct_codex_sessions(root, 3)
+
+    receipt = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+
+    timings = receipt.timings_s
+    assert {
+        "selection_s",
+        "cohort_s",
+        "parse_s",
+        "apply_s",
+        "insight_s",
+        "terminal_s",
+    }.issubset(timings)
+    assert all(timings[key] >= 0.0 for key in timings)
+
+    stage_timings = receipt.replay["stage_timings_s"]
+    assert isinstance(stage_timings, dict)
+    cohort_stage_seconds = sum(
+        float(value)
+        for key, value in stage_timings.items()
+        if isinstance(key, str)
+        and isinstance(value, int | float)
+        and not isinstance(value, bool)
+        and (
+            key.startswith("replay.classify_cohort")
+            or key.startswith("replay.adoptable_check")
+            or key.startswith("membership.")
+        )
+    )
+    assert cohort_stage_seconds > 0.0
+    assert timings["cohort_s"] == pytest.approx(cohort_stage_seconds, abs=0.005)
+    parse_seconds = receipt.replay["parse_s"]
+    apply_seconds = receipt.replay["apply_s"]
+    assert isinstance(parse_seconds, int | float) and not isinstance(parse_seconds, bool)
+    assert isinstance(apply_seconds, int | float) and not isinstance(apply_seconds, bool)
+    assert timings["parse_s"] == pytest.approx(float(parse_seconds), abs=0.005)
+    assert timings["apply_s"] == pytest.approx(float(apply_seconds), abs=0.005)
+    assert timings["insight_s"] == pytest.approx(timings["terminal.session_insights"], abs=0.005)
+    assert timings["terminal_s"] == pytest.approx(
+        sum(value for key, value in timings.items() if key.startswith("terminal.") and key != "terminal_s"),
+        abs=0.005,
+    )
+
+
+def test_phase_rollups_are_bound_to_production_stage_timing_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The receipt's phase rollups cannot pass from selection timing alone."""
+    root = tmp_path / "archive"
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
+    _seed_distinct_codex_sessions(root, 2)
+
+    original = rebuild_index._repopulate_bulk_build_derived_state
+
+    def instrumented_repopulate(index_path: Path) -> dict[str, float]:
+        timings = original(index_path)
+        timings["mutation_probe"] = 0.125
+        return timings
+
+    monkeypatch.setattr(rebuild_index, "_repopulate_bulk_build_derived_state", instrumented_repopulate)
+    receipt = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+
+    assert receipt.timings_s["terminal.bulk_build.mutation_probe"] == pytest.approx(0.125, abs=0.001)
+    assert receipt.timings_s["terminal_s"] >= receipt.timings_s["terminal.bulk_build.mutation_probe"]
+
+
 def test_partial_rebuild_cannot_complete_when_candidate_omits_source_document(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -21,6 +21,7 @@ import pytest
 
 import polylogue.sources.live.watcher as live_watcher
 from polylogue import Polylogue
+from polylogue.daemon.events import emit_catch_up_cycle, query_daemon_events
 from polylogue.sources.live import LiveWatcher, WatchSource
 from polylogue.sources.live.batch import (
     _SMALL_FULL_PARSE_PROGRESS_MAX_BYTES,
@@ -774,13 +775,21 @@ def _make_watcher(
     *,
     debounce_s: float = 0.01,
     event_emitter: MagicMock | None = None,
+    catch_up_event_emitter: Callable[..., None] | None = None,
     sources: tuple[WatchSource, ...] | None = None,
 ) -> tuple[LiveWatcher, _FullIngestMock]:
     polylogue = MagicMock()
     polylogue.archive_root = tmp_path
     cursor = CursorStore(tmp_path / "cursor.sqlite")
     sources = sources or (WatchSource(name="test", root=root),)
-    watcher = LiveWatcher(polylogue, sources, debounce_s=debounce_s, cursor=cursor, event_emitter=event_emitter)
+    watcher = LiveWatcher(
+        polylogue,
+        sources,
+        debounce_s=debounce_s,
+        cursor=cursor,
+        event_emitter=event_emitter,
+        catch_up_event_emitter=catch_up_event_emitter,
+    )
     full_ingest = _FullIngestMock()
     watcher._batch_processor._ingest_full_paths = full_ingest  # type: ignore[method-assign]
     return watcher, full_ingest
@@ -843,6 +852,34 @@ def test_catch_up_uses_bulk_cursor_records(tmp_path: Path, monkeypatch: pytest.M
     assert captured["paths"] == files
     assert captured["queued_file_count"] == 3
     assert captured["skipped_file_count"] == 0
+
+
+def test_real_catch_up_route_emits_daemon_cycle_start_and_end(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    source = root / "session.jsonl"
+    source.write_text('{"role":"user","content":"a"}\n')
+    archive_root = tmp_path / "archive"
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(archive_root))
+    watcher, full_ingest = _make_watcher(tmp_path, root, catch_up_event_emitter=emit_catch_up_cycle)
+
+    asyncio.run(watcher._catch_up([root]))
+
+    assert full_ingest.await_count == 1
+    events = list(reversed(query_daemon_events(kind="catch_up_cycle", limit=10)))
+    payloads: list[dict[str, object]] = []
+    for event in events:
+        payload = event["payload"]
+        assert isinstance(payload, dict)
+        payloads.append(payload)
+    assert [payload["phase"] for payload in payloads] == ["start", "end"]
+    start, end = events
+    assert start["operation_id"] == end["operation_id"]
+    start_payload, end_payload = payloads
+    assert start_payload["backlog_start"] == 1
+    assert end_payload["attempted"] == 1
+    assert end_payload["ingested"] == 1
+    assert end_payload["backlog_end"] == 0
 
 
 async def _ingest_one(watcher: LiveWatcher, path: Path) -> None:

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -22,6 +22,7 @@ import pytest
 import polylogue.sources.live.watcher as live_watcher
 from polylogue import Polylogue
 from polylogue.daemon.events import emit_catch_up_cycle, query_daemon_events
+from polylogue.daemon.write_coordinator import DaemonWriteCoordinator, DaemonWriteEvent
 from polylogue.sources.live import LiveWatcher, WatchSource
 from polylogue.sources.live.batch import (
     _SMALL_FULL_PARSE_PROGRESS_MAX_BYTES,
@@ -776,6 +777,7 @@ def _make_watcher(
     debounce_s: float = 0.01,
     event_emitter: MagicMock | None = None,
     catch_up_event_emitter: Callable[..., None] | None = None,
+    write_coordinator: object | None = None,
     sources: tuple[WatchSource, ...] | None = None,
 ) -> tuple[LiveWatcher, _FullIngestMock]:
     polylogue = MagicMock()
@@ -789,6 +791,7 @@ def _make_watcher(
         cursor=cursor,
         event_emitter=event_emitter,
         catch_up_event_emitter=catch_up_event_emitter,
+        write_coordinator=write_coordinator,
     )
     full_ingest = _FullIngestMock()
     watcher._batch_processor._ingest_full_paths = full_ingest  # type: ignore[method-assign]
@@ -854,14 +857,23 @@ def test_catch_up_uses_bulk_cursor_records(tmp_path: Path, monkeypatch: pytest.M
     assert captured["skipped_file_count"] == 0
 
 
-def test_real_catch_up_route_emits_daemon_cycle_start_and_end(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_real_catch_up_route_emits_coordinated_success_lifecycle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     root = tmp_path / "src"
     root.mkdir()
     source = root / "session.jsonl"
     source.write_text('{"role":"user","content":"a"}\n')
     archive_root = tmp_path / "archive"
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(archive_root))
-    watcher, full_ingest = _make_watcher(tmp_path, root, catch_up_event_emitter=emit_catch_up_cycle)
+    coordinator_events: list[DaemonWriteEvent] = []
+    coordinator = DaemonWriteCoordinator(observer=coordinator_events.append)
+    watcher, full_ingest = _make_watcher(
+        tmp_path,
+        root,
+        catch_up_event_emitter=emit_catch_up_cycle,
+        write_coordinator=coordinator,
+    )
 
     asyncio.run(watcher._catch_up([root]))
 
@@ -872,14 +884,106 @@ def test_real_catch_up_route_emits_daemon_cycle_start_and_end(tmp_path: Path, mo
         payload = event["payload"]
         assert isinstance(payload, dict)
         payloads.append(payload)
-    assert [payload["phase"] for payload in payloads] == ["start", "end"]
-    start, end = events
-    assert start["operation_id"] == end["operation_id"]
-    start_payload, end_payload = payloads
+    assert [payload["phase"] for payload in payloads] == ["start", "end", "terminal"]
+    start, end, terminal = events
+    assert start["operation_id"] == end["operation_id"] == terminal["operation_id"]
+    start_payload, end_payload, terminal_payload = payloads
     assert start_payload["backlog_start"] == 1
     assert end_payload["attempted"] == 1
     assert end_payload["ingested"] == 1
     assert end_payload["backlog_end"] == 0
+    assert terminal_payload["terminal_outcome"] == "success"
+    assert [
+        event.actor
+        for event in coordinator_events
+        if event.actor == "watcher.catch_up.event" and event.phase == "released"
+    ] == [
+        "watcher.catch_up.event",
+        "watcher.catch_up.event",
+        "watcher.catch_up.event",
+    ]
+
+
+@pytest.mark.parametrize(("outcome", "exception"), [("failure", RuntimeError), ("cancelled", asyncio.CancelledError)])
+def test_real_catch_up_route_emits_terminal_receipt_after_ingest_abort(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    outcome: str,
+    exception: type[BaseException],
+) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    (root / "session.jsonl").write_text('{"role":"user","content":"a"}\n')
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path / "archive"))
+    coordinator_events: list[DaemonWriteEvent] = []
+    watcher, _ = _make_watcher(
+        tmp_path,
+        root,
+        catch_up_event_emitter=emit_catch_up_cycle,
+        write_coordinator=DaemonWriteCoordinator(observer=coordinator_events.append),
+    )
+
+    async def abort_ingest(
+        _paths: list[Path],
+        *,
+        queued_file_count: int | None = None,
+        skipped_file_count: int = 0,
+    ) -> LiveBatchMetrics:
+        del queued_file_count, skipped_file_count
+        raise exception("abort")
+
+    watcher._ingest_files = abort_ingest  # type: ignore[assignment]
+
+    with pytest.raises(exception):
+        asyncio.run(watcher._catch_up([root]))
+
+    events = list(reversed(query_daemon_events(kind="catch_up_cycle", limit=10)))
+    payloads = [cast(dict[str, object], event["payload"]) for event in events]
+    assert [payload["phase"] for payload in payloads] == ["start", "terminal"]
+    assert payloads[-1]["terminal_outcome"] == outcome
+    assert any(event.actor == "watcher.catch_up.event" and event.phase == "released" for event in coordinator_events)
+
+
+def test_real_catch_up_route_emits_terminal_receipt_when_stopped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    (root / "session.jsonl").write_text('{"role":"user","content":"a"}\n')
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path / "archive"))
+    coordinator_events: list[DaemonWriteEvent] = []
+    watcher, full_ingest = _make_watcher(
+        tmp_path,
+        root,
+        catch_up_event_emitter=emit_catch_up_cycle,
+        write_coordinator=DaemonWriteCoordinator(observer=coordinator_events.append),
+    )
+    original_ingest = watcher._ingest_files
+
+    async def stop_after_ingest(
+        paths: list[Path],
+        *,
+        queued_file_count: int | None = None,
+        skipped_file_count: int = 0,
+    ) -> LiveBatchMetrics:
+        metrics = await original_ingest(
+            paths,
+            queued_file_count=queued_file_count,
+            skipped_file_count=skipped_file_count,
+        )
+        watcher.stop()
+        return metrics
+
+    watcher._ingest_files = stop_after_ingest  # type: ignore[method-assign]
+
+    asyncio.run(watcher._catch_up([root]))
+
+    assert full_ingest.await_count == 1
+    events = list(reversed(query_daemon_events(kind="catch_up_cycle", limit=10)))
+    payloads = [cast(dict[str, object], event["payload"]) for event in events]
+    assert [payload["phase"] for payload in payloads] == ["start", "terminal"]
+    assert payloads[-1]["terminal_outcome"] == "stopped"
+    assert any(event.actor == "watcher.catch_up.event" and event.phase == "released" for event in coordinator_events)
 
 
 async def _ingest_one(watcher: LiveWatcher, path: Path) -> None:

--- a/tests/unit/storage/test_archive_tiers_ops_write.py
+++ b/tests/unit/storage/test_archive_tiers_ops_write.py
@@ -7,6 +7,7 @@ import pytest
 
 from polylogue.core.enums import OperationStatus, Origin
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database, initialize_archive_tier
+from polylogue.storage.sqlite.archive_tiers.ops import OPS_BENIGN_DDL_CONVERGENCE_PLAN
 from polylogue.storage.sqlite.archive_tiers.ops_write import (
     ROUTE_OBSERVATION_ROW_CAP,
     ArchiveCursorLagSample,
@@ -93,6 +94,7 @@ def test_existing_ops_db_converges_old_status_checks_and_preserves_rows(tmp_path
             PRAGMA user_version = 1;
             """
         )
+
         conn.execute(
             "INSERT INTO ingest_attempts (attempt_id, status, started_at_ms) VALUES ('legacy-attempt', 'completed', 1)"
         )
@@ -130,6 +132,38 @@ def test_existing_ops_db_converges_old_status_checks_and_preserves_rows(tmp_path
         assert conn.execute("SELECT status FROM embedding_catchup_runs WHERE run_id = 'new-run'").fetchone() == (
             "interrupted",
         )
+
+
+def test_fresh_ops_schema_declares_daemon_event_lifecycle_indexes(tmp_path: Path) -> None:
+    ops_db = tmp_path / "ops.db"
+    initialize_archive_database(ops_db, ArchiveTier.OPS)
+
+    with sqlite3.connect(ops_db) as conn:
+        indexes = {row[1] for row in conn.execute("PRAGMA index_list('daemon_events')")}
+
+    assert {"idx_daemon_events_kind_id", "idx_daemon_events_lifecycle"} <= indexes
+
+
+def test_existing_ops_db_applies_daemon_event_index_convergence_plan(tmp_path: Path) -> None:
+    ops_db = tmp_path / "ops.db"
+    with sqlite3.connect(ops_db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE daemon_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts_ms INTEGER NOT NULL,
+                kind TEXT NOT NULL,
+                operation_id TEXT,
+                payload_json TEXT NOT NULL DEFAULT '{}'
+            ) STRICT;
+            PRAGMA user_version = 1;
+            """
+        )
+        initialize_archive_tier(conn, ArchiveTier.OPS)
+        indexes = {row[1] for row in conn.execute("PRAGMA index_list('daemon_events')")}
+
+    assert {"idx_daemon_events_kind_id", "idx_daemon_events_lifecycle"} <= indexes
+    assert len(OPS_BENIGN_DDL_CONVERGENCE_PLAN) == 2
 
 
 def test_ops_upsert_ingest_cursor_updates_single_row(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Adds daemon rebuild receipt timing and offered-work observability, including fail-closed catch-up lifecycle status.

## Problem

Catch-up activity could not distinguish idle backlog from offered-but-undrained work, and incomplete or malformed lifecycle receipts could be masked by newer healthy activity.

## Solution

Records coordinated lifecycle receipts, projects status from insertion-ordered event history, rejects malformed and incomplete sequences as UNKNOWN, and bounds paired history at 32 identities with four receipts each plus one bulk marker. Canonical OPS DDL now owns lifecycle-query indexes and an idempotent in-place convergence plan for existing OPS connections.

## Verification

`POLYLOGUE_PYTEST_WORKERS=1 devtools test tests/unit/daemon/test_slo_observability.py tests/unit/sources/test_live_watcher.py::test_real_catch_up_route_emits_coordinated_success_lifecycle tests/unit/sources/test_live_watcher.py::test_real_catch_up_route_emits_terminal_receipt_after_ingest_abort tests/unit/sources/test_live_watcher.py::test_real_catch_up_route_emits_terminal_receipt_when_stopped tests/unit/daemon/test_daemon_events_endpoint.py tests/unit/storage/test_archive_tiers_ops_write.py tests/unit/storage/test_index_fast_forward_lifecycle.py` completed with `97 passed in 39.45s` after rebase.

The push hook also ran `devtools verify --quick` successfully with exit code 0.
