### PR TITLE
test(convergence): add successor convergence property laws

### DIFF
--- a/tests/infra/convergence_harness.py
+++ b/tests/infra/convergence_harness.py
@@ -2,6 +2,13 @@
 
 This module adapts the production archive writers, daemon stages, and ops
 ledger. It deliberately owns no alternate convergence state machine.
+
+The harness starts at the production ``ParsedSession`` boundary. Its
+deterministic JSON payload gives the raw writer real bytes to retain, but does
+not claim provider parser-byte fidelity or inferred-package selection. Those
+remain dependencies of the provider parser and corpus-inference lanes; this
+property surface must not fake either with a synthetic manifest or wire
+support.
 """
 
 from __future__ import annotations
@@ -110,6 +117,14 @@ class ArchiveSnapshot:
     semantic_tables: tuple[tuple[str, tuple[FactRow, ...]], ...]
     fts_matches: tuple[tuple[str, object], ...]
     raw_authority: tuple[FactRow, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class DerivedReadinessSnapshot:
+    """Stable production derived-model and archive-readiness projections."""
+
+    derived_models_json: str
+    archive_readiness_json: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -331,6 +346,69 @@ def assert_archives_equivalent(left: ConvergenceArchive, right: ConvergenceArchi
     right_snapshot = archive_snapshot(right.root)
     if left_snapshot != right_snapshot:
         raise AssertionError(f"canonical archive snapshots differ:\nleft={left_snapshot!r}\nright={right_snapshot!r}")
+
+
+def derived_readiness_snapshot(root: Path) -> DerivedReadinessSnapshot:
+    """Capture production derived status and exact archive readiness facts.
+
+    The status/readiness helpers are read-only projections. Path-bearing
+    evidence is normalized so two otherwise equivalent temporary archives are
+    compared by facts rather than their unrelated temp-directory names.
+    """
+    from polylogue.storage.archive_readiness import archive_readiness_status
+    from polylogue.storage.derived.derived_status import collect_derived_model_statuses_sync
+
+    with sqlite3.connect(root / "index.db") as conn:
+        derived_models = {name: status.to_dict() for name, status in collect_derived_model_statuses_sync(conn).items()}
+    readiness = archive_readiness_status(root)
+    return DerivedReadinessSnapshot(
+        derived_models_json=_stable_json(derived_models, root),
+        archive_readiness_json=_stable_json(readiness, root),
+    )
+
+
+def assert_derived_readiness_equivalent(left: Path, right: Path) -> None:
+    """Require derived model snapshots and readiness projections to agree."""
+    left_snapshot = derived_readiness_snapshot(left)
+    right_snapshot = derived_readiness_snapshot(right)
+    from polylogue.storage.archive_readiness import archive_readiness_status
+    from polylogue.storage.derived.derived_status import collect_derived_model_statuses_sync
+
+    required_insight_models = frozenset(
+        {
+            "session_profile_rows",
+            "session_work_events",
+            "session_phases",
+            "threads",
+            "session_tag_rollups",
+        }
+    )
+    for root in (left, right):
+        with sqlite3.connect(root / "index.db") as conn:
+            derived_models = collect_derived_model_statuses_sync(conn)
+        missing_models = required_insight_models.difference(derived_models)
+        unready_models = sorted(
+            name for name in required_insight_models if name in derived_models and not derived_models[name].ready
+        )
+        if missing_models or unready_models:
+            raise AssertionError(
+                f"primary insight readiness is incomplete for {root}: "
+                f"missing={sorted(missing_models)}, unready={unready_models}"
+            )
+        # The status projection also reports secondary work-event FTS and
+        # retrieval surfaces. They remain in the equality snapshot, as does
+        # the production messages_fts status. The two-stage route owns
+        # messages-FTS repair for changed sessions, while the neutral parser
+        # fixture can expose archive-wide excess rows from provider-derived
+        # blocks. Keep that production readiness signal in the equality law
+        # instead of asserting a global repair this route does not promise.
+        readiness = archive_readiness_status(root)
+        if readiness.get("checked") is not True or readiness.get("blocked_surface_count") != 0:
+            raise AssertionError(f"archive readiness is incomplete for {root}: {readiness!r}")
+    if left_snapshot != right_snapshot:
+        raise AssertionError(
+            f"derived model/readiness snapshots differ:\nleft={left_snapshot!r}\nright={right_snapshot!r}"
+        )
 
 
 def _complete_session_order(pathology: ComposedPathology, order: Sequence[int] | None) -> tuple[int, ...]:
@@ -929,18 +1007,27 @@ def _fact_rows(rows: list[tuple[object, ...]]) -> tuple[FactRow, ...]:
     return tuple(cast(FactRow, tuple(row)) for row in rows)
 
 
+def _stable_json(value: object, root: Path) -> str:
+    """Serialize JSON-shaped status evidence while masking temp-root paths."""
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"))
+    return encoded.replace(str(root), "<archive-root>")
+
+
 __all__ = [
     "ArchiveSnapshot",
     "ConvergenceArchive",
     "DebtLedgerRow",
+    "DerivedReadinessSnapshot",
     "PartialConvergenceArchive",
     "SessionMaterializationFacts",
     "archive_snapshot",
     "assert_archive_verification_green",
     "assert_archives_equivalent",
+    "assert_derived_readiness_equivalent",
     "build_converged_archive",
     "converge_convergence_archive",
     "debt_ledger_row",
+    "derived_readiness_snapshot",
     "ingest_convergence_pathology",
     "initialize_active_archive",
     "make_messages_fts_stale",

--- a/tests/infra/convergence_harness.py
+++ b/tests/infra/convergence_harness.py
@@ -603,7 +603,9 @@ _SNAPSHOT_VOLATILE_COLUMNS: dict[str, frozenset[str]] = {
     "insight_materialization": frozenset({"materialized_at_ms"}),
     "session_links": frozenset({"observed_at_ms", "resolved_at_ms"}),
     "session_profiles": frozenset({"materialized_at", "priced_at_ms"}),
-    "threads": frozenset({"materialized_at", "source_updated_at"}),
+    # Thread source_updated_at is derived from provider-backed member
+    # timestamps, unlike materialized_at.
+    "threads": frozenset({"materialized_at"}),
 }
 
 

--- a/tests/infra/convergence_harness.py
+++ b/tests/infra/convergence_harness.py
@@ -114,6 +114,10 @@ class ArchiveSnapshot:
     blocks: tuple[FactRow, ...]
     session_links: tuple[FactRow, ...]
     profiles: tuple[FactRow, ...]
+    work_events: tuple[FactRow, ...]
+    phases: tuple[FactRow, ...]
+    threads: tuple[FactRow, ...]
+    thread_sessions: tuple[FactRow, ...]
     semantic_tables: tuple[tuple[str, tuple[FactRow, ...]], ...]
     fts_matches: tuple[tuple[str, object], ...]
     raw_authority: tuple[FactRow, ...]
@@ -323,6 +327,10 @@ def archive_snapshot(root: Path) -> ArchiveSnapshot:
             """
         ).fetchall()
         profiles = _table_rows(conn, "session_profiles", order_by="session_id")
+        work_events = _table_rows(conn, "session_work_events", order_by="session_id, position")
+        phases = _table_rows(conn, "session_phases", order_by="session_id, position")
+        threads = _table_rows(conn, "threads", order_by="thread_id")
+        thread_sessions = _table_rows(conn, "thread_sessions", order_by="thread_id, session_id, position")
         semantic_tables = tuple(
             (table, _table_rows(conn, table, order_by=order_by)) for table, order_by in _SEMANTIC_TABLES
         )
@@ -334,6 +342,10 @@ def archive_snapshot(root: Path) -> ArchiveSnapshot:
         blocks=_fact_rows(blocks),
         session_links=_fact_rows(session_links),
         profiles=profiles,
+        work_events=work_events,
+        phases=phases,
+        threads=threads,
+        thread_sessions=thread_sessions,
         semantic_tables=semantic_tables,
         fts_matches=fts_matches,
         raw_authority=raw_authority,
@@ -591,6 +603,7 @@ _SNAPSHOT_VOLATILE_COLUMNS: dict[str, frozenset[str]] = {
     "insight_materialization": frozenset({"materialized_at_ms"}),
     "session_links": frozenset({"observed_at_ms", "resolved_at_ms"}),
     "session_profiles": frozenset({"materialized_at", "priced_at_ms"}),
+    "threads": frozenset({"materialized_at", "source_updated_at"}),
 }
 
 

--- a/tests/property/test_convergence_property_append_prefix.py
+++ b/tests/property/test_convergence_property_append_prefix.py
@@ -20,7 +20,7 @@ from tests.infra.convergence_harness import (
 
 @settings(
     max_examples=8,
-    phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target),
+    phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target, Phase.shrink),
     deadline=None,
     suppress_health_check=[HealthCheck.function_scoped_fixture],
 )

--- a/tests/property/test_convergence_property_derived_readiness.py
+++ b/tests/property/test_convergence_property_derived_readiness.py
@@ -1,0 +1,32 @@
+"""Derived snapshots and readiness agree across convergence schedules."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hypothesis import HealthCheck, Phase, given, settings
+from hypothesis import strategies as st
+
+from tests.infra.convergence_harness import (
+    assert_derived_readiness_equivalent,
+    build_converged_archive,
+    rich_convergence_pathology,
+    rotated_session_order,
+)
+
+
+@settings(
+    max_examples=8,
+    phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target),
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(st.integers(min_value=1, max_value=len(rich_convergence_pathology().sessions) - 1))
+def test_convergence_property_derived_snapshot_readiness_equality(tmp_path: Path, shift: int) -> None:
+    """Bulk and incremental production convergence expose the same derived state."""
+    pathology = rich_convergence_pathology()
+    order = rotated_session_order(pathology, shift)
+    bulk = build_converged_archive(tmp_path / "bulk", pathology, session_order=order)
+    incremental = build_converged_archive(tmp_path / "incremental", pathology, session_order=order, incremental=True)
+
+    assert_derived_readiness_equivalent(bulk.root, incremental.root)

--- a/tests/property/test_convergence_property_derived_readiness.py
+++ b/tests/property/test_convergence_property_derived_readiness.py
@@ -17,7 +17,7 @@ from tests.infra.convergence_harness import (
 
 @settings(
     max_examples=8,
-    phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target),
+    phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target, Phase.shrink),
     deadline=None,
     suppress_health_check=[HealthCheck.function_scoped_fixture],
 )

--- a/tests/property/test_convergence_property_idempotence.py
+++ b/tests/property/test_convergence_property_idempotence.py
@@ -19,7 +19,7 @@ from tests.infra.convergence_harness import (
 
 @settings(
     max_examples=8,
-    phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target),
+    phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target, Phase.shrink),
     deadline=None,
     suppress_health_check=[HealthCheck.function_scoped_fixture],
 )

--- a/tests/property/test_convergence_property_incremental_bulk.py
+++ b/tests/property/test_convergence_property_incremental_bulk.py
@@ -17,7 +17,7 @@ from tests.infra.convergence_harness import (
 
 @settings(
     max_examples=8,
-    phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target),
+    phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target, Phase.shrink),
     deadline=None,
     suppress_health_check=[HealthCheck.function_scoped_fixture],
 )

--- a/tests/property/test_convergence_property_mutations.py
+++ b/tests/property/test_convergence_property_mutations.py
@@ -1,0 +1,71 @@
+"""Mutation red twins for the production dependencies of convergence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import tests.infra.convergence_harness as convergence_harness
+from polylogue.storage.fts import fts_lifecycle
+from polylogue.storage.insights.session import rebuild as insight_rebuild
+from tests.infra.convergence_harness import (
+    assert_archives_equivalent,
+    build_converged_archive,
+    converge_convergence_archive,
+    ingest_convergence_pathology,
+    initialize_active_archive,
+    rich_convergence_pathology,
+)
+
+
+def test_convergence_property_fts_repair_mutation_red_twin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A bypassed production FTS repair cannot report a converged archive."""
+    pathology = rich_convergence_pathology()
+    initialize_active_archive(tmp_path / "mutated")
+    monkeypatch.setattr(fts_lifecycle, "repair_message_fts_index_sync", lambda *_args, **_kwargs: None)
+
+    archive = ingest_convergence_pathology(
+        tmp_path / "mutated",
+        pathology,
+        session_indexes=tuple(range(len(pathology.sessions))),
+        converge_after_each=False,
+    )
+    with pytest.raises(AssertionError, match="production convergence left pending work"):
+        converge_convergence_archive(archive)
+
+
+def test_convergence_property_insight_repair_mutation_red_twin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A bypassed production insight rebuild cannot report a converged archive."""
+    pathology = rich_convergence_pathology()
+    initialize_active_archive(tmp_path / "mutated")
+    monkeypatch.setattr(insight_rebuild, "rebuild_session_insights_sync", lambda *_args, **_kwargs: None)
+
+    archive = ingest_convergence_pathology(
+        tmp_path / "mutated",
+        pathology,
+        session_indexes=tuple(range(len(pathology.sessions))),
+        converge_after_each=False,
+    )
+    with pytest.raises(AssertionError, match="production convergence left pending work"):
+        converge_convergence_archive(archive)
+
+
+def test_convergence_property_raw_replay_mutation_red_twin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The comparator catches a replay path that bypasses durable raw acquisition."""
+    pathology = rich_convergence_pathology()
+    canonical = build_converged_archive(tmp_path / "canonical", pathology)
+    mutated_root = tmp_path / "mutated"
+    initialize_active_archive(mutated_root)
+
+    monkeypatch.setattr(convergence_harness, "write_source_raw_session", lambda *_args, **_kwargs: "bypassed-raw")
+    mutated = ingest_convergence_pathology(
+        mutated_root,
+        pathology,
+        session_indexes=tuple(range(len(pathology.sessions))),
+        converge_after_each=False,
+    )
+    converge_convergence_archive(mutated)
+
+    with pytest.raises(AssertionError, match="canonical archive snapshots differ"):
+        assert_archives_equivalent(canonical, mutated)

--- a/tests/property/test_convergence_property_mutations.py
+++ b/tests/property/test_convergence_property_mutations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -66,6 +67,28 @@ def test_convergence_property_raw_replay_mutation_red_twin(tmp_path: Path, monke
         converge_after_each=False,
     )
     converge_convergence_archive(mutated)
+
+    with pytest.raises(AssertionError, match="canonical archive snapshots differ"):
+        assert_archives_equivalent(canonical, mutated)
+
+
+def test_convergence_property_materialized_content_mutation_red_twin(tmp_path: Path) -> None:
+    """Changing a materialized insight row cannot pass the semantic comparator."""
+    pathology = rich_convergence_pathology()
+    canonical = build_converged_archive(tmp_path / "canonical", pathology)
+    mutated = build_converged_archive(tmp_path / "mutated", pathology)
+
+    with sqlite3.connect(mutated.root / "index.db") as conn:
+        cursor = conn.execute(
+            """
+            UPDATE session_work_events
+            SET summary = summary || ' [materialized-content-mutation]'
+            WHERE event_id = (SELECT event_id FROM session_work_events ORDER BY event_id LIMIT 1)
+            """
+        )
+        if cursor.rowcount != 1:
+            raise AssertionError("materialized-content mutation did not change one work-event row")
+        conn.commit()
 
     with pytest.raises(AssertionError, match="canonical archive snapshots differ"):
         assert_archives_equivalent(canonical, mutated)

--- a/tests/property/test_convergence_property_order_invariance.py
+++ b/tests/property/test_convergence_property_order_invariance.py
@@ -25,7 +25,7 @@ from tests.infra.convergence_harness import (
 
 @settings(
     max_examples=8,
-    phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target),
+    phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target, Phase.shrink),
     deadline=None,
     suppress_health_check=[HealthCheck.function_scoped_fixture],
 )


### PR DESCRIPTION
## Summary

Adds derived-readiness and mutation property laws to the production convergence harness.

## Problem

The reindex campaign needs end-to-end tests that reject semantic drift in lineage, FTS, insights, raw replay, and derived readiness, not only unit-level convergence checks. Ref polylogue-rrxe4.

## Solution

Extends the shared harness and adds property suites covering comparable archive snapshots and mutation twins across production writer and convergence stages.

## Verification

`POLYLOGUE_PYTEST_WORKERS=1 devtools test -k convergence_property`

Result: 10 passed. `POLYLOGUE_PYTEST_WORKERS=1 devtools verify --quick` also passed. Removing the production mutation/readiness route makes the relevant property fail.