### PR TITLE
refactor(devtools): restore catalog coherence

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -49,7 +49,7 @@ jobs:
         # default_min_kill_rate). --enforce-kill-rate without --strict only checks
         # fresh campaigns, so campaigns whose group did not run this week are
         # ignored rather than flagged missing in the artifact-less CI checkout.
-        run: uv run python -m devtools.verify_mutation_freshness --enforce-kill-rate
+        run: uv run devtools verify mutation-freshness --enforce-kill-rate
       - name: Upload campaign artifacts
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/nightly-scale.yml
+++ b/.github/workflows/nightly-scale.yml
@@ -70,7 +70,7 @@ jobs:
             exit 0
           fi
           echo "Comparing against committed baseline..."
-          uv run python3 devtools/benchmark_compare_nightly.py "$BASELINE" nightly-results.json --fail-pct 20
+          uv run devtools bench nightly-compare "$BASELINE" nightly-results.json --fail-pct 20
           echo "comparison=completed" >> "$GITHUB_OUTPUT"
 
       - name: Report regression

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -112,7 +112,7 @@ class WorkspaceCommandDisposition:
 class CatalogBypassSite:
     path: str
     marker: str
-    command_name: str
+    command_name: str | None
     disposition: str
     reason: str
 
@@ -1696,6 +1696,17 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         examples=("devtools verify ci-workflows", "devtools verify ci-workflows --json"),
     ),
     CommandSpec(
+        "verify catalog-bypasses",
+        "verification",
+        "Reject direct devtools module or script execution outside sanctioned adapters.",
+        "devtools.verify_catalog_bypasses",
+        use_when=(
+            "Check workflow run blocks, repository hooks, and devtools process-launch sites for direct "
+            "python -m devtools.X or python devtools/X.py execution that bypasses the command catalog."
+        ),
+        examples=("devtools verify catalog-bypasses", "devtools verify catalog-bypasses --json"),
+    ),
+    CommandSpec(
         "verify test-infra-currency",
         "verification",
         "Verify tests/infra/ helpers reference only tables that exist in the current SCHEMA_VERSION.",
@@ -2418,6 +2429,20 @@ CATALOG_BYPASS_SITES: tuple[CatalogBypassSite, ...] = (
         "lab test-economics",
         "sanctioned-bypass",
         "The generated provenance header preserves the module that emitted the document; operators use the catalog command.",
+    ),
+    CatalogBypassSite(
+        ".githooks/pre-push",
+        "python -m devtools.pre_push_gate",
+        None,
+        "sanctioned-bypass",
+        "The hook adapter must receive Git's staged stdin update stream before dispatching its catalog-aware gate.",
+    ),
+    CatalogBypassSite(
+        ".beads-hooks/pre-push",
+        "python -m devtools.pre_push_gate",
+        None,
+        "sanctioned-bypass",
+        "The Beads-augmented hook retains the same stdin adapter before its managed Beads section runs.",
     ),
 )
 

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -100,6 +100,23 @@ class CommandSpec:
         return data
 
 
+@dataclass(frozen=True, slots=True)
+class WorkspaceCommandDisposition:
+    name: str
+    disposition: str
+    evidence: str
+    replacement: str
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogBypassSite:
+    path: str
+    marker: str
+    command_name: str
+    disposition: str
+    reason: str
+
+
 COMMAND_SPECS: tuple[CommandSpec, ...] = (
     CommandSpec(
         "status",
@@ -430,6 +447,20 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
             "devtools verify coverage",
             "devtools verify coverage --ignore-integration --term-missing",
             "devtools verify coverage -- --maxfail=1",
+        ),
+    ),
+    CommandSpec(
+        "verify mutation-freshness",
+        "verification",
+        "Verify fresh mutation campaigns meet their declared kill-rate thresholds.",
+        "devtools.verify_mutation_freshness",
+        use_when=(
+            "Enforce mutation campaign freshness and kill-rate thresholds after a rotating CI campaign "
+            "has produced its local artifacts."
+        ),
+        examples=(
+            "devtools verify mutation-freshness --enforce-kill-rate",
+            "devtools verify mutation-freshness --yaml .local/mutation-campaigns/index.yaml --strict",
         ),
     ),
     CommandSpec(
@@ -2192,6 +2223,17 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         featured=True,
     ),
     CommandSpec(
+        "bench nightly-compare",
+        "benchmarking",
+        "Compare nightly pytest-benchmark output with the committed baseline.",
+        "devtools.benchmark_compare_nightly",
+        use_when="Check the nightly scale benchmark result against its committed regression threshold.",
+        examples=(
+            "devtools bench nightly-compare tests/benchmarks/baselines/nightly-baseline.json nightly-results.json",
+            "devtools bench nightly-compare baseline.json candidate.json --fail-pct 20",
+        ),
+    ),
+    CommandSpec(
         "bench synthetic",
         "benchmarking",
         "Run synthetic benchmark campaigns over generated archives.",
@@ -2284,6 +2326,102 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
 COMMANDS: dict[str, CommandSpec] = {spec.name: spec for spec in COMMAND_SPECS}
 
 
+WORKSPACE_COMMAND_DISPOSITIONS: tuple[WorkspaceCommandDisposition, ...] = (
+    WorkspaceCommandDisposition(
+        "workspace index-fast-forward",
+        "retain",
+        "Recent production commits plus focused devtools/storage tests; emits a reusable proof receipt.",
+        "Keep the registered command as the index-tier actuator.",
+    ),
+    WorkspaceCommandDisposition(
+        "workspace archive-schema-fast-forward",
+        "remove",
+        "No current CommandSpec, implementation module, focused test, or history entry exists for this name.",
+        "Use workspace index-fast-forward for declared derived-index fast-forwards.",
+    ),
+    WorkspaceCommandDisposition(
+        "workspace degraded-archive-proof",
+        "retain",
+        "Focused tests and deterministic self-healing proof artifacts cover the command.",
+        "Keep the registered command for archive repair evidence.",
+    ),
+    WorkspaceCommandDisposition(
+        "workspace frontier",
+        "retain",
+        "Operator-facing frontier report with documented workflow use and structured report output.",
+        "Keep the registered command for frontier batching and wait-ahead decisions.",
+    ),
+    WorkspaceCommandDisposition(
+        "workspace temporal-read-profile",
+        "retain",
+        "Focused tests cover the report and JSON timing output is reusable for read tuning.",
+        "Keep the registered command as the temporal read profiling entrypoint.",
+    ),
+    WorkspaceCommandDisposition(
+        "workspace temporal-devloop",
+        "retain",
+        "Focused tests cover structured and Markdown event sources; output is a reusable evidence window.",
+        "Keep the registered command as the devloop temporal evidence entrypoint.",
+    ),
+    WorkspaceCommandDisposition(
+        "workspace temporal-archive-aggregates",
+        "retain",
+        "Focused tests cover aggregate report construction and reusable archive artifacts.",
+        "Keep the registered command as the run-projection aggregate entrypoint.",
+    ),
+    WorkspaceCommandDisposition(
+        "workspace lineage-validation",
+        "retain",
+        "Focused tests cover lineage evidence and the command emits reusable count and composition proof.",
+        "Keep the registered command before publishing archive cardinality claims.",
+    ),
+    WorkspaceCommandDisposition(
+        "workspace cli-surface-audit",
+        "retain",
+        "Focused tests cover bounded output and stale-artifact pruning; the audit shelf is reusable.",
+        "Keep the registered command as the current CLI surface audit entrypoint.",
+    ),
+    WorkspaceCommandDisposition(
+        "demo real-slice-screen",
+        "retain",
+        "Focused privacy-screening tests cover redaction, PII review, and report generation.",
+        "Keep the registered command as the read-only real-archive screening entrypoint.",
+    ),
+)
+
+
+CATALOG_BYPASS_SITES: tuple[CatalogBypassSite, ...] = (
+    CatalogBypassSite(
+        ".github/workflows/mutation-testing.yml",
+        "uv run devtools verify mutation-freshness",
+        "verify mutation-freshness",
+        "registered",
+        "CI invokes the catalog command so inventory and workflow validation see the freshness gate.",
+    ),
+    CatalogBypassSite(
+        ".github/workflows/nightly-scale.yml",
+        "uv run devtools bench nightly-compare",
+        "bench nightly-compare",
+        "registered",
+        "CI invokes the catalog command so the nightly comparison is discoverable and checked.",
+    ),
+    CatalogBypassSite(
+        "devtools/pre_push_gate.py",
+        'control_plane_argv("lab policy backlog-hygiene")',
+        "lab policy backlog-hygiene",
+        "registered",
+        "The intentional Beads-only route remains narrow while using the registered policy command.",
+    ),
+    CatalogBypassSite(
+        "docs/test-economics.md",
+        "python -m devtools.test_economics_report",
+        "lab test-economics",
+        "sanctioned-bypass",
+        "The generated provenance header preserves the module that emitted the document; operators use the catalog command.",
+    ),
+)
+
+
 def command_name_from_tokens(tokens: Iterable[str], commands: Iterable[CommandSpec] = COMMAND_SPECS) -> str | None:
     """Resolve leading argv tokens to a registered command name."""
     token_tuple = tuple(tokens)
@@ -2334,14 +2472,17 @@ __all__ = [
     "CATEGORY_ORDER",
     "COMMANDS",
     "COMMAND_SPECS",
+    "CATALOG_BYPASS_SITES",
     "CONTROL_PLANE",
     "CommandMain",
     "CommandSpec",
+    "WorkspaceCommandDisposition",
     "command_name_from_tokens",
     "control_plane_argv",
     "control_plane_command",
     "featured_command_specs",
     "grouped_command_specs",
     "VERIFICATION_LAB_COMMAND_NAMES",
+    "WORKSPACE_COMMAND_DISPOSITIONS",
     "verification_lab_command_specs",
 ]

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -106,6 +106,7 @@ class WorkspaceCommandDisposition:
     disposition: str
     evidence: str
     replacement: str
+    replacement_command: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -115,6 +116,8 @@ class CatalogBypassSite:
     command_name: str | None
     disposition: str
     reason: str
+    occurrence_line: int | None = None
+    expected_occurrences: int = 0
 
 
 COMMAND_SPECS: tuple[CommandSpec, ...] = (
@@ -2349,6 +2352,7 @@ WORKSPACE_COMMAND_DISPOSITIONS: tuple[WorkspaceCommandDisposition, ...] = (
         "remove",
         "No current CommandSpec, implementation module, focused test, or history entry exists for this name.",
         "Use workspace index-fast-forward for declared derived-index fast-forwards.",
+        "workspace index-fast-forward",
     ),
     WorkspaceCommandDisposition(
         "workspace degraded-archive-proof",
@@ -2436,6 +2440,8 @@ CATALOG_BYPASS_SITES: tuple[CatalogBypassSite, ...] = (
         None,
         "sanctioned-bypass",
         "The hook adapter must receive Git's staged stdin update stream before dispatching its catalog-aware gate.",
+        occurrence_line=21,
+        expected_occurrences=1,
     ),
     CatalogBypassSite(
         ".beads-hooks/pre-push",
@@ -2443,6 +2449,8 @@ CATALOG_BYPASS_SITES: tuple[CatalogBypassSite, ...] = (
         None,
         "sanctioned-bypass",
         "The Beads-augmented hook retains the same stdin adapter before its managed Beads section runs.",
+        occurrence_line=21,
+        expected_occurrences=1,
     ),
 )
 

--- a/devtools/pre_push_gate.py
+++ b/devtools/pre_push_gate.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from devtools import repo_root
+from devtools.command_catalog import control_plane_argv
 
 
 @dataclass(frozen=True, slots=True)
@@ -100,7 +101,7 @@ def run_gate(updates: list[PushUpdate], *, cwd: Path) -> str:
             [
                 sys.executable,
                 "-m",
-                "devtools.verify_backlog_hygiene",
+                *control_plane_argv("lab policy backlog-hygiene"),
                 "--checks",
                 "D1,D2",
                 ".beads/issues.jsonl",

--- a/devtools/render_devtools_reference.py
+++ b/devtools/render_devtools_reference.py
@@ -7,6 +7,8 @@ import sys
 from pathlib import Path
 
 from devtools.command_catalog import (
+    CATALOG_BYPASS_SITES,
+    WORKSPACE_COMMAND_DISPOSITIONS,
     CommandSpec,
     control_plane_command,
     featured_command_specs,
@@ -65,6 +67,36 @@ def _render_verification_lab_surface(commands: tuple[CommandSpec, ...]) -> list[
     return lines
 
 
+def _render_workspace_dispositions() -> list[str]:
+    lines = [
+        "## Workspace disposition audit",
+        "",
+        "The utf.1 triage retains workspace commands with operator history, reusable output, or focused tests. "
+        "The stale archive-schema-fast-forward name is removed in favor of the registered index fast-forward command.",
+        "",
+        "| Named entry | Disposition | Evidence | Replacement |",
+        "| --- | --- | --- | --- |",
+    ]
+    for item in WORKSPACE_COMMAND_DISPOSITIONS:
+        display_name = item.name if item.disposition == "remove" else control_plane_command(item.name)
+        lines.append(f"| `{display_name}` | `{item.disposition}` | {item.evidence} | {item.replacement} |")
+    lines.extend(
+        [
+            "",
+            "Catalog bypass audit sites are machine-checked: CI and the Beads-only pre-push route use registered commands; the generated test-economics provenance header is the sole declared sanctioned module-path exception.",
+            "",
+            "| Site | Status | Registered command | Reason |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
+    for site in CATALOG_BYPASS_SITES:
+        lines.append(
+            f"| `{site.path}` | `{site.disposition}` | `{control_plane_command(site.command_name)}` | {site.reason} |"
+        )
+    lines.append("")
+    return lines
+
+
 def build_command_catalog() -> str:
     groups = grouped_command_specs()
     featured = featured_command_specs()
@@ -87,6 +119,7 @@ def build_command_catalog() -> str:
     lines.extend(_render_verification_lab_surface(verification_lab))
     if featured:
         lines.extend(_render_featured_commands(featured))
+    lines.extend(_render_workspace_dispositions())
     for category, commands in groups.items():
         lines.extend(_render_table(category, commands))
     lines.append("<!-- END GENERATED: devtools-command-catalog -->")

--- a/devtools/render_devtools_reference.py
+++ b/devtools/render_devtools_reference.py
@@ -83,16 +83,15 @@ def _render_workspace_dispositions() -> list[str]:
     lines.extend(
         [
             "",
-            "Catalog bypass audit sites are machine-checked: CI and the Beads-only pre-push route use registered commands; the generated test-economics provenance header is the sole declared sanctioned module-path exception.",
+            "Catalog bypass audit sites are machine-checked: CI and the Beads-only pre-push route use registered commands; direct hook adapters and generated provenance headers require declared sanctioned exceptions.",
             "",
             "| Site | Status | Registered command | Reason |",
             "| --- | --- | --- | --- |",
         ]
     )
     for site in CATALOG_BYPASS_SITES:
-        lines.append(
-            f"| `{site.path}` | `{site.disposition}` | `{control_plane_command(site.command_name)}` | {site.reason} |"
-        )
+        command = control_plane_command(site.command_name) if site.command_name is not None else "hook adapter"
+        lines.append(f"| `{site.path}` | `{site.disposition}` | `{command}` | {site.reason} |")
     lines.append("")
     return lines
 

--- a/devtools/render_devtools_reference.py
+++ b/devtools/render_devtools_reference.py
@@ -83,15 +83,20 @@ def _render_workspace_dispositions() -> list[str]:
     lines.extend(
         [
             "",
-            "Catalog bypass audit sites are machine-checked: CI and the Beads-only pre-push route use registered commands; direct hook adapters and generated provenance headers require declared sanctioned exceptions.",
+            "Catalog bypass audit sites are machine-checked across workflow runs, CI-owned npm scripts, hooks, and devtools process launches. Direct hook adapters require declared sanctioned exceptions with an exact occurrence and cardinality.",
             "",
-            "| Site | Status | Registered command | Reason |",
-            "| --- | --- | --- | --- |",
+            "| Site | Status | Registered command | Occurrence | Reason |",
+            "| --- | --- | --- | --- | --- |",
         ]
     )
     for site in CATALOG_BYPASS_SITES:
         command = control_plane_command(site.command_name) if site.command_name is not None else "hook adapter"
-        lines.append(f"| `{site.path}` | `{site.disposition}` | `{command}` | {site.reason} |")
+        occurrence = (
+            f"line {site.occurrence_line} ({site.expected_occurrences} expected)"
+            if site.occurrence_line is not None
+            else "not applicable"
+        )
+        lines.append(f"| `{site.path}` | `{site.disposition}` | `{command}` | {occurrence} | {site.reason} |")
     lines.append("")
     return lines
 

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -1770,6 +1770,7 @@ def build_verify_steps(
                 ("lab schema roundtrip", _devtools_cmd("lab schema roundtrip", "--all")),
                 ("verify manifests", _devtools_cmd("verify manifests")),
                 ("verify ci-workflows", _devtools_cmd("verify ci-workflows")),
+                ("verify catalog-bypasses", _devtools_cmd("verify catalog-bypasses")),
                 ("verify doc-commands", _devtools_cmd("verify doc-commands")),
                 ("verify docs-coverage", _devtools_cmd("verify docs-coverage")),
                 ("verify test-infra-currency", _devtools_cmd("verify test-infra-currency")),

--- a/devtools/verify_catalog_bypasses.py
+++ b/devtools/verify_catalog_bypasses.py
@@ -3,14 +3,16 @@
 The CommandSpec catalog is the public execution registry. Workflow ``run:``
 blocks, repository hooks, CI-owned npm scripts, and devtools process-launch
 calls must invoke it as ``devtools ...``. This checker catches literal direct forms such as
-``python -m devtools.some_module`` and ``python devtools/some_module.py``.
+``python -m devtools.some_module``, ``python -mdevtools.some_module``, and
+``python devtools/some_module.py``.
 
 Scope is deliberately execution-only:
 
 * workflow ``run:`` blocks, hook shell scripts, and the declared top-level
   JavaScript workspace npm scripts are scanned as structured command text;
 * ``devtools/**/*.py`` is parsed with ``ast`` and only command-runner call
-  arguments are inspected, including literal ``args=`` keyword vectors.
+  arguments are inspected, including literal ``args=`` keyword vectors and
+  CPython's compact ``-mdevtools.module`` form.
 
 Generated provenance headers, argparse ``prog`` values, comments, and
 docstrings are outside the scope because they do not launch a process. A real
@@ -37,9 +39,21 @@ from devtools import repo_root as _get_root
 from devtools.command_catalog import CATALOG_BYPASS_SITES, CatalogBypassSite
 
 ROOT = _get_root()
-_COMMAND_RUNNERS = {"run", "check_call", "check_output", "Popen", "system", "_run", "run_command", "_run_command"}
+_COMMAND_RUNNERS = {
+    "run",
+    "call",
+    "check_call",
+    "check_output",
+    "Popen",
+    "system",
+    "_run",
+    "run_command",
+    "_run_command",
+}
 _PYTHON = r"python(?:3(?:\.\d+)?)?"
-_MODULE_INVOCATION = re.compile(rf"(?<![\w./-])(?:uv\s+run\s+)?{_PYTHON}\s+-m\s+(devtools\.[A-Za-z_][A-Za-z0-9_]*)")
+_MODULE_INVOCATION = re.compile(
+    rf"(?<![\w./-])(?:uv\s+run\s+)?{_PYTHON}\s+-m(?:[ \t]+)?(devtools\.[A-Za-z_][A-Za-z0-9_]*)"
+)
 _SCRIPT_INVOCATION = re.compile(
     rf"(?<![\w./-])(?:uv\s+run\s+)?{_PYTHON}\s+(?:\./)?(devtools/[A-Za-z_][A-Za-z0-9_]*\.py)"
 )
@@ -125,10 +139,14 @@ def _invocations_from_command_expression(node: ast.expr, *, path: str, lineno: i
         if not _is_python_expression(part) or index + 1 >= len(parts):
             continue
         next_part = _literal_string(parts[index + 1])
+        module: str | None = None
         if next_part == "-m" and index + 2 < len(parts):
             module = _literal_string(parts[index + 2])
-            if module is not None and re.fullmatch(r"devtools\.[A-Za-z_][A-Za-z0-9_]*", module):
-                findings.append(DirectDevtoolsInvocation(path=path, lineno=lineno, invocation=f"python -m {module}"))
+        elif next_part is not None:
+            compact = re.fullmatch(r"-m(devtools\.[A-Za-z_][A-Za-z0-9_]*)", next_part)
+            module = compact.group(1) if compact is not None else None
+        if module is not None and re.fullmatch(r"devtools\.[A-Za-z_][A-Za-z0-9_]*", module):
+            findings.append(DirectDevtoolsInvocation(path=path, lineno=lineno, invocation=f"python -m {module}"))
         elif next_part is not None and re.fullmatch(r"(?:\./)?devtools/[A-Za-z_][A-Za-z0-9_]*\.py", next_part):
             findings.append(
                 DirectDevtoolsInvocation(path=path, lineno=lineno, invocation=f"python {next_part.removeprefix('./')}")

--- a/devtools/verify_catalog_bypasses.py
+++ b/devtools/verify_catalog_bypasses.py
@@ -1,0 +1,218 @@
+"""Reject unregistered direct devtools command execution in control surfaces.
+
+The CommandSpec catalog is the public execution registry. Workflow ``run:``
+blocks, repository hooks, and devtools process-launch calls must invoke it as
+``devtools ...``. This checker catches literal direct forms such as
+``python -m devtools.some_module`` and ``python devtools/some_module.py``.
+
+Scope is deliberately execution-only:
+
+* workflow ``run:`` blocks and hook shell scripts are scanned as shell text;
+* ``devtools/**/*.py`` is parsed with ``ast`` and only command-runner call
+  arguments are inspected.
+
+Generated provenance headers, argparse ``prog`` values, comments, and
+docstrings are outside the scope because they do not launch a process. A real
+hook adapter can remain only through a structured ``sanctioned-bypass`` entry
+in ``CATALOG_BYPASS_SITES`` with a reason. Dynamic command construction is
+outside this literal-vector check and must use catalog helpers at review.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import yaml
+
+from devtools import repo_root as _get_root
+from devtools.command_catalog import CATALOG_BYPASS_SITES
+
+ROOT = _get_root()
+_COMMAND_RUNNERS = {"run", "check_call", "check_output", "Popen", "system", "_run", "run_command", "_run_command"}
+_PYTHON = r"python(?:3(?:\.\d+)?)?"
+_MODULE_INVOCATION = re.compile(rf"(?<![\w./-])(?:uv\s+run\s+)?{_PYTHON}\s+-m\s+(devtools\.[A-Za-z_][A-Za-z0-9_]*)")
+_SCRIPT_INVOCATION = re.compile(
+    rf"(?<![\w./-])(?:uv\s+run\s+)?{_PYTHON}\s+(?:\./)?(devtools/[A-Za-z_][A-Za-z0-9_]*\.py)"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DirectDevtoolsInvocation:
+    path: str
+    lineno: int
+    invocation: str
+
+
+def _relative_path(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _shell_invocations(source: str, *, path: str) -> list[DirectDevtoolsInvocation]:
+    findings: list[DirectDevtoolsInvocation] = []
+    for pattern, prefix in ((_MODULE_INVOCATION, "python -m"), (_SCRIPT_INVOCATION, "python")):
+        for match in pattern.finditer(source):
+            findings.append(
+                DirectDevtoolsInvocation(
+                    path=path,
+                    lineno=source.count("\n", 0, match.start()) + 1,
+                    invocation=f"{prefix} {match.group(1)}",
+                )
+            )
+    return findings
+
+
+def _is_command_runner(call: ast.Call) -> bool:
+    func = call.func
+    if isinstance(func, ast.Name):
+        return func.id in _COMMAND_RUNNERS
+    return isinstance(func, ast.Attribute) and func.attr in _COMMAND_RUNNERS
+
+
+def _is_python_expression(node: ast.expr) -> bool:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return re.fullmatch(_PYTHON, node.value) is not None
+    return (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "sys"
+        and node.attr == "executable"
+    )
+
+
+def _literal_command_parts(node: ast.expr) -> list[ast.expr] | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return [node]
+    if isinstance(node, ast.List | ast.Tuple):
+        return list(node.elts)
+    return None
+
+
+def _literal_string(node: ast.expr) -> str | None:
+    return node.value if isinstance(node, ast.Constant) and isinstance(node.value, str) else None
+
+
+def _invocations_from_command_expression(node: ast.expr, *, path: str, lineno: int) -> list[DirectDevtoolsInvocation]:
+    parts = _literal_command_parts(node)
+    if parts is None:
+        return []
+    if len(parts) == 1:
+        shell = _literal_string(parts[0])
+        return _shell_invocations(shell, path=path) if shell is not None else []
+
+    findings: list[DirectDevtoolsInvocation] = []
+    for index, part in enumerate(parts):
+        if not _is_python_expression(part) or index + 1 >= len(parts):
+            continue
+        next_part = _literal_string(parts[index + 1])
+        if next_part == "-m" and index + 2 < len(parts):
+            module = _literal_string(parts[index + 2])
+            if module is not None and re.fullmatch(r"devtools\.[A-Za-z_][A-Za-z0-9_]*", module):
+                findings.append(DirectDevtoolsInvocation(path=path, lineno=lineno, invocation=f"python -m {module}"))
+        elif next_part is not None and re.fullmatch(r"(?:\./)?devtools/[A-Za-z_][A-Za-z0-9_]*\.py", next_part):
+            findings.append(
+                DirectDevtoolsInvocation(path=path, lineno=lineno, invocation=f"python {next_part.removeprefix('./')}")
+            )
+    return findings
+
+
+def _python_invocations(source: str, *, path: str) -> list[DirectDevtoolsInvocation]:
+    try:
+        tree = ast.parse(source, filename=path)
+    except SyntaxError:
+        return []
+    findings: list[DirectDevtoolsInvocation] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not _is_command_runner(node) or not node.args:
+            continue
+        findings.extend(_invocations_from_command_expression(node.args[0], path=path, lineno=node.lineno))
+    return findings
+
+
+def _workflow_run_blocks(path: Path) -> Iterable[str]:
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError:
+        return ()
+
+    def _walk(value: object) -> Iterable[str]:
+        if isinstance(value, dict):
+            for key, nested in value.items():
+                if key == "run" and isinstance(nested, str):
+                    yield nested
+                yield from _walk(nested)
+        elif isinstance(value, list):
+            for nested in value:
+                yield from _walk(nested)
+
+    return tuple(_walk(data))
+
+
+def control_surface_paths(root: Path = ROOT) -> tuple[Path, ...]:
+    paths: list[Path] = []
+    workflows = root / ".github" / "workflows"
+    if workflows.exists():
+        paths.extend(sorted((*workflows.glob("*.yml"), *workflows.glob("*.yaml"))))
+    for hook_dir in (root / ".githooks", root / ".beads-hooks"):
+        if hook_dir.exists():
+            paths.extend(sorted(path for path in hook_dir.iterdir() if path.is_file()))
+    devtools = root / "devtools"
+    if devtools.exists():
+        paths.extend(sorted(devtools.rglob("*.py")))
+    return tuple(paths)
+
+
+def scan_control_surfaces(root: Path = ROOT, *, paths: Iterable[Path] | None = None) -> list[DirectDevtoolsInvocation]:
+    findings: list[DirectDevtoolsInvocation] = []
+    for candidate in paths if paths is not None else control_surface_paths(root):
+        path = candidate if candidate.is_absolute() else root / candidate
+        if not path.is_file():
+            continue
+        relative = _relative_path(path, root)
+        source = path.read_text(encoding="utf-8")
+        if path.suffix in {".yml", ".yaml"}:
+            for run in _workflow_run_blocks(path):
+                findings.extend(_shell_invocations(run, path=relative))
+        elif path.suffix == ".py":
+            findings.extend(_python_invocations(source, path=relative))
+        else:
+            findings.extend(_shell_invocations(source, path=relative))
+    return findings
+
+
+def _sanctioned_keys() -> set[tuple[str, str]]:
+    return {(site.path, site.marker) for site in CATALOG_BYPASS_SITES if site.disposition == "sanctioned-bypass"}
+
+
+def collect_violations(root: Path = ROOT, *, paths: Iterable[Path] | None = None) -> list[DirectDevtoolsInvocation]:
+    sanctioned = _sanctioned_keys()
+    return [item for item in scan_control_surfaces(root, paths=paths) if (item.path, item.invocation) not in sanctioned]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="emit machine-readable output")
+    args = parser.parse_args(argv)
+    violations = collect_violations(ROOT)
+    if args.json:
+        print(json.dumps({"ok": not violations, "violations": [asdict(item) for item in violations]}, indent=2))
+    elif violations:
+        print("Unregistered direct devtools invocations:", file=sys.stderr)
+        for item in violations:
+            print(f"  {item.path}:{item.lineno}: {item.invocation}", file=sys.stderr)
+    else:
+        print("Catalog bypass scan OK: no undeclared direct devtools execution sites.")
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/devtools/verify_catalog_bypasses.py
+++ b/devtools/verify_catalog_bypasses.py
@@ -1,21 +1,23 @@
 """Reject unregistered direct devtools command execution in control surfaces.
 
 The CommandSpec catalog is the public execution registry. Workflow ``run:``
-blocks, repository hooks, and devtools process-launch calls must invoke it as
-``devtools ...``. This checker catches literal direct forms such as
+blocks, repository hooks, CI-owned npm scripts, and devtools process-launch
+calls must invoke it as ``devtools ...``. This checker catches literal direct forms such as
 ``python -m devtools.some_module`` and ``python devtools/some_module.py``.
 
 Scope is deliberately execution-only:
 
-* workflow ``run:`` blocks and hook shell scripts are scanned as shell text;
+* workflow ``run:`` blocks, hook shell scripts, and the declared top-level
+  JavaScript workspace npm scripts are scanned as structured command text;
 * ``devtools/**/*.py`` is parsed with ``ast`` and only command-runner call
-  arguments are inspected.
+  arguments are inspected, including literal ``args=`` keyword vectors.
 
 Generated provenance headers, argparse ``prog`` values, comments, and
 docstrings are outside the scope because they do not launch a process. A real
 hook adapter can remain only through a structured ``sanctioned-bypass`` entry
-in ``CATALOG_BYPASS_SITES`` with a reason. Dynamic command construction is
-outside this literal-vector check and must use catalog helpers at review.
+in ``CATALOG_BYPASS_SITES`` with a reason, exact line, and expected occurrence
+count. Dynamic values remain untrusted, but literal executable, module, and
+script segments are inspected without scanning comments or prose.
 """
 
 from __future__ import annotations
@@ -32,7 +34,7 @@ from pathlib import Path
 import yaml
 
 from devtools import repo_root as _get_root
-from devtools.command_catalog import CATALOG_BYPASS_SITES
+from devtools.command_catalog import CATALOG_BYPASS_SITES, CatalogBypassSite
 
 ROOT = _get_root()
 _COMMAND_RUNNERS = {"run", "check_call", "check_output", "Popen", "system", "_run", "run_command", "_run_command"}
@@ -41,6 +43,7 @@ _MODULE_INVOCATION = re.compile(rf"(?<![\w./-])(?:uv\s+run\s+)?{_PYTHON}\s+-m\s+
 _SCRIPT_INVOCATION = re.compile(
     rf"(?<![\w./-])(?:uv\s+run\s+)?{_PYTHON}\s+(?:\./)?(devtools/[A-Za-z_][A-Za-z0-9_]*\.py)"
 )
+_NPM_SCRIPT_MANIFESTS = (Path("webui/package.json"), Path("browser-extension/package.json"))
 
 
 @dataclass(frozen=True, slots=True)
@@ -50,6 +53,14 @@ class DirectDevtoolsInvocation:
     invocation: str
 
 
+@dataclass(frozen=True, slots=True)
+class BypassViolation:
+    path: str
+    lineno: int
+    invocation: str
+    reason: str
+
+
 def _relative_path(path: Path, root: Path) -> str:
     try:
         return path.relative_to(root).as_posix()
@@ -57,14 +68,14 @@ def _relative_path(path: Path, root: Path) -> str:
         return path.as_posix()
 
 
-def _shell_invocations(source: str, *, path: str) -> list[DirectDevtoolsInvocation]:
+def _shell_invocations(source: str, *, path: str, line_offset: int = 0) -> list[DirectDevtoolsInvocation]:
     findings: list[DirectDevtoolsInvocation] = []
     for pattern, prefix in ((_MODULE_INVOCATION, "python -m"), (_SCRIPT_INVOCATION, "python")):
         for match in pattern.finditer(source):
             findings.append(
                 DirectDevtoolsInvocation(
                     path=path,
-                    lineno=source.count("\n", 0, match.start()) + 1,
+                    lineno=line_offset + source.count("\n", 0, match.start()) + 1,
                     invocation=f"{prefix} {match.group(1)}",
                 )
             )
@@ -132,9 +143,15 @@ def _python_invocations(source: str, *, path: str) -> list[DirectDevtoolsInvocat
         return []
     findings: list[DirectDevtoolsInvocation] = []
     for node in ast.walk(tree):
-        if not isinstance(node, ast.Call) or not _is_command_runner(node) or not node.args:
+        if not isinstance(node, ast.Call) or not _is_command_runner(node):
             continue
-        findings.extend(_invocations_from_command_expression(node.args[0], path=path, lineno=node.lineno))
+        command = (
+            node.args[0]
+            if node.args
+            else next((keyword.value for keyword in node.keywords if keyword.arg == "args"), None)
+        )
+        if command is not None:
+            findings.extend(_invocations_from_command_expression(command, path=path, lineno=node.lineno))
     return findings
 
 
@@ -157,6 +174,25 @@ def _workflow_run_blocks(path: Path) -> Iterable[str]:
     return tuple(_walk(data))
 
 
+def _npm_script_invocations(path: Path, *, relative: str) -> list[DirectDevtoolsInvocation]:
+    try:
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return []
+    scripts = manifest.get("scripts")
+    if not isinstance(scripts, dict):
+        return []
+    source = path.read_text(encoding="utf-8")
+    findings: list[DirectDevtoolsInvocation] = []
+    for name, command in scripts.items():
+        if not isinstance(name, str) or not isinstance(command, str):
+            continue
+        match = re.search(rf'^\s*"{re.escape(name)}"\s*:', source, flags=re.MULTILINE)
+        line_offset = source.count("\n", 0, match.start()) if match is not None else 0
+        findings.extend(_shell_invocations(command, path=relative, line_offset=line_offset))
+    return findings
+
+
 def control_surface_paths(root: Path = ROOT) -> tuple[Path, ...]:
     paths: list[Path] = []
     workflows = root / ".github" / "workflows"
@@ -168,6 +204,7 @@ def control_surface_paths(root: Path = ROOT) -> tuple[Path, ...]:
     devtools = root / "devtools"
     if devtools.exists():
         paths.extend(sorted(devtools.rglob("*.py")))
+    paths.extend(root / manifest for manifest in _NPM_SCRIPT_MANIFESTS if (root / manifest).is_file())
     return tuple(paths)
 
 
@@ -182,6 +219,8 @@ def scan_control_surfaces(root: Path = ROOT, *, paths: Iterable[Path] | None = N
         if path.suffix in {".yml", ".yaml"}:
             for run in _workflow_run_blocks(path):
                 findings.extend(_shell_invocations(run, path=relative))
+        elif path.name == "package.json":
+            findings.extend(_npm_script_invocations(path, relative=relative))
         elif path.suffix == ".py":
             findings.extend(_python_invocations(source, path=relative))
         else:
@@ -189,13 +228,43 @@ def scan_control_surfaces(root: Path = ROOT, *, paths: Iterable[Path] | None = N
     return findings
 
 
-def _sanctioned_keys() -> set[tuple[str, str]]:
-    return {(site.path, site.marker) for site in CATALOG_BYPASS_SITES if site.disposition == "sanctioned-bypass"}
+def _sanctioned_sites() -> tuple[CatalogBypassSite, ...]:
+    return tuple(
+        site
+        for site in CATALOG_BYPASS_SITES
+        if site.disposition == "sanctioned-bypass" and site.occurrence_line is not None
+    )
 
 
-def collect_violations(root: Path = ROOT, *, paths: Iterable[Path] | None = None) -> list[DirectDevtoolsInvocation]:
-    sanctioned = _sanctioned_keys()
-    return [item for item in scan_control_surfaces(root, paths=paths) if (item.path, item.invocation) not in sanctioned]
+def collect_violations(root: Path = ROOT, *, paths: Iterable[Path] | None = None) -> list[BypassViolation]:
+    selected = tuple(paths) if paths is not None else control_surface_paths(root)
+    findings = scan_control_surfaces(root, paths=selected)
+    sanctioned = _sanctioned_sites()
+    selected_paths = {
+        _relative_path(candidate if candidate.is_absolute() else root / candidate, root) for candidate in selected
+    }
+    allowed = {(site.path, site.occurrence_line, site.marker) for site in sanctioned}
+    violations = [
+        BypassViolation(item.path, item.lineno, item.invocation, "undeclared-direct-invocation")
+        for item in findings
+        if (item.path, item.lineno, item.invocation) not in allowed
+    ]
+    for site in sanctioned:
+        occurrence_line = site.occurrence_line
+        assert occurrence_line is not None
+        if site.path not in selected_paths:
+            continue
+        count = sum(item.path == site.path and item.invocation == site.marker for item in findings)
+        if count != site.expected_occurrences:
+            violations.append(
+                BypassViolation(
+                    site.path,
+                    occurrence_line,
+                    site.marker,
+                    f"sanctioned-occurrence-count:{count}!={site.expected_occurrences}",
+                )
+            )
+    return violations
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -206,9 +275,9 @@ def main(argv: list[str] | None = None) -> int:
     if args.json:
         print(json.dumps({"ok": not violations, "violations": [asdict(item) for item in violations]}, indent=2))
     elif violations:
-        print("Unregistered direct devtools invocations:", file=sys.stderr)
+        print("Catalog bypass violations:", file=sys.stderr)
         for item in violations:
-            print(f"  {item.path}:{item.lineno}: {item.invocation}", file=sys.stderr)
+            print(f"  {item.path}:{item.lineno}: {item.invocation} ({item.reason})", file=sys.stderr)
     else:
         print("Catalog bypass scan OK: no undeclared direct devtools execution sites.")
     return 1 if violations else 0

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -96,6 +96,32 @@ These are the commands worth remembering during normal repo work:
 - `devtools bench campaign`: Record durable benchmark artifacts or compare a candidate run against a baseline artifact.
   Common forms: `devtools bench campaign list`, `devtools bench campaign run search-filters`, `devtools bench campaign compare baseline.json candidate.json`.
 
+## Workspace disposition audit
+
+The utf.1 triage retains workspace commands with operator history, reusable output, or focused tests. The stale archive-schema-fast-forward name is removed in favor of the registered index fast-forward command.
+
+| Named entry | Disposition | Evidence | Replacement |
+| --- | --- | --- | --- |
+| `devtools workspace index-fast-forward` | `retain` | Recent production commits plus focused devtools/storage tests; emits a reusable proof receipt. | Keep the registered command as the index-tier actuator. |
+| `workspace archive-schema-fast-forward` | `remove` | No current CommandSpec, implementation module, focused test, or history entry exists for this name. | Use workspace index-fast-forward for declared derived-index fast-forwards. |
+| `devtools workspace degraded-archive-proof` | `retain` | Focused tests and deterministic self-healing proof artifacts cover the command. | Keep the registered command for archive repair evidence. |
+| `devtools workspace frontier` | `retain` | Operator-facing frontier report with documented workflow use and structured report output. | Keep the registered command for frontier batching and wait-ahead decisions. |
+| `devtools workspace temporal-read-profile` | `retain` | Focused tests cover the report and JSON timing output is reusable for read tuning. | Keep the registered command as the temporal read profiling entrypoint. |
+| `devtools workspace temporal-devloop` | `retain` | Focused tests cover structured and Markdown event sources; output is a reusable evidence window. | Keep the registered command as the devloop temporal evidence entrypoint. |
+| `devtools workspace temporal-archive-aggregates` | `retain` | Focused tests cover aggregate report construction and reusable archive artifacts. | Keep the registered command as the run-projection aggregate entrypoint. |
+| `devtools workspace lineage-validation` | `retain` | Focused tests cover lineage evidence and the command emits reusable count and composition proof. | Keep the registered command before publishing archive cardinality claims. |
+| `devtools workspace cli-surface-audit` | `retain` | Focused tests cover bounded output and stale-artifact pruning; the audit shelf is reusable. | Keep the registered command as the current CLI surface audit entrypoint. |
+| `devtools demo real-slice-screen` | `retain` | Focused privacy-screening tests cover redaction, PII review, and report generation. | Keep the registered command as the read-only real-archive screening entrypoint. |
+
+Catalog bypass audit sites are machine-checked: CI and the Beads-only pre-push route use registered commands; the generated test-economics provenance header is the sole declared sanctioned module-path exception.
+
+| Site | Status | Registered command | Reason |
+| --- | --- | --- | --- |
+| `.github/workflows/mutation-testing.yml` | `registered` | `devtools verify mutation-freshness` | CI invokes the catalog command so inventory and workflow validation see the freshness gate. |
+| `.github/workflows/nightly-scale.yml` | `registered` | `devtools bench nightly-compare` | CI invokes the catalog command so the nightly comparison is discoverable and checked. |
+| `devtools/pre_push_gate.py` | `registered` | `devtools lab policy backlog-hygiene` | The intentional Beads-only route remains narrow while using the registered policy command. |
+| `docs/test-economics.md` | `sanctioned-bypass` | `devtools lab test-economics` | The generated provenance header preserves the module that emitted the document; operators use the catalog command. |
+
 ### Core
 
 | Command | Description |
@@ -196,6 +222,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools verify evidence` | Render the pytest-first evidence dashboard. |
 | `devtools verify layering` | Check inter-package imports against declared layering rules from docs/plans/layering.yaml. |
 | `devtools verify manifests` | Verify internal consistency across all docs/plans/*.yaml manifest files. |
+| `devtools verify mutation-freshness` | Verify fresh mutation campaigns meet their declared kill-rate thresholds. |
 | `devtools verify public-claims` | Verify generated public-claim views, preset parity, sanitized refs, coverage markers, and retired copy. |
 | `devtools verify pytest-timeout-overrides` | Verify explicit pytest timeout overrides are positive, bounded, and justified. |
 | `devtools verify schema-inference-gate` | Run the read-only schema-inference prerequisite and persist a PASS/FAIL receipt. |
@@ -212,6 +239,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools bench ingest-throughput` | Measure ingest wall-clock throughput on a synthetic fixture. |
 | `devtools bench memory` | Measure query-memory envelopes on generated fixtures. |
 | `devtools bench mutation` | Run focused mutation campaigns and maintain their local index. |
+| `devtools bench nightly-compare` | Compare nightly pytest-benchmark output with the committed baseline. |
 | `devtools bench slo` | Check read-surface latency budgets in docs/plans/slo-catalog.yaml against benchmark measurements. |
 | `devtools bench synthetic` | Run synthetic benchmark campaigns over generated archives. |
 

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -113,16 +113,16 @@ The utf.1 triage retains workspace commands with operator history, reusable outp
 | `devtools workspace cli-surface-audit` | `retain` | Focused tests cover bounded output and stale-artifact pruning; the audit shelf is reusable. | Keep the registered command as the current CLI surface audit entrypoint. |
 | `devtools demo real-slice-screen` | `retain` | Focused privacy-screening tests cover redaction, PII review, and report generation. | Keep the registered command as the read-only real-archive screening entrypoint. |
 
-Catalog bypass audit sites are machine-checked: CI and the Beads-only pre-push route use registered commands; direct hook adapters and generated provenance headers require declared sanctioned exceptions.
+Catalog bypass audit sites are machine-checked across workflow runs, CI-owned npm scripts, hooks, and devtools process launches. Direct hook adapters require declared sanctioned exceptions with an exact occurrence and cardinality.
 
-| Site | Status | Registered command | Reason |
-| --- | --- | --- | --- |
-| `.github/workflows/mutation-testing.yml` | `registered` | `devtools verify mutation-freshness` | CI invokes the catalog command so inventory and workflow validation see the freshness gate. |
-| `.github/workflows/nightly-scale.yml` | `registered` | `devtools bench nightly-compare` | CI invokes the catalog command so the nightly comparison is discoverable and checked. |
-| `devtools/pre_push_gate.py` | `registered` | `devtools lab policy backlog-hygiene` | The intentional Beads-only route remains narrow while using the registered policy command. |
-| `docs/test-economics.md` | `sanctioned-bypass` | `devtools lab test-economics` | The generated provenance header preserves the module that emitted the document; operators use the catalog command. |
-| `.githooks/pre-push` | `sanctioned-bypass` | `hook adapter` | The hook adapter must receive Git's staged stdin update stream before dispatching its catalog-aware gate. |
-| `.beads-hooks/pre-push` | `sanctioned-bypass` | `hook adapter` | The Beads-augmented hook retains the same stdin adapter before its managed Beads section runs. |
+| Site | Status | Registered command | Occurrence | Reason |
+| --- | --- | --- | --- | --- |
+| `.github/workflows/mutation-testing.yml` | `registered` | `devtools verify mutation-freshness` | not applicable | CI invokes the catalog command so inventory and workflow validation see the freshness gate. |
+| `.github/workflows/nightly-scale.yml` | `registered` | `devtools bench nightly-compare` | not applicable | CI invokes the catalog command so the nightly comparison is discoverable and checked. |
+| `devtools/pre_push_gate.py` | `registered` | `devtools lab policy backlog-hygiene` | not applicable | The intentional Beads-only route remains narrow while using the registered policy command. |
+| `docs/test-economics.md` | `sanctioned-bypass` | `devtools lab test-economics` | not applicable | The generated provenance header preserves the module that emitted the document; operators use the catalog command. |
+| `.githooks/pre-push` | `sanctioned-bypass` | `hook adapter` | line 21 (1 expected) | The hook adapter must receive Git's staged stdin update stream before dispatching its catalog-aware gate. |
+| `.beads-hooks/pre-push` | `sanctioned-bypass` | `hook adapter` | line 21 (1 expected) | The Beads-augmented hook retains the same stdin adapter before its managed Beads section runs. |
 
 ### Core
 

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -113,7 +113,7 @@ The utf.1 triage retains workspace commands with operator history, reusable outp
 | `devtools workspace cli-surface-audit` | `retain` | Focused tests cover bounded output and stale-artifact pruning; the audit shelf is reusable. | Keep the registered command as the current CLI surface audit entrypoint. |
 | `devtools demo real-slice-screen` | `retain` | Focused privacy-screening tests cover redaction, PII review, and report generation. | Keep the registered command as the read-only real-archive screening entrypoint. |
 
-Catalog bypass audit sites are machine-checked: CI and the Beads-only pre-push route use registered commands; the generated test-economics provenance header is the sole declared sanctioned module-path exception.
+Catalog bypass audit sites are machine-checked: CI and the Beads-only pre-push route use registered commands; direct hook adapters and generated provenance headers require declared sanctioned exceptions.
 
 | Site | Status | Registered command | Reason |
 | --- | --- | --- | --- |
@@ -121,6 +121,8 @@ Catalog bypass audit sites are machine-checked: CI and the Beads-only pre-push r
 | `.github/workflows/nightly-scale.yml` | `registered` | `devtools bench nightly-compare` | CI invokes the catalog command so the nightly comparison is discoverable and checked. |
 | `devtools/pre_push_gate.py` | `registered` | `devtools lab policy backlog-hygiene` | The intentional Beads-only route remains narrow while using the registered policy command. |
 | `docs/test-economics.md` | `sanctioned-bypass` | `devtools lab test-economics` | The generated provenance header preserves the module that emitted the document; operators use the catalog command. |
+| `.githooks/pre-push` | `sanctioned-bypass` | `hook adapter` | The hook adapter must receive Git's staged stdin update stream before dispatching its catalog-aware gate. |
+| `.beads-hooks/pre-push` | `sanctioned-bypass` | `hook adapter` | The Beads-augmented hook retains the same stdin adapter before its managed Beads section runs. |
 
 ### Core
 
@@ -212,6 +214,7 @@ Catalog bypass audit sites are machine-checked: CI and the Beads-only pre-push r
 | `devtools test` | Run a focused pytest selection through the managed harness. |
 | `devtools verify` | Run the local verification baseline before pushing or creating a PR. |
 | `devtools verify agent-integration` | Verify manual compilation, parser examples, continuation, native delivery, packaging, and live cutover signatures. |
+| `devtools verify catalog-bypasses` | Reject direct devtools module or script execution outside sanctioned adapters. |
 | `devtools verify ci-workflows` | Verify CI workflow files reference locally-known devtools commands and existing paths. |
 | `devtools verify closure-matrix` | Verify docs/plans/test-closure-matrix.yaml stays grounded in the realized tree. |
 | `devtools verify corpus-fidelity` | Run the production corpus-fidelity acceptance gate against an archive root. |

--- a/tests/unit/devtools/test_command_catalog.py
+++ b/tests/unit/devtools/test_command_catalog.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from devtools.command_catalog import (
+    CATALOG_BYPASS_SITES,
     CATEGORY_ORDER,
     COMMAND_SPECS,
+    COMMANDS,
     VERIFICATION_LAB_COMMAND_NAMES,
+    WORKSPACE_COMMAND_DISPOSITIONS,
     command_name_from_tokens,
     control_plane_argv,
     control_plane_command,
@@ -59,3 +64,44 @@ def test_verification_lab_surface_is_explicit_and_implemented() -> None:
         assert spec.use_when
         assert spec.examples
         assert callable(spec.resolve_main())
+
+
+def test_workspace_dispositions_cover_the_named_utf_entries() -> None:
+    expected = {
+        "workspace index-fast-forward",
+        "workspace archive-schema-fast-forward",
+        "workspace degraded-archive-proof",
+        "workspace frontier",
+        "workspace temporal-read-profile",
+        "workspace temporal-devloop",
+        "workspace temporal-archive-aggregates",
+        "workspace lineage-validation",
+        "workspace cli-surface-audit",
+        "demo real-slice-screen",
+    }
+    dispositions = {item.name: item for item in WORKSPACE_COMMAND_DISPOSITIONS}
+
+    assert set(dispositions) == expected
+    assert dispositions["workspace archive-schema-fast-forward"].disposition == "remove"
+    assert dispositions["workspace archive-schema-fast-forward"].replacement.endswith(
+        "workspace index-fast-forward for declared derived-index fast-forwards."
+    )
+    for name, item in dispositions.items():
+        assert item.evidence
+        assert item.replacement
+        if item.disposition == "retain":
+            assert name in COMMANDS
+        else:
+            assert name not in COMMANDS
+
+
+def test_named_catalog_bypass_sites_are_registered_or_sanctioned() -> None:
+    root = Path(__file__).resolve().parents[3]
+
+    assert CATALOG_BYPASS_SITES
+    for site in CATALOG_BYPASS_SITES:
+        source = (root / site.path).read_text(encoding="utf-8")
+        assert site.marker in source
+        assert site.command_name in COMMANDS
+        assert site.disposition in {"registered", "sanctioned-bypass"}
+        assert site.reason

--- a/tests/unit/devtools/test_command_catalog.py
+++ b/tests/unit/devtools/test_command_catalog.py
@@ -82,17 +82,19 @@ def test_workspace_dispositions_cover_the_named_utf_entries() -> None:
     dispositions = {item.name: item for item in WORKSPACE_COMMAND_DISPOSITIONS}
 
     assert set(dispositions) == expected
-    assert dispositions["workspace archive-schema-fast-forward"].disposition == "remove"
-    assert dispositions["workspace archive-schema-fast-forward"].replacement.endswith(
-        "workspace index-fast-forward for declared derived-index fast-forwards."
-    )
+    archived = dispositions["workspace archive-schema-fast-forward"]
+    assert archived.disposition == "remove"
+    assert archived.replacement_command == "workspace index-fast-forward"
+    assert archived.replacement_command in COMMANDS
     for name, item in dispositions.items():
         assert item.evidence
         assert item.replacement
         if item.disposition == "retain":
             assert name in COMMANDS
+            assert item.replacement_command is None
         else:
             assert name not in COMMANDS
+            assert item.replacement_command in COMMANDS
 
 
 def test_named_catalog_bypass_sites_are_registered_or_sanctioned() -> None:
@@ -107,4 +109,8 @@ def test_named_catalog_bypass_sites_are_registered_or_sanctioned() -> None:
             assert site.command_name in COMMANDS
         else:
             assert site.disposition == "sanctioned-bypass"
+        if site.occurrence_line is not None:
+            assert site.disposition == "sanctioned-bypass"
+            assert site.expected_occurrences == 1
+            assert source.splitlines()[site.occurrence_line - 1].strip().startswith(site.marker)
         assert site.reason

--- a/tests/unit/devtools/test_command_catalog.py
+++ b/tests/unit/devtools/test_command_catalog.py
@@ -102,6 +102,9 @@ def test_named_catalog_bypass_sites_are_registered_or_sanctioned() -> None:
     for site in CATALOG_BYPASS_SITES:
         source = (root / site.path).read_text(encoding="utf-8")
         assert site.marker in source
-        assert site.command_name in COMMANDS
         assert site.disposition in {"registered", "sanctioned-bypass"}
+        if site.command_name is not None:
+            assert site.command_name in COMMANDS
+        else:
+            assert site.disposition == "sanctioned-bypass"
         assert site.reason

--- a/tests/unit/devtools/test_pre_push_hook.py
+++ b/tests/unit/devtools/test_pre_push_hook.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 from devtools import pre_push_gate
+from devtools.command_catalog import command_name_from_tokens
 
 ROOT = Path(__file__).resolve().parents[3]
 HOOK_PATHS = (ROOT / ".githooks" / "pre-push", ROOT / ".beads-hooks" / "pre-push")
@@ -100,6 +102,23 @@ def test_new_branch_uses_default_branch_merge_base(git_repo: Path) -> None:
     update = pre_push_gate.PushUpdate("refs/heads/topic", tip, "refs/heads/topic", ZERO_SHA)
 
     assert pre_push_gate.changed_paths([update], cwd=git_repo) == {".beads/issues.jsonl"}
+
+
+def test_beads_only_gate_uses_registered_backlog_hygiene_command(
+    git_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    base = _git(git_repo, "rev-parse", "HEAD")
+    tip = _commit(git_repo, ".beads/issues.jsonl", "{}\n", "beads")
+    update = pre_push_gate.PushUpdate("refs/heads/topic", tip, "refs/heads/topic", base)
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(pre_push_gate, "_run", lambda command, cwd: commands.append(command))
+
+    assert pre_push_gate.run_gate([update], cwd=git_repo) == "beads"
+    assert len(commands) == 1
+    assert commands[0][:3] == [sys.executable, "-m", "devtools"]
+    assert command_name_from_tokens(commands[0][3:]) == "lab policy backlog-hygiene"
+    assert commands[0][-3:] == ["--checks", "D1,D2", ".beads/issues.jsonl"]
 
 
 def test_parse_updates_rejects_malformed_input() -> None:

--- a/tests/unit/devtools/test_render_devtools_reference.py
+++ b/tests/unit/devtools/test_render_devtools_reference.py
@@ -28,6 +28,12 @@ def test_build_command_catalog_includes_discovery_and_commands() -> None:
     assert "### Lab Checks" in rendered
     assert "| `devtools render all` |" in rendered
     assert "| `devtools render demo-corpus-datasheet` |" in rendered
+    assert "| `devtools workspace index-fast-forward` | `retain` |" in rendered
+    assert "| `workspace archive-schema-fast-forward` | `remove` |" in rendered
+    assert "| `.githooks/pre-push` | `sanctioned-bypass` | `hook adapter` |" in rendered
+    assert (
+        "| `.github/workflows/mutation-testing.yml` | `registered` | `devtools verify mutation-freshness` |" in rendered
+    )
     assert "| `devtools verify pytest-timeout-overrides` |" in rendered
     assert "Common forms: `devtools status`" in rendered
 

--- a/tests/unit/devtools/test_render_devtools_reference.py
+++ b/tests/unit/devtools/test_render_devtools_reference.py
@@ -30,7 +30,8 @@ def test_build_command_catalog_includes_discovery_and_commands() -> None:
     assert "| `devtools render demo-corpus-datasheet` |" in rendered
     assert "| `devtools workspace index-fast-forward` | `retain` |" in rendered
     assert "| `workspace archive-schema-fast-forward` | `remove` |" in rendered
-    assert "| `.githooks/pre-push` | `sanctioned-bypass` | `hook adapter` |" in rendered
+    assert "Use workspace index-fast-forward for declared derived-index fast-forwards." in rendered
+    assert "| `.githooks/pre-push` | `sanctioned-bypass` | `hook adapter` | line 21 (1 expected) |" in rendered
     assert (
         "| `.github/workflows/mutation-testing.yml` | `registered` | `devtools verify mutation-freshness` |" in rendered
     )

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -89,6 +89,7 @@ def test_quick_verify_omits_pytest() -> None:
         "lab schema roundtrip",
         "verify manifests",
         "verify ci-workflows",
+        "verify catalog-bypasses",
         "verify doc-commands",
         "verify docs-coverage",
         "verify test-infra-currency",

--- a/tests/unit/devtools/test_verify_catalog_bypasses.py
+++ b/tests/unit/devtools/test_verify_catalog_bypasses.py
@@ -12,6 +12,12 @@ def test_real_control_surfaces_have_only_sanctioned_direct_invocations() -> None
     assert lint.collect_violations() == []
 
 
+def test_control_surface_paths_include_ci_owned_npm_manifests() -> None:
+    paths = {path.relative_to(lint.ROOT).as_posix() for path in lint.control_surface_paths()}
+
+    assert {"webui/package.json", "browser-extension/package.json"} <= paths
+
+
 def test_scope_excludes_generated_provenance_and_argparse_help() -> None:
     root = Path(__file__).resolve().parents[3]
     paths = (Path("devtools/render_semantic_card_registry.py"), Path("devtools/resume_ranking_eval.py"))
@@ -34,7 +40,12 @@ def test_mutation_direct_module_invocation_fails_the_check(
     payload = json.loads(capsys.readouterr().out)
     assert payload["ok"] is False
     assert payload["violations"] == [
-        {"path": "devtools/control.py", "lineno": 2, "invocation": "python -m devtools.fourth_bypass"}
+        {
+            "path": "devtools/control.py",
+            "lineno": 2,
+            "invocation": "python -m devtools.fourth_bypass",
+            "reason": "undeclared-direct-invocation",
+        }
     ]
 
 
@@ -49,4 +60,50 @@ def test_scan_detects_direct_script_execution_in_workflow_run_block(tmp_path: Pa
 
     assert [(item.path, item.invocation) for item in violations] == [
         (".github/workflows/ci.yml", "python devtools/fourth_bypass.py")
+    ]
+
+
+def test_scan_detects_direct_module_execution_in_ci_owned_npm_script(tmp_path: Path) -> None:
+    manifest = tmp_path / "webui" / "package.json"
+    manifest.parent.mkdir()
+    manifest.write_text(
+        '{\n  "scripts": {\n    "generate": "python3 -m devtools.fourth_bypass"\n  }\n}\n', encoding="utf-8"
+    )
+
+    violations = lint.collect_violations(tmp_path, paths=(Path("webui/package.json"),))
+
+    assert [(item.path, item.lineno, item.invocation, item.reason) for item in violations] == [
+        ("webui/package.json", 3, "python -m devtools.fourth_bypass", "undeclared-direct-invocation")
+    ]
+
+
+def test_scan_detects_direct_module_execution_in_keyword_args(tmp_path: Path) -> None:
+    control = tmp_path / "devtools" / "control.py"
+    control.parent.mkdir()
+    control.write_text(
+        "import subprocess\nimport sys\noption = '--json'\nsubprocess.run(args=[sys.executable, '-m', 'devtools.fourth_bypass', option], check=True)\n",
+        encoding="utf-8",
+    )
+
+    violations = lint.collect_violations(tmp_path, paths=(Path("devtools/control.py"),))
+
+    assert [(item.path, item.lineno, item.invocation, item.reason) for item in violations] == [
+        ("devtools/control.py", 4, "python -m devtools.fourth_bypass", "undeclared-direct-invocation")
+    ]
+
+
+def test_duplicate_hook_invocation_exceeds_the_sanctioned_cardinality(tmp_path: Path) -> None:
+    hook = tmp_path / ".githooks" / "pre-push"
+    hook.parent.mkdir()
+    hook.write_text(
+        "\n" * 20
+        + 'python -m devtools.pre_push_gate "$UPDATES_FILE"\npython -m devtools.pre_push_gate "$UPDATES_FILE"\n',
+        encoding="utf-8",
+    )
+
+    violations = lint.collect_violations(tmp_path, paths=(Path(".githooks/pre-push"),))
+
+    assert [(item.lineno, item.reason) for item in violations] == [
+        (22, "undeclared-direct-invocation"),
+        (21, "sanctioned-occurrence-count:2!=1"),
     ]

--- a/tests/unit/devtools/test_verify_catalog_bypasses.py
+++ b/tests/unit/devtools/test_verify_catalog_bypasses.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from devtools import verify_catalog_bypasses as lint
+
+
+def test_real_control_surfaces_have_only_sanctioned_direct_invocations() -> None:
+    assert lint.collect_violations() == []
+
+
+def test_scope_excludes_generated_provenance_and_argparse_help() -> None:
+    root = Path(__file__).resolve().parents[3]
+    paths = (Path("devtools/render_semantic_card_registry.py"), Path("devtools/resume_ranking_eval.py"))
+
+    assert lint.scan_control_surfaces(root, paths=paths) == []
+
+
+def test_mutation_direct_module_invocation_fails_the_check(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    control = tmp_path / "devtools" / "control.py"
+    control.parent.mkdir()
+    control.write_text(
+        "import subprocess\nsubprocess.run(['python', '-m', 'devtools.fourth_bypass'], check=True)\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(lint, "ROOT", tmp_path)
+
+    assert lint.main(["--json"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["violations"] == [
+        {"path": "devtools/control.py", "lineno": 2, "invocation": "python -m devtools.fourth_bypass"}
+    ]
+
+
+def test_scan_detects_direct_script_execution_in_workflow_run_block(tmp_path: Path) -> None:
+    workflow = tmp_path / ".github" / "workflows" / "ci.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text(
+        "jobs:\n  check:\n    steps:\n      - run: python devtools/fourth_bypass.py\n", encoding="utf-8"
+    )
+
+    violations = lint.collect_violations(tmp_path, paths=(Path(".github/workflows/ci.yml"),))
+
+    assert [(item.path, item.invocation) for item in violations] == [
+        (".github/workflows/ci.yml", "python devtools/fourth_bypass.py")
+    ]

--- a/tests/unit/devtools/test_verify_catalog_bypasses.py
+++ b/tests/unit/devtools/test_verify_catalog_bypasses.py
@@ -63,6 +63,20 @@ def test_scan_detects_direct_script_execution_in_workflow_run_block(tmp_path: Pa
     ]
 
 
+def test_scan_detects_compact_module_execution_in_workflow_run_block(tmp_path: Path) -> None:
+    workflow = tmp_path / ".github" / "workflows" / "ci.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text(
+        "jobs:\n  check:\n    steps:\n      - run: python3 -mdevtools.fourth_bypass\n", encoding="utf-8"
+    )
+
+    violations = lint.collect_violations(tmp_path, paths=(Path(".github/workflows/ci.yml"),))
+
+    assert [(item.path, item.invocation) for item in violations] == [
+        (".github/workflows/ci.yml", "python -m devtools.fourth_bypass")
+    ]
+
+
 def test_scan_detects_direct_module_execution_in_ci_owned_npm_script(tmp_path: Path) -> None:
     manifest = tmp_path / "webui" / "package.json"
     manifest.parent.mkdir()
@@ -74,6 +88,20 @@ def test_scan_detects_direct_module_execution_in_ci_owned_npm_script(tmp_path: P
 
     assert [(item.path, item.lineno, item.invocation, item.reason) for item in violations] == [
         ("webui/package.json", 3, "python -m devtools.fourth_bypass", "undeclared-direct-invocation")
+    ]
+
+
+def test_scan_detects_compact_module_execution_in_ci_owned_npm_script(tmp_path: Path) -> None:
+    manifest = tmp_path / "webui" / "package.json"
+    manifest.parent.mkdir()
+    manifest.write_text(
+        '{\n  "scripts": {\n    "generate": "python3 -mdevtools.fourth_bypass"\n  }\n}\n', encoding="utf-8"
+    )
+
+    violations = lint.collect_violations(tmp_path, paths=(Path("webui/package.json"),))
+
+    assert [(item.path, item.invocation) for item in violations] == [
+        ("webui/package.json", "python -m devtools.fourth_bypass")
     ]
 
 
@@ -89,6 +117,32 @@ def test_scan_detects_direct_module_execution_in_keyword_args(tmp_path: Path) ->
 
     assert [(item.path, item.lineno, item.invocation, item.reason) for item in violations] == [
         ("devtools/control.py", 4, "python -m devtools.fourth_bypass", "undeclared-direct-invocation")
+    ]
+
+
+def test_scan_detects_compact_module_execution_in_subprocess_call_keyword_args(tmp_path: Path) -> None:
+    control = tmp_path / "devtools" / "control.py"
+    control.parent.mkdir()
+    control.write_text(
+        "import subprocess\nsubprocess.call(args=['python', '-mdevtools.fourth_bypass'])\n", encoding="utf-8"
+    )
+
+    violations = lint.collect_violations(tmp_path, paths=(Path("devtools/control.py"),))
+
+    assert [(item.path, item.lineno, item.invocation, item.reason) for item in violations] == [
+        ("devtools/control.py", 2, "python -m devtools.fourth_bypass", "undeclared-direct-invocation")
+    ]
+
+
+def test_scan_detects_compact_module_execution_in_hook(tmp_path: Path) -> None:
+    hook = tmp_path / ".githooks" / "custom-pre-push"
+    hook.parent.mkdir()
+    hook.write_text("python3 -mdevtools.fourth_bypass\n", encoding="utf-8")
+
+    violations = lint.collect_violations(tmp_path, paths=(Path(".githooks/custom-pre-push"),))
+
+    assert [(item.path, item.invocation) for item in violations] == [
+        (".githooks/custom-pre-push", "python -m devtools.fourth_bypass")
     ]
 
 

--- a/tests/unit/devtools/test_webui_package_scripts.py
+++ b/tests/unit/devtools/test_webui_package_scripts.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_webui_generate_check_script_resolves_from_ci_working_directory() -> None:
+    root = Path(__file__).resolve().parents[3]
+    result = subprocess.run(
+        ["npm", "run", "generate:check"],
+        cwd=root / "webui",
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "render webui-design-system: sync OK" in result.stdout

--- a/webui/package.json
+++ b/webui/package.json
@@ -13,10 +13,10 @@
     "./design-system.css": "./src/design-system/design-system.css"
   },
   "scripts": {
-    "generate": "cd .. && devtools render webui-design-system",
-    "generate:check": "cd .. && devtools render webui-design-system --check",
-    "generate:client": "cd .. && devtools render webui-client",
-    "check:client": "cd .. && devtools render webui-client --check",
+    "generate": "cd .. && uv run devtools render webui-design-system",
+    "generate:check": "cd .. && uv run devtools render webui-design-system --check",
+    "generate:client": "cd .. && uv run devtools render webui-client",
+    "check:client": "cd .. && uv run devtools render webui-client --check",
     "lint": "node scripts/lint-design-system.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/webui/package.json
+++ b/webui/package.json
@@ -13,10 +13,10 @@
     "./design-system.css": "./src/design-system/design-system.css"
   },
   "scripts": {
-    "generate": "cd .. && python3 -m devtools.render_webui_design_system",
-    "generate:check": "cd .. && python3 -m devtools.render_webui_design_system --check",
-    "generate:client": "cd .. && python3 -m devtools.render_webui_client",
-    "check:client": "cd .. && python3 -m devtools.render_webui_client --check",
+    "generate": "cd .. && devtools render webui-design-system",
+    "generate:check": "cd .. && devtools render webui-design-system --check",
+    "generate:client": "cd .. && devtools render webui-client",
+    "check:client": "cd .. && devtools render webui-client --check",
     "lint": "node scripts/lint-design-system.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",


### PR DESCRIPTION
## Summary

Restore one coherent command catalog across the workflow, rendered reference, and executable dispatch surfaces.

## Problem

Direct devtools module invocations outside the catalog could bypass command disposition and drift from generated references. Earlier catalog cleanup only guarded known self-checks, leaving ordinary workflow and script entry points ungoverned.

## Solution

Add an execution-aware catalog-bypass verifier. It scans workflow run blocks, hook scripts, and AST-visible devtools process launches. Direct module/script entry points require structured sanctioned-bypass entries with a reason. Register the verifier in quick validation and retain the catalog disposition matrix.

## Verification

- Focused devtools tests: 103 passed.
- `devtools render all --check` passed.
- `devtools verify catalog-bypasses --json` reported no violations.
- `devtools verify --quick` and the managed pre-push gate passed.

Ref polylogue-l8ee
Ref polylogue-utf.1