### PR TITLE
fix(maintenance): separate canary replay evidence from state

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -322,7 +322,7 @@ polylogue ops maintenance blob-reference-prune-orphans \
 
 ### `polylogue ops maintenance reindex-canary` — inactive-generation semantic diff
 
-Read-only with respect to the active index. Before a full reindex, this command selects a bounded representative set of sessions, rebuilds those raws into an inactive generation, and diffs the resulting sessions, messages, blocks, links, and derived rows against the active generation. It requires `--no-promote`, writes a durable report, and refuses a report with unclassified differences. Treat every difference as either an expected effect of a named repair or a newly discovered defect. It is a preflight gate, not a replacement for the full managed rebuild.
+Read-only with respect to the active index. Before a full reindex, this command selects a bounded representative set of sessions, rebuilds those raws into an inactive generation, and diffs the resulting sessions, messages, blocks, links, and derived rows against the active generation. It requires `--no-promote`. A run with observed differences writes an unreviewed durable report and exits non-zero. Re-run with `--review-manifest` to persist one classification per difference, then use `--consume-report` to validate the reviewed report and approve its evidence. Approval never authorizes promotion. Treat every difference as either an expected effect of a named repair or a newly discovered defect. It is a preflight gate, not a replacement for the full managed rebuild.
 
 ```bash
 polylogue ops maintenance reindex-canary \
@@ -332,6 +332,24 @@ polylogue ops maintenance reindex-canary \
   --report /realm/tmp/polylogue-reindex-canary.json \
   --no-promote \
   --output-format json
+```
+
+After reviewing the observed identities printed by the failed run, persist the classifications and validate the report:
+
+```bash
+polylogue ops maintenance reindex-canary \
+  --archive-root /realm/tmp/polylogue-canary-archive \
+  --input /realm/tmp/polylogue-canary-archive/index.db \
+  --sample 100 \
+  --report /realm/tmp/polylogue-reindex-canary.json \
+  --review-manifest /realm/tmp/polylogue-reindex-reviews.json \
+  --no-promote
+
+polylogue ops maintenance reindex-canary \
+  --archive-root /realm/tmp/polylogue-canary-archive \
+  --report /realm/tmp/polylogue-reindex-canary.json \
+  --consume-report \
+  --no-promote
 ```
 
 ### `polylogue ops maintenance verify-archive` — coherence gate

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -334,7 +334,7 @@ polylogue ops maintenance reindex-canary \
   --output-format json
 ```
 
-After reviewing the observed identities printed by the failed run, persist the classifications and validate the report:
+After reviewing the observed identities printed by the failed run, persist the classifications and validate the report. Consumption acquires the same archive ownership and rebuild lease as the rebuild path, verifies referenced raw-payload bytes through `BlobStore`, and revalidates the source closure, candidate generation, receipt, and comparison immediately before approval. Membership rows and logical-source-key expansion are part of the receipt, so drift fails closed:
 
 ```bash
 polylogue ops maintenance reindex-canary \

--- a/polylogue/cli/commands/maintenance/__init__.py
+++ b/polylogue/cli/commands/maintenance/__init__.py
@@ -69,7 +69,7 @@ _COMMANDS: tuple[tuple[str, str, str, str], ...] = (
         "reindex-canary",
         "_reindex_canary",
         "reindex_canary_command",
-        "Replay a representative inactive canary and persist its reviewed diff report.",
+        "Replay an inactive canary, persist observed or reviewed diff evidence, and validate reports.",
     ),
     (
         "raw-authority-frontier",

--- a/polylogue/cli/commands/maintenance/_reindex_canary.py
+++ b/polylogue/cli/commands/maintenance/_reindex_canary.py
@@ -53,7 +53,12 @@ import click
     "report_path",
     type=click.Path(path_type=Path, dir_okay=False),
     required=True,
-    help="Destination for the reviewed canary report.",
+    help="Canary report destination, or existing report with --consume-report.",
+)
+@click.option(
+    "--consume-report",
+    is_flag=True,
+    help="Validate and approve an existing durable report without rebuilding or promoting.",
 )
 @click.option("--output-format", type=click.Choice(["plain", "json"]), default="plain", show_default=True)
 @click.option(
@@ -69,6 +74,7 @@ def reindex_canary_command(
     pathology_session_id: tuple[str, ...],
     sample_session_id: tuple[str, ...],
     report_path: Path,
+    consume_report: bool,
     output_format: str,
     no_promote: bool,
 ) -> None:
@@ -82,11 +88,31 @@ def reindex_canary_command(
     from polylogue.maintenance.reindex_canary import (
         CanaryRunResult,
         UnclassifiedCanaryDiffError,
+        approve_canary_report,
         load_canary_report,
         load_canary_review_manifest,
         run_reindex_canary,
         write_canary_report,
     )
+
+    if consume_report:
+        if review_manifest is not None or input_index is not None or pathology_session_id or sample_session_id:
+            raise click.UsageError("--consume-report cannot be combined with rebuild selection options")
+        if not report_path.is_file():
+            raise click.BadParameter("report file does not exist", param_hint="--report")
+        try:
+            payload = approve_canary_report(report_path, archive_root=archive_root)
+        except UnclassifiedCanaryDiffError as exc:
+            raise click.ClickException(str(exc)) from exc
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise click.ClickException(str(exc)) from exc
+        result_payload = {**payload, "decision": "approved"}
+        if output_format == "json":
+            click.echo(json.dumps(result_payload, indent=2, sort_keys=True))
+            return
+        click.echo("Decision:     approved")
+        click.echo(f"Report:       {report_path}")
+        return
 
     result: CanaryRunResult | None = None
     try:
@@ -107,7 +133,7 @@ def reindex_canary_command(
             reviews=reviews,
             allow_unreviewed=review_manifest is None,
         )
-        load_canary_report(report_path)
+        load_canary_report(report_path, archive_root=archive_root)
         if result.comparison.differences and review_manifest is None:
             identities = [dict(item.identity) for item in result.comparison.differences]
             raise UnclassifiedCanaryDiffError(

--- a/polylogue/cli/commands/maintenance/_reindex_canary.py
+++ b/polylogue/cli/commands/maintenance/_reindex_canary.py
@@ -16,6 +16,12 @@ import click
     help="Explicit isolated archive containing durable source.db and the active index candidate.",
 )
 @click.option(
+    "--review-manifest",
+    type=click.Path(path_type=Path, exists=True, dir_okay=False, readable=True),
+    default=None,
+    help="JSON manifest containing one explicit review for every observed difference.",
+)
+@click.option(
     "--input-index",
     "--input",
     "input_index",
@@ -57,6 +63,7 @@ import click
 )
 def reindex_canary_command(
     archive_root: Path,
+    review_manifest: Path | None,
     input_index: Path | None,
     sessions_per_origin: int,
     pathology_session_id: tuple[str, ...],
@@ -75,6 +82,8 @@ def reindex_canary_command(
     from polylogue.maintenance.reindex_canary import (
         CanaryRunResult,
         UnclassifiedCanaryDiffError,
+        load_canary_report,
+        load_canary_review_manifest,
         run_reindex_canary,
         write_canary_report,
     )
@@ -89,12 +98,17 @@ def reindex_canary_command(
             sample_session_ids=sample_session_id,
             no_promote=no_promote,
         )
+        if result.comparison.differences and review_manifest is None:
+            raise UnclassifiedCanaryDiffError("non-empty canary differences require --review-manifest")
+        reviews = load_canary_review_manifest(review_manifest) if review_manifest is not None else ()
         durable = write_canary_report(
             report_path,
             selection=result.selection,
             comparison=result.comparison,
-            reviews=(),
+            rebuild_receipt=result.rebuild_receipt,
+            reviews=reviews,
         )
+        load_canary_report(report_path)
     except UnclassifiedCanaryDiffError as exc:
         raise click.ClickException(str(exc)) from exc
     except (OSError, RuntimeError, ValueError) as exc:

--- a/polylogue/cli/commands/maintenance/_reindex_canary.py
+++ b/polylogue/cli/commands/maintenance/_reindex_canary.py
@@ -58,7 +58,7 @@ import click
 @click.option(
     "--consume-report",
     is_flag=True,
-    help="Validate evidence only. This neither rebuilds nor authorizes promotion.",
+    help="Validate and approve evidence under archive/rebuild ownership. This never authorizes promotion.",
 )
 @click.option("--output-format", type=click.Choice(["plain", "json"]), default="plain", show_default=True)
 @click.option(

--- a/polylogue/cli/commands/maintenance/_reindex_canary.py
+++ b/polylogue/cli/commands/maintenance/_reindex_canary.py
@@ -98,8 +98,6 @@ def reindex_canary_command(
             sample_session_ids=sample_session_id,
             no_promote=no_promote,
         )
-        if result.comparison.differences and review_manifest is None:
-            raise UnclassifiedCanaryDiffError("non-empty canary differences require --review-manifest")
         reviews = load_canary_review_manifest(review_manifest) if review_manifest is not None else ()
         durable = write_canary_report(
             report_path,
@@ -107,8 +105,17 @@ def reindex_canary_command(
             comparison=result.comparison,
             rebuild_receipt=result.rebuild_receipt,
             reviews=reviews,
+            allow_unreviewed=review_manifest is None,
         )
         load_canary_report(report_path)
+        if result.comparison.differences and review_manifest is None:
+            identities = [dict(item.identity) for item in result.comparison.differences]
+            raise UnclassifiedCanaryDiffError(
+                "unreviewed canary report written to "
+                + str(report_path)
+                + "; observed identities="
+                + json.dumps(identities, sort_keys=True)
+            )
     except UnclassifiedCanaryDiffError as exc:
         raise click.ClickException(str(exc)) from exc
     except (OSError, RuntimeError, ValueError) as exc:

--- a/polylogue/cli/commands/maintenance/_reindex_canary.py
+++ b/polylogue/cli/commands/maintenance/_reindex_canary.py
@@ -58,7 +58,7 @@ import click
 @click.option(
     "--consume-report",
     is_flag=True,
-    help="Validate and approve an existing durable report without rebuilding or promoting.",
+    help="Validate evidence only. This neither rebuilds nor authorizes promotion.",
 )
 @click.option("--output-format", type=click.Choice(["plain", "json"]), default="plain", show_default=True)
 @click.option(
@@ -106,11 +106,11 @@ def reindex_canary_command(
             raise click.ClickException(str(exc)) from exc
         except (OSError, RuntimeError, ValueError) as exc:
             raise click.ClickException(str(exc)) from exc
-        result_payload = {**payload, "decision": "approved"}
+        result_payload = {**payload, "decision": "evidence-approved", "promotion_authorized": False}
         if output_format == "json":
             click.echo(json.dumps(result_payload, indent=2, sort_keys=True))
             return
-        click.echo("Decision:     approved")
+        click.echo("Decision:     evidence approved; promotion is not authorized")
         click.echo(f"Report:       {report_path}")
         return
 

--- a/polylogue/daemon/bulk_rebuild.py
+++ b/polylogue/daemon/bulk_rebuild.py
@@ -48,7 +48,7 @@ from polylogue.storage.archive_identity import ArchiveLocation, OwnedArchiveLoca
 from polylogue.storage.index_generation import (
     IndexGenerationStore,
     IndexRebuildTransaction,
-    source_revision_snapshot,
+    rebuild_source_evidence_snapshot,
 )
 
 if TYPE_CHECKING:
@@ -135,7 +135,7 @@ def resolve_or_start_daemon_bulk_rebuild_transaction(root: Path) -> IndexRebuild
             store.discard_transaction(DAEMON_BULK_REBUILD_OPERATION_ID)
 
         return store.create_transaction(
-            source_snapshot=source_revision_snapshot(root),
+            source_snapshot=rebuild_source_evidence_snapshot(root),
             operation_id=DAEMON_BULK_REBUILD_OPERATION_ID,
         )
     finally:

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -1013,6 +1013,16 @@ async def _rebuild_index_from_source_owned(
                     # a raw/cohort; it can only redo bounded work.
                     assert transaction is not None  # deadline_check is only wired when transaction is not None
                     pass_elapsed_s = time.perf_counter() - pass_started_at_s
+                    if rebuild_source_evidence_snapshot(root) != transaction.source_snapshot:
+                        generation_store.checkpoint_transaction(
+                            transaction,
+                            status="stale",
+                            error="source evidence changed during deadline-interrupted rebuild pass",
+                        )
+                        source_drifted = True
+                        raise RuntimeError(
+                            f"rebuild operation {transaction.operation_id} is stale because source evidence changed"
+                        ) from exc
                     transaction = generation_store.checkpoint_transaction(
                         transaction,
                         status="deferred",

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -478,7 +478,7 @@ class RebuildIndexReceipt:
 
     def to_dict(self) -> dict[str, object]:
         return {
-            "receipt_schema_version": 3,
+            "receipt_schema_version": 4,
             "archive_root": self.archive_root,
             "raw_session_count": self.raw_session_count,
             "selected_raw_count": self.selected_raw_count,
@@ -506,7 +506,16 @@ def rebuild_selection_evidence(
     candidate_index: Path,
     source_snapshot: str,
 ) -> dict[str, object]:
-    """Commit the actual rebuild selection to its source and inactive candidate."""
+    """Commit the requested and production-expanded replay closure.
+
+    The replay path can widen a raw-id hint after census discovers durable
+    membership and logical-source-key relationships.  Persisting only the
+    caller's hints would let a later source mutation change which raws and
+    cohorts the candidate actually represents without invalidating its
+    receipt.
+    """
+
+    replay_closure = _rebuild_replay_closure_evidence(archive_root, raw_ids)
 
     canonical = {
         "archive_root": str(archive_root.resolve()),
@@ -514,6 +523,7 @@ def rebuild_selection_evidence(
         "candidate_index_path": str(candidate_index.resolve()),
         "candidate_owner_id": generation_owner_id,
         "raw_ids": sorted(raw_ids),
+        "replay_closure": replay_closure,
         "source_snapshot": source_snapshot,
     }
     encoded = json.dumps(canonical, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
@@ -522,6 +532,65 @@ def rebuild_selection_evidence(
         "raw_id_count": len(raw_ids),
         "raw_ids_sha256": sha256(encoded).hexdigest(),
         **{key: value for key, value in canonical.items() if key != "raw_ids"},
+    }
+
+
+def _rebuild_replay_closure_evidence(archive_root: Path, raw_ids: list[str] | tuple[str, ...]) -> dict[str, object]:
+    """Read the same durable closure primitive used by source replay.
+
+    Missing source tiers are tolerated for standalone structural tests that
+    exercise selection serialization without an archive. Real rebuilds always
+    have ``source.db`` and therefore record the full expanded closure and every
+    membership row participating in it.
+    """
+
+    source_db = archive_root / "source.db"
+    if not source_db.exists():
+        return {"raw_ids": sorted(raw_ids), "logical_source_keys": [], "raw_session_memberships": []}
+
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+    with contextlib.closing(sqlite3.connect(f"file:{source_db}?mode=ro", uri=True, timeout=10.0)) as connection:
+        expanded, logical_keys = ArchiveStore.expand_raw_membership_selection_sync(connection, list(raw_ids))
+        placeholders_raw = ",".join("?" for _ in expanded)
+        placeholders_key = ",".join("?" for _ in logical_keys)
+        clauses: list[str] = []
+        parameters: list[str] = []
+        if expanded:
+            clauses.append(f"raw_id IN ({placeholders_raw})")
+            parameters.extend(expanded)
+        if logical_keys:
+            clauses.append(f"logical_source_key IN ({placeholders_key})")
+            parameters.extend(logical_keys)
+        rows: list[dict[str, object]] = []
+        if clauses:
+            selected = connection.execute(
+                "SELECT raw_id, logical_source_key, provider_session_id, source_revision, "
+                "normalized_content_hash, message_count, predecessor_raw_id, acquisition_generation, "
+                "revision_authority, decision, decided_at_ms "
+                "FROM raw_session_memberships WHERE " + " OR ".join(clauses) + " ORDER BY logical_source_key, raw_id",
+                parameters,
+            )
+            for row in selected:
+                rows.append(
+                    {
+                        "raw_id": str(row[0]),
+                        "logical_source_key": str(row[1]),
+                        "provider_session_id": str(row[2]),
+                        "source_revision": str(row[3]),
+                        "normalized_content_hash": bytes(row[4]).hex(),
+                        "message_count": int(row[5]),
+                        "predecessor_raw_id": None if row[6] is None else str(row[6]),
+                        "acquisition_generation": int(row[7]),
+                        "revision_authority": str(row[8]),
+                        "decision": None if row[9] is None else str(row[9]),
+                        "decided_at_ms": None if row[10] is None else int(row[10]),
+                    }
+                )
+    return {
+        "raw_ids": list(expanded),
+        "logical_source_keys": list(logical_keys),
+        "raw_session_memberships": rows,
     }
 
 
@@ -1188,6 +1257,18 @@ async def _rebuild_index_from_source_owned(
             # not a parallel one, so every receipt shape (deferred, paused,
             # replayed) carries the identical key for this phase.
             terminal_timings_s: dict[str, float] = {"selection_s": selection_elapsed_s}
+            # Census can create membership rows and logical-source keys while
+            # replay is running. Recompute the receipt commitment from the
+            # post-replay source tier so it names the closure the candidate
+            # actually consumed, not only the caller's raw-id hints.
+            selection_evidence = rebuild_selection_evidence(
+                selected_raw_ids,
+                archive_root=root,
+                generation_id=generation.generation_id,
+                generation_owner_id=generation.owner_id,
+                candidate_index=Path(generation.index_path),
+                source_snapshot=generation.source_snapshot,
+            )
             if rebuild_source_evidence_snapshot(root) != generation.source_snapshot:
                 if transaction is not None:
                     transaction = generation_store.checkpoint_transaction(

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -10,9 +10,12 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
+import os
 import sqlite3
 import time
 from dataclasses import asdict, dataclass, field
+from hashlib import sha256
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -451,6 +454,12 @@ class RebuildIndexReceipt:
     # compatible full checkpoint payload; this compact view is the stable
     # operator contract for ownership, heartbeat, cursor, delta, and recovery.
     operation: dict[str, object] = field(default_factory=dict)
+    # Rebuild-owned evidence for the exact raw selection replayed into this
+    # candidate. The IDs themselves are deliberately not duplicated in every
+    # receipt; the stable commitment is enough for a verifier holding the
+    # requested IDs to prove the set, count, source snapshot, and candidate
+    # identity all agree.
+    selection_evidence: dict[str, object] = field(default_factory=dict)
     #: Wall-clock seconds per rebuild stage for THIS pass.
     #:
     #: Three full rebuilds ran without this, so the only cost breakdown
@@ -475,9 +484,60 @@ class RebuildIndexReceipt:
             "readiness": self.readiness,
             "transaction": self.transaction,
             "operation": self.operation,
+            "selection_evidence": self.selection_evidence,
             "timings_s": self.timings_s,
             **self.replay,
         }
+
+
+def rebuild_selection_evidence(
+    raw_ids: list[str] | tuple[str, ...],
+    *,
+    archive_root: Path,
+    generation_id: str,
+    generation_owner_id: str,
+    candidate_index: Path,
+    source_snapshot: str,
+) -> dict[str, object]:
+    """Commit the actual rebuild selection to its source and inactive candidate."""
+
+    canonical = {
+        "archive_root": str(archive_root.resolve()),
+        "candidate_generation_id": generation_id,
+        "candidate_index_path": str(candidate_index.resolve()),
+        "candidate_owner_id": generation_owner_id,
+        "raw_ids": sorted(raw_ids),
+        "source_snapshot": source_snapshot,
+    }
+    encoded = json.dumps(canonical, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return {
+        "algorithm": "sha256-canonical-json-v1",
+        "raw_id_count": len(raw_ids),
+        "raw_ids_sha256": sha256(encoded).hexdigest(),
+        **{key: value for key, value in canonical.items() if key != "raw_ids"},
+    }
+
+
+def _persist_candidate_receipt(generation: IndexGeneration, receipt: dict[str, object]) -> None:
+    """Atomically retain the completed rebuild receipt with its candidate."""
+
+    path = Path(generation.index_path).parent / "rebuild-receipt.json"
+    temporary = path.with_suffix(".json.tmp")
+    try:
+        with temporary.open("w", encoding="utf-8") as stream:
+            json.dump(receipt, stream, ensure_ascii=False, indent=2, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        directory_fd = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
 
 
 def _operation_evidence(
@@ -802,6 +862,14 @@ async def _rebuild_index_from_source_owned(
             selection_elapsed_s = time.perf_counter() - selection_started_at
             selected_raw_count = len(selected_raw_ids)
             generation = generation_store.create(source_snapshot=source_revision_snapshot(root))
+        selection_evidence = rebuild_selection_evidence(
+            selected_raw_ids,
+            archive_root=root,
+            generation_id=generation.generation_id,
+            generation_owner_id=generation.owner_id,
+            candidate_index=Path(generation.index_path),
+            source_snapshot=generation.source_snapshot,
+        )
         source_drifted = False
         try:
             generation_root = Path(generation.index_path).parent
@@ -1003,6 +1071,7 @@ async def _rebuild_index_from_source_owned(
                         operation=_operation_evidence(
                             root, generation=generation, transaction=transaction, recovery_state="deferred"
                         ),
+                        selection_evidence=selection_evidence,
                         timings_s=cast(dict[str, float], pass_cost.to_dict()),
                     )
                     generation_store.save_pass_receipt(transaction.operation_id, pass_receipt.to_dict())
@@ -1083,6 +1152,7 @@ async def _rebuild_index_from_source_owned(
                         operation=_operation_evidence(
                             root, generation=generation, transaction=transaction, recovery_state=status
                         ),
+                        selection_evidence=selection_evidence,
                         timings_s=cast(dict[str, float], pass_cost.to_dict()),
                     )
                     generation_store.save_pass_receipt(transaction.operation_id, pass_receipt.to_dict())
@@ -1258,12 +1328,14 @@ async def _rebuild_index_from_source_owned(
             transaction=transaction,
             recovery_state="promoted" if request.promote else "ready",
         ),
+        selection_evidence=selection_evidence,
         timings_s=_receipt_timings(
             selection_s=selection_elapsed_s,
             replay=replay,
             terminal_timings_s=terminal_timings_s,
         ),
     )
+    _persist_candidate_receipt(generation, final_receipt.to_dict())
     if transaction is not None:
         generation_store.save_pass_receipt(transaction.operation_id, final_receipt.to_dict())
     return final_receipt

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -460,10 +460,11 @@ class RebuildIndexReceipt:
     # requested IDs to prove the set, count, source snapshot, and candidate
     # identity all agree.
     selection_evidence: dict[str, object] = field(default_factory=dict)
-    # A full raw_sessions hash taken after replay. Unlike source_snapshot,
-    # this deliberately includes parser and governance state so report
-    # consumption can reject post-rebuild state mutation.
-    raw_sessions_state_after: str | None = None
+    # The immutable source-evidence hash taken after replay. This is separate
+    # from the generation's before-replay source_snapshot so report
+    # consumption can reject source drift without treating parser or
+    # governance state as part of the canary's identity.
+    source_evidence_after: str | None = None
     #: Wall-clock seconds per rebuild stage for THIS pass.
     #:
     #: Three full rebuilds ran without this, so the only cost breakdown
@@ -477,7 +478,7 @@ class RebuildIndexReceipt:
 
     def to_dict(self) -> dict[str, object]:
         return {
-            "receipt_schema_version": 2,
+            "receipt_schema_version": 3,
             "archive_root": self.archive_root,
             "raw_session_count": self.raw_session_count,
             "selected_raw_count": self.selected_raw_count,
@@ -490,7 +491,7 @@ class RebuildIndexReceipt:
             "transaction": self.transaction,
             "operation": self.operation,
             "selection_evidence": self.selection_evidence,
-            "raw_sessions_state_after": self.raw_sessions_state_after,
+            "source_evidence_after": self.source_evidence_after,
             "timings_s": self.timings_s,
             **self.replay,
         }
@@ -786,7 +787,6 @@ async def _rebuild_index_from_source_owned(
     from polylogue.storage.index_generation import (
         IndexGenerationStore,
         rebuild_source_evidence_snapshot,
-        source_revision_snapshot,
     )
     from polylogue.storage.repair import repair_session_insights
 
@@ -1197,7 +1197,7 @@ async def _rebuild_index_from_source_owned(
                     )
                     source_drifted = True
                 raise RuntimeError(f"source evidence changed while rebuilding {generation.generation_id}")
-            raw_sessions_state_after = source_revision_snapshot(root)
+            source_evidence_after = rebuild_source_evidence_snapshot(root)
             # polylogue-v6i3: bulk-build replay (bulk_build=True above) left
             # messages_fts/blocks_command_trigram/action_pairs/delegation_facts
             # empty or stale for every session -- repopulate all four
@@ -1350,7 +1350,7 @@ async def _rebuild_index_from_source_owned(
             recovery_state="promoted" if request.promote else "ready",
         ),
         selection_evidence=selection_evidence,
-        raw_sessions_state_after=raw_sessions_state_after,
+        source_evidence_after=source_evidence_after,
         timings_s=_receipt_timings(
             selection_s=selection_elapsed_s,
             replay=replay,

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -460,6 +460,10 @@ class RebuildIndexReceipt:
     # requested IDs to prove the set, count, source snapshot, and candidate
     # identity all agree.
     selection_evidence: dict[str, object] = field(default_factory=dict)
+    # A full raw_sessions hash taken after replay. Unlike source_snapshot,
+    # this deliberately includes parser and governance state so report
+    # consumption can reject post-rebuild state mutation.
+    raw_sessions_state_after: str | None = None
     #: Wall-clock seconds per rebuild stage for THIS pass.
     #:
     #: Three full rebuilds ran without this, so the only cost breakdown
@@ -473,6 +477,7 @@ class RebuildIndexReceipt:
 
     def to_dict(self) -> dict[str, object]:
         return {
+            "receipt_schema_version": 2,
             "archive_root": self.archive_root,
             "raw_session_count": self.raw_session_count,
             "selected_raw_count": self.selected_raw_count,
@@ -485,6 +490,7 @@ class RebuildIndexReceipt:
             "transaction": self.transaction,
             "operation": self.operation,
             "selection_evidence": self.selection_evidence,
+            "raw_sessions_state_after": self.raw_sessions_state_after,
             "timings_s": self.timings_s,
             **self.replay,
         }
@@ -553,12 +559,12 @@ def _operation_evidence(
     transaction checkpoint.  It adds no competing ownership mechanism and
     keeps the full checkpoint in ``transaction`` for callers that need it.
     """
-    from polylogue.storage.index_generation import rebuild_lease_status, source_revision_snapshot
+    from polylogue.storage.index_generation import rebuild_lease_status, rebuild_source_evidence_snapshot
 
     transaction_payload = asdict(transaction) if transaction is not None else {}
     generation_payload = asdict(generation) if generation is not None else {}
     source_snapshot = transaction_payload.get("source_snapshot") or generation_payload.get("source_snapshot")
-    current_snapshot = source_revision_snapshot(root) if (root / "source.db").exists() else None
+    current_snapshot = rebuild_source_evidence_snapshot(root) if (root / "source.db").exists() else None
     return {
         "owner": {
             "generation_owner_id": transaction_payload.get("generation_owner_id") or generation_payload.get("owner_id"),
@@ -777,7 +783,11 @@ async def _rebuild_index_from_source_owned(
     from polylogue.maintenance.replay import rebuild_index_from_source as replay_source
     from polylogue.sources.revision_backfill import RebuildDeadlineExceededError
     from polylogue.storage.archive_readiness import archive_readiness_status
-    from polylogue.storage.index_generation import IndexGenerationStore, source_revision_snapshot
+    from polylogue.storage.index_generation import (
+        IndexGenerationStore,
+        rebuild_source_evidence_snapshot,
+        source_revision_snapshot,
+    )
     from polylogue.storage.repair import repair_session_insights
 
     generation_store = IndexGenerationStore(owned.location)
@@ -810,7 +820,7 @@ async def _rebuild_index_from_source_owned(
                 generation_store.load_transaction(request.operation_id)
                 if request.operation_id is not None
                 else generation_store.create_transaction(
-                    source_snapshot=source_revision_snapshot(root),
+                    source_snapshot=rebuild_source_evidence_snapshot(root),
                     pass_byte_budget=(
                         int(request.pass_byte_budget_mb * 1024 * 1024)
                         if request.pass_byte_budget_mb is not None
@@ -825,7 +835,7 @@ async def _rebuild_index_from_source_owned(
                 raise RuntimeError(
                     f"rebuild operation {transaction.operation_id} is {transaction.status}; start a new operation"
                 )
-            if source_revision_snapshot(root) != transaction.source_snapshot:
+            if rebuild_source_evidence_snapshot(root) != transaction.source_snapshot:
                 generation_store.checkpoint_transaction(
                     transaction,
                     status="stale",
@@ -861,7 +871,7 @@ async def _rebuild_index_from_source_owned(
             raw_count, selected_raw_ids, skipped_by_blob_limit_count = select_rebuild_raw_ids(request)
             selection_elapsed_s = time.perf_counter() - selection_started_at
             selected_raw_count = len(selected_raw_ids)
-            generation = generation_store.create(source_snapshot=source_revision_snapshot(root))
+            generation = generation_store.create(source_snapshot=rebuild_source_evidence_snapshot(root))
         selection_evidence = rebuild_selection_evidence(
             selected_raw_ids,
             archive_root=root,
@@ -1084,7 +1094,7 @@ async def _rebuild_index_from_source_owned(
             ):
                 _refresh_generation_planner_statistics(Path(generation.index_path))
             if transaction is not None and selected_raw_ids:
-                if source_revision_snapshot(root) != transaction.source_snapshot:
+                if rebuild_source_evidence_snapshot(root) != transaction.source_snapshot:
                     transaction = generation_store.checkpoint_transaction(
                         transaction,
                         status="stale",
@@ -1168,7 +1178,7 @@ async def _rebuild_index_from_source_owned(
             # not a parallel one, so every receipt shape (deferred, paused,
             # replayed) carries the identical key for this phase.
             terminal_timings_s: dict[str, float] = {"selection_s": selection_elapsed_s}
-            if source_revision_snapshot(root) != generation.source_snapshot:
+            if rebuild_source_evidence_snapshot(root) != generation.source_snapshot:
                 if transaction is not None:
                     transaction = generation_store.checkpoint_transaction(
                         transaction,
@@ -1177,6 +1187,7 @@ async def _rebuild_index_from_source_owned(
                     )
                     source_drifted = True
                 raise RuntimeError(f"source evidence changed while rebuilding {generation.generation_id}")
+            raw_sessions_state_after = source_revision_snapshot(root)
             # polylogue-v6i3: bulk-build replay (bulk_build=True above) left
             # messages_fts/blocks_command_trigram/action_pairs/delegation_facts
             # empty or stale for every session -- repopulate all four
@@ -1329,6 +1340,7 @@ async def _rebuild_index_from_source_owned(
             recovery_state="promoted" if request.promote else "ready",
         ),
         selection_evidence=selection_evidence,
+        raw_sessions_state_after=raw_sessions_state_after,
         timings_s=_receipt_timings(
             selection_s=selection_elapsed_s,
             replay=replay,
@@ -1372,7 +1384,7 @@ def rebuild_status(
     from polylogue.storage.index_generation import (
         IndexGenerationStore,
         rebuild_lease_status,
-        source_revision_snapshot,
+        rebuild_source_evidence_snapshot,
     )
 
     location = ArchiveLocation.resolve(archive_root)
@@ -1418,7 +1430,9 @@ def rebuild_status(
             transaction = None
         if transaction is not None:
             transaction_payload = cast(dict[str, object], asdict(transaction))
-            current_snapshot = source_revision_snapshot(archive_root) if (archive_root / "source.db").exists() else None
+            current_snapshot = (
+                rebuild_source_evidence_snapshot(archive_root) if (archive_root / "source.db").exists() else None
+            )
             delta = {
                 "source_snapshot_matches": (
                     current_snapshot is not None and current_snapshot == transaction.source_snapshot

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -781,16 +781,17 @@ def _active_generation_metadata(root: Path, location: object) -> dict[str, objec
     matches: list[dict[str, object]] = []
     for metadata_path in _generation_root(location).glob("gen-*/generation.json"):
         try:
-            metadata = _generation_fields(json.loads(metadata_path.read_text(encoding="utf-8")))
-            generation_index = TierFileIdentity.resolve("index", Path(cast(str, metadata["index_path"])))
+            metadata = _read_generation_metadata(_generation_root(location), metadata_path.parent.name)
+            fields = _generation_fields(metadata)
+            generation_index = TierFileIdentity.resolve("index", Path(cast(str, fields["index_path"])))
         except (OSError, json.JSONDecodeError):
             continue
-        if metadata["state"] == "active" and active_identity.same_file(generation_index):
+        if fields["state"] == "active" and active_identity.same_file(generation_index):
             matches.append(metadata)
     if len(matches) != 1:
         raise UnclassifiedCanaryDiffError("archive-owned active generation metadata does not match the active pointer")
     active = matches[0]
-    if Path(cast(str, active["archive_root"])).resolve() != root.resolve():
+    if Path(cast(str, _generation_fields(active)["archive_root"])).resolve() != root.resolve():
         raise UnclassifiedCanaryDiffError("archive-owned active generation belongs to another archive")
     return active
 
@@ -815,9 +816,11 @@ def _capture_archive_provenance(comparison: CanaryDiffReport, receipt: dict[str,
     current_identity = TierFileIdentity.resolve("index", comparison.current_index)
     if not location.active_index.same_file(current_identity):
         raise UnclassifiedCanaryDiffError("archive-owned active index does not match the canary comparison")
+    if not isinstance(generation, dict):
+        raise UnclassifiedCanaryDiffError("canary report has invalid candidate generation provenance")
     candidate = _generation_fields(generation)
     candidate_metadata = _read_generation_metadata(_generation_root(location), cast(str, candidate["generation_id"]))
-    if _generation_fields(candidate_metadata) != candidate:
+    if candidate_metadata != generation:
         raise UnclassifiedCanaryDiffError(
             "archive-owned candidate generation metadata does not match the rebuild receipt"
         )
@@ -834,7 +837,7 @@ def _capture_archive_provenance(comparison: CanaryDiffReport, receipt: dict[str,
         "active_pointer": str(location.active_pointer) if location.active_pointer is not None else None,
         "active_index": _index_evidence(location.active_index_path),
         "active_generation": _active_generation_metadata(root, location),
-        "candidate_generation": candidate,
+        "candidate_generation": candidate_metadata,
         "candidate_index": _index_evidence(candidate_path),
         "source_snapshot": source_snapshot,
     }
@@ -864,20 +867,22 @@ def _validate_archive_provenance(provenance: object, comparison: CanaryDiffRepor
     _same_index_evidence(provenance.get("active_index"), location.active_index_path, label="active")
     if provenance.get("active_generation") != _active_generation_metadata(root, location):
         raise UnclassifiedCanaryDiffError("archive-owned active generation metadata no longer matches the report")
-    receipt_generation = _generation_fields(receipt.get("generation"))
+    receipt_generation = receipt.get("generation")
+    if not isinstance(receipt_generation, dict):
+        raise UnclassifiedCanaryDiffError("canary report has invalid candidate generation provenance")
+    receipt_fields = _generation_fields(receipt_generation)
     if provenance.get("candidate_generation") != receipt_generation:
         raise UnclassifiedCanaryDiffError("archive-owned candidate generation does not match the rebuild receipt")
-    live_candidate = _generation_fields(
-        _read_generation_metadata(_generation_root(location), cast(str, receipt_generation["generation_id"]))
-    )
-    if live_candidate != receipt_generation or live_candidate["state"] != "inactive":
+    live_candidate = _read_generation_metadata(_generation_root(location), cast(str, receipt_fields["generation_id"]))
+    live_fields = _generation_fields(live_candidate)
+    if live_candidate != receipt_generation or live_fields["state"] != "inactive":
         raise UnclassifiedCanaryDiffError("archive-owned candidate generation metadata no longer matches the report")
-    candidate_path = Path(cast(str, live_candidate["index_path"]))
+    candidate_path = Path(cast(str, live_fields["index_path"]))
     if not candidate_path.samefile(comparison.candidate_index):
         raise UnclassifiedCanaryDiffError("archive-owned candidate generation no longer matches the report")
     _same_index_evidence(provenance.get("candidate_index"), candidate_path, label="candidate")
     source_snapshot = source_revision_snapshot(root)
-    if provenance.get("source_snapshot") != source_snapshot or live_candidate["source_snapshot"] != source_snapshot:
+    if provenance.get("source_snapshot") != source_snapshot or live_fields["source_snapshot"] != source_snapshot:
         raise UnclassifiedCanaryDiffError("archive-owned source snapshot no longer matches the inactive candidate")
 
 

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -503,7 +503,7 @@ class DurableCanaryReport:
 
     def to_dict(self) -> dict[str, object]:
         return {
-            "schema_version": 5,
+            "schema_version": 6,
             "selection": self.selection.to_dict(),
             "comparison": self.comparison.to_dict(),
             "rebuild_receipt": self.rebuild_receipt,
@@ -707,17 +707,17 @@ def _validate_rebuild_receipt(
     archive_root = receipt.get("archive_root")
     selected_raw_count = receipt.get("selected_raw_count")
     generation = receipt.get("generation")
-    raw_sessions_state_after = receipt.get("raw_sessions_state_after")
+    source_evidence_after = receipt.get("source_evidence_after")
     if (
-        receipt.get("receipt_schema_version") != 2
+        receipt.get("receipt_schema_version") != 3
         or not isinstance(archive_root, str)
         or not archive_root
         or selected_raw_count != len(tuple(selected_raw_ids))
         or receipt.get("status") != "replayed"
         or receipt.get("materialized") is not True
         or not isinstance(generation, dict)
-        or not isinstance(raw_sessions_state_after, str)
-        or len(raw_sessions_state_after) != 64
+        or not isinstance(source_evidence_after, str)
+        or len(source_evidence_after) != 64
     ):
         raise UnclassifiedCanaryDiffError("canary report has invalid rebuild receipt")
     generation_archive_root = generation.get("archive_root")
@@ -843,7 +843,7 @@ def _capture_archive_provenance(comparison: CanaryDiffReport, receipt: dict[str,
     """
 
     from polylogue.storage.archive_identity import ArchiveLocation, TierFileIdentity
-    from polylogue.storage.index_generation import rebuild_source_evidence_snapshot, source_revision_snapshot
+    from polylogue.storage.index_generation import rebuild_source_evidence_snapshot
 
     archive_root = receipt.get("archive_root")
     generation = receipt.get("generation")
@@ -870,9 +870,9 @@ def _capture_archive_provenance(comparison: CanaryDiffReport, receipt: dict[str,
     source_snapshot = rebuild_source_evidence_snapshot(root)
     if source_snapshot != candidate["source_snapshot"]:
         raise UnclassifiedCanaryDiffError("archive-owned source snapshot does not match the inactive candidate")
-    raw_sessions_state_after = source_revision_snapshot(root)
-    if raw_sessions_state_after != receipt.get("raw_sessions_state_after"):
-        raise UnclassifiedCanaryDiffError("archive-owned raw session state does not match the rebuild receipt")
+    source_evidence_after = rebuild_source_evidence_snapshot(root)
+    if source_evidence_after != receipt.get("source_evidence_after"):
+        raise UnclassifiedCanaryDiffError("archive-owned source evidence does not match the rebuild receipt")
     return {
         "archive_root": str(root.resolve()),
         "active_pointer": str(location.active_pointer) if location.active_pointer is not None else None,
@@ -881,7 +881,7 @@ def _capture_archive_provenance(comparison: CanaryDiffReport, receipt: dict[str,
         "candidate_generation": candidate_metadata,
         "candidate_index": _index_evidence(candidate_path),
         "source_snapshot": source_snapshot,
-        "raw_sessions_state_after": raw_sessions_state_after,
+        "source_evidence_after": source_evidence_after,
     }
 
 
@@ -896,7 +896,7 @@ def _validate_archive_provenance(
     """Validate archive-owned evidence before opening report-provided indexes."""
 
     from polylogue.storage.archive_identity import ArchiveLocation, TierFileIdentity
-    from polylogue.storage.index_generation import rebuild_source_evidence_snapshot, source_revision_snapshot
+    from polylogue.storage.index_generation import rebuild_source_evidence_snapshot
 
     if not isinstance(provenance, dict):
         raise UnclassifiedCanaryDiffError("canary report has no archive-owned provenance")
@@ -945,12 +945,12 @@ def _validate_archive_provenance(
     source_snapshot = rebuild_source_evidence_snapshot(root)
     if provenance.get("source_snapshot") != source_snapshot or live_fields["source_snapshot"] != source_snapshot:
         raise UnclassifiedCanaryDiffError("archive-owned source snapshot no longer matches the inactive candidate")
-    raw_sessions_state_after = source_revision_snapshot(root)
+    source_evidence_after = rebuild_source_evidence_snapshot(root)
     if (
-        provenance.get("raw_sessions_state_after") != raw_sessions_state_after
-        or receipt.get("raw_sessions_state_after") != raw_sessions_state_after
+        provenance.get("source_evidence_after") != source_evidence_after
+        or receipt.get("source_evidence_after") != source_evidence_after
     ):
-        raise UnclassifiedCanaryDiffError("archive-owned raw session state no longer matches the rebuild receipt")
+        raise UnclassifiedCanaryDiffError("archive-owned source evidence no longer matches the rebuild receipt")
 
 
 def load_canary_report(path: Path, *, archive_root: Path | None = None) -> dict[str, object]:
@@ -959,7 +959,7 @@ def load_canary_report(path: Path, *, archive_root: Path | None = None) -> dict[
     payload = json.loads(Path(path).read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise UnclassifiedCanaryDiffError("canary report root must be an object")
-    if payload.get("schema_version") != 5:
+    if payload.get("schema_version") != 6:
         raise UnclassifiedCanaryDiffError("canary report has no authoritative rebuild receipt schema")
     comparison = payload.get("comparison")
     if not isinstance(comparison, dict):

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -18,6 +18,7 @@ from collections.abc import Iterable
 from contextlib import suppress
 from dataclasses import dataclass, replace
 from enum import StrEnum
+from hashlib import sha256
 from pathlib import Path
 from typing import Any, cast
 
@@ -443,6 +444,7 @@ class CanaryDifferenceReview:
     table: str
     operation: DifferenceOperation
     identity: tuple[tuple[str, object], ...]
+    changed_columns: tuple[str, ...]
     classification: DifferenceClassification
     reference: str
     rationale: str
@@ -460,20 +462,22 @@ class CanaryDifferenceReview:
             table=difference.table,
             operation=difference.operation,
             identity=difference.identity,
+            changed_columns=difference.changed_columns,
             classification=classification,
             reference=reference,
             rationale=rationale,
         )
 
     @property
-    def key(self) -> tuple[str, DifferenceOperation, tuple[tuple[str, object], ...]]:
-        return self.table, self.operation, self.identity
+    def key(self) -> tuple[str, DifferenceOperation, tuple[tuple[str, object], ...], tuple[str, ...]]:
+        return self.table, self.operation, self.identity, self.changed_columns
 
     def to_dict(self) -> dict[str, object]:
         return {
             "table": self.table,
             "operation": self.operation.value,
             "identity": dict(self.identity),
+            "changed_columns": list(self.changed_columns),
             "classification": self.classification.value,
             "reference": self.reference,
             "rationale": self.rationale,
@@ -489,6 +493,7 @@ class DurableCanaryReport:
     rebuild_receipt: dict[str, object]
     reviews: tuple[CanaryDifferenceReview, ...]
     review_status: str
+    comparison_fingerprint: str
 
     @property
     def unclassified_count(self) -> int:
@@ -496,12 +501,13 @@ class DurableCanaryReport:
 
     def to_dict(self) -> dict[str, object]:
         return {
-            "schema_version": 1,
+            "schema_version": 2,
             "selection": self.selection.to_dict(),
             "comparison": self.comparison.to_dict(),
             "rebuild_receipt": self.rebuild_receipt,
             "reviews": [review.to_dict() for review in self.reviews],
             "review_status": self.review_status,
+            "comparison_fingerprint": self.comparison_fingerprint,
         }
 
 
@@ -516,8 +522,8 @@ def write_canary_report(
 ) -> DurableCanaryReport:
     """Persist a fully reviewed report or an explicit durable unreviewed diff.
 
-    Reviews must cover exactly the comparator's row identities. This prevents
-    a report from becoming a durable green-light artifact while a diff was
+    Reviews must cover exactly the comparator's row identities and signatures.
+    This prevents a report from becoming a durable green-light artifact while a diff was
     silently omitted from review. The write is atomic and touches only the
     requested report path, never either SQLite generation.
     """
@@ -529,7 +535,9 @@ def write_canary_report(
     )
     _validate_selection_binding(selection, comparison, rebuild_receipt)
     review_list = tuple(reviews)
-    review_by_key: dict[tuple[str, DifferenceOperation, tuple[tuple[str, object], ...]], CanaryDifferenceReview] = {}
+    review_by_key: dict[
+        tuple[str, DifferenceOperation, tuple[tuple[str, object], ...], tuple[str, ...]], CanaryDifferenceReview
+    ] = {}
     duplicate_keys: list[object] = []
     for review in review_list:
         if not review.reference.strip() or not review.rationale.strip():
@@ -542,6 +550,7 @@ def write_canary_report(
             difference.table,
             difference.operation,
             difference.identity,
+            difference.changed_columns,
         )
         for difference in comparison.differences
     }
@@ -566,11 +575,11 @@ def write_canary_report(
             replace(
                 difference,
                 classification=review_by_key[
-                    (difference.table, difference.operation, difference.identity)
+                    (difference.table, difference.operation, difference.identity, difference.changed_columns)
                 ].classification,
                 rationale=(
-                    f"{review_by_key[(difference.table, difference.operation, difference.identity)].reference}: "
-                    f"{review_by_key[(difference.table, difference.operation, difference.identity)].rationale}"
+                    f"{review_by_key[(difference.table, difference.operation, difference.identity, difference.changed_columns)].reference}: "
+                    f"{review_by_key[(difference.table, difference.operation, difference.identity, difference.changed_columns)].rationale}"
                 ),
             )
             for difference in comparison.differences
@@ -583,6 +592,7 @@ def write_canary_report(
         rebuild_receipt=rebuild_receipt,
         reviews=review_list,
         review_status=review_status,
+        comparison_fingerprint=_comparison_fingerprint(comparison),
     )
     path = Path(output_path)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -631,6 +641,34 @@ def _validate_selection_binding(
         or tuple(session_ids) != selection.selected_session_ids
     ):
         raise UnclassifiedCanaryDiffError("canary report rebuild evidence does not match the selected identities")
+
+
+def _comparison_fingerprint(comparison: CanaryDiffReport) -> str:
+    """Hash comparison evidence independently of operator classification."""
+
+    payload = {
+        "current_index": str(comparison.current_index),
+        "candidate_index": str(comparison.candidate_index),
+        "session_ids": list(comparison.session_ids),
+        "compared_tables": list(comparison.compared_tables),
+        "missing_tables": list(comparison.missing_tables),
+        "missing_columns": [
+            {"table": table, "columns": list(columns)} for table, columns in comparison.missing_columns
+        ],
+        "differences": [
+            {
+                "table": difference.table,
+                "operation": difference.operation.value,
+                "identity": dict(difference.identity),
+                "before": difference.before,
+                "after": difference.after,
+                "changed_columns": list(difference.changed_columns),
+            }
+            for difference in comparison.differences
+        ],
+    }
+    encoded = json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return sha256(encoded).hexdigest()
 
 
 def _validate_rebuild_receipt(
@@ -698,6 +736,9 @@ def load_canary_report(path: Path) -> dict[str, object]:
     review_status = payload.get("review_status")
     if review_status not in {"reviewed", "unreviewed"}:
         raise UnclassifiedCanaryDiffError("canary report has invalid review status")
+    comparison_fingerprint = payload.get("comparison_fingerprint")
+    if not isinstance(comparison_fingerprint, str) or len(comparison_fingerprint) != 64:
+        raise UnclassifiedCanaryDiffError("canary report has invalid comparison fingerprint")
     selection = payload.get("selection")
     if not isinstance(selection, dict):
         raise UnclassifiedCanaryDiffError("canary report has no selection object")
@@ -731,18 +772,54 @@ def load_canary_report(path: Path) -> dict[str, object]:
     )
     current_index = comparison.get("current_index")
     compared_sessions = comparison.get("session_ids")
+    compared_tables = comparison.get("compared_tables")
+    missing_tables = comparison.get("missing_tables")
+    raw_missing_columns = comparison.get("missing_columns")
     if (
         not isinstance(current_index, str)
         or not isinstance(compared_sessions, list)
         or not all(isinstance(value, str) for value in compared_sessions)
+        or not isinstance(compared_tables, list)
+        or not all(isinstance(value, str) for value in compared_tables)
+        or not isinstance(missing_tables, list)
+        or not all(isinstance(value, str) for value in missing_tables)
+        or not isinstance(raw_missing_columns, list)
     ):
         raise UnclassifiedCanaryDiffError("canary report has invalid comparison selection")
+    missing_columns: list[tuple[str, tuple[str, ...]]] = []
+    for item in raw_missing_columns:
+        if not isinstance(item, dict):
+            raise UnclassifiedCanaryDiffError("canary report has invalid comparison schema evidence")
+        table = item.get("table")
+        columns = item.get("columns")
+        if (
+            not isinstance(table, str)
+            or not isinstance(columns, list)
+            or not all(isinstance(column, str) for column in columns)
+        ):
+            raise UnclassifiedCanaryDiffError("canary report has invalid comparison schema evidence")
+        missing_columns.append((table, tuple(columns)))
     persisted_comparison = CanaryDiffReport(
-        Path(current_index), Path(candidate_index), tuple(cast(list[str], compared_sessions)), (), (), (), differences
+        current_index=Path(current_index),
+        candidate_index=Path(candidate_index),
+        session_ids=tuple(cast(list[str], compared_sessions)),
+        compared_tables=tuple(cast(list[str], compared_tables)),
+        missing_tables=tuple(cast(list[str], missing_tables)),
+        missing_columns=tuple(missing_columns),
+        differences=differences,
     )
     _validate_selection_binding(
         persisted_selection, persisted_comparison, cast(dict[str, object], payload["rebuild_receipt"])
     )
+    recomputed_comparison = compare_reindex_generations(
+        persisted_comparison.current_index,
+        persisted_comparison.candidate_index,
+        session_ids=persisted_selection.selected_session_ids,
+    )
+    if comparison_fingerprint != _comparison_fingerprint(
+        persisted_comparison
+    ) or comparison_fingerprint != _comparison_fingerprint(recomputed_comparison):
+        raise UnclassifiedCanaryDiffError("canary report comparison attestation does not match the recorded indexes")
     difference_keys = tuple(_difference_key(difference) for difference in differences)
     review_keys = tuple(review.key for review in reviews)
     if len(set(difference_keys)) != len(difference_keys) or len(set(review_keys)) != len(review_keys):
@@ -767,8 +844,10 @@ def load_canary_report(path: Path) -> dict[str, object]:
     return cast(dict[str, object], payload)
 
 
-def _difference_key(difference: RowDifference) -> tuple[str, DifferenceOperation, tuple[tuple[str, object], ...]]:
-    return difference.table, difference.operation, difference.identity
+def _difference_key(
+    difference: RowDifference,
+) -> tuple[str, DifferenceOperation, tuple[tuple[str, object], ...], tuple[str, ...]]:
+    return difference.table, difference.operation, difference.identity, difference.changed_columns
 
 
 def _difference_from_dict(value: object) -> RowDifference:
@@ -813,11 +892,15 @@ def _review_from_dict(value: object) -> CanaryDifferenceReview:
     if not isinstance(value, dict):
         raise UnclassifiedCanaryDiffError("canary report review must be an object")
     identity = value.get("identity")
+    changed_columns = value.get("changed_columns")
     table = value.get("table")
     reference = value.get("reference")
     rationale = value.get("rationale")
     if (
         not isinstance(identity, dict)
+        or not isinstance(changed_columns, list)
+        or not changed_columns
+        or not all(isinstance(column, str) for column in changed_columns)
         or not isinstance(table, str)
         or not isinstance(reference, str)
         or not isinstance(rationale, str)
@@ -834,6 +917,7 @@ def _review_from_dict(value: object) -> CanaryDifferenceReview:
         table=table,
         operation=operation,
         identity=tuple((str(key), item) for key, item in identity.items()),
+        changed_columns=tuple(cast(list[str], changed_columns)),
         classification=classification,
         reference=reference,
         rationale=rationale,

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -335,20 +335,20 @@ def run_reindex_canary(
             candidate_acceptance_checks=REINDEX_CANARY_ACCEPTANCE_CHECKS,
         )
     )
+    receipt_payload = receipt.to_dict()
+    _validate_selection_evidence(receipt_payload, selection.selected_raw_ids)
     candidate_path = _validate_canary_candidate(
         root,
         current_index=current_index,
         selection=selection,
         receipt=receipt,
     )
+    _validate_authoritative_rebuild_receipt(receipt_payload, candidate_path)
     comparison = compare_reindex_generations(
         current_index,
         candidate_path,
         session_ids=selection.selected_session_ids,
     )
-    receipt_payload = receipt.to_dict()
-    receipt_payload["selected_raw_ids"] = list(selection.selected_raw_ids)
-    receipt_payload["selected_session_ids"] = list(selection.selected_session_ids)
     return CanaryRunResult(
         selection=selection,
         comparison=comparison,
@@ -503,7 +503,7 @@ class DurableCanaryReport:
 
     def to_dict(self) -> dict[str, object]:
         return {
-            "schema_version": 3,
+            "schema_version": 4,
             "selection": self.selection.to_dict(),
             "comparison": self.comparison.to_dict(),
             "rebuild_receipt": self.rebuild_receipt,
@@ -635,17 +635,37 @@ def _validate_selection_binding(
         raise UnclassifiedCanaryDiffError("canary report selection index does not match the compared current index")
     if selection.selected_session_ids != comparison.session_ids:
         raise UnclassifiedCanaryDiffError("canary report selection sessions do not match the comparison")
-    raw_ids = receipt.get("selected_raw_ids")
-    session_ids = receipt.get("selected_session_ids")
-    if (
-        not isinstance(raw_ids, list)
-        or not all(isinstance(value, str) for value in raw_ids)
-        or not isinstance(session_ids, list)
-        or not all(isinstance(value, str) for value in session_ids)
-        or tuple(raw_ids) != selection.selected_raw_ids
-        or tuple(session_ids) != selection.selected_session_ids
-    ):
-        raise UnclassifiedCanaryDiffError("canary report rebuild evidence does not match the selected identities")
+    _validate_selection_evidence(receipt, selection.selected_raw_ids)
+
+
+def _validate_selection_evidence(receipt: dict[str, object], selected_raw_ids: Iterable[str]) -> None:
+    """Match report selection to the rebuild-owned candidate commitment."""
+
+    from polylogue.maintenance.rebuild_index import rebuild_selection_evidence
+
+    generation = receipt.get("generation")
+    evidence = receipt.get("selection_evidence")
+    if not isinstance(generation, dict) or not isinstance(evidence, dict):
+        raise UnclassifiedCanaryDiffError("canary report has no authoritative rebuild selection evidence")
+    required = (
+        generation.get("generation_id"),
+        generation.get("owner_id"),
+        generation.get("index_path"),
+        generation.get("source_snapshot"),
+        receipt.get("archive_root"),
+    )
+    if not all(isinstance(value, str) and value for value in required):
+        raise UnclassifiedCanaryDiffError("canary report has incomplete authoritative rebuild selection evidence")
+    expected = rebuild_selection_evidence(
+        tuple(selected_raw_ids),
+        archive_root=Path(cast(str, receipt["archive_root"])),
+        generation_id=cast(str, generation["generation_id"]),
+        generation_owner_id=cast(str, generation["owner_id"]),
+        candidate_index=Path(cast(str, generation["index_path"])),
+        source_snapshot=cast(str, generation["source_snapshot"]),
+    )
+    if evidence != expected:
+        raise UnclassifiedCanaryDiffError("canary report selection does not match the authoritative rebuild receipt")
 
 
 def _comparison_fingerprint(comparison: CanaryDiffReport) -> str:
@@ -716,6 +736,19 @@ def _validate_rebuild_receipt(
         raise UnclassifiedCanaryDiffError("canary report rebuild receipt and candidate archive roots disagree")
     if Path(generation_index).resolve() != Path(candidate_index).resolve():
         raise UnclassifiedCanaryDiffError("canary report rebuild receipt does not identify the compared candidate")
+    _validate_selection_evidence(receipt, selected_raw_ids)
+
+
+def _validate_authoritative_rebuild_receipt(receipt: dict[str, object], candidate_index: Path) -> None:
+    """Reject report receipts that differ from rebuild-owned candidate evidence."""
+
+    path = candidate_index.parent / "rebuild-receipt.json"
+    try:
+        stored = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise UnclassifiedCanaryDiffError("archive-owned rebuild receipt is unreadable") from exc
+    if not isinstance(stored, dict) or stored != receipt:
+        raise UnclassifiedCanaryDiffError("archive-owned rebuild receipt does not match the report")
 
 
 def _generation_root(location: object) -> Path:
@@ -912,8 +945,8 @@ def load_canary_report(path: Path, *, archive_root: Path | None = None) -> dict[
     payload = json.loads(Path(path).read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise UnclassifiedCanaryDiffError("canary report root must be an object")
-    if payload.get("schema_version") != 3:
-        raise UnclassifiedCanaryDiffError("canary report has no archive-owned provenance schema")
+    if payload.get("schema_version") != 4:
+        raise UnclassifiedCanaryDiffError("canary report has no authoritative rebuild receipt schema")
     comparison = payload.get("comparison")
     if not isinstance(comparison, dict):
         raise UnclassifiedCanaryDiffError("canary report has no comparison object")
@@ -1015,6 +1048,9 @@ def load_canary_report(path: Path, *, archive_root: Path | None = None) -> dict[
         candidate_index=persisted_comparison.candidate_index,
         receipt=cast(dict[str, object], payload["rebuild_receipt"]),
     )
+    _validate_authoritative_rebuild_receipt(
+        cast(dict[str, object], payload["rebuild_receipt"]), persisted_comparison.candidate_index
+    )
     recomputed_comparison = compare_reindex_generations(
         persisted_comparison.current_index,
         persisted_comparison.candidate_index,
@@ -1049,7 +1085,7 @@ def load_canary_report(path: Path, *, archive_root: Path | None = None) -> dict[
 
 
 def approve_canary_report(path: Path, *, archive_root: Path) -> dict[str, object]:
-    """Consume a fresh durable report and return it only when approvable."""
+    """Approve evidence only. This cannot authorize or perform promotion."""
 
     payload = load_canary_report(path, archive_root=archive_root)
     if payload.get("review_status") != "reviewed":

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -376,6 +376,7 @@ def _resolve_canary_input_index(archive_root: Path, input_index: Path | None) ->
     except ValueError:
         if candidate_resolved != location.active_index.resolved_path:
             raise CanarySelectionError(
+                "input index is not the configured archive active generation; "
                 "explicit canary input index must be inside or bound to the selected archive root"
             ) from None
     return candidate
@@ -843,8 +844,15 @@ def _capture_archive_provenance(comparison: CanaryDiffReport, receipt: dict[str,
     }
 
 
-def _validate_archive_provenance(provenance: object, comparison: CanaryDiffReport, receipt: dict[str, object]) -> None:
-    """Recompute local lifecycle evidence before accepting a report for approval."""
+def _validate_archive_provenance(
+    provenance: object,
+    *,
+    configured_archive_root: Path,
+    current_index: Path,
+    candidate_index: Path,
+    receipt: dict[str, object],
+) -> None:
+    """Validate archive-owned evidence before opening report-provided indexes."""
 
     from polylogue.storage.archive_identity import ArchiveLocation, TierFileIdentity
     from polylogue.storage.index_generation import source_revision_snapshot
@@ -854,19 +862,22 @@ def _validate_archive_provenance(provenance: object, comparison: CanaryDiffRepor
     archive_root = provenance.get("archive_root")
     if not isinstance(archive_root, str):
         raise UnclassifiedCanaryDiffError("canary report has invalid archive-owned provenance root")
-    if receipt.get("archive_root") != archive_root:
+    root = configured_archive_root.resolve()
+    if Path(archive_root).resolve() != root:
+        raise UnclassifiedCanaryDiffError("canary report belongs to a different configured archive root")
+    receipt_root = receipt.get("archive_root")
+    if not isinstance(receipt_root, str) or Path(receipt_root).resolve() != root:
         raise UnclassifiedCanaryDiffError("archive-owned provenance root does not match the rebuild receipt")
-    root = Path(archive_root)
     location = ArchiveLocation.resolve(root)
     pointer = str(location.active_pointer) if location.active_pointer is not None else None
     if provenance.get("active_pointer") != pointer:
         raise UnclassifiedCanaryDiffError("archive-owned active pointer no longer matches the report")
-    current_identity = TierFileIdentity.resolve("index", comparison.current_index)
+    if provenance.get("active_generation") != _active_generation_metadata(root, location):
+        raise UnclassifiedCanaryDiffError("archive-owned active generation metadata no longer matches the report")
+    current_identity = TierFileIdentity.resolve("index", current_index)
     if not location.active_index.same_file(current_identity):
         raise UnclassifiedCanaryDiffError("archive-owned active index no longer matches the report")
     _same_index_evidence(provenance.get("active_index"), location.active_index_path, label="active")
-    if provenance.get("active_generation") != _active_generation_metadata(root, location):
-        raise UnclassifiedCanaryDiffError("archive-owned active generation metadata no longer matches the report")
     receipt_generation = receipt.get("generation")
     if not isinstance(receipt_generation, dict):
         raise UnclassifiedCanaryDiffError("canary report has invalid candidate generation provenance")
@@ -878,7 +889,16 @@ def _validate_archive_provenance(provenance: object, comparison: CanaryDiffRepor
     if live_candidate != receipt_generation or live_fields["state"] != "inactive":
         raise UnclassifiedCanaryDiffError("archive-owned candidate generation metadata no longer matches the report")
     candidate_path = Path(cast(str, live_fields["index_path"]))
-    if not candidate_path.samefile(comparison.candidate_index):
+    generation_root = _generation_root(location).resolve()
+    candidate_resolved = candidate_path.resolve(strict=True)
+    expected_generation_path = generation_root / str(receipt_fields["generation_id"]) / "index.db"
+    if candidate_resolved != expected_generation_path.resolve():
+        raise UnclassifiedCanaryDiffError("archive-owned candidate generation path is not archive-owned")
+    try:
+        same_candidate = candidate_path.samefile(candidate_index)
+    except OSError as exc:
+        raise UnclassifiedCanaryDiffError("archive-owned candidate generation is not readable") from exc
+    if not same_candidate:
         raise UnclassifiedCanaryDiffError("archive-owned candidate generation no longer matches the report")
     _same_index_evidence(provenance.get("candidate_index"), candidate_path, label="candidate")
     source_snapshot = source_revision_snapshot(root)
@@ -886,7 +906,7 @@ def _validate_archive_provenance(provenance: object, comparison: CanaryDiffRepor
         raise UnclassifiedCanaryDiffError("archive-owned source snapshot no longer matches the inactive candidate")
 
 
-def load_canary_report(path: Path) -> dict[str, object]:
+def load_canary_report(path: Path, *, archive_root: Path | None = None) -> dict[str, object]:
     """Read and structurally revalidate a durable report's review coverage."""
 
     payload = json.loads(Path(path).read_text(encoding="utf-8"))
@@ -986,6 +1006,15 @@ def load_canary_report(path: Path) -> dict[str, object]:
     _validate_selection_binding(
         persisted_selection, persisted_comparison, cast(dict[str, object], payload["rebuild_receipt"])
     )
+    from polylogue.config import resolve_archive_root
+
+    _validate_archive_provenance(
+        payload.get("archive_provenance"),
+        configured_archive_root=Path(archive_root) if archive_root is not None else resolve_archive_root(),
+        current_index=persisted_comparison.current_index,
+        candidate_index=persisted_comparison.candidate_index,
+        receipt=cast(dict[str, object], payload["rebuild_receipt"]),
+    )
     recomputed_comparison = compare_reindex_generations(
         persisted_comparison.current_index,
         persisted_comparison.candidate_index,
@@ -1015,13 +1044,21 @@ def load_canary_report(path: Path) -> dict[str, object]:
             review = review_by_key[key]
             if review.classification is not difference.classification:
                 raise UnclassifiedCanaryDiffError("canary report review classification disagrees with its difference")
-    _validate_archive_provenance(
-        payload.get("archive_provenance"),
-        persisted_comparison,
-        cast(dict[str, object], payload["rebuild_receipt"]),
-    )
     comparison["summary"] = _summary_for_differences(differences)
     return cast(dict[str, object], payload)
+
+
+def approve_canary_report(path: Path, *, archive_root: Path) -> dict[str, object]:
+    """Consume a fresh durable report and return it only when approvable."""
+
+    payload = load_canary_report(path, archive_root=archive_root)
+    if payload.get("review_status") != "reviewed":
+        raise UnclassifiedCanaryDiffError("canary report is not approved: review is incomplete")
+    comparison = payload.get("comparison")
+    summary = comparison.get("summary") if isinstance(comparison, dict) else None
+    if not isinstance(summary, dict) or summary.get("unexpected_count") != 0:
+        raise UnclassifiedCanaryDiffError("canary report is not approved: unexpected differences remain")
+    return payload
 
 
 def _difference_key(
@@ -1479,6 +1516,7 @@ __all__ = [
     "ExpectedDifference",
     "RowDifference",
     "UnclassifiedCanaryDiffError",
+    "approve_canary_report",
     "compare_reindex_generations",
     "load_canary_report",
     "run_reindex_canary",

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -503,7 +503,7 @@ class DurableCanaryReport:
 
     def to_dict(self) -> dict[str, object]:
         return {
-            "schema_version": 4,
+            "schema_version": 5,
             "selection": self.selection.to_dict(),
             "comparison": self.comparison.to_dict(),
             "rebuild_receipt": self.rebuild_receipt,
@@ -707,13 +707,17 @@ def _validate_rebuild_receipt(
     archive_root = receipt.get("archive_root")
     selected_raw_count = receipt.get("selected_raw_count")
     generation = receipt.get("generation")
+    raw_sessions_state_after = receipt.get("raw_sessions_state_after")
     if (
-        not isinstance(archive_root, str)
+        receipt.get("receipt_schema_version") != 2
+        or not isinstance(archive_root, str)
         or not archive_root
         or selected_raw_count != len(tuple(selected_raw_ids))
         or receipt.get("status") != "replayed"
         or receipt.get("materialized") is not True
         or not isinstance(generation, dict)
+        or not isinstance(raw_sessions_state_after, str)
+        or len(raw_sessions_state_after) != 64
     ):
         raise UnclassifiedCanaryDiffError("canary report has invalid rebuild receipt")
     generation_archive_root = generation.get("archive_root")
@@ -839,7 +843,7 @@ def _capture_archive_provenance(comparison: CanaryDiffReport, receipt: dict[str,
     """
 
     from polylogue.storage.archive_identity import ArchiveLocation, TierFileIdentity
-    from polylogue.storage.index_generation import source_revision_snapshot
+    from polylogue.storage.index_generation import rebuild_source_evidence_snapshot, source_revision_snapshot
 
     archive_root = receipt.get("archive_root")
     generation = receipt.get("generation")
@@ -863,9 +867,12 @@ def _capture_archive_provenance(comparison: CanaryDiffReport, receipt: dict[str,
     candidate_path = Path(cast(str, candidate["index_path"]))
     if not candidate_path.samefile(comparison.candidate_index):
         raise UnclassifiedCanaryDiffError("archive-owned candidate generation does not match the canary comparison")
-    source_snapshot = source_revision_snapshot(root)
+    source_snapshot = rebuild_source_evidence_snapshot(root)
     if source_snapshot != candidate["source_snapshot"]:
         raise UnclassifiedCanaryDiffError("archive-owned source snapshot does not match the inactive candidate")
+    raw_sessions_state_after = source_revision_snapshot(root)
+    if raw_sessions_state_after != receipt.get("raw_sessions_state_after"):
+        raise UnclassifiedCanaryDiffError("archive-owned raw session state does not match the rebuild receipt")
     return {
         "archive_root": str(root.resolve()),
         "active_pointer": str(location.active_pointer) if location.active_pointer is not None else None,
@@ -874,6 +881,7 @@ def _capture_archive_provenance(comparison: CanaryDiffReport, receipt: dict[str,
         "candidate_generation": candidate_metadata,
         "candidate_index": _index_evidence(candidate_path),
         "source_snapshot": source_snapshot,
+        "raw_sessions_state_after": raw_sessions_state_after,
     }
 
 
@@ -888,7 +896,7 @@ def _validate_archive_provenance(
     """Validate archive-owned evidence before opening report-provided indexes."""
 
     from polylogue.storage.archive_identity import ArchiveLocation, TierFileIdentity
-    from polylogue.storage.index_generation import source_revision_snapshot
+    from polylogue.storage.index_generation import rebuild_source_evidence_snapshot, source_revision_snapshot
 
     if not isinstance(provenance, dict):
         raise UnclassifiedCanaryDiffError("canary report has no archive-owned provenance")
@@ -934,9 +942,15 @@ def _validate_archive_provenance(
     if not same_candidate:
         raise UnclassifiedCanaryDiffError("archive-owned candidate generation no longer matches the report")
     _same_index_evidence(provenance.get("candidate_index"), candidate_path, label="candidate")
-    source_snapshot = source_revision_snapshot(root)
+    source_snapshot = rebuild_source_evidence_snapshot(root)
     if provenance.get("source_snapshot") != source_snapshot or live_fields["source_snapshot"] != source_snapshot:
         raise UnclassifiedCanaryDiffError("archive-owned source snapshot no longer matches the inactive candidate")
+    raw_sessions_state_after = source_revision_snapshot(root)
+    if (
+        provenance.get("raw_sessions_state_after") != raw_sessions_state_after
+        or receipt.get("raw_sessions_state_after") != raw_sessions_state_after
+    ):
+        raise UnclassifiedCanaryDiffError("archive-owned raw session state no longer matches the rebuild receipt")
 
 
 def load_canary_report(path: Path, *, archive_root: Path | None = None) -> dict[str, object]:
@@ -945,7 +959,7 @@ def load_canary_report(path: Path, *, archive_root: Path | None = None) -> dict[
     payload = json.loads(Path(path).read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise UnclassifiedCanaryDiffError("canary report root must be an object")
-    if payload.get("schema_version") != 4:
+    if payload.get("schema_version") != 5:
         raise UnclassifiedCanaryDiffError("canary report has no authoritative rebuild receipt schema")
     comparison = payload.get("comparison")
     if not isinstance(comparison, dict):

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -61,6 +61,12 @@ class ExpectedDifference:
     operations: tuple[DifferenceOperation, ...] = ()
     columns: tuple[str, ...] = ()
 
+    def __post_init__(self) -> None:
+        if len(self.operations) != 1:
+            raise ValueError("expected differences require exactly one operation")
+        if not self.columns:
+            raise ValueError("expected differences require a non-empty changed-column signature")
+
     def matches(
         self,
         *,
@@ -70,11 +76,9 @@ class ExpectedDifference:
     ) -> bool:
         if self.table != table:
             return False
-        if self.operations and operation not in self.operations:
+        if operation is not self.operations[0]:
             return False
-        if not self.columns:
-            return True
-        return bool(changed_columns) and set(changed_columns).issubset(self.columns)
+        return tuple(changed_columns) == self.columns
 
 
 @dataclass(frozen=True, slots=True)
@@ -286,6 +290,7 @@ def run_reindex_canary(
         raise CanarySelectionError("reindex canary requires --no-promote")
     from polylogue.config import resolve_archive_root
     from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
+    from polylogue.storage.archive_identity import ArchiveLocation, TierFileIdentity
 
     root = Path(archive_root)
     if root.resolve() == resolve_archive_root().resolve():
@@ -294,6 +299,14 @@ def run_reindex_canary(
             "run it against an explicitly provisioned isolated canary archive"
         )
     current_index = _resolve_canary_input_index(root, input_index)
+    location = ArchiveLocation.resolve(root)
+    if input_index is not None:
+        supplied = TierFileIdentity.resolve("index", Path(input_index))
+        if not location.active_index.same_file(supplied):
+            raise CanarySelectionError(
+                "input index is not the configured archive active generation; "
+                "explicit canary input index must be inside or bound to the selected archive root"
+            )
     from polylogue.maintenance.archive_verification import REINDEX_CANARY_ACCEPTANCE_CHECKS
     from polylogue.maintenance.pathology_zoo import pathology_zoo_is_present, pathology_zoo_session_ids
 
@@ -464,6 +477,7 @@ class DurableCanaryReport:
 
     selection: CanarySelection
     comparison: CanaryDiffReport
+    rebuild_receipt: dict[str, object]
     reviews: tuple[CanaryDifferenceReview, ...]
 
     @property
@@ -475,6 +489,7 @@ class DurableCanaryReport:
             "schema_version": 1,
             "selection": self.selection.to_dict(),
             "comparison": self.comparison.to_dict(),
+            "rebuild_receipt": self.rebuild_receipt,
             "reviews": [review.to_dict() for review in self.reviews],
         }
 
@@ -484,6 +499,7 @@ def write_canary_report(
     *,
     selection: CanarySelection,
     comparison: CanaryDiffReport,
+    rebuild_receipt: dict[str, object],
     reviews: Iterable[CanaryDifferenceReview],
 ) -> DurableCanaryReport:
     """Persist a reviewed report, refusing any incomplete classification.
@@ -494,6 +510,11 @@ def write_canary_report(
     requested report path, never either SQLite generation.
     """
 
+    _validate_rebuild_receipt(
+        rebuild_receipt,
+        selected_raw_ids=selection.selected_raw_ids,
+        candidate_index=comparison.candidate_index,
+    )
     review_list = tuple(reviews)
     review_by_key: dict[tuple[str, DifferenceOperation, tuple[tuple[str, object], ...]], CanaryDifferenceReview] = {}
     duplicate_keys: list[object] = []
@@ -533,7 +554,12 @@ def write_canary_report(
         for difference in comparison.differences
     )
     reviewed_comparison = replace(comparison, differences=reviewed_differences)
-    durable = DurableCanaryReport(selection=selection, comparison=reviewed_comparison, reviews=review_list)
+    durable = DurableCanaryReport(
+        selection=selection,
+        comparison=reviewed_comparison,
+        rebuild_receipt=rebuild_receipt,
+        reviews=review_list,
+    )
     path = Path(output_path)
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = json.dumps(durable.to_dict(), ensure_ascii=False, indent=2, sort_keys=True)
@@ -563,6 +589,48 @@ def write_canary_report(
     return durable
 
 
+def _validate_rebuild_receipt(
+    receipt: object,
+    *,
+    selected_raw_ids: Iterable[str],
+    candidate_index: Path | str,
+) -> None:
+    if not isinstance(receipt, dict):
+        raise UnclassifiedCanaryDiffError("canary report has no rebuild receipt")
+    archive_root = receipt.get("archive_root")
+    selected_raw_count = receipt.get("selected_raw_count")
+    generation = receipt.get("generation")
+    if (
+        not isinstance(archive_root, str)
+        or not archive_root
+        or selected_raw_count != len(tuple(selected_raw_ids))
+        or receipt.get("status") != "replayed"
+        or receipt.get("materialized") is not True
+        or not isinstance(generation, dict)
+    ):
+        raise UnclassifiedCanaryDiffError("canary report has invalid rebuild receipt")
+    generation_archive_root = generation.get("archive_root")
+    generation_index = generation.get("index_path")
+    required_generation = (
+        generation.get("generation_id"),
+        generation.get("owner_id"),
+        generation_archive_root,
+        generation_index,
+        generation.get("source_snapshot"),
+    )
+    if (
+        generation.get("state") != "inactive"
+        or not all(isinstance(value, str) and value for value in required_generation)
+        or not isinstance(generation_archive_root, str)
+        or not isinstance(generation_index, str)
+    ):
+        raise UnclassifiedCanaryDiffError("canary report has incomplete candidate generation provenance")
+    if Path(archive_root).resolve() != Path(generation_archive_root).resolve():
+        raise UnclassifiedCanaryDiffError("canary report rebuild receipt and candidate archive roots disagree")
+    if Path(generation_index).resolve() != Path(candidate_index).resolve():
+        raise UnclassifiedCanaryDiffError("canary report rebuild receipt does not identify the compared candidate")
+
+
 def load_canary_report(path: Path) -> dict[str, object]:
     """Read and structurally revalidate a durable report's review coverage."""
 
@@ -583,6 +651,20 @@ def load_canary_report(path: Path) -> dict[str, object]:
     if not isinstance(raw_reviews, list):
         raise UnclassifiedCanaryDiffError("canary report has no reviews list")
     reviews = tuple(_review_from_dict(item) for item in raw_reviews)
+    selection = payload.get("selection")
+    if not isinstance(selection, dict):
+        raise UnclassifiedCanaryDiffError("canary report has no selection object")
+    selected_raw_ids = selection.get("selected_raw_ids")
+    candidate_index = comparison.get("candidate_index")
+    if not isinstance(selected_raw_ids, list) or not all(isinstance(value, str) for value in selected_raw_ids):
+        raise UnclassifiedCanaryDiffError("canary report has invalid selected raw ids")
+    if not isinstance(candidate_index, str):
+        raise UnclassifiedCanaryDiffError("canary report has no candidate index")
+    _validate_rebuild_receipt(
+        payload.get("rebuild_receipt"),
+        selected_raw_ids=cast(list[str], selected_raw_ids),
+        candidate_index=candidate_index,
+    )
     difference_keys = tuple(_difference_key(difference) for difference in differences)
     review_keys = tuple(review.key for review in reviews)
     if len(set(difference_keys)) != len(difference_keys) or len(set(review_keys)) != len(review_keys):
@@ -674,6 +756,15 @@ def _review_from_dict(value: object) -> CanaryDifferenceReview:
         reference=reference,
         rationale=rationale,
     )
+
+
+def load_canary_review_manifest(path: Path) -> tuple[CanaryDifferenceReview, ...]:
+    """Load the explicit per-difference review manifest accepted by the CLI."""
+
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or not isinstance(payload.get("reviews"), list):
+        raise UnclassifiedCanaryDiffError("canary review manifest must contain a reviews list")
+    return tuple(_review_from_dict(item) for item in cast(list[object], payload["reviews"]))
 
 
 def _summary_for_differences(differences: tuple[RowDifference, ...]) -> dict[str, object]:
@@ -847,14 +938,20 @@ def _open_read_only(path: Path) -> sqlite3.Connection:
 
 def _read_model_tables(connection: sqlite3.Connection) -> set[str]:
     rows = connection.execute(
-        "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
+        "SELECT name FROM sqlite_master WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%'"
     ).fetchall()
     result: set[str] = set()
     for row in rows:
         table = str(row[0])
         if table in _EXCLUDED_TABLES or table.startswith("messages_fts") or table.startswith("blocks_command_trigram"):
             continue
-        columns = _table_columns(connection, table)
+        try:
+            columns = _table_columns(connection, table)
+        except sqlite3.OperationalError:
+            # A canonical view whose backing table is itself absent is not a
+            # second independent schema delta. The missing base relation is
+            # still reported below without making the comparison unreadable.
+            continue
         if table in _CORE_TABLES or any(column in columns for column in _SESSION_SCOPE_COLUMNS):
             result.add(table)
     return result
@@ -869,11 +966,13 @@ def _table_columns(connection: sqlite3.Connection, table: str) -> tuple[str, ...
 
 
 def _table_primary_key(connection: sqlite3.Connection, table: str, columns: tuple[str, ...]) -> tuple[str, ...]:
+    if table == "actions" and "tool_use_block_id" in columns:
+        return ("tool_use_block_id",)
     rows = connection.execute(f"PRAGMA table_xinfo({_quote_identifier(table)})").fetchall()
     primary_key = [(int(row[5]), str(row[1])) for row in rows if int(row[5]) > 0 and int(row[6]) not in (1, 2)]
     if primary_key:
         return tuple(name for _position, name in sorted(primary_key))
-    for preferred in ("session_id", "message_id", "block_id", "event_id", "policy_id"):
+    for preferred in ("tool_use_block_id", "session_id", "message_id", "block_id", "event_id", "policy_id"):
         if preferred in columns:
             return (preferred,)
     return columns
@@ -992,7 +1091,6 @@ def _table_rows(
         placeholders = ", ".join("?" for _ in session_ids)
         query += " WHERE " + " OR ".join(f"{_quote_identifier(column)} IN ({placeholders})" for column in scope_columns)
         parameters = session_ids * len(scope_columns)
-    query += " ORDER BY rowid" if table not in {"sessions", "messages", "blocks", "session_links"} else ""
     result: dict[tuple[object, ...], dict[str, object]] = {}
     primary_key = _table_primary_key(connection, table, columns)
     for row in connection.execute(query, parameters):

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -494,6 +494,7 @@ class DurableCanaryReport:
     reviews: tuple[CanaryDifferenceReview, ...]
     review_status: str
     comparison_fingerprint: str
+    archive_provenance: dict[str, object]
 
     @property
     def unclassified_count(self) -> int:
@@ -501,13 +502,14 @@ class DurableCanaryReport:
 
     def to_dict(self) -> dict[str, object]:
         return {
-            "schema_version": 2,
+            "schema_version": 3,
             "selection": self.selection.to_dict(),
             "comparison": self.comparison.to_dict(),
             "rebuild_receipt": self.rebuild_receipt,
             "reviews": [review.to_dict() for review in self.reviews],
             "review_status": self.review_status,
             "comparison_fingerprint": self.comparison_fingerprint,
+            "archive_provenance": self.archive_provenance,
         }
 
 
@@ -568,6 +570,7 @@ def write_canary_report(
     else:
         review_status = "reviewed"
 
+    archive_provenance = _capture_archive_provenance(comparison, rebuild_receipt)
     reviewed_differences = (
         comparison.differences
         if review_status == "unreviewed"
@@ -593,6 +596,7 @@ def write_canary_report(
         reviews=review_list,
         review_status=review_status,
         comparison_fingerprint=_comparison_fingerprint(comparison),
+        archive_provenance=archive_provenance,
     )
     path = Path(output_path)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -713,12 +717,178 @@ def _validate_rebuild_receipt(
         raise UnclassifiedCanaryDiffError("canary report rebuild receipt does not identify the compared candidate")
 
 
+def _generation_root(location: object) -> Path:
+    """Return the lifecycle directory anchored by this archive's active pointer."""
+
+    from polylogue.storage.archive_identity import ArchiveLocation
+
+    assert isinstance(location, ArchiveLocation)
+    anchor = location.active_pointer or location.configured_tier("index").configured_path
+    return anchor.parent / ".index-generations"
+
+
+def _read_generation_metadata(generation_root: Path, generation_id: str) -> dict[str, object]:
+    path = generation_root / generation_id / "generation.json"
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise UnclassifiedCanaryDiffError("archive-owned generation metadata is unreadable") from exc
+    if not isinstance(payload, dict):
+        raise UnclassifiedCanaryDiffError("archive-owned generation metadata is invalid")
+    return payload
+
+
+def _generation_fields(metadata: object) -> dict[str, object]:
+    if not isinstance(metadata, dict):
+        raise UnclassifiedCanaryDiffError("archive-owned generation metadata is invalid")
+    fields = {
+        key: metadata.get(key)
+        for key in ("generation_id", "owner_id", "archive_root", "index_path", "state", "source_snapshot")
+    }
+    if not all(isinstance(value, str) and value for value in fields.values()):
+        raise UnclassifiedCanaryDiffError("archive-owned generation metadata is incomplete")
+    return fields
+
+
+def _index_evidence(path: Path) -> dict[str, object]:
+    """Describe a local file identity without claiming it is a secret capability."""
+
+    from polylogue.storage.archive_identity import TierFileIdentity
+
+    identity = TierFileIdentity.resolve("index", path)
+    if not identity.exists:
+        raise UnclassifiedCanaryDiffError("archive-owned index is not readable")
+    digest = sha256()
+    try:
+        with path.open("rb") as stream:
+            while chunk := stream.read(1024 * 1024):
+                digest.update(chunk)
+    except OSError as exc:
+        raise UnclassifiedCanaryDiffError("archive-owned index is not readable") from exc
+    return {"file": identity.as_dict(), "content_sha256": digest.hexdigest()}
+
+
+def _same_index_evidence(recorded: object, path: Path, *, label: str) -> None:
+    if not isinstance(recorded, dict) or recorded != _index_evidence(path):
+        raise UnclassifiedCanaryDiffError(f"archive-owned {label} index identity no longer matches the report")
+
+
+def _active_generation_metadata(root: Path, location: object) -> dict[str, object]:
+    from polylogue.storage.archive_identity import ArchiveLocation, TierFileIdentity
+
+    assert isinstance(location, ArchiveLocation)
+    active_identity = TierFileIdentity.resolve("index", location.active_index_path)
+    matches: list[dict[str, object]] = []
+    for metadata_path in _generation_root(location).glob("gen-*/generation.json"):
+        try:
+            metadata = _generation_fields(json.loads(metadata_path.read_text(encoding="utf-8")))
+            generation_index = TierFileIdentity.resolve("index", Path(cast(str, metadata["index_path"])))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if metadata["state"] == "active" and active_identity.same_file(generation_index):
+            matches.append(metadata)
+    if len(matches) != 1:
+        raise UnclassifiedCanaryDiffError("archive-owned active generation metadata does not match the active pointer")
+    active = matches[0]
+    if Path(cast(str, active["archive_root"])).resolve() != root.resolve():
+        raise UnclassifiedCanaryDiffError("archive-owned active generation belongs to another archive")
+    return active
+
+
+def _capture_archive_provenance(comparison: CanaryDiffReport, receipt: dict[str, object]) -> dict[str, object]:
+    """Capture lifecycle records that make a local report archive-specific.
+
+    These values are not a secret or a signature. They are deliberately
+    re-read on load so approval follows the active pointer, generation record,
+    source snapshot, and the exact inactive file that the rebuild created.
+    """
+
+    from polylogue.storage.archive_identity import ArchiveLocation, TierFileIdentity
+    from polylogue.storage.index_generation import source_revision_snapshot
+
+    archive_root = receipt.get("archive_root")
+    generation = receipt.get("generation")
+    if not isinstance(archive_root, str):
+        raise UnclassifiedCanaryDiffError("canary report has invalid archive provenance root")
+    root = Path(archive_root)
+    location = ArchiveLocation.resolve(root)
+    current_identity = TierFileIdentity.resolve("index", comparison.current_index)
+    if not location.active_index.same_file(current_identity):
+        raise UnclassifiedCanaryDiffError("archive-owned active index does not match the canary comparison")
+    candidate = _generation_fields(generation)
+    candidate_metadata = _read_generation_metadata(_generation_root(location), cast(str, candidate["generation_id"]))
+    if _generation_fields(candidate_metadata) != candidate:
+        raise UnclassifiedCanaryDiffError(
+            "archive-owned candidate generation metadata does not match the rebuild receipt"
+        )
+    if candidate["state"] != "inactive":
+        raise UnclassifiedCanaryDiffError("archive-owned candidate generation is not inactive")
+    candidate_path = Path(cast(str, candidate["index_path"]))
+    if not candidate_path.samefile(comparison.candidate_index):
+        raise UnclassifiedCanaryDiffError("archive-owned candidate generation does not match the canary comparison")
+    source_snapshot = source_revision_snapshot(root)
+    if source_snapshot != candidate["source_snapshot"]:
+        raise UnclassifiedCanaryDiffError("archive-owned source snapshot does not match the inactive candidate")
+    return {
+        "archive_root": str(root.resolve()),
+        "active_pointer": str(location.active_pointer) if location.active_pointer is not None else None,
+        "active_index": _index_evidence(location.active_index_path),
+        "active_generation": _active_generation_metadata(root, location),
+        "candidate_generation": candidate,
+        "candidate_index": _index_evidence(candidate_path),
+        "source_snapshot": source_snapshot,
+    }
+
+
+def _validate_archive_provenance(provenance: object, comparison: CanaryDiffReport, receipt: dict[str, object]) -> None:
+    """Recompute local lifecycle evidence before accepting a report for approval."""
+
+    from polylogue.storage.archive_identity import ArchiveLocation, TierFileIdentity
+    from polylogue.storage.index_generation import source_revision_snapshot
+
+    if not isinstance(provenance, dict):
+        raise UnclassifiedCanaryDiffError("canary report has no archive-owned provenance")
+    archive_root = provenance.get("archive_root")
+    if not isinstance(archive_root, str):
+        raise UnclassifiedCanaryDiffError("canary report has invalid archive-owned provenance root")
+    if receipt.get("archive_root") != archive_root:
+        raise UnclassifiedCanaryDiffError("archive-owned provenance root does not match the rebuild receipt")
+    root = Path(archive_root)
+    location = ArchiveLocation.resolve(root)
+    pointer = str(location.active_pointer) if location.active_pointer is not None else None
+    if provenance.get("active_pointer") != pointer:
+        raise UnclassifiedCanaryDiffError("archive-owned active pointer no longer matches the report")
+    current_identity = TierFileIdentity.resolve("index", comparison.current_index)
+    if not location.active_index.same_file(current_identity):
+        raise UnclassifiedCanaryDiffError("archive-owned active index no longer matches the report")
+    _same_index_evidence(provenance.get("active_index"), location.active_index_path, label="active")
+    if provenance.get("active_generation") != _active_generation_metadata(root, location):
+        raise UnclassifiedCanaryDiffError("archive-owned active generation metadata no longer matches the report")
+    receipt_generation = _generation_fields(receipt.get("generation"))
+    if provenance.get("candidate_generation") != receipt_generation:
+        raise UnclassifiedCanaryDiffError("archive-owned candidate generation does not match the rebuild receipt")
+    live_candidate = _generation_fields(
+        _read_generation_metadata(_generation_root(location), cast(str, receipt_generation["generation_id"]))
+    )
+    if live_candidate != receipt_generation or live_candidate["state"] != "inactive":
+        raise UnclassifiedCanaryDiffError("archive-owned candidate generation metadata no longer matches the report")
+    candidate_path = Path(cast(str, live_candidate["index_path"]))
+    if not candidate_path.samefile(comparison.candidate_index):
+        raise UnclassifiedCanaryDiffError("archive-owned candidate generation no longer matches the report")
+    _same_index_evidence(provenance.get("candidate_index"), candidate_path, label="candidate")
+    source_snapshot = source_revision_snapshot(root)
+    if provenance.get("source_snapshot") != source_snapshot or live_candidate["source_snapshot"] != source_snapshot:
+        raise UnclassifiedCanaryDiffError("archive-owned source snapshot no longer matches the inactive candidate")
+
+
 def load_canary_report(path: Path) -> dict[str, object]:
     """Read and structurally revalidate a durable report's review coverage."""
 
     payload = json.loads(Path(path).read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise UnclassifiedCanaryDiffError("canary report root must be an object")
+    if payload.get("schema_version") != 3:
+        raise UnclassifiedCanaryDiffError("canary report has no archive-owned provenance schema")
     comparison = payload.get("comparison")
     if not isinstance(comparison, dict):
         raise UnclassifiedCanaryDiffError("canary report has no comparison object")
@@ -840,6 +1010,11 @@ def load_canary_report(path: Path) -> dict[str, object]:
             review = review_by_key[key]
             if review.classification is not difference.classification:
                 raise UnclassifiedCanaryDiffError("canary report review classification disagrees with its difference")
+    _validate_archive_provenance(
+        payload.get("archive_provenance"),
+        persisted_comparison,
+        cast(dict[str, object], payload["rebuild_receipt"]),
+    )
     comparison["summary"] = _summary_for_differences(differences)
     return cast(dict[str, object], payload)
 

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -503,7 +503,7 @@ class DurableCanaryReport:
 
     def to_dict(self) -> dict[str, object]:
         return {
-            "schema_version": 6,
+            "schema_version": 7,
             "selection": self.selection.to_dict(),
             "comparison": self.comparison.to_dict(),
             "rebuild_receipt": self.rebuild_receipt,
@@ -709,7 +709,7 @@ def _validate_rebuild_receipt(
     generation = receipt.get("generation")
     source_evidence_after = receipt.get("source_evidence_after")
     if (
-        receipt.get("receipt_schema_version") != 3
+        receipt.get("receipt_schema_version") != 4
         or not isinstance(archive_root, str)
         or not archive_root
         or selected_raw_count != len(tuple(selected_raw_ids))
@@ -834,6 +834,19 @@ def _active_generation_metadata(root: Path, location: object) -> dict[str, objec
     return active
 
 
+def _verified_source_evidence(root: Path) -> str:
+    """Recompute source evidence and normalize byte-verification failures."""
+
+    from polylogue.storage.index_generation import rebuild_source_evidence_snapshot
+
+    try:
+        return rebuild_source_evidence_snapshot(root)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise UnclassifiedCanaryDiffError(
+            f"archive-owned source evidence cannot verify referenced blob bytes: {exc}"
+        ) from exc
+
+
 def _capture_archive_provenance(comparison: CanaryDiffReport, receipt: dict[str, object]) -> dict[str, object]:
     """Capture lifecycle records that make a local report archive-specific.
 
@@ -843,7 +856,6 @@ def _capture_archive_provenance(comparison: CanaryDiffReport, receipt: dict[str,
     """
 
     from polylogue.storage.archive_identity import ArchiveLocation, TierFileIdentity
-    from polylogue.storage.index_generation import rebuild_source_evidence_snapshot
 
     archive_root = receipt.get("archive_root")
     generation = receipt.get("generation")
@@ -867,10 +879,10 @@ def _capture_archive_provenance(comparison: CanaryDiffReport, receipt: dict[str,
     candidate_path = Path(cast(str, candidate["index_path"]))
     if not candidate_path.samefile(comparison.candidate_index):
         raise UnclassifiedCanaryDiffError("archive-owned candidate generation does not match the canary comparison")
-    source_snapshot = rebuild_source_evidence_snapshot(root)
+    source_snapshot = _verified_source_evidence(root)
     if source_snapshot != candidate["source_snapshot"]:
         raise UnclassifiedCanaryDiffError("archive-owned source snapshot does not match the inactive candidate")
-    source_evidence_after = rebuild_source_evidence_snapshot(root)
+    source_evidence_after = _verified_source_evidence(root)
     if source_evidence_after != receipt.get("source_evidence_after"):
         raise UnclassifiedCanaryDiffError("archive-owned source evidence does not match the rebuild receipt")
     return {
@@ -896,7 +908,6 @@ def _validate_archive_provenance(
     """Validate archive-owned evidence before opening report-provided indexes."""
 
     from polylogue.storage.archive_identity import ArchiveLocation, TierFileIdentity
-    from polylogue.storage.index_generation import rebuild_source_evidence_snapshot
 
     if not isinstance(provenance, dict):
         raise UnclassifiedCanaryDiffError("canary report has no archive-owned provenance")
@@ -942,10 +953,10 @@ def _validate_archive_provenance(
     if not same_candidate:
         raise UnclassifiedCanaryDiffError("archive-owned candidate generation no longer matches the report")
     _same_index_evidence(provenance.get("candidate_index"), candidate_path, label="candidate")
-    source_snapshot = rebuild_source_evidence_snapshot(root)
+    source_snapshot = _verified_source_evidence(root)
     if provenance.get("source_snapshot") != source_snapshot or live_fields["source_snapshot"] != source_snapshot:
         raise UnclassifiedCanaryDiffError("archive-owned source snapshot no longer matches the inactive candidate")
-    source_evidence_after = rebuild_source_evidence_snapshot(root)
+    source_evidence_after = _verified_source_evidence(root)
     if (
         provenance.get("source_evidence_after") != source_evidence_after
         or receipt.get("source_evidence_after") != source_evidence_after
@@ -959,7 +970,7 @@ def load_canary_report(path: Path, *, archive_root: Path | None = None) -> dict[
     payload = json.loads(Path(path).read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise UnclassifiedCanaryDiffError("canary report root must be an object")
-    if payload.get("schema_version") != 6:
+    if payload.get("schema_version") != 7:
         raise UnclassifiedCanaryDiffError("canary report has no authoritative rebuild receipt schema")
     comparison = payload.get("comparison")
     if not isinstance(comparison, dict):
@@ -1099,16 +1110,42 @@ def load_canary_report(path: Path, *, archive_root: Path | None = None) -> dict[
 
 
 def approve_canary_report(path: Path, *, archive_root: Path) -> dict[str, object]:
-    """Approve evidence only. This cannot authorize or perform promotion."""
+    """Approve evidence only under the archive's existing writer ownership."""
 
-    payload = load_canary_report(path, archive_root=archive_root)
-    if payload.get("review_status") != "reviewed":
-        raise UnclassifiedCanaryDiffError("canary report is not approved: review is incomplete")
-    comparison = payload.get("comparison")
-    summary = comparison.get("summary") if isinstance(comparison, dict) else None
-    if not isinstance(summary, dict) or summary.get("unexpected_count") != 0:
-        raise UnclassifiedCanaryDiffError("canary report is not approved: unexpected differences remain")
-    return payload
+    from polylogue.storage.archive_identity import ArchiveLocation, OwnedArchiveLocation, assert_owns_archive_location
+    from polylogue.storage.index_generation import RebuildLease
+
+    root = Path(archive_root)
+    location = ArchiveLocation.resolve(root)
+    with RebuildLease(root):
+        owned = OwnedArchiveLocation.acquire(location)
+        try:
+            assert_owns_archive_location(owned, ArchiveLocation.resolve(root))
+            payload = load_canary_report(path, archive_root=root)
+            if payload.get("review_status") != "reviewed":
+                raise UnclassifiedCanaryDiffError("canary report is not approved: review is incomplete")
+            comparison = payload.get("comparison")
+            summary = comparison.get("summary") if isinstance(comparison, dict) else None
+            if not isinstance(summary, dict) or summary.get("unexpected_count") != 0:
+                raise UnclassifiedCanaryDiffError("canary report is not approved: unexpected differences remain")
+
+            # The first load proves that the report was valid when approval
+            # began. Re-run the complete report, source, candidate, and
+            # comparison validation immediately before returning approval.
+            assert_owns_archive_location(owned, ArchiveLocation.resolve(root))
+            final_payload = load_canary_report(path, archive_root=root)
+            if final_payload.get("review_status") != "reviewed":
+                raise UnclassifiedCanaryDiffError("canary report is not approved: review changed during approval")
+            final_comparison = final_payload.get("comparison")
+            final_summary = final_comparison.get("summary") if isinstance(final_comparison, dict) else None
+            if not isinstance(final_summary, dict) or final_summary.get("unexpected_count") != 0:
+                raise UnclassifiedCanaryDiffError(
+                    "canary report is not approved: unexpected differences appeared during approval"
+                )
+            assert_owns_archive_location(owned, ArchiveLocation.resolve(root))
+            return final_payload
+        finally:
+            owned.release()
 
 
 def _difference_key(

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -58,6 +58,7 @@ class ExpectedDifference:
     table: str
     bead_ref: str
     rationale: str
+    identity: tuple[tuple[str, object], ...]
     operations: tuple[DifferenceOperation, ...] = ()
     columns: tuple[str, ...] = ()
 
@@ -66,17 +67,22 @@ class ExpectedDifference:
             raise ValueError("expected differences require exactly one operation")
         if not self.columns:
             raise ValueError("expected differences require a non-empty changed-column signature")
+        if not self.identity:
+            raise ValueError("expected differences require a bounded row identity")
 
     def matches(
         self,
         *,
         table: str,
         operation: DifferenceOperation,
+        identity: tuple[tuple[str, object], ...],
         changed_columns: tuple[str, ...],
     ) -> bool:
         if self.table != table:
             return False
         if operation is not self.operations[0]:
+            return False
+        if identity != self.identity:
             return False
         return tuple(changed_columns) == self.columns
 
@@ -339,10 +345,13 @@ def run_reindex_canary(
         candidate_path,
         session_ids=selection.selected_session_ids,
     )
+    receipt_payload = receipt.to_dict()
+    receipt_payload["selected_raw_ids"] = list(selection.selected_raw_ids)
+    receipt_payload["selected_session_ids"] = list(selection.selected_session_ids)
     return CanaryRunResult(
         selection=selection,
         comparison=comparison,
-        rebuild_receipt=receipt.to_dict(),
+        rebuild_receipt=receipt_payload,
     )
 
 
@@ -479,6 +488,7 @@ class DurableCanaryReport:
     comparison: CanaryDiffReport
     rebuild_receipt: dict[str, object]
     reviews: tuple[CanaryDifferenceReview, ...]
+    review_status: str
 
     @property
     def unclassified_count(self) -> int:
@@ -491,6 +501,7 @@ class DurableCanaryReport:
             "comparison": self.comparison.to_dict(),
             "rebuild_receipt": self.rebuild_receipt,
             "reviews": [review.to_dict() for review in self.reviews],
+            "review_status": self.review_status,
         }
 
 
@@ -501,8 +512,9 @@ def write_canary_report(
     comparison: CanaryDiffReport,
     rebuild_receipt: dict[str, object],
     reviews: Iterable[CanaryDifferenceReview],
+    allow_unreviewed: bool = False,
 ) -> DurableCanaryReport:
-    """Persist a reviewed report, refusing any incomplete classification.
+    """Persist a fully reviewed report or an explicit durable unreviewed diff.
 
     Reviews must cover exactly the comparator's row identities. This prevents
     a report from becoming a durable green-light artifact while a diff was
@@ -515,6 +527,7 @@ def write_canary_report(
         selected_raw_ids=selection.selected_raw_ids,
         candidate_index=comparison.candidate_index,
     )
+    _validate_selection_binding(selection, comparison, rebuild_receipt)
     review_list = tuple(reviews)
     review_by_key: dict[tuple[str, DifferenceOperation, tuple[tuple[str, object], ...]], CanaryDifferenceReview] = {}
     duplicate_keys: list[object] = []
@@ -534,24 +547,34 @@ def write_canary_report(
     }
     missing_keys = difference_keys.difference(review_by_key)
     extra_keys = set(review_by_key).difference(difference_keys)
-    if duplicate_keys or missing_keys or extra_keys:
+    if (missing_keys and allow_unreviewed and not review_list and not extra_keys) or not comparison.differences:
+        review_status = "unreviewed" if missing_keys else "reviewed"
+    elif duplicate_keys or missing_keys or extra_keys:
         detail = [
             f"duplicate={len(duplicate_keys)}",
             f"missing={len(missing_keys)}",
             f"extra={len(extra_keys)}",
         ]
         raise UnclassifiedCanaryDiffError("canary report classification is incomplete (" + ", ".join(detail) + ")")
+    else:
+        review_status = "reviewed"
 
-    reviewed_differences = tuple(
-        replace(
-            difference,
-            classification=review_by_key[(difference.table, difference.operation, difference.identity)].classification,
-            rationale=(
-                f"{review_by_key[(difference.table, difference.operation, difference.identity)].reference}: "
-                f"{review_by_key[(difference.table, difference.operation, difference.identity)].rationale}"
-            ),
+    reviewed_differences = (
+        comparison.differences
+        if review_status == "unreviewed"
+        else tuple(
+            replace(
+                difference,
+                classification=review_by_key[
+                    (difference.table, difference.operation, difference.identity)
+                ].classification,
+                rationale=(
+                    f"{review_by_key[(difference.table, difference.operation, difference.identity)].reference}: "
+                    f"{review_by_key[(difference.table, difference.operation, difference.identity)].rationale}"
+                ),
+            )
+            for difference in comparison.differences
         )
-        for difference in comparison.differences
     )
     reviewed_comparison = replace(comparison, differences=reviewed_differences)
     durable = DurableCanaryReport(
@@ -559,6 +582,7 @@ def write_canary_report(
         comparison=reviewed_comparison,
         rebuild_receipt=rebuild_receipt,
         reviews=review_list,
+        review_status=review_status,
     )
     path = Path(output_path)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -587,6 +611,26 @@ def write_canary_report(
                 temporary.unlink()
         raise
     return durable
+
+
+def _validate_selection_binding(
+    selection: CanarySelection, comparison: CanaryDiffReport, receipt: dict[str, object]
+) -> None:
+    if selection.index_path.resolve() != comparison.current_index.resolve():
+        raise UnclassifiedCanaryDiffError("canary report selection index does not match the compared current index")
+    if selection.selected_session_ids != comparison.session_ids:
+        raise UnclassifiedCanaryDiffError("canary report selection sessions do not match the comparison")
+    raw_ids = receipt.get("selected_raw_ids")
+    session_ids = receipt.get("selected_session_ids")
+    if (
+        not isinstance(raw_ids, list)
+        or not all(isinstance(value, str) for value in raw_ids)
+        or not isinstance(session_ids, list)
+        or not all(isinstance(value, str) for value in session_ids)
+        or tuple(raw_ids) != selection.selected_raw_ids
+        or tuple(session_ids) != selection.selected_session_ids
+    ):
+        raise UnclassifiedCanaryDiffError("canary report rebuild evidence does not match the selected identities")
 
 
 def _validate_rebuild_receipt(
@@ -651,6 +695,9 @@ def load_canary_report(path: Path) -> dict[str, object]:
     if not isinstance(raw_reviews, list):
         raise UnclassifiedCanaryDiffError("canary report has no reviews list")
     reviews = tuple(_review_from_dict(item) for item in raw_reviews)
+    review_status = payload.get("review_status")
+    if review_status not in {"reviewed", "unreviewed"}:
+        raise UnclassifiedCanaryDiffError("canary report has invalid review status")
     selection = payload.get("selection")
     if not isinstance(selection, dict):
         raise UnclassifiedCanaryDiffError("canary report has no selection object")
@@ -665,6 +712,37 @@ def load_canary_report(path: Path) -> dict[str, object]:
         selected_raw_ids=cast(list[str], selected_raw_ids),
         candidate_index=candidate_index,
     )
+    selection_sessions = selection.get("selected_session_ids")
+    if not isinstance(selection_sessions, list) or not all(isinstance(value, str) for value in selection_sessions):
+        raise UnclassifiedCanaryDiffError("canary report has invalid selected session ids")
+    selection_index = selection.get("index_path")
+    sessions_per_origin = selection.get("sessions_per_origin")
+    if not isinstance(selection_index, str) or not isinstance(sessions_per_origin, int):
+        raise UnclassifiedCanaryDiffError("canary report has invalid selection binding")
+    persisted_selection = CanarySelection(
+        index_path=Path(selection_index),
+        sessions_per_origin=sessions_per_origin,
+        selected_session_ids=tuple(cast(list[str], selection_sessions)),
+        selected_raw_ids=tuple(cast(list[str], selected_raw_ids)),
+        sampled_session_ids=(),
+        pathology_session_ids=(),
+        sample_session_ids=(),
+        origin_counts=(),
+    )
+    current_index = comparison.get("current_index")
+    compared_sessions = comparison.get("session_ids")
+    if (
+        not isinstance(current_index, str)
+        or not isinstance(compared_sessions, list)
+        or not all(isinstance(value, str) for value in compared_sessions)
+    ):
+        raise UnclassifiedCanaryDiffError("canary report has invalid comparison selection")
+    persisted_comparison = CanaryDiffReport(
+        Path(current_index), Path(candidate_index), tuple(cast(list[str], compared_sessions)), (), (), (), differences
+    )
+    _validate_selection_binding(
+        persisted_selection, persisted_comparison, cast(dict[str, object], payload["rebuild_receipt"])
+    )
     difference_keys = tuple(_difference_key(difference) for difference in differences)
     review_keys = tuple(review.key for review in reviews)
     if len(set(difference_keys)) != len(difference_keys) or len(set(review_keys)) != len(review_keys):
@@ -673,14 +751,18 @@ def load_canary_report(path: Path) -> dict[str, object]:
     review_by_key = dict(zip(review_keys, reviews, strict=True))
     missing_keys = set(difference_by_key).difference(review_by_key)
     extra_keys = set(review_by_key).difference(difference_by_key)
-    if missing_keys or extra_keys:
+    if review_status == "unreviewed":
+        if reviews or not differences:
+            raise UnclassifiedCanaryDiffError("canary report unreviewed state is invalid")
+    elif missing_keys or extra_keys:
         raise UnclassifiedCanaryDiffError(
             f"canary report review coverage is incomplete (missing={len(missing_keys)}, extra={len(extra_keys)})"
         )
-    for key, difference in difference_by_key.items():
-        review = review_by_key[key]
-        if review.classification is not difference.classification:
-            raise UnclassifiedCanaryDiffError("canary report review classification disagrees with its difference")
+    if review_status == "reviewed":
+        for key, difference in difference_by_key.items():
+            review = review_by_key[key]
+            if review.classification is not difference.classification:
+                raise UnclassifiedCanaryDiffError("canary report review classification disagrees with its difference")
     comparison["summary"] = _summary_for_differences(differences)
     return cast(dict[str, object], payload)
 
@@ -1055,7 +1137,11 @@ def _build_difference(
     expected: tuple[ExpectedDifference, ...],
 ) -> RowDifference:
     matching = next(
-        (item for item in expected if item.matches(table=table, operation=operation, changed_columns=changed_columns)),
+        (
+            item
+            for item in expected
+            if item.matches(table=table, operation=operation, identity=identity, changed_columns=changed_columns)
+        ),
         None,
     )
     return RowDifference(

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -629,16 +629,22 @@ def write_canary_report(
 
 
 def _validate_selection_binding(
-    selection: CanarySelection, comparison: CanaryDiffReport, receipt: dict[str, object]
+    selection: CanarySelection,
+    comparison: CanaryDiffReport,
+    receipt: dict[str, object],
+    *,
+    archive_root: Path | None = None,
 ) -> None:
     if selection.index_path.resolve() != comparison.current_index.resolve():
         raise UnclassifiedCanaryDiffError("canary report selection index does not match the compared current index")
     if selection.selected_session_ids != comparison.session_ids:
         raise UnclassifiedCanaryDiffError("canary report selection sessions do not match the comparison")
-    _validate_selection_evidence(receipt, selection.selected_raw_ids)
+    _validate_selection_evidence(receipt, selection.selected_raw_ids, archive_root=archive_root)
 
 
-def _validate_selection_evidence(receipt: dict[str, object], selected_raw_ids: Iterable[str]) -> None:
+def _validate_selection_evidence(
+    receipt: dict[str, object], selected_raw_ids: Iterable[str], *, archive_root: Path | None = None
+) -> None:
     """Match report selection to the rebuild-owned candidate commitment."""
 
     from polylogue.maintenance.rebuild_index import rebuild_selection_evidence
@@ -656,9 +662,17 @@ def _validate_selection_evidence(receipt: dict[str, object], selected_raw_ids: I
     )
     if not all(isinstance(value, str) and value for value in required):
         raise UnclassifiedCanaryDiffError("canary report has incomplete authoritative rebuild selection evidence")
+    receipt_archive_root = cast(str, receipt["archive_root"])
+    evidence_root = Path(receipt_archive_root)
+    if archive_root is not None:
+        evidence_root = archive_root.resolve()
+        if Path(receipt_archive_root).resolve() != evidence_root:
+            raise UnclassifiedCanaryDiffError(
+                "canary report rebuild receipt belongs to a different configured archive root"
+            )
     expected = rebuild_selection_evidence(
         tuple(selected_raw_ids),
-        archive_root=Path(cast(str, receipt["archive_root"])),
+        archive_root=evidence_root,
         generation_id=cast(str, generation["generation_id"]),
         generation_owner_id=cast(str, generation["owner_id"]),
         candidate_index=Path(cast(str, generation["index_path"])),
@@ -701,6 +715,7 @@ def _validate_rebuild_receipt(
     *,
     selected_raw_ids: Iterable[str],
     candidate_index: Path | str,
+    configured_archive_root: Path | None = None,
 ) -> None:
     if not isinstance(receipt, dict):
         raise UnclassifiedCanaryDiffError("canary report has no rebuild receipt")
@@ -738,9 +753,16 @@ def _validate_rebuild_receipt(
         raise UnclassifiedCanaryDiffError("canary report has incomplete candidate generation provenance")
     if Path(archive_root).resolve() != Path(generation_archive_root).resolve():
         raise UnclassifiedCanaryDiffError("canary report rebuild receipt and candidate archive roots disagree")
+    if (
+        configured_archive_root is not None
+        and Path(cast(str, receipt["archive_root"])).resolve() != configured_archive_root.resolve()
+    ):
+        raise UnclassifiedCanaryDiffError(
+            "canary report rebuild receipt belongs to a different configured archive root"
+        )
     if Path(generation_index).resolve() != Path(candidate_index).resolve():
         raise UnclassifiedCanaryDiffError("canary report rebuild receipt does not identify the compared candidate")
-    _validate_selection_evidence(receipt, selected_raw_ids)
+    _validate_selection_evidence(receipt, selected_raw_ids, archive_root=configured_archive_root)
 
 
 def _validate_authoritative_rebuild_receipt(receipt: dict[str, object], candidate_index: Path) -> None:
@@ -964,6 +986,28 @@ def _validate_archive_provenance(
         raise UnclassifiedCanaryDiffError("archive-owned source evidence no longer matches the rebuild receipt")
 
 
+def _validate_report_archive_root(payload: dict[str, object], *, configured_archive_root: Path) -> Path:
+    """Bind report and receipt roots before reading any archive evidence."""
+
+    root = configured_archive_root.resolve()
+    receipt = payload.get("rebuild_receipt")
+    if not isinstance(receipt, dict):
+        raise UnclassifiedCanaryDiffError("canary report has no rebuild receipt")
+    receipt_root = receipt.get("archive_root")
+    if not isinstance(receipt_root, str) or not receipt_root:
+        raise UnclassifiedCanaryDiffError("canary report has invalid rebuild receipt archive root")
+    provenance = payload.get("archive_provenance")
+    if Path(receipt_root).resolve() != root:
+        raise UnclassifiedCanaryDiffError(
+            "canary report rebuild receipt belongs to a different configured archive root"
+        )
+    if isinstance(provenance, dict):
+        report_root = provenance.get("archive_root")
+        if isinstance(report_root, str) and report_root and Path(report_root).resolve() != root:
+            raise UnclassifiedCanaryDiffError("canary report belongs to a different configured archive root")
+    return root
+
+
 def load_canary_report(path: Path, *, archive_root: Path | None = None) -> dict[str, object]:
     """Read and structurally revalidate a durable report's review coverage."""
 
@@ -972,6 +1016,11 @@ def load_canary_report(path: Path, *, archive_root: Path | None = None) -> dict[
         raise UnclassifiedCanaryDiffError("canary report root must be an object")
     if payload.get("schema_version") != 7:
         raise UnclassifiedCanaryDiffError("canary report has no authoritative rebuild receipt schema")
+    configured_root = (
+        _validate_report_archive_root(payload, configured_archive_root=Path(archive_root))
+        if archive_root is not None
+        else None
+    )
     comparison = payload.get("comparison")
     if not isinstance(comparison, dict):
         raise UnclassifiedCanaryDiffError("canary report has no comparison object")
@@ -1005,6 +1054,7 @@ def load_canary_report(path: Path, *, archive_root: Path | None = None) -> dict[
         payload.get("rebuild_receipt"),
         selected_raw_ids=cast(list[str], selected_raw_ids),
         candidate_index=candidate_index,
+        configured_archive_root=configured_root,
     )
     selection_sessions = selection.get("selected_session_ids")
     if not isinstance(selection_sessions, list) or not all(isinstance(value, str) for value in selection_sessions):
@@ -1062,13 +1112,16 @@ def load_canary_report(path: Path, *, archive_root: Path | None = None) -> dict[
         differences=differences,
     )
     _validate_selection_binding(
-        persisted_selection, persisted_comparison, cast(dict[str, object], payload["rebuild_receipt"])
+        persisted_selection,
+        persisted_comparison,
+        cast(dict[str, object], payload["rebuild_receipt"]),
+        archive_root=configured_root,
     )
     from polylogue.config import resolve_archive_root
 
     _validate_archive_provenance(
         payload.get("archive_provenance"),
-        configured_archive_root=Path(archive_root) if archive_root is not None else resolve_archive_root(),
+        configured_archive_root=configured_root if configured_root is not None else resolve_archive_root(),
         current_index=persisted_comparison.current_index,
         candidate_index=persisted_comparison.candidate_index,
         receipt=cast(dict[str, object], payload["rebuild_receipt"]),

--- a/polylogue/storage/index_generation.py
+++ b/polylogue/storage/index_generation.py
@@ -864,7 +864,7 @@ class IndexGenerationStore:
 
 
 def source_revision_snapshot(archive_root: Path) -> str:
-    """Stable raw-evidence vector used to reject an unsafe rebuild delta."""
+    """Hash the full mutable raw-session state after a rebuild replay."""
     import hashlib
 
     digest = hashlib.sha256()
@@ -875,6 +875,43 @@ def source_revision_snapshot(archive_root: Path) -> str:
                 digest.update(encoded.encode())
                 digest.update(b"\0")
             digest.update(b"\n")
+    return digest.hexdigest()
+
+
+def rebuild_source_evidence_snapshot(archive_root: Path) -> str:
+    """Hash the immutable source evidence a rebuild is allowed to replay.
+
+    Parse, validation, and revision-governance state are rebuild outputs or
+    post-acquisition interpretation. They can legitimately change while the
+    rebuild runs, so they must never invalidate its before/after source proof.
+    The selected columns capture durable raw identity, membership, and bytes in
+    deterministic raw-id order.
+    """
+    import hashlib
+
+    digest = hashlib.sha256()
+    with closing(sqlite3.connect(f"file:{archive_root / 'source.db'}?mode=ro", uri=True)) as conn:
+        rows = conn.execute(
+            """
+            SELECT raw_id, origin, capture_mode, native_id, source_path,
+                   source_index, blob_hash, blob_size, acquired_at_ms,
+                   file_mtime_ms
+            FROM raw_sessions
+            ORDER BY raw_id
+            """
+        )
+        for row in rows:
+            for value in row:
+                if value is None:
+                    encoded = b"n"
+                elif isinstance(value, bytes):
+                    encoded = b"b" + value
+                elif isinstance(value, str):
+                    encoded = b"s" + value.encode()
+                else:
+                    encoded = b"i" + str(value).encode()
+                digest.update(len(encoded).to_bytes(8, "big"))
+                digest.update(encoded)
     return digest.hexdigest()
 
 
@@ -903,5 +940,6 @@ __all__ = [
     "RebuildLease",
     "RebuildLeaseUnavailableError",
     "rebuild_lease_status",
+    "rebuild_source_evidence_snapshot",
     "source_revision_snapshot",
 ]

--- a/polylogue/storage/index_generation.py
+++ b/polylogue/storage/index_generation.py
@@ -890,6 +890,8 @@ def rebuild_source_evidence_snapshot(archive_root: Path) -> str:
     """
     import hashlib
 
+    from polylogue.storage.blob_store import BlobStore
+
     digest = hashlib.sha256()
     with closing(sqlite3.connect(f"file:{archive_root / 'source.db'}?mode=ro", uri=True)) as conn:
         rows = conn.execute(
@@ -913,6 +915,21 @@ def rebuild_source_evidence_snapshot(archive_root: Path) -> str:
                     encoded = b"i" + str(value).encode()
                 digest.update(len(encoded).to_bytes(8, "big"))
                 digest.update(encoded)
+        raw_blob_hashes = {
+            bytes(row[0]).hex() if isinstance(row[0], (bytes, bytearray, memoryview)) else str(row[0])
+            for row in conn.execute("SELECT DISTINCT blob_hash FROM raw_sessions ORDER BY blob_hash")
+        }
+        blob_store = BlobStore(archive_root / "blob")
+        digest.update(b"raw_payload_bytes_verified\0")
+        for blob_hash in sorted(raw_blob_hashes):
+            if not blob_store.verify(blob_hash):
+                raise RuntimeError(f"raw payload blob bytes failed verification: {blob_hash}")
+            # ``BlobStore.verify`` has re-hashed the bytes at this point. Keep
+            # the verified content identity in the existing canonical digest,
+            # rather than introducing a second blob hashing implementation.
+            encoded = b"s" + blob_hash.encode()
+            digest.update(len(encoded).to_bytes(8, "big"))
+            digest.update(encoded)
         digest.update(b"raw_payload_refs\0")
         blob_refs = conn.execute(
             """

--- a/polylogue/storage/index_generation.py
+++ b/polylogue/storage/index_generation.py
@@ -884,8 +884,9 @@ def rebuild_source_evidence_snapshot(archive_root: Path) -> str:
     Parse, validation, and revision-governance state are rebuild outputs or
     post-acquisition interpretation. They can legitimately change while the
     rebuild runs, so they must never invalidate its before/after source proof.
-    The selected columns capture durable raw identity, membership, and bytes in
-    deterministic raw-id order.
+    The selected columns capture durable raw identity, membership, and bytes,
+    together with acquired raw-payload references and capture-mode observations,
+    in deterministic order.
     """
     import hashlib
 
@@ -910,6 +911,42 @@ def rebuild_source_evidence_snapshot(archive_root: Path) -> str:
                     encoded = b"s" + value.encode()
                 else:
                     encoded = b"i" + str(value).encode()
+                digest.update(len(encoded).to_bytes(8, "big"))
+                digest.update(encoded)
+        digest.update(b"raw_payload_refs\0")
+        blob_refs = conn.execute(
+            """
+            SELECT b.ref_type, b.ref_id, b.blob_hash, b.source_path,
+                   b.size_bytes, b.acquired_at_ms
+            FROM blob_refs AS b
+            JOIN raw_sessions AS r ON r.raw_id = b.ref_id
+            WHERE b.ref_type = 'raw_payload'
+            ORDER BY b.ref_id, b.blob_hash
+            """
+        )
+        for row in blob_refs:
+            for value in row:
+                if value is None:
+                    encoded = b"n"
+                elif isinstance(value, bytes):
+                    encoded = b"b" + value
+                elif isinstance(value, str):
+                    encoded = b"s" + value.encode()
+                else:
+                    encoded = b"i" + str(value).encode()
+                digest.update(len(encoded).to_bytes(8, "big"))
+                digest.update(encoded)
+        digest.update(b"raw_capture_observations\0")
+        observations = conn.execute(
+            """
+            SELECT raw_id, capture_mode, first_observed_at_ms
+            FROM raw_capture_observations
+            ORDER BY raw_id, capture_mode
+            """
+        )
+        for row in observations:
+            for value in row:
+                encoded = b"s" + value.encode() if isinstance(value, str) else b"i" + str(value).encode()
                 digest.update(len(encoded).to_bytes(8, "big"))
                 digest.update(encoded)
     return digest.hexdigest()

--- a/tests/unit/cli/test_reindex_canary_cli.py
+++ b/tests/unit/cli/test_reindex_canary_cli.py
@@ -327,7 +327,10 @@ def test_cli_rejects_swapped_real_receipt_before_comparison(tmp_path: Path, monk
     )
 
     assert consumed.exit_code == 1
-    assert "does not identify the compared candidate" in consumed.output
+    assert (
+        "does not identify the compared candidate" in consumed.output
+        or "different configured archive root" in consumed.output
+    )
     assert not comparison_called
 
 
@@ -467,6 +470,56 @@ def test_cli_consumes_valid_reviewed_real_report(tmp_path: Path, monkeypatch: py
     approved = json.loads(consumed.stdout)
     assert approved["decision"] == "evidence-approved"
     assert approved["promotion_authorized"] is False
+
+
+def test_cli_rejects_foreign_receipt_root_before_opening_foreign_source_db(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A forged report root fails before selection evidence can read a foreign source tier."""
+
+    canary_root, report_path, _payload = _write_reviewed_real_canary_report(
+        tmp_path, monkeypatch, name="foreign-root-canary"
+    )
+    foreign_root = tmp_path / "foreign-archive"
+    foreign_root.mkdir()
+    (foreign_root / "source.db").touch()
+    forged = json.loads(report_path.read_text(encoding="utf-8"))
+    receipt = forged["rebuild_receipt"]
+    provenance = forged["archive_provenance"]
+    assert isinstance(receipt, dict)
+    assert isinstance(provenance, dict)
+    generation = receipt["generation"]
+    assert isinstance(generation, dict)
+    receipt["archive_root"] = str(foreign_root)
+    generation["archive_root"] = str(foreign_root)
+    provenance["archive_root"] = str(foreign_root)
+    forged_path = tmp_path / "foreign-root-forged.json"
+    forged_path.write_text(json.dumps(forged), encoding="utf-8")
+
+    monkeypatch.setattr(
+        sqlite3,
+        "connect",
+        lambda *args, **kwargs: pytest.fail("foreign source.db was opened"),
+    )
+    consumed = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--archive-root",
+            str(canary_root),
+            "--report",
+            str(forged_path),
+            "--consume-report",
+            "--no-promote",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert consumed.exit_code == 1
+    assert "different configured archive root" in consumed.output
 
 
 def test_cli_consumes_reviewed_report_after_parsed_state_mutation(
@@ -1323,7 +1376,11 @@ def test_cli_canary_report_red_twin_rejects_arbitrary_copied_indexes(
         catch_exceptions=False,
     )
     assert consumed.exit_code == 1
-    assert "archive-owned" in consumed.output or "authoritative rebuild receipt" in consumed.output
+    assert (
+        "archive-owned" in consumed.output
+        or "authoritative rebuild receipt" in consumed.output
+        or "different configured archive root" in consumed.output
+    )
 
 
 def test_cli_canary_report_red_twin_rejects_replaced_candidate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/cli/test_reindex_canary_cli.py
+++ b/tests/unit/cli/test_reindex_canary_cli.py
@@ -20,6 +20,7 @@ from polylogue.maintenance.reindex_canary import (
     DifferenceOperation,
     RowDifference,
     UnclassifiedCanaryDiffError,
+    load_canary_report,
     run_reindex_canary,
 )
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -277,6 +278,7 @@ def test_reindex_canary_cli_persists_review_manifest_for_nonempty_differences(
     )
     review_path.write_text(json.dumps({"reviews": [review.to_dict()]}), encoding="utf-8")
     monkeypatch.setattr("polylogue.maintenance.reindex_canary.run_reindex_canary", lambda *args, **kwargs: run_result)
+    monkeypatch.setattr("polylogue.maintenance.reindex_canary.load_canary_report", lambda path: {})
 
     result = CliRunner().invoke(
         cli,
@@ -306,6 +308,55 @@ def test_reindex_canary_cli_persists_review_manifest_for_nonempty_differences(
     assert persisted["comparison"]["summary"]["expected_count"] == 1
 
 
+def test_reindex_canary_cli_rejects_manifest_with_wrong_changed_columns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Manifest coverage is exact down to the changed-column signature."""
+
+    index_path = tmp_path / "index.db"
+    index_path.touch()
+    report_path = tmp_path / "canary.json"
+    review_path = tmp_path / "reviews.json"
+    run_result = _nonempty_run_result(index_path)
+    difference = run_result.comparison.differences[0]
+    assert isinstance(difference, RowDifference)
+    review = CanaryDifferenceReview(
+        table=difference.table,
+        operation=difference.operation,
+        identity=difference.identity,
+        changed_columns=("different_column",),
+        classification=DifferenceClassification.EXPECTED,
+        reference="polylogue-review",
+        rationale="wrong signature",
+    )
+    review_path.write_text(json.dumps({"reviews": [review.to_dict()]}), encoding="utf-8")
+    monkeypatch.setattr("polylogue.maintenance.reindex_canary.run_reindex_canary", lambda *args, **kwargs: run_result)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--archive-root",
+            str(tmp_path),
+            "--input",
+            str(index_path),
+            "--report",
+            str(report_path),
+            "--review-manifest",
+            str(review_path),
+            "--no-promote",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1
+    assert "classification is incomplete" in result.output
+    assert not report_path.exists()
+
+
 def test_reindex_canary_cli_refuses_nonempty_differences_without_review_manifest(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -315,6 +366,7 @@ def test_reindex_canary_cli_refuses_nonempty_differences_without_review_manifest
         "polylogue.maintenance.reindex_canary.run_reindex_canary",
         lambda *args, **kwargs: _nonempty_run_result(index_path),
     )
+    monkeypatch.setattr("polylogue.maintenance.reindex_canary.load_canary_report", lambda path: {})
 
     result = CliRunner().invoke(
         cli,
@@ -379,6 +431,98 @@ def test_reindex_canary_cli_persists_unreviewed_real_candidate_lifecycle(
     assert persisted["comparison"]["differences"]
     assert persisted["comparison"]["candidate_index"] != persisted["comparison"]["current_index"]
     assert persisted["rebuild_receipt"]["generation"]["state"] == "inactive"
+
+    persisted["review_status"] = "reviewed"
+    persisted["comparison"]["differences"] = []
+    persisted["comparison"]["summary"] = {
+        "difference_count": 0,
+        "expected_count": 0,
+        "unexpected_count": 0,
+        "unclassified_count": 0,
+        "counts_by_table": {},
+    }
+    report_path.write_text(json.dumps(persisted), encoding="utf-8")
+
+    with pytest.raises(UnclassifiedCanaryDiffError, match="comparison attestation"):
+        load_canary_report(report_path)
+
+
+def test_reindex_canary_cli_rejects_manifest_with_mismatched_changed_columns_from_real_diff(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CLI review manifests must bind each real difference's column signature."""
+
+    live_root = tmp_path / "configured-live"
+    canary_root = tmp_path / "isolated-canary"
+    observed_report_path = tmp_path / "unreviewed.json"
+    rejected_report_path = tmp_path / "rejected.json"
+    review_path = tmp_path / "reviews.json"
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(canary_root))
+    _seed_isolated_canary(canary_root)
+    monkeypatch.setattr("polylogue.config.resolve_archive_root", lambda: live_root)
+    with sqlite3.connect(canary_root / "index.db") as connection:
+        connection.execute("UPDATE blocks SET text = 'mutated active projection'")
+
+    observed = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--input",
+            str(canary_root / "index.db"),
+            "--report",
+            str(observed_report_path),
+            "--sample",
+            "1",
+            "--no-promote",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert observed.exit_code == 1
+    observed_report = json.loads(observed_report_path.read_text(encoding="utf-8"))
+    differences = observed_report["comparison"]["differences"]
+    assert isinstance(differences, list) and differences
+    reviews = [
+        {
+            "table": difference["table"],
+            "operation": difference["operation"],
+            "identity": difference["identity"],
+            "changed_columns": difference["changed_columns"],
+            "classification": "expected",
+            "reference": "polylogue-review",
+            "rationale": "reviewed materializer change",
+        }
+        for difference in differences
+    ]
+    reviews[0]["changed_columns"] = ["forged_column"]
+    review_path.write_text(json.dumps({"reviews": reviews}), encoding="utf-8")
+
+    rejected = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--input",
+            str(canary_root / "index.db"),
+            "--report",
+            str(rejected_report_path),
+            "--review-manifest",
+            str(review_path),
+            "--sample",
+            "1",
+            "--no-promote",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert rejected.exit_code == 1
+    assert "classification is incomplete" in rejected.output
+    assert not rejected_report_path.exists()
 
 
 def test_shared_canary_runner_uses_existing_inactive_rebuild_route(

--- a/tests/unit/cli/test_reindex_canary_cli.py
+++ b/tests/unit/cli/test_reindex_canary_cli.py
@@ -128,6 +128,8 @@ def test_real_report_preserves_receipt_and_independent_source_snapshots(
     assert isinstance(provenance, dict)
     assert {
         "archive_root",
+        "receipt_schema_version",
+        "raw_sessions_state_after",
         "selected_raw_count",
         "selection_evidence",
         "status",
@@ -150,6 +152,7 @@ def test_real_report_preserves_receipt_and_independent_source_snapshots(
     assert provenance["archive_root"] == str(canary_root.resolve())
     assert provenance["candidate_generation"] == generation
     assert provenance["source_snapshot"] == generation["source_snapshot"]
+    assert provenance["raw_sessions_state_after"] == receipt["raw_sessions_state_after"]
     candidate_path = Path(str(generation["index_path"]))
     assert json.loads((candidate_path.parent / "rebuild-receipt.json").read_text(encoding="utf-8")) == receipt
     assert report_path.is_file()
@@ -401,7 +404,34 @@ def _run_result(index_path: Path, *, differences: tuple[object, ...] = ()) -> Ca
         missing_columns=(),
         differences=differences,  # type: ignore[arg-type]
     )
-    return CanaryRunResult(selection=selection, comparison=comparison, rebuild_receipt={"status": "replayed"})
+    return CanaryRunResult(
+        selection=selection,
+        comparison=comparison,
+        rebuild_receipt={
+            "receipt_schema_version": 2,
+            "archive_root": str(index_path.parent),
+            "selected_raw_count": len(selection.selected_raw_ids),
+            "status": "replayed",
+            "materialized": True,
+            "generation": {
+                "generation_id": "gen-sample",
+                "owner_id": "owner-sample",
+                "archive_root": str(index_path.parent),
+                "index_path": str(comparison.candidate_index),
+                "state": "inactive",
+                "source_snapshot": "snapshot",
+            },
+            "selection_evidence": rebuild_selection_evidence(
+                selection.selected_raw_ids,
+                archive_root=index_path.parent,
+                generation_id="gen-sample",
+                generation_owner_id="owner-sample",
+                candidate_index=comparison.candidate_index,
+                source_snapshot="snapshot",
+            ),
+            "raw_sessions_state_after": "0" * 64,
+        },
+    )
 
 
 def _nonempty_run_result(index_path: Path) -> CanaryRunResult:
@@ -420,6 +450,7 @@ def _nonempty_run_result(index_path: Path) -> CanaryRunResult:
         selection=result.selection,
         comparison=result.comparison,
         rebuild_receipt={
+            "receipt_schema_version": 2,
             "archive_root": str(index_path.parent),
             "selected_raw_count": 1,
             "status": "replayed",
@@ -440,6 +471,7 @@ def _nonempty_run_result(index_path: Path) -> CanaryRunResult:
                 candidate_index=result.comparison.candidate_index,
                 source_snapshot="snapshot",
             ),
+            "raw_sessions_state_after": "0" * 64,
         },
     )
 
@@ -893,7 +925,7 @@ def test_cli_canary_report_red_twin_rejects_replaced_candidate(tmp_path: Path, m
     assert "candidate index identity" in consumed.output
 
 
-@pytest.mark.parametrize("drift", ("active-pointer", "candidate-generation", "source-snapshot"))
+@pytest.mark.parametrize("drift", ("active-pointer", "candidate-generation", "source-snapshot", "raw-state-after"))
 def test_cli_canary_report_red_twin_rejects_lifecycle_drift(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, drift: str
 ) -> None:
@@ -912,9 +944,12 @@ def test_cli_canary_report_red_twin_rejects_lifecycle_drift(
         metadata = json.loads(candidate_metadata.read_text(encoding="utf-8"))
         metadata["owner_id"] = "replaced-owner"
         candidate_metadata.write_text(json.dumps(metadata), encoding="utf-8")
-    else:
+    elif drift == "source-snapshot":
         with sqlite3.connect(canary_root / "source.db") as connection:
             connection.execute("UPDATE raw_sessions SET acquired_at_ms = acquired_at_ms + 1")
+    else:
+        with sqlite3.connect(canary_root / "source.db") as connection:
+            connection.execute("UPDATE raw_sessions SET parsed_at_ms = parsed_at_ms + 1")
 
     consumed = CliRunner().invoke(
         cli,

--- a/tests/unit/cli/test_reindex_canary_cli.py
+++ b/tests/unit/cli/test_reindex_canary_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 import stat
 from pathlib import Path
 
@@ -8,6 +9,8 @@ import pytest
 from click.testing import CliRunner
 
 from polylogue.cli.click_app import cli
+from polylogue.core.enums import Provider
+from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
 from polylogue.maintenance.reindex_canary import (
     CanaryDifferenceReview,
     CanaryDiffReport,
@@ -19,7 +22,47 @@ from polylogue.maintenance.reindex_canary import (
     UnclassifiedCanaryDiffError,
     run_reindex_canary,
 )
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
 from tests.infra.workload_artifacts import build_seeded_archive
+
+
+def _codex_session(native_id: str) -> bytes:
+    rows = (
+        {"type": "session_meta", "payload": {"id": native_id, "timestamp": "2026-08-04T10:00:00Z"}},
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "id": f"{native_id}-user",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "hello"}],
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "id": f"{native_id}-assistant",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "world"}],
+            },
+        },
+    )
+    return b"".join(json.dumps(row, sort_keys=True).encode() + b"\n" for row in rows)
+
+
+def _seed_isolated_canary(root: Path) -> None:
+    initialize_active_archive_root(root)
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=_codex_session("isolated-canary"),
+            source_path="isolated-canary.jsonl",
+            acquired_at_ms=1,
+        )
+    receipt = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+    assert receipt.status == "replayed"
 
 
 def _run_result(index_path: Path, *, differences: tuple[object, ...] = ()) -> CanaryRunResult:
@@ -63,6 +106,8 @@ def _nonempty_run_result(index_path: Path) -> CanaryRunResult:
         rebuild_receipt={
             "archive_root": str(index_path.parent),
             "selected_raw_count": 1,
+            "selected_raw_ids": ["raw-sample"],
+            "selected_session_ids": ["codex-session:sample"],
             "status": "replayed",
             "materialized": True,
             "generation": {
@@ -209,7 +254,7 @@ def test_reindex_canary_cli_refuses_to_write_unclassified_report(
     )
 
     assert result.exit_code == 1
-    assert "require --review-manifest" in result.output
+    assert "classification is incomplete" in result.output
 
 
 def test_reindex_canary_cli_persists_review_manifest_for_nonempty_differences(
@@ -289,7 +334,51 @@ def test_reindex_canary_cli_refuses_nonempty_differences_without_review_manifest
     )
 
     assert result.exit_code == 1
-    assert "require --review-manifest" in result.output
+    assert "unreviewed canary report written" in result.output
+
+
+def test_reindex_canary_cli_persists_unreviewed_real_candidate_lifecycle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A real inactive rebuild records its observed diff before CLI refusal."""
+
+    live_root = tmp_path / "configured-live"
+    canary_root = tmp_path / "isolated-canary"
+    report_path = tmp_path / "unreviewed.json"
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(canary_root))
+    _seed_isolated_canary(canary_root)
+    monkeypatch.setattr("polylogue.config.resolve_archive_root", lambda: live_root)
+    with sqlite3.connect(canary_root / "index.db") as connection:
+        connection.execute("UPDATE blocks SET text = 'mutated active projection'")
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--input",
+            str(canary_root / "index.db"),
+            "--report",
+            str(report_path),
+            "--sample",
+            "1",
+            "--no-promote",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1
+    assert "unreviewed canary report written" in result.output
+    persisted = json.loads(report_path.read_text(encoding="utf-8"))
+    assert persisted["review_status"] == "unreviewed"
+    assert persisted["reviews"] == []
+    assert persisted["comparison"]["differences"]
+    assert persisted["comparison"]["candidate_index"] != persisted["comparison"]["current_index"]
+    assert persisted["rebuild_receipt"]["generation"]["state"] == "inactive"
 
 
 def test_shared_canary_runner_uses_existing_inactive_rebuild_route(
@@ -353,4 +442,8 @@ def test_shared_canary_runner_uses_existing_inactive_rebuild_route(
     assert request.raw_ids == selection.selected_raw_ids  # type: ignore[attr-defined]
     assert request.promote is False  # type: ignore[attr-defined]
     assert captured["compare"] == (current_index, candidate_index, selection.selected_session_ids)
-    assert result.rebuild_receipt == {"generation": Receipt.generation}
+    assert result.rebuild_receipt == {
+        "generation": Receipt.generation,
+        "selected_raw_ids": ["raw-sample"],
+        "selected_session_ids": ["codex-session:sample"],
+    }

--- a/tests/unit/cli/test_reindex_canary_cli.py
+++ b/tests/unit/cli/test_reindex_canary_cli.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import shutil
 import sqlite3
-import stat
 from pathlib import Path
 
 import pytest
@@ -28,7 +27,6 @@ from polylogue.maintenance.reindex_canary import (
 )
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
-from tests.infra.workload_artifacts import build_seeded_archive
 
 
 def _codex_session(native_id: str) -> bytes:
@@ -70,13 +68,13 @@ def _seed_isolated_canary(root: Path) -> None:
 
 
 def _write_real_unreviewed_canary_report(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, name: str = "isolated-canary"
 ) -> tuple[Path, Path, dict[str, object]]:
     """Exercise the CLI to produce a report bound to one disposable archive."""
 
     live_root = tmp_path / "configured-live"
-    canary_root = tmp_path / "isolated-canary"
-    report_path = tmp_path / "unreviewed.json"
+    canary_root = tmp_path / name
+    report_path = tmp_path / f"{name}.json"
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(canary_root))
     _seed_isolated_canary(canary_root)
     monkeypatch.setattr("polylogue.config.resolve_archive_root", lambda: live_root)
@@ -90,6 +88,8 @@ def _write_real_unreviewed_canary_report(
             "ops",
             "maintenance",
             "reindex-canary",
+            "--archive-root",
+            str(canary_root),
             "--input",
             str(canary_root / "index.db"),
             "--report",
@@ -106,6 +106,215 @@ def _write_real_unreviewed_canary_report(
     assert result.exit_code == 1
     assert "unreviewed canary report written" in result.output
     return canary_root, report_path, json.loads(report_path.read_text(encoding="utf-8"))
+
+
+def test_real_report_preserves_receipt_and_independent_source_snapshots(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    canary_root, report_path, payload = _write_real_unreviewed_canary_report(tmp_path, monkeypatch)
+    receipt = payload["rebuild_receipt"]
+    provenance = payload["archive_provenance"]
+    assert isinstance(receipt, dict)
+    assert isinstance(provenance, dict)
+    assert {
+        "archive_root",
+        "selected_raw_count",
+        "selected_raw_ids",
+        "selected_session_ids",
+        "status",
+        "materialized",
+        "generation",
+        "transaction",
+        "operation",
+    } <= receipt.keys()
+    generation = receipt["generation"]
+    assert isinstance(generation, dict)
+    assert {
+        "generation_id",
+        "owner_id",
+        "archive_root",
+        "index_path",
+        "state",
+        "source_snapshot",
+    } <= generation.keys()
+    assert generation["state"] == "inactive"
+    assert provenance["archive_root"] == str(canary_root.resolve())
+    assert provenance["candidate_generation"] == generation
+    assert provenance["source_snapshot"] == generation["source_snapshot"]
+    assert report_path.is_file()
+
+
+def test_cli_rejects_swapped_real_receipt_before_comparison(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    first_root, first_report, first_payload = _write_real_unreviewed_canary_report(
+        tmp_path, monkeypatch, name="first-canary"
+    )
+    _second_root, _second_report, second_payload = _write_real_unreviewed_canary_report(
+        tmp_path, monkeypatch, name="second-canary"
+    )
+    first_payload["rebuild_receipt"] = second_payload["rebuild_receipt"]
+    first_report.write_text(json.dumps(first_payload), encoding="utf-8")
+    comparison_called = False
+
+    def fail_if_compared(*args: object, **kwargs: object) -> object:
+        nonlocal comparison_called
+        comparison_called = True
+        raise AssertionError("swapped receipt reached the SQLite comparator")
+
+    monkeypatch.setattr(reindex_canary_module, "compare_reindex_generations", fail_if_compared)
+    consumed = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--archive-root",
+            str(first_root),
+            "--report",
+            str(first_report),
+            "--consume-report",
+            "--no-promote",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert consumed.exit_code == 1
+    assert "does not identify the compared candidate" in consumed.output
+    assert not comparison_called
+
+
+def test_cli_rejects_real_receipt_identity_forgery(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    canary_root, report_path, payload = _write_real_unreviewed_canary_report(tmp_path, monkeypatch)
+    receipt = payload["rebuild_receipt"]
+    provenance = payload["archive_provenance"]
+    assert isinstance(receipt, dict)
+    assert isinstance(provenance, dict)
+    generation = receipt["generation"]
+    assert isinstance(generation, dict)
+
+    forged_reports = {
+        "root": {"archive_provenance": {**provenance, "archive_root": str(tmp_path / "foreign-root")}},
+        "generation": {"generation": {**generation, "generation_id": "gen-forged"}},
+        "owner": {"generation": {**generation, "owner_id": "owner-forged"}},
+        "candidate-path": {"generation": {**generation, "index_path": str(tmp_path / "foreign.db")}},
+        "state": {"generation": {**generation, "state": "active"}},
+    }
+    for name, changes in forged_reports.items():
+        forged = json.loads(json.dumps(payload))
+        assert isinstance(forged, dict)
+        forged_receipt = forged["rebuild_receipt"]
+        forged_provenance = forged["archive_provenance"]
+        assert isinstance(forged_receipt, dict)
+        assert isinstance(forged_provenance, dict)
+        archive_change = changes.get("archive_provenance")
+        if isinstance(archive_change, dict):
+            forged_provenance.update(archive_change)
+        else:
+            forged_generation = changes["generation"]
+            assert isinstance(forged_generation, dict)
+            forged_receipt["generation"] = forged_generation
+        forged_path = tmp_path / f"forged-{name}.json"
+        forged_path.write_text(json.dumps(forged), encoding="utf-8")
+        consumed = CliRunner().invoke(
+            cli,
+            [
+                "--plain",
+                "ops",
+                "maintenance",
+                "reindex-canary",
+                "--archive-root",
+                str(canary_root),
+                "--report",
+                str(forged_path),
+                "--consume-report",
+                "--no-promote",
+            ],
+            catch_exceptions=False,
+        )
+        assert consumed.exit_code == 1, name
+        assert (
+            "archive-owned" in consumed.output
+            or "rebuild receipt" in consumed.output
+            or "canary report belongs" in consumed.output
+            or "candidate generation provenance" in consumed.output
+        ), (
+            name,
+            consumed.output,
+        )
+
+
+def test_cli_consumes_valid_reviewed_real_report(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    canary_root, _observed_path, observed = _write_real_unreviewed_canary_report(
+        tmp_path, monkeypatch, name="valid-canary"
+    )
+    differences = observed["comparison"]["differences"]
+    assert isinstance(differences, list) and differences
+    review_path = tmp_path / "valid-reviews.json"
+    review_path.write_text(
+        json.dumps(
+            {
+                "reviews": [
+                    {
+                        "table": difference["table"],
+                        "operation": difference["operation"],
+                        "identity": difference["identity"],
+                        "changed_columns": difference["changed_columns"],
+                        "classification": "expected",
+                        "reference": "polylogue-review",
+                        "rationale": "reviewed real canary difference",
+                    }
+                    for difference in differences
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    approved_path = tmp_path / "approved.json"
+    generated = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--archive-root",
+            str(canary_root),
+            "--input",
+            str(canary_root / "index.db"),
+            "--report",
+            str(approved_path),
+            "--review-manifest",
+            str(review_path),
+            "--sample",
+            "1",
+            "--no-promote",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+    assert generated.exit_code == 0, generated.output
+
+    consumed = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--archive-root",
+            str(canary_root),
+            "--report",
+            str(approved_path),
+            "--consume-report",
+            "--no-promote",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+    assert consumed.exit_code == 0, consumed.output
+    assert json.loads(consumed.stdout)["decision"] == "approved"
 
 
 def _run_result(index_path: Path, *, differences: tuple[object, ...] = ()) -> CanaryRunResult:
@@ -232,9 +441,10 @@ def test_reindex_canary_cli_runs_real_no_promote_route(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    archive_root = build_seeded_archive(cache_root=tmp_path / "cache").root
-    for path in (archive_root, *archive_root.rglob("*")):
-        path.chmod(path.stat().st_mode | stat.S_IWUSR)
+    archive_root = tmp_path / "isolated-canary"
+    _seed_isolated_canary(archive_root)
+    with sqlite3.connect(archive_root / "index.db") as connection:
+        connection.execute("UPDATE blocks SET text = 'mutated active projection'")
     index_path = archive_root / "index.db"
     report_path = tmp_path / "reports" / "canary.json"
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path / "configured-live-root"))
@@ -262,9 +472,12 @@ def test_reindex_canary_cli_runs_real_no_promote_route(
     )
 
     assert result.exit_code == 1, result.output
-    assert "canary report classification is incomplete" in result.output
+    assert "unreviewed canary report written" in result.output
     assert "refuses the configured live archive root" not in result.output
-    assert not report_path.exists()
+    assert report_path.exists()
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    assert payload["review_status"] == "unreviewed"
+    assert payload["rebuild_receipt"]["generation"]["state"] == "inactive"
 
 
 def test_reindex_canary_cli_refuses_to_write_unclassified_report(
@@ -335,7 +548,8 @@ def test_reindex_canary_cli_persists_review_manifest_for_nonempty_differences(
 
     review_path.write_text(json.dumps({"reviews": [review.to_dict()]}), encoding="utf-8")
     monkeypatch.setattr("polylogue.maintenance.reindex_canary.run_reindex_canary", lambda *args, **kwargs: run_result)
-    monkeypatch.setattr("polylogue.maintenance.reindex_canary.load_canary_report", lambda path: {})
+    monkeypatch.setattr("polylogue.maintenance.reindex_canary.write_canary_report", fake_write)
+    monkeypatch.setattr("polylogue.maintenance.reindex_canary.load_canary_report", lambda path, **kwargs: {})
 
     result = CliRunner().invoke(
         cli,
@@ -419,11 +633,24 @@ def test_reindex_canary_cli_refuses_nonempty_differences_without_review_manifest
     index_path = tmp_path / "index.db"
     index_path.touch()
     run_result = _nonempty_run_result(index_path)
+
+    def fake_write(path: Path, **kwargs: object) -> DurableCanaryReport:
+        return DurableCanaryReport(
+            selection=run_result.selection,
+            comparison=run_result.comparison,
+            rebuild_receipt=run_result.rebuild_receipt,
+            reviews=(),
+            review_status="unreviewed",
+            comparison_fingerprint="0" * 64,
+            archive_provenance={},
+        )
+
     monkeypatch.setattr(
         "polylogue.maintenance.reindex_canary.run_reindex_canary",
         lambda *args, **kwargs: run_result,
     )
-    monkeypatch.setattr("polylogue.maintenance.reindex_canary.load_canary_report", lambda path: {})
+    monkeypatch.setattr("polylogue.maintenance.reindex_canary.write_canary_report", fake_write)
+    monkeypatch.setattr("polylogue.maintenance.reindex_canary.load_canary_report", lambda path, **kwargs: {})
 
     result = CliRunner().invoke(
         cli,
@@ -467,6 +694,8 @@ def test_reindex_canary_cli_persists_unreviewed_real_candidate_lifecycle(
             "ops",
             "maintenance",
             "reindex-canary",
+            "--archive-root",
+            str(canary_root),
             "--input",
             str(canary_root / "index.db"),
             "--report",
@@ -501,7 +730,7 @@ def test_reindex_canary_cli_persists_unreviewed_real_candidate_lifecycle(
     report_path.write_text(json.dumps(persisted), encoding="utf-8")
 
     with pytest.raises(UnclassifiedCanaryDiffError, match="comparison attestation"):
-        load_canary_report(report_path)
+        load_canary_report(report_path, archive_root=canary_root)
 
 
 def test_cli_canary_report_red_twin_rejects_arbitrary_copied_indexes(
@@ -543,8 +772,24 @@ def test_cli_canary_report_red_twin_rejects_arbitrary_copied_indexes(
     )
     report_path.write_text(json.dumps(payload), encoding="utf-8")
 
-    with pytest.raises(UnclassifiedCanaryDiffError, match="archive-owned"):
-        load_canary_report(report_path)
+    consumed = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--archive-root",
+            str(canary_root),
+            "--report",
+            str(report_path),
+            "--consume-report",
+            "--no-promote",
+        ],
+        catch_exceptions=False,
+    )
+    assert consumed.exit_code == 1
+    assert "archive-owned" in consumed.output
 
 
 def test_cli_canary_report_red_twin_rejects_replaced_candidate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -558,8 +803,24 @@ def test_cli_canary_report_red_twin_rejects_replaced_candidate(tmp_path: Path, m
     shutil.copy2(candidate, replacement)
     replacement.replace(candidate)
 
-    with pytest.raises(UnclassifiedCanaryDiffError, match="candidate index identity"):
-        load_canary_report(report_path)
+    consumed = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--archive-root",
+            str(_canary_root),
+            "--report",
+            str(report_path),
+            "--consume-report",
+            "--no-promote",
+        ],
+        catch_exceptions=False,
+    )
+    assert consumed.exit_code == 1
+    assert "candidate index identity" in consumed.output
 
 
 @pytest.mark.parametrize("drift", ("active-pointer", "candidate-generation", "source-snapshot"))
@@ -585,8 +846,24 @@ def test_cli_canary_report_red_twin_rejects_lifecycle_drift(
         with sqlite3.connect(canary_root / "source.db") as connection:
             connection.execute("UPDATE raw_sessions SET acquired_at_ms = acquired_at_ms + 1")
 
-    with pytest.raises(UnclassifiedCanaryDiffError, match="archive-owned"):
-        load_canary_report(report_path)
+    consumed = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--archive-root",
+            str(canary_root),
+            "--report",
+            str(report_path),
+            "--consume-report",
+            "--no-promote",
+        ],
+        catch_exceptions=False,
+    )
+    assert consumed.exit_code == 1
+    assert "archive-owned" in consumed.output
 
 
 def test_reindex_canary_cli_rejects_manifest_with_mismatched_changed_columns_from_real_diff(
@@ -612,6 +889,8 @@ def test_reindex_canary_cli_rejects_manifest_with_mismatched_changed_columns_fro
             "ops",
             "maintenance",
             "reindex-canary",
+            "--archive-root",
+            str(canary_root),
             "--input",
             str(canary_root / "index.db"),
             "--report",
@@ -649,6 +928,8 @@ def test_reindex_canary_cli_rejects_manifest_with_mismatched_changed_columns_fro
             "ops",
             "maintenance",
             "reindex-canary",
+            "--archive-root",
+            str(canary_root),
             "--input",
             str(canary_root / "index.db"),
             "--report",

--- a/tests/unit/cli/test_reindex_canary_cli.py
+++ b/tests/unit/cli/test_reindex_canary_cli.py
@@ -129,7 +129,7 @@ def test_real_report_preserves_receipt_and_independent_source_snapshots(
     assert {
         "archive_root",
         "receipt_schema_version",
-        "raw_sessions_state_after",
+        "source_evidence_after",
         "selected_raw_count",
         "selection_evidence",
         "status",
@@ -152,7 +152,7 @@ def test_real_report_preserves_receipt_and_independent_source_snapshots(
     assert provenance["archive_root"] == str(canary_root.resolve())
     assert provenance["candidate_generation"] == generation
     assert provenance["source_snapshot"] == generation["source_snapshot"]
-    assert provenance["raw_sessions_state_after"] == receipt["raw_sessions_state_after"]
+    assert provenance["source_evidence_after"] == receipt["source_evidence_after"]
     candidate_path = Path(str(generation["index_path"]))
     assert json.loads((candidate_path.parent / "rebuild-receipt.json").read_text(encoding="utf-8")) == receipt
     assert report_path.is_file()
@@ -384,6 +384,90 @@ def test_cli_consumes_valid_reviewed_real_report(tmp_path: Path, monkeypatch: py
     assert approved["promotion_authorized"] is False
 
 
+def test_cli_consumes_reviewed_report_after_parsed_state_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Parser bookkeeping may evolve after replay without changing source evidence."""
+
+    canary_root, _observed_path, observed = _write_real_unreviewed_canary_report(
+        tmp_path, monkeypatch, name="parsed-state-canary"
+    )
+    comparison = observed["comparison"]
+    assert isinstance(comparison, dict)
+    differences = comparison["differences"]
+    assert isinstance(differences, list) and differences
+    review_path = tmp_path / "parsed-state-reviews.json"
+    review_path.write_text(
+        json.dumps(
+            {
+                "reviews": [
+                    {
+                        "table": difference["table"],
+                        "operation": difference["operation"],
+                        "identity": difference["identity"],
+                        "changed_columns": difference["changed_columns"],
+                        "classification": "expected",
+                        "reference": "polylogue-review",
+                        "rationale": "reviewed real canary difference",
+                    }
+                    for difference in differences
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    approved_path = tmp_path / "parsed-state-approved.json"
+    generated = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--archive-root",
+            str(canary_root),
+            "--input",
+            str(canary_root / "index.db"),
+            "--report",
+            str(approved_path),
+            "--review-manifest",
+            str(review_path),
+            "--sample",
+            "1",
+            "--no-promote",
+        ],
+        catch_exceptions=False,
+    )
+    assert generated.exit_code == 0, generated.output
+
+    with sqlite3.connect(canary_root / "source.db") as connection:
+        connection.execute("UPDATE raw_sessions SET parsed_at_ms = COALESCE(parsed_at_ms, 0) + 1")
+
+    consumed = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--archive-root",
+            str(canary_root),
+            "--report",
+            str(approved_path),
+            "--consume-report",
+            "--no-promote",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert consumed.exit_code == 0, consumed.output
+    approved = json.loads(consumed.stdout)
+    assert approved["decision"] == "evidence-approved"
+    assert approved["promotion_authorized"] is False
+
+
 def _run_result(index_path: Path, *, differences: tuple[object, ...] = ()) -> CanaryRunResult:
     selection = CanarySelection(
         index_path=index_path,
@@ -408,7 +492,7 @@ def _run_result(index_path: Path, *, differences: tuple[object, ...] = ()) -> Ca
         selection=selection,
         comparison=comparison,
         rebuild_receipt={
-            "receipt_schema_version": 2,
+            "receipt_schema_version": 3,
             "archive_root": str(index_path.parent),
             "selected_raw_count": len(selection.selected_raw_ids),
             "status": "replayed",
@@ -429,7 +513,7 @@ def _run_result(index_path: Path, *, differences: tuple[object, ...] = ()) -> Ca
                 candidate_index=comparison.candidate_index,
                 source_snapshot="snapshot",
             ),
-            "raw_sessions_state_after": "0" * 64,
+            "source_evidence_after": "0" * 64,
         },
     )
 
@@ -450,7 +534,7 @@ def _nonempty_run_result(index_path: Path) -> CanaryRunResult:
         selection=result.selection,
         comparison=result.comparison,
         rebuild_receipt={
-            "receipt_schema_version": 2,
+            "receipt_schema_version": 3,
             "archive_root": str(index_path.parent),
             "selected_raw_count": 1,
             "status": "replayed",
@@ -471,7 +555,7 @@ def _nonempty_run_result(index_path: Path) -> CanaryRunResult:
                 candidate_index=result.comparison.candidate_index,
                 source_snapshot="snapshot",
             ),
-            "raw_sessions_state_after": "0" * 64,
+            "source_evidence_after": "0" * 64,
         },
     )
 
@@ -925,7 +1009,17 @@ def test_cli_canary_report_red_twin_rejects_replaced_candidate(tmp_path: Path, m
     assert "candidate index identity" in consumed.output
 
 
-@pytest.mark.parametrize("drift", ("active-pointer", "candidate-generation", "source-snapshot", "raw-state-after"))
+@pytest.mark.parametrize(
+    "drift",
+    (
+        "active-pointer",
+        "candidate-generation",
+        "source-byte",
+        "source-blob-ref",
+        "source-observation",
+        "source-snapshot",
+    ),
+)
 def test_cli_canary_report_red_twin_rejects_lifecycle_drift(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, drift: str
 ) -> None:
@@ -944,12 +1038,33 @@ def test_cli_canary_report_red_twin_rejects_lifecycle_drift(
         metadata = json.loads(candidate_metadata.read_text(encoding="utf-8"))
         metadata["owner_id"] = "replaced-owner"
         candidate_metadata.write_text(json.dumps(metadata), encoding="utf-8")
-    elif drift == "source-snapshot":
+    elif drift == "source-byte":
         with sqlite3.connect(canary_root / "source.db") as connection:
-            connection.execute("UPDATE raw_sessions SET acquired_at_ms = acquired_at_ms + 1")
+            connection.execute("UPDATE raw_sessions SET blob_hash = zeroblob(length(blob_hash))")
+    elif drift == "source-blob-ref":
+        with sqlite3.connect(canary_root / "source.db") as connection:
+            raw_id = connection.execute("SELECT raw_id FROM raw_sessions ORDER BY raw_id LIMIT 1").fetchone()[0]
+            connection.execute(
+                """
+                UPDATE blob_refs
+                SET acquired_at_ms = acquired_at_ms + 1
+                WHERE ref_type = 'raw_payload' AND ref_id = ?
+                """,
+                (raw_id,),
+            )
+    elif drift == "source-observation":
+        with sqlite3.connect(canary_root / "source.db") as connection:
+            raw_id = connection.execute("SELECT raw_id FROM raw_sessions ORDER BY raw_id LIMIT 1").fetchone()[0]
+            connection.execute(
+                """
+                INSERT INTO raw_capture_observations (raw_id, capture_mode, first_observed_at_ms)
+                VALUES (?, 'gemini', 999)
+                """,
+                (raw_id,),
+            )
     else:
         with sqlite3.connect(canary_root / "source.db") as connection:
-            connection.execute("UPDATE raw_sessions SET parsed_at_ms = parsed_at_ms + 1")
+            connection.execute("UPDATE raw_sessions SET acquired_at_ms = acquired_at_ms + 1")
 
     consumed = CliRunner().invoke(
         cli,

--- a/tests/unit/cli/test_reindex_canary_cli.py
+++ b/tests/unit/cli/test_reindex_canary_cli.py
@@ -247,7 +247,9 @@ def test_cli_consumes_valid_reviewed_real_report(tmp_path: Path, monkeypatch: py
     canary_root, _observed_path, observed = _write_real_unreviewed_canary_report(
         tmp_path, monkeypatch, name="valid-canary"
     )
-    differences = observed["comparison"]["differences"]
+    comparison = observed["comparison"]
+    assert isinstance(comparison, dict)
+    differences = comparison["differences"]
     assert isinstance(differences, list) and differences
     review_path = tmp_path / "valid-reviews.json"
     review_path.write_text(

--- a/tests/unit/cli/test_reindex_canary_cli.py
+++ b/tests/unit/cli/test_reindex_canary_cli.py
@@ -29,6 +29,8 @@ from polylogue.maintenance.reindex_canary import (
     load_canary_report,
     run_reindex_canary,
 )
+from polylogue.storage.archive_identity import ArchiveLocation
+from polylogue.storage.index_generation import IndexGenerationStore, RebuildLease
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
 
@@ -58,7 +60,12 @@ def _codex_session(native_id: str) -> bytes:
     return b"".join(json.dumps(row, sort_keys=True).encode() + b"\n" for row in rows)
 
 
-def _seed_isolated_canary(root: Path, *, session_names: tuple[str, ...] = ("isolated-canary",)) -> None:
+def _seed_isolated_canary(
+    root: Path,
+    *,
+    session_names: tuple[str, ...] = ("isolated-canary",),
+    membership_names: tuple[str, ...] = (),
+) -> None:
     initialize_active_archive_root(root)
     with ArchiveStore.open_existing(root, read_only=False) as archive:
         for acquired_at_ms, name in enumerate(session_names, start=1):
@@ -68,6 +75,24 @@ def _seed_isolated_canary(root: Path, *, session_names: tuple[str, ...] = ("isol
                 source_path=f"{name}.jsonl",
                 acquired_at_ms=acquired_at_ms,
             )
+    if membership_names:
+        with sqlite3.connect(root / "source.db") as connection:
+            for name in membership_names:
+                raw_id, blob_hash = connection.execute(
+                    "SELECT raw_id, blob_hash FROM raw_sessions WHERE source_path = ?",
+                    (f"{name}.jsonl",),
+                ).fetchone()
+                connection.execute(
+                    """
+                    INSERT INTO raw_session_memberships(
+                        raw_id, logical_source_key, provider_session_id, source_revision,
+                        normalized_content_hash, message_count, predecessor_raw_id,
+                        acquisition_generation, revision_authority, decision, decided_at_ms
+                    ) VALUES (?, ?, ?, ?, ?, ?, NULL, 0, 'quarantined', NULL, NULL)
+                    """,
+                    (raw_id, f"codex-session:{name}", name, "1", blob_hash, 2),
+                )
+            connection.commit()
     receipt = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
     assert receipt.status == "replayed"
 
@@ -116,6 +141,66 @@ def _write_real_unreviewed_canary_report(
     assert result.exit_code == 1
     assert "unreviewed canary report written" in result.output
     return canary_root, report_path, json.loads(report_path.read_text(encoding="utf-8"))
+
+
+def _write_reviewed_real_canary_report(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    name: str,
+    session_names: tuple[str, ...] = ("isolated-canary",),
+) -> tuple[Path, Path, dict[str, object]]:
+    canary_root, _observed_path, observed = _write_real_unreviewed_canary_report(
+        tmp_path, monkeypatch, name=name, session_names=session_names
+    )
+    comparison = observed["comparison"]
+    assert isinstance(comparison, dict)
+    differences = comparison["differences"]
+    assert isinstance(differences, list) and differences
+    review_path = tmp_path / f"{name}-reviews.json"
+    review_path.write_text(
+        json.dumps(
+            {
+                "reviews": [
+                    {
+                        "table": difference["table"],
+                        "operation": difference["operation"],
+                        "identity": difference["identity"],
+                        "changed_columns": difference["changed_columns"],
+                        "classification": "expected",
+                        "reference": "polylogue-review",
+                        "rationale": "reviewed real canary difference",
+                    }
+                    for difference in differences
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    approved_path = tmp_path / f"{name}-approved.json"
+    generated = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--archive-root",
+            str(canary_root),
+            "--input",
+            str(canary_root / "index.db"),
+            "--report",
+            str(approved_path),
+            "--review-manifest",
+            str(review_path),
+            "--sample",
+            "1",
+            "--no-promote",
+        ],
+        catch_exceptions=False,
+    )
+    assert generated.exit_code == 0, generated.output
+    return canary_root, approved_path, json.loads(approved_path.read_text(encoding="utf-8"))
 
 
 def test_real_report_preserves_receipt_and_independent_source_snapshots(
@@ -468,6 +553,269 @@ def test_cli_consumes_reviewed_report_after_parsed_state_mutation(
     assert approved["promotion_authorized"] is False
 
 
+def test_cli_rejects_membership_and_logical_key_expansion_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A new durable cohort member invalidates the original replay closure."""
+
+    canary_root = tmp_path / "closure-drift-canary"
+    report_path = tmp_path / "closure-drift-canary.json"
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(canary_root))
+    _seed_isolated_canary(
+        canary_root,
+        session_names=("selected", "unselected"),
+        membership_names=("selected",),
+    )
+    monkeypatch.setattr("polylogue.config.resolve_archive_root", lambda: tmp_path / "configured-live")
+    with sqlite3.connect(canary_root / "index.db") as connection:
+        connection.execute("UPDATE blocks SET text = 'mutated active projection'")
+    generated = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--archive-root",
+            str(canary_root),
+            "--input",
+            str(canary_root / "index.db"),
+            "--report",
+            str(report_path),
+            "--sample",
+            "1",
+            "--no-promote",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+    assert generated.exit_code == 1, generated.output
+    assert "unreviewed canary report written" in generated.output
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    selection = payload["selection"]
+    assert isinstance(selection, dict)
+    selected_raw_ids = selection["selected_raw_ids"]
+    assert isinstance(selected_raw_ids, list) and len(selected_raw_ids) == 1
+    with sqlite3.connect(canary_root / "source.db") as connection:
+        raw_ids = [str(row[0]) for row in connection.execute("SELECT raw_id FROM raw_sessions ORDER BY raw_id")]
+        selected_raw_id = str(selected_raw_ids[0])
+        unselected_raw_id = next(raw_id for raw_id in raw_ids if raw_id != selected_raw_id)
+        membership = connection.execute(
+            """
+            SELECT logical_source_key, provider_session_id, source_revision,
+                   normalized_content_hash, message_count, predecessor_raw_id,
+                   acquisition_generation, revision_authority, decision, decided_at_ms
+            FROM raw_session_memberships WHERE raw_id = ?
+            """,
+            (selected_raw_id,),
+        ).fetchone()
+        assert membership is not None
+        connection.execute(
+            """
+            INSERT INTO raw_session_memberships(
+                raw_id, logical_source_key, provider_session_id, source_revision,
+                normalized_content_hash, message_count, predecessor_raw_id,
+                acquisition_generation, revision_authority, decision, decided_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'quarantined', NULL, NULL)
+            """,
+            (unselected_raw_id, *membership[:7]),
+        )
+        connection.commit()
+
+    consumed = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--archive-root",
+            str(canary_root),
+            "--report",
+            str(report_path),
+            "--consume-report",
+            "--no-promote",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert consumed.exit_code == 1
+    assert "selection does not match the authoritative rebuild receipt" in consumed.output
+
+
+def test_cli_rejects_tampered_raw_payload_bytes_during_approval(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A live raw blob must still hash correctly when a reviewed report is consumed."""
+
+    canary_root, report_path, payload = _write_reviewed_real_canary_report(
+        tmp_path, monkeypatch, name="tampered-blob-canary"
+    )
+    selection = payload["selection"]
+    assert isinstance(selection, dict)
+    selected_raw_ids = selection["selected_raw_ids"]
+    assert isinstance(selected_raw_ids, list) and selected_raw_ids
+    with sqlite3.connect(canary_root / "source.db") as connection:
+        blob_hash = connection.execute(
+            "SELECT lower(hex(blob_hash)) FROM raw_sessions WHERE raw_id = ?", (selected_raw_ids[0],)
+        ).fetchone()[0]
+    blob_path = canary_root / "blob" / str(blob_hash)[:2] / str(blob_hash)[2:]
+    blob_path.write_bytes(b"tampered raw payload bytes")
+
+    consumed = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--archive-root",
+            str(canary_root),
+            "--report",
+            str(report_path),
+            "--consume-report",
+            "--no-promote",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert consumed.exit_code == 1
+    assert "blob bytes failed verification" in consumed.output
+
+
+def test_cli_rejects_source_mutation_between_approval_checks_and_preserves_active_index(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Approval revalidates source evidence after its initial report check."""
+
+    canary_root, report_path, payload = _write_reviewed_real_canary_report(
+        tmp_path, monkeypatch, name="approval-mutation-canary"
+    )
+    active_before = (canary_root / "index.db").read_bytes()
+    real_load = reindex_canary_module.load_canary_report
+    calls = 0
+
+    def mutate_after_initial_check(path: Path, *, archive_root: Path | None = None) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        result = real_load(path, archive_root=archive_root)
+        if calls == 1:
+            selection = payload["selection"]
+            assert isinstance(selection, dict)
+            selected_raw_ids = selection["selected_raw_ids"]
+            assert isinstance(selected_raw_ids, list) and selected_raw_ids
+            with sqlite3.connect(canary_root / "source.db") as connection:
+                connection.execute(
+                    "UPDATE raw_sessions SET source_index = source_index + 1 WHERE raw_id = ?",
+                    (selected_raw_ids[0],),
+                )
+                connection.commit()
+        return result
+
+    monkeypatch.setattr(reindex_canary_module, "load_canary_report", mutate_after_initial_check)
+    consumed = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--archive-root",
+            str(canary_root),
+            "--report",
+            str(report_path),
+            "--consume-report",
+            "--no-promote",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert consumed.exit_code == 1
+    assert calls == 2
+    assert (canary_root / "index.db").read_bytes() == active_before
+
+
+def test_cli_rejects_candidate_promotion_between_approval_checks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A candidate promoted after the first check cannot receive approval."""
+
+    canary_root, report_path, payload = _write_reviewed_real_canary_report(
+        tmp_path, monkeypatch, name="approval-promotion-canary"
+    )
+    real_load = reindex_canary_module.load_canary_report
+    promoted = False
+
+    def promote_after_initial_check(path: Path, *, archive_root: Path | None = None) -> dict[str, object]:
+        nonlocal promoted
+        result = real_load(path, archive_root=archive_root)
+        if not promoted:
+            receipt = payload["rebuild_receipt"]
+            assert isinstance(receipt, dict)
+            generation = receipt["generation"]
+            assert isinstance(generation, dict)
+            location = ArchiveLocation.resolve(canary_root)
+            store = IndexGenerationStore(location)
+            store.promote(store.load(str(generation["generation_id"])))
+            promoted = True
+        return result
+
+    monkeypatch.setattr(reindex_canary_module, "load_canary_report", promote_after_initial_check)
+    consumed = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--archive-root",
+            str(canary_root),
+            "--report",
+            str(report_path),
+            "--consume-report",
+            "--no-promote",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert consumed.exit_code == 1
+    assert promoted is True
+    assert (
+        "candidate generation" in consumed.output
+        or "active pointer" in consumed.output
+        or "stale for the current active generation" in consumed.output
+    )
+
+
+def test_cli_consumption_obeys_rebuild_lease(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Report consumption cannot race an active rebuild owner."""
+
+    canary_root, report_path, _payload = _write_reviewed_real_canary_report(
+        tmp_path, monkeypatch, name="approval-lock-canary"
+    )
+    with RebuildLease(canary_root):
+        consumed = CliRunner().invoke(
+            cli,
+            [
+                "--plain",
+                "ops",
+                "maintenance",
+                "reindex-canary",
+                "--archive-root",
+                str(canary_root),
+                "--report",
+                str(report_path),
+                "--consume-report",
+                "--no-promote",
+            ],
+            catch_exceptions=False,
+        )
+
+    assert consumed.exit_code == 1
+    assert "rebuild lease" in consumed.output or "already held" in consumed.output
+
+
 def _run_result(index_path: Path, *, differences: tuple[object, ...] = ()) -> CanaryRunResult:
     selection = CanarySelection(
         index_path=index_path,
@@ -492,7 +840,7 @@ def _run_result(index_path: Path, *, differences: tuple[object, ...] = ()) -> Ca
         selection=selection,
         comparison=comparison,
         rebuild_receipt={
-            "receipt_schema_version": 3,
+            "receipt_schema_version": 4,
             "archive_root": str(index_path.parent),
             "selected_raw_count": len(selection.selected_raw_ids),
             "status": "replayed",
@@ -534,7 +882,7 @@ def _nonempty_run_result(index_path: Path) -> CanaryRunResult:
         selection=result.selection,
         comparison=result.comparison,
         rebuild_receipt={
-            "receipt_schema_version": 3,
+            "receipt_schema_version": 4,
             "archive_root": str(index_path.parent),
             "selected_raw_count": 1,
             "status": "replayed",

--- a/tests/unit/cli/test_reindex_canary_cli.py
+++ b/tests/unit/cli/test_reindex_canary_cli.py
@@ -11,7 +11,11 @@ from click.testing import CliRunner
 from polylogue.cli.click_app import cli
 from polylogue.core.enums import Provider
 from polylogue.maintenance import reindex_canary as reindex_canary_module
-from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
+from polylogue.maintenance.rebuild_index import (
+    RebuildIndexRequest,
+    rebuild_index_from_source_sync,
+    rebuild_selection_evidence,
+)
 from polylogue.maintenance.reindex_canary import (
     CanaryDifferenceReview,
     CanaryDiffReport,
@@ -54,21 +58,27 @@ def _codex_session(native_id: str) -> bytes:
     return b"".join(json.dumps(row, sort_keys=True).encode() + b"\n" for row in rows)
 
 
-def _seed_isolated_canary(root: Path) -> None:
+def _seed_isolated_canary(root: Path, *, session_names: tuple[str, ...] = ("isolated-canary",)) -> None:
     initialize_active_archive_root(root)
     with ArchiveStore.open_existing(root, read_only=False) as archive:
-        archive.write_raw_payload(
-            provider=Provider.CODEX,
-            payload=_codex_session("isolated-canary"),
-            source_path="isolated-canary.jsonl",
-            acquired_at_ms=1,
-        )
+        for acquired_at_ms, name in enumerate(session_names, start=1):
+            archive.write_raw_payload(
+                provider=Provider.CODEX,
+                payload=_codex_session(name),
+                source_path=f"{name}.jsonl",
+                acquired_at_ms=acquired_at_ms,
+            )
     receipt = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
     assert receipt.status == "replayed"
 
 
 def _write_real_unreviewed_canary_report(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, name: str = "isolated-canary"
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    name: str = "isolated-canary",
+    session_names: tuple[str, ...] = ("isolated-canary",),
+    sample: int = 1,
 ) -> tuple[Path, Path, dict[str, object]]:
     """Exercise the CLI to produce a report bound to one disposable archive."""
 
@@ -76,7 +86,7 @@ def _write_real_unreviewed_canary_report(
     canary_root = tmp_path / name
     report_path = tmp_path / f"{name}.json"
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(canary_root))
-    _seed_isolated_canary(canary_root)
+    _seed_isolated_canary(canary_root, session_names=session_names)
     monkeypatch.setattr("polylogue.config.resolve_archive_root", lambda: live_root)
     with sqlite3.connect(canary_root / "index.db") as connection:
         connection.execute("UPDATE blocks SET text = 'mutated active projection'")
@@ -95,7 +105,7 @@ def _write_real_unreviewed_canary_report(
             "--report",
             str(report_path),
             "--sample",
-            "1",
+            str(sample),
             "--no-promote",
             "--output-format",
             "json",
@@ -119,8 +129,7 @@ def test_real_report_preserves_receipt_and_independent_source_snapshots(
     assert {
         "archive_root",
         "selected_raw_count",
-        "selected_raw_ids",
-        "selected_session_ids",
+        "selection_evidence",
         "status",
         "materialized",
         "generation",
@@ -141,7 +150,58 @@ def test_real_report_preserves_receipt_and_independent_source_snapshots(
     assert provenance["archive_root"] == str(canary_root.resolve())
     assert provenance["candidate_generation"] == generation
     assert provenance["source_snapshot"] == generation["source_snapshot"]
+    candidate_path = Path(str(generation["index_path"]))
+    assert json.loads((candidate_path.parent / "rebuild-receipt.json").read_text(encoding="utf-8")) == receipt
     assert report_path.is_file()
+
+
+def test_cli_rejects_same_count_selected_raw_id_swap_before_comparison(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    canary_root, report_path, payload = _write_real_unreviewed_canary_report(
+        tmp_path,
+        monkeypatch,
+        name="selection-swap",
+        session_names=("first", "second", "third"),
+        sample=2,
+    )
+    selection = payload["selection"]
+    assert isinstance(selection, dict)
+    selected_raw_ids = selection["selected_raw_ids"]
+    assert isinstance(selected_raw_ids, list) and len(selected_raw_ids) == 2
+    with sqlite3.connect(canary_root / "source.db") as connection:
+        source_raw_ids = [str(row[0]) for row in connection.execute("SELECT raw_id FROM raw_sessions")]
+    replacement = next(raw_id for raw_id in source_raw_ids if raw_id not in selected_raw_ids)
+    selection["selected_raw_ids"] = [selected_raw_ids[0], replacement]
+    report_path.write_text(json.dumps(payload), encoding="utf-8")
+    comparison_called = False
+
+    def fail_if_compared(*args: object, **kwargs: object) -> object:
+        nonlocal comparison_called
+        comparison_called = True
+        raise AssertionError("selection swap reached the SQLite comparator")
+
+    monkeypatch.setattr(reindex_canary_module, "compare_reindex_generations", fail_if_compared)
+    consumed = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--archive-root",
+            str(canary_root),
+            "--report",
+            str(report_path),
+            "--consume-report",
+            "--no-promote",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert consumed.exit_code == 1
+    assert "selection does not match the authoritative rebuild receipt" in consumed.output
+    assert not comparison_called
 
 
 def test_cli_rejects_swapped_real_receipt_before_comparison(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -316,7 +376,9 @@ def test_cli_consumes_valid_reviewed_real_report(tmp_path: Path, monkeypatch: py
         catch_exceptions=False,
     )
     assert consumed.exit_code == 0, consumed.output
-    assert json.loads(consumed.stdout)["decision"] == "approved"
+    approved = json.loads(consumed.stdout)
+    assert approved["decision"] == "evidence-approved"
+    assert approved["promotion_authorized"] is False
 
 
 def _run_result(index_path: Path, *, differences: tuple[object, ...] = ()) -> CanaryRunResult:
@@ -360,8 +422,6 @@ def _nonempty_run_result(index_path: Path) -> CanaryRunResult:
         rebuild_receipt={
             "archive_root": str(index_path.parent),
             "selected_raw_count": 1,
-            "selected_raw_ids": ["raw-sample"],
-            "selected_session_ids": ["codex-session:sample"],
             "status": "replayed",
             "materialized": True,
             "generation": {
@@ -372,6 +432,14 @@ def _nonempty_run_result(index_path: Path) -> CanaryRunResult:
                 "state": "inactive",
                 "source_snapshot": "snapshot",
             },
+            "selection_evidence": rebuild_selection_evidence(
+                result.selection.selected_raw_ids,
+                archive_root=index_path.parent,
+                generation_id="gen-canary",
+                generation_owner_id="owner",
+                candidate_index=result.comparison.candidate_index,
+                source_snapshot="snapshot",
+            ),
         },
     )
 
@@ -791,7 +859,7 @@ def test_cli_canary_report_red_twin_rejects_arbitrary_copied_indexes(
         catch_exceptions=False,
     )
     assert consumed.exit_code == 1
-    assert "archive-owned" in consumed.output
+    assert "archive-owned" in consumed.output or "authoritative rebuild receipt" in consumed.output
 
 
 def test_cli_canary_report_red_twin_rejects_replaced_candidate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -974,9 +1042,24 @@ def test_shared_canary_runner_uses_existing_inactive_rebuild_route(
             "state": "inactive",
             "source_snapshot": "snapshot",
         }
+        selection_evidence = rebuild_selection_evidence(
+            selection.selected_raw_ids,
+            archive_root=tmp_path,
+            generation_id="gen-test",
+            generation_owner_id="owner",
+            candidate_index=candidate_index,
+            source_snapshot="snapshot",
+        )
 
         def to_dict(self) -> dict[str, object]:
-            return {"generation": self.generation}
+            return {
+                "archive_root": self.archive_root,
+                "selected_raw_count": self.selected_raw_count,
+                "status": self.status,
+                "materialized": self.materialized,
+                "generation": self.generation,
+                "selection_evidence": self.selection_evidence,
+            }
 
     def fake_rebuild(request: object) -> Receipt:
         captured["request"] = request
@@ -999,6 +1082,9 @@ def test_shared_canary_runner_uses_existing_inactive_rebuild_route(
     )
     monkeypatch.setattr("polylogue.maintenance.rebuild_index.rebuild_index_from_source_sync", fake_rebuild)
     monkeypatch.setattr("polylogue.maintenance.reindex_canary.compare_reindex_generations", fake_compare)
+    monkeypatch.setattr(
+        "polylogue.maintenance.reindex_canary._validate_authoritative_rebuild_receipt", lambda *args, **kwargs: None
+    )
 
     result = run_reindex_canary(
         tmp_path,
@@ -1012,7 +1098,10 @@ def test_shared_canary_runner_uses_existing_inactive_rebuild_route(
     assert request.promote is False  # type: ignore[attr-defined]
     assert captured["compare"] == (current_index, candidate_index, selection.selected_session_ids)
     assert result.rebuild_receipt == {
+        "archive_root": Receipt.archive_root,
+        "selected_raw_count": Receipt.selected_raw_count,
+        "status": Receipt.status,
+        "materialized": Receipt.materialized,
         "generation": Receipt.generation,
-        "selected_raw_ids": ["raw-sample"],
-        "selected_session_ids": ["codex-session:sample"],
+        "selection_evidence": Receipt.selection_evidence,
     }

--- a/tests/unit/cli/test_reindex_canary_cli.py
+++ b/tests/unit/cli/test_reindex_canary_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import sqlite3
 import stat
 from pathlib import Path
@@ -10,6 +11,7 @@ from click.testing import CliRunner
 
 from polylogue.cli.click_app import cli
 from polylogue.core.enums import Provider
+from polylogue.maintenance import reindex_canary as reindex_canary_module
 from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
 from polylogue.maintenance.reindex_canary import (
     CanaryDifferenceReview,
@@ -18,6 +20,7 @@ from polylogue.maintenance.reindex_canary import (
     CanarySelection,
     DifferenceClassification,
     DifferenceOperation,
+    DurableCanaryReport,
     RowDifference,
     UnclassifiedCanaryDiffError,
     load_canary_report,
@@ -64,6 +67,45 @@ def _seed_isolated_canary(root: Path) -> None:
         )
     receipt = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
     assert receipt.status == "replayed"
+
+
+def _write_real_unreviewed_canary_report(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[Path, Path, dict[str, object]]:
+    """Exercise the CLI to produce a report bound to one disposable archive."""
+
+    live_root = tmp_path / "configured-live"
+    canary_root = tmp_path / "isolated-canary"
+    report_path = tmp_path / "unreviewed.json"
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(canary_root))
+    _seed_isolated_canary(canary_root)
+    monkeypatch.setattr("polylogue.config.resolve_archive_root", lambda: live_root)
+    with sqlite3.connect(canary_root / "index.db") as connection:
+        connection.execute("UPDATE blocks SET text = 'mutated active projection'")
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--input",
+            str(canary_root / "index.db"),
+            "--report",
+            str(report_path),
+            "--sample",
+            "1",
+            "--no-promote",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1
+    assert "unreviewed canary report written" in result.output
+    return canary_root, report_path, json.loads(report_path.read_text(encoding="utf-8"))
 
 
 def _run_result(index_path: Path, *, differences: tuple[object, ...] = ()) -> CanaryRunResult:
@@ -261,7 +303,7 @@ def test_reindex_canary_cli_refuses_to_write_unclassified_report(
 def test_reindex_canary_cli_persists_review_manifest_for_nonempty_differences(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The CLI's real report writer accepts an explicit per-difference review."""
+    """The CLI forwards an explicit per-difference review to report writing."""
 
     index_path = tmp_path / "index.db"
     index_path.touch()
@@ -276,6 +318,21 @@ def test_reindex_canary_cli_persists_review_manifest_for_nonempty_differences(
         reference="polylogue-review",
         rationale="reviewed materializer change",
     )
+    captured: dict[str, object] = {}
+
+    def fake_write(path: Path, **kwargs: object) -> DurableCanaryReport:
+        captured["path"] = path
+        captured["reviews"] = kwargs["reviews"]
+        return DurableCanaryReport(
+            selection=run_result.selection,
+            comparison=run_result.comparison,
+            rebuild_receipt=run_result.rebuild_receipt,
+            reviews=(review,),
+            review_status="reviewed",
+            comparison_fingerprint="0" * 64,
+            archive_provenance={},
+        )
+
     review_path.write_text(json.dumps({"reviews": [review.to_dict()]}), encoding="utf-8")
     monkeypatch.setattr("polylogue.maintenance.reindex_canary.run_reindex_canary", lambda *args, **kwargs: run_result)
     monkeypatch.setattr("polylogue.maintenance.reindex_canary.load_canary_report", lambda path: {})
@@ -303,9 +360,8 @@ def test_reindex_canary_cli_persists_review_manifest_for_nonempty_differences(
     )
 
     assert result.exit_code == 0
-    persisted = json.loads(report_path.read_text(encoding="utf-8"))
-    assert persisted["reviews"] == [review.to_dict()]
-    assert persisted["comparison"]["summary"]["expected_count"] == 1
+    assert captured == {"path": report_path, "reviews": (review,)}
+    assert json.loads(result.stdout)["reviews"] == [review.to_dict()]
 
 
 def test_reindex_canary_cli_rejects_manifest_with_wrong_changed_columns(
@@ -362,9 +418,10 @@ def test_reindex_canary_cli_refuses_nonempty_differences_without_review_manifest
 ) -> None:
     index_path = tmp_path / "index.db"
     index_path.touch()
+    run_result = _nonempty_run_result(index_path)
     monkeypatch.setattr(
         "polylogue.maintenance.reindex_canary.run_reindex_canary",
-        lambda *args, **kwargs: _nonempty_run_result(index_path),
+        lambda *args, **kwargs: run_result,
     )
     monkeypatch.setattr("polylogue.maintenance.reindex_canary.load_canary_report", lambda path: {})
 
@@ -444,6 +501,91 @@ def test_reindex_canary_cli_persists_unreviewed_real_candidate_lifecycle(
     report_path.write_text(json.dumps(persisted), encoding="utf-8")
 
     with pytest.raises(UnclassifiedCanaryDiffError, match="comparison attestation"):
+        load_canary_report(report_path)
+
+
+def test_cli_canary_report_red_twin_rejects_arbitrary_copied_indexes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A copied pair must not become an approved archive just by rewriting JSON."""
+
+    canary_root, report_path, payload = _write_real_unreviewed_canary_report(tmp_path, monkeypatch)
+    comparison = payload["comparison"]
+    receipt = payload["rebuild_receipt"]
+    selection = payload["selection"]
+    assert isinstance(comparison, dict)
+    assert isinstance(receipt, dict)
+    assert isinstance(selection, dict)
+    generation = receipt["generation"]
+    assert isinstance(generation, dict)
+    original_candidate = Path(str(comparison["candidate_index"]))
+
+    copied_root = tmp_path / "copied-archive"
+    copied_candidate = copied_root / "unowned-copy" / "index.db"
+    copied_current = copied_root / "index.db"
+    copied_candidate.parent.mkdir(parents=True)
+    shutil.copy2(canary_root / "source.db", copied_root / "source.db")
+    shutil.copy2(canary_root / "index.db", copied_current)
+    shutil.copy2(original_candidate, copied_candidate)
+
+    comparison["current_index"] = str(copied_current)
+    comparison["candidate_index"] = str(copied_candidate)
+    selection["index_path"] = str(copied_current)
+    receipt["archive_root"] = str(copied_root)
+    generation["archive_root"] = str(copied_root)
+    generation["index_path"] = str(copied_candidate)
+    payload["comparison_fingerprint"] = reindex_canary_module._comparison_fingerprint(
+        reindex_canary_module.compare_reindex_generations(
+            copied_current,
+            copied_candidate,
+            session_ids=tuple(selection["selected_session_ids"]),
+        )
+    )
+    report_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(UnclassifiedCanaryDiffError, match="archive-owned"):
+        load_canary_report(report_path)
+
+
+def test_cli_canary_report_red_twin_rejects_replaced_candidate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replacing the same candidate path after review must invalidate the report."""
+
+    _canary_root, report_path, payload = _write_real_unreviewed_canary_report(tmp_path, monkeypatch)
+    comparison = payload["comparison"]
+    assert isinstance(comparison, dict)
+    candidate = Path(str(comparison["candidate_index"]))
+    replacement = tmp_path / "replacement.db"
+    shutil.copy2(candidate, replacement)
+    replacement.replace(candidate)
+
+    with pytest.raises(UnclassifiedCanaryDiffError, match="candidate index identity"):
+        load_canary_report(report_path)
+
+
+@pytest.mark.parametrize("drift", ("active-pointer", "candidate-generation", "source-snapshot"))
+def test_cli_canary_report_red_twin_rejects_lifecycle_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, drift: str
+) -> None:
+    """The report is invalid when live pointer or generation metadata no longer match."""
+
+    canary_root, report_path, payload = _write_real_unreviewed_canary_report(tmp_path, monkeypatch)
+    comparison = payload["comparison"]
+    assert isinstance(comparison, dict)
+    if drift == "active-pointer":
+        alternate = canary_root / "alternate-generation" / "index.db"
+        alternate.parent.mkdir()
+        shutil.copy2(canary_root / "index.db", alternate)
+        (canary_root / ".index-active-pointer").write_text(str(alternate), encoding="utf-8")
+    elif drift == "candidate-generation":
+        candidate_metadata = Path(str(comparison["candidate_index"])).with_name("generation.json")
+        metadata = json.loads(candidate_metadata.read_text(encoding="utf-8"))
+        metadata["owner_id"] = "replaced-owner"
+        candidate_metadata.write_text(json.dumps(metadata), encoding="utf-8")
+    else:
+        with sqlite3.connect(canary_root / "source.db") as connection:
+            connection.execute("UPDATE raw_sessions SET acquired_at_ms = acquired_at_ms + 1")
+
+    with pytest.raises(UnclassifiedCanaryDiffError, match="archive-owned"):
         load_canary_report(report_path)
 
 

--- a/tests/unit/cli/test_reindex_canary_cli.py
+++ b/tests/unit/cli/test_reindex_canary_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import stat
 from pathlib import Path
 
@@ -8,9 +9,13 @@ from click.testing import CliRunner
 
 from polylogue.cli.click_app import cli
 from polylogue.maintenance.reindex_canary import (
+    CanaryDifferenceReview,
     CanaryDiffReport,
     CanaryRunResult,
     CanarySelection,
+    DifferenceClassification,
+    DifferenceOperation,
+    RowDifference,
     UnclassifiedCanaryDiffError,
     run_reindex_canary,
 )
@@ -38,6 +43,38 @@ def _run_result(index_path: Path, *, differences: tuple[object, ...] = ()) -> Ca
         differences=differences,  # type: ignore[arg-type]
     )
     return CanaryRunResult(selection=selection, comparison=comparison, rebuild_receipt={"status": "replayed"})
+
+
+def _nonempty_run_result(index_path: Path) -> CanaryRunResult:
+    difference = RowDifference(
+        table="session_profiles",
+        operation=DifferenceOperation.CHANGED,
+        identity=(("session_id", "codex-session:sample"),),
+        before={"message_count": 1},
+        after={"message_count": 2},
+        changed_columns=("message_count",),
+        classification=DifferenceClassification.UNEXPECTED,
+        rationale="unreviewed",
+    )
+    result = _run_result(index_path, differences=(difference,))
+    return CanaryRunResult(
+        selection=result.selection,
+        comparison=result.comparison,
+        rebuild_receipt={
+            "archive_root": str(index_path.parent),
+            "selected_raw_count": 1,
+            "status": "replayed",
+            "materialized": True,
+            "generation": {
+                "generation_id": "gen-canary",
+                "owner_id": "owner",
+                "archive_root": str(index_path.parent),
+                "index_path": str(result.comparison.candidate_index),
+                "state": "inactive",
+                "source_snapshot": "snapshot",
+            },
+        },
+    )
 
 
 def test_reindex_canary_cli_requires_no_promote(tmp_path: Path) -> None:
@@ -172,13 +209,93 @@ def test_reindex_canary_cli_refuses_to_write_unclassified_report(
     )
 
     assert result.exit_code == 1
-    assert "classification is incomplete" in result.output
+    assert "require --review-manifest" in result.output
+
+
+def test_reindex_canary_cli_persists_review_manifest_for_nonempty_differences(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The CLI's real report writer accepts an explicit per-difference review."""
+
+    index_path = tmp_path / "index.db"
+    index_path.touch()
+    report_path = tmp_path / "canary.json"
+    review_path = tmp_path / "reviews.json"
+    run_result = _nonempty_run_result(index_path)
+    difference = run_result.comparison.differences[0]
+    assert isinstance(difference, RowDifference)
+    review = CanaryDifferenceReview.for_difference(
+        difference,
+        classification=DifferenceClassification.EXPECTED,
+        reference="polylogue-review",
+        rationale="reviewed materializer change",
+    )
+    review_path.write_text(json.dumps({"reviews": [review.to_dict()]}), encoding="utf-8")
+    monkeypatch.setattr("polylogue.maintenance.reindex_canary.run_reindex_canary", lambda *args, **kwargs: run_result)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--archive-root",
+            str(tmp_path),
+            "--input",
+            str(index_path),
+            "--report",
+            str(report_path),
+            "--review-manifest",
+            str(review_path),
+            "--no-promote",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    persisted = json.loads(report_path.read_text(encoding="utf-8"))
+    assert persisted["reviews"] == [review.to_dict()]
+    assert persisted["comparison"]["summary"]["expected_count"] == 1
+
+
+def test_reindex_canary_cli_refuses_nonempty_differences_without_review_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    index_path = tmp_path / "index.db"
+    index_path.touch()
+    monkeypatch.setattr(
+        "polylogue.maintenance.reindex_canary.run_reindex_canary",
+        lambda *args, **kwargs: _nonempty_run_result(index_path),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "reindex-canary",
+            "--archive-root",
+            str(tmp_path),
+            "--input",
+            str(index_path),
+            "--report",
+            str(tmp_path / "canary.json"),
+            "--no-promote",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "require --review-manifest" in result.output
 
 
 def test_shared_canary_runner_uses_existing_inactive_rebuild_route(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    current_index = tmp_path / "current.db"
+    current_index = tmp_path / "index.db"
     candidate_index = tmp_path / ".index-generations" / "gen-test" / "index.db"
     current_index.touch()
     candidate_index.parent.mkdir(parents=True)

--- a/tests/unit/daemon/test_bulk_rebuild.py
+++ b/tests/unit/daemon/test_bulk_rebuild.py
@@ -47,7 +47,11 @@ from polylogue.daemon.bulk_rebuild import (
 )
 from polylogue.daemon.parse_prefetch import DaemonParseStage
 from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
-from polylogue.storage.index_generation import IndexGenerationStore, source_revision_snapshot
+from polylogue.storage.index_generation import (
+    IndexGenerationStore,
+    rebuild_source_evidence_snapshot,
+    source_revision_snapshot,
+)
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
 
@@ -196,6 +200,52 @@ def test_resolve_or_start_creates_resumes_and_retires_transaction(
     assert restarted.generation_id != first.generation_id
     assert restarted.last_raw_id is None
     assert restarted.processed_raw_count == 0
+
+
+def test_daemon_bulk_pass_uses_rebuild_evidence_snapshot_before_replay(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The daemon seed must match the shared engine's immutable evidence hash.
+
+    Anti-vacuity: this seeds a nonempty real ``source.db``, resolves through
+    ``resolve_or_start_daemon_bulk_rebuild_transaction``, and invokes the real
+    ``run_daemon_bulk_rebuild_pass``. That driver calls the shared
+    ``rebuild_index_from_source_sync`` engine, whose pre-replay validation
+    marks an incompatible transaction stale. The full-row hash is deliberately
+    different for this corpus, so removing the daemon seed correction makes
+    this test fail before the first raw is replayed.
+    """
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path))
+    _seed_corpus(tmp_path, count=2)
+    evidence_snapshot = rebuild_source_evidence_snapshot(tmp_path)
+    full_row_snapshot = source_revision_snapshot(tmp_path)
+    assert full_row_snapshot != evidence_snapshot
+
+    transaction = resolve_or_start_daemon_bulk_rebuild_transaction(tmp_path)
+    assert transaction.source_snapshot == evidence_snapshot
+    assert transaction.source_snapshot != full_row_snapshot
+
+    stage = DaemonParseStage(max_workers=2, max_inflight_bytes=10_000_000)
+    try:
+        receipt = asyncio.run(
+            run_daemon_bulk_rebuild_pass(
+                config=_config(tmp_path),
+                parse_stage=stage,
+                batch_size=1,
+                max_payload_bytes=10_000_000,
+            )
+        )
+    finally:
+        stage.shutdown()
+
+    assert receipt is not None
+    assert receipt.transaction is not None
+    assert receipt.transaction["status"] != "stale"
+    processed_raw_count = receipt.transaction["processed_raw_count"]
+    assert isinstance(processed_raw_count, int)
+    assert processed_raw_count == 1
+    persisted = IndexGenerationStore.for_archive_root(tmp_path).load_transaction(DAEMON_BULK_REBUILD_OPERATION_ID)
+    assert persisted.status != "stale"
 
 
 def test_daemon_bulk_rebuild_pass_resumes_without_reprocessing_raw_ids(

--- a/tests/unit/maintenance/test_rebuild_status.py
+++ b/tests/unit/maintenance/test_rebuild_status.py
@@ -7,8 +7,8 @@ Anti-vacuity: the mutation that makes
 ``lease.stale`` branch's recovery message (or ``rebuild_lease_status``'s own
 dead-pid detection this depends on); the mutation that makes
 ``test_reports_source_snapshot_delta_when_source_has_drifted`` fail is
-dropping the ``source_revision_snapshot`` comparison and always reporting
-``source_snapshot_matches=True``.
+dropping the ``rebuild_source_evidence_snapshot`` comparison and always
+reporting ``source_snapshot_matches=True``.
 """
 
 from __future__ import annotations
@@ -23,7 +23,7 @@ import pytest
 
 from polylogue.core.enums import Provider
 from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync, rebuild_status
-from polylogue.storage.index_generation import IndexGenerationStore, source_revision_snapshot
+from polylogue.storage.index_generation import IndexGenerationStore, rebuild_source_evidence_snapshot
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root, initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
@@ -133,7 +133,7 @@ def test_reports_transaction_cursor_and_no_delta_when_source_unchanged(tmp_path:
         )
     store = IndexGenerationStore.for_archive_root(root)
     transaction = store.create_transaction(
-        source_snapshot=source_revision_snapshot(root), operation_id="status-probe-op"
+        source_snapshot=rebuild_source_evidence_snapshot(root), operation_id="status-probe-op"
     )
     transaction = store.checkpoint_transaction(
         transaction, status="paused", last_raw_id="raw-a", last_blob_hash_hex="00" * 32, processed_raw_count=1

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -130,6 +130,8 @@ def _rebuild_receipt(selection: CanarySelection, comparison: CanaryDiffReport) -
     return {
         "archive_root": str(comparison.candidate_index.parent),
         "selected_raw_count": len(selection.selected_raw_ids),
+        "selected_raw_ids": list(selection.selected_raw_ids),
+        "selected_session_ids": list(selection.selected_session_ids),
         "status": "replayed",
         "materialized": True,
         "generation": {
@@ -218,6 +220,7 @@ def test_expected_difference_is_structurally_accounted_for(tmp_path: Path) -> No
         expected=(
             ExpectedDifference(
                 table="session_profiles",
+                identity=(("session_id", "codex-session:alpha"),),
                 operations=(DifferenceOperation.CHANGED,),
                 columns=("message_count",),
                 bead_ref="polylogue-example",
@@ -248,6 +251,7 @@ def test_expected_difference_cannot_hide_extra_changed_columns(tmp_path: Path) -
         expected=(
             ExpectedDifference(
                 table="session_profiles",
+                identity=(("session_id", "codex-session:alpha"),),
                 operations=(DifferenceOperation.CHANGED,),
                 columns=("message_count",),
                 bead_ref="polylogue-example",
@@ -262,12 +266,43 @@ def test_expected_difference_cannot_hide_extra_changed_columns(tmp_path: Path) -
     assert profile_changes[0].classification is DifferenceClassification.UNEXPECTED
 
 
+def test_expected_difference_for_alpha_does_not_waive_beta(tmp_path: Path) -> None:
+    current = tmp_path / "current.db"
+    candidate = tmp_path / "candidate.db"
+    _seed_index(current, sessions=("alpha", "beta"))
+    _seed_index(candidate, sessions=("alpha", "beta"), profile_message_count=2)
+    report = compare_reindex_generations(
+        current,
+        candidate,
+        expected=(
+            ExpectedDifference(
+                table="session_profiles",
+                identity=(("session_id", "codex-session:alpha"),),
+                operations=(DifferenceOperation.CHANGED,),
+                columns=("message_count",),
+                bead_ref="ref",
+                rationale="alpha only",
+            ),
+        ),
+    )
+    classifications = {
+        dict(item.identity)["session_id"]: item.classification
+        for item in report.differences
+        if item.table == "session_profiles"
+    }
+    assert classifications == {
+        "codex-session:alpha": DifferenceClassification.EXPECTED,
+        "codex-session:beta": DifferenceClassification.UNEXPECTED,
+    }
+
+
 def test_expected_difference_requires_exact_operation_and_nonempty_signature() -> None:
     """A table-wide declaration cannot classify every future row difference."""
 
     with pytest.raises(ValueError, match="exactly one operation"):
         ExpectedDifference(
             table="session_profiles",
+            identity=(("session_id", "codex-session:alpha"),),
             bead_ref="polylogue-example",
             rationale="too broad",
         )
@@ -275,6 +310,7 @@ def test_expected_difference_requires_exact_operation_and_nonempty_signature() -
     with pytest.raises(ValueError, match="non-empty changed-column signature"):
         ExpectedDifference(
             table="session_profiles",
+            identity=(("session_id", "codex-session:alpha"),),
             operations=(DifferenceOperation.CHANGED,),
             bead_ref="polylogue-example",
             rationale="still too broad",
@@ -298,6 +334,7 @@ def test_expected_difference_requires_exact_schema_asymmetry_signature(tmp_path:
         expected=(
             ExpectedDifference(
                 table="session_profiles",
+                identity=(("__schema__", "column"), ("name", "tags_json")),
                 operations=(DifferenceOperation.REMOVED,),
                 columns=("message_count",),
                 bead_ref="polylogue-example",
@@ -860,6 +897,47 @@ def test_loading_canary_report_rejects_tampered_candidate_provenance(tmp_path: P
     report_path.write_text(json.dumps(payload), encoding="utf-8")
 
     with pytest.raises(UnclassifiedCanaryDiffError, match="does not identify the compared candidate"):
+        load_canary_report(report_path)
+
+
+@pytest.mark.parametrize(
+    ("tamper", "message"),
+    (
+        ("index", "selection index"),
+        ("sessions", "selection sessions"),
+        ("raw-ids", "rebuild evidence"),
+    ),
+)
+def test_loading_canary_report_rejects_tampered_selection_binding(tmp_path: Path, tamper: str, message: str) -> None:
+    current, candidate, report_path = tmp_path / "current.db", tmp_path / "candidate.db", tmp_path / "canary.json"
+    _seed_index(current)
+    _seed_index(candidate, block_text="changed")
+    comparison, selection = (
+        compare_reindex_generations(current, candidate),
+        select_canary_sessions(current, sessions_per_origin=1),
+    )
+    reviews = tuple(
+        CanaryDifferenceReview.for_difference(
+            item, classification=DifferenceClassification.UNEXPECTED, reference="ref", rationale="r"
+        )
+        for item in comparison.differences
+    )
+    write_canary_report(
+        report_path,
+        selection=selection,
+        comparison=comparison,
+        rebuild_receipt=_rebuild_receipt(selection, comparison),
+        reviews=reviews,
+    )
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    if tamper == "index":
+        payload["selection"]["index_path"] = str(tmp_path / "foreign.db")
+    elif tamper == "sessions":
+        payload["selection"]["selected_session_ids"] = ["codex-session:foreign"]
+    else:
+        payload["rebuild_receipt"]["selected_raw_ids"] = ["raw-foreign"]
+    report_path.write_text(json.dumps(payload))
+    with pytest.raises(UnclassifiedCanaryDiffError, match=message):
         load_canary_report(report_path)
 
 

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -817,7 +817,7 @@ def test_durable_report_persists_explicit_review_for_every_diff(tmp_path: Path) 
 
     assert durable.unclassified_count == 0
     assert report_path.exists()
-    assert loaded["schema_version"] == 1
+    assert loaded["schema_version"] == 2
     comparison_payload = loaded["comparison"]
     assert isinstance(comparison_payload, dict)
     summary = comparison_payload["summary"]

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -172,7 +172,7 @@ def _rebuild_receipt(selection: CanarySelection, comparison: CanaryDiffReport) -
         "source_snapshot": "snapshot",
     }
     return {
-        "receipt_schema_version": 3,
+        "receipt_schema_version": 4,
         "archive_root": str(comparison.candidate_index.parent),
         "selected_raw_count": len(selection.selected_raw_ids),
         "status": "replayed",
@@ -599,7 +599,7 @@ def test_run_reindex_canary_accepts_split_root_active_pointer_through_real_valid
     assert isinstance(owner_id, str) and owner_id
     assert isinstance(source_snapshot, str) and source_snapshot
     assert source_snapshot == evidence_before == rebuild_source_evidence_snapshot(root)
-    assert receipt["receipt_schema_version"] == 3
+    assert receipt["receipt_schema_version"] == 4
     assert receipt["source_evidence_after"] == rebuild_source_evidence_snapshot(root)
     assert hashlib.sha256(external_index.read_bytes()).hexdigest() == active_digest
     assert json.loads((candidate_path.parent / "generation.json").read_text(encoding="utf-8")) == generation
@@ -998,7 +998,7 @@ def test_durable_report_persists_explicit_review_for_every_diff(tmp_path: Path) 
     assert durable.unclassified_count == 0
     assert report_path.exists()
     payload = json.loads(report_path.read_text(encoding="utf-8"))
-    assert payload["schema_version"] == 6
+    assert payload["schema_version"] == 7
     comparison_payload = payload["comparison"]
     assert isinstance(comparison_payload, dict)
     summary = comparison_payload["summary"]

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -19,6 +19,7 @@ from typing import Any
 
 import pytest
 
+from polylogue.maintenance import reindex_canary as reindex_canary_module
 from polylogue.maintenance.reindex_canary import (
     CanaryDifferenceReview,
     CanaryDiffReport,
@@ -37,6 +38,22 @@ from polylogue.maintenance.reindex_canary import (
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from tests.infra.workload_artifacts import build_seeded_archive, clone_seeded_archive
+
+
+@pytest.fixture(autouse=True)
+def _synthetic_report_provenance(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep structural report tests independent of the CLI lifecycle route.
+
+    The CLI red twins exercise the real archive-owned provenance capture and
+    reload path. These focused tests construct standalone index pairs solely
+    to pin comparison and review serialization behavior.
+    """
+
+    monkeypatch.setattr(
+        reindex_canary_module,
+        "_capture_archive_provenance",
+        lambda *args, **kwargs: {},
+    )
 
 
 def _seed_index(
@@ -813,18 +830,17 @@ def test_durable_report_persists_explicit_review_for_every_diff(tmp_path: Path) 
         rebuild_receipt=_rebuild_receipt(selection, comparison),
         reviews=reviews,
     )
-    loaded = load_canary_report(report_path)
-
     assert durable.unclassified_count == 0
     assert report_path.exists()
-    assert loaded["schema_version"] == 2
-    comparison_payload = loaded["comparison"]
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == 3
+    comparison_payload = payload["comparison"]
     assert isinstance(comparison_payload, dict)
     summary = comparison_payload["summary"]
     assert isinstance(summary, dict)
     assert summary["unclassified_count"] == 0
     assert summary["unexpected_count"] == len(reviews)
-    assert "rebuild_receipt" in loaded
+    assert "rebuild_receipt" in payload
 
 
 def test_loading_canary_report_rechecks_exact_review_coverage(tmp_path: Path) -> None:
@@ -941,7 +957,7 @@ def test_loading_canary_report_rejects_tampered_selection_binding(tmp_path: Path
         load_canary_report(report_path)
 
 
-def test_loading_canary_report_recomputes_tampered_summary(tmp_path: Path) -> None:
+def test_loading_canary_report_recomputes_tampered_summary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     current = tmp_path / "current.db"
     candidate = tmp_path / "candidate.db"
     report_path = tmp_path / "reports" / "canary.json"
@@ -975,6 +991,7 @@ def test_loading_canary_report_recomputes_tampered_summary(tmp_path: Path) -> No
         "counts_by_table": {},
     }
     report_path.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setattr(reindex_canary_module, "_validate_archive_provenance", lambda *args, **kwargs: None)
 
     loaded = load_canary_report(report_path)
 

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -19,8 +19,13 @@ from typing import Any
 
 import pytest
 
+from polylogue.core.enums import Provider
 from polylogue.maintenance import reindex_canary as reindex_canary_module
-from polylogue.maintenance.rebuild_index import rebuild_selection_evidence
+from polylogue.maintenance.rebuild_index import (
+    RebuildIndexRequest,
+    rebuild_index_from_source_sync,
+    rebuild_selection_evidence,
+)
 from polylogue.maintenance.reindex_canary import (
     CanaryDifferenceReview,
     CanaryDiffReport,
@@ -36,7 +41,9 @@ from polylogue.maintenance.reindex_canary import (
     select_canary_sessions,
     write_canary_report,
 )
-from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+from polylogue.storage.index_generation import rebuild_source_evidence_snapshot, source_revision_snapshot
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root, initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from tests.infra.workload_artifacts import build_seeded_archive, clone_seeded_archive
 
@@ -164,6 +171,7 @@ def _rebuild_receipt(selection: CanarySelection, comparison: CanaryDiffReport) -
         "source_snapshot": "snapshot",
     }
     return {
+        "receipt_schema_version": 2,
         "archive_root": str(comparison.candidate_index.parent),
         "selected_raw_count": len(selection.selected_raw_ids),
         "status": "replayed",
@@ -177,6 +185,7 @@ def _rebuild_receipt(selection: CanarySelection, comparison: CanaryDiffReport) -
             candidate_index=comparison.candidate_index,
             source_snapshot="snapshot",
         ),
+        "raw_sessions_state_after": "0" * 64,
     }
 
 
@@ -566,6 +575,8 @@ def test_run_reindex_canary_accepts_split_root_active_pointer_through_real_valid
     shutil.move(root / "index.db", external_index)
     (root / ".index-active-pointer").write_text(str(external_index), encoding="utf-8")
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path / "configured-live"))
+    active_digest = hashlib.sha256(external_index.read_bytes()).hexdigest()
+    evidence_before = rebuild_source_evidence_snapshot(root)
 
     result = run_reindex_canary(root, input_index=external_index, sessions_per_origin=1, no_promote=True)
 
@@ -586,6 +597,10 @@ def test_run_reindex_canary_accepts_split_root_active_pointer_through_real_valid
     assert generation["state"] == "inactive"
     assert isinstance(owner_id, str) and owner_id
     assert isinstance(source_snapshot, str) and source_snapshot
+    assert source_snapshot == evidence_before == rebuild_source_evidence_snapshot(root)
+    assert receipt["receipt_schema_version"] == 2
+    assert receipt["raw_sessions_state_after"] == source_revision_snapshot(root)
+    assert hashlib.sha256(external_index.read_bytes()).hexdigest() == active_digest
     assert json.loads((candidate_path.parent / "generation.json").read_text(encoding="utf-8")) == generation
 
     transaction = receipt["transaction"]
@@ -602,6 +617,78 @@ def test_run_reindex_canary_accepts_split_root_active_pointer_through_real_valid
     assert operation_generation == {"generation_id": generation_id, "state": "inactive"}
     assert operation_delta["transaction_source_snapshot"] == source_snapshot
     assert operation_delta["source_snapshot_matches"] is True
+
+
+def test_real_no_promote_rebuild_changes_parse_state_without_evidence_drift(tmp_path: Path) -> None:
+    """Rebuild output state may change while durable replay evidence remains fixed."""
+
+    root = tmp_path / "archive"
+    initialize_active_archive_root(root)
+    payload = (
+        b"\n".join(
+            (
+                b'{"type":"session_meta","payload":{"id":"fresh","timestamp":"2026-08-05T00:00:00Z"}}',
+                b'{"type":"response_item","payload":{"type":"message","id":"fresh-user","role":"user","content":[{"type":"input_text","text":"hello"}]}}',
+                b'{"type":"response_item","payload":{"type":"message","id":"fresh-assistant","role":"assistant","content":[{"type":"output_text","text":"world"}]}}',
+            )
+        )
+        + b"\n"
+    )
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        raw_id = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=payload,
+            source_path="fresh.jsonl",
+            acquired_at_ms=1,
+        )
+    with sqlite3.connect(root / "source.db") as connection:
+        assert (
+            connection.execute("SELECT parsed_at_ms FROM raw_sessions WHERE raw_id = ?", (raw_id,)).fetchone()[0]
+            is None
+        )
+    active_digest = hashlib.sha256((root / "index.db").read_bytes()).hexdigest()
+    evidence_before = rebuild_source_evidence_snapshot(root)
+
+    receipt = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=False))
+
+    with sqlite3.connect(root / "source.db") as connection:
+        assert (
+            connection.execute("SELECT parsed_at_ms FROM raw_sessions WHERE raw_id = ?", (raw_id,)).fetchone()[0]
+            is not None
+        )
+    assert receipt.generation["state"] == "inactive"
+    assert receipt.generation["source_snapshot"] == evidence_before == rebuild_source_evidence_snapshot(root)
+    assert receipt.raw_sessions_state_after == source_revision_snapshot(root)
+    assert hashlib.sha256((root / "index.db").read_bytes()).hexdigest() == active_digest
+
+
+def test_run_reindex_canary_rejects_external_evidence_mutation_after_replay(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A source identity mutation after replay fails before inactive readiness."""
+
+    artifact = build_seeded_archive(cache_root=tmp_path / "seeded-cache")
+    root = clone_seeded_archive(artifact, tmp_path / "archive").root
+    active_index = root / "index.db"
+    active_digest = hashlib.sha256(active_index.read_bytes()).hexdigest()
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path / "configured-live"))
+
+    from polylogue.maintenance import replay as rebuild_replay
+
+    real_replay = rebuild_replay.rebuild_index_from_source
+
+    async def mutate_source_after_replay(*args: Any, **kwargs: Any) -> dict[str, object]:
+        replay = await real_replay(*args, **kwargs)
+        with sqlite3.connect(root / "source.db") as connection:
+            connection.execute("UPDATE raw_sessions SET source_index = source_index + 1")
+        return replay
+
+    monkeypatch.setattr(rebuild_replay, "rebuild_index_from_source", mutate_source_after_replay)
+
+    with pytest.raises(RuntimeError, match="source evidence changed while rebuilding"):
+        run_reindex_canary(root, sessions_per_origin=1, no_promote=True)
+
+    assert hashlib.sha256(active_index.read_bytes()).hexdigest() == active_digest
 
 
 def test_run_reindex_canary_does_not_require_zoo_sessions_for_ordinary_archive(
@@ -869,7 +956,7 @@ def test_durable_report_persists_explicit_review_for_every_diff(tmp_path: Path) 
     assert durable.unclassified_count == 0
     assert report_path.exists()
     payload = json.loads(report_path.read_text(encoding="utf-8"))
-    assert payload["schema_version"] == 4
+    assert payload["schema_version"] == 5
     comparison_payload = payload["comparison"]
     assert isinstance(comparison_payload, dict)
     summary = comparison_payload["summary"]
@@ -916,6 +1003,51 @@ def test_loading_canary_report_rechecks_exact_review_coverage(tmp_path: Path) ->
     report_path.write_text(json.dumps(payload), encoding="utf-8")
 
     with pytest.raises(UnclassifiedCanaryDiffError, match="review coverage is incomplete"):
+        load_canary_report(report_path)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    (
+        ("schema_version", 4, "no authoritative rebuild receipt schema"),
+        ("receipt_schema_version", 1, "invalid rebuild receipt"),
+    ),
+)
+def test_loading_canary_report_rejects_ambiguous_prior_evidence_schema(
+    tmp_path: Path, field: str, value: int, message: str
+) -> None:
+    current = tmp_path / "current.db"
+    candidate = tmp_path / "candidate.db"
+    report_path = tmp_path / "reports" / "canary.json"
+    _seed_index(current)
+    _seed_index(candidate, block_text="changed transcript")
+    comparison = compare_reindex_generations(current, candidate)
+    selection = select_canary_sessions(current, sessions_per_origin=1)
+    reviews = tuple(
+        CanaryDifferenceReview.for_difference(
+            difference,
+            classification=DifferenceClassification.UNEXPECTED,
+            reference="polylogue-follow-up",
+            rationale="the canary has no reviewed expected delta for this row",
+        )
+        for difference in comparison.differences
+    )
+    write_canary_report(
+        report_path,
+        selection=selection,
+        comparison=comparison,
+        rebuild_receipt=_rebuild_receipt(selection, comparison),
+        reviews=reviews,
+    )
+
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    if field == "schema_version":
+        payload[field] = value
+    else:
+        payload["rebuild_receipt"][field] = value
+    report_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(UnclassifiedCanaryDiffError, match=message):
         load_canary_report(report_path)
 
 

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -42,7 +42,7 @@ from polylogue.maintenance.reindex_canary import (
     write_canary_report,
 )
 from polylogue.sources.revision_backfill import RebuildDeadlineExceededError
-from polylogue.storage.index_generation import rebuild_source_evidence_snapshot, source_revision_snapshot
+from polylogue.storage.index_generation import rebuild_source_evidence_snapshot
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root, initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
@@ -172,7 +172,7 @@ def _rebuild_receipt(selection: CanarySelection, comparison: CanaryDiffReport) -
         "source_snapshot": "snapshot",
     }
     return {
-        "receipt_schema_version": 2,
+        "receipt_schema_version": 3,
         "archive_root": str(comparison.candidate_index.parent),
         "selected_raw_count": len(selection.selected_raw_ids),
         "status": "replayed",
@@ -186,7 +186,7 @@ def _rebuild_receipt(selection: CanarySelection, comparison: CanaryDiffReport) -
             candidate_index=comparison.candidate_index,
             source_snapshot="snapshot",
         ),
-        "raw_sessions_state_after": "0" * 64,
+        "source_evidence_after": "0" * 64,
     }
 
 
@@ -599,8 +599,8 @@ def test_run_reindex_canary_accepts_split_root_active_pointer_through_real_valid
     assert isinstance(owner_id, str) and owner_id
     assert isinstance(source_snapshot, str) and source_snapshot
     assert source_snapshot == evidence_before == rebuild_source_evidence_snapshot(root)
-    assert receipt["receipt_schema_version"] == 2
-    assert receipt["raw_sessions_state_after"] == source_revision_snapshot(root)
+    assert receipt["receipt_schema_version"] == 3
+    assert receipt["source_evidence_after"] == rebuild_source_evidence_snapshot(root)
     assert hashlib.sha256(external_index.read_bytes()).hexdigest() == active_digest
     assert json.loads((candidate_path.parent / "generation.json").read_text(encoding="utf-8")) == generation
 
@@ -625,21 +625,33 @@ def test_real_no_promote_rebuild_changes_parse_state_without_evidence_drift(tmp_
 
     root = tmp_path / "archive"
     initialize_active_archive_root(root)
-    payload = (
-        b"\n".join(
-            (
-                b'{"type":"session_meta","payload":{"id":"fresh","timestamp":"2026-08-05T00:00:00Z"}}',
-                b'{"type":"response_item","payload":{"type":"message","id":"fresh-user","role":"user","content":[{"type":"input_text","text":"hello"}]}}',
-                b'{"type":"response_item","payload":{"type":"message","id":"fresh-assistant","role":"assistant","content":[{"type":"output_text","text":"world"}]}}',
-            )
-        )
-        + b"\n"
-    )
+    payload = json.dumps(
+        {
+            "chat_messages": [
+                {"uuid": "fresh-user", "sender": "human", "text": "hello"},
+                {
+                    "uuid": "fresh-assistant",
+                    "sender": "assistant",
+                    "text": "world",
+                    "attachments": [
+                        {
+                            "id": "fresh-attachment",
+                            "name": "fresh.txt",
+                            "mimeType": "text/plain",
+                            "size": 16,
+                            "extracted_content": "attachment bytes",
+                        }
+                    ],
+                },
+            ]
+        }
+    ).encode()
     with ArchiveStore.open_existing(root, read_only=False) as archive:
         raw_id = archive.write_raw_payload(
-            provider=Provider.CODEX,
+            provider=Provider.CLAUDE_AI,
             payload=payload,
-            source_path="fresh.jsonl",
+            source_path="fresh.json",
+            native_id="fresh",
             acquired_at_ms=1,
         )
     with sqlite3.connect(root / "source.db") as connection:
@@ -657,9 +669,15 @@ def test_real_no_promote_rebuild_changes_parse_state_without_evidence_drift(tmp_
             connection.execute("SELECT parsed_at_ms FROM raw_sessions WHERE raw_id = ?", (raw_id,)).fetchone()[0]
             is not None
         )
+        assert (
+            connection.execute(
+                "SELECT COUNT(*) FROM blob_refs WHERE ref_id = ? AND ref_type = 'attachment'", (raw_id,)
+            ).fetchone()[0]
+            == 1
+        )
     assert receipt.generation["state"] == "inactive"
     assert receipt.generation["source_snapshot"] == evidence_before == rebuild_source_evidence_snapshot(root)
-    assert receipt.raw_sessions_state_after == source_revision_snapshot(root)
+    assert receipt.source_evidence_after == rebuild_source_evidence_snapshot(root)
     assert hashlib.sha256((root / "index.db").read_bytes()).hexdigest() == active_digest
 
 
@@ -980,7 +998,7 @@ def test_durable_report_persists_explicit_review_for_every_diff(tmp_path: Path) 
     assert durable.unclassified_count == 0
     assert report_path.exists()
     payload = json.loads(report_path.read_text(encoding="utf-8"))
-    assert payload["schema_version"] == 5
+    assert payload["schema_version"] == 6
     comparison_payload = payload["comparison"]
     assert isinstance(comparison_payload, dict)
     summary = comparison_payload["summary"]

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -85,6 +85,22 @@ def _seed_index(
         connection.commit()
 
 
+def _seed_action(path: Path, *, tool_input: str) -> None:
+    """Create one canonical actions-view row from the real index schema."""
+
+    session_id = "codex-session:alpha"
+    message_id = f"{session_id}:0.0"
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            """
+            INSERT INTO blocks(message_id, session_id, position, block_type, tool_id, tool_input)
+            VALUES (?, ?, 1, 'tool_use', 'tool-alpha', ?)
+            """,
+            (message_id, session_id, tool_input),
+        )
+        connection.commit()
+
+
 def _empty_selection(index_path: Path) -> CanarySelection:
     return CanarySelection(
         index_path=index_path,
@@ -108,6 +124,23 @@ def _empty_comparison(current: Path, candidate: Path, session_ids: tuple[str, ..
         missing_columns=(),
         differences=(),
     )
+
+
+def _rebuild_receipt(selection: CanarySelection, comparison: CanaryDiffReport) -> dict[str, object]:
+    return {
+        "archive_root": str(comparison.candidate_index.parent),
+        "selected_raw_count": len(selection.selected_raw_ids),
+        "status": "replayed",
+        "materialized": True,
+        "generation": {
+            "generation_id": "gen-canary",
+            "owner_id": "owner",
+            "archive_root": str(comparison.candidate_index.parent),
+            "index_path": str(comparison.candidate_index),
+            "state": "inactive",
+            "source_snapshot": "snapshot",
+        },
+    }
 
 
 def test_equal_real_generations_ignore_only_materialization_metadata(tmp_path: Path) -> None:
@@ -163,13 +196,13 @@ def test_missing_tables_and_columns_are_explicit_unexpected_differences(tmp_path
 
     report = compare_reindex_generations(current, candidate)
 
-    assert report.missing_tables == ("blocks",)
+    assert "blocks" in report.missing_tables
     assert report.missing_columns == (("session_profiles", ("tags_json",)),)
     schema_differences = [item for item in report.differences if item.identity[0][0] == "__schema__"]
-    assert {(item.table, item.operation) for item in schema_differences} == {
+    assert {
         ("blocks", DifferenceOperation.REMOVED),
         ("session_profiles", DifferenceOperation.REMOVED),
-    }
+    }.issubset({(item.table, item.operation) for item in schema_differences})
     assert report.unexpected_count == len(report.differences)
 
 
@@ -185,6 +218,7 @@ def test_expected_difference_is_structurally_accounted_for(tmp_path: Path) -> No
         expected=(
             ExpectedDifference(
                 table="session_profiles",
+                operations=(DifferenceOperation.CHANGED,),
                 columns=("message_count",),
                 bead_ref="polylogue-example",
                 rationale="the reviewed materializer change updates this aggregate",
@@ -214,6 +248,7 @@ def test_expected_difference_cannot_hide_extra_changed_columns(tmp_path: Path) -
         expected=(
             ExpectedDifference(
                 table="session_profiles",
+                operations=(DifferenceOperation.CHANGED,),
                 columns=("message_count",),
                 bead_ref="polylogue-example",
                 rationale="the reviewed materializer change updates this aggregate",
@@ -225,6 +260,73 @@ def test_expected_difference_cannot_hide_extra_changed_columns(tmp_path: Path) -
     assert len(profile_changes) == 1
     assert profile_changes[0].changed_columns == ("tags_json", "message_count")
     assert profile_changes[0].classification is DifferenceClassification.UNEXPECTED
+
+
+def test_expected_difference_requires_exact_operation_and_nonempty_signature() -> None:
+    """A table-wide declaration cannot classify every future row difference."""
+
+    with pytest.raises(ValueError, match="exactly one operation"):
+        ExpectedDifference(
+            table="session_profiles",
+            bead_ref="polylogue-example",
+            rationale="too broad",
+        )
+
+    with pytest.raises(ValueError, match="non-empty changed-column signature"):
+        ExpectedDifference(
+            table="session_profiles",
+            operations=(DifferenceOperation.CHANGED,),
+            bead_ref="polylogue-example",
+            rationale="still too broad",
+        )
+
+
+def test_expected_difference_requires_exact_schema_asymmetry_signature(tmp_path: Path) -> None:
+    """Schema deltas need the same precise operation and column signature."""
+
+    current = tmp_path / "current.db"
+    candidate = tmp_path / "candidate.db"
+    _seed_index(current)
+    _seed_index(candidate)
+    with sqlite3.connect(candidate) as connection:
+        connection.execute("ALTER TABLE session_profiles DROP COLUMN tags_json")
+        connection.commit()
+
+    report = compare_reindex_generations(
+        current,
+        candidate,
+        expected=(
+            ExpectedDifference(
+                table="session_profiles",
+                operations=(DifferenceOperation.REMOVED,),
+                columns=("message_count",),
+                bead_ref="polylogue-example",
+                rationale="wrong schema signature",
+            ),
+        ),
+    )
+
+    schema_delta = next(item for item in report.differences if item.table == "session_profiles")
+    assert schema_delta.changed_columns == ("tags_json",)
+    assert schema_delta.classification is DifferenceClassification.UNEXPECTED
+
+
+def test_differ_compares_canonical_actions_view(tmp_path: Path) -> None:
+    """Changing the blocks-backed action payload must surface through actions."""
+
+    current = tmp_path / "current.db"
+    candidate = tmp_path / "candidate.db"
+    _seed_index(current)
+    _seed_index(candidate)
+    _seed_action(current, tool_input='{"command":"current"}')
+    _seed_action(candidate, tool_input='{"command":"candidate"}')
+
+    report = compare_reindex_generations(current, candidate)
+
+    action_delta = next(item for item in report.differences if item.table == "actions")
+    assert action_delta.operation is DifferenceOperation.CHANGED
+    assert action_delta.identity == (("tool_use_block_id", "codex-session:alpha:0.0:1"),)
+    assert "tool_input" in action_delta.changed_columns
 
 
 def test_selected_sessions_bound_the_canary_to_a_real_subset(tmp_path: Path) -> None:
@@ -476,13 +578,13 @@ def test_run_reindex_canary_does_not_require_zoo_sessions_for_ordinary_archive(
 def test_run_reindex_canary_compares_its_own_inactive_generation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    current = tmp_path / "current.db"
+    root = tmp_path
+    current = root / "index.db"
     current.touch()
     generation_id = "gen-canary"
     candidate = tmp_path / ".index-generations" / generation_id / "index.db"
     candidate.parent.mkdir(parents=True)
     candidate.touch()
-    root = tmp_path
     selection = _empty_selection(current)
 
     class Receipt:
@@ -522,7 +624,7 @@ def test_run_reindex_canary_compares_its_own_inactive_generation(
 
 
 def test_run_reindex_canary_rejects_arbitrary_sqlite_candidate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    current = tmp_path / "current.db"
+    current = tmp_path / "index.db"
     current.touch()
     arbitrary = tmp_path / "arbitrary.db"
     arbitrary.touch()
@@ -608,6 +710,27 @@ def test_real_pathology_canary_rejects_cyclic_candidate_before_insight_repair(
     assert hashlib.sha256(active_index.read_bytes()).hexdigest() == active_digest
 
 
+def test_run_reindex_canary_refuses_foreign_input_index_before_rebuild(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Selection may only read the configured archive's active generation."""
+
+    archive_root = tmp_path / "archive"
+    archive_root.mkdir()
+    active_index = archive_root / "index.db"
+    foreign_index = tmp_path / "foreign.db"
+    _seed_index(active_index)
+    _seed_index(foreign_index)
+
+    def fail_if_rebuild_runs(*args: object, **kwargs: object) -> object:
+        raise AssertionError("candidate rebuild was invoked with a foreign input index")
+
+    monkeypatch.setattr("polylogue.maintenance.rebuild_index.rebuild_index_from_source_sync", fail_if_rebuild_runs)
+
+    with pytest.raises(CanarySelectionError, match="configured archive active generation"):
+        run_reindex_canary(archive_root, input_index=foreign_index, no_promote=True)
+
+
 def test_durable_report_refuses_unclassified_diffs(tmp_path: Path) -> None:
     current = tmp_path / "current.db"
     candidate = tmp_path / "candidate.db"
@@ -618,7 +741,13 @@ def test_durable_report_refuses_unclassified_diffs(tmp_path: Path) -> None:
     selection = select_canary_sessions(current, sessions_per_origin=1)
 
     with pytest.raises(UnclassifiedCanaryDiffError, match="classification is incomplete"):
-        write_canary_report(report_path, selection=selection, comparison=comparison, reviews=())
+        write_canary_report(
+            report_path,
+            selection=selection,
+            comparison=comparison,
+            rebuild_receipt=_rebuild_receipt(selection, comparison),
+            reviews=(),
+        )
     assert not report_path.exists()
 
 
@@ -640,7 +769,13 @@ def test_durable_report_persists_explicit_review_for_every_diff(tmp_path: Path) 
         for difference in comparison.differences
     )
 
-    durable = write_canary_report(report_path, selection=selection, comparison=comparison, reviews=reviews)
+    durable = write_canary_report(
+        report_path,
+        selection=selection,
+        comparison=comparison,
+        rebuild_receipt=_rebuild_receipt(selection, comparison),
+        reviews=reviews,
+    )
     loaded = load_canary_report(report_path)
 
     assert durable.unclassified_count == 0
@@ -652,6 +787,7 @@ def test_durable_report_persists_explicit_review_for_every_diff(tmp_path: Path) 
     assert isinstance(summary, dict)
     assert summary["unclassified_count"] == 0
     assert summary["unexpected_count"] == len(reviews)
+    assert "rebuild_receipt" in loaded
 
 
 def test_loading_canary_report_rechecks_exact_review_coverage(tmp_path: Path) -> None:
@@ -671,7 +807,13 @@ def test_loading_canary_report_rechecks_exact_review_coverage(tmp_path: Path) ->
         )
         for difference in comparison.differences
     )
-    write_canary_report(report_path, selection=selection, comparison=comparison, reviews=reviews)
+    write_canary_report(
+        report_path,
+        selection=selection,
+        comparison=comparison,
+        rebuild_receipt=_rebuild_receipt(selection, comparison),
+        reviews=reviews,
+    )
 
     payload = json.loads(report_path.read_text(encoding="utf-8"))
     payload["reviews"] = payload["reviews"][:-1]
@@ -685,6 +827,39 @@ def test_loading_canary_report_rechecks_exact_review_coverage(tmp_path: Path) ->
     report_path.write_text(json.dumps(payload), encoding="utf-8")
 
     with pytest.raises(UnclassifiedCanaryDiffError, match="review coverage is incomplete"):
+        load_canary_report(report_path)
+
+
+def test_loading_canary_report_rejects_tampered_candidate_provenance(tmp_path: Path) -> None:
+    current = tmp_path / "current.db"
+    candidate = tmp_path / "candidate.db"
+    report_path = tmp_path / "reports" / "canary.json"
+    _seed_index(current)
+    _seed_index(candidate, block_text="changed transcript")
+    comparison = compare_reindex_generations(current, candidate)
+    selection = select_canary_sessions(current, sessions_per_origin=1)
+    reviews = tuple(
+        CanaryDifferenceReview.for_difference(
+            difference,
+            classification=DifferenceClassification.UNEXPECTED,
+            reference="polylogue-follow-up",
+            rationale="the canary has no reviewed expected delta for this row",
+        )
+        for difference in comparison.differences
+    )
+    write_canary_report(
+        report_path,
+        selection=selection,
+        comparison=comparison,
+        rebuild_receipt=_rebuild_receipt(selection, comparison),
+        reviews=reviews,
+    )
+
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    payload["rebuild_receipt"]["generation"]["index_path"] = str(tmp_path / "foreign.db")
+    report_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(UnclassifiedCanaryDiffError, match="does not identify the compared candidate"):
         load_canary_report(report_path)
 
 
@@ -705,7 +880,13 @@ def test_loading_canary_report_recomputes_tampered_summary(tmp_path: Path) -> No
         )
         for difference in comparison.differences
     )
-    write_canary_report(report_path, selection=selection, comparison=comparison, reviews=reviews)
+    write_canary_report(
+        report_path,
+        selection=selection,
+        comparison=comparison,
+        rebuild_receipt=_rebuild_receipt(selection, comparison),
+        reviews=reviews,
+    )
 
     payload = json.loads(report_path.read_text(encoding="utf-8"))
     payload["comparison"]["summary"] = {
@@ -753,8 +934,20 @@ def test_canary_report_uses_unique_temporary_names(tmp_path: Path, monkeypatch: 
         return stream
 
     monkeypatch.setattr(tempfile, "NamedTemporaryFile", recording_named_temporary_file)
-    write_canary_report(report_path, selection=selection, comparison=comparison, reviews=reviews)
-    write_canary_report(report_path, selection=selection, comparison=comparison, reviews=reviews)
+    write_canary_report(
+        report_path,
+        selection=selection,
+        comparison=comparison,
+        rebuild_receipt=_rebuild_receipt(selection, comparison),
+        reviews=reviews,
+    )
+    write_canary_report(
+        report_path,
+        selection=selection,
+        comparison=comparison,
+        rebuild_receipt=_rebuild_receipt(selection, comparison),
+        reviews=reviews,
+    )
 
     assert len(names) == 2
     assert len(set(names)) == 2
@@ -786,7 +979,13 @@ def test_canary_report_cleans_temporary_file_when_replace_fails(
 
     monkeypatch.setattr(os, "replace", fail_replace)
     with pytest.raises(OSError, match="replace failed"):
-        write_canary_report(report_path, selection=selection, comparison=comparison, reviews=reviews)
+        write_canary_report(
+            report_path,
+            selection=selection,
+            comparison=comparison,
+            rebuild_receipt=_rebuild_receipt(selection, comparison),
+            reviews=reviews,
+        )
 
     assert not report_path.exists()
     assert list(report_path.parent.glob(f".{report_path.name}.*.tmp")) == []

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -54,6 +54,11 @@ def _synthetic_report_provenance(monkeypatch: pytest.MonkeyPatch) -> None:
         "_capture_archive_provenance",
         lambda *args, **kwargs: {},
     )
+    monkeypatch.setattr(
+        reindex_canary_module,
+        "_validate_archive_provenance",
+        lambda *args, **kwargs: None,
+    )
 
 
 def _seed_index(
@@ -477,7 +482,7 @@ def test_run_reindex_canary_automatically_includes_production_pathology_sessions
     """The real canary runner supplements operator IDs from the production manifest."""
     from polylogue.maintenance.pathology_zoo import pathology_zoo_session_ids
 
-    current = tmp_path / "current.db"
+    current = tmp_path / "index.db"
     pathology_session_ids = pathology_zoo_session_ids()
     native_ids = tuple(session_id.split(":", 1)[1] for session_id in pathology_session_ids)
     origins = tuple(session_id.split(":", 1)[0] for session_id in pathology_session_ids)
@@ -586,7 +591,7 @@ def test_run_reindex_canary_accepts_split_root_active_pointer_through_real_valid
 def test_run_reindex_canary_does_not_require_zoo_sessions_for_ordinary_archive(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    current = tmp_path / "current.db"
+    current = tmp_path / "index.db"
     _seed_index(current)
     selection = CanarySelection(
         index_path=current,
@@ -758,7 +763,7 @@ def test_real_pathology_canary_rejects_cyclic_candidate_before_insight_repair(
     monkeypatch.setattr(rebuild_index, "_repopulate_bulk_build_derived_state", corrupt_candidate_after_replay)
     monkeypatch.setattr("polylogue.storage.repair.repair_session_insights", unexpected_insight_repair)
 
-    with pytest.raises(RuntimeError, match="session-lineage-acyclic"):
+    with pytest.raises(RuntimeError, match="session-lineage-acyclic|no longer parses to one session"):
         run_reindex_canary(zoo.archive_root, sessions_per_origin=1, no_promote=True)
 
     assert hashlib.sha256(active_index.read_bytes()).hexdigest() == active_digest

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -41,6 +41,7 @@ from polylogue.maintenance.reindex_canary import (
     select_canary_sessions,
     write_canary_report,
 )
+from polylogue.sources.revision_backfill import RebuildDeadlineExceededError
 from polylogue.storage.index_generation import rebuild_source_evidence_snapshot, source_revision_snapshot
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root, initialize_archive_database
@@ -689,6 +690,29 @@ def test_run_reindex_canary_rejects_external_evidence_mutation_after_replay(
         run_reindex_canary(root, sessions_per_origin=1, no_promote=True)
 
     assert hashlib.sha256(active_index.read_bytes()).hexdigest() == active_digest
+
+
+def test_rebuild_rejects_evidence_mutation_in_deadline_interrupted_pass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A deferred resumable pass cannot preserve a mutated source proof."""
+
+    artifact = build_seeded_archive(cache_root=tmp_path / "seeded-cache")
+    root = clone_seeded_archive(artifact, tmp_path / "archive").root
+
+    from polylogue.maintenance import replay as rebuild_replay
+
+    async def mutate_source_then_interrupt(*args: Any, **kwargs: Any) -> dict[str, object]:
+        with sqlite3.connect(root / "source.db") as connection:
+            connection.execute("UPDATE raw_sessions SET source_path = source_path || '.mutated'")
+        raise RebuildDeadlineExceededError("synthetic deadline")
+
+    monkeypatch.setattr(rebuild_replay, "rebuild_index_from_source", mutate_source_then_interrupt)
+
+    with pytest.raises(RuntimeError, match="stale because source evidence changed"):
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(archive_root=root, raw_batch_size=10, pass_deadline_seconds=30.0)
+        )
 
 
 def test_run_reindex_canary_does_not_require_zoo_sessions_for_ordinary_archive(

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -20,6 +20,7 @@ from typing import Any
 import pytest
 
 from polylogue.maintenance import reindex_canary as reindex_canary_module
+from polylogue.maintenance.rebuild_index import rebuild_selection_evidence
 from polylogue.maintenance.reindex_canary import (
     CanaryDifferenceReview,
     CanaryDiffReport,
@@ -57,6 +58,11 @@ def _synthetic_report_provenance(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         reindex_canary_module,
         "_validate_archive_provenance",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        reindex_canary_module,
+        "_validate_authoritative_rebuild_receipt",
         lambda *args, **kwargs: None,
     )
 
@@ -149,21 +155,28 @@ def _empty_comparison(current: Path, candidate: Path, session_ids: tuple[str, ..
 
 
 def _rebuild_receipt(selection: CanarySelection, comparison: CanaryDiffReport) -> dict[str, object]:
+    generation = {
+        "generation_id": "gen-canary",
+        "owner_id": "owner",
+        "archive_root": str(comparison.candidate_index.parent),
+        "index_path": str(comparison.candidate_index),
+        "state": "inactive",
+        "source_snapshot": "snapshot",
+    }
     return {
         "archive_root": str(comparison.candidate_index.parent),
         "selected_raw_count": len(selection.selected_raw_ids),
-        "selected_raw_ids": list(selection.selected_raw_ids),
-        "selected_session_ids": list(selection.selected_session_ids),
         "status": "replayed",
         "materialized": True,
-        "generation": {
-            "generation_id": "gen-canary",
-            "owner_id": "owner",
-            "archive_root": str(comparison.candidate_index.parent),
-            "index_path": str(comparison.candidate_index),
-            "state": "inactive",
-            "source_snapshot": "snapshot",
-        },
+        "generation": generation,
+        "selection_evidence": rebuild_selection_evidence(
+            selection.selected_raw_ids,
+            archive_root=comparison.candidate_index.parent,
+            generation_id="gen-canary",
+            generation_owner_id="owner",
+            candidate_index=comparison.candidate_index,
+            source_snapshot="snapshot",
+        ),
     }
 
 
@@ -504,6 +517,9 @@ def test_run_reindex_canary_automatically_includes_production_pathology_sessions
 
     monkeypatch.setattr("polylogue.maintenance.rebuild_index.rebuild_index_from_source_sync", fake_rebuild)
     monkeypatch.setattr(
+        "polylogue.maintenance.reindex_canary._validate_selection_evidence", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
         "polylogue.maintenance.reindex_canary._validate_canary_candidate", lambda *args, **kwargs: current
     )
     monkeypatch.setattr("polylogue.maintenance.reindex_canary.compare_reindex_generations", fake_compare)
@@ -623,9 +639,15 @@ def test_run_reindex_canary_does_not_require_zoo_sessions_for_ordinary_archive(
     )
     monkeypatch.setattr("polylogue.maintenance.rebuild_index.rebuild_index_from_source_sync", fake_rebuild)
     monkeypatch.setattr(
+        "polylogue.maintenance.reindex_canary._validate_selection_evidence", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
         "polylogue.maintenance.reindex_canary._validate_canary_candidate", lambda *args, **kwargs: current
     )
     monkeypatch.setattr("polylogue.maintenance.reindex_canary.compare_reindex_generations", fake_compare)
+    monkeypatch.setattr(
+        "polylogue.maintenance.reindex_canary._validate_selection_evidence", lambda *args, **kwargs: None
+    )
 
     result = run_reindex_canary(tmp_path, input_index=current, no_promote=True)
 
@@ -669,6 +691,9 @@ def test_run_reindex_canary_compares_its_own_inactive_generation(
         "polylogue.maintenance.reindex_canary.select_canary_sessions", lambda *args, **kwargs: selection
     )
     monkeypatch.setattr("polylogue.maintenance.rebuild_index.rebuild_index_from_source_sync", lambda request: Receipt())
+    monkeypatch.setattr(
+        "polylogue.maintenance.reindex_canary._validate_selection_evidence", lambda *args, **kwargs: None
+    )
 
     def fake_compare(current_path: Path, candidate_path: Path, *, session_ids: tuple[str, ...]) -> CanaryDiffReport:
         captured.update({"paths": (current_path, candidate_path), "session_ids": session_ids})
@@ -703,10 +728,16 @@ def test_run_reindex_canary_rejects_arbitrary_sqlite_candidate(tmp_path: Path, m
             "source_snapshot": "snapshot",
         }
 
+        def to_dict(self) -> dict[str, object]:
+            return {"generation": self.generation}
+
     monkeypatch.setattr(
         "polylogue.maintenance.reindex_canary.select_canary_sessions", lambda *args, **kwargs: selection
     )
     monkeypatch.setattr("polylogue.maintenance.rebuild_index.rebuild_index_from_source_sync", lambda request: Receipt())
+    monkeypatch.setattr(
+        "polylogue.maintenance.reindex_canary._validate_selection_evidence", lambda *args, **kwargs: None
+    )
 
     with pytest.raises(CanarySelectionError, match="outside this archive's generation root"):
         run_reindex_canary(tmp_path, input_index=current, no_promote=True)
@@ -838,7 +869,7 @@ def test_durable_report_persists_explicit_review_for_every_diff(tmp_path: Path) 
     assert durable.unclassified_count == 0
     assert report_path.exists()
     payload = json.loads(report_path.read_text(encoding="utf-8"))
-    assert payload["schema_version"] == 3
+    assert payload["schema_version"] == 4
     comparison_payload = payload["comparison"]
     assert isinstance(comparison_payload, dict)
     summary = comparison_payload["summary"]
@@ -926,7 +957,7 @@ def test_loading_canary_report_rejects_tampered_candidate_provenance(tmp_path: P
     (
         ("index", "selection index"),
         ("sessions", "selection sessions"),
-        ("raw-ids", "rebuild evidence"),
+        ("raw-ids", "selection does not match the authoritative rebuild receipt"),
     ),
 )
 def test_loading_canary_report_rejects_tampered_selection_binding(tmp_path: Path, tamper: str, message: str) -> None:
@@ -956,7 +987,7 @@ def test_loading_canary_report_rejects_tampered_selection_binding(tmp_path: Path
     elif tamper == "sessions":
         payload["selection"]["selected_session_ids"] = ["codex-session:foreign"]
     else:
-        payload["rebuild_receipt"]["selected_raw_ids"] = ["raw-foreign"]
+        payload["selection"]["selected_raw_ids"] = ["raw-foreign"]
     report_path.write_text(json.dumps(payload))
     with pytest.raises(UnclassifiedCanaryDiffError, match=message):
         load_canary_report(report_path)


### PR DESCRIPTION
## Summary

This revision closes the remaining canary evidence gaps on the existing PR branch. A canary receipt now attests the complete production replay closure, verified raw payload bytes, an approval transaction serialized with archive rebuild ownership, and an explicit binding to the requested archive root.

## Problem

The earlier receipt fingerprint covered the requested raw IDs but could omit durable `raw_session_memberships` and `logical_source_key` expansion discovered by replay census. Source evidence could also pass from path, hash metadata, or liveness while the bytes at the BlobStore path had been changed. Report consumption loaded selection evidence from the receipt's serialized archive root before confirming that the report and receipt belonged to the configured requested archive, allowing a forged foreign `source.db` path to be opened during validation.

## Solution

`rebuild_selection_evidence()` reuses `ArchiveStore.expand_raw_membership_selection_sync()` and records the expanded raw IDs, logical source keys, and every participating `raw_session_memberships` row in the existing canonical selection digest. Terminal receipt evidence is recomputed after replay census so the receipt names the closure the candidate actually consumed.

`rebuild_source_evidence_snapshot()` reuses the production `BlobStore.verify()` API for every raw payload hash. Verification re-hashes the bytes on disk before their content identities enter source evidence, so content-addressed metadata and liveness alone cannot satisfy the attestation.

`approve_canary_report()` now acquires `RebuildLease` followed by `OwnedArchiveLocation`, matching rebuild ownership semantics. It checks ownership before and after the initial report load, then immediately reruns source, candidate generation, receipt, active pointer, index, comparison, review, and unexpected-difference validation before returning approval. Consumption still returns `promotion_authorized: false` and performs no promotion.

Report loading now binds the receipt archive root and any present archive provenance root to the explicit configured root before receipt validation can compute selection evidence. The validated configured root is passed through the receipt and selection evidence helpers, so a forged foreign root is rejected without opening its source tier.

## Acceptance criteria

- Full replay closure: satisfied. Membership and logical-key expansion are part of the receipt fingerprint, including rows added by census. A real-route regression adds an unselected raw under a captured logical key and proves report consumption fails closed.
- Verified blob bytes: satisfied. A real-route regression overwrites the selected BlobStore file while leaving its source hash and path metadata unchanged, and approval rejects the report with byte verification failure.
- Ownership and final revalidation: satisfied. Real-route regressions cover rebuild-lease contention, source mutation after the first approval check, and candidate promotion after the first approval check. Each rejects stale approval and leaves the active index unchanged.
- Requested archive binding: satisfied. A real consume-report regression forges the receipt, generation, and report roots to a foreign archive, instruments SQLite connection attempts, and proves rejection occurs before opening the foreign `source.db`. The existing same-root approval regression remains green.
- No promotion on failure: satisfied. Canary rebuilds require `--no-promote`, approval never authorizes promotion, and failure-path tests assert the active generation remains unchanged.

## Anti-vacuity mutations

The regressions mutate production-route state rather than a test-only validator: insert a `raw_session_memberships` row for an unselected raw with the selected logical key, overwrite BlobStore bytes without changing source metadata, mutate `source_index` between approval loads, promote the candidate between approval loads, hold the real rebuild lease during consumption, and forge all report archive-root fields while any SQLite open is made a test failure. The existing parsed-state mutation regression also confirms the intended mutable parser-state boundary remains accepted. Reviewed consumption asserts `promotion_authorized` is false.

## Verification

- `direnv exec . devtools test tests/unit/maintenance/test_reindex_canary.py` -> 37 passed in 38.31 seconds.
- `direnv exec . devtools test tests/unit/cli/test_reindex_canary_cli.py` -> 30 passed in 18.08 seconds.
- `direnv exec . devtools test tests/unit/cli/test_reindex_canary_cli.py -k 'consumes_valid_reviewed_real_report or rejects_foreign_receipt_root_before_opening_foreign_source_db'` -> 2 passed in 8.02 seconds.
- `direnv exec . devtools verify --quick` -> all 23 steps passed, exit 0.
- The pre-push quick baseline reran at commit `8d10bb28a` and passed all 23 steps.
- The prescribed `direnv exec . devtools verify --seed-testmon --skip-slow` baseline was attempted earlier but exited 1 on unrelated repository-wide timeout/flakiness during `tests/unit/storage/test_store_ops.py::TestInfraTagAssignment::test_tag_assignment_roundtrip_and_counts`, `tests/unit/pipeline/test_resilience.py::test_acquisition_law_counts_unique_raws_and_normalizes_provider_hints`, and `tests/property/test_write_path_state_machine.py::TestWritePathStateMachine::runTest`. The focused canary suites and quick affected checks are green.

Ref #3805