### PR TITLE
fix(beads): guard stale worktree bd invocations

### DIFF
--- a/.agent/CONVENTIONS.md
+++ b/.agent/CONVENTIONS.md
@@ -103,10 +103,13 @@ bead's cited facts against master before coding.
   trusting anything the lane reports — a 2026-08-01 dispatch silently ran in
   the main checkout and left ~1700 uncommitted lines in the live tree. The
   same check warns when the worktree's frozen `.beads/issues.jsonl` has gone
-  stale relative to the main checkout. Hook auto-import is disabled because it
-  would blindly upsert that snapshot into shared live state. Lanes still make
-  no bd writes; coordinators audit and re-apply their Beads writes at
-  merge-train boundaries before exporting state (polylogue-2ara).
+  stale relative to the main checkout. All ordinary `bd` invocations must
+  resolve to `scripts/bd` through the devshell or the hook-local path. That
+  wrapper compares rows with live Dolt state, imports only new/strictly newer
+  rows, and disables Beads' blind automatic import for the delegated command.
+  Do not bypass it with the absolute Nix-store binary. Lanes still make no bd
+  writes; coordinators audit and re-apply explicit Beads writes at merge-train
+  boundaries before exporting state (polylogue-2ara).
 - **Serial heavy, parallel light.** Serialize anything sharing the pytest
   temp DBs (`/realm/tmp/polylogue-pytest`) or the archive DB; parallel tool
   calls are for reads/searches only.

--- a/.agent/CONVENTIONS.md
+++ b/.agent/CONVENTIONS.md
@@ -104,10 +104,11 @@ bead's cited facts against master before coding.
   the main checkout and left ~1700 uncommitted lines in the live tree. The
   same check warns when the worktree's frozen `.beads/issues.jsonl` has gone
   stale relative to the main checkout. All ordinary `bd` invocations must
-  resolve to `scripts/bd` through the devshell or the hook-local path. That
-  wrapper compares rows with live Dolt state, imports only new/strictly newer
-  rows, and disables Beads' blind automatic import for the delegated command.
-  Do not bypass it with the absolute Nix-store binary. Lanes still make no bd
+  resolve to the deployed common-checkout `scripts/bd` through the devshell or
+  Git's shared absolute `core.hooksPath`. That wrapper compares rows with live
+  Dolt state, imports only new/strictly newer rows, and disables Beads' blind
+  automatic import for the delegated command. Do not bypass it with the
+  absolute Nix-store binary. Lanes still make no bd
   writes; coordinators audit and re-apply explicit Beads writes at merge-train
   boundaries before exporting state (polylogue-2ara).
 - **Serial heavy, parallel light.** Serialize anything sharing the pytest

--- a/.beads-hooks/post-checkout
+++ b/.beads-hooks/post-checkout
@@ -1,6 +1,17 @@
 #!/usr/bin/env sh
-_bd_command="$(CDPATH= cd -- "$(dirname -- "$0")/../scripts" && pwd -P)/bd"
-if [ ! -x "$_bd_command" ]; then _bd_command="$(command -v bd 2>/dev/null || true)"; fi
+_bd_common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+if [ -n "$_bd_common_dir" ]; then
+  case "$_bd_common_dir" in
+    /*) ;;
+    *) _bd_common_dir="$(pwd -P)/$_bd_common_dir" ;;
+  esac
+fi
+if [ -n "$_bd_common_dir" ] && [ -d "$_bd_common_dir" ]; then
+  _bd_common_dir="$(CDPATH= cd -- "$_bd_common_dir" && pwd -P)"
+  _bd_command="$(CDPATH= cd -- "$_bd_common_dir/.." && pwd -P)/scripts/bd"
+else
+  _bd_command=
+fi
 # --- BEGIN BEADS INTEGRATION v1.0.4 ---
 # This section is managed by beads. Do not remove these markers.
 if [ -n "$_bd_command" ]; then

--- a/.beads-hooks/post-checkout
+++ b/.beads-hooks/post-checkout
@@ -15,6 +15,10 @@ fi
 # --- BEGIN BEADS INTEGRATION v1.0.4 ---
 # This section is managed by beads. Do not remove these markers.
 if [ -n "$_bd_command" ]; then
+  _bd_configure_hooks="$(CDPATH= cd -- "$_bd_common_dir/.." && pwd -P)/scripts/configure-git-hooks"
+  if [ -x "$_bd_configure_hooks" ]; then
+    "$_bd_configure_hooks"
+  fi
   # Linked worktrees share a live Beads store but retain branch-point JSONL.
   # Do not let a caller re-enable hook imports through Viper's BD_* override.
   unset BD_IMPORT_AUTO

--- a/.beads-hooks/post-checkout
+++ b/.beads-hooks/post-checkout
@@ -1,21 +1,23 @@
 #!/usr/bin/env sh
+_bd_command="$(CDPATH= cd -- "$(dirname -- "$0")/../scripts" && pwd -P)/bd"
+if [ ! -x "$_bd_command" ]; then _bd_command="$(command -v bd 2>/dev/null || true)"; fi
 # --- BEGIN BEADS INTEGRATION v1.0.4 ---
 # This section is managed by beads. Do not remove these markers.
-if command -v bd >/dev/null 2>&1; then
+if [ -n "$_bd_command" ]; then
   # Linked worktrees share a live Beads store but retain branch-point JSONL.
   # Do not let a caller re-enable hook imports through Viper's BD_* override.
   unset BD_IMPORT_AUTO
   export BD_GIT_HOOK=1
   _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
   if command -v timeout >/dev/null 2>&1; then
-    timeout "$_bd_timeout" bd hooks run post-checkout "$@"
+    timeout "$_bd_timeout" "$_bd_command" hooks run post-checkout "$@"
     _bd_exit=$?
     if [ $_bd_exit -eq 124 ]; then
       echo >&2 "beads: hook 'post-checkout' timed out after ${_bd_timeout}s — continuing without beads"
       _bd_exit=0
     fi
   else
-    bd hooks run post-checkout "$@"
+    "$_bd_command" hooks run post-checkout "$@"
     _bd_exit=$?
   fi
   if [ $_bd_exit -eq 3 ]; then

--- a/.beads-hooks/post-merge
+++ b/.beads-hooks/post-merge
@@ -1,21 +1,23 @@
 #!/usr/bin/env sh
+_bd_command="$(CDPATH= cd -- "$(dirname -- "$0")/../scripts" && pwd -P)/bd"
+if [ ! -x "$_bd_command" ]; then _bd_command="$(command -v bd 2>/dev/null || true)"; fi
 # --- BEGIN BEADS INTEGRATION v1.0.4 ---
 # This section is managed by beads. Do not remove these markers.
-if command -v bd >/dev/null 2>&1; then
+if [ -n "$_bd_command" ]; then
   # Linked worktrees share a live Beads store but retain branch-point JSONL.
   # Do not let a caller re-enable hook imports through Viper's BD_* override.
   unset BD_IMPORT_AUTO
   export BD_GIT_HOOK=1
   _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
   if command -v timeout >/dev/null 2>&1; then
-    timeout "$_bd_timeout" bd hooks run post-merge "$@"
+    timeout "$_bd_timeout" "$_bd_command" hooks run post-merge "$@"
     _bd_exit=$?
     if [ $_bd_exit -eq 124 ]; then
       echo >&2 "beads: hook 'post-merge' timed out after ${_bd_timeout}s — continuing without beads"
       _bd_exit=0
     fi
   else
-    bd hooks run post-merge "$@"
+    "$_bd_command" hooks run post-merge "$@"
     _bd_exit=$?
   fi
   if [ $_bd_exit -eq 3 ]; then

--- a/.beads-hooks/post-merge
+++ b/.beads-hooks/post-merge
@@ -1,6 +1,17 @@
 #!/usr/bin/env sh
-_bd_command="$(CDPATH= cd -- "$(dirname -- "$0")/../scripts" && pwd -P)/bd"
-if [ ! -x "$_bd_command" ]; then _bd_command="$(command -v bd 2>/dev/null || true)"; fi
+_bd_common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+if [ -n "$_bd_common_dir" ]; then
+  case "$_bd_common_dir" in
+    /*) ;;
+    *) _bd_common_dir="$(pwd -P)/$_bd_common_dir" ;;
+  esac
+fi
+if [ -n "$_bd_common_dir" ] && [ -d "$_bd_common_dir" ]; then
+  _bd_common_dir="$(CDPATH= cd -- "$_bd_common_dir" && pwd -P)"
+  _bd_command="$(CDPATH= cd -- "$_bd_common_dir/.." && pwd -P)/scripts/bd"
+else
+  _bd_command=
+fi
 # --- BEGIN BEADS INTEGRATION v1.0.4 ---
 # This section is managed by beads. Do not remove these markers.
 if [ -n "$_bd_command" ]; then

--- a/.beads-hooks/pre-commit
+++ b/.beads-hooks/pre-commit
@@ -18,6 +18,9 @@
 
 set -euo pipefail
 
+_bd_command="$(CDPATH= cd -- "$(dirname -- "$0")/../scripts" && pwd -P)/bd"
+if [ ! -x "$_bd_command" ]; then _bd_command="$(command -v bd 2>/dev/null || true)"; fi
+
 # Worktree-escape detection.
 git_dir=$(git rev-parse --git-dir)
 git_common_dir=$(git rev-parse --git-common-dir)
@@ -89,18 +92,18 @@ fi
 
 # --- BEGIN BEADS INTEGRATION v1.0.4 ---
 # This section is managed by beads. Do not remove these markers.
-if command -v bd >/dev/null 2>&1; then
+if [ -n "$_bd_command" ]; then
   export BD_GIT_HOOK=1
   _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
   if command -v timeout >/dev/null 2>&1; then
-    timeout "$_bd_timeout" bd hooks run pre-commit "$@"
+    timeout "$_bd_timeout" "$_bd_command" hooks run pre-commit "$@"
     _bd_exit=$?
     if [ $_bd_exit -eq 124 ]; then
       echo >&2 "beads: hook 'pre-commit' timed out after ${_bd_timeout}s — continuing without beads"
       _bd_exit=0
     fi
   else
-    bd hooks run pre-commit "$@"
+    "$_bd_command" hooks run pre-commit "$@"
     _bd_exit=$?
   fi
   if [ $_bd_exit -eq 3 ]; then

--- a/.beads-hooks/pre-commit
+++ b/.beads-hooks/pre-commit
@@ -18,8 +18,19 @@
 
 set -euo pipefail
 
-_bd_command="$(CDPATH= cd -- "$(dirname -- "$0")/../scripts" && pwd -P)/bd"
-if [ ! -x "$_bd_command" ]; then _bd_command="$(command -v bd 2>/dev/null || true)"; fi
+_bd_common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+if [ -n "$_bd_common_dir" ]; then
+  case "$_bd_common_dir" in
+    /*) ;;
+    *) _bd_common_dir="$(pwd -P)/$_bd_common_dir" ;;
+  esac
+fi
+if [ -n "$_bd_common_dir" ] && [ -d "$_bd_common_dir" ]; then
+  _bd_common_dir="$(CDPATH= cd -- "$_bd_common_dir" && pwd -P)"
+  _bd_command="$(CDPATH= cd -- "$_bd_common_dir/.." && pwd -P)/scripts/bd"
+else
+  _bd_command=
+fi
 
 # Worktree-escape detection.
 git_dir=$(git rev-parse --git-dir)

--- a/.beads-hooks/pre-push
+++ b/.beads-hooks/pre-push
@@ -20,8 +20,19 @@ fi
 
 python -m devtools.pre_push_gate "$UPDATES_FILE"
 
-_bd_command="$(CDPATH= cd -- "$(dirname -- "$0")/../scripts" && pwd -P)/bd"
-if [ ! -x "$_bd_command" ]; then _bd_command="$(command -v bd 2>/dev/null || true)"; fi
+_bd_common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+if [ -n "$_bd_common_dir" ]; then
+  case "$_bd_common_dir" in
+    /*) ;;
+    *) _bd_common_dir="$(pwd -P)/$_bd_common_dir" ;;
+  esac
+fi
+if [ -n "$_bd_common_dir" ] && [ -d "$_bd_common_dir" ]; then
+  _bd_common_dir="$(CDPATH= cd -- "$_bd_common_dir" && pwd -P)"
+  _bd_command="$(CDPATH= cd -- "$_bd_common_dir/.." && pwd -P)/scripts/bd"
+else
+  _bd_command=
+fi
 
 # --- BEGIN BEADS INTEGRATION v1.0.4 ---
 # This section is managed by beads. Do not remove these markers.

--- a/.beads-hooks/pre-push
+++ b/.beads-hooks/pre-push
@@ -20,20 +20,23 @@ fi
 
 python -m devtools.pre_push_gate "$UPDATES_FILE"
 
+_bd_command="$(CDPATH= cd -- "$(dirname -- "$0")/../scripts" && pwd -P)/bd"
+if [ ! -x "$_bd_command" ]; then _bd_command="$(command -v bd 2>/dev/null || true)"; fi
+
 # --- BEGIN BEADS INTEGRATION v1.0.4 ---
 # This section is managed by beads. Do not remove these markers.
-if command -v bd >/dev/null 2>&1; then
+if [ -n "$_bd_command" ]; then
   export BD_GIT_HOOK=1
   _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
   if command -v timeout >/dev/null 2>&1; then
-    timeout "$_bd_timeout" bd hooks run pre-push "$@" <"$UPDATES_FILE"
+    timeout "$_bd_timeout" "$_bd_command" hooks run pre-push "$@" <"$UPDATES_FILE"
     _bd_exit=$?
     if [ $_bd_exit -eq 124 ]; then
       echo >&2 "beads: hook 'pre-push' timed out after ${_bd_timeout}s — continuing without beads"
       _bd_exit=0
     fi
   else
-    bd hooks run pre-push "$@" <"$UPDATES_FILE"
+    "$_bd_command" hooks run pre-push "$@" <"$UPDATES_FILE"
     _bd_exit=$?
   fi
   if [ $_bd_exit -eq 3 ]; then

--- a/.beads-hooks/prepare-commit-msg
+++ b/.beads-hooks/prepare-commit-msg
@@ -1,6 +1,17 @@
 #!/usr/bin/env sh
-_bd_command="$(CDPATH= cd -- "$(dirname -- "$0")/../scripts" && pwd -P)/bd"
-if [ ! -x "$_bd_command" ]; then _bd_command="$(command -v bd 2>/dev/null || true)"; fi
+_bd_common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+if [ -n "$_bd_common_dir" ]; then
+  case "$_bd_common_dir" in
+    /*) ;;
+    *) _bd_common_dir="$(pwd -P)/$_bd_common_dir" ;;
+  esac
+fi
+if [ -n "$_bd_common_dir" ] && [ -d "$_bd_common_dir" ]; then
+  _bd_common_dir="$(CDPATH= cd -- "$_bd_common_dir" && pwd -P)"
+  _bd_command="$(CDPATH= cd -- "$_bd_common_dir/.." && pwd -P)/scripts/bd"
+else
+  _bd_command=
+fi
 # --- BEGIN BEADS INTEGRATION v1.0.4 ---
 # This section is managed by beads. Do not remove these markers.
 if [ -n "$_bd_command" ]; then

--- a/.beads-hooks/prepare-commit-msg
+++ b/.beads-hooks/prepare-commit-msg
@@ -1,18 +1,20 @@
 #!/usr/bin/env sh
+_bd_command="$(CDPATH= cd -- "$(dirname -- "$0")/../scripts" && pwd -P)/bd"
+if [ ! -x "$_bd_command" ]; then _bd_command="$(command -v bd 2>/dev/null || true)"; fi
 # --- BEGIN BEADS INTEGRATION v1.0.4 ---
 # This section is managed by beads. Do not remove these markers.
-if command -v bd >/dev/null 2>&1; then
+if [ -n "$_bd_command" ]; then
   export BD_GIT_HOOK=1
   _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
   if command -v timeout >/dev/null 2>&1; then
-    timeout "$_bd_timeout" bd hooks run prepare-commit-msg "$@"
+    timeout "$_bd_timeout" "$_bd_command" hooks run prepare-commit-msg "$@"
     _bd_exit=$?
     if [ $_bd_exit -eq 124 ]; then
       echo >&2 "beads: hook 'prepare-commit-msg' timed out after ${_bd_timeout}s — continuing without beads"
       _bd_exit=0
     fi
   else
-    bd hooks run prepare-commit-msg "$@"
+    "$_bd_command" hooks run prepare-commit-msg "$@"
     _bd_exit=$?
   fi
   if [ $_bd_exit -eq 3 ]; then

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -46,10 +46,11 @@
 #   git-repo: ""       # Separate git repo for backups (default: project repo)
 
 # A linked worktree keeps the JSONL snapshot from its branch point while all
-# worktrees share one live Dolt database. The Beads post-checkout/post-merge
-# importer is a blind upsert, so importing that snapshot can revert newer
-# coordinator writes. JSONL remains an export and explicit reconciliation
-# input; automatic hook imports stay disabled.
+# worktrees share one live Dolt database. The repository's scripts/bd wrapper
+# performs a monotonic per-row preflight before every normal invocation. Keep
+# Beads' own automatic import disabled so bypassing the wrapper cannot perform
+# a blind upsert; explicit newer rows are imported by the wrapper and explicit
+# recovery still goes through devtools/bd_reimport_guard.py reconcile.
 import.auto: false
 
 # Integration settings (access with 'bd config get/set')

--- a/.envrc
+++ b/.envrc
@@ -1,21 +1,36 @@
 use flake
 
 # Keep ordinary `bd` commands on the repository's monotonic JSONL preflight
-# boundary. The wrapper delegates to the Nix-installed binary after importing
-# only new or strictly newer rows from the checked-out snapshot.
+# boundary. Resolve the deployed wrapper and installed binary from Git's
+# shared common checkout so a stale linked worktree does not fall back to its
+# historical relative paths.
+_polylogue_git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null || true)
+if [ -n "$_polylogue_git_common_dir" ]; then
+  case "$_polylogue_git_common_dir" in
+    /*) ;;
+    *) _polylogue_git_common_dir="$PWD/$_polylogue_git_common_dir" ;;
+  esac
+  _polylogue_git_common_dir=$(CDPATH= cd -- "$_polylogue_git_common_dir" && pwd -P)
+  _polylogue_common_root=$(CDPATH= cd -- "$_polylogue_git_common_dir/.." && pwd -P)
+else
+  _polylogue_common_root=$PWD
+fi
+_polylogue_bd_wrapper="$_polylogue_common_root/scripts/bd"
 _polylogue_bd_real=${POLYLOGUE_BD_REAL:-}
-if [ -z "$_polylogue_bd_real" ] || [ "$_polylogue_bd_real" = "$PWD/scripts/bd" ]; then
+if [ -z "$_polylogue_bd_real" ] || [ "$_polylogue_bd_real" = "$_polylogue_bd_wrapper" ]; then
   _polylogue_bd_search_path=$PATH
   case ":$_polylogue_bd_search_path:" in
-    *":$PWD/scripts:"*) _polylogue_bd_search_path=${_polylogue_bd_search_path#"$PWD/scripts:"} ;;
+    *":$_polylogue_common_root/scripts:"*) _polylogue_bd_search_path=${_polylogue_bd_search_path#*":$_polylogue_common_root/scripts:"} ;;
   esac
   _polylogue_bd_real=$(PATH="$_polylogue_bd_search_path" command -v bd 2>/dev/null || true)
 fi
 if [ -n "$_polylogue_bd_real" ]; then
   export POLYLOGUE_BD_REAL="$_polylogue_bd_real"
-  PATH_add "$PWD/scripts"
+  if [ -x "$_polylogue_bd_wrapper" ]; then
+    PATH_add "$_polylogue_common_root/scripts"
+  fi
 fi
-unset _polylogue_bd_real _polylogue_bd_search_path
+unset _polylogue_git_common_dir _polylogue_common_root _polylogue_bd_wrapper _polylogue_bd_real _polylogue_bd_search_path
 
 export PYTHONDONTWRITEBYTECODE=1
 export PYTHONPYCACHEPREFIX="$PWD/.cache/pycache"

--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,22 @@
 use flake
 
+# Keep ordinary `bd` commands on the repository's monotonic JSONL preflight
+# boundary. The wrapper delegates to the Nix-installed binary after importing
+# only new or strictly newer rows from the checked-out snapshot.
+_polylogue_bd_real=${POLYLOGUE_BD_REAL:-}
+if [ -z "$_polylogue_bd_real" ] || [ "$_polylogue_bd_real" = "$PWD/scripts/bd" ]; then
+  _polylogue_bd_search_path=$PATH
+  case ":$_polylogue_bd_search_path:" in
+    *":$PWD/scripts:"*) _polylogue_bd_search_path=${_polylogue_bd_search_path#"$PWD/scripts:"} ;;
+  esac
+  _polylogue_bd_real=$(PATH="$_polylogue_bd_search_path" command -v bd 2>/dev/null || true)
+fi
+if [ -n "$_polylogue_bd_real" ]; then
+  export POLYLOGUE_BD_REAL="$_polylogue_bd_real"
+  PATH_add "$PWD/scripts"
+fi
+unset _polylogue_bd_real _polylogue_bd_search_path
+
 export PYTHONDONTWRITEBYTECODE=1
 export PYTHONPYCACHEPREFIX="$PWD/.cache/pycache"
 mkdir -p "$PYTHONPYCACHEPREFIX"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,8 +227,11 @@ The repository should stay aligned with the workflow above:
 
 ## Git Hooks
 
-The devshell installs git hooks automatically. In a Beads-enabled checkout it
-sets `core.hooksPath` to `.beads-hooks`; otherwise it falls back to `.githooks`.
+The devshell installs git hooks automatically. It anchors `core.hooksPath` at
+the absolute checkout selected through Git's shared common directory, so
+linked worktrees cannot retain a branch-point relative hook path. In a
+Beads-enabled checkout it selects `.beads-hooks`; otherwise it falls back to
+`.githooks`.
 The Beads composite hooks chain the ordinary Polylogue gates below and then run
 the matching `bd hooks run ...` integration.
 

--- a/devtools/bd_reimport_guard.py
+++ b/devtools/bd_reimport_guard.py
@@ -227,6 +227,22 @@ def _repo_root() -> Path:
 
 
 _EXEC_TARGET = re.compile(r"(?m)^\s*exec(?:\s+-a\s+(?:'[^']*'|\"[^\"]*\"|\S+))?\s+(?:'([^']+)'|\"([^\"]+)\"|(\S+))")
+_INTERPRETER_NAMES = frozenset(
+    {
+        "bash",
+        "dash",
+        "env",
+        "fish",
+        "ksh",
+        "perl",
+        "python",
+        "python2",
+        "python3",
+        "ruby",
+        "sh",
+        "zsh",
+    }
+)
 
 
 def _resolve_launcher_target(target: str, launcher: Path) -> Path:
@@ -240,6 +256,11 @@ def _resolve_launcher_target(target: str, launcher: Path) -> Path:
     if resolved is None:
         raise ValueError(f"launcher target is unavailable: {target}")
     return Path(resolved)
+
+
+def _is_interpreter(path: Path) -> bool:
+    """Return whether a launcher target is an interpreter entry point."""
+    return path.name in _INTERPRETER_NAMES or Path(os.path.realpath(path)).name in _INTERPRETER_NAMES
 
 
 def _validate_executable_route(path: Path, wrapper: Path, seen: set[Path]) -> None:
@@ -264,7 +285,14 @@ def _validate_executable_route(path: Path, wrapper: Path, seen: set[Path]) -> No
     targets = [next(value for value in groups if value) for groups in _EXEC_TARGET.findall(launcher)]
     if len(targets) != 1:
         raise ValueError("refusing launcher without one explicit executable target")
-    _validate_executable_route(_resolve_launcher_target(targets[0], resolved), wrapper, seen)
+    target = _resolve_launcher_target(targets[0], resolved)
+    # A route such as `exec /bin/sh -c ...` can hide another wrapper behind
+    # shell parsing. We do not interpret shell syntax here. Reject known
+    # interpreter entry points before the shared invocation lock and only
+    # accept launcher chains whose next target is itself explicit.
+    if _is_interpreter(target):
+        raise ValueError("refusing unresolved interpreter launcher route")
+    _validate_executable_route(target, wrapper, seen)
 
 
 def _validated_real_bd_path(path: str) -> Path:

--- a/devtools/bd_reimport_guard.py
+++ b/devtools/bd_reimport_guard.py
@@ -1,10 +1,11 @@
 """Monotonic, receipted reconciliation for Beads JSONL snapshots.
 
 Linked worktrees share one live Dolt database but retain the JSONL snapshot
-from their branch point. Beads hook imports are blind upserts, so this repo
-disables ``import.auto`` in ``.beads/config.yaml`` rather than trying to repair
-state after an import has happened. The 2026-07-15 planning audit showed why:
-a staged issues.jsonl can be syntactically valid yet contain stale rows.
+from their branch point. Beads' automatic JSONL import path can blind-upsert,
+so the repository's ``scripts/bd`` entry point compares the snapshot with live
+state before every normal invocation and delegates with automatic imports
+disabled. The 2026-07-15 planning audit showed why: a staged issues.jsonl can
+be syntactically valid yet contain stale rows.
 
 This module owns the explicit reconciliation flows that remain legitimate:
 
@@ -28,17 +29,17 @@ This module owns the explicit reconciliation flows that remain legitimate:
   marker-bearing file can never be staged as if it were clean.
 - ``cmd_reconcile`` is the explicit, operator-invokable entry point for
   explicit-recovery flows such as `git reset --hard` or a hand-merged
-  conflict file. Hook auto-import is disabled, so a stale file is not
-  imported merely by subsequent hook execution; ordinary reconcile can only
-  apply new/updated rows. Recovering a genuine downgrade (accepting an older
-  row on purpose, e.g. because live state itself was corrupted) requires
-  ``--allow-downgrade`` plus a recorded ``--actor``/``--reason``, and every
-  downgraded row is still named in the receipt.
+  conflict file. Normal ``scripts/bd`` invocations apply only new/updated
+  rows before delegating to Beads. Recovering a genuine downgrade (accepting
+  an older row on purpose, e.g. because live state itself was corrupted)
+  requires ``--allow-downgrade`` plus a recorded ``--actor``/``--reason``,
+  and every downgraded row is still named in the receipt.
 
 This module deliberately depends on nothing beyond the Python stdlib so an
 operator can use it from a repository checkout without the devshell/venv.
 
 Usage:
+  bd_reimport_guard.py invoke <real-bd-path> <bd-args...>
   bd_reimport_guard.py reconcile <candidate-jsonl-path> [--source NAME]
       [--allow-downgrade --actor ACTOR --reason REASON] [--dry-run]
   bd_reimport_guard.py export <target-jsonl-path>
@@ -46,6 +47,8 @@ Usage:
 
 from __future__ import annotations
 
+import fcntl
+import hashlib
 import json
 import os
 import subprocess
@@ -54,7 +57,7 @@ import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal
+from typing import IO, Any, Literal
 
 # --- revision-comparable row classification ---------------------------------
 
@@ -220,6 +223,53 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parent.parent
 
 
+def _invocation_directory(args: list[str]) -> Path:
+    """Resolve bd's optional ``-C``/``--directory`` target for guard I/O."""
+    for index, arg in enumerate(args):
+        if arg in ("-C", "--directory") and index + 1 < len(args):
+            return Path(args[index + 1]).expanduser().resolve()
+        for prefix in ("-C=", "--directory="):
+            if arg.startswith(prefix):
+                return Path(arg[len(prefix) :]).expanduser().resolve()
+    return Path.cwd().resolve()
+
+
+def _shared_lock_path(start: Path) -> Path:
+    """Return one lock path shared by all linked worktrees of this repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(start), "rev-parse", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            common_dir = Path(result.stdout.strip())
+            if not common_dir.is_absolute():
+                common_dir = start / common_dir
+            return common_dir.resolve() / "polylogue-bd-guard.lock"
+    except (OSError, subprocess.SubprocessError):
+        pass
+
+    runtime_dir = Path(os.environ.get("XDG_RUNTIME_DIR", tempfile.gettempdir()))
+    token = hashlib.sha256(str(start).encode()).hexdigest()[:20]
+    return runtime_dir / f"polylogue-bd-guard-{token}.lock"
+
+
+def _acquire_invocation_lock(start: Path) -> IO[str]:
+    """Serialize guarded bd calls across linked worktrees and retain the lock.
+
+    The file descriptor is made inheritable by ``cmd_invoke`` before it
+    replaces this process with the real bd binary. This covers the check,
+    filtered import, and delegated command as one writer boundary.
+    """
+    path = _shared_lock_path(start)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = path.open("a+")
+    fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+    return handle
+
+
 def _receipts_dir() -> Path:
     return _repo_root() / ".cache" / "bd-sync-receipts"
 
@@ -300,7 +350,12 @@ def atomic_write_jsonl(path: Path, rows: dict[str, dict[str, Any]]) -> None:
 # --- live bd state ------------------------------------------------------------
 
 
-def _export_live_state() -> dict[str, dict[str, Any]]:
+def _export_live_state(
+    *,
+    bd_command: str = "bd",
+    env: dict[str, str] | None = None,
+    cwd: Path | None = None,
+) -> dict[str, dict[str, Any]]:
     """Return {id: full_row_dict} for every issue currently live.
 
     Uses default `bd export` filtering (excludes infra beads/memories) --
@@ -310,12 +365,16 @@ def _export_live_state() -> dict[str, dict[str, Any]]:
     with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as tf:
         path = tf.name
     try:
-        subprocess.run(
-            ["bd", "export", "-o", path],
+        process_result = subprocess.run(
+            [bd_command, "export", "-o", path],
             capture_output=True,
             text=True,
             timeout=30,
+            env=env,
+            cwd=cwd,
         )
+        if process_result.returncode != 0:
+            raise RuntimeError(f"bd export failed ({process_result.returncode}): {process_result.stderr.strip()}")
         result: dict[str, dict[str, Any]] = {}
         with open(path) as f:
             for line in f:
@@ -334,20 +393,118 @@ def _export_live_state() -> dict[str, dict[str, Any]]:
         Path(path).unlink(missing_ok=True)
 
 
-def _bd_import_rows(rows: dict[str, dict[str, Any]]) -> None:
+def _bd_import_rows(
+    rows: dict[str, dict[str, Any]],
+    *,
+    bd_command: str = "bd",
+    env: dict[str, str] | None = None,
+    reexport: bool = True,
+    cwd: Path | None = None,
+) -> None:
     if not rows:
         return
+    # The installed bd importer performs its own conditional upsert. Never
+    # pass --allow-stale here: an explicit downgrade remains an audited
+    # reconcile operation, not part of ordinary wrapper synchronization.
     with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as tf:
         import_path = tf.name
         for row in rows.values():
             tf.write(json.dumps(row) + "\n")
     try:
-        subprocess.run(["bd", "import", import_path], capture_output=True, text=True, timeout=30)
-        # Re-export so the working tree's issues.jsonl matches restored live
-        # state (avoids the restore looking like a phantom git diff).
-        subprocess.run(["bd", "export"], capture_output=True, text=True, timeout=30)
+        result = subprocess.run(
+            [bd_command, "import", import_path],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+            cwd=cwd,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"bd import failed ({result.returncode}): {result.stderr.strip()}")
+        if reexport:
+            # Re-export so the working tree's issues.jsonl matches restored live
+            # state (avoids the restore looking like a phantom git diff).
+            subprocess.run(
+                [bd_command, "export"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                env=env,
+                cwd=cwd,
+            )
     finally:
         Path(import_path).unlink(missing_ok=True)
+
+
+def _find_candidate_jsonl(start: Path | None = None) -> Path | None:
+    """Find the checked-out workspace snapshot without invoking bd."""
+    current = (start or Path.cwd()).resolve()
+    for directory in (current, *current.parents):
+        candidate = directory / ".beads" / "issues.jsonl"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _preflight_invocation(
+    bd_command: str,
+    candidate_path: Path | None = None,
+    *,
+    cwd: Path | None = None,
+) -> None:
+    """Import only candidate rows newer than live state before ``bd`` runs.
+
+    The delegated command receives ``BD_IMPORT_AUTO=false`` so Beads cannot
+    perform its blind automatic import after this comparison. Failures are
+    reported as warnings and leave the live database untouched; the requested
+    bd command still gets to run against the live database.
+    """
+    candidate_path = candidate_path or _find_candidate_jsonl()
+    if candidate_path is None:
+        return
+
+    safe_env = os.environ.copy()
+    safe_env["BD_IMPORT_AUTO"] = "false"
+    try:
+        live = _export_live_state(bd_command=bd_command, env=safe_env, cwd=cwd)
+        candidate = parse_and_validate_jsonl(candidate_path.read_text())
+        merged, outcomes = merge_rows(live, candidate)
+    except (OSError, InvalidJsonlError, RuntimeError, subprocess.SubprocessError) as exc:
+        print(f"bd guard: skipped automatic JSONL reconciliation: {exc}", file=sys.stderr)
+        return
+
+    to_apply = {o.issue_id: merged[o.issue_id] for o in outcomes if o.outcome in ("new", "updated")}
+    skipped = [o.issue_id for o in outcomes if o.outcome == "skipped_downgrade"]
+    if skipped:
+        print(
+            f"bd guard: skipped {len(skipped)} stale JSONL row(s) before bd invocation",
+            file=sys.stderr,
+        )
+    if not to_apply:
+        return
+
+    try:
+        _bd_import_rows(to_apply, bd_command=bd_command, env=safe_env, reexport=False, cwd=cwd)
+    except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+        print(f"bd guard: skipped automatic JSONL reconciliation: {exc}", file=sys.stderr)
+
+
+def cmd_invoke(args: list[str]) -> int:
+    """Run the installed bd binary behind the monotonic preflight boundary."""
+    if len(args) < 1:
+        print("usage: bd_reimport_guard.py invoke <real-bd-path> <bd-args...>", file=sys.stderr)
+        return 1
+
+    bd_command, *bd_args = args
+    invocation_dir = _invocation_directory(bd_args)
+    candidate_path = _find_candidate_jsonl(invocation_dir)
+    lock = _acquire_invocation_lock(invocation_dir)
+    _preflight_invocation(bd_command, candidate_path, cwd=invocation_dir)
+    safe_env = os.environ.copy()
+    safe_env["BD_IMPORT_AUTO"] = "false"
+    os.set_inheritable(lock.fileno(), True)
+    os.execvpe(bd_command, [bd_command, *bd_args], safe_env)
+    return 1
 
 
 # --- commands ------------------------------------------------------------------
@@ -467,11 +624,13 @@ def main(argv: list[str] | None = None) -> int:
     args = sys.argv[1:] if argv is None else list(argv)
     if len(args) < 1:
         print(
-            "usage: bd_reimport_guard.py <reconcile|export> ...",
+            "usage: bd_reimport_guard.py <invoke|reconcile|export> ...",
             file=sys.stderr,
         )
         return 1
     command = args[0]
+    if command == "invoke":
+        return cmd_invoke(args[1:])
     if command == "reconcile":
         return cmd_reconcile(args[1:])
     if command == "export":

--- a/devtools/bd_reimport_guard.py
+++ b/devtools/bd_reimport_guard.py
@@ -51,6 +51,9 @@ import fcntl
 import hashlib
 import json
 import os
+import re
+import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -221,6 +224,66 @@ def build_receipt(
 
 def _repo_root() -> Path:
     return Path(__file__).resolve().parent.parent
+
+
+_EXEC_TARGET = re.compile(r"(?m)^\s*exec(?:\s+-a\s+(?:'[^']*'|\"[^\"]*\"|\S+))?\s+(?:'([^']+)'|\"([^\"]+)\"|(\S+))")
+
+
+def _resolve_launcher_target(target: str, launcher: Path) -> Path:
+    if target.startswith("$"):
+        raise ValueError("refusing dynamic launcher route")
+    if target.startswith("/"):
+        return Path(target)
+    if "/" in target:
+        return launcher.parent / target
+    resolved = shutil.which(target)
+    if resolved is None:
+        raise ValueError(f"launcher target is unavailable: {target}")
+    return Path(resolved)
+
+
+def _validate_executable_route(path: Path, wrapper: Path, seen: set[Path]) -> None:
+    resolved = Path(os.path.realpath(path))
+    if resolved in seen:
+        raise ValueError("refusing recursive wrapper route")
+    if resolved == wrapper:
+        raise ValueError("refusing recursive wrapper route")
+    seen.add(resolved)
+    try:
+        header = resolved.read_bytes()[:2]
+    except OSError as exc:
+        raise ValueError(f"real Beads binary is unreadable: {resolved}") from exc
+    if header != b"#!":
+        return
+    try:
+        launcher = resolved.read_text(errors="replace")
+    except OSError as exc:
+        raise ValueError(f"real Beads launcher is unreadable: {resolved}") from exc
+    if "POLYLOGUE_BD_REAL" in launcher:
+        raise ValueError("refusing dynamic launcher route")
+    targets = [next(value for value in groups if value) for groups in _EXEC_TARGET.findall(launcher)]
+    if len(targets) != 1:
+        raise ValueError("refusing launcher without one explicit executable target")
+    _validate_executable_route(_resolve_launcher_target(targets[0], resolved), wrapper, seen)
+
+
+def _validated_real_bd_path(path: str) -> Path:
+    """Validate the delegated Beads executable before taking the shared lock."""
+    candidate = Path(path)
+    if not candidate.is_absolute():
+        raise ValueError("real Beads binary path must be absolute")
+    resolved = Path(os.path.realpath(candidate))
+    wrapper = Path(os.path.realpath(_repo_root() / "scripts" / "bd"))
+    if resolved == wrapper:
+        raise ValueError("refusing recursive wrapper route")
+    try:
+        mode = resolved.stat().st_mode
+    except OSError as exc:
+        raise ValueError(f"real Beads binary is unavailable: {resolved}") from exc
+    if not stat.S_ISREG(mode) or not os.access(resolved, os.X_OK):
+        raise ValueError(f"real Beads binary is not an executable file: {resolved}")
+    _validate_executable_route(resolved, wrapper, set())
+    return resolved
 
 
 def _invocation_directory(args: list[str]) -> Path:
@@ -496,6 +559,11 @@ def cmd_invoke(args: list[str]) -> int:
         return 1
 
     bd_command, *bd_args = args
+    try:
+        bd_command = str(_validated_real_bd_path(bd_command))
+    except ValueError as exc:
+        print(f"bd guard: {exc}", file=sys.stderr)
+        return 126
     invocation_dir = _invocation_directory(bd_args)
     candidate_path = _find_candidate_jsonl(invocation_dir)
     lock = _acquire_invocation_lock(invocation_dir)

--- a/flake.nix
+++ b/flake.nix
@@ -378,16 +378,39 @@
             touch "$legacy_stamp"
           fi
 
-          # Install repo git hooks — skip if already set correctly.
-          # Prefer the Beads composite hook path when present; those hooks
-          # chain the ordinary Polylogue .githooks checks and the Beads hooks.
-          desired_hooks_path=".githooks"
-          if [ -d .beads-hooks ]; then
-            desired_hooks_path=".beads-hooks"
+          # Install repo git hooks through the shared Git common directory.
+          # Linked worktrees retain their branch-point relative `.beads-hooks`
+          # files, so a relative core.hooksPath would keep executing stale
+          # safety code. The common checkout is the deployment anchor for all
+          # worktrees sharing this Git database.
+          git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null || true)
+          if [ -n "$git_common_dir" ]; then
+            case "$git_common_dir" in
+              /*) ;;
+              *) git_common_dir="$PWD/$git_common_dir" ;;
+            esac
+            git_common_dir=$(cd "$git_common_dir" && pwd -P)
+            git_common_root=$(cd "$git_common_dir/.." && pwd -P)
+            desired_hooks_path="$git_common_root/.githooks"
+            if [ -d "$git_common_root/.beads-hooks" ]; then
+              desired_hooks_path="$git_common_root/.beads-hooks"
+            fi
+          else
+            git_common_root="$PWD"
+            desired_hooks_path="$PWD/.githooks"
+            if [ -d .beads-hooks ]; then
+              desired_hooks_path="$PWD/.beads-hooks"
+            fi
           fi
           current_hooks_path=$(git config --local core.hooksPath 2>/dev/null || true)
           if [ "$current_hooks_path" != "$desired_hooks_path" ]; then
             git config --local core.hooksPath "$desired_hooks_path" 2>/dev/null || true
+          fi
+          if [ -x "$git_common_root/scripts/bd" ]; then
+            case ":$PATH:" in
+              *":$git_common_root/scripts:"*) ;;
+              *) export PATH="$git_common_root/scripts:$PATH" ;;
+            esac
           fi
 
           # Clean stale __pycache__ dirs under source trees — skip if stamp

--- a/flake.nix
+++ b/flake.nix
@@ -379,10 +379,9 @@
           fi
 
           # Install repo git hooks through the shared Git common directory.
-          # Linked worktrees retain their branch-point relative `.beads-hooks`
-          # files, so a relative core.hooksPath would keep executing stale
-          # safety code. The common checkout is the deployment anchor for all
-          # worktrees sharing this Git database.
+          # The helper pins an absolute common-directory path in every
+          # worktree's config, so a historical shell hook cannot restore its
+          # relative path as the effective route for that worktree.
           git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null || true)
           if [ -n "$git_common_dir" ]; then
             case "$git_common_dir" in
@@ -391,20 +390,25 @@
             esac
             git_common_dir=$(cd "$git_common_dir" && pwd -P)
             git_common_root=$(cd "$git_common_dir/.." && pwd -P)
-            desired_hooks_path="$git_common_root/.githooks"
-            if [ -d "$git_common_root/.beads-hooks" ]; then
-              desired_hooks_path="$git_common_root/.beads-hooks"
+            if [ -x "$git_common_root/scripts/configure-git-hooks" ]; then
+              "$git_common_root/scripts/configure-git-hooks"
+            else
+              # Transitional fallback for a common checkout that predates
+              # the helper. Keep the same worktree-config invariant.
+              desired_hooks_path="$git_common_root/.githooks"
+              if [ -d "$git_common_root/.beads-hooks" ]; then
+                desired_hooks_path="$git_common_root/.beads-hooks"
+              fi
+              git -C "$git_common_root" config --local extensions.worktreeConfig true
+              git -C "$git_common_root" config --local core.hooksPath "$desired_hooks_path"
+              while IFS= read -r worktree_path; do
+                [ -n "$worktree_path" ] || continue
+                [ -d "$worktree_path" ] || continue
+                git -C "$worktree_path" config --worktree core.hooksPath "$desired_hooks_path"
+              done < <(git -C "$git_common_root" worktree list --porcelain | sed -n 's/^worktree //p')
             fi
           else
             git_common_root="$PWD"
-            desired_hooks_path="$PWD/.githooks"
-            if [ -d .beads-hooks ]; then
-              desired_hooks_path="$PWD/.beads-hooks"
-            fi
-          fi
-          current_hooks_path=$(git config --local core.hooksPath 2>/dev/null || true)
-          if [ "$current_hooks_path" != "$desired_hooks_path" ]; then
-            git config --local core.hooksPath "$desired_hooks_path" 2>/dev/null || true
           fi
           if [ -x "$git_common_root/scripts/bd" ]; then
             case ":$PATH:" in

--- a/scripts/bd
+++ b/scripts/bd
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+set -eu
+
+_bd_script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+_bd_guard="$_bd_script_dir/../devtools/bd_reimport_guard.py"
+_bd_real=${POLYLOGUE_BD_REAL:-}
+
+if [ -z "$_bd_real" ] || [ "$_bd_real" = "$_bd_script_dir/bd" ]; then
+  _bd_search_path=$PATH
+  case ":$_bd_search_path:" in
+    *":$_bd_script_dir:"*) _bd_search_path=${_bd_search_path#"$_bd_script_dir:"} ;;
+  esac
+  _bd_real=$(PATH="$_bd_search_path" command -v bd 2>/dev/null || true)
+fi
+
+if [ -z "$_bd_real" ] || [ "$_bd_real" = "$_bd_script_dir/bd" ]; then
+  echo "polylogue bd wrapper: installed bd binary not found" >&2
+  exit 127
+fi
+
+exec python3 "$_bd_guard" invoke "$_bd_real" "$@"

--- a/scripts/bd
+++ b/scripts/bd
@@ -3,19 +3,56 @@ set -eu
 
 _bd_script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
 _bd_guard="$_bd_script_dir/../devtools/bd_reimport_guard.py"
+_bd_wrapper_real=$(readlink -f "$_bd_script_dir/bd")
 _bd_real=${POLYLOGUE_BD_REAL:-}
 
-if [ -z "$_bd_real" ] || [ "$_bd_real" = "$_bd_script_dir/bd" ]; then
-  _bd_search_path=$PATH
-  case ":$_bd_search_path:" in
-    *":$_bd_script_dir:"*) _bd_search_path=${_bd_search_path#"$_bd_script_dir:"} ;;
-  esac
-  _bd_real=$(PATH="$_bd_search_path" command -v bd 2>/dev/null || true)
+if [ -z "$_bd_real" ]; then
+  _bd_real=bd
 fi
 
-if [ -z "$_bd_real" ] || [ "$_bd_real" = "$_bd_script_dir/bd" ]; then
+case "$_bd_real" in
+  */*)
+    case "$_bd_real" in
+      /*) ;;
+      *)
+        echo "polylogue bd wrapper: POLYLOGUE_BD_REAL must be an absolute path or a bare command name" >&2
+        exit 126
+        ;;
+    esac
+    ;;
+  *)
+    _bd_name=$_bd_real
+    _bd_real=
+    _bd_old_ifs=$IFS
+    IFS=:
+    for _bd_path_entry in $PATH; do
+      [ -n "$_bd_path_entry" ] || _bd_path_entry=.
+      _bd_candidate="$_bd_path_entry/$_bd_name"
+      if [ -x "$_bd_candidate" ] && [ ! -d "$_bd_candidate" ]; then
+        _bd_candidate_real=$(readlink -f "$_bd_candidate" 2>/dev/null || true)
+        if [ -n "$_bd_candidate_real" ] && [ "$_bd_candidate_real" != "$_bd_wrapper_real" ]; then
+          _bd_real="$_bd_candidate_real"
+          break
+        fi
+      fi
+    done
+    IFS=$_bd_old_ifs
+    ;;
+esac
+
+if [ -z "$_bd_real" ]; then
   echo "polylogue bd wrapper: installed bd binary not found" >&2
   exit 127
+fi
+
+_bd_real=$(readlink -f "$_bd_real" 2>/dev/null || true)
+if [ -z "$_bd_real" ] || [ "$_bd_real" = "$_bd_wrapper_real" ]; then
+  echo "polylogue bd wrapper: refusing recursive wrapper route" >&2
+  exit 126
+fi
+if [ ! -f "$_bd_real" ] || [ ! -x "$_bd_real" ]; then
+  echo "polylogue bd wrapper: real Beads binary is not an executable file" >&2
+  exit 126
 fi
 
 exec python3 "$_bd_guard" invoke "$_bd_real" "$@"

--- a/scripts/configure-git-hooks
+++ b/scripts/configure-git-hooks
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pin the hook route in each worktree's config. Historical shell hooks use
+# `git config --local`, which writes the shared config even when
+# extensions.worktreeConfig is enabled. A per-worktree value therefore acts
+# as the durable read-side interception point for old checkouts.
+
+_polylogue_common_dir=$(git rev-parse --git-common-dir 2>/dev/null || true)
+if [ -z "$_polylogue_common_dir" ]; then
+  exit 0
+fi
+case "$_polylogue_common_dir" in
+  /*) ;;
+  *) _polylogue_common_dir="$PWD/$_polylogue_common_dir" ;;
+esac
+_polylogue_common_dir=$(CDPATH= cd -- "$_polylogue_common_dir" && pwd -P)
+_polylogue_common_root=$(CDPATH= cd -- "$_polylogue_common_dir/.." && pwd -P)
+
+_polylogue_hooks_path="$_polylogue_common_root/.githooks"
+if [ -d "$_polylogue_common_root/.beads-hooks" ]; then
+  _polylogue_hooks_path="$_polylogue_common_root/.beads-hooks"
+fi
+
+# This is the shared installation anchor. The per-worktree values below are
+# higher-precedence guards against a branch-point shell hook restoring a
+# relative path in the common config.
+git -C "$_polylogue_common_root" config --local extensions.worktreeConfig true
+git -C "$_polylogue_common_root" config --local core.hooksPath "$_polylogue_hooks_path"
+
+while IFS= read -r _polylogue_worktree; do
+  [ -n "$_polylogue_worktree" ] || continue
+  [ -d "$_polylogue_worktree" ] || continue
+  git -C "$_polylogue_worktree" config --worktree core.hooksPath "$_polylogue_hooks_path"
+done < <(git -C "$_polylogue_common_root" worktree list --porcelain | sed -n 's/^worktree //p')

--- a/tests/integration/test_beads_stale_worktree_guard.py
+++ b/tests/integration/test_beads_stale_worktree_guard.py
@@ -19,6 +19,20 @@ import pytest
 ROOT = Path(__file__).resolve().parents[2]
 
 
+def _installed_bd() -> str | None:
+    """Resolve the Nix-installed binary even when this checkout's shim is on PATH."""
+    configured = os.environ.get("POLYLOGUE_BD_REAL")
+    if configured and Path(configured).resolve() != (ROOT / "scripts/bd").resolve():
+        return configured
+    scripts_dir = str((ROOT / "scripts").resolve())
+    search_path = os.pathsep.join(
+        entry
+        for entry in os.environ.get("PATH", "").split(os.pathsep)
+        if Path(entry or ".").resolve() != Path(scripts_dir)
+    )
+    return shutil.which("bd", path=search_path)
+
+
 def _run(command: list[str], cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
     result = subprocess.run(command, cwd=cwd, env=env, capture_output=True, text=True, timeout=60)
     if result.returncode != 0:
@@ -98,12 +112,21 @@ def _set_export_timestamp(repo: Path, issue_id: str, updated_at: str) -> None:
     export_path.write_text("".join(json.dumps(row, sort_keys=True) + "\n" for row in rows))
 
 
+def _set_export_row(repo: Path, issue_id: str, **updates: object) -> None:
+    export_path = repo / ".beads" / "issues.jsonl"
+    rows = [json.loads(line) for line in export_path.read_text().splitlines()]
+    matching_rows = [row for row in rows if row.get("id") == issue_id]
+    assert len(matching_rows) == 1
+    matching_rows[0].update(updates)
+    export_path.write_text("".join(json.dumps(row, sort_keys=True) + "\n" for row in rows))
+
+
 def _setup_stale_worktree(
     tmp_path: Path,
     import_auto: bool,
     stale_snapshot_updated_at: str | None = None,
 ) -> tuple[str, dict[str, str], Path, Path, Path]:
-    bd = shutil.which("bd")
+    bd = _installed_bd()
     if bd is None:
         pytest.skip("bd is not installed")
 
@@ -111,12 +134,18 @@ def _setup_stale_worktree(
     wrapper_dir = tmp_path / "bin"
     wrapper_dir.mkdir()
     invocation_log = tmp_path / "bd-invocations.log"
-    wrapper = wrapper_dir / "bd"
-    wrapper.write_text('#!/bin/sh\nprintf "%s\\n" "$*" >> "$BD_GUARD_COMMAND_LOG"\nexec "$BD_GUARD_REAL_BD" "$@"\n')
-    wrapper.chmod(0o755)
+    real_wrapper = wrapper_dir / "bd-real"
+    real_wrapper.write_text(
+        '#!/bin/sh\nprintf "%s\\n" "$*" >> "$BD_GUARD_COMMAND_LOG"\nexec "$BD_GUARD_REAL_BD" "$@"\n'
+    )
+    real_wrapper.chmod(0o755)
     env["BD_GUARD_COMMAND_LOG"] = str(invocation_log)
     env["BD_GUARD_REAL_BD"] = bd
-    env["PATH"] = str(wrapper_dir) + os.pathsep + env["PATH"]
+    env["POLYLOGUE_BD_REAL"] = str(real_wrapper)
+    # The lane deliberately does not contain a copy of the new files. The
+    # machine-level devshell path supplies the current checkout's stable
+    # wrapper, just as an operator shell does after entering this repo.
+    env["PATH"] = os.pathsep.join((str(ROOT / "scripts"), str(wrapper_dir), env["PATH"]))
     repo = tmp_path / "coordinator"
     lane = tmp_path / "stale-lane"
     repo.mkdir()
@@ -127,12 +156,11 @@ def _setup_stale_worktree(
     _run([bd, "init", "--prefix", "guard", "--quiet", "--non-interactive", "--skip-hooks", "--skip-agents"], repo, env)
     _write_import_policy(repo, import_auto)
 
-    hooks_dir = repo / ".githooks"
-    hooks_dir.mkdir()
-    hook_path = hooks_dir / "post-checkout"
-    hook_path.write_text((ROOT / ".beads-hooks" / "post-checkout").read_text())
-    hook_path.chmod(0o755)
-    _run(["git", "config", "core.hooksPath", str(hooks_dir)], repo, env)
+    # Keep setup commits hook-free, then point the linked lane at the actual
+    # production hook path for the checkout that exercises the guard.
+    setup_hooks = repo / ".setup-hooks"
+    setup_hooks.mkdir()
+    _run(["git", "config", "core.hooksPath", str(setup_hooks)], repo, env)
 
     _run([bd, "create", "coordinator-owned issue", "--type", "bug"], repo, env)
     _run([bd, "export", "-o", ".beads/issues.jsonl"], repo, env)
@@ -142,8 +170,9 @@ def _setup_stale_worktree(
     if stale_snapshot_updated_at is not None:
         _set_export_timestamp(repo, issue_id, stale_snapshot_updated_at)
 
-    _run(["git", "add", ".beads", ".githooks"], repo, env)
+    _run(["git", "add", ".beads"], repo, env)
     _run(["git", "commit", "-m", "baseline Beads snapshot"], repo, env)
+    _run(["git", "config", "core.hooksPath", str(ROOT / ".beads-hooks")], repo, env)
     _run(["git", "branch", "stale-lane"], repo, env)
     _run(["git", "worktree", "add", str(lane), "stale-lane"], repo, env)
     _run([bd, "close", issue_id, "--reason", "coordinator close"], repo, env)
@@ -160,17 +189,34 @@ def test_stale_worktree_plain_read_preserves_coordinator_write_when_env_reenable
     it to ``true`` only for the stale lane. The production shim must clear that
     unsafe Viper override before it can re-enable imports.
     """
-    issue_id, env, _repo, lane, invocation_log = _setup_stale_worktree(tmp_path, import_auto=False)
+    issue_id, env, _repo, lane, invocation_log = _setup_stale_worktree(tmp_path, import_auto=True)
     env["BD_IMPORT_AUTO"] = "true"
     _run(["git", "switch", "--detach", "HEAD"], lane, env)
 
-    shown = _json_from_output(_run([env["BD_GUARD_REAL_BD"], "show", issue_id, "--json"], lane, env).stdout)
+    shown = _json_from_output(_run(["bd", "show", issue_id, "--json"], lane, env).stdout)
     assert isinstance(shown, list) and len(shown) == 1
     assert shown[0]["status"] == "closed"
 
     delegated_commands = invocation_log.read_text().splitlines()
-    imported = any(command.startswith("import --quiet ") for command in delegated_commands)
-    assert not imported
+    imported = any(command.startswith("import ") for command in delegated_commands)
+    assert not imported, "the stale row must be filtered before the real bd entry point sees it"
+
+
+def test_bd_wrapper_preserves_legitimate_newer_snapshot_import(tmp_path: Path) -> None:
+    """The guard rejects stale rows without disabling genuinely newer rows."""
+    issue_id, env, _repo, lane, _invocation_log = _setup_stale_worktree(tmp_path, import_auto=True)
+    _set_export_row(
+        lane,
+        issue_id,
+        status="open",
+        updated_at="2099-01-01T00:00:00Z",
+        title="legitimate newer snapshot",
+    )
+
+    shown = _json_from_output(_run(["bd", "show", issue_id, "--json"], lane, env).stdout)
+    assert isinstance(shown, list) and len(shown) == 1
+    assert shown[0]["status"] == "open"
+    assert shown[0]["title"] == "legitimate newer snapshot"
 
 
 def test_unsafe_import_auto_control_reverts_clock_skewed_stale_snapshot(tmp_path: Path) -> None:
@@ -194,4 +240,4 @@ def test_unsafe_import_auto_control_reverts_clock_skewed_stale_snapshot(tmp_path
     assert shown[0]["status"] == "open"
 
     delegated_commands = invocation_log.read_text().splitlines()
-    assert any(command.startswith("import --quiet ") for command in delegated_commands)
+    assert any(command.startswith("import ") for command in delegated_commands)

--- a/tests/integration/test_beads_stale_worktree_guard.py
+++ b/tests/integration/test_beads_stale_worktree_guard.py
@@ -1,8 +1,10 @@
 """Regression coverage for the linked-worktree Beads import guard.
 
-This exercises the production post-checkout hook and the installed ``bd``
-binary against a temporary git repository and temporary embedded Dolt store.
-It never opens the repository's shared Beads database.
+The fixture has a deployed coordinator checkout and a linked lane created
+before deployment. The lane therefore retains the historical relative
+``.beads-hooks`` and ``.envrc`` paths while Git routes hooks through the
+coordinator's shared common-directory installation. It never opens this
+checkout's Beads database.
 """
 
 from __future__ import annotations
@@ -17,18 +19,14 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
+BASE_COMMIT = "a516b3caa791ef84a1a4133d217e39c20123651a"
 
 
 def _installed_bd() -> str | None:
-    """Resolve the Nix-installed binary even when this checkout's shim is on PATH."""
-    configured = os.environ.get("POLYLOGUE_BD_REAL")
-    if configured and Path(configured).resolve() != (ROOT / "scripts/bd").resolve():
-        return configured
-    scripts_dir = str((ROOT / "scripts").resolve())
+    """Resolve the installed binary without using this checkout's wrapper."""
+    scripts_dir = (ROOT / "scripts").resolve()
     search_path = os.pathsep.join(
-        entry
-        for entry in os.environ.get("PATH", "").split(os.pathsep)
-        if Path(entry or ".").resolve() != Path(scripts_dir)
+        entry for entry in os.environ.get("PATH", "").split(os.pathsep) if Path(entry or ".").resolve() != scripts_dir
     )
     return shutil.which("bd", path=search_path)
 
@@ -58,6 +56,7 @@ def _bd_environment(tmp_path: Path) -> dict[str, str]:
         "BEADS_DIR",
         "BEADS_DOLT_SERVER_DATABASE",
         "BEADS_DOLT_SERVER_PORT",
+        "POLYLOGUE_BD_REAL",
     ):
         env.pop(key, None)
     env.update(
@@ -103,15 +102,6 @@ def _write_import_policy(repo: Path, import_auto: bool) -> None:
     config_path.write_text(updated)
 
 
-def _set_export_timestamp(repo: Path, issue_id: str, updated_at: str) -> None:
-    export_path = repo / ".beads" / "issues.jsonl"
-    rows = [json.loads(line) for line in export_path.read_text().splitlines()]
-    matching_rows = [row for row in rows if row.get("id") == issue_id]
-    assert len(matching_rows) == 1
-    matching_rows[0]["updated_at"] = updated_at
-    export_path.write_text("".join(json.dumps(row, sort_keys=True) + "\n" for row in rows))
-
-
 def _set_export_row(repo: Path, issue_id: str, **updates: object) -> None:
     export_path = repo / ".beads" / "issues.jsonl"
     rows = [json.loads(line) for line in export_path.read_text().splitlines()]
@@ -121,31 +111,45 @@ def _set_export_row(repo: Path, issue_id: str, **updates: object) -> None:
     export_path.write_text("".join(json.dumps(row, sort_keys=True) + "\n" for row in rows))
 
 
+def _historical_file(relative_path: str) -> str:
+    result = subprocess.run(
+        ["git", "show", f"{BASE_COMMIT}^:{relative_path}"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def _deploy_current_common_checkout(repo: Path) -> None:
+    hooks = repo / ".beads-hooks"
+    hooks.mkdir(parents=True, exist_ok=True)
+    for hook in ("post-checkout", "post-merge", "pre-commit", "pre-push", "prepare-commit-msg"):
+        target = hooks / hook
+        shutil.copy2(ROOT / ".beads-hooks" / hook, target)
+        target.chmod(0o755)
+
+    envrc = repo / ".envrc"
+    shutil.copy2(ROOT / ".envrc", envrc)
+    wrapper = repo / "scripts" / "bd"
+    wrapper.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(ROOT / "scripts" / "bd", wrapper)
+    wrapper.chmod(0o755)
+    guard = repo / "devtools" / "bd_reimport_guard.py"
+    guard.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(ROOT / "devtools" / "bd_reimport_guard.py", guard)
+
+
 def _setup_stale_worktree(
     tmp_path: Path,
     import_auto: bool,
-    stale_snapshot_updated_at: str | None = None,
-) -> tuple[str, dict[str, str], Path, Path, Path]:
+) -> tuple[str, dict[str, str], Path, Path]:
     bd = _installed_bd()
     if bd is None:
         pytest.skip("bd is not installed")
 
     env = _bd_environment(tmp_path)
-    wrapper_dir = tmp_path / "bin"
-    wrapper_dir.mkdir()
-    invocation_log = tmp_path / "bd-invocations.log"
-    real_wrapper = wrapper_dir / "bd-real"
-    real_wrapper.write_text(
-        '#!/bin/sh\nprintf "%s\\n" "$*" >> "$BD_GUARD_COMMAND_LOG"\nexec "$BD_GUARD_REAL_BD" "$@"\n'
-    )
-    real_wrapper.chmod(0o755)
-    env["BD_GUARD_COMMAND_LOG"] = str(invocation_log)
-    env["BD_GUARD_REAL_BD"] = bd
-    env["POLYLOGUE_BD_REAL"] = str(real_wrapper)
-    # The lane deliberately does not contain a copy of the new files. The
-    # machine-level devshell path supplies the current checkout's stable
-    # wrapper, just as an operator shell does after entering this repo.
-    env["PATH"] = os.pathsep.join((str(ROOT / "scripts"), str(wrapper_dir), env["PATH"]))
     repo = tmp_path / "coordinator"
     lane = tmp_path / "stale-lane"
     repo.mkdir()
@@ -156,55 +160,58 @@ def _setup_stale_worktree(
     _run([bd, "init", "--prefix", "guard", "--quiet", "--non-interactive", "--skip-hooks", "--skip-agents"], repo, env)
     _write_import_policy(repo, import_auto)
 
-    # Keep setup commits hook-free, then point the linked lane at the actual
-    # production hook path for the checkout that exercises the guard.
+    # This is the branch-point checkout: it has only the historical relative
+    # hook and envrc paths, with no current wrapper or guard files.
+    historical_hooks = repo / ".beads-hooks"
+    historical_hooks.mkdir()
+    historical_hook = historical_hooks / "post-checkout"
+    historical_hook.write_text(_historical_file(".beads-hooks/post-checkout"))
+    historical_hook.chmod(0o755)
+    (repo / ".envrc").write_text(_historical_file(".envrc"))
+
     setup_hooks = repo / ".setup-hooks"
     setup_hooks.mkdir()
     _run(["git", "config", "core.hooksPath", str(setup_hooks)], repo, env)
-
     _run([bd, "create", "coordinator-owned issue", "--type", "bug"], repo, env)
     _run([bd, "export", "-o", ".beads/issues.jsonl"], repo, env)
     issue_rows = _json_from_output(_run([bd, "list", "--json"], repo, env).stdout)
     assert isinstance(issue_rows, list) and len(issue_rows) == 1
     issue_id = issue_rows[0]["id"]
-    if stale_snapshot_updated_at is not None:
-        _set_export_timestamp(repo, issue_id, stale_snapshot_updated_at)
 
-    _run(["git", "add", ".beads"], repo, env)
-    _run(["git", "commit", "-m", "baseline Beads snapshot"], repo, env)
-    _run(["git", "config", "core.hooksPath", str(ROOT / ".beads-hooks")], repo, env)
+    _run(["git", "add", ".beads", ".beads-hooks", ".envrc"], repo, env)
+    _run(["git", "commit", "-m", "historical Beads snapshot"], repo, env)
     _run(["git", "branch", "stale-lane"], repo, env)
     _run(["git", "worktree", "add", str(lane), "stale-lane"], repo, env)
+
+    # Deployment happens only in the common coordinator checkout. The shared
+    # absolute hook path is what protects the stale lane's historical files.
+    _deploy_current_common_checkout(repo)
+    _run(["git", "add", ".beads-hooks", ".envrc", "scripts/bd", "devtools/bd_reimport_guard.py"], repo, env)
+    _run(["git", "commit", "-m", "deploy Beads guard"], repo, env)
+    _run(["git", "config", "core.hooksPath", str(repo / ".beads-hooks")], repo, env)
+
+    env["PATH"] = os.pathsep.join((str(repo / "scripts"), env["PATH"]))
     _run([bd, "close", issue_id, "--reason", "coordinator close"], repo, env)
-    invocation_log.write_text("")
-    return issue_id, env, repo, lane, invocation_log
+    assert not (lane / "scripts" / "bd").exists()
+    assert (lane / ".envrc").read_text() == _historical_file(".envrc")
+    assert (lane / ".beads-hooks" / "post-checkout").read_text() == _historical_file(".beads-hooks/post-checkout")
+    return issue_id, env, repo, lane
 
 
-def test_stale_worktree_plain_read_preserves_coordinator_write_when_env_reenables_import(tmp_path: Path) -> None:
-    """A stale branch cannot overwrite a coordinator close before its read.
-
-    Production dependency exercised: Git invokes the committed
-    ``.beads-hooks/post-checkout`` shim, which invokes Beads' real hook import
-    gate. The fixture clears ambient ``BD_IMPORT_AUTO`` before setup, then sets
-    it to ``true`` only for the stale lane. The production shim must clear that
-    unsafe Viper override before it can re-enable imports.
-    """
-    issue_id, env, _repo, lane, invocation_log = _setup_stale_worktree(tmp_path, import_auto=True)
+def test_stale_worktree_plain_read_preserves_coordinator_write(tmp_path: Path) -> None:
+    """A stale branch's historical hook path cannot overwrite a close."""
+    issue_id, env, _repo, lane = _setup_stale_worktree(tmp_path, import_auto=True)
     env["BD_IMPORT_AUTO"] = "true"
-    _run(["git", "switch", "--detach", "HEAD"], lane, env)
 
+    _run(["git", "switch", "--detach", "HEAD"], lane, env)
     shown = _json_from_output(_run(["bd", "show", issue_id, "--json"], lane, env).stdout)
     assert isinstance(shown, list) and len(shown) == 1
     assert shown[0]["status"] == "closed"
 
-    delegated_commands = invocation_log.read_text().splitlines()
-    imported = any(command.startswith("import ") for command in delegated_commands)
-    assert not imported, "the stale row must be filtered before the real bd entry point sees it"
-
 
 def test_bd_wrapper_preserves_legitimate_newer_snapshot_import(tmp_path: Path) -> None:
-    """The guard rejects stale rows without disabling genuinely newer rows."""
-    issue_id, env, _repo, lane, _invocation_log = _setup_stale_worktree(tmp_path, import_auto=True)
+    """The guard rejects stale rows without disabling newer rows."""
+    issue_id, env, _repo, lane = _setup_stale_worktree(tmp_path, import_auto=True)
     _set_export_row(
         lane,
         issue_id,
@@ -220,24 +227,72 @@ def test_bd_wrapper_preserves_legitimate_newer_snapshot_import(tmp_path: Path) -
 
 
 def test_unsafe_import_auto_control_reverts_clock_skewed_stale_snapshot(tmp_path: Path) -> None:
-    """The config mutation reaches the importer and reopens the stale issue.
+    """The installed Beads importer remains a causal unsafe control."""
+    issue_id, env, _repo, lane = _setup_stale_worktree(tmp_path, import_auto=True)
+    _set_export_row(lane, issue_id, status="open", updated_at="2099-01-01T00:00:00Z")
+    env["BD_IMPORT_AUTO"] = "true"
 
-    This is the causal negative control for the protected test. It removes the
-    production ``import.auto: false`` mutation while retaining the same actual
-    git checkout and installed Beads engine. A clock-skewed branch snapshot
-    has a later ``updated_at`` despite containing the old open status, so the
-    importer accepts it over the coordinator's close.
-    """
-    issue_id, env, _repo, lane, invocation_log = _setup_stale_worktree(
-        tmp_path,
-        import_auto=True,
-        stale_snapshot_updated_at="2099-01-01T00:00:00Z",
-    )
+    bd = _installed_bd()
+    assert bd is not None
+    unsafe_hooks = tmp_path / "unsafe-hooks"
+    unsafe_hooks.mkdir()
+    unsafe_hook = unsafe_hooks / "post-checkout"
+    unsafe_hook.write_text(f"#!/bin/sh\nexec {bd} import .beads/issues.jsonl\n")
+    unsafe_hook.chmod(0o755)
+    _run(["git", "config", "core.hooksPath", str(unsafe_hooks)], lane, env)
     _run(["git", "switch", "--detach", "HEAD"], lane, env)
-
-    shown = _json_from_output(_run([env["BD_GUARD_REAL_BD"], "show", issue_id, "--json"], lane, env).stdout)
+    shown = _json_from_output(_run([bd, "show", issue_id, "--json"], lane, env).stdout)
     assert isinstance(shown, list) and len(shown) == 1
     assert shown[0]["status"] == "open"
 
-    delegated_commands = invocation_log.read_text().splitlines()
-    assert any(command.startswith("import ") for command in delegated_commands)
+
+@pytest.mark.parametrize("route", ["bare-wrapper", "symlink-wrapper", "script-recursion", "script-symlink-recursion"])
+def test_bd_wrapper_rejects_recursive_real_binary_routes(tmp_path: Path, route: str) -> None:
+    """Wrapper aliases and script recursion fail before the guard lock."""
+    deployed = tmp_path / "deployed"
+    scripts = deployed / "scripts"
+    scripts.mkdir(parents=True)
+    shutil.copy2(ROOT / "scripts" / "bd", scripts / "bd")
+    (scripts / "bd").chmod(0o755)
+    guard = deployed / "devtools" / "bd_reimport_guard.py"
+    guard.parent.mkdir()
+    shutil.copy2(ROOT / "devtools" / "bd_reimport_guard.py", guard)
+    wrapper = scripts / "bd"
+    probe = tmp_path / "probe"
+    probe.mkdir()
+
+    env = os.environ.copy()
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    env["XDG_RUNTIME_DIR"] = str(runtime)
+    tool_dirs: list[str] = []
+    for tool in ("sh", "dirname", "readlink", "python3"):
+        executable = shutil.which(tool)
+        assert executable is not None
+        directory = str(Path(executable).parent)
+        if directory not in tool_dirs:
+            tool_dirs.append(directory)
+    env["PATH"] = os.pathsep.join((str(scripts), *tool_dirs))
+    if route == "bare-wrapper":
+        env["POLYLOGUE_BD_REAL"] = "bd"
+    elif route == "symlink-wrapper":
+        alias = tmp_path / "bd-alias"
+        alias.symlink_to(wrapper)
+        env["POLYLOGUE_BD_REAL"] = str(alias)
+    elif route == "script-recursion":
+        recursive = tmp_path / "recursive-bd"
+        recursive.write_text(f'#!/bin/sh\nexec {wrapper!s} "$@"\n')
+        recursive.chmod(0o755)
+        env["POLYLOGUE_BD_REAL"] = str(recursive)
+    else:
+        alias = tmp_path / "bd-alias"
+        alias.symlink_to(wrapper)
+        recursive = tmp_path / "recursive-bd"
+        recursive.write_text(f'#!/bin/sh\nexec {alias!s} "$@"\n')
+        recursive.chmod(0o755)
+        env["POLYLOGUE_BD_REAL"] = str(recursive)
+
+    result = subprocess.run([str(wrapper), "--help"], cwd=probe, env=env, capture_output=True, text=True, timeout=10)
+    expected_returncode = 126 if route != "bare-wrapper" else 127
+    assert result.returncode == expected_returncode
+    assert not list(runtime.iterdir())

--- a/tests/integration/test_beads_stale_worktree_guard.py
+++ b/tests/integration/test_beads_stale_worktree_guard.py
@@ -14,6 +14,7 @@ import os
 import re
 import shutil
 import subprocess
+import textwrap
 from pathlib import Path
 
 import pytest
@@ -26,7 +27,9 @@ def _installed_bd() -> str | None:
     """Resolve the installed binary without using this checkout's wrapper."""
     scripts_dir = (ROOT / "scripts").resolve()
     search_path = os.pathsep.join(
-        entry for entry in os.environ.get("PATH", "").split(os.pathsep) if Path(entry or ".").resolve() != scripts_dir
+        entry
+        for entry in os.environ.get("PATH", "").split(os.pathsep)
+        if (Path(entry or ".").resolve() / "bd").resolve().parent.name != scripts_dir.name
     )
     return shutil.which("bd", path=search_path)
 
@@ -136,9 +139,60 @@ def _deploy_current_common_checkout(repo: Path) -> None:
     wrapper.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(ROOT / "scripts" / "bd", wrapper)
     wrapper.chmod(0o755)
+    hook_configurator = repo / "scripts" / "configure-git-hooks"
+    shutil.copy2(ROOT / "scripts" / "configure-git-hooks", hook_configurator)
+    hook_configurator.chmod(0o755)
     guard = repo / "devtools" / "bd_reimport_guard.py"
     guard.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(ROOT / "devtools" / "bd_reimport_guard.py", guard)
+
+
+def _execute_historical_envrc(lane: Path, env: dict[str, str], tmp_path: Path, installed_bd: str) -> None:
+    """Source the retained envrc and execute its branch-point use-flake hook."""
+    historical_use_flake = tmp_path / "historical-use-flake"
+    historical_flake = _historical_file("flake.nix")
+    start_marker = "          # Install repo git hooks"
+    end_marker = "          # Clean stale __pycache__"
+    start = historical_flake.index(start_marker)
+    end = historical_flake.index(end_marker, start)
+    historical_shell_hook = textwrap.dedent(historical_flake[start:end])
+    historical_use_flake.write_text(f"#!/usr/bin/env bash\nset -euo pipefail\n{historical_shell_hook}")
+    historical_use_flake.chmod(0o755)
+
+    marker = tmp_path / "historical-direct-bd-ran"
+    probe_bin = tmp_path / "historical-bin"
+    probe_bin.mkdir()
+    direct_bd = probe_bin / "bd"
+    direct_bd.write_text(f"#!/bin/sh\nprintf '%s\\n' ran > {marker!s}\n")
+    direct_bd.chmod(0o755)
+
+    historical_env = env.copy()
+    historical_env["HISTORICAL_USE_FLAKE"] = str(historical_use_flake)
+    # Keep the historical direct command-v bd route observable through the
+    # probe while the deployed wrapper follows the valid installed binary.
+    historical_env["POLYLOGUE_BD_REAL"] = installed_bd
+    historical_env["PATH"] = os.pathsep.join((str(probe_bin), historical_env["PATH"]))
+    _run(
+        [
+            "bash",
+            "-c",
+            'use() { "$HISTORICAL_USE_FLAKE" "$@"; }; source .envrc',
+        ],
+        lane,
+        historical_env,
+    )
+
+    # The old shell hook wrote a relative value through git config --local.
+    # The worktree-level common-dir pin must still select the deployed hook.
+    effective_hooks_path = _run(["git", "config", "--get", "core.hooksPath"], lane, historical_env).stdout.strip()
+    assert effective_hooks_path == str((lane.parent / "coordinator" / ".beads-hooks").resolve())
+    effective_hooks_origin = _run(
+        ["git", "config", "--show-origin", "--get", "core.hooksPath"], lane, historical_env
+    ).stdout.strip()
+    assert effective_hooks_origin.endswith("/config.worktree\t" + effective_hooks_path)
+
+    _run(["git", "switch", "--detach", "HEAD"], lane, historical_env)
+    assert not marker.exists(), "historical direct bd hook must not execute"
 
 
 def _setup_stale_worktree(
@@ -186,9 +240,23 @@ def _setup_stale_worktree(
     # Deployment happens only in the common coordinator checkout. The shared
     # absolute hook path is what protects the stale lane's historical files.
     _deploy_current_common_checkout(repo)
-    _run(["git", "add", ".beads-hooks", ".envrc", "scripts/bd", "devtools/bd_reimport_guard.py"], repo, env)
+    _run(
+        [
+            "git",
+            "add",
+            ".beads-hooks",
+            ".envrc",
+            "scripts/bd",
+            "scripts/configure-git-hooks",
+            "devtools/bd_reimport_guard.py",
+        ],
+        repo,
+        env,
+    )
     _run(["git", "commit", "-m", "deploy Beads guard"], repo, env)
-    _run(["git", "config", "core.hooksPath", str(repo / ".beads-hooks")], repo, env)
+
+    _run([str(repo / "scripts" / "configure-git-hooks")], repo, env)
+    _execute_historical_envrc(lane, env, tmp_path, bd)
 
     env["PATH"] = os.pathsep.join((str(repo / "scripts"), env["PATH"]))
     _run([bd, "close", issue_id, "--reason", "coordinator close"], repo, env)
@@ -246,7 +314,10 @@ def test_unsafe_import_auto_control_reverts_clock_skewed_stale_snapshot(tmp_path
     assert shown[0]["status"] == "open"
 
 
-@pytest.mark.parametrize("route", ["bare-wrapper", "symlink-wrapper", "script-recursion", "script-symlink-recursion"])
+@pytest.mark.parametrize(
+    "route",
+    ["bare-wrapper", "symlink-wrapper", "script-recursion", "script-symlink-recursion", "interpreter-recursion"],
+)
 def test_bd_wrapper_rejects_recursive_real_binary_routes(tmp_path: Path, route: str) -> None:
     """Wrapper aliases and script recursion fail before the guard lock."""
     deployed = tmp_path / "deployed"
@@ -284,11 +355,16 @@ def test_bd_wrapper_rejects_recursive_real_binary_routes(tmp_path: Path, route: 
         recursive.write_text(f'#!/bin/sh\nexec {wrapper!s} "$@"\n')
         recursive.chmod(0o755)
         env["POLYLOGUE_BD_REAL"] = str(recursive)
-    else:
+    elif route == "script-symlink-recursion":
         alias = tmp_path / "bd-alias"
         alias.symlink_to(wrapper)
         recursive = tmp_path / "recursive-bd"
         recursive.write_text(f'#!/bin/sh\nexec {alias!s} "$@"\n')
+        recursive.chmod(0o755)
+        env["POLYLOGUE_BD_REAL"] = str(recursive)
+    else:
+        recursive = tmp_path / "interpreter-recursive-bd"
+        recursive.write_text(f'#!/bin/sh\nexec /bin/sh -c \'exec {wrapper!s} "$@"\' sh "$@"\n')
         recursive.chmod(0o755)
         env["POLYLOGUE_BD_REAL"] = str(recursive)
 

--- a/tests/unit/devtools/test_bd_reimport_guard.py
+++ b/tests/unit/devtools/test_bd_reimport_guard.py
@@ -25,6 +25,42 @@ def test_main_rejects_unknown_command() -> None:
     assert guard.main(["frobnicate", "post-checkout"]) == 1
 
 
+def test_validated_real_bd_path_accepts_absolute_binary(tmp_path: Path) -> None:
+    binary = tmp_path / "bd"
+    binary.write_bytes(b"\x7fELF\x02\x01")
+    binary.chmod(0o755)
+
+    assert guard._validated_real_bd_path(str(binary)) == binary
+
+
+def test_validated_real_bd_path_rejects_wrapper_symlink() -> None:
+    wrapper = Path(__file__).resolve().parents[3] / "scripts" / "bd"
+
+    with pytest.raises(ValueError, match="recursive wrapper"):
+        guard._validated_real_bd_path(str(wrapper))
+
+
+def test_validated_real_bd_path_rejects_script_recursion(tmp_path: Path) -> None:
+    recursive = tmp_path / "bd-recursive"
+    wrapper = Path(__file__).resolve().parents[3] / "scripts" / "bd"
+    recursive.write_text(f'#!/bin/sh\nexec {wrapper!s} "$@"\n')
+    recursive.chmod(0o755)
+
+    with pytest.raises(ValueError, match="recursive wrapper"):
+        guard._validated_real_bd_path(str(recursive))
+
+
+def test_validated_real_bd_path_accepts_explicit_launcher_target(tmp_path: Path) -> None:
+    binary = tmp_path / "bd-bin"
+    binary.write_bytes(b"\x7fELF\x02\x01")
+    binary.chmod(0o755)
+    launcher = tmp_path / "bd-launcher"
+    launcher.write_text(f'#!/bin/sh\nexec {binary!s} "$@"\n')
+    launcher.chmod(0o755)
+
+    assert guard._validated_real_bd_path(str(launcher)) == launcher
+
+
 # --- merge_rows: the monotonic per-row merge engine --------------------------
 
 

--- a/tests/unit/devtools/test_bd_reimport_guard.py
+++ b/tests/unit/devtools/test_bd_reimport_guard.py
@@ -61,6 +61,15 @@ def test_validated_real_bd_path_accepts_explicit_launcher_target(tmp_path: Path)
     assert guard._validated_real_bd_path(str(launcher)) == launcher
 
 
+def test_validated_real_bd_path_rejects_interpreter_mediated_launcher(tmp_path: Path) -> None:
+    launcher = tmp_path / "bd-shell-launcher"
+    launcher.write_text('#!/bin/sh\nexec /bin/sh -c \'exec /tmp/hidden-bd "$@"\' sh "$@"\n')
+    launcher.chmod(0o755)
+
+    with pytest.raises(ValueError, match="interpreter launcher"):
+        guard._validated_real_bd_path(str(launcher))
+
+
 # --- merge_rows: the monotonic per-row merge engine --------------------------
 
 


### PR DESCRIPTION
## Summary

Harden the Beads boundary against both stale linked-worktree execution and interpreter-mediated recursive `POLYLOGUE_BD_REAL` routes.

## Problem

A linked worktree can retain an older relative `.envrc`, flake shell hook, and direct `.beads-hooks` files. If that historical environment writes `core.hooksPath` through `git config --local`, the effective hook route can fall back to stale code. The launcher guard also accepted a script that delegated through an interpreter such as `/bin/sh -c exec-wrapper`, allowing recursion to reach the shared lock before failing.

## Solution

- Add `scripts/configure-git-hooks`, which enables Git worktree config, anchors the shared config at the absolute common-directory hook path, and pins that path in every existing worktree's `config.worktree`.
- Run the configurator from the devshell deployment and the current common `post-checkout` hook, covering existing and newly-created linked worktrees.
- Extend launcher validation to reject known interpreter entry points as recursive targets. The guard performs this validation before `_acquire_invocation_lock`.
- Keep the direct alias, symlink, script recursion, valid explicit launcher, installed-Beads, newer-snapshot, and no-lock protections.

## Acceptance criteria

| Criterion | Result |
| --- | --- |
| Historical linked worktrees cannot restore a stale effective hook route | Satisfied. The integration fixture creates the lane before deployment, retains the historical `.envrc` and `.beads-hooks/post-checkout`, sources the retained `.envrc`, executes the exact historical shell-hook fragment extracted from the branch-point flake, and verifies that Git resolves the absolute common hook from the lane's `config.worktree`. A real `git switch` confirms the historical direct `bd` probe is not executed. |
| No current hook path is manually injected into that regression | Satisfied. Deployment copies the common-directory files and invokes the production configurator. The test does not set `core.hooksPath` to the current checkout after deployment. The installed Beads path is supplied only as a valid delegated binary so the historical direct-hook probe remains distinguishable from the deployed wrapper. |
| Interpreter-mediated recursive routes fail before lock acquisition | Satisfied. Unit and integration coverage reject `/bin/sh -c exec-wrapper`; the integration assertion finds no file in the isolated runtime lock directory. Direct wrapper aliases, symlinks, and script recursion remain covered. |
| Valid installed-Beads behavior remains supported | Satisfied. The real installed binary imports a newer snapshot row in the disposable Git and Dolt fixture and preserves the expected status and title. |

## Verification

- `direnv exec . devtools test tests/unit/devtools/test_bd_reimport_guard.py tests/integration/test_beads_stale_worktree_guard.py`: 32 passed in 11.17s.
- `direnv exec . devtools verify --quick`: 24 steps passed, run `20260805T143014Z-quick-2041776-81d9ba70`, head `5ad41b2f5`.
- `bash -n scripts/configure-git-hooks scripts/bd .beads-hooks/post-checkout .beads-hooks/post-merge .beads-hooks/pre-commit .beads-hooks/pre-push .beads-hooks/prepare-commit-msg`: passed.
- `direnv exec . ruff check devtools/bd_reimport_guard.py tests/unit/devtools/test_bd_reimport_guard.py tests/integration/test_beads_stale_worktree_guard.py`: all checks passed.
- `git diff --check`: passed.

No live repository Beads command, production archive, or production database was used. The integration Beads operations ran only inside disposable temporary Git, Dolt, and runtime-lock state. The full test suite was not run.

## Review closure

The final independent review findings are addressed by the common-directory worktree-config pin and by fail-closed interpreter target validation. The branch is pushed at `5ad41b2f5`.

Ref polylogue-2ara