### PR TITLE
fix(maintenance): make blob-ref liveness apply safe at scale

### DIFF
--- a/polylogue/cli/commands/maintenance/_blob_integrity.py
+++ b/polylogue/cli/commands/maintenance/_blob_integrity.py
@@ -74,7 +74,7 @@ def _render_blob_reference_liveness_plain(report: BlobRefLivenessReconciliationR
     click.echo(f"Source DB:    {report.source_db}")
     click.echo(f"Mode:         {'apply' if report.applied else 'dry-run'}")
     click.echo(f"Scanned:      {report.classification.scanned_count:,} blob_refs row(s)")
-    click.echo(f"Orphans:      {len(report.classification.candidates):,} row(s)")
+    click.echo(f"Orphans:      {report.classification.orphaned_count:,} row(s)")
     click.echo(f"Deleted:      {report.deleted_count:,} row(s)")
     click.echo(f"Safe to apply: {'yes' if report.classification.safe_to_apply else 'no'}")
     if report.classification.rekeyable_hook_payload_count:

--- a/polylogue/maintenance/blob_ref_liveness_reconciliation.py
+++ b/polylogue/maintenance/blob_ref_liveness_reconciliation.py
@@ -7,6 +7,7 @@ import json
 import os
 import sqlite3
 import time
+from collections.abc import Iterable, Iterator
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
@@ -15,11 +16,18 @@ from polylogue.config import Config
 from polylogue.maintenance.offline_guard import running_daemon_pid
 from polylogue.paths import render_root
 from polylogue.storage.blob_ref_liveness import (
+    BlobRefLivenessCandidate,
     BlobRefLivenessClassification,
     classify_blob_ref_liveness,
+    stage_blob_ref_liveness,
 )
+from polylogue.storage.hook_payload_ref_reconciliation import _deterministic_raw_session_id_udf
+from polylogue.storage.introspection import table_exists as _table_exists
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
-from polylogue.storage.sqlite.migration_runner import validate_migration_backup_manifest
+from polylogue.storage.sqlite.migration_runner import (
+    validate_migration_backup_live_fingerprint,
+    validate_migration_backup_manifest,
+)
 
 TOOL_VERSION = "blob-ref-liveness-reconciliation-v1"
 
@@ -75,13 +83,38 @@ def _checkpoint_source_db(conn: sqlite3.Connection) -> None:
         raise BlobRefLivenessReconciliationError("could not checkpoint source.db before backup validation")
 
 
-def _candidate_digest(classification: BlobRefLivenessClassification) -> str:
-    encoded = json.dumps(
-        [candidate.to_dict() for candidate in classification.candidates],
-        sort_keys=True,
-        separators=(",", ":"),
-    ).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()
+def _candidate_digest(candidates: Iterable[BlobRefLivenessCandidate]) -> str:
+    digest = hashlib.sha256()
+    digest.update(b"[")
+    first = True
+    for candidate in candidates:
+        if not first:
+            digest.update(b",")
+        digest.update(json.dumps(candidate.to_dict(), sort_keys=True, separators=(",", ":")).encode("utf-8"))
+        first = False
+    digest.update(b"]")
+    return digest.hexdigest()
+
+
+def _iter_staged_candidates(conn: sqlite3.Connection, table_name: str) -> Iterator[BlobRefLivenessCandidate]:
+    for row in conn.execute(
+        f"""
+        SELECT blob_hash, ref_type, ref_id, source_path, size_bytes,
+               acquired_at_ms, referent_table, referent_column
+        FROM {table_name}
+        ORDER BY ref_type, ref_id, blob_hash
+        """
+    ):
+        yield BlobRefLivenessCandidate(
+            blob_hash=bytes(row[0]).hex(),
+            ref_type=str(row[1]),
+            ref_id=str(row[2]),
+            source_path=str(row[3]) if row[3] is not None else None,
+            size_bytes=int(row[4]),
+            acquired_at_ms=int(row[5]),
+            referent_table=str(row[6]),
+            referent_column=str(row[7]),
+        )
 
 
 def _fsync_directory(path: Path) -> None:
@@ -97,6 +130,9 @@ def _write_prepared_receipt(
     source_db: Path,
     classification: BlobRefLivenessClassification,
     backup_manifest: Path,
+    *,
+    candidates: Iterable[BlobRefLivenessCandidate] | None = None,
+    candidate_digest: str | None = None,
 ) -> None:
     receipt_path.parent.mkdir(parents=True, exist_ok=True)
     header = {
@@ -106,8 +142,9 @@ def _write_prepared_receipt(
         "source_db": str(source_db),
         "backup_manifest": str(backup_manifest),
         "prepared_at_ms": int(time.time() * 1000),
-        "candidate_count": len(classification.candidates),
-        "candidate_digest": _candidate_digest(classification),
+        "candidate_count": classification.orphaned_count,
+        "candidate_digest": candidate_digest
+        or _candidate_digest(classification.candidates if candidates is None else candidates),
         "orphaned_by_ref_type": dict(classification.orphaned_by_ref_type),
         "referent_joins": [
             {"ref_type": ref_type, "referent_table": table, "referent_column": column}
@@ -116,10 +153,12 @@ def _write_prepared_receipt(
     }
     try:
         with receipt_path.open("x", encoding="utf-8") as handle:
-            rows = [header]
-            rows.extend({"kind": "candidate", **candidate.to_dict()} for candidate in classification.candidates)
-            for row in rows:
-                handle.write(json.dumps(row, sort_keys=True, separators=(",", ":")))
+            handle.write(json.dumps(header, sort_keys=True, separators=(",", ":")))
+            handle.write("\n")
+            for candidate in classification.candidates if candidates is None else candidates:
+                handle.write(
+                    json.dumps({"kind": "candidate", **candidate.to_dict()}, sort_keys=True, separators=(",", ":"))
+                )
                 handle.write("\n")
             handle.flush()
             os.fsync(handle.fileno())
@@ -152,6 +191,85 @@ def _append_receipt_footer(
     _fsync_directory(receipt_path.parent)
 
 
+def _receipt_candidate(row: dict[str, object]) -> tuple[bytes, str, str]:
+    try:
+        return bytes.fromhex(str(row["blob_hash"])), str(row["ref_type"]), str(row["ref_id"])
+    except (KeyError, ValueError) as exc:
+        raise BlobRefLivenessReconciliationError("prepared receipt contains an invalid candidate") from exc
+
+
+def _stage_receipt_candidates(conn: sqlite3.Connection, receipt_path: Path) -> tuple[int, str, dict[str, object]]:
+    table_name = "blob_ref_liveness_receipt_candidates"
+    conn.execute(f"DROP TABLE IF EXISTS temp.{table_name}")
+    conn.execute(
+        f"""
+        CREATE TEMP TABLE {table_name} (
+            blob_hash BLOB NOT NULL,
+            ref_type TEXT NOT NULL,
+            ref_id TEXT NOT NULL,
+            PRIMARY KEY (blob_hash, ref_type, ref_id)
+        ) STRICT
+        """
+    )
+    header: dict[str, object] | None = None
+    terminal_phases: list[str] = []
+    digest = hashlib.sha256()
+    digest.update(b"[")
+    first_candidate = True
+    candidate_count = 0
+    with receipt_path.open(encoding="utf-8") as handle:
+        for line in handle:
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise BlobRefLivenessReconciliationError(f"receipt is not valid JSON: {receipt_path}") from exc
+            if not isinstance(row, dict):
+                raise BlobRefLivenessReconciliationError(f"receipt row is not an object: {receipt_path}")
+            if row.get("kind") == "blob_ref_liveness_reconciliation":
+                if header is None:
+                    header = row
+                else:
+                    phase = row.get("phase")
+                    if phase is not None:
+                        terminal_phases.append(str(phase))
+            elif row.get("kind") == "candidate":
+                candidate = _receipt_candidate(row)
+                conn.execute(f"INSERT INTO {table_name} (blob_hash, ref_type, ref_id) VALUES (?, ?, ?)", candidate)
+                if not first_candidate:
+                    digest.update(b",")
+                digest.update(
+                    json.dumps(
+                        {
+                            "blob_hash": candidate[0].hex(),
+                            "ref_id": candidate[2],
+                            "ref_type": candidate[1],
+                            "source_path": row.get("source_path"),
+                            "size_bytes": row.get("size_bytes"),
+                            "acquired_at_ms": row.get("acquired_at_ms"),
+                            "referent_table": row.get("referent_table"),
+                            "referent_column": row.get("referent_column"),
+                        },
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ).encode("utf-8")
+                )
+                first_candidate = False
+                candidate_count += 1
+    if header is None or header.get("phase") != "prepared":
+        raise BlobRefLivenessReconciliationError(f"receipt does not contain a prepared plan: {receipt_path}")
+    if terminal_phases:
+        raise BlobRefLivenessReconciliationError(f"receipt is already terminal: {receipt_path}")
+    receipt_candidate_count = header.get("candidate_count")
+    if not isinstance(receipt_candidate_count, int) or receipt_candidate_count != candidate_count:
+        raise BlobRefLivenessReconciliationError(f"prepared receipt candidate count mismatch: {receipt_path}")
+    digest.update(b"]")
+    if str(header.get("candidate_digest")) != digest.hexdigest():
+        raise BlobRefLivenessReconciliationError(f"prepared receipt candidate digest mismatch: {receipt_path}")
+    return candidate_count, table_name, header
+
+
 def _recover_prepared_receipt(source_db: Path, receipt_path: Path) -> str:
     """Resolve the only crash window between SQLite commit and receipt footer.
 
@@ -161,31 +279,23 @@ def _recover_prepared_receipt(source_db: Path, receipt_path: Path) -> str:
     Recovery appends durable evidence but never performs another mutation.
     """
 
-    rows = [json.loads(line) for line in receipt_path.read_text(encoding="utf-8").splitlines() if line]
-    if not rows or rows[0].get("kind") != "blob_ref_liveness_reconciliation":
-        raise BlobRefLivenessReconciliationError(f"receipt is not a liveness reconciliation receipt: {receipt_path}")
-    phases = [str(row.get("phase")) for row in rows if row.get("kind") == "blob_ref_liveness_reconciliation"]
-    if not phases or phases[0] != "prepared":
-        raise BlobRefLivenessReconciliationError(f"receipt does not contain a prepared plan: {receipt_path}")
-    if any(
-        phase in {"committed", "aborted", "recovered_committed", "recovered_rolled_back", "indeterminate"}
-        for phase in phases[1:]
-    ):
-        raise BlobRefLivenessReconciliationError(f"receipt is already terminal: {receipt_path}")
-    candidates = [row for row in rows if row.get("kind") == "candidate"]
     with sqlite3.connect(f"file:{source_db}?mode=ro", uri=True) as conn:
-        still_present = [
-            candidate
-            for candidate in candidates
-            if conn.execute(
-                "SELECT 1 FROM blob_refs WHERE blob_hash = ? AND ref_type = ? AND ref_id = ?",
-                (bytes.fromhex(str(candidate["blob_hash"])), candidate["ref_type"], candidate["ref_id"]),
-            ).fetchone()
-            is not None
-        ]
-    if len(still_present) == len(candidates):
+        candidate_count, table_name, _header = _stage_receipt_candidates(conn, receipt_path)
+        present_count = int(
+            conn.execute(
+                f"""
+                SELECT COUNT(*)
+                FROM {table_name} AS c
+                JOIN blob_refs AS b
+                  ON b.blob_hash = c.blob_hash
+                 AND b.ref_type = c.ref_type
+                 AND b.ref_id = c.ref_id
+                """
+            ).fetchone()[0]
+        )
+    if present_count == candidate_count:
         outcome = "recovered_rolled_back"
-    elif not still_present:
+    elif present_count == 0:
         outcome = "recovered_committed"
     else:
         outcome = "indeterminate"
@@ -193,37 +303,113 @@ def _recover_prepared_receipt(source_db: Path, receipt_path: Path) -> str:
     return outcome
 
 
-def _delete_candidates(conn: sqlite3.Connection, classification: BlobRefLivenessClassification) -> int:
-    conn.execute(
-        """
-        CREATE TEMP TABLE blob_ref_liveness_candidates (
-            blob_hash BLOB NOT NULL,
-            ref_type TEXT NOT NULL,
-            ref_id TEXT NOT NULL,
-            PRIMARY KEY (blob_hash, ref_type, ref_id)
-        ) STRICT
-        """
-    )
-    conn.executemany(
-        "INSERT INTO blob_ref_liveness_candidates (blob_hash, ref_type, ref_id) VALUES (?, ?, ?)",
-        (
-            (bytes.fromhex(candidate.blob_hash), candidate.ref_type, candidate.ref_id)
-            for candidate in classification.candidates
-        ),
-    )
-    deleted = conn.execute(
-        """
-        DELETE FROM blob_refs
-        WHERE EXISTS (
-            SELECT 1
-            FROM blob_ref_liveness_candidates AS c
-            WHERE c.blob_hash = blob_refs.blob_hash
-              AND c.ref_type = blob_refs.ref_type
-              AND c.ref_id = blob_refs.ref_id
+def _delete_candidates(conn: sqlite3.Connection, candidate_table: str, *, batch_size: int = 1000) -> int:
+    deleted_count = 0
+    while True:
+        deleted = conn.execute(
+            f"""
+            DELETE FROM blob_refs
+            WHERE rowid IN (
+                SELECT b.rowid
+                FROM blob_refs AS b
+                JOIN {candidate_table} AS c
+                  ON c.blob_hash = b.blob_hash
+                 AND c.ref_type = b.ref_type
+                 AND c.ref_id = b.ref_id
+                LIMIT ?
+            )
+            """,
+            (batch_size,),
         )
-        """
+        count = max(0, int(deleted.rowcount))
+        deleted_count += count
+        if count == 0:
+            return deleted_count
+
+
+def _validate_locked_candidate_plan(conn: sqlite3.Connection, candidate_table: str, expected_count: int) -> None:
+    present_count = int(
+        conn.execute(
+            f"""
+            SELECT COUNT(*)
+            FROM {candidate_table} AS c
+            JOIN blob_refs AS b
+              ON b.blob_hash = c.blob_hash
+             AND b.ref_type = c.ref_type
+             AND b.ref_id = c.ref_id
+            """
+        ).fetchone()[0]
     )
-    return max(0, int(deleted.rowcount))
+    if present_count != expected_count:
+        raise BlobRefLivenessReconciliationError(
+            f"prepared candidate presence mismatch: planned={expected_count} present={present_count}"
+        )
+    conn.execute("DROP TABLE IF EXISTS temp.blob_ref_liveness_locked_hooks")
+    if _table_exists(conn, "raw_hook_events"):
+        conn.execute(
+            """
+            CREATE TEMP TABLE blob_ref_liveness_locked_hooks AS
+            SELECT h.hook_event_id, h.origin, h.native_id, h.source_path, h.blob_hash
+            FROM raw_hook_events AS h
+            WHERE NOT EXISTS (
+                SELECT 1 FROM blob_refs AS b
+                WHERE b.blob_hash = h.blob_hash
+                  AND b.ref_type = 'hook_payload'
+                  AND b.ref_id = h.hook_event_id
+            )
+            """
+        )
+    else:
+        conn.execute(
+            """
+            CREATE TEMP TABLE blob_ref_liveness_locked_hooks (
+                hook_event_id TEXT NOT NULL,
+                origin TEXT,
+                native_id TEXT,
+                source_path TEXT,
+                blob_hash BLOB
+            )
+            """
+        )
+    conn.execute(
+        "CREATE INDEX blob_ref_liveness_locked_hooks_source_hash "
+        "ON blob_ref_liveness_locked_hooks(source_path, blob_hash)"
+    )
+    conn.create_function("polylogue_deterministic_raw_session_id", 5, _deterministic_raw_session_id_udf)
+    rekeyable = int(
+        conn.execute(
+            f"""
+            SELECT COUNT(*)
+            FROM (
+                SELECT c.blob_hash, c.ref_id
+                FROM {candidate_table} AS c
+                JOIN blob_ref_liveness_locked_hooks AS h
+                  ON h.source_path IS c.source_path
+                 AND h.blob_hash = c.blob_hash
+                 AND polylogue_deterministic_raw_session_id(h.origin, c.source_path, 0, c.blob_hash, h.native_id) = c.ref_id
+                WHERE c.ref_type = 'raw_payload'
+                GROUP BY c.blob_hash, c.ref_id
+                HAVING COUNT(*) = 1
+                UNION ALL
+                SELECT c.blob_hash, c.ref_id
+                FROM {candidate_table} AS c
+                JOIN blob_ref_liveness_locked_hooks AS h
+                  ON h.source_path IS c.source_path
+                 AND h.blob_hash IS NULL
+                 AND polylogue_deterministic_raw_session_id(h.origin, c.source_path, 0, c.blob_hash, h.native_id) = c.ref_id
+                WHERE c.ref_type = 'raw_payload'
+                  AND (SELECT COUNT(*) FROM {candidate_table} AS c2
+                       WHERE c2.ref_type = 'raw_payload' AND c2.source_path IS c.source_path) = 1
+                  AND (SELECT COUNT(*) FROM blob_ref_liveness_locked_hooks AS h2
+                       WHERE h2.source_path IS h.source_path AND h2.blob_hash IS NULL) = 1
+            )
+            """
+        ).fetchone()[0]
+    )
+    if rekeyable:
+        raise BlobRefLivenessReconciliationError(
+            f"prepared candidates became rekeyable hook payloads under lock: {rekeyable}"
+        )
 
 
 def reconcile_blob_ref_liveness(
@@ -236,8 +422,9 @@ def reconcile_blob_ref_liveness(
     """Classify orphaned source-tier refs, or apply the exact locked plan.
 
     Apply requires both a verified source-tier backup manifest and a receipt
-    path. Classification is repeated after ``BEGIN IMMEDIATE`` and the
-    receipt is fsynced before the set-based DELETE starts.
+    path. A compact SQLite plan and prepared receipt are built before
+    ownership; exact candidate keys and rekeyable hook matches are rechecked
+    after ``BEGIN IMMEDIATE`` before bounded deletes start.
     """
 
     source_db = archive_root / "source.db"
@@ -271,61 +458,90 @@ def reconcile_blob_ref_liveness(
     if reason := _offline_apply_block_reason(archive_root):
         raise BlobRefLivenessReconciliationError(reason)
 
-    conn = sqlite3.connect(source_db)
-    classification: BlobRefLivenessClassification | None = None
-    prepared = False
+    pre_conn = sqlite3.connect(source_db)
+    staged_plan = None
     try:
-        _checkpoint_source_db(conn)
-        validate_migration_backup_manifest(backup_manifest, ArchiveTier.SOURCE, connection=conn)
+        _checkpoint_source_db(pre_conn)
+        validate_migration_backup_manifest(backup_manifest, ArchiveTier.SOURCE, connection=pre_conn)
+        staged_plan = stage_blob_ref_liveness(pre_conn)
+        classification = staged_plan.classification
+        if not classification.safe_to_apply:
+            raise BlobRefLivenessReconciliationError(
+                "ref types cannot be proven with source-tier joins: "
+                f"unknown={classification.unknown_ref_types!r}, "
+                f"unavailable={classification.unavailable_ref_types!r}, "
+                f"rekeyable_hook_payloads={classification.rekeyable_hook_payload_count!r}. "
+                "Run hook-payload reference reconciliation before deleting orphan refs."
+            )
+        candidates = _iter_staged_candidates(pre_conn, staged_plan.candidate_table)
+        candidate_digest = _candidate_digest(_iter_staged_candidates(pre_conn, staged_plan.candidate_table))
+        _write_prepared_receipt(
+            receipt_path,
+            source_db,
+            classification,
+            backup_manifest,
+            candidates=candidates,
+            candidate_digest=candidate_digest,
+        )
+        expected_count = classification.orphaned_count
+        # Temp tables survive a commit. Clearing the staging transaction here
+        # lets this same connection carry the exact plan into ownership without
+        # reparsing the durable receipt under the write lock.
+        pre_conn.commit()
+    except Exception:
+        pre_conn.close()
+        raise
+
+    conn = pre_conn
+    try:
         conn.execute("BEGIN IMMEDIATE")
         try:
-            validate_migration_backup_manifest(backup_manifest, ArchiveTier.SOURCE, connection=conn)
-            classification = classify_blob_ref_liveness(conn)
-            if not classification.safe_to_apply:
+            # The full backup-tree attestation happened before ownership. This
+            # ownership check re-authenticates the receipt and checks only the
+            # live source fingerprint, so backup hashing cannot occupy the
+            # write lock twice.
+            validate_migration_backup_live_fingerprint(backup_manifest, ArchiveTier.SOURCE, connection=conn)
+            _validate_locked_candidate_plan(conn, staged_plan.candidate_table, expected_count)
+            deleted_count = _delete_candidates(conn, staged_plan.candidate_table)
+            if deleted_count != expected_count:
                 raise BlobRefLivenessReconciliationError(
-                    "ref types cannot be proven with source-tier joins: "
-                    f"unknown={classification.unknown_ref_types!r}, "
-                    f"unavailable={classification.unavailable_ref_types!r}, "
-                    f"rekeyable_hook_payloads={classification.rekeyable_hook_payload_count!r}. "
-                    "Run hook-payload reference reconciliation before deleting orphan refs."
+                    f"candidate/delete count mismatch: planned={expected_count} deleted={deleted_count}"
                 )
-            _write_prepared_receipt(receipt_path, source_db, classification, backup_manifest)
-            prepared = True
-            deleted_count = _delete_candidates(conn, classification)
-            if deleted_count != len(classification.candidates):
-                raise BlobRefLivenessReconciliationError(
-                    f"candidate/delete count mismatch: planned={len(classification.candidates)} deleted={deleted_count}"
-                )
-            quick_check = conn.execute("PRAGMA quick_check").fetchone()
-            if quick_check is None or str(quick_check[0]).lower() != "ok":
-                raise BlobRefLivenessReconciliationError(f"source.db quick_check failed: {quick_check!r}")
         except Exception:
             if conn.in_transaction:
                 conn.rollback()
+            with suppress(OSError):
+                _append_receipt_footer(receipt_path, phase="aborted", error="transaction rolled back")
             raise
         else:
             conn.commit()
-    except Exception as exc:
-        if prepared:
-            with suppress(OSError):
-                _append_receipt_footer(receipt_path, phase="aborted", error=str(exc))
-        raise
     finally:
         conn.close()
 
-    assert classification is not None
     try:
-        _append_receipt_footer(receipt_path, phase="committed", deleted_count=len(classification.candidates))
+        _append_receipt_footer(receipt_path, phase="committed", deleted_count=expected_count)
     except OSError as exc:
         raise BlobRefLivenessReconciliationError(
             f"source.db committed but could not finalize receipt {receipt_path}"
         ) from exc
+
+    try:
+        with sqlite3.connect(f"file:{source_db}?mode=ro", uri=True) as verify_conn:
+            quick_check = verify_conn.execute("PRAGMA quick_check").fetchone()
+        if quick_check is None or str(quick_check[0]).lower() != "ok":
+            with suppress(OSError):
+                _append_receipt_footer(receipt_path, phase="post_check_failed", error=f"quick_check={quick_check!r}")
+            raise BlobRefLivenessReconciliationError(f"source.db quick_check failed after commit: {quick_check!r}")
+    finally:
+        pass
+
+    assert staged_plan is not None
     return BlobRefLivenessReconciliationReport(
         source_db=str(source_db),
         dry_run=False,
-        classification=classification,
+        classification=staged_plan.classification,
         applied=True,
-        deleted_count=len(classification.candidates),
+        deleted_count=expected_count,
         receipt_path=receipt_path,
         backup_manifest=backup_manifest,
     )

--- a/polylogue/maintenance/blob_ref_liveness_reconciliation.py
+++ b/polylogue/maintenance/blob_ref_liveness_reconciliation.py
@@ -31,6 +31,15 @@ from polylogue.storage.sqlite.migration_runner import (
 )
 
 TOOL_VERSION = "blob-ref-liveness-reconciliation-v1"
+BATCH_SIZE = 1_000
+_RECOVERY_TERMINAL_PHASES = {
+    "committed",
+    "aborted",
+    "recovered_committed",
+    "recovered_rolled_back",
+    "recovered_partial",
+    "indeterminate",
+}
 
 
 class BlobRefLivenessReconciliationError(RuntimeError):
@@ -233,7 +242,7 @@ def _stage_receipt_candidates(conn: sqlite3.Connection, receipt_path: Path) -> t
                     header = row
                 else:
                     phase = row.get("phase")
-                    if phase is not None:
+                    if phase is not None and str(phase) in _RECOVERY_TERMINAL_PHASES:
                         terminal_phases.append(str(phase))
             elif row.get("kind") == "candidate":
                 candidate = _receipt_candidate(row)
@@ -272,11 +281,10 @@ def _stage_receipt_candidates(conn: sqlite3.Connection, receipt_path: Path) -> t
 
 
 def _recover_prepared_receipt(source_db: Path, receipt_path: Path) -> str:
-    """Resolve the only crash window between SQLite commit and receipt footer.
+    """Resolve crashes between bounded batch commits and receipt progress.
 
-    The DELETE is one SQLite transaction, so every prepared candidate is either
-    still present (the transaction rolled back) or absent (it committed). A
-    mixture is external interference and remains deliberately indeterminate.
+    Each batch is one SQLite transaction. Exact receipt keys therefore show a
+    fully rolled-back plan, a fully committed plan, or a partial batch train.
     Recovery appends durable evidence but never performs another mutation.
     """
 
@@ -299,33 +307,65 @@ def _recover_prepared_receipt(source_db: Path, receipt_path: Path) -> str:
     elif present_count == 0:
         outcome = "recovered_committed"
     else:
-        outcome = "indeterminate"
-    _append_receipt_footer(receipt_path, phase=outcome)
+        outcome = "recovered_partial"
+    _append_receipt_footer(
+        receipt_path,
+        phase=outcome,
+        deleted_count=candidate_count - present_count,
+        error=None if outcome != "recovered_partial" else f"{present_count} candidate(s) remain present",
+    )
     return outcome
 
 
-def _delete_candidates(conn: sqlite3.Connection, candidate_table: str, *, batch_size: int = 1000) -> int:
-    deleted_count = 0
-    while True:
-        deleted = conn.execute(
-            f"""
-            DELETE FROM blob_refs
-            WHERE rowid IN (
-                SELECT b.rowid
-                FROM blob_refs AS b
-                JOIN {candidate_table} AS c
-                  ON c.blob_hash = b.blob_hash
-                 AND c.ref_type = b.ref_type
-                 AND c.ref_id = b.ref_id
-                LIMIT ?
-            )
-            """,
-            (batch_size,),
+def _stage_candidate_batch(conn: sqlite3.Connection, candidate_table: str, batch_table: str, *, batch_size: int) -> int:
+    conn.execute(f"DROP TABLE IF EXISTS temp.{batch_table}")
+    conn.execute(
+        f"""
+        CREATE TEMP TABLE {batch_table} AS
+        SELECT blob_hash, ref_type, ref_id, source_path, size_bytes,
+               acquired_at_ms, referent_table, referent_column
+        FROM {candidate_table}
+        ORDER BY ref_type, ref_id, blob_hash
+        LIMIT ?
+        """,
+        (batch_size,),
+    )
+    conn.execute(f"CREATE INDEX {batch_table}_source_hash ON {batch_table}(ref_type, source_path, blob_hash)")
+    return int(conn.execute(f"SELECT COUNT(*) FROM {batch_table}").fetchone()[0])
+
+
+def _delete_candidate_batch(conn: sqlite3.Connection, candidate_table: str, batch_table: str) -> int:
+    planned_count = int(conn.execute(f"SELECT COUNT(*) FROM {batch_table}").fetchone()[0])
+    deleted = conn.execute(
+        f"""
+        DELETE FROM blob_refs
+        WHERE rowid IN (
+            SELECT b.rowid
+            FROM blob_refs AS b
+            JOIN {batch_table} AS c
+              ON c.blob_hash = b.blob_hash
+             AND c.ref_type = b.ref_type
+             AND c.ref_id = b.ref_id
         )
-        count = max(0, int(deleted.rowcount))
-        deleted_count += count
-        if count == 0:
-            return deleted_count
+        """
+    )
+    deleted_count = max(0, int(deleted.rowcount))
+    if deleted_count != planned_count:
+        raise BlobRefLivenessReconciliationError(
+            f"candidate/delete count mismatch: planned={planned_count} deleted={deleted_count}"
+        )
+    conn.execute(
+        f"""
+        DELETE FROM {candidate_table}
+        WHERE EXISTS (
+            SELECT 1 FROM {batch_table} AS b
+            WHERE b.blob_hash = {candidate_table}.blob_hash
+              AND b.ref_type = {candidate_table}.ref_type
+              AND b.ref_id = {candidate_table}.ref_id
+        )
+        """
+    )
+    return deleted_count
 
 
 def _validate_locked_candidate_plan(conn: sqlite3.Connection, candidate_table: str, expected_count: int) -> None:
@@ -370,11 +410,18 @@ def _validate_locked_candidate_plan(conn: sqlite3.Connection, candidate_table: s
     conn.execute("DROP TABLE IF EXISTS temp.blob_ref_liveness_locked_hooks")
     if _table_exists(conn, "raw_hook_events"):
         conn.execute(
-            """
+            f"""
             CREATE TEMP TABLE blob_ref_liveness_locked_hooks AS
             SELECT h.hook_event_id, h.origin, h.native_id, h.source_path, h.blob_hash
             FROM raw_hook_events AS h
-            WHERE NOT EXISTS (
+            WHERE EXISTS (
+                SELECT 1
+                FROM {candidate_table} AS c
+                WHERE c.ref_type = 'raw_payload'
+                  AND c.source_path IS h.source_path
+                  AND (h.blob_hash IS NULL OR h.blob_hash = c.blob_hash)
+            )
+              AND NOT EXISTS (
                 SELECT 1 FROM blob_refs AS b
                 WHERE b.blob_hash = h.blob_hash
                   AND b.ref_type = 'hook_payload'
@@ -516,33 +563,50 @@ def reconcile_blob_ref_liveness(
         raise
 
     conn = pre_conn
+    deleted_count = 0
+    first_batch = True
+    batch_table = "blob_ref_liveness_batch"
     try:
-        conn.execute("BEGIN IMMEDIATE")
-        try:
-            # The full backup-tree attestation happened before ownership. This
-            # ownership check re-authenticates the receipt and checks only the
-            # live source fingerprint, so backup hashing cannot occupy the
-            # write lock twice.
-            validate_migration_backup_live_fingerprint(backup_manifest, ArchiveTier.SOURCE, connection=conn)
-            _validate_locked_candidate_plan(conn, staged_plan.candidate_table, expected_count)
-            deleted_count = _delete_candidates(conn, staged_plan.candidate_table)
-            if deleted_count != expected_count:
-                raise BlobRefLivenessReconciliationError(
-                    f"candidate/delete count mismatch: planned={expected_count} deleted={deleted_count}"
-                )
-        except Exception:
-            if conn.in_transaction:
-                conn.rollback()
-            with suppress(OSError):
-                _append_receipt_footer(receipt_path, phase="aborted", error="transaction rolled back")
-            raise
-        else:
-            conn.commit()
+        while True:
+            batch_count = _stage_candidate_batch(
+                conn,
+                staged_plan.candidate_table,
+                batch_table,
+                batch_size=BATCH_SIZE,
+            )
+            if batch_count == 0:
+                break
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                if first_batch:
+                    # This is the ownership-boundary attestation. The helper
+                    # re-authenticates the receipt and validates the cached
+                    # full backup inventory, rehashing only if its stat
+                    # signature changed since the pre-lock validation.
+                    validate_migration_backup_live_fingerprint(backup_manifest, ArchiveTier.SOURCE, connection=conn)
+                _validate_locked_candidate_plan(conn, batch_table, batch_count)
+                batch_deleted = _delete_candidate_batch(conn, staged_plan.candidate_table, batch_table)
+            except Exception:
+                if conn.in_transaction:
+                    conn.rollback()
+                # Leave the prepared receipt without a terminal footer. A
+                # retry can inspect exact key presence and record rollback,
+                # commit, or partial-batch recovery without guessing.
+                raise
+            else:
+                conn.commit()
+            deleted_count += batch_deleted
+            first_batch = False
+            _append_receipt_footer(receipt_path, phase="batch_committed", deleted_count=deleted_count)
+        if deleted_count != expected_count:
+            raise BlobRefLivenessReconciliationError(
+                f"candidate/delete count mismatch: planned={expected_count} deleted={deleted_count}"
+            )
     finally:
         conn.close()
 
     try:
-        _append_receipt_footer(receipt_path, phase="committed", deleted_count=expected_count)
+        _append_receipt_footer(receipt_path, phase="committed", deleted_count=deleted_count)
     except OSError as exc:
         raise BlobRefLivenessReconciliationError(
             f"source.db committed but could not finalize receipt {receipt_path}"

--- a/polylogue/maintenance/blob_ref_liveness_reconciliation.py
+++ b/polylogue/maintenance/blob_ref_liveness_reconciliation.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from polylogue.config import Config
 from polylogue.maintenance.offline_guard import running_daemon_pid
 from polylogue.paths import render_root
+from polylogue.storage.blob_gc import BLOB_REF_LIVENESS_JOIN
 from polylogue.storage.blob_ref_liveness import (
     BlobRefLivenessCandidate,
     BlobRefLivenessClassification,
@@ -344,6 +345,28 @@ def _validate_locked_candidate_plan(conn: sqlite3.Connection, candidate_table: s
         raise BlobRefLivenessReconciliationError(
             f"prepared candidate presence mismatch: planned={expected_count} present={present_count}"
         )
+    referent_branches = [
+        f"""
+        SELECT c.blob_hash, c.ref_type, c.ref_id
+        FROM {candidate_table} AS c
+        JOIN {table} AS r ON r.{column} = c.ref_id
+        WHERE c.ref_type = ?
+        """
+        for ref_type, (table, column) in {
+            ref_type: (table, column) for ref_type, table, column in BLOB_REF_LIVENESS_JOIN
+        }.items()
+    ]
+    if referent_branches:
+        live_referent_count = int(
+            conn.execute(
+                f"SELECT COUNT(*) FROM ({' UNION ALL '.join(referent_branches)})",
+                tuple(ref_type for ref_type, _table, _column in BLOB_REF_LIVENESS_JOIN),
+            ).fetchone()[0]
+        )
+        if live_referent_count:
+            raise BlobRefLivenessReconciliationError(
+                f"prepared candidate referents became live under lock: {live_referent_count}"
+            )
     conn.execute("DROP TABLE IF EXISTS temp.blob_ref_liveness_locked_hooks")
     if _table_exists(conn, "raw_hook_events"):
         conn.execute(

--- a/polylogue/maintenance/blob_ref_liveness_reconciliation.py
+++ b/polylogue/maintenance/blob_ref_liveness_reconciliation.py
@@ -445,6 +445,35 @@ def _validate_locked_candidate_plan(conn: sqlite3.Connection, candidate_table: s
         "CREATE INDEX blob_ref_liveness_locked_hooks_source_hash "
         "ON blob_ref_liveness_locked_hooks(source_path, blob_hash)"
     )
+    legacy_ambiguous_path_count = int(
+        conn.execute(
+            f"""
+            SELECT COUNT(*)
+            FROM (
+                SELECT candidates.source_path
+                FROM (
+                    SELECT source_path, COUNT(*) AS candidate_count
+                    FROM {candidate_table}
+                    WHERE ref_type = 'raw_payload'
+                    GROUP BY source_path
+                ) AS candidates
+                JOIN (
+                    SELECT source_path, COUNT(*) AS hook_count
+                    FROM blob_ref_liveness_locked_hooks
+                    WHERE blob_hash IS NULL
+                    GROUP BY source_path
+                ) AS hooks
+                  ON hooks.source_path IS candidates.source_path
+                WHERE candidates.candidate_count > 1 OR hooks.hook_count > 1
+            )
+            """
+        ).fetchone()[0]
+    )
+    if legacy_ambiguous_path_count:
+        raise BlobRefLivenessReconciliationError(
+            "prepared candidates have ambiguous legacy hook evidence under lock: "
+            f"{legacy_ambiguous_path_count} source path(s)"
+        )
     conn.create_function("polylogue_deterministic_raw_session_id", 5, _deterministic_raw_session_id_udf)
     rekeyable = int(
         conn.execute(
@@ -584,7 +613,12 @@ def reconcile_blob_ref_liveness(
                     # full backup inventory, rehashing only if its stat
                     # signature changed since the pre-lock validation.
                     validate_migration_backup_live_fingerprint(backup_manifest, ArchiveTier.SOURCE, connection=conn)
-                _validate_locked_candidate_plan(conn, batch_table, batch_count)
+                    # Hook evidence is validated against the complete staged
+                    # population before any bounded delete can commit. Later
+                    # batches retain their own short lock-scoped validation.
+                    _validate_locked_candidate_plan(conn, staged_plan.candidate_table, expected_count)
+                else:
+                    _validate_locked_candidate_plan(conn, batch_table, batch_count)
                 batch_deleted = _delete_candidate_batch(conn, staged_plan.candidate_table, batch_table)
             except Exception:
                 if conn.in_transaction:

--- a/polylogue/storage/blob_ref_liveness.py
+++ b/polylogue/storage/blob_ref_liveness.py
@@ -9,10 +9,12 @@ prove liveness with the same referent joins.
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Iterator
 from dataclasses import dataclass
+from typing import cast
 
 from polylogue.storage.blob_gc import BLOB_REF_LIVENESS_JOIN
-from polylogue.storage.hook_payload_ref_reconciliation import plan_hook_payload_ref_reconciliation
+from polylogue.storage.hook_payload_ref_reconciliation import _create_match_stage
 from polylogue.storage.introspection import table_exists
 
 
@@ -58,6 +60,11 @@ class BlobRefLivenessClassification:
     unavailable_ref_types: tuple[str, ...]
     rekeyable_hook_payload_count: int
     candidates: tuple[BlobRefLivenessCandidate, ...]
+    candidate_count: int | None = None
+
+    @property
+    def orphaned_count(self) -> int:
+        return len(self.candidates) if self.candidate_count is None else self.candidate_count
 
     @property
     def safe_to_apply(self) -> bool:
@@ -67,7 +74,7 @@ class BlobRefLivenessClassification:
         payload: dict[str, object] = {
             "scanned_count": self.scanned_count,
             "ref_type_counts": dict(self.ref_type_counts),
-            "orphaned_count": len(self.candidates),
+            "orphaned_count": self.orphaned_count,
             "orphaned_by_ref_type": dict(self.orphaned_by_ref_type),
             "ref_type_joins": [
                 {"ref_type": ref_type, "referent_table": table, "referent_column": column}
@@ -85,6 +92,36 @@ class BlobRefLivenessClassification:
         return payload
 
 
+@dataclass(frozen=True, slots=True)
+class BlobRefLivenessStagedPlan:
+    """SQLite-backed candidate plan whose rows never need Python duplication."""
+
+    classification: BlobRefLivenessClassification
+    candidate_table: str
+
+    def candidates(self, conn: sqlite3.Connection) -> Iterator[BlobRefLivenessCandidate]:
+        return (
+            BlobRefLivenessCandidate(
+                blob_hash=bytes(row[0]).hex(),
+                ref_type=str(row[1]),
+                ref_id=str(row[2]),
+                source_path=str(row[3]) if row[3] is not None else None,
+                size_bytes=int(row[4]),
+                acquired_at_ms=int(row[5]),
+                referent_table=str(row[6]),
+                referent_column=str(row[7]),
+            )
+            for row in conn.execute(
+                f"""
+                SELECT blob_hash, ref_type, ref_id, source_path, size_bytes,
+                       acquired_at_ms, referent_table, referent_column
+                FROM {self.candidate_table}
+                ORDER BY ref_type, ref_id, blob_hash
+                """
+            )
+        )
+
+
 def _blob_ref_columns(conn: sqlite3.Connection) -> set[str]:
     return {str(row[1]) for row in conn.execute("PRAGMA table_info(blob_refs)")}
 
@@ -93,17 +130,32 @@ def _referent_columns(conn: sqlite3.Connection, table: str) -> set[str]:
     return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})")}
 
 
-def classify_blob_ref_liveness(conn: sqlite3.Connection) -> BlobRefLivenessClassification:
+def _candidate_from_row(row: sqlite3.Row | tuple[object, ...]) -> BlobRefLivenessCandidate:
+    return BlobRefLivenessCandidate(
+        blob_hash=cast(bytes, row[0]).hex(),
+        ref_type=str(row[1]),
+        ref_id=str(row[2]),
+        source_path=str(row[3]) if row[3] is not None else None,
+        size_bytes=int(cast(int, row[4])),
+        acquired_at_ms=int(cast(int, row[5])),
+        referent_table=str(row[6]),
+        referent_column=str(row[7]),
+    )
+
+
+def stage_blob_ref_liveness(conn: sqlite3.Connection, *, sample_limit: int = 30) -> BlobRefLivenessStagedPlan:
     """Classify every ``blob_refs`` row using its mapped referent LEFT JOIN.
 
-    The SQL is set-based: one ``LEFT JOIN`` branch per known ref type, joined
-    on the actual referent table and key. Unknown ref types, missing referent
-    tables, and missing referent columns are reported and make an apply unsafe
-    rather than silently treating an unproven row as dead.
+    Candidate rows are staged in SQLite. This is the apply path's bounded
+    representation: receipts and deletes can stream from the temp table rather
+    than materializing the same population in several Python lists.
     """
 
     if not table_exists(conn, "blob_refs"):
-        return BlobRefLivenessClassification(0, {}, {}, (), (), (), 0, ())
+        return BlobRefLivenessStagedPlan(
+            BlobRefLivenessClassification(0, {}, {}, (), (), (), 0, (), 0),
+            "blob_ref_liveness_candidates",
+        )
     columns = _blob_ref_columns(conn)
     required = {"blob_hash", "ref_id", "ref_type", "source_path", "size_bytes", "acquired_at_ms"}
     missing = sorted(required - columns)
@@ -138,46 +190,128 @@ def classify_blob_ref_liveness(conn: sqlite3.Connection) -> BlobRefLivenessClass
         params.append(ref_type)
         ref_type_joins.append((ref_type, table, column))
 
-    rekeyable_hook_payloads = {
-        (candidate.blob_hash.hex(), candidate.orphaned_ref_id)
-        for candidate in plan_hook_payload_ref_reconciliation(conn).matched
-    }
-    candidates: list[BlobRefLivenessCandidate] = []
+    rekeyable_hook_payload_count = 0
+    if table_exists(conn, "raw_hook_events"):
+        _scanned_hook_refs, rekeyable_hook_payload_count, _matched_bytes, ambiguous_count = _create_match_stage(conn)
+        rekeyable_hook_payload_count += ambiguous_count
+    else:
+        conn.execute("DROP TABLE IF EXISTS temp.hook_payload_ref_reconciliation_matches")
+        conn.execute(
+            """
+            CREATE TEMP TABLE hook_payload_ref_reconciliation_matches (
+                blob_hash BLOB NOT NULL,
+                orphaned_ref_id TEXT NOT NULL,
+                source_path TEXT,
+                size_bytes INTEGER NOT NULL,
+                acquired_at_ms INTEGER NOT NULL,
+                hook_event_id TEXT NOT NULL,
+                PRIMARY KEY (blob_hash, orphaned_ref_id)
+            ) STRICT
+            """
+        )
+        conn.execute(
+            """
+            CREATE TEMP TABLE hook_payload_ref_reconciliation_ambiguous (
+                blob_hash BLOB NOT NULL,
+                orphaned_ref_id TEXT NOT NULL,
+                PRIMARY KEY (blob_hash, orphaned_ref_id)
+            ) STRICT
+            """
+        )
+
+    candidate_table = "blob_ref_liveness_candidates"
+    conn.execute(f"DROP TABLE IF EXISTS temp.{candidate_table}")
+    conn.execute(
+        f"""
+        CREATE TEMP TABLE {candidate_table} (
+            blob_hash BLOB NOT NULL,
+            ref_type TEXT NOT NULL,
+            ref_id TEXT NOT NULL,
+            source_path TEXT,
+            size_bytes INTEGER NOT NULL,
+            acquired_at_ms INTEGER NOT NULL,
+            referent_table TEXT NOT NULL,
+            referent_column TEXT NOT NULL,
+            PRIMARY KEY (blob_hash, ref_type, ref_id)
+        ) STRICT
+        """
+    )
     if branches:
-        query = " UNION ALL ".join(branches) + " ORDER BY 2, 3, 1"
-        for row in conn.execute(query, tuple(params)):
-            blob_hash = bytes(row[0]).hex()
-            ref_type = str(row[1])
-            ref_id = str(row[2])
-            # Pre-v22 hook refs were stored as raw_payload with a synthetic
-            # raw id. They are durable live payloads awaiting a provable
-            # re-key to hook_payload, never deletion candidates.
-            if (blob_hash, ref_id) in rekeyable_hook_payloads:
-                continue
-            candidates.append(
-                BlobRefLivenessCandidate(
-                    blob_hash=blob_hash,
-                    ref_type=ref_type,
-                    ref_id=ref_id,
-                    source_path=str(row[3]) if row[3] is not None else None,
-                    size_bytes=int(row[4]),
-                    acquired_at_ms=int(row[5]),
-                    referent_table=str(row[6]),
-                    referent_column=str(row[7]),
-                )
+        query = " UNION ALL ".join(branches)
+        conn.execute(
+            f"""
+            INSERT INTO {candidate_table} (
+                blob_hash, ref_type, ref_id, source_path, size_bytes, acquired_at_ms,
+                referent_table, referent_column
             )
-    orphaned_by_ref_type: dict[str, int] = {}
-    for candidate in candidates:
-        orphaned_by_ref_type[candidate.ref_type] = orphaned_by_ref_type.get(candidate.ref_type, 0) + 1
-    return BlobRefLivenessClassification(
+            SELECT candidate.blob_hash, candidate.ref_type, candidate.ref_id,
+                   candidate.source_path, candidate.size_bytes, candidate.acquired_at_ms,
+                   candidate.referent_table, candidate.referent_column
+            FROM ({query}) AS candidate
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM temp.hook_payload_ref_reconciliation_matches AS hook_match
+                WHERE candidate.ref_type = 'raw_payload'
+                  AND hook_match.blob_hash = candidate.blob_hash
+                  AND hook_match.orphaned_ref_id = candidate.ref_id
+            )
+              AND NOT EXISTS (
+                SELECT 1
+                FROM temp.hook_payload_ref_reconciliation_ambiguous AS ambiguous_hook
+                WHERE candidate.ref_type = 'raw_payload'
+                  AND ambiguous_hook.blob_hash = candidate.blob_hash
+                  AND ambiguous_hook.orphaned_ref_id = candidate.ref_id
+            )
+            """,
+            tuple(params),
+        )
+    candidate_count = int(conn.execute(f"SELECT COUNT(*) FROM {candidate_table}").fetchone()[0])
+    orphaned_by_ref_type = {
+        str(row[0]): int(row[1])
+        for row in conn.execute(f"SELECT ref_type, COUNT(*) FROM {candidate_table} GROUP BY ref_type ORDER BY ref_type")
+    }
+    samples = tuple(
+        _candidate_from_row(row)
+        for row in conn.execute(
+            f"""
+            SELECT blob_hash, ref_type, ref_id, source_path, size_bytes,
+                   acquired_at_ms, referent_table, referent_column
+            FROM {candidate_table}
+            ORDER BY ref_type, ref_id, blob_hash
+            LIMIT ?
+            """,
+            (max(0, sample_limit),),
+        )
+    )
+    classification = BlobRefLivenessClassification(
         scanned_count=sum(ref_type_counts.values()),
         ref_type_counts=ref_type_counts,
         orphaned_by_ref_type=orphaned_by_ref_type,
         ref_type_joins=tuple(ref_type_joins),
         unknown_ref_types=unknown,
         unavailable_ref_types=tuple(sorted(unavailable)),
-        rekeyable_hook_payload_count=len(rekeyable_hook_payloads),
-        candidates=tuple(candidates),
+        rekeyable_hook_payload_count=rekeyable_hook_payload_count,
+        candidates=samples,
+        candidate_count=candidate_count,
+    )
+    return BlobRefLivenessStagedPlan(classification, candidate_table)
+
+
+def classify_blob_ref_liveness(conn: sqlite3.Connection) -> BlobRefLivenessClassification:
+    """Return the complete candidate projection for read-only callers."""
+
+    staged = stage_blob_ref_liveness(conn, sample_limit=0)
+    candidates = tuple(staged.candidates(conn))
+    return BlobRefLivenessClassification(
+        scanned_count=staged.classification.scanned_count,
+        ref_type_counts=staged.classification.ref_type_counts,
+        orphaned_by_ref_type=staged.classification.orphaned_by_ref_type,
+        ref_type_joins=staged.classification.ref_type_joins,
+        unknown_ref_types=staged.classification.unknown_ref_types,
+        unavailable_ref_types=staged.classification.unavailable_ref_types,
+        rekeyable_hook_payload_count=staged.classification.rekeyable_hook_payload_count,
+        candidates=candidates,
+        candidate_count=len(candidates),
     )
 
 
@@ -186,4 +320,6 @@ __all__ = [
     "BlobRefLivenessClassification",
     "BlobRefLivenessError",
     "classify_blob_ref_liveness",
+    "stage_blob_ref_liveness",
+    "BlobRefLivenessStagedPlan",
 ]

--- a/polylogue/storage/blob_ref_liveness.py
+++ b/polylogue/storage/blob_ref_liveness.py
@@ -265,6 +265,7 @@ def stage_blob_ref_liveness(conn: sqlite3.Connection, *, sample_limit: int = 30)
             """,
             tuple(params),
         )
+    conn.execute(f"CREATE INDEX {candidate_table}_source_hash ON {candidate_table}(ref_type, source_path, blob_hash)")
     candidate_count = int(conn.execute(f"SELECT COUNT(*) FROM {candidate_table}").fetchone()[0])
     orphaned_by_ref_type = {
         str(row[0]): int(row[1])

--- a/polylogue/storage/hook_payload_ref_reconciliation.py
+++ b/polylogue/storage/hook_payload_ref_reconciliation.py
@@ -72,20 +72,50 @@ class HookPayloadRefReconciliationPlan:
         return sum(candidate.size_bytes for candidate in self.matched)
 
 
-def _orphaned_raw_payload_refs(conn: sqlite3.Connection) -> list[sqlite3.Row]:
-    return conn.execute(
-        """
-        SELECT blob_hash, ref_id, source_path, size_bytes, acquired_at_ms
-        FROM blob_refs
-        WHERE ref_type = 'raw_payload'
-          AND NOT EXISTS (SELECT 1 FROM raw_sessions WHERE raw_sessions.raw_id = blob_refs.ref_id)
-        """
-    ).fetchall()
+_MATCH_TABLE = "hook_payload_ref_reconciliation_matches"
+_ORPHAN_TABLE = "hook_payload_ref_reconciliation_orphans"
+_HOOK_TABLE = "hook_payload_ref_reconciliation_hooks"
+_AMBIGUOUS_TABLE = "hook_payload_ref_reconciliation_ambiguous"
 
 
-def _hook_events_without_canonical_blob_ref(conn: sqlite3.Connection) -> list[sqlite3.Row]:
-    return conn.execute(
+def _deterministic_raw_session_id_udf(
+    origin: object, source_path: object, source_index: object, blob_hash: object, native_id: object
+) -> str | None:
+    if origin is None or blob_hash is None:
+        return None
+    try:
+        if not isinstance(source_index, (int, str)) or not isinstance(blob_hash, bytes):
+            return None
+        return deterministic_raw_session_id(
+            str(origin),
+            "" if source_path is None else str(source_path),
+            int(source_index),
+            blob_hash,
+            None if native_id is None else str(native_id),
+        )
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+def _create_match_stage(conn: sqlite3.Connection) -> tuple[int, int, int, int]:
+    """Stage exact hook matches in SQLite, avoiding a Python cross-product."""
+
+    conn.create_function("polylogue_deterministic_raw_session_id", 5, _deterministic_raw_session_id_udf)
+    for table in (_MATCH_TABLE, _ORPHAN_TABLE, _HOOK_TABLE, _AMBIGUOUS_TABLE):
+        conn.execute(f"DROP TABLE IF EXISTS temp.{table}")
+    conn.execute(
+        f"""
+        CREATE TEMP TABLE {_ORPHAN_TABLE} AS
+        SELECT b.blob_hash, b.ref_id, b.source_path, b.size_bytes, b.acquired_at_ms
+        FROM blob_refs AS b
+        WHERE b.ref_type = 'raw_payload'
+          AND NOT EXISTS (SELECT 1 FROM raw_sessions AS r WHERE r.raw_id = b.ref_id)
         """
+    )
+    conn.execute(f"CREATE INDEX {_ORPHAN_TABLE}_source_path ON {_ORPHAN_TABLE}(source_path, blob_hash)")
+    conn.execute(
+        f"""
+        CREATE TEMP TABLE {_HOOK_TABLE} AS
         SELECT h.hook_event_id, h.origin, h.native_id, h.source_path, h.blob_hash
         FROM raw_hook_events AS h
         WHERE NOT EXISTS (
@@ -95,7 +125,87 @@ def _hook_events_without_canonical_blob_ref(conn: sqlite3.Connection) -> list[sq
               AND b.ref_id = h.hook_event_id
         )
         """
-    ).fetchall()
+    )
+    conn.execute(f"CREATE INDEX {_HOOK_TABLE}_source_path ON {_HOOK_TABLE}(source_path, blob_hash)")
+    conn.execute(
+        f"""
+        CREATE TEMP TABLE {_AMBIGUOUS_TABLE} (
+            blob_hash BLOB NOT NULL,
+            orphaned_ref_id TEXT NOT NULL,
+            PRIMARY KEY (blob_hash, orphaned_ref_id)
+        ) STRICT
+        """
+    )
+    conn.execute(
+        f"""
+        INSERT INTO {_AMBIGUOUS_TABLE} (blob_hash, orphaned_ref_id)
+        SELECT o.blob_hash, o.ref_id
+        FROM {_ORPHAN_TABLE} AS o
+        WHERE EXISTS (
+            SELECT 1 FROM {_HOOK_TABLE} AS h
+            WHERE h.source_path IS o.source_path AND h.blob_hash IS NULL
+        )
+          AND (
+            (SELECT COUNT(*) FROM {_ORPHAN_TABLE} AS o2 WHERE o2.source_path IS o.source_path) > 1
+            OR (SELECT COUNT(*) FROM {_HOOK_TABLE} AS h2
+                WHERE h2.source_path IS o.source_path AND h2.blob_hash IS NULL) > 1
+          )
+        GROUP BY o.blob_hash, o.ref_id
+        """
+    )
+    conn.execute(
+        f"""
+        CREATE TEMP TABLE {_MATCH_TABLE} (
+            blob_hash BLOB NOT NULL,
+            orphaned_ref_id TEXT NOT NULL,
+            source_path TEXT,
+            size_bytes INTEGER NOT NULL,
+            acquired_at_ms INTEGER NOT NULL,
+            hook_event_id TEXT NOT NULL,
+            PRIMARY KEY (blob_hash, orphaned_ref_id)
+        ) STRICT
+        """
+    )
+    conn.execute(
+        f"""
+        INSERT INTO {_MATCH_TABLE} (
+            blob_hash, orphaned_ref_id, source_path, size_bytes, acquired_at_ms, hook_event_id
+        )
+        SELECT o.blob_hash, o.ref_id, o.source_path, o.size_bytes, o.acquired_at_ms, MIN(h.hook_event_id)
+        FROM {_ORPHAN_TABLE} AS o
+        JOIN {_HOOK_TABLE} AS h
+          ON h.source_path IS o.source_path
+         AND h.blob_hash = o.blob_hash
+         AND polylogue_deterministic_raw_session_id(h.origin, o.source_path, 0, o.blob_hash, h.native_id) = o.ref_id
+        GROUP BY o.blob_hash, o.ref_id, o.source_path, o.size_bytes, o.acquired_at_ms
+        HAVING COUNT(*) = 1
+        """
+    )
+    # Legacy rows have no hook blob_hash, so a shared source path cannot be
+    # used as a bounded identity key. Leave those paths untouched unless both
+    # sides contain exactly one row. This preserves the ambiguity rule without
+    # evaluating an orphan-by-hook cross-product.
+    conn.execute(
+        f"""
+        INSERT INTO {_MATCH_TABLE} (
+            blob_hash, orphaned_ref_id, source_path, size_bytes, acquired_at_ms, hook_event_id
+        )
+        SELECT o.blob_hash, o.ref_id, o.source_path, o.size_bytes, o.acquired_at_ms, h.hook_event_id
+        FROM {_ORPHAN_TABLE} AS o
+        JOIN {_HOOK_TABLE} AS h
+          ON h.source_path IS o.source_path
+         AND h.blob_hash IS NULL
+        WHERE (SELECT COUNT(*) FROM {_ORPHAN_TABLE} AS o2 WHERE o2.source_path IS o.source_path) = 1
+          AND (SELECT COUNT(*) FROM {_HOOK_TABLE} AS h2
+               WHERE h2.source_path IS h.source_path AND h2.blob_hash IS NULL) = 1
+          AND polylogue_deterministic_raw_session_id(h.origin, o.source_path, 0, o.blob_hash, h.native_id) = o.ref_id
+        """
+    )
+    scanned_count = int(conn.execute(f"SELECT COUNT(*) FROM {_ORPHAN_TABLE}").fetchone()[0])
+    matched_count = int(conn.execute(f"SELECT COUNT(*) FROM {_MATCH_TABLE}").fetchone()[0])
+    matched_bytes = int(conn.execute(f"SELECT COALESCE(SUM(size_bytes), 0) FROM {_MATCH_TABLE}").fetchone()[0])
+    ambiguous_count = int(conn.execute(f"SELECT COUNT(*) FROM {_AMBIGUOUS_TABLE}").fetchone()[0])
+    return scanned_count, matched_count, matched_bytes, ambiguous_count
 
 
 def plan_hook_payload_ref_reconciliation(conn: sqlite3.Connection) -> HookPayloadRefReconciliationPlan:
@@ -104,62 +214,35 @@ def plan_hook_payload_ref_reconciliation(conn: sqlite3.Connection) -> HookPayloa
     Read-only: issues only ``SELECT`` statements. Safe against a read-only
     connection.
     """
-    conn.row_factory = sqlite3.Row
     if not _table_exists(conn, "blob_refs") or not _table_exists(conn, "raw_hook_events"):
         return HookPayloadRefReconciliationPlan(scanned_count=0, matched=(), unmatched_count=0)
 
-    orphaned_refs = _orphaned_raw_payload_refs(conn)
-    if not orphaned_refs:
+    scanned_count, matched_count, _matched_bytes, _ambiguous_count = _create_match_stage(conn)
+    if not scanned_count:
         return HookPayloadRefReconciliationPlan(scanned_count=0, matched=(), unmatched_count=0)
 
-    candidates_by_source_path: dict[str | None, list[sqlite3.Row]] = {}
-    for row in _hook_events_without_canonical_blob_ref(conn):
-        candidates_by_source_path.setdefault(row["source_path"], []).append(row)
-
-    matched: list[HookPayloadRefReconciliationCandidate] = []
-    unmatched_count = 0
-    for ref in orphaned_refs:
-        blob_hash = bytes(ref["blob_hash"])
-        candidates = candidates_by_source_path.get(ref["source_path"], ())
-        hits: list[str] = []
-        for candidate in candidates:
-            # A completed post-v22 write already owns its canonical ref and
-            # was excluded above. An interrupted/historical re-key may have
-            # written the durable hash to the hook row but not restored that
-            # ref; it is the same payload only when the hashes agree.
-            if candidate["blob_hash"] is not None and bytes(candidate["blob_hash"]) != blob_hash:
-                continue
-            recomputed = deterministic_raw_session_id(
-                candidate["origin"],
-                ref["source_path"] or "",
-                0,
-                blob_hash,
-                candidate["native_id"],
-            )
-            if recomputed == ref["ref_id"]:
-                hits.append(candidate["hook_event_id"])
-        if len(hits) == 1:
-            matched.append(
-                HookPayloadRefReconciliationCandidate(
-                    blob_hash=blob_hash,
-                    orphaned_ref_id=ref["ref_id"],
-                    source_path=ref["source_path"],
-                    size_bytes=int(ref["size_bytes"]),
-                    acquired_at_ms=int(ref["acquired_at_ms"]),
-                    hook_event_id=hits[0],
-                )
-            )
-        else:
-            # Zero hits (no candidate hook event shares this source_path, or
-            # none recomputes to this exact ref_id) or more than one hit (a
-            # genuine collision -- recompute ambiguity) are both left
-            # unmatched rather than guessed at.
-            unmatched_count += 1
+    matched = tuple(
+        HookPayloadRefReconciliationCandidate(
+            blob_hash=bytes(row[0]),
+            orphaned_ref_id=str(row[1]),
+            source_path=str(row[2]) if row[2] is not None else None,
+            size_bytes=int(row[3]),
+            acquired_at_ms=int(row[4]),
+            hook_event_id=str(row[5]),
+        )
+        for row in conn.execute(
+            f"""
+            SELECT blob_hash, orphaned_ref_id, source_path, size_bytes, acquired_at_ms, hook_event_id
+            FROM {_MATCH_TABLE}
+            ORDER BY orphaned_ref_id, blob_hash
+            """
+        )
+    )
 
     return HookPayloadRefReconciliationPlan(
-        scanned_count=len(orphaned_refs),
-        matched=tuple(matched),
-        unmatched_count=unmatched_count,
+        scanned_count=scanned_count,
+        matched=matched,
+        unmatched_count=scanned_count - matched_count,
     )
 
 

--- a/polylogue/storage/sqlite/migration_runner.py
+++ b/polylogue/storage/sqlite/migration_runner.py
@@ -741,13 +741,14 @@ def validate_migration_backup_manifest(
 def validate_migration_backup_live_fingerprint(
     path: Path, tier: ArchiveTier, *, connection: sqlite3.Connection
 ) -> Path:
-    """Recheck receipt authority and the live tier without rescanning backups.
+    """Recheck receipt authority and the live tier with a cached inventory.
 
     Callers run ``validate_migration_backup_manifest`` before taking the live
     tier lock. Once ownership is held, this helper repeats the local HMAC and
-    manifest binding checks, then checks the live source fingerprint. It does
-    not rebuild the backup artifact inventory, so the immutable backup tree is
-    hashed once per apply invocation rather than once per lock boundary.
+    manifest binding checks, then validates the complete cached backup
+    inventory. A stat change invalidates the process cache and re-hashes the
+    tree, so source.db/blob mutations after the precheck are rejected without
+    repeating the expensive scan when the tree is unchanged.
     """
 
     if tier not in DURABLE_MIGRATION_TIERS:
@@ -777,23 +778,27 @@ def validate_migration_backup_live_fingerprint(
         raise MigrationError(f"migration backup receipt authentication failed: {exc}") from exc
     if receipt.get("verdict") != "success":
         raise MigrationError(f"migration backup receipt is not a successful verification: {receipt_path}")
-    if _json_int(receipt.get("manifest_size_bytes")) != manifest_path.stat().st_size:
+    artifact_inventory = _cached_backup_artifact_inventory(backup_root)
+    file_evidence = {str(item["path"]): item for item in artifact_inventory if item.get("type") == "file"}
+    manifest_evidence = file_evidence.get("manifest.json", {})
+    if _json_int(receipt.get("manifest_size_bytes")) != _json_int(manifest_evidence.get("size_bytes")):
         raise MigrationError("migration backup receipt does not match manifest size")
-    if receipt.get("manifest_sha256") != _sha256_file(manifest_path):
+    if receipt.get("manifest_sha256") != manifest_evidence.get("sha256"):
         raise MigrationError("migration backup receipt does not match manifest bytes")
-    artifacts = receipt.get("tier_artifacts")
-    if not isinstance(artifacts, list):
-        raise MigrationError("migration backup receipt does not bind tier artifacts")
-    artifact = next((item for item in artifacts if isinstance(item, dict) and item.get("tier") == tier.value), None)
+    artifacts = _validated_receipt_artifacts(
+        backup_root,
+        manifest,
+        receipt,
+        target_tier=tier.value,
+        live_tier_path=live_tier_path,
+        file_evidence=file_evidence,
+    )
+    artifact = artifacts.get(tier.value)
     if artifact is None:
         raise MigrationError(f"migration backup receipt does not include {tier.value}.db: {receipt_path}")
-    source_fingerprint = artifact.get("source_fingerprint")
-    if not isinstance(source_fingerprint, dict) or any(
-        artifact.get(field) != source_fingerprint.get(field) for field in ("size_bytes", "sha256", "user_version")
-    ):
-        raise MigrationError(
-            f"migration backup tier artifact does not match its live source fingerprint: {tier.value}.db"
-        )
+    _validate_blob_inventory(backup_root, manifest, receipt, file_evidence=file_evidence)
+    if receipt.get("artifact_inventory") != artifact_inventory:
+        raise MigrationError("migration backup receipt does not match the closed artifact inventory")
     _validate_live_source_fingerprint(connection, artifact)
     return receipt_path
 

--- a/polylogue/storage/sqlite/migration_runner.py
+++ b/polylogue/storage/sqlite/migration_runner.py
@@ -738,6 +738,66 @@ def validate_migration_backup_manifest(
     return _validate_backup_manifest_covers_tier(path, tier, connection=connection, require_attestation=True)
 
 
+def validate_migration_backup_live_fingerprint(
+    path: Path, tier: ArchiveTier, *, connection: sqlite3.Connection
+) -> Path:
+    """Recheck receipt authority and the live tier without rescanning backups.
+
+    Callers run ``validate_migration_backup_manifest`` before taking the live
+    tier lock. Once ownership is held, this helper repeats the local HMAC and
+    manifest binding checks, then checks the live source fingerprint. It does
+    not rebuild the backup artifact inventory, so the immutable backup tree is
+    hashed once per apply invocation rather than once per lock boundary.
+    """
+
+    if tier not in DURABLE_MIGRATION_TIERS:
+        raise MigrationError(f"{tier.value} tier is not a durable migration tier")
+    manifest_path = _backup_manifest_path(path)
+    if not manifest_path.exists() and not manifest_path.is_symlink():
+        raise MigrationError(f"migration requires an existing backup manifest; missing {manifest_path}")
+    backup_root = manifest_path.parent
+    _require_real_backup_directory(backup_root, label="backup root")
+    _require_regular_backup_artifact(manifest_path, backup_root=backup_root, label="backup manifest")
+    manifest = _load_json(manifest_path, label="manifest")
+    if manifest.get("format") != "polylogue-backup-v1":
+        raise MigrationError(f"migration backup manifest has unsupported format: {manifest_path}")
+    if f"{tier.value}.db" not in _json_str_list(manifest.get("included_tiers")):
+        raise MigrationError(f"migration backup manifest does not include {tier.value}.db: {manifest_path}")
+    receipt_path = _receipt_path(manifest_path)
+    if not receipt_path.exists() and not receipt_path.is_symlink():
+        raise MigrationError(f"migration requires a successful backup verification receipt; missing {receipt_path}")
+    _require_regular_backup_artifact(receipt_path, backup_root=backup_root, label="backup verification receipt")
+    receipt = _load_json(receipt_path, label="verification receipt")
+    if receipt.get("format") != VERIFICATION_RECEIPT_FORMAT:
+        raise MigrationError(f"migration backup receipt has unsupported format: {receipt_path}")
+    live_tier_path = _connection_main_path(connection).resolve(strict=False)
+    try:
+        verify_verification_receipt(receipt, tier=tier.value, live_tier_path=live_tier_path)
+    except BackupAttestationError as exc:
+        raise MigrationError(f"migration backup receipt authentication failed: {exc}") from exc
+    if receipt.get("verdict") != "success":
+        raise MigrationError(f"migration backup receipt is not a successful verification: {receipt_path}")
+    if _json_int(receipt.get("manifest_size_bytes")) != manifest_path.stat().st_size:
+        raise MigrationError("migration backup receipt does not match manifest size")
+    if receipt.get("manifest_sha256") != _sha256_file(manifest_path):
+        raise MigrationError("migration backup receipt does not match manifest bytes")
+    artifacts = receipt.get("tier_artifacts")
+    if not isinstance(artifacts, list):
+        raise MigrationError("migration backup receipt does not bind tier artifacts")
+    artifact = next((item for item in artifacts if isinstance(item, dict) and item.get("tier") == tier.value), None)
+    if artifact is None:
+        raise MigrationError(f"migration backup receipt does not include {tier.value}.db: {receipt_path}")
+    source_fingerprint = artifact.get("source_fingerprint")
+    if not isinstance(source_fingerprint, dict) or any(
+        artifact.get(field) != source_fingerprint.get(field) for field in ("size_bytes", "sha256", "user_version")
+    ):
+        raise MigrationError(
+            f"migration backup tier artifact does not match its live source fingerprint: {tier.value}.db"
+        )
+    _validate_live_source_fingerprint(connection, artifact)
+    return receipt_path
+
+
 def validate_backup_manifest_covers_derived_tier(
     path: Path, tier: ArchiveTier, *, connection: sqlite3.Connection
 ) -> Path:
@@ -3273,6 +3333,7 @@ __all__ = [
     "reserve_durable_change_train",
     "validate_durable_change_train_manifest",
     "validate_backup_manifest_covers_derived_tier",
+    "validate_migration_backup_live_fingerprint",
     "validate_migration_backup_manifest",
     "write_durable_change_train_manifest",
 ]

--- a/tests/unit/storage/test_blob_gc_ref_type_liveness.py
+++ b/tests/unit/storage/test_blob_gc_ref_type_liveness.py
@@ -262,6 +262,10 @@ def test_interrupted_hook_rekey_blocks_liveness_deletion_and_preserves_blob(
         lambda *args, **kwargs: args[0],
     )
     monkeypatch.setattr(
+        "polylogue.maintenance.blob_ref_liveness_reconciliation.validate_migration_backup_live_fingerprint",
+        lambda *args, **kwargs: args[0],
+    )
+    monkeypatch.setattr(
         "polylogue.maintenance.blob_ref_liveness_reconciliation.running_daemon_pid",
         lambda _config: None,
     )

--- a/tests/unit/storage/test_blob_ref_liveness.py
+++ b/tests/unit/storage/test_blob_ref_liveness.py
@@ -289,6 +289,47 @@ def test_apply_deletes_only_join_proven_orphans_and_persists_receipt(
     assert receipt_rows[-1]["deleted_count"] == 4
 
 
+def test_locked_plan_rejects_referent_that_appears_after_staging(tmp_path: Path) -> None:
+    archive_root = _source_archive(tmp_path)
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        candidate = next(item for item in classify_blob_ref_liveness(conn).candidates if item.ref_type == "raw_payload")
+        conn.execute(
+            """
+            CREATE TEMP TABLE locked_candidates (
+                blob_hash BLOB NOT NULL, ref_type TEXT NOT NULL, ref_id TEXT NOT NULL,
+                source_path TEXT, size_bytes INTEGER NOT NULL, acquired_at_ms INTEGER NOT NULL,
+                referent_table TEXT NOT NULL, referent_column TEXT NOT NULL,
+                PRIMARY KEY (blob_hash, ref_type, ref_id)
+            ) STRICT
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO locked_candidates VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                bytes.fromhex(candidate.blob_hash),
+                candidate.ref_type,
+                candidate.ref_id,
+                candidate.source_path,
+                candidate.size_bytes,
+                candidate.acquired_at_ms,
+                candidate.referent_table,
+                candidate.referent_column,
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, source_path, source_index, blob_hash, blob_size, acquired_at_ms
+            ) VALUES (?, 'codex-session', '/appeared.jsonl', 0, ?, 1, 1)
+            """,
+            (candidate.ref_id, bytes.fromhex(candidate.blob_hash)),
+        )
+        with pytest.raises(BlobRefLivenessReconciliationError, match="referents became live"):
+            liveness_reconciliation._validate_locked_candidate_plan(conn, "locked_candidates", 1)
+
+
 def test_scale_apply_streams_distinct_hook_paths_and_preserves_exact_survivors(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/storage/test_blob_ref_liveness.py
+++ b/tests/unit/storage/test_blob_ref_liveness.py
@@ -10,13 +10,25 @@ import pytest
 
 import polylogue.maintenance.blob_ref_liveness_reconciliation as liveness_reconciliation
 import polylogue.storage.hook_payload_ref_reconciliation as hook_payload_ref_reconciliation
+from polylogue.daemon.backup import backup_archive
 from polylogue.maintenance.blob_ref_liveness_reconciliation import (
     BlobRefLivenessReconciliationError,
     reconcile_blob_ref_liveness,
 )
-from polylogue.storage.blob_ref_liveness import classify_blob_ref_liveness
+from polylogue.storage.blob_ref_liveness import (
+    BlobRefLivenessStagedPlan,
+    classify_blob_ref_liveness,
+    stage_blob_ref_liveness,
+)
+from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
-from polylogue.storage.sqlite.archive_tiers.source_write import deterministic_raw_session_id
+from polylogue.storage.sqlite.archive_tiers.source_write import deterministic_blob_hash, deterministic_raw_session_id
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.migration_runner import (
+    MigrationError,
+    validate_migration_backup_live_fingerprint,
+    validate_migration_backup_manifest,
+)
 
 
 def _source_archive(tmp_path: Path) -> Path:
@@ -61,6 +73,41 @@ def _source_archive(tmp_path: Path) -> Path:
             VALUES (?, ?, ?, '/fixture', 1, 1)
             """,
             refs,
+        )
+    return archive_root
+
+
+def _real_source_archive(archive_root: Path) -> Path:
+    initialize_active_archive_root(archive_root)
+    blob_store = BlobStore(archive_root / "blob")
+    live_payload = b"live-payload"
+    gone_payloads = (b"gone-payload-1", b"gone-payload-2")
+    live_hash = deterministic_blob_hash(live_payload)
+    gone_hashes = tuple(deterministic_blob_hash(payload) for payload in gone_payloads)
+    blob_store.write_from_bytes(live_payload)
+    for payload in gone_payloads:
+        blob_store.write_from_bytes(payload)
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_sessions (raw_id, origin, source_path, source_index, blob_hash, blob_size, acquired_at_ms)
+            VALUES ('raw-live', 'codex-session', '/live.jsonl', 0, ?, 1, 1)
+            """,
+            (live_hash,),
+        )
+        conn.executemany(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, ?, 'raw_payload', ?, 1, 1)
+            """,
+            ((gone_hashes[index - 1], f"raw-gone-{index}", f"/gone-{index}.jsonl") for index in range(1, 3)),
+        )
+        conn.execute(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, 'raw-live', 'raw_payload', '/live.jsonl', 1, 1)
+            """,
+            (live_hash,),
         )
     return archive_root
 
@@ -209,7 +256,7 @@ def test_restart_recovers_prepared_receipt_after_rollback(tmp_path: Path) -> Non
     assert rows[-1]["phase"] == "recovered_rolled_back"
 
 
-def test_restart_marks_partial_prepared_plan_indeterminate(tmp_path: Path) -> None:
+def test_restart_recovers_partial_prepared_plan_with_exact_counts(tmp_path: Path) -> None:
     archive_root = _source_archive(tmp_path)
     receipt = tmp_path / "receipts" / "partial.jsonl"
     with sqlite3.connect(archive_root / "source.db") as conn:
@@ -224,13 +271,16 @@ def test_restart_marks_partial_prepared_plan_indeterminate(tmp_path: Path) -> No
             (bytes.fromhex(candidate.blob_hash), candidate.ref_type, candidate.ref_id),
         )
 
-    with pytest.raises(BlobRefLivenessReconciliationError, match="indeterminate"):
+    with pytest.raises(BlobRefLivenessReconciliationError, match="recovered_partial"):
         reconcile_blob_ref_liveness(
             archive_root,
             backup_manifest=tmp_path / "backup.json",
             receipt_path=receipt,
             dry_run=False,
         )
+    rows = [json.loads(line) for line in receipt.read_text(encoding="utf-8").splitlines()]
+    assert rows[-1]["phase"] == "recovered_partial"
+    assert rows[-1]["deleted_count"] == 1
     with pytest.raises(BlobRefLivenessReconciliationError, match="already terminal"):
         reconcile_blob_ref_liveness(
             archive_root,
@@ -287,6 +337,94 @@ def test_apply_deletes_only_join_proven_orphans_and_persists_receipt(
     assert receipt_rows[0]["candidate_digest"]
     assert receipt_rows[-1]["phase"] == "committed"
     assert receipt_rows[-1]["deleted_count"] == 4
+
+
+def test_real_backup_tamper_between_validations_refuses_before_delete(
+    workspace_env: dict[str, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive_root = _real_source_archive(workspace_env["archive_root"])
+    backup_result = backup_archive(output_dir=tmp_path / "backups", profile="rebuildable_cache_exclude", verify=True)
+    assert backup_result.ok and backup_result.output_path is not None, backup_result.error
+    manifest = Path(backup_result.output_path) / "manifest.json"
+    receipt = tmp_path / "receipts" / "tampered.jsonl"
+    calls: list[str] = []
+    real_pre_validate = validate_migration_backup_manifest
+    real_live_validate = validate_migration_backup_live_fingerprint
+    real_stage = stage_blob_ref_liveness
+
+    def record_pre(path: Path, tier: ArchiveTier, *, connection: sqlite3.Connection) -> Path:
+        calls.append("pre")
+        return real_pre_validate(path, tier, connection=connection)
+
+    def record_live(path: Path, tier: ArchiveTier, *, connection: sqlite3.Connection) -> Path:
+        calls.append("live")
+        return real_live_validate(path, tier, connection=connection)
+
+    def stage_then_tamper(conn: sqlite3.Connection) -> BlobRefLivenessStagedPlan:
+        staged = real_stage(conn)
+        with (manifest.parent / "source.db").open("ab") as handle:
+            handle.write(b"tampered-after-precheck")
+        return staged
+
+    monkeypatch.setattr(liveness_reconciliation, "validate_migration_backup_manifest", record_pre)
+    monkeypatch.setattr(liveness_reconciliation, "validate_migration_backup_live_fingerprint", record_live)
+    monkeypatch.setattr(liveness_reconciliation, "stage_blob_ref_liveness", stage_then_tamper)
+
+    with pytest.raises(MigrationError, match="tier artifact size mismatch"):
+        reconcile_blob_ref_liveness(
+            archive_root,
+            backup_manifest=manifest,
+            receipt_path=receipt,
+            dry_run=False,
+        )
+
+    assert calls == ["pre", "live"]
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        assert conn.execute("SELECT COUNT(*) FROM blob_refs").fetchone() == (3,)
+    rows = [json.loads(line) for line in receipt.read_text(encoding="utf-8").splitlines()]
+    assert rows[0]["phase"] == "prepared"
+    assert all(row.get("phase") != "committed" for row in rows)
+
+
+def test_real_prepared_failure_rolls_back_and_recovery_records_exact_state(
+    workspace_env: dict[str, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive_root = _real_source_archive(workspace_env["archive_root"])
+    backup_result = backup_archive(output_dir=tmp_path / "backups", profile="rebuildable_cache_exclude", verify=True)
+    assert backup_result.ok and backup_result.output_path is not None, backup_result.error
+    manifest = Path(backup_result.output_path) / "manifest.json"
+    receipt = tmp_path / "receipts" / "failed.jsonl"
+    real_delete = liveness_reconciliation._delete_candidate_batch
+
+    def delete_then_fail(conn: sqlite3.Connection, candidate_table: str, batch_table: str) -> int:
+        deleted = real_delete(conn, candidate_table, batch_table)
+        raise RuntimeError(f"injected after deleting {deleted} candidate(s) before commit")
+
+    monkeypatch.setattr(liveness_reconciliation, "_delete_candidate_batch", delete_then_fail)
+    with pytest.raises(RuntimeError, match="before commit"):
+        reconcile_blob_ref_liveness(
+            archive_root,
+            backup_manifest=manifest,
+            receipt_path=receipt,
+            dry_run=False,
+        )
+
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        assert conn.execute("SELECT COUNT(*) FROM blob_refs").fetchone() == (3,)
+    prepared_rows = [json.loads(line) for line in receipt.read_text(encoding="utf-8").splitlines()]
+    assert prepared_rows[0]["phase"] == "prepared"
+    assert prepared_rows[-1].get("phase") != "committed"
+
+    with pytest.raises(BlobRefLivenessReconciliationError, match="recovered_rolled_back"):
+        reconcile_blob_ref_liveness(
+            archive_root,
+            backup_manifest=manifest,
+            receipt_path=receipt,
+            dry_run=False,
+        )
+    recovered_rows = [json.loads(line) for line in receipt.read_text(encoding="utf-8").splitlines()]
+    assert recovered_rows[-1]["phase"] == "recovered_rolled_back"
+    assert recovered_rows[-1]["deleted_count"] == 0
 
 
 def test_locked_plan_rejects_referent_that_appears_after_staging(tmp_path: Path) -> None:
@@ -389,6 +527,7 @@ def test_scale_apply_streams_distinct_hook_paths_and_preserves_exact_survivors(
     monkeypatch.setattr(
         "polylogue.storage.hook_payload_ref_reconciliation._deterministic_raw_session_id_udf", count_udf
     )
+    monkeypatch.setattr(liveness_reconciliation, "_deterministic_raw_session_id_udf", count_udf)
 
     def fake_validate(path: Path, tier: object, *, connection: sqlite3.Connection) -> Path:
         assert connection.execute("SELECT 1").fetchone() == (1,)
@@ -405,6 +544,15 @@ def test_scale_apply_streams_distinct_hook_paths_and_preserves_exact_survivors(
     monkeypatch.setattr(
         "polylogue.maintenance.blob_ref_liveness_reconciliation.running_daemon_pid", lambda _config: None
     )
+    batches = 0
+    real_delete = liveness_reconciliation._delete_candidate_batch
+
+    def count_batch_delete(conn: sqlite3.Connection, candidate_table: str, batch_table: str) -> int:
+        nonlocal batches
+        batches += 1
+        return real_delete(conn, candidate_table, batch_table)
+
+    monkeypatch.setattr(liveness_reconciliation, "_delete_candidate_batch", count_batch_delete)
     receipt = tmp_path / "receipts" / "scale.jsonl"
     report = reconcile_blob_ref_liveness(
         archive_root,
@@ -416,6 +564,7 @@ def test_scale_apply_streams_distinct_hook_paths_and_preserves_exact_survivors(
     assert report.deleted_count == orphan_count
     assert report.classification.orphaned_count == orphan_count
     assert calls <= orphan_count * 2
+    assert batches == orphan_count // liveness_reconciliation.BATCH_SIZE
     with sqlite3.connect(archive_root / "source.db") as conn:
         assert conn.execute("SELECT COUNT(*) FROM blob_refs").fetchone() == (1,)
         assert conn.execute("SELECT ref_type, ref_id FROM blob_refs").fetchone() == ("raw_payload", "raw-live")
@@ -497,6 +646,7 @@ def test_shared_legacy_hook_path_fails_closed_without_cross_product(
     monkeypatch.setattr(
         "polylogue.storage.hook_payload_ref_reconciliation._deterministic_raw_session_id_udf", count_udf
     )
+    monkeypatch.setattr(liveness_reconciliation, "_deterministic_raw_session_id_udf", count_udf)
     with sqlite3.connect(archive_root / "source.db") as conn:
         classification = classify_blob_ref_liveness(conn)
 

--- a/tests/unit/storage/test_blob_ref_liveness.py
+++ b/tests/unit/storage/test_blob_ref_liveness.py
@@ -427,6 +427,62 @@ def test_real_prepared_failure_rolls_back_and_recovery_records_exact_state(
     assert recovered_rows[-1]["deleted_count"] == 0
 
 
+def test_apply_rejects_post_staging_legacy_hook_before_deleting_any_candidate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+    orphan_count = 2_000
+    source_path = "/hooks/post-staging.jsonl"
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        conn.executemany(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, ?, 'raw_payload', ?, 1, 1)
+            """,
+            (
+                (index.to_bytes(4, "big") + b"o" * 28, f"raw-orphan-{index}", source_path)
+                for index in range(orphan_count)
+            ),
+        )
+
+    real_stage = stage_blob_ref_liveness
+
+    def stage_then_insert_hook(conn: sqlite3.Connection) -> BlobRefLivenessStagedPlan:
+        staged = real_stage(conn)
+        conn.execute(
+            """
+            INSERT INTO raw_hook_events (
+                hook_event_id, origin, native_id, source_path, event_type, payload_json, observed_at_ms
+            ) VALUES ('post-staging-hook', 'codex-session', 'post-staging-native', ?, 'PostToolUse', '{}', 1)
+            """,
+            (source_path,),
+        )
+        return staged
+
+    def fake_validate(path: Path, tier: object, *, connection: sqlite3.Connection) -> Path:
+        assert connection.execute("SELECT 1").fetchone() == (1,)
+        return path
+
+    monkeypatch.setattr(liveness_reconciliation, "stage_blob_ref_liveness", stage_then_insert_hook)
+    monkeypatch.setattr(liveness_reconciliation, "validate_migration_backup_manifest", fake_validate)
+    monkeypatch.setattr(liveness_reconciliation, "validate_migration_backup_live_fingerprint", fake_validate)
+    monkeypatch.setattr(liveness_reconciliation, "running_daemon_pid", lambda _config: None)
+    receipt = tmp_path / "receipts" / "post-staging-hook.jsonl"
+
+    with pytest.raises(BlobRefLivenessReconciliationError, match="ambiguous legacy hook evidence"):
+        reconcile_blob_ref_liveness(
+            archive_root,
+            backup_manifest=tmp_path / "backup" / "manifest.json",
+            receipt_path=receipt,
+            dry_run=False,
+        )
+
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        assert conn.execute("SELECT COUNT(*) FROM blob_refs").fetchone() == (orphan_count,)
+        assert conn.execute("SELECT COUNT(*) FROM raw_hook_events").fetchone() == (1,)
+
+
 def test_locked_plan_rejects_referent_that_appears_after_staging(tmp_path: Path) -> None:
     archive_root = _source_archive(tmp_path)
     with sqlite3.connect(archive_root / "source.db") as conn:
@@ -474,6 +530,7 @@ def test_scale_apply_streams_distinct_hook_paths_and_preserves_exact_survivors(
     archive_root = tmp_path / "archive"
     initialize_active_archive_root(archive_root)
     orphan_count = 10_000
+    irrelevant_hook_count = orphan_count * 5
     with sqlite3.connect(archive_root / "source.db") as conn:
         conn.execute(
             """
@@ -496,6 +553,17 @@ def test_scale_apply_streams_distinct_hook_paths_and_preserves_exact_survivors(
             ) VALUES (?, 'codex-session', ?, ?, 'PostToolUse', '{}', 1)
             """,
             ((f"hook-{index}", f"native-{index}", f"/hooks/{index}.jsonl") for index in range(orphan_count)),
+        )
+        conn.executemany(
+            """
+            INSERT INTO raw_hook_events (
+                hook_event_id, origin, native_id, source_path, event_type, payload_json, observed_at_ms
+            ) VALUES (?, 'codex-session', ?, ?, 'PostToolUse', '{}', 1)
+            """,
+            (
+                (f"irrelevant-hook-{index}", f"irrelevant-native-{index}", f"/unrelated/{index}.jsonl")
+                for index in range(irrelevant_hook_count)
+            ),
         )
         conn.executemany(
             """
@@ -563,7 +631,10 @@ def test_scale_apply_streams_distinct_hook_paths_and_preserves_exact_survivors(
 
     assert report.deleted_count == orphan_count
     assert report.classification.orphaned_count == orphan_count
-    assert calls <= orphan_count * 2
+    # Initial staging, one whole-plan ownership validation, and subsequent
+    # batch validations are all bounded by candidates, not all hook rows.
+    assert calls <= orphan_count * 3
+    assert calls < irrelevant_hook_count
     assert batches == orphan_count // liveness_reconciliation.BATCH_SIZE
     with sqlite3.connect(archive_root / "source.db") as conn:
         assert conn.execute("SELECT COUNT(*) FROM blob_refs").fetchone() == (1,)

--- a/tests/unit/storage/test_blob_ref_liveness.py
+++ b/tests/unit/storage/test_blob_ref_liveness.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 import polylogue.maintenance.blob_ref_liveness_reconciliation as liveness_reconciliation
+import polylogue.storage.hook_payload_ref_reconciliation as hook_payload_ref_reconciliation
 from polylogue.maintenance.blob_ref_liveness_reconciliation import (
     BlobRefLivenessReconciliationError,
     reconcile_blob_ref_liveness,
@@ -255,6 +256,10 @@ def test_apply_deletes_only_join_proven_orphans_and_persists_receipt(
         fake_validate,
     )
     monkeypatch.setattr(
+        "polylogue.maintenance.blob_ref_liveness_reconciliation.validate_migration_backup_live_fingerprint",
+        fake_validate,
+    )
+    monkeypatch.setattr(
         "polylogue.maintenance.blob_ref_liveness_reconciliation.running_daemon_pid",
         lambda _config: None,
     )
@@ -282,6 +287,182 @@ def test_apply_deletes_only_join_proven_orphans_and_persists_receipt(
     assert receipt_rows[0]["candidate_digest"]
     assert receipt_rows[-1]["phase"] == "committed"
     assert receipt_rows[-1]["deleted_count"] == 4
+
+
+def test_scale_apply_streams_distinct_hook_paths_and_preserves_exact_survivors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+    orphan_count = 10_000
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_sessions (raw_id, origin, source_path, source_index, blob_hash, blob_size, acquired_at_ms)
+            VALUES ('raw-live', 'codex-session', '/live.jsonl', 0, ?, 10, 1)
+            """,
+            (b"l" * 32,),
+        )
+        conn.execute(
+            """
+            INSERT INTO raw_hook_events (
+                hook_event_id, origin, native_id, source_path, event_type, payload_json, observed_at_ms
+            ) VALUES ('hook-live', 'codex-session', 'native-live', '/hooks/live.jsonl', 'PostToolUse', '{}', 1)
+            """
+        )
+        conn.executemany(
+            """
+            INSERT INTO raw_hook_events (
+                hook_event_id, origin, native_id, source_path, event_type, payload_json, observed_at_ms
+            ) VALUES (?, 'codex-session', ?, ?, 'PostToolUse', '{}', 1)
+            """,
+            ((f"hook-{index}", f"native-{index}", f"/hooks/{index}.jsonl") for index in range(orphan_count)),
+        )
+        conn.executemany(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, ?, 'raw_payload', ?, 1, 1)
+            """,
+            (
+                (index.to_bytes(4, "big") + b"o" * 28, f"raw-gone-{index}", f"/hooks/{index}.jsonl")
+                for index in range(orphan_count)
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, 'raw-live', 'raw_payload', '/live.jsonl', 10, 1)
+            """,
+            (b"l" * 32,),
+        )
+        conn.commit()
+
+    calls = 0
+    original_id = hook_payload_ref_reconciliation._deterministic_raw_session_id_udf
+
+    def count_udf(*args: object) -> str | None:
+        nonlocal calls
+        calls += 1
+        return original_id(*args)
+
+    monkeypatch.setattr(
+        "polylogue.storage.hook_payload_ref_reconciliation._deterministic_raw_session_id_udf", count_udf
+    )
+
+    def fake_validate(path: Path, tier: object, *, connection: sqlite3.Connection) -> Path:
+        assert connection.execute("SELECT 1").fetchone() == (1,)
+        return path
+
+    monkeypatch.setattr(
+        "polylogue.maintenance.blob_ref_liveness_reconciliation.validate_migration_backup_manifest",
+        fake_validate,
+    )
+    monkeypatch.setattr(
+        "polylogue.maintenance.blob_ref_liveness_reconciliation.validate_migration_backup_live_fingerprint",
+        fake_validate,
+    )
+    monkeypatch.setattr(
+        "polylogue.maintenance.blob_ref_liveness_reconciliation.running_daemon_pid", lambda _config: None
+    )
+    receipt = tmp_path / "receipts" / "scale.jsonl"
+    report = reconcile_blob_ref_liveness(
+        archive_root,
+        backup_manifest=tmp_path / "backup" / "manifest.json",
+        receipt_path=receipt,
+        dry_run=False,
+    )
+
+    assert report.deleted_count == orphan_count
+    assert report.classification.orphaned_count == orphan_count
+    assert calls <= orphan_count * 2
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        assert conn.execute("SELECT COUNT(*) FROM blob_refs").fetchone() == (1,)
+        assert conn.execute("SELECT ref_type, ref_id FROM blob_refs").fetchone() == ("raw_payload", "raw-live")
+    receipt_rows = [json.loads(line) for line in receipt.read_text(encoding="utf-8").splitlines()]
+    assert receipt_rows[0]["candidate_count"] == orphan_count
+    assert sum(row.get("kind") == "candidate" for row in receipt_rows) == orphan_count
+    assert receipt_rows[-1]["phase"] == "committed"
+    assert receipt_rows[-1]["deleted_count"] == orphan_count
+
+
+def test_failure_before_prepared_receipt_rolls_back_without_receipt_or_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive_root = _source_archive(tmp_path)
+    receipt = tmp_path / "receipts" / "injected.jsonl"
+
+    def fake_validate(path: Path, tier: object, *, connection: sqlite3.Connection) -> Path:
+        return path
+
+    monkeypatch.setattr(
+        "polylogue.maintenance.blob_ref_liveness_reconciliation.validate_migration_backup_manifest",
+        fake_validate,
+    )
+    monkeypatch.setattr(
+        "polylogue.maintenance.blob_ref_liveness_reconciliation.running_daemon_pid", lambda _config: None
+    )
+    monkeypatch.setattr(
+        "polylogue.maintenance.blob_ref_liveness_reconciliation._write_prepared_receipt",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("injected before prepared receipt")),
+    )
+
+    with pytest.raises(RuntimeError, match="before prepared receipt"):
+        reconcile_blob_ref_liveness(
+            archive_root,
+            backup_manifest=tmp_path / "backup" / "manifest.json",
+            receipt_path=receipt,
+            dry_run=False,
+        )
+    assert not receipt.exists()
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        assert conn.execute("SELECT COUNT(*) FROM blob_refs").fetchone() == (8,)
+
+
+def test_shared_legacy_hook_path_fails_closed_without_cross_product(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive_root = _source_archive(tmp_path)
+    row_count = 10_000
+    source_path = "/hooks/shared-legacy.jsonl"
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        conn.executemany(
+            """
+            INSERT INTO raw_hook_events (
+                hook_event_id, origin, native_id, source_path, event_type, payload_json, observed_at_ms
+            ) VALUES (?, 'codex-session', ?, ?, 'PostToolUse', '{}', 1)
+            """,
+            ((f"shared-hook-{index}", f"native-{index}", source_path) for index in range(row_count)),
+        )
+        conn.executemany(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, ?, 'raw_payload', ?, 1, 1)
+            """,
+            (
+                (index.to_bytes(4, "big") + b"s" * 28, f"shared-orphan-{index}", source_path)
+                for index in range(row_count)
+            ),
+        )
+        conn.commit()
+
+    calls = 0
+    original_id = hook_payload_ref_reconciliation._deterministic_raw_session_id_udf
+
+    def count_udf(*args: object) -> str | None:
+        nonlocal calls
+        calls += 1
+        return original_id(*args)
+
+    monkeypatch.setattr(
+        "polylogue.storage.hook_payload_ref_reconciliation._deterministic_raw_session_id_udf", count_udf
+    )
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        classification = classify_blob_ref_liveness(conn)
+
+    assert classification.orphaned_count == 4
+    assert classification.rekeyable_hook_payload_count == row_count
+    assert sum(candidate.source_path == source_path for candidate in classification.candidates) == 0
+    assert calls == 0
 
 
 def test_unknown_ref_type_blocks_apply_fail_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
Ref polylogue-0v4tn. This successor branch makes blob-reference-liveness apply executable at live orphan-ref scale with compact SQLite staging, candidate-relevant locked validation, cached backup attestation under ownership, bounded durable delete batches, and exact prepared-receipt recovery.

## Problem
The prior actuator held BEGIN IMMEDIATE across the full locked classification and delete plan. It also rechecked only the receipt and live fingerprint after ownership, so a backup artifact mutation between validations was not detected. The incident involved 69,340 orphan raw_payload refs, 10.6 GB peak memory, 39.2 GB reads, and rollback after three minutes.

## Solution
The candidate plan is staged in SQLite and retained on the owning connection. Locked hook validation is limited to candidate-relevant source_path/blob_hash pairs; legacy null-hook ambiguity remains fail-closed. The full backup artifact inventory is cached by a cheap stat signature and revalidated under ownership, with a real mutation invalidating the cache and causing a fresh hash validation. Apply deletes in 1,000-row transactions, appends batch progress, and recovers exact rollback, commit, or partial states from the durable prepared receipt without reparsing a candidate population under the write lock.

## Acceptance matrix
| Requirement | Evidence |
| --- | --- |
| Preserve ref-type, rekeyable-hook, and exact candidate identity rules | Existing join checks, exact key receipt digest, and fail-closed legacy null ambiguity remain in the reconciler path. |
| Avoid all-row duplicate Python populations | Candidate rows stay in temp SQLite staging; Python retains only bounded report samples and receipt streaming state. |
| Detect backup tampering after precheck | Real `backup_archive(..., verify=True)` fixture mutates the copied `source.db` between real validators; apply raises before any live delete. |
| Restrict locked hook work and bound lock tenure | Locked hook SQL uses candidate-relevant EXISTS filtering; 10,000 distinct paths execute in 10 batches of `BATCH_SIZE=1000`. |
| Durable prepared evidence and recovery | Real prepared receipt plus injected failure after delete and before commit leaves source rows intact; retry records `recovered_rolled_back` with exact count. Partial presence records `recovered_partial`. |
| Scale regression and no cross-product comparison | 10,000 distinct hook paths exercise the imported locked UDF with bounded calls; 10,000 shared legacy-null rows remain fail-closed with zero UDF calls. |

## Integration
Fresh `origin/master` is `a9f71f303`. The old 31-commit branch was not published as the critical fix. This successor contains only the coherent prerequisite stack and lane changes: `de54b64dc` (SQLite staging and scale path), `c989fab5a` (locked referent revalidation), and `38e1788ff` (backup inventory ownership check, candidate-relevant locking, short-lock batches, and real regressions). It is exactly three commits ahead of fresh master.

## Verification
- `direnv exec . devtools test tests/unit/storage/test_blob_ref_liveness.py tests/unit/storage/test_hook_payload_ref_reconciliation.py tests/unit/storage/test_blob_gc_ref_type_liveness.py` -> `27 passed in 16.10s`, devtools `ok (20.5s)`.
- `direnv exec . devtools verify --quick` -> exit 0; all 24 steps passed.
- The pre-push quick verification at commit `38e1788ff` -> exit 0; all 24 steps passed.
- Commit hooks -> 4 files formatted and linted.

## Production sequence
Run the default dry run first. Create and verify a fresh source backup. Then run `polylogue ops maintenance blob-reference-liveness --apply --backup-manifest <manifest.json> --receipt-file <new-receipt.jsonl>`. The prepared receipt is written before the first delete. Each committed batch appends progress, followed by a committed footer. If the process stops with a prepared receipt, rerun with the same archive and receipt path once to record exact recovery, then choose a fresh receipt path for a new apply. The command remains offline-only and requires the daemon to be stopped.

## Residual uncertainty
No live production archive was mutated. A same-size, same-mtime backup byte replacement remains outside the existing backup attestation threat model; ordinary artifact mutations change the cached stat signature and trigger a full inventory rehash. The full test suite and integration corpus were not run.