### PR TITLE
fix(rebuild): guard provenance across sharded resumability

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -492,6 +492,29 @@ operation that already advanced past target *N* will not redo target
 
 ---
 
+### Rebuilding the derived index from source
+
+`polylogue ops maintenance rebuild-index` and the daemon bulk-rebuild route
+require a fresh schema-inference PASS receipt before they acquire the rebuild
+lease or create an inactive candidate. Pass `--schema-inference-receipt PATH`
+or set `POLYLOGUE_SCHEMA_INFERENCE_RECEIPT` in the policy environment. The
+same reference must be supplied when resuming an operation.
+
+Receipts are valid for 24 hours after `generated_at`. The validator allows a
+fixed five-minute clock-skew window for both future timestamps and expiry.
+It binds the receipt to the requested archive root, durable source and user
+tier identities, the current source revision snapshot, and a canonical
+external-ground-truth digest. That digest includes the complete external file
+inventory and a deterministic mapping for every raw row: raw ID, recorded
+`source_path`, selected external relative path, content hash, size, and
+disposition. A stale source path or changed mapping invalidates reuse even when
+aggregate counts and hashes remain unchanged.
+
+The rebuild result includes the receipt path, validation time, source snapshot,
+durable identity, and consumed external-ground-truth digest. A missing,
+malformed, stale, future, wrong-archive, wrong-source, changed-snapshot, or
+changed-corpus receipt fails before any candidate or active-index mutation.
+
 ## Runbooks
 
 The runbooks below assume:

--- a/polylogue/cli/commands/maintenance/_rebuild_index.py
+++ b/polylogue/cli/commands/maintenance/_rebuild_index.py
@@ -43,6 +43,7 @@ def _run_daemon_rebuild(
     max_blob_mb: float | None,
     no_promote: bool,
     operation_id: str | None,
+    schema_inference_receipt_path: Path | None,
     raw_batch_size: int,
     pass_byte_budget_mb: float | None,
     pass_deadline_seconds: float | None,
@@ -58,6 +59,9 @@ def _run_daemon_rebuild(
             "max_blob_mb": max_blob_mb,
             "promote": not no_promote,
             "operation_id": operation_id,
+            "schema_inference_receipt_path": (
+                str(schema_inference_receipt_path) if schema_inference_receipt_path is not None else None
+            ),
             "raw_batch_size": raw_batch_size,
             "pass_byte_budget_mb": pass_byte_budget_mb,
             "pass_deadline_seconds": pass_deadline_seconds,
@@ -330,6 +334,13 @@ def _rebuild_index_selection_plan(
     help="Resume the retained candidate generation for this rebuild operation.",
 )
 @click.option(
+    "--schema-inference-receipt",
+    "schema_inference_receipt_path",
+    type=click.Path(path_type=Path, dir_okay=False),
+    default=None,
+    help="Fresh schema-inference PASS receipt; policy fallback is POLYLOGUE_SCHEMA_INFERENCE_RECEIPT.",
+)
+@click.option(
     "--raw-batch-size",
     type=int,
     default=500,
@@ -384,6 +395,7 @@ def rebuild_index_command(
     plan_only: bool,
     plan_limit: int,
     operation_id: str | None,
+    schema_inference_receipt_path: Path | None,
     raw_batch_size: int,
     pass_byte_budget_mb: float | None,
     pass_deadline_seconds: float | None,
@@ -437,6 +449,7 @@ def rebuild_index_command(
             max_blob_mb=max_blob_mb,
             no_promote=no_promote,
             operation_id=operation_id,
+            schema_inference_receipt_path=schema_inference_receipt_path,
             raw_batch_size=raw_batch_size,
             pass_byte_budget_mb=pass_byte_budget_mb,
             pass_deadline_seconds=pass_deadline_seconds,
@@ -531,6 +544,7 @@ def rebuild_index_command(
                 max_blob_mb=max_blob_mb,
                 promote=not no_promote,
                 operation_id=operation_id,
+                schema_inference_receipt_path=schema_inference_receipt_path,
                 raw_batch_size=raw_batch_size,
                 pass_byte_budget_mb=pass_byte_budget_mb,
                 pass_deadline_seconds=pass_deadline_seconds,

--- a/polylogue/daemon/bulk_rebuild.py
+++ b/polylogue/daemon/bulk_rebuild.py
@@ -176,14 +176,23 @@ def has_resumable_daemon_bulk_rebuild_transaction(root: Path) -> bool:
     threshold -- abandoning a partially-built generation mid-flight would
     waste every page already replayed into it.
     """
-    store = IndexGenerationStore.for_archive_root(root)
+    anchor = root / ".index-active-pointer"
+    if not anchor.exists() and not anchor.is_symlink():
+        return False
+    location = ArchiveLocation.resolve(root)
+    owned = OwnedArchiveLocation.acquire(location)
     try:
-        transaction = store.load_transaction(DAEMON_BULK_REBUILD_OPERATION_ID)
-    except FileNotFoundError:
-        return False
-    except (OSError, ValueError, TypeError, KeyError):
-        return False
-    return transaction.status not in _TERMINAL_NOT_RESUMABLE
+        assert_owns_archive_location(owned, location)
+        store = IndexGenerationStore(location)
+        try:
+            transaction = store.load_transaction(DAEMON_BULK_REBUILD_OPERATION_ID)
+        except FileNotFoundError:
+            return False
+        except (OSError, ValueError, TypeError, KeyError):
+            return False
+        return transaction.status not in _TERMINAL_NOT_RESUMABLE
+    finally:
+        owned.release()
 
 
 async def run_daemon_bulk_rebuild_pass(
@@ -223,8 +232,16 @@ async def run_daemon_bulk_rebuild_pass(
     if transaction.status == "promoted":
         return None
 
-    store = IndexGenerationStore.for_archive_root(root)
-    page = await asyncio.to_thread(store.next_raw_page, transaction, limit=batch_size)
+    location = ArchiveLocation.resolve(root)
+    owned = await asyncio.to_thread(OwnedArchiveLocation.acquire, location)
+    try:
+        await asyncio.to_thread(assert_owns_archive_location, owned, location)
+        await asyncio.to_thread(_validate_rebuild_provenance_receipt, root, receipt_path)
+        store = IndexGenerationStore(location)
+        await asyncio.to_thread(_validate_rebuild_provenance_receipt, root, receipt_path)
+        page = await asyncio.to_thread(store.next_raw_page, transaction, limit=batch_size)
+    finally:
+        owned.release()
     raw_ids = [raw_id for raw_id, _blob_hash_hex, _blob_size in page.rows]
     if raw_ids:
         warmed = await asyncio.to_thread(

--- a/polylogue/daemon/bulk_rebuild.py
+++ b/polylogue/daemon/bulk_rebuild.py
@@ -82,7 +82,9 @@ DAEMON_BULK_REBUILD_BATCH_SIZE = 500
 _TERMINAL_NOT_RESUMABLE = frozenset({"promoted", "stale", "failed"})
 
 
-def resolve_or_start_daemon_bulk_rebuild_transaction(root: Path) -> IndexRebuildTransaction:
+def resolve_or_start_daemon_bulk_rebuild_transaction(
+    root: Path, *, schema_inference_receipt_path: Path | None = None
+) -> IndexRebuildTransaction:
     """Load the daemon's resumable bulk-rebuild transaction, starting one if needed.
 
     Read-only fast path when a resumable transaction already exists (a
@@ -100,6 +102,15 @@ def resolve_or_start_daemon_bulk_rebuild_transaction(root: Path) -> IndexRebuild
     generation directory, so both must fail closed against a foreign/rotated
     archive location before touching disk, not just the eventual write pass.
     """
+    from polylogue.maintenance.schema_inference_gate import (
+        SchemaInferenceGateError,
+        validate_schema_inference_receipt,
+    )
+
+    try:
+        validate_schema_inference_receipt(root, schema_inference_receipt_path)
+    except SchemaInferenceGateError as exc:
+        raise RuntimeError(f"daemon bulk rebuild schema-inference preflight gate failed: {exc}") from exc
     location = ArchiveLocation.resolve(root)
     store = IndexGenerationStore(location)
     transaction: IndexRebuildTransaction | None
@@ -186,9 +197,15 @@ async def run_daemon_bulk_rebuild_pass(
     """
     from polylogue.daemon.write_coordinator import daemon_write_coordinator
     from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
+    from polylogue.maintenance.schema_inference_gate import resolve_schema_inference_receipt_reference
 
     root = Path(config.archive_root)
-    transaction = await asyncio.to_thread(resolve_or_start_daemon_bulk_rebuild_transaction, root)
+    receipt_path = resolve_schema_inference_receipt_reference(root)
+    transaction = await asyncio.to_thread(
+        resolve_or_start_daemon_bulk_rebuild_transaction,
+        root,
+        schema_inference_receipt_path=receipt_path,
+    )
     if transaction.status == "promoted":
         return None
 
@@ -213,6 +230,7 @@ async def run_daemon_bulk_rebuild_pass(
         archive_root=root,
         promote=True,
         operation_id=transaction.operation_id,
+        schema_inference_receipt_path=receipt_path,
         raw_batch_size=batch_size,
         prefetch_cache=parse_stage.cache,
     )

--- a/polylogue/daemon/bulk_rebuild.py
+++ b/polylogue/daemon/bulk_rebuild.py
@@ -39,6 +39,7 @@ Two properties this module adds on top of the existing rebuild engine:
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -69,6 +70,29 @@ def _validate_rebuild_provenance_receipt(root: Path, receipt_path: Path | None) 
         validate_schema_inference_receipt(root, receipt_path)
     except SchemaInferenceGateError as exc:
         raise RuntimeError(f"daemon bulk rebuild schema-inference preflight gate failed: {exc}") from exc
+
+
+def _discard_daemon_transaction_after_provenance_failure(
+    store: IndexGenerationStore, transaction: IndexRebuildTransaction
+) -> None:
+    """Best-effort cleanup after a post-create provenance failure.
+
+    The caller still owns the archive location. Cleanup does not consume source
+    evidence, so it must remain available even when the receipt that authorized
+    candidate creation has just expired or the source snapshot has drifted.
+    Each record is retired independently so one failed cleanup step cannot
+    strand the other record.
+    """
+    try:
+        generation = store.load(transaction.generation_id)
+        if generation.state == "inactive":
+            store.discard_if_inactive(generation)
+    except Exception:
+        logger.warning("bulk-rebuild: failed to discard post-validation candidate", exc_info=True)
+    try:
+        store.discard_transaction(transaction.operation_id)
+    except Exception:
+        logger.warning("bulk-rebuild: failed to discard post-validation transaction", exc_info=True)
 
 
 #: Fixed operation id for the daemon's own bulk-rebuild transaction. Exactly
@@ -159,10 +183,19 @@ def resolve_or_start_daemon_bulk_rebuild_transaction(
             store.discard_transaction(DAEMON_BULK_REBUILD_OPERATION_ID)
 
         _validate_rebuild_provenance_receipt(root, schema_inference_receipt_path)
-        return store.create_transaction(
-            source_snapshot=rebuild_source_revision_snapshot(root),
+        source_snapshot = rebuild_source_revision_snapshot(root)
+        transaction = store.create_transaction(
+            source_snapshot=source_snapshot,
             operation_id=DAEMON_BULK_REBUILD_OPERATION_ID,
         )
+        try:
+            _validate_rebuild_provenance_receipt(root, schema_inference_receipt_path)
+            if rebuild_source_revision_snapshot(root) != source_snapshot:
+                raise RuntimeError("daemon bulk rebuild source evidence changed during transaction creation")
+        except Exception:
+            _discard_daemon_transaction_after_provenance_failure(store, transaction)
+            raise
+        return transaction
     finally:
         owned.release()
 
@@ -179,20 +212,17 @@ def has_resumable_daemon_bulk_rebuild_transaction(root: Path) -> bool:
     anchor = root / ".index-active-pointer"
     if not anchor.exists() and not anchor.is_symlink():
         return False
-    location = ArchiveLocation.resolve(root)
-    owned = OwnedArchiveLocation.acquire(location)
     try:
-        assert_owns_archive_location(owned, location)
-        store = IndexGenerationStore(location)
-        try:
-            transaction = store.load_transaction(DAEMON_BULK_REBUILD_OPERATION_ID)
-        except FileNotFoundError:
+        pointer_target = Path(anchor.read_text(encoding="utf-8").strip())
+        if not pointer_target.is_absolute() or pointer_target.name != "index.db":
             return False
-        except (OSError, ValueError, TypeError, KeyError):
-            return False
-        return transaction.status not in _TERMINAL_NOT_RESUMABLE
-    finally:
-        owned.release()
+        transaction_path = (
+            pointer_target.parent / ".index-rebuild-transactions" / f"{DAEMON_BULK_REBUILD_OPERATION_ID}.json"
+        )
+        transaction = IndexRebuildTransaction(**json.loads(transaction_path.read_text(encoding="utf-8")))
+    except (FileNotFoundError, OSError, ValueError, TypeError, KeyError):
+        return False
+    return transaction.status not in _TERMINAL_NOT_RESUMABLE
 
 
 async def run_daemon_bulk_rebuild_pass(

--- a/polylogue/daemon/bulk_rebuild.py
+++ b/polylogue/daemon/bulk_rebuild.py
@@ -44,11 +44,11 @@ from typing import TYPE_CHECKING
 
 from polylogue.config import Config
 from polylogue.logging import get_logger
+from polylogue.maintenance.schema_inference_gate import rebuild_source_revision_snapshot
 from polylogue.storage.archive_identity import ArchiveLocation, OwnedArchiveLocation, assert_owns_archive_location
 from polylogue.storage.index_generation import (
     IndexGenerationStore,
     IndexRebuildTransaction,
-    source_revision_snapshot,
 )
 
 if TYPE_CHECKING:
@@ -146,7 +146,7 @@ def resolve_or_start_daemon_bulk_rebuild_transaction(
             store.discard_transaction(DAEMON_BULK_REBUILD_OPERATION_ID)
 
         return store.create_transaction(
-            source_snapshot=source_revision_snapshot(root),
+            source_snapshot=rebuild_source_revision_snapshot(root),
             operation_id=DAEMON_BULK_REBUILD_OPERATION_ID,
         )
     finally:

--- a/polylogue/daemon/bulk_rebuild.py
+++ b/polylogue/daemon/bulk_rebuild.py
@@ -57,6 +57,20 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+
+def _validate_rebuild_provenance_receipt(root: Path, receipt_path: Path | None) -> None:
+    """Validate daemon rebuild provenance at the current ownership boundary."""
+    from polylogue.maintenance.schema_inference_gate import (
+        SchemaInferenceGateError,
+        validate_schema_inference_receipt,
+    )
+
+    try:
+        validate_schema_inference_receipt(root, receipt_path)
+    except SchemaInferenceGateError as exc:
+        raise RuntimeError(f"daemon bulk rebuild schema-inference preflight gate failed: {exc}") from exc
+
+
 #: Fixed operation id for the daemon's own bulk-rebuild transaction. Exactly
 #: one such operation is ever in flight per archive -- this module's only
 #: caller is a single daemon asyncio loop -- so a well-known id lets every
@@ -102,36 +116,33 @@ def resolve_or_start_daemon_bulk_rebuild_transaction(
     generation directory, so both must fail closed against a foreign/rotated
     archive location before touching disk, not just the eventual write pass.
     """
-    from polylogue.maintenance.schema_inference_gate import (
-        SchemaInferenceGateError,
-        validate_schema_inference_receipt,
-    )
-
-    try:
-        validate_schema_inference_receipt(root, schema_inference_receipt_path)
-    except SchemaInferenceGateError as exc:
-        raise RuntimeError(f"daemon bulk rebuild schema-inference preflight gate failed: {exc}") from exc
+    _validate_rebuild_provenance_receipt(root, schema_inference_receipt_path)
     location = ArchiveLocation.resolve(root)
-    store = IndexGenerationStore(location)
-    transaction: IndexRebuildTransaction | None
-    try:
-        transaction = store.load_transaction(DAEMON_BULK_REBUILD_OPERATION_ID)
-    except FileNotFoundError:
-        transaction = None
-    except (OSError, ValueError, TypeError, KeyError) as exc:
-        logger.warning(
-            "bulk-rebuild: could not load persisted transaction %s; starting a fresh one: %s",
-            DAEMON_BULK_REBUILD_OPERATION_ID,
-            exc,
-        )
-        transaction = None
-
-    if transaction is not None and transaction.status not in _TERMINAL_NOT_RESUMABLE:
-        return transaction
-
     owned = OwnedArchiveLocation.acquire(location)
     try:
         assert_owns_archive_location(owned, location)
+        # The first validation is only a cheap early rejection. Revalidate
+        # after ownership acquisition so receipt expiry, source revision, or
+        # external-corpus drift cannot reach generation bookkeeping.
+        _validate_rebuild_provenance_receipt(root, schema_inference_receipt_path)
+        store = IndexGenerationStore(location)
+        transaction: IndexRebuildTransaction | None
+        try:
+            transaction = store.load_transaction(DAEMON_BULK_REBUILD_OPERATION_ID)
+        except FileNotFoundError:
+            transaction = None
+        except (OSError, ValueError, TypeError, KeyError) as exc:
+            logger.warning(
+                "bulk-rebuild: could not load persisted transaction %s; starting a fresh one: %s",
+                DAEMON_BULK_REBUILD_OPERATION_ID,
+                exc,
+            )
+            transaction = None
+
+        if transaction is not None and transaction.status not in _TERMINAL_NOT_RESUMABLE:
+            _validate_rebuild_provenance_receipt(root, schema_inference_receipt_path)
+            return transaction
+
         if transaction is not None:
             # Terminal: retire the old candidate/transaction record before
             # reusing the well-known operation id. A "promoted" generation is
@@ -142,9 +153,12 @@ def resolve_or_start_daemon_bulk_rebuild_transaction(
             except (FileNotFoundError, OSError, ValueError):
                 generation = None
             if generation is not None and generation.state == "inactive":
+                _validate_rebuild_provenance_receipt(root, schema_inference_receipt_path)
                 store.discard_if_inactive(generation)
+            _validate_rebuild_provenance_receipt(root, schema_inference_receipt_path)
             store.discard_transaction(DAEMON_BULK_REBUILD_OPERATION_ID)
 
+        _validate_rebuild_provenance_receipt(root, schema_inference_receipt_path)
         return store.create_transaction(
             source_snapshot=rebuild_source_revision_snapshot(root),
             operation_id=DAEMON_BULK_REBUILD_OPERATION_ID,

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -933,9 +933,20 @@ async def _daemon_bulk_rebuild_transaction_in_flight() -> bool:
     Checking survives a daemon restart via a durable transaction record.
     """
     from polylogue.daemon.bulk_rebuild import has_resumable_daemon_bulk_rebuild_transaction
+    from polylogue.maintenance.schema_inference_gate import (
+        SchemaInferenceGateError,
+        resolve_schema_inference_receipt_reference,
+        validate_schema_inference_receipt,
+    )
     from polylogue.paths import archive_root
 
-    return await asyncio.to_thread(has_resumable_daemon_bulk_rebuild_transaction, archive_root())
+    root = archive_root()
+    try:
+        receipt_path = resolve_schema_inference_receipt_reference(root)
+        await asyncio.to_thread(validate_schema_inference_receipt, root, receipt_path)
+    except (SchemaInferenceGateError, RuntimeError, OSError, ValueError):
+        return False
+    return await asyncio.to_thread(has_resumable_daemon_bulk_rebuild_transaction, root)
 
 
 async def _maybe_route_daemon_bulk_rebuild(counts: RawMaterializationCounts) -> bool:
@@ -971,15 +982,12 @@ async def _maybe_route_daemon_bulk_rebuild(counts: RawMaterializationCounts) -> 
     from polylogue.config import Config
     from polylogue.daemon.bulk_rebuild import (
         DAEMON_BULK_REBUILD_OPERATION_ID,
-        has_resumable_daemon_bulk_rebuild_transaction,
         run_daemon_bulk_rebuild_pass,
     )
     from polylogue.paths import archive_root, render_root
 
     root = archive_root()
-    if not _bulk_scale_raw_materialization_backlog(counts) and not await asyncio.to_thread(
-        has_resumable_daemon_bulk_rebuild_transaction, root
-    ):
+    if not _bulk_scale_raw_materialization_backlog(counts) and not await _daemon_bulk_rebuild_transaction_in_flight():
         return False
     config = Config(archive_root=root, render_root=render_root(), sources=[])
     try:

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -5292,6 +5292,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         promote = body.get("promote", True)
         max_blob_mb = body.get("max_blob_mb")
         operation_id = body.get("operation_id")
+        schema_inference_receipt_path = body.get("schema_inference_receipt_path")
         raw_batch_size = body.get("raw_batch_size", 500)
         pass_byte_budget_mb = body.get("pass_byte_budget_mb")
         pass_deadline_seconds = body.get("pass_deadline_seconds")
@@ -5304,6 +5305,11 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             self._send_error(HTTPStatus.BAD_REQUEST, "invalid_request")
             return
         if operation_id is not None and (not isinstance(operation_id, str) or not operation_id):
+            self._send_error(HTTPStatus.BAD_REQUEST, "invalid_request")
+            return
+        if schema_inference_receipt_path is not None and (
+            not isinstance(schema_inference_receipt_path, str) or not schema_inference_receipt_path
+        ):
             self._send_error(HTTPStatus.BAD_REQUEST, "invalid_request")
             return
         if isinstance(raw_batch_size, bool) or not isinstance(raw_batch_size, int):
@@ -5334,6 +5340,9 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             max_blob_mb=float(max_blob_mb) if max_blob_mb is not None else None,
             promote=promote,
             operation_id=operation_id,
+            schema_inference_receipt_path=(
+                Path(schema_inference_receipt_path) if schema_inference_receipt_path is not None else None
+            ),
             raw_batch_size=raw_batch_size,
             pass_byte_budget_mb=float(pass_byte_budget_mb) if pass_byte_budget_mb is not None else None,
             pass_deadline_seconds=(float(pass_deadline_seconds) if pass_deadline_seconds is not None else None),

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -55,6 +55,14 @@ _PLANNER_STATS_ANALYZE_STATEMENTS = (
 logger = get_logger(__name__)
 
 
+class RebuildProvenanceError(RuntimeError):
+    """Raised when rebuild evidence is no longer valid for a mutation."""
+
+
+class RebuildDerivedStateProvenanceError(RebuildProvenanceError):
+    """A derived-state stage was blocked by a failed provenance recheck."""
+
+
 @dataclass(frozen=True, slots=True)
 class RebuildProvenanceContext:
     """Validated evidence shared by every mutation in one rebuild pass.
@@ -77,7 +85,9 @@ class RebuildProvenanceContext:
         from polylogue.maintenance.schema_inference_gate import rebuild_source_revision_snapshot
 
         if rebuild_source_revision_snapshot(self.root) != self.source_snapshot:
-            raise RuntimeError("rebuild schema-inference preflight gate failed: source evidence changed during replay")
+            raise RebuildProvenanceError(
+                "rebuild schema-inference preflight gate failed: source evidence changed during replay"
+            )
 
     def validate_cleanup(self) -> None:
         """Authorize failure cleanup from the immutable pre-mutation proof."""
@@ -95,7 +105,80 @@ def _validate_rebuild_provenance_receipt(root: Path, receipt_path: Path | None) 
     try:
         return validate_schema_inference_receipt(root, receipt_path)
     except SchemaInferenceGateError as exc:
-        raise RuntimeError(f"rebuild schema-inference preflight gate failed: {exc}") from exc
+        raise RebuildProvenanceError(f"rebuild schema-inference preflight gate failed: {exc}") from exc
+
+
+def _validate_before_derived_state(provenance: RebuildProvenanceContext) -> None:
+    """Validate immediately before a derived-state mutation begins."""
+    try:
+        provenance.validate()
+    except Exception as exc:
+        raise RebuildDerivedStateProvenanceError(str(exc)) from exc
+
+
+def _discard_generation_after_provenance_failure(
+    generation_store: IndexGenerationStore, generation: IndexGeneration, provenance: RebuildProvenanceContext
+) -> list[BaseException]:
+    """Discard a fresh candidate without rereading mutable source evidence."""
+    errors: list[BaseException] = []
+    try:
+        provenance.validate_cleanup()
+        generation_store.discard_if_inactive(generation)
+    except BaseException as exc:
+        errors.append(exc)
+    return errors
+
+
+def _discard_transaction_after_provenance_failure(
+    generation_store: IndexGenerationStore,
+    transaction: IndexRebuildTransaction,
+    provenance: RebuildProvenanceContext,
+) -> list[BaseException]:
+    """Discard a fresh candidate and transaction, attempting both independently."""
+    errors: list[BaseException] = []
+    try:
+        generation = generation_store.load(transaction.generation_id)
+    except FileNotFoundError:
+        generation = None
+    except BaseException as exc:
+        errors.append(exc)
+        generation = None
+    if generation is not None:
+        errors.extend(_discard_generation_after_provenance_failure(generation_store, generation, provenance))
+    try:
+        generation_store.discard_transaction(transaction.operation_id)
+    except BaseException as exc:
+        errors.append(exc)
+    return errors
+
+
+def _cleanup_transaction_after_provenance_failure(
+    generation_store: IndexGenerationStore,
+    transaction: IndexRebuildTransaction,
+    root: Path,
+    receipt_path: Path | None,
+    consumed_evidence: dict[str, object],
+    primary: BaseException,
+) -> None:
+    """Clean a fresh transaction and candidate while preserving its failure."""
+    cleanup_context = RebuildProvenanceContext(
+        root=root,
+        receipt_path=receipt_path,
+        source_snapshot=transaction.source_snapshot,
+        consumed_evidence=consumed_evidence,
+    )
+    try:
+        cleanup_errors = _discard_transaction_after_provenance_failure(generation_store, transaction, cleanup_context)
+    except BaseException as cleanup_error:
+        cleanup_errors = [cleanup_error]
+    _add_cleanup_failure_notes(primary, cleanup_errors, label="rebuild transaction")
+
+
+def _add_cleanup_failure_notes(primary: BaseException, errors: list[BaseException], *, label: str) -> None:
+    """Keep the primary exception while making cleanup failures visible."""
+    if errors:
+        detail = "; ".join(f"{type(error).__name__}: {error}" for error in errors)
+        primary.add_note(f"{label} cleanup also failed: {detail}")
 
 
 def _create_rebuild_transaction_after_receipt_validation(
@@ -107,8 +190,9 @@ def _create_rebuild_transaction_after_receipt_validation(
     from polylogue.maintenance.schema_inference_gate import rebuild_source_revision_snapshot
 
     _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
-    return generation_store.create_transaction(
-        source_snapshot=rebuild_source_revision_snapshot(root),
+    source_snapshot = rebuild_source_revision_snapshot(root)
+    transaction = generation_store.create_transaction(
+        source_snapshot=source_snapshot,
         pass_byte_budget=(
             int(request.pass_byte_budget_mb * 1024 * 1024) if request.pass_byte_budget_mb is not None else None
         ),
@@ -116,6 +200,23 @@ def _create_rebuild_transaction_after_receipt_validation(
             int(request.pass_deadline_seconds * 1000) if request.pass_deadline_seconds is not None else None
         ),
     )
+    try:
+        _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
+        if rebuild_source_revision_snapshot(root) != source_snapshot:
+            raise RebuildProvenanceError(
+                "rebuild schema-inference preflight gate failed: source evidence changed during transaction creation"
+            )
+    except BaseException as exc:
+        _cleanup_transaction_after_provenance_failure(
+            generation_store,
+            transaction,
+            root,
+            request.schema_inference_receipt_path,
+            {"source_snapshot": source_snapshot},
+            exc,
+        )
+        raise
+    return transaction
 
 
 def _checkpoint_rebuild_transaction_after_receipt_validation(
@@ -808,31 +909,44 @@ async def _rebuild_index_from_source_owned(
             )
         resumable_full_source = not request.raw_ids and not request.only_missing and request.max_blob_mb is None
         transaction = None
+        transaction_created_here = False
         page = None
         pass_started_at_ms = int(time.time() * 1000)
         if resumable_full_source:
-            transaction = (
-                generation_store.load_transaction(request.operation_id)
-                if request.operation_id is not None
-                else _create_rebuild_transaction_after_receipt_validation(
+            if request.operation_id is not None:
+                transaction = generation_store.load_transaction(request.operation_id)
+            else:
+                transaction = _create_rebuild_transaction_after_receipt_validation(
                     generation_store,
                     request,
                     root,
                 )
-            )
+                transaction_created_here = True
             if transaction.status in {"promoted", "stale"}:
                 raise RuntimeError(
                     f"rebuild operation {transaction.operation_id} is {transaction.status}; start a new operation"
                 )
             if rebuild_source_revision_snapshot(root) != transaction.source_snapshot:
-                _checkpoint_rebuild_transaction_after_receipt_validation(
-                    generation_store,
-                    transaction,
-                    root,
-                    request.schema_inference_receipt_path,
-                    status="stale",
-                    error="source evidence changed since this rebuild was planned",
-                )
+                try:
+                    _checkpoint_rebuild_transaction_after_receipt_validation(
+                        generation_store,
+                        transaction,
+                        root,
+                        request.schema_inference_receipt_path,
+                        status="stale",
+                        error="source evidence changed since this rebuild was planned",
+                    )
+                except RebuildProvenanceError as exc:
+                    if transaction_created_here:
+                        _cleanup_transaction_after_provenance_failure(
+                            generation_store,
+                            transaction,
+                            root,
+                            request.schema_inference_receipt_path,
+                            consumed_evidence,
+                            exc,
+                        )
+                    raise
                 raise RuntimeError(
                     f"rebuild operation {transaction.operation_id} is stale because source evidence changed"
                 )
@@ -840,16 +954,28 @@ async def _rebuild_index_from_source_owned(
             if generation.owner_id != transaction.generation_owner_id or generation.state != "inactive":
                 raise RuntimeError(f"rebuild operation {transaction.operation_id} lost its inactive candidate")
             if not transaction.derived_stores_cleared:
-                _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
-                _clear_bulk_build_derived_stores(Path(generation.index_path))
-                transaction = _checkpoint_rebuild_transaction_after_receipt_validation(
-                    generation_store,
-                    transaction,
-                    root,
-                    request.schema_inference_receipt_path,
-                    status=transaction.status,
-                    derived_stores_cleared=True,
-                )
+                try:
+                    _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
+                    _clear_bulk_build_derived_stores(Path(generation.index_path))
+                    transaction = _checkpoint_rebuild_transaction_after_receipt_validation(
+                        generation_store,
+                        transaction,
+                        root,
+                        request.schema_inference_receipt_path,
+                        status=transaction.status,
+                        derived_stores_cleared=True,
+                    )
+                except RebuildProvenanceError as exc:
+                    if transaction_created_here:
+                        _cleanup_transaction_after_provenance_failure(
+                            generation_store,
+                            transaction,
+                            root,
+                            request.schema_inference_receipt_path,
+                            consumed_evidence,
+                            exc,
+                        )
+                    raise
             # polylogue-6mvg: the pass's SELECTION phase -- which raws
             # replay THIS pass -- previously had no durable timing at all. A
             # live full rebuild spent ~86s of one CPU core on selection
@@ -882,6 +1008,7 @@ async def _rebuild_index_from_source_owned(
             source_snapshot=generation.source_snapshot,
             consumed_evidence=consumed_evidence,
         )
+        sharded_replay = request.shard_count > 1 and len(selected_raw_ids) >= request.shard_count
         source_drifted = False
         try:
             provenance.validate()
@@ -911,7 +1038,7 @@ async def _rebuild_index_from_source_owned(
                     _warm_offline_prefetch_cache, warm_config, selected_raw_ids
                 )
             pass_started_at_s = time.perf_counter()
-            if request.shard_count > 1 and len(selected_raw_ids) >= request.shard_count:
+            if sharded_replay:
                 # polylogue-pzxm: build request.shard_count owned-inactive
                 # generations in parallel and merge them into `generation`
                 # instead of replaying `selected_raw_ids` through the single
@@ -1100,6 +1227,7 @@ async def _rebuild_index_from_source_owned(
                     return pass_receipt
             pass_elapsed_s = time.perf_counter() - pass_started_at_s
             processed_before = transaction.processed_raw_count if transaction is not None else None
+            _validate_before_derived_state(provenance)
             if selected_raw_ids and _should_refresh_generation_planner_statistics(
                 processed_before=processed_before,
                 processed_after=(processed_before or 0) + len(selected_raw_ids),
@@ -1220,6 +1348,7 @@ async def _rebuild_index_from_source_owned(
             # empty or stale for every session -- repopulate all four
             # archive-wide exactly once here, then prove exact parity before
             # readiness can observe (and silently accept) a mismatch.
+            _validate_before_derived_state(provenance)
             bulk_timings_s = _repopulate_bulk_build_derived_state(Path(generation.index_path))
             for stage, elapsed_s in bulk_timings_s.items():
                 terminal_timings_s[f"terminal.bulk_build.{stage}"] = elapsed_s
@@ -1274,6 +1403,7 @@ async def _rebuild_index_from_source_owned(
             # it, so the acceptance receipt names the actual bad invariant
             # instead of reporting an incidental derived-model failure.
             terminal_started_at = time.perf_counter()
+            _validate_before_derived_state(provenance)
             insight_result = repair_session_insights(
                 config,
                 dry_run=False,
@@ -1343,8 +1473,21 @@ async def _rebuild_index_from_source_owned(
                         request.schema_inference_receipt_path,
                         status="promoted",
                     )
-        except Exception:
-            if transaction is not None and not source_drifted:
+        except Exception as exc:
+            fresh_provenance_failure = isinstance(exc, RebuildProvenanceError) and (
+                transaction_created_here or sharded_replay
+            )
+            if fresh_provenance_failure:
+                if transaction is not None:
+                    cleanup_errors = _discard_transaction_after_provenance_failure(
+                        generation_store, transaction, provenance
+                    )
+                else:
+                    cleanup_errors = _discard_generation_after_provenance_failure(
+                        generation_store, generation, provenance
+                    )
+                _add_cleanup_failure_notes(exc, cleanup_errors, label="rebuild provenance")
+            elif transaction is not None and not source_drifted:
                 with contextlib.suppress(Exception):
                     # A process can fail after ``checkpoint_transaction`` has
                     # atomically published the output batch but before this

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -245,6 +245,7 @@ class RebuildIndexRequest:
     promote: bool = True
     candidate_acceptance_checks: tuple[str, ...] | None = None
     operation_id: str | None = None
+    schema_inference_receipt_path: Path | None = None
     raw_batch_size: int = 500
     pass_byte_budget_mb: float | None = None
     pass_deadline_seconds: float | None = None
@@ -404,6 +405,7 @@ class RebuildIndexReceipt:
     #: not measured at all. Persisting it here makes the next optimisation
     #: evidence-based rather than a guess.
     timings_s: dict[str, float] = field(default_factory=dict)
+    consumed_evidence: dict[str, object] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -419,6 +421,7 @@ class RebuildIndexReceipt:
             "transaction": self.transaction,
             "operation": self.operation,
             "timings_s": self.timings_s,
+            "consumed_evidence": self.consumed_evidence,
             **self.replay,
         }
 
@@ -615,6 +618,15 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
     log_mapped_bytes_budget_check(logger, check_mapped_bytes_budget_against_cgroup_limit())
     validate_rebuild_index_request(request)
     root = request.archive_root
+    from polylogue.maintenance.schema_inference_gate import (
+        SchemaInferenceGateError,
+        validate_schema_inference_receipt,
+    )
+
+    try:
+        consumed_evidence = validate_schema_inference_receipt(root, request.schema_inference_receipt_path)
+    except SchemaInferenceGateError as exc:
+        raise RuntimeError(f"rebuild schema-inference preflight gate failed: {exc}") from exc
     location = ArchiveLocation.resolve(root)
     active_config = Config(
         archive_root=root,
@@ -643,13 +655,19 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
         owned = OwnedArchiveLocation.acquire(location)
         try:
             assert_owns_archive_location(owned, location)
-            return await _rebuild_index_from_source_owned(request, root=root, owned=owned)
+            return await _rebuild_index_from_source_owned(
+                request, root=root, owned=owned, consumed_evidence=consumed_evidence
+            )
         finally:
             owned.release()
 
 
 async def _rebuild_index_from_source_owned(
-    request: RebuildIndexRequest, *, root: Path, owned: OwnedArchiveLocation
+    request: RebuildIndexRequest,
+    *,
+    root: Path,
+    owned: OwnedArchiveLocation,
+    consumed_evidence: dict[str, object],
 ) -> RebuildIndexReceipt:
     """Ownership-proven body of :func:`rebuild_index_from_source`."""
     from polylogue.maintenance.archive_verification import (
@@ -683,6 +701,7 @@ async def _rebuild_index_from_source_owned(
                 readiness={},
                 replay={},
                 operation=_operation_evidence(root, generation=None, transaction=None, recovery_state="empty-source"),
+                consumed_evidence=consumed_evidence,
             )
         resumable_full_source = not request.raw_ids and not request.only_missing and request.max_blob_mb is None
         transaction = None
@@ -946,6 +965,7 @@ async def _rebuild_index_from_source_owned(
                             root, generation=generation, transaction=transaction, recovery_state="deferred"
                         ),
                         timings_s=cast(dict[str, float], pass_cost.to_dict()),
+                        consumed_evidence=consumed_evidence,
                     )
                     generation_store.save_pass_receipt(transaction.operation_id, pass_receipt.to_dict())
                     return pass_receipt
@@ -1025,6 +1045,7 @@ async def _rebuild_index_from_source_owned(
                             root, generation=generation, transaction=transaction, recovery_state=status
                         ),
                         timings_s=cast(dict[str, float], pass_cost.to_dict()),
+                        consumed_evidence=consumed_evidence,
                     )
                     generation_store.save_pass_receipt(transaction.operation_id, pass_receipt.to_dict())
                     return pass_receipt
@@ -1200,6 +1221,7 @@ async def _rebuild_index_from_source_owned(
             recovery_state="promoted" if request.promote else "ready",
         ),
         timings_s={key: round(value, 3) for key, value in terminal_timings_s.items()},
+        consumed_evidence=consumed_evidence,
     )
     if transaction is not None:
         generation_store.save_pass_receipt(transaction.operation_id, final_receipt.to_dict())

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -88,6 +88,46 @@ def _create_rebuild_transaction_after_receipt_validation(
     )
 
 
+def _checkpoint_rebuild_transaction_after_receipt_validation(
+    generation_store: IndexGenerationStore,
+    transaction: IndexRebuildTransaction,
+    root: Path,
+    receipt_path: Path | None,
+    *,
+    status: str,
+    last_blob_hash_hex: str | None = None,
+    last_raw_id: str | None = None,
+    processed_raw_count: int | None = None,
+    processed_blob_bytes: int | None = None,
+    error: str | None = None,
+    derived_stores_cleared: bool | None = None,
+) -> IndexRebuildTransaction:
+    """Validate immediately before every persisted rebuild state transition."""
+    _validate_rebuild_provenance_receipt(root, receipt_path)
+    return generation_store.checkpoint_transaction(
+        transaction,
+        status=status,
+        last_blob_hash_hex=last_blob_hash_hex,
+        last_raw_id=last_raw_id,
+        processed_raw_count=processed_raw_count,
+        processed_blob_bytes=processed_blob_bytes,
+        error=error,
+        derived_stores_cleared=derived_stores_cleared,
+    )
+
+
+def _save_rebuild_pass_receipt_after_receipt_validation(
+    generation_store: IndexGenerationStore,
+    operation_id: str,
+    pass_receipt: RebuildIndexReceipt,
+    root: Path,
+    receipt_path: Path | None,
+) -> None:
+    """Validate before publishing a pass receipt tied to rebuild state."""
+    _validate_rebuild_provenance_receipt(root, receipt_path)
+    generation_store.save_pass_receipt(operation_id, pass_receipt.to_dict())
+
+
 #: Passed through to ``CensusParseStage.warm_raw_ids``'s ``max_payload_bytes``
 #: parameter for symmetry with the daemon's own call site
 #: (``daemon/bulk_rebuild.py``); the parameter is currently accepted but not
@@ -755,9 +795,11 @@ async def _rebuild_index_from_source_owned(
                     f"rebuild operation {transaction.operation_id} is {transaction.status}; start a new operation"
                 )
             if rebuild_source_revision_snapshot(root) != transaction.source_snapshot:
-                _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
-                generation_store.checkpoint_transaction(
+                _checkpoint_rebuild_transaction_after_receipt_validation(
+                    generation_store,
                     transaction,
+                    root,
+                    request.schema_inference_receipt_path,
                     status="stale",
                     error="source evidence changed since this rebuild was planned",
                 )
@@ -770,8 +812,11 @@ async def _rebuild_index_from_source_owned(
             if not transaction.derived_stores_cleared:
                 _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
                 _clear_bulk_build_derived_stores(Path(generation.index_path))
-                transaction = generation_store.checkpoint_transaction(
+                transaction = _checkpoint_rebuild_transaction_after_receipt_validation(
+                    generation_store,
                     transaction,
+                    root,
+                    request.schema_inference_receipt_path,
                     status=transaction.status,
                     derived_stores_cleared=True,
                 )
@@ -927,8 +972,11 @@ async def _rebuild_index_from_source_owned(
                     # a raw/cohort; it can only redo bounded work.
                     assert transaction is not None  # deadline_check is only wired when transaction is not None
                     pass_elapsed_s = time.perf_counter() - pass_started_at_s
-                    transaction = generation_store.checkpoint_transaction(
+                    transaction = _checkpoint_rebuild_transaction_after_receipt_validation(
+                        generation_store,
                         transaction,
+                        root,
+                        request.schema_inference_receipt_path,
                         status="deferred",
                         error=str(exc),
                     )
@@ -997,7 +1045,13 @@ async def _rebuild_index_from_source_owned(
                         timings_s=cast(dict[str, float], pass_cost.to_dict()),
                         consumed_evidence=consumed_evidence,
                     )
-                    generation_store.save_pass_receipt(transaction.operation_id, pass_receipt.to_dict())
+                    _save_rebuild_pass_receipt_after_receipt_validation(
+                        generation_store,
+                        transaction.operation_id,
+                        pass_receipt,
+                        root,
+                        request.schema_inference_receipt_path,
+                    )
                     return pass_receipt
             pass_elapsed_s = time.perf_counter() - pass_started_at_s
             processed_before = transaction.processed_raw_count if transaction is not None else None
@@ -1009,8 +1063,11 @@ async def _rebuild_index_from_source_owned(
             if transaction is not None and selected_raw_ids:
                 if rebuild_source_revision_snapshot(root) != transaction.source_snapshot:
                     _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
-                    transaction = generation_store.checkpoint_transaction(
+                    transaction = _checkpoint_rebuild_transaction_after_receipt_validation(
+                        generation_store,
                         transaction,
+                        root,
+                        request.schema_inference_receipt_path,
                         status="stale",
                         error="source evidence changed during this bounded rebuild pass",
                     )
@@ -1025,8 +1082,11 @@ async def _rebuild_index_from_source_owned(
                     transaction.pass_deadline_ms is not None and elapsed_ms >= transaction.pass_deadline_ms
                 )
                 status = "deferred" if page.deferred_reason == "byte-budget" or deadline_expired else "paused"
-                transaction = generation_store.checkpoint_transaction(
+                transaction = _checkpoint_rebuild_transaction_after_receipt_validation(
+                    generation_store,
                     transaction,
+                    root,
+                    request.schema_inference_receipt_path,
                     status=status,
                     last_blob_hash_hex=last_blob_hash_hex,
                     last_raw_id=last_raw_id,
@@ -1078,7 +1138,13 @@ async def _rebuild_index_from_source_owned(
                         timings_s=cast(dict[str, float], pass_cost.to_dict()),
                         consumed_evidence=consumed_evidence,
                     )
-                    generation_store.save_pass_receipt(transaction.operation_id, pass_receipt.to_dict())
+                    _save_rebuild_pass_receipt_after_receipt_validation(
+                        generation_store,
+                        transaction.operation_id,
+                        pass_receipt,
+                        root,
+                        request.schema_inference_receipt_path,
+                    )
                     return pass_receipt
             # polylogue-o56w: terminal-stage costs used to survive only as log
             # lines; collect them here and persist them on the final receipt
@@ -1094,8 +1160,11 @@ async def _rebuild_index_from_source_owned(
             if rebuild_source_revision_snapshot(root) != generation.source_snapshot:
                 if transaction is not None:
                     _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
-                    transaction = generation_store.checkpoint_transaction(
+                    transaction = _checkpoint_rebuild_transaction_after_receipt_validation(
+                        generation_store,
                         transaction,
+                        root,
+                        request.schema_inference_receipt_path,
                         status="stale",
                         error="source evidence changed before terminal readiness",
                     )
@@ -1197,8 +1266,13 @@ async def _rebuild_index_from_source_owned(
                 )
                 raise RuntimeError(f"inactive generation {generation.generation_id} is not exact-ready; {detail}")
             if transaction is not None:
-                _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
-                transaction = generation_store.checkpoint_transaction(transaction, status="ready")
+                transaction = _checkpoint_rebuild_transaction_after_receipt_validation(
+                    generation_store,
+                    transaction,
+                    root,
+                    request.schema_inference_receipt_path,
+                    status="ready",
+                )
             if request.promote:
                 # Re-prove ownership immediately before the activation swap:
                 # a long-running rebuild pass can outlast a concurrent
@@ -1217,8 +1291,13 @@ async def _rebuild_index_from_source_owned(
                     elapsed_s=round(terminal_timings_s["terminal.promote"], 3),
                 )
                 if transaction is not None:
-                    _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
-                    transaction = generation_store.checkpoint_transaction(transaction, status="promoted")
+                    transaction = _checkpoint_rebuild_transaction_after_receipt_validation(
+                        generation_store,
+                        transaction,
+                        root,
+                        request.schema_inference_receipt_path,
+                        status="promoted",
+                    )
         except Exception:
             if transaction is not None and not source_drifted:
                 with contextlib.suppress(Exception):
@@ -1228,13 +1307,17 @@ async def _rebuild_index_from_source_owned(
                     # let this stale local value rewind that committed cursor
                     # while recording recovery state.
                     transaction = generation_store.load_transaction(transaction.operation_id)
-                    generation_store.checkpoint_transaction(
+                    _checkpoint_rebuild_transaction_after_receipt_validation(
+                        generation_store,
                         transaction,
+                        root,
+                        request.schema_inference_receipt_path,
                         status="failed",
                         error="bounded rebuild pass failed; candidate retained for diagnosis or explicit recovery",
                     )
             else:
                 with contextlib.suppress(Exception):
+                    _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
                     generation_store.discard_if_inactive(generation)
             raise
     final_receipt = RebuildIndexReceipt(
@@ -1259,7 +1342,13 @@ async def _rebuild_index_from_source_owned(
         consumed_evidence=consumed_evidence,
     )
     if transaction is not None:
-        generation_store.save_pass_receipt(transaction.operation_id, final_receipt.to_dict())
+        _save_rebuild_pass_receipt_after_receipt_validation(
+            generation_store,
+            transaction.operation_id,
+            final_receipt,
+            root,
+            request.schema_inference_receipt_path,
+        )
     return final_receipt
 
 

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -55,6 +55,36 @@ _PLANNER_STATS_ANALYZE_STATEMENTS = (
 logger = get_logger(__name__)
 
 
+@dataclass(frozen=True, slots=True)
+class RebuildProvenanceContext:
+    """Validated evidence shared by every mutation in one rebuild pass.
+
+    ``validate`` is the guard for operations that consume source evidence.
+    Cleanup has a narrower contract: it may remove only a generation that was
+    created under this already-validated context, and never reads or writes
+    source evidence.  Keeping that distinction lets a failed receipt still
+    clean up non-promotable scratch generations without treating the stale
+    receipt as authorization to continue replaying.
+    """
+
+    root: Path
+    receipt_path: Path | None
+    source_snapshot: str
+    consumed_evidence: dict[str, object]
+
+    def validate(self) -> None:
+        _validate_rebuild_provenance_receipt(self.root, self.receipt_path)
+        from polylogue.maintenance.schema_inference_gate import rebuild_source_revision_snapshot
+
+        if rebuild_source_revision_snapshot(self.root) != self.source_snapshot:
+            raise RuntimeError("rebuild schema-inference preflight gate failed: source evidence changed during replay")
+
+    def validate_cleanup(self) -> None:
+        """Authorize failure cleanup from the immutable pre-mutation proof."""
+        if not self.consumed_evidence or not self.source_snapshot:
+            raise RuntimeError("rebuild cleanup has no validated provenance context")
+
+
 def _validate_rebuild_provenance_receipt(root: Path, receipt_path: Path | None) -> dict[str, object]:
     """Validate rebuild provenance at the current ownership boundary."""
     from polylogue.maintenance.schema_inference_gate import (
@@ -837,10 +867,24 @@ async def _rebuild_index_from_source_owned(
             raw_count, selected_raw_ids, skipped_by_blob_limit_count = select_rebuild_raw_ids(request)
             selection_elapsed_s = time.perf_counter() - selection_started_at
             selected_raw_count = len(selected_raw_ids)
-            _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
-            generation = generation_store.create(source_snapshot=rebuild_source_revision_snapshot(root))
+            source_snapshot = rebuild_source_revision_snapshot(root)
+            precreate_provenance = RebuildProvenanceContext(
+                root=root,
+                receipt_path=request.schema_inference_receipt_path,
+                source_snapshot=source_snapshot,
+                consumed_evidence=consumed_evidence,
+            )
+            precreate_provenance.validate()
+            generation = generation_store.create(source_snapshot=source_snapshot)
+        provenance = RebuildProvenanceContext(
+            root=root,
+            receipt_path=request.schema_inference_receipt_path,
+            source_snapshot=generation.source_snapshot,
+            consumed_evidence=consumed_evidence,
+        )
         source_drifted = False
         try:
+            provenance.validate()
             generation_root = Path(generation.index_path).parent
             config = Config(
                 archive_root=generation_root,
@@ -908,6 +952,7 @@ async def _rebuild_index_from_source_owned(
                     raw_batch_size=request.raw_batch_size,
                     shard_count=request.shard_count,
                     prefetch_cache=effective_prefetch_cache,
+                    provenance=provenance,
                 )
             else:
                 # polylogue-uhgm: the pass deadline used to be checked only AFTER
@@ -1317,7 +1362,10 @@ async def _rebuild_index_from_source_owned(
                     )
             else:
                 with contextlib.suppress(Exception):
-                    _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
+                    try:
+                        provenance.validate()
+                    except Exception:
+                        provenance.validate_cleanup()
                     generation_store.discard_if_inactive(generation)
             raise
     final_receipt = RebuildIndexReceipt(

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -30,7 +30,7 @@ from polylogue.storage.sqlite.delegation_facts import rebuild_all_delegation_fac
 
 if TYPE_CHECKING:
     from polylogue.sources.revision_backfill import RawParsePrefetchCache
-    from polylogue.storage.index_generation import IndexGeneration, IndexRebuildTransaction
+    from polylogue.storage.index_generation import IndexGeneration, IndexGenerationStore, IndexRebuildTransaction
 
 _PLANNER_STATS_ANALYSIS_LIMIT = 1000
 # A fresh generation begins with representative bootstrap statistics, but a
@@ -53,6 +53,40 @@ _PLANNER_STATS_ANALYZE_STATEMENTS = (
 )
 
 logger = get_logger(__name__)
+
+
+def _validate_rebuild_provenance_receipt(root: Path, receipt_path: Path | None) -> dict[str, object]:
+    """Validate rebuild provenance at the current ownership boundary."""
+    from polylogue.maintenance.schema_inference_gate import (
+        SchemaInferenceGateError,
+        validate_schema_inference_receipt,
+    )
+
+    try:
+        return validate_schema_inference_receipt(root, receipt_path)
+    except SchemaInferenceGateError as exc:
+        raise RuntimeError(f"rebuild schema-inference preflight gate failed: {exc}") from exc
+
+
+def _create_rebuild_transaction_after_receipt_validation(
+    generation_store: IndexGenerationStore,
+    request: RebuildIndexRequest,
+    root: Path,
+) -> IndexRebuildTransaction:
+    """Create the first candidate only after an ownership-bound validation."""
+    from polylogue.maintenance.schema_inference_gate import rebuild_source_revision_snapshot
+
+    _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
+    return generation_store.create_transaction(
+        source_snapshot=rebuild_source_revision_snapshot(root),
+        pass_byte_budget=(
+            int(request.pass_byte_budget_mb * 1024 * 1024) if request.pass_byte_budget_mb is not None else None
+        ),
+        pass_deadline_ms=(
+            int(request.pass_deadline_seconds * 1000) if request.pass_deadline_seconds is not None else None
+        ),
+    )
+
 
 #: Passed through to ``CensusParseStage.warm_raw_ids``'s ``max_payload_bytes``
 #: parameter for symmetry with the daemon's own call site
@@ -619,15 +653,7 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
     log_mapped_bytes_budget_check(logger, check_mapped_bytes_budget_against_cgroup_limit())
     validate_rebuild_index_request(request)
     root = request.archive_root
-    from polylogue.maintenance.schema_inference_gate import (
-        SchemaInferenceGateError,
-        validate_schema_inference_receipt,
-    )
-
-    try:
-        consumed_evidence = validate_schema_inference_receipt(root, request.schema_inference_receipt_path)
-    except SchemaInferenceGateError as exc:
-        raise RuntimeError(f"rebuild schema-inference preflight gate failed: {exc}") from exc
+    consumed_evidence = _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
     location = ArchiveLocation.resolve(root)
     active_config = Config(
         archive_root=root,
@@ -648,19 +674,24 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
         )
         raise RuntimeError(f"reindex source preflight gate failed: {failing}")
 
-    # This is deliberately outside archive-location acquisition and
-    # generation-store construction.  Those steps can create/rewrite archive
-    # bookkeeping, so a competing ArchiveStore writer must fail before the
-    # rebuild's first lifecycle mutation, not only during replay.
-    with RebuildLease(root):
-        owned = OwnedArchiveLocation.acquire(location)
-        try:
-            assert_owns_archive_location(owned, location)
+    # Ownership acquisition itself only claims the lock. Revalidate after it
+    # so receipt expiry/source/external-corpus drift between the cheap
+    # preflight and ownership acquisition cannot reach the rebuild lease or a
+    # candidate mutation.
+    owned = OwnedArchiveLocation.acquire(location)
+    try:
+        assert_owns_archive_location(owned, location)
+        consumed_evidence = _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
+        # The lease is itself lifecycle state guarded by the provenance gate.
+        # Revalidate again under the lease immediately before the owned body
+        # can create or mutate a candidate/transaction.
+        with RebuildLease(root):
+            consumed_evidence = _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
             return await _rebuild_index_from_source_owned(
                 request, root=root, owned=owned, consumed_evidence=consumed_evidence
             )
-        finally:
-            owned.release()
+    finally:
+        owned.release()
 
 
 async def _rebuild_index_from_source_owned(
@@ -713,16 +744,10 @@ async def _rebuild_index_from_source_owned(
             transaction = (
                 generation_store.load_transaction(request.operation_id)
                 if request.operation_id is not None
-                else generation_store.create_transaction(
-                    source_snapshot=rebuild_source_revision_snapshot(root),
-                    pass_byte_budget=(
-                        int(request.pass_byte_budget_mb * 1024 * 1024)
-                        if request.pass_byte_budget_mb is not None
-                        else None
-                    ),
-                    pass_deadline_ms=(
-                        int(request.pass_deadline_seconds * 1000) if request.pass_deadline_seconds is not None else None
-                    ),
+                else _create_rebuild_transaction_after_receipt_validation(
+                    generation_store,
+                    request,
+                    root,
                 )
             )
             if transaction.status in {"promoted", "stale"}:
@@ -730,6 +755,7 @@ async def _rebuild_index_from_source_owned(
                     f"rebuild operation {transaction.operation_id} is {transaction.status}; start a new operation"
                 )
             if rebuild_source_revision_snapshot(root) != transaction.source_snapshot:
+                _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
                 generation_store.checkpoint_transaction(
                     transaction,
                     status="stale",
@@ -742,6 +768,7 @@ async def _rebuild_index_from_source_owned(
             if generation.owner_id != transaction.generation_owner_id or generation.state != "inactive":
                 raise RuntimeError(f"rebuild operation {transaction.operation_id} lost its inactive candidate")
             if not transaction.derived_stores_cleared:
+                _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
                 _clear_bulk_build_derived_stores(Path(generation.index_path))
                 transaction = generation_store.checkpoint_transaction(
                     transaction,
@@ -765,6 +792,7 @@ async def _rebuild_index_from_source_owned(
             raw_count, selected_raw_ids, skipped_by_blob_limit_count = select_rebuild_raw_ids(request)
             selection_elapsed_s = time.perf_counter() - selection_started_at
             selected_raw_count = len(selected_raw_ids)
+            _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
             generation = generation_store.create(source_snapshot=rebuild_source_revision_snapshot(root))
         source_drifted = False
         try:
@@ -980,6 +1008,7 @@ async def _rebuild_index_from_source_owned(
                 _refresh_generation_planner_statistics(Path(generation.index_path))
             if transaction is not None and selected_raw_ids:
                 if rebuild_source_revision_snapshot(root) != transaction.source_snapshot:
+                    _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
                     transaction = generation_store.checkpoint_transaction(
                         transaction,
                         status="stale",
@@ -1064,6 +1093,7 @@ async def _rebuild_index_from_source_owned(
             terminal_timings_s: dict[str, float] = {"selection_s": selection_elapsed_s}
             if rebuild_source_revision_snapshot(root) != generation.source_snapshot:
                 if transaction is not None:
+                    _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
                     transaction = generation_store.checkpoint_transaction(
                         transaction,
                         status="stale",
@@ -1167,6 +1197,7 @@ async def _rebuild_index_from_source_owned(
                 )
                 raise RuntimeError(f"inactive generation {generation.generation_id} is not exact-ready; {detail}")
             if transaction is not None:
+                _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
                 transaction = generation_store.checkpoint_transaction(transaction, status="ready")
             if request.promote:
                 # Re-prove ownership immediately before the activation swap:
@@ -1175,6 +1206,7 @@ async def _rebuild_index_from_source_owned(
                 # caught before clobbering someone else's activation rather
                 # than after (polylogue-ovme.2 AC3).
                 assert_owns_archive_location(owned, ArchiveLocation.resolve(root))
+                _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
                 terminal_started_at = time.perf_counter()
                 generation = generation_store.promote(generation)
                 terminal_timings_s["terminal.promote"] = time.perf_counter() - terminal_started_at
@@ -1185,6 +1217,7 @@ async def _rebuild_index_from_source_owned(
                     elapsed_s=round(terminal_timings_s["terminal.promote"], 3),
                 )
                 if transaction is not None:
+                    _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
                     transaction = generation_store.checkpoint_transaction(transaction, status="promoted")
         except Exception:
             if transaction is not None and not source_drifted:

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -439,12 +439,13 @@ def _operation_evidence(
     transaction checkpoint.  It adds no competing ownership mechanism and
     keeps the full checkpoint in ``transaction`` for callers that need it.
     """
-    from polylogue.storage.index_generation import rebuild_lease_status, source_revision_snapshot
+    from polylogue.maintenance.schema_inference_gate import rebuild_source_revision_snapshot
+    from polylogue.storage.index_generation import rebuild_lease_status
 
     transaction_payload = asdict(transaction) if transaction is not None else {}
     generation_payload = asdict(generation) if generation is not None else {}
     source_snapshot = transaction_payload.get("source_snapshot") or generation_payload.get("source_snapshot")
-    current_snapshot = source_revision_snapshot(root) if (root / "source.db").exists() else None
+    current_snapshot = rebuild_source_revision_snapshot(root) if (root / "source.db").exists() else None
     return {
         "owner": {
             "generation_owner_id": transaction_payload.get("generation_owner_id") or generation_payload.get("owner_id"),
@@ -676,9 +677,10 @@ async def _rebuild_index_from_source_owned(
         verify_archive,
     )
     from polylogue.maintenance.replay import rebuild_index_from_source as replay_source
+    from polylogue.maintenance.schema_inference_gate import rebuild_source_revision_snapshot
     from polylogue.sources.revision_backfill import RebuildDeadlineExceededError
     from polylogue.storage.archive_readiness import archive_readiness_status
-    from polylogue.storage.index_generation import IndexGenerationStore, source_revision_snapshot
+    from polylogue.storage.index_generation import IndexGenerationStore
     from polylogue.storage.repair import repair_session_insights
 
     generation_store = IndexGenerationStore(owned.location)
@@ -712,7 +714,7 @@ async def _rebuild_index_from_source_owned(
                 generation_store.load_transaction(request.operation_id)
                 if request.operation_id is not None
                 else generation_store.create_transaction(
-                    source_snapshot=source_revision_snapshot(root),
+                    source_snapshot=rebuild_source_revision_snapshot(root),
                     pass_byte_budget=(
                         int(request.pass_byte_budget_mb * 1024 * 1024)
                         if request.pass_byte_budget_mb is not None
@@ -727,7 +729,7 @@ async def _rebuild_index_from_source_owned(
                 raise RuntimeError(
                     f"rebuild operation {transaction.operation_id} is {transaction.status}; start a new operation"
                 )
-            if source_revision_snapshot(root) != transaction.source_snapshot:
+            if rebuild_source_revision_snapshot(root) != transaction.source_snapshot:
                 generation_store.checkpoint_transaction(
                     transaction,
                     status="stale",
@@ -763,7 +765,7 @@ async def _rebuild_index_from_source_owned(
             raw_count, selected_raw_ids, skipped_by_blob_limit_count = select_rebuild_raw_ids(request)
             selection_elapsed_s = time.perf_counter() - selection_started_at
             selected_raw_count = len(selected_raw_ids)
-            generation = generation_store.create(source_snapshot=source_revision_snapshot(root))
+            generation = generation_store.create(source_snapshot=rebuild_source_revision_snapshot(root))
         source_drifted = False
         try:
             generation_root = Path(generation.index_path).parent
@@ -977,7 +979,7 @@ async def _rebuild_index_from_source_owned(
             ):
                 _refresh_generation_planner_statistics(Path(generation.index_path))
             if transaction is not None and selected_raw_ids:
-                if source_revision_snapshot(root) != transaction.source_snapshot:
+                if rebuild_source_revision_snapshot(root) != transaction.source_snapshot:
                     transaction = generation_store.checkpoint_transaction(
                         transaction,
                         status="stale",
@@ -1060,7 +1062,7 @@ async def _rebuild_index_from_source_owned(
             # not a parallel one, so every receipt shape (deferred, paused,
             # replayed) carries the identical key for this phase.
             terminal_timings_s: dict[str, float] = {"selection_s": selection_elapsed_s}
-            if source_revision_snapshot(root) != generation.source_snapshot:
+            if rebuild_source_revision_snapshot(root) != generation.source_snapshot:
                 if transaction is not None:
                     transaction = generation_store.checkpoint_transaction(
                         transaction,
@@ -1256,11 +1258,8 @@ def rebuild_status(
     acquires ``RebuildLease``, never mutates any transaction or generation.
     """
     from polylogue.daemon.bulk_rebuild import DAEMON_BULK_REBUILD_OPERATION_ID
-    from polylogue.storage.index_generation import (
-        IndexGenerationStore,
-        rebuild_lease_status,
-        source_revision_snapshot,
-    )
+    from polylogue.maintenance.schema_inference_gate import rebuild_source_revision_snapshot
+    from polylogue.storage.index_generation import IndexGenerationStore, rebuild_lease_status
 
     location = ArchiveLocation.resolve(archive_root)
     lease = rebuild_lease_status(archive_root)
@@ -1305,7 +1304,9 @@ def rebuild_status(
             transaction = None
         if transaction is not None:
             transaction_payload = cast(dict[str, object], asdict(transaction))
-            current_snapshot = source_revision_snapshot(archive_root) if (archive_root / "source.db").exists() else None
+            current_snapshot = (
+                rebuild_source_revision_snapshot(archive_root) if (archive_root / "source.db").exists() else None
+            )
             delta = {
                 "source_snapshot_matches": (
                     current_snapshot is not None and current_snapshot == transaction.source_snapshot

--- a/polylogue/maintenance/schema_inference_gate.py
+++ b/polylogue/maintenance/schema_inference_gate.py
@@ -549,6 +549,28 @@ def _parse_receipt_datetime(value: object, *, field: str) -> datetime:
     return parsed.astimezone(UTC)
 
 
+def rebuild_source_revision_snapshot(archive_root: Path) -> str:
+    """Hash immutable source-row revision fields used by a derived rebuild."""
+
+    digest = hashlib.sha256()
+    source_path = Path(archive_root) / ARCHIVE_TIER_SPECS[ArchiveTier.SOURCE].filename
+    with open_readonly_connection(source_path) as source:
+        for row in source.execute(
+            """
+            SELECT raw_id, origin, native_id, source_path,
+                   acquired_at_ms, blob_hash, blob_size, validation_status
+            FROM raw_sessions
+            ORDER BY raw_id
+            """
+        ):
+            for value in row:
+                encoded = value.hex() if isinstance(value, bytes) else str(value)
+                digest.update(encoded.encode("utf-8"))
+                digest.update(b"\0")
+            digest.update(b"\n")
+    return digest.hexdigest()
+
+
 def _canonical_external_ground_truth_digest(origins: Mapping[str, object]) -> str:
     """Digest the complete external corpus inventory recorded in a receipt."""
 
@@ -1330,10 +1352,8 @@ def validate_schema_inference_receipt(
         if not source_path.exists():
             errors.append("source.db is missing")
         else:
-            from polylogue.storage.index_generation import source_revision_snapshot
-
             expected_snapshot = document.get("source_snapshot")
-            actual_snapshot = source_revision_snapshot(root)
+            actual_snapshot = rebuild_source_revision_snapshot(root)
             if not isinstance(expected_snapshot, str) or expected_snapshot != actual_snapshot:
                 errors.append("receipt source snapshot does not match source.db")
     except (OSError, sqlite3.Error, ValueError, RuntimeError) as exc:
@@ -1481,9 +1501,7 @@ def run_schema_inference_gate(
     source_snapshot: str | None = None
     reasons_for_snapshot: str | None = None
     try:
-        from polylogue.storage.index_generation import source_revision_snapshot
-
-        source_snapshot = source_revision_snapshot(root)
+        source_snapshot = rebuild_source_revision_snapshot(root)
     except (OSError, sqlite3.Error) as exc:
         reasons_for_snapshot = f"source revision snapshot could not be read: {exc}"
     gate_results = _as_dict(source_gates.get("gates"))
@@ -1561,6 +1579,7 @@ __all__ = [
     "SCHEMA_INFERENCE_RECEIPT_ENV",
     "SchemaInferenceGateError",
     "SchemaInferenceGateResult",
+    "rebuild_source_revision_snapshot",
     "resolve_schema_inference_receipt_reference",
     "run_schema_inference_gate",
     "validate_schema_inference_receipt",

--- a/polylogue/maintenance/schema_inference_gate.py
+++ b/polylogue/maintenance/schema_inference_gate.py
@@ -11,13 +11,14 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import platform
 import sqlite3
 import sys
 from collections import Counter
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Literal, NotRequired, TypeAlias, TypedDict, cast
 
@@ -30,10 +31,13 @@ from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 from polylogue.version import POLYLOGUE_VERSION
 
-RECEIPT_SCHEMA = "polylogue.schema-inference-gate.v1"
-GATE_VERSION = "2"
+RECEIPT_SCHEMA = "polylogue.schema-inference-gate.v2"
+GATE_VERSION = "3"
 DEFAULT_SAMPLE_LIMIT = 10
 RECEIPT_FILENAME = "schema-inference-gate-receipt.json"
+SCHEMA_INFERENCE_RECEIPT_ENV = "POLYLOGUE_SCHEMA_INFERENCE_RECEIPT"
+RECEIPT_TTL = timedelta(hours=24)
+RECEIPT_CLOCK_SKEW = timedelta(minutes=5)
 
 _ALLOWED_RESIDUAL_EXPLANATIONS = frozenset(
     {"materialized", "superseded-duplicate", "legitimately-excluded-non-conversation"}
@@ -510,6 +514,148 @@ def _resolve_receipt_path(receipt_path: Path, *, archive_root: Path) -> Path:
     raise SchemaInferenceGateError("receipt path must be outside the archive root")
 
 
+def resolve_schema_inference_receipt_reference(archive_root: Path, receipt_path: Path | None = None) -> Path:
+    """Resolve the policy-controlled receipt reference used by rebuild callers."""
+
+    if receipt_path is not None:
+        return receipt_path.expanduser().resolve()
+    configured = os.environ.get(SCHEMA_INFERENCE_RECEIPT_ENV, "").strip()
+    if not configured:
+        raise SchemaInferenceGateError(
+            f"a fresh schema-inference receipt is required; pass a receipt path or set {SCHEMA_INFERENCE_RECEIPT_ENV}"
+        )
+    return Path(configured).expanduser().resolve()
+
+
+def _archive_receipt_identity(location: ArchiveLocation) -> dict[str, object]:
+    identity = ArchiveIdentity.resolve_location(location)
+    return {
+        "configured_root": str(location.configured_root),
+        "durable_id": identity.durable_id,
+        "source_tier": identity.tier("source").as_dict(),
+        "user_tier": identity.tier("user").as_dict(),
+    }
+
+
+def _parse_receipt_datetime(value: object, *, field: str) -> datetime:
+    if not isinstance(value, str) or not value.strip():
+        raise SchemaInferenceGateError(f"receipt field {field!r} must be an ISO-8601 timestamp")
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise SchemaInferenceGateError(f"receipt field {field!r} is not a valid ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise SchemaInferenceGateError(f"receipt field {field!r} must include a timezone")
+    return parsed.astimezone(UTC)
+
+
+def _canonical_external_ground_truth_digest(origins: Mapping[str, object]) -> str:
+    """Digest the complete external corpus inventory recorded in a receipt."""
+
+    canonical: list[dict[str, object]] = []
+    for origin in sorted(origins):
+        evidence = _as_dict(origins[origin])
+        mapping = evidence.get("raw_external_mapping")
+        if not isinstance(mapping, list) or not all(
+            isinstance(item, dict)
+            and isinstance(item.get("raw_id"), str)
+            and isinstance(item.get("source_path"), str)
+            and isinstance(item.get("disposition"), str)
+            for item in mapping
+        ):
+            raise SchemaInferenceGateError(f"raw external mapping for {origin} is missing or malformed")
+        if bool(evidence.get("exempt")):
+            canonical.append(
+                {
+                    "origin": origin,
+                    "exempt": True,
+                    "reason": evidence.get("reason"),
+                    "mapping": sorted(mapping, key=lambda item: str(item["raw_id"])),
+                }
+            )
+            continue
+        roots = evidence.get("declared_roots")
+        inventory = evidence.get("external_inventory")
+        if not isinstance(roots, list) or not all(isinstance(root, str) for root in roots):
+            raise SchemaInferenceGateError(f"ground truth roots for {origin} are missing or malformed")
+        if not isinstance(inventory, list):
+            raise SchemaInferenceGateError(f"ground truth inventory for {origin} is missing or malformed")
+        files: list[dict[str, object]] = []
+        for item in inventory:
+            record = _as_dict(item)
+            root_index = record.get("root_index")
+            relative_path = record.get("relative_path")
+            content_hash = record.get("hash")
+            size = record.get("size")
+            if (
+                not isinstance(root_index, int)
+                or isinstance(root_index, bool)
+                or not isinstance(relative_path, str)
+                or not isinstance(content_hash, str)
+                or not isinstance(size, int)
+                or isinstance(size, bool)
+                or size < 0
+            ):
+                raise SchemaInferenceGateError(f"ground truth inventory for {origin} contains a malformed file")
+            files.append(
+                {
+                    "root_index": root_index,
+                    "relative_path": relative_path,
+                    "hash": content_hash.lower(),
+                    "size": size,
+                }
+            )
+        mappings: list[dict[str, object]] = []
+        for item in mapping:
+            record = _as_dict(item)
+            raw_id = record.get("raw_id")
+            source_path = record.get("source_path")
+            disposition = record.get("disposition")
+            blob_hash = record.get("blob_hash")
+            blob_size = record.get("blob_size")
+            external_relative_path = record.get("external_relative_path")
+            external_hash = record.get("external_hash")
+            external_size = record.get("external_size")
+            if (
+                not isinstance(raw_id, str)
+                or not isinstance(source_path, str)
+                or not isinstance(disposition, str)
+                or not isinstance(blob_hash, str)
+                or not isinstance(blob_size, int)
+                or isinstance(blob_size, bool)
+                or blob_size < 0
+                or (external_relative_path is not None and not isinstance(external_relative_path, str))
+                or (external_hash is not None and not isinstance(external_hash, str))
+                or (
+                    external_size is not None
+                    and (not isinstance(external_size, int) or isinstance(external_size, bool))
+                )
+            ):
+                raise SchemaInferenceGateError(f"raw external mapping for {origin} contains a malformed row")
+            mappings.append(
+                {
+                    "raw_id": raw_id,
+                    "source_path": source_path,
+                    "blob_hash": blob_hash.lower(),
+                    "blob_size": blob_size,
+                    "external_relative_path": external_relative_path,
+                    "external_hash": external_hash.lower() if isinstance(external_hash, str) else None,
+                    "external_size": external_size,
+                    "disposition": disposition,
+                }
+            )
+        canonical.append(
+            {
+                "origin": origin,
+                "roots": sorted(str(Path(root).expanduser().resolve()) for root in roots),
+                "files": sorted(files, key=lambda item: (int(item["root_index"]), str(item["relative_path"]))),
+                "mapping": sorted(mappings, key=lambda item: str(item["raw_id"])),
+            }
+        )
+    encoded = json.dumps(canonical, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
 def _snapshot_blob_root(blob_root: Path) -> dict[str, object]:
     """Fingerprint the canonical namespace before and after full verification."""
 
@@ -658,6 +804,51 @@ def _raw_provenance(
     }
 
 
+def _raw_external_mapping(
+    source: sqlite3.Connection,
+    *,
+    origin: str,
+    inventory: Sequence[_ExternalGroundTruthFile],
+    exempt: bool,
+) -> list[dict[str, object]]:
+    """Persist one deterministic external-file choice for every source raw."""
+
+    rows = source.execute(
+        """
+        SELECT raw_id, source_path, hex(blob_hash), blob_size
+        FROM raw_sessions
+        WHERE origin = ?
+        ORDER BY raw_id
+        """,
+        (origin,),
+    ).fetchall()
+    by_key: dict[GroundTruthKey, list[_ExternalGroundTruthFile]] = {}
+    for item in inventory:
+        by_key.setdefault(item.key, []).append(item)
+    mapping: list[dict[str, object]] = []
+    for raw_id, source_path, blob_hash, blob_size in rows:
+        canonical_hash = str(blob_hash).lower()
+        canonical_size = int(blob_size)
+        match = by_key.get((canonical_hash, canonical_size), [None])[0]
+        mapping.append(
+            {
+                "raw_id": str(raw_id),
+                "source_path": str(source_path),
+                "blob_hash": canonical_hash,
+                "blob_size": canonical_size,
+                "external_relative_path": match.relative_path if match is not None else None,
+                "external_hash": match.content_hash if match is not None else None,
+                "external_size": match.size if match is not None else None,
+                "disposition": "origin-exempt"
+                if exempt
+                else "matched-external"
+                if match is not None
+                else "unmatched-source-raw",
+            }
+        )
+    return mapping
+
+
 def _raw_dispositions(
     source: sqlite3.Connection,
     *,
@@ -740,7 +931,11 @@ def _ground_truth_evidence(
         for origin in origins:
             declared = GROUND_TRUTH_INPUTS.get(origin, {"exempt": False})
             if bool(declared.get("exempt")):
-                evidence[origin] = {"exempt": True, "reason": declared.get("reason")}
+                evidence[origin] = {
+                    "exempt": True,
+                    "reason": declared.get("reason"),
+                    "raw_external_mapping": _raw_external_mapping(source, origin=origin, inventory=(), exempt=True),
+                }
                 continue
             declared_roots = tuple(Path(path).expanduser().resolve() for path in root_map.get(origin, ()))
             unavailable = [str(path) for path in declared_roots if not path.exists()]
@@ -750,6 +945,8 @@ def _ground_truth_evidence(
                     "exempt": False,
                     "declared_roots": [str(path) for path in declared_roots],
                     "unavailable_roots": unavailable,
+                    "external_inventory": [],
+                    "raw_external_mapping": _raw_external_mapping(source, origin=origin, inventory=(), exempt=False),
                     "passed": False,
                 }
                 continue
@@ -760,6 +957,8 @@ def _ground_truth_evidence(
                 evidence[origin] = {
                     "exempt": False,
                     "declared_roots": [str(path) for path in declared_roots],
+                    "external_inventory": [],
+                    "raw_external_mapping": _raw_external_mapping(source, origin=origin, inventory=(), exempt=False),
                     "passed": False,
                 }
                 continue
@@ -855,6 +1054,12 @@ def _ground_truth_evidence(
             missing = sorted(
                 source_keys_hash for source_keys_hash, _size in source_keys if source_keys_hash not in hashes
             )
+            mapping = _raw_external_mapping(source, origin=origin, inventory=inventory, exempt=False)
+            unmatched_mapping = [item for item in mapping if item.get("disposition") == "unmatched-source-raw"]
+            if missing:
+                errors.append(f"ground truth for {origin} does not verify every source raw blob")
+            if unmatched_mapping:
+                errors.append(f"ground truth for {origin} has {len(unmatched_mapping)} unmapped source raw(s)")
             evidence[origin] = {
                 "exempt": False,
                 "declared_roots": [str(path) for path in declared_roots],
@@ -873,9 +1078,24 @@ def _ground_truth_evidence(
                 "unmatched_external_files": unmatched_external_files[:DEFAULT_SAMPLE_LIMIT],
                 "cross_origin_mismatches": cross_origin_mismatches[:DEFAULT_SAMPLE_LIMIT],
                 "provenance": provenance,
-                "passed": not origin_errors,
+                "external_inventory": [
+                    {
+                        "root_index": item.root_index,
+                        "relative_path": item.relative_path,
+                        "hash": item.content_hash,
+                        "size": item.size,
+                    }
+                    for item in inventory
+                ],
+                "raw_external_mapping": mapping,
+                "passed": not missing and not unmatched_mapping,
             }
-    return {"passed": not errors, "origins": evidence, "reasons": errors}
+    return {
+        "passed": not errors,
+        "origins": evidence,
+        "reasons": errors,
+        "external_ground_truth_digest": _canonical_external_ground_truth_digest(evidence),
+    }
 
 
 def _fidelity_evidence(report: object) -> dict[str, object]:
@@ -1018,6 +1238,171 @@ def _int_or_zero(value: object) -> int:
     return value if isinstance(value, int) and not isinstance(value, bool) else 0
 
 
+def _current_external_ground_truth_digest(archive_root: Path, ground_truth: Mapping[str, object]) -> str:
+    origins = _as_dict(ground_truth.get("origins"))
+    current: dict[str, object] = {}
+    with open_readonly_connection(archive_root / "source.db") as source:
+        for origin, raw_evidence in origins.items():
+            evidence = _as_dict(raw_evidence)
+            if bool(evidence.get("exempt")):
+                current[origin] = {
+                    "exempt": True,
+                    "reason": evidence.get("reason"),
+                    "raw_external_mapping": _raw_external_mapping(source, origin=origin, inventory=(), exempt=True),
+                }
+                continue
+            roots = evidence.get("declared_roots")
+            if not isinstance(roots, list) or not all(isinstance(root, str) and root for root in roots):
+                raise SchemaInferenceGateError(f"ground truth roots for {origin} are missing or malformed")
+            resolved_roots = tuple(Path(root).expanduser().resolve() for root in roots)
+            unavailable = [str(root) for root in resolved_roots if not root.exists()]
+            if unavailable:
+                raise SchemaInferenceGateError(
+                    f"ground truth roots for {origin} are unavailable: {', '.join(unavailable)}"
+                )
+            inventory = _external_inventory(resolved_roots)
+            current[origin] = {
+                "declared_roots": [str(root) for root in resolved_roots],
+                "external_inventory": inventory,
+                "raw_external_mapping": _raw_external_mapping(source, origin=origin, inventory=inventory, exempt=False),
+            }
+    return _canonical_external_ground_truth_digest(current)
+
+
+def validate_schema_inference_receipt(
+    archive_root: Path,
+    receipt_path: Path | None = None,
+    *,
+    now: datetime | None = None,
+) -> dict[str, object]:
+    """Validate the evidence a rebuild is authorized to consume.
+
+    This validator deliberately checks the embedded subgates instead of
+    trusting the top-level verdict. It also recomputes archive/source identity,
+    the source snapshot, and the external corpus digest against the live
+    read-only inputs.
+    """
+
+    root = Path(archive_root).absolute()
+    path = resolve_schema_inference_receipt_reference(root, receipt_path)
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SchemaInferenceGateError(f"could not read schema-inference receipt: {exc}") from exc
+    if not isinstance(document, dict):
+        raise SchemaInferenceGateError("schema-inference receipt root must be an object")
+
+    errors: list[str] = []
+    if document.get("schema") != RECEIPT_SCHEMA:
+        errors.append(f"schema must be {RECEIPT_SCHEMA!r}")
+    if document.get("verdict") != "PASS":
+        errors.append("receipt verdict must be PASS")
+    if document.get("archive_root") != str(root):
+        errors.append("receipt archive_root does not match the requested archive")
+
+    generated_at: datetime | None = None
+    try:
+        generated_at = _parse_receipt_datetime(document.get("generated_at"), field="generated_at")
+    except SchemaInferenceGateError as exc:
+        errors.append(str(exc))
+    effective_now = (now or datetime.now(UTC)).astimezone(UTC)
+    if generated_at is not None:
+        if generated_at > effective_now + RECEIPT_CLOCK_SKEW:
+            errors.append("receipt generated_at is in the future")
+        if effective_now - generated_at > RECEIPT_TTL + RECEIPT_CLOCK_SKEW:
+            errors.append("schema-inference receipt is stale")
+
+    try:
+        location = ArchiveLocation.resolve(root)
+        current_identity = _archive_receipt_identity(location)
+        receipt_identity = _as_dict(document.get("archive_identity"))
+        for field in ("configured_root", "durable_id", "source_tier", "user_tier"):
+            if receipt_identity.get(field) != current_identity.get(field):
+                errors.append(f"receipt archive identity field {field!r} does not match the requested archive")
+        source_path = root / ARCHIVE_TIER_SPECS[ArchiveTier.SOURCE].filename
+        if not source_path.exists():
+            errors.append("source.db is missing")
+        else:
+            from polylogue.storage.index_generation import source_revision_snapshot
+
+            expected_snapshot = document.get("source_snapshot")
+            actual_snapshot = source_revision_snapshot(root)
+            if not isinstance(expected_snapshot, str) or expected_snapshot != actual_snapshot:
+                errors.append("receipt source snapshot does not match source.db")
+    except (OSError, sqlite3.Error, ValueError, RuntimeError) as exc:
+        errors.append(f"archive/source identity validation failed: {exc}")
+
+    source_identity = _as_dict(document.get("source_identity"))
+    if source_identity.get("durable_id") != _as_dict(document.get("archive_identity")).get("durable_id"):
+        errors.append("receipt source identity is missing or does not match durable identity")
+    if source_identity.get("source_tier") != _as_dict(document.get("archive_identity")).get("source_tier"):
+        errors.append("receipt source identity is missing or does not match source tier identity")
+    if _as_dict(document.get("source_schema_identity")).get("matches_expected") is not True:
+        errors.append("receipt source schema identity is not PASS")
+
+    query_results = document.get("query_results")
+    required_gates = (*_HARD_GATE_SQL, "zero-unexplained-byte-duplicates")
+    if not isinstance(query_results, dict):
+        errors.append("receipt query_results are missing or malformed")
+    else:
+        for gate_id in required_gates:
+            result = query_results.get(gate_id)
+            if not isinstance(result, dict) or result.get("passed") is not True:
+                errors.append(f"receipt subgate {gate_id} is not PASS")
+
+    for field in ("corpus_fidelity", "full_blob_hash_verification", "ground_truth_inputs"):
+        if _as_dict(document.get(field)).get("passed") is not True:
+            errors.append(f"receipt subgate {field} is not PASS")
+
+    ground_truth = document.get("ground_truth_inputs")
+    if not isinstance(ground_truth, dict):
+        errors.append("receipt ground_truth_inputs are missing or malformed")
+    else:
+        recorded_digest = document.get("external_ground_truth_digest")
+        nested_digest = ground_truth.get("external_ground_truth_digest")
+        if not isinstance(recorded_digest, str) or recorded_digest != nested_digest:
+            errors.append("receipt external ground-truth digest is missing or inconsistent")
+        try:
+            recorded_structure_digest = _canonical_external_ground_truth_digest(
+                cast(Mapping[str, object], _as_dict(ground_truth.get("origins")))
+            )
+            if recorded_digest != recorded_structure_digest:
+                errors.append("receipt raw external mapping or inventory does not match its digest")
+            current_digest = _current_external_ground_truth_digest(root, ground_truth)
+            if recorded_digest != current_digest:
+                errors.append("external ground-truth corpus changed since the receipt was produced")
+        except (OSError, SchemaInferenceGateError, sqlite3.Error) as exc:
+            errors.append(str(exc))
+        try:
+            with open_readonly_connection(root / "source.db") as source:
+                source_origins = {str(row[0]) for row in source.execute("SELECT DISTINCT origin FROM raw_sessions")}
+            receipt_origins = set(_as_dict(ground_truth.get("origins")))
+            if source_origins != receipt_origins:
+                errors.append("receipt ground-truth origins do not match source.db")
+            for origin, raw_evidence in _as_dict(ground_truth.get("origins")).items():
+                evidence = _as_dict(raw_evidence)
+                if not bool(evidence.get("exempt")) and evidence.get("passed") is not True:
+                    errors.append(f"receipt ground-truth subgate for {origin} is not PASS")
+        except (OSError, sqlite3.Error) as exc:
+            errors.append(f"could not compare receipt ground-truth origins: {exc}")
+
+    if errors:
+        raise SchemaInferenceGateError("schema-inference receipt rejected: " + "; ".join(errors))
+
+    identity = _as_dict(document.get("archive_identity"))
+    return {
+        "receipt_path": str(path),
+        "schema": document.get("schema"),
+        "generated_at": document.get("generated_at"),
+        "validated_at": effective_now.isoformat(),
+        "archive_root": str(root),
+        "durable_id": identity.get("durable_id"),
+        "source_identity": document.get("source_identity"),
+        "source_snapshot": document.get("source_snapshot"),
+        "external_ground_truth_digest": document.get("external_ground_truth_digest"),
+    }
+
+
 def _write_json(path: Path, payload: dict[str, object]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = path.with_name(f".{path.name}.tmp")
@@ -1042,9 +1427,11 @@ def run_schema_inference_gate(
         location = ArchiveLocation.resolve(root)
         index_path = location.active_index_path
         schema_identity = _tier_schema_identity(root, location)
+        archive_receipt_identity = _archive_receipt_identity(location)
     except (OSError, ValueError, RuntimeError) as exc:
         schema_identity = {"error": str(exc), "tiers": {}}
         index_path = root / "index.db"
+        archive_receipt_identity = {"error": str(exc)}
 
     source_entry = _as_dict(_as_dict(schema_identity.get("tiers")).get("source"))
     source_schema_ok = bool(source_entry.get("matches_expected"))
@@ -1081,7 +1468,18 @@ def run_schema_inference_gate(
             "passed": False,
             "origins": {},
             "reasons": [f"ground truth reconciliation could not read source evidence: {exc}"],
+            "external_ground_truth_digest": None,
         }
+
+    try:
+        from polylogue.storage.index_generation import source_revision_snapshot
+
+        source_snapshot = source_revision_snapshot(root)
+    except (OSError, sqlite3.Error) as exc:
+        source_snapshot = None
+        reasons_for_snapshot = f"source revision snapshot could not be read: {exc}"
+    else:
+        reasons_for_snapshot = None
 
     gate_results = _as_dict(source_gates.get("gates"))
     duplicate_gate = source_gates.get("duplicate_gate", {})
@@ -1103,6 +1501,8 @@ def run_schema_inference_gate(
         ground_truth_reasons = ground_truth.get("reasons", [])
         if isinstance(ground_truth_reasons, list):
             reasons.extend(str(reason) for reason in ground_truth_reasons)
+    if source_snapshot is None:
+        reasons.append(reasons_for_snapshot or "source revision snapshot could not be computed")
 
     payload: dict[str, object] = {
         "schema": RECEIPT_SCHEMA,
@@ -1110,6 +1510,13 @@ def run_schema_inference_gate(
         "generated_at": datetime.now(UTC).isoformat(),
         "verdict": "PASS" if not reasons and passed_hard_gates else "FAIL",
         "archive_root": str(root),
+        "archive_identity": archive_receipt_identity,
+        "source_identity": {
+            "durable_id": archive_receipt_identity.get("durable_id"),
+            "source_tier": archive_receipt_identity.get("source_tier"),
+        },
+        "source_snapshot": source_snapshot,
+        "external_ground_truth_digest": ground_truth.get("external_ground_truth_digest"),
         "schema_identity": schema_identity,
         "source_schema_identity": source_entry,
         "query_results": gate_results,
@@ -1144,7 +1551,12 @@ __all__ = [
     "GROUND_TRUTH_INPUTS",
     "RECEIPT_FILENAME",
     "RECEIPT_SCHEMA",
+    "RECEIPT_CLOCK_SKEW",
+    "RECEIPT_TTL",
+    "SCHEMA_INFERENCE_RECEIPT_ENV",
     "SchemaInferenceGateError",
     "SchemaInferenceGateResult",
+    "resolve_schema_inference_receipt_reference",
     "run_schema_inference_gate",
+    "validate_schema_inference_receipt",
 ]

--- a/polylogue/maintenance/schema_inference_gate.py
+++ b/polylogue/maintenance/schema_inference_gate.py
@@ -648,7 +648,10 @@ def _canonical_external_ground_truth_digest(origins: Mapping[str, object]) -> st
             {
                 "origin": origin,
                 "roots": sorted(str(Path(root).expanduser().resolve()) for root in roots),
-                "files": sorted(files, key=lambda item: (int(item["root_index"]), str(item["relative_path"]))),
+                "files": sorted(
+                    files,
+                    key=lambda item: (int(cast(int, item["root_index"])), str(item["relative_path"])),
+                ),
                 "mapping": sorted(mappings, key=lambda item: str(item["raw_id"])),
             }
         )
@@ -1471,16 +1474,14 @@ def run_schema_inference_gate(
             "external_ground_truth_digest": None,
         }
 
+    source_snapshot: str | None = None
+    reasons_for_snapshot: str | None = None
     try:
         from polylogue.storage.index_generation import source_revision_snapshot
 
         source_snapshot = source_revision_snapshot(root)
     except (OSError, sqlite3.Error) as exc:
-        source_snapshot = None
         reasons_for_snapshot = f"source revision snapshot could not be read: {exc}"
-    else:
-        reasons_for_snapshot = None
-
     gate_results = _as_dict(source_gates.get("gates"))
     duplicate_gate = source_gates.get("duplicate_gate", {})
     if isinstance(duplicate_gate, dict):

--- a/polylogue/maintenance/schema_inference_gate.py
+++ b/polylogue/maintenance/schema_inference_gate.py
@@ -770,6 +770,18 @@ def _external_inventory(roots: Sequence[Path]) -> list[_ExternalGroundTruthFile]
     return inventory
 
 
+def _external_inventory_records(inventory: Sequence[_ExternalGroundTruthFile]) -> list[dict[str, object]]:
+    return [
+        {
+            "root_index": item.root_index,
+            "relative_path": item.relative_path,
+            "hash": item.content_hash,
+            "size": item.size,
+        }
+        for item in inventory
+    ]
+
+
 def _external_receipt(
     item: _ExternalGroundTruthFile,
     disposition: ExternalDisposition,
@@ -1081,15 +1093,7 @@ def _ground_truth_evidence(
                 "unmatched_external_files": unmatched_external_files[:DEFAULT_SAMPLE_LIMIT],
                 "cross_origin_mismatches": cross_origin_mismatches[:DEFAULT_SAMPLE_LIMIT],
                 "provenance": provenance,
-                "external_inventory": [
-                    {
-                        "root_index": item.root_index,
-                        "relative_path": item.relative_path,
-                        "hash": item.content_hash,
-                        "size": item.size,
-                    }
-                    for item in inventory
-                ],
+                "external_inventory": _external_inventory_records(inventory),
                 "raw_external_mapping": mapping,
                 "passed": not missing and not unmatched_mapping,
             }
@@ -1266,7 +1270,7 @@ def _current_external_ground_truth_digest(archive_root: Path, ground_truth: Mapp
             inventory = _external_inventory(resolved_roots)
             current[origin] = {
                 "declared_roots": [str(root) for root in resolved_roots],
-                "external_inventory": inventory,
+                "external_inventory": _external_inventory_records(inventory),
                 "raw_external_mapping": _raw_external_mapping(source, origin=origin, inventory=inventory, exempt=False),
             }
     return _canonical_external_ground_truth_digest(current)

--- a/polylogue/maintenance/sharded_rebuild.py
+++ b/polylogue/maintenance/sharded_rebuild.py
@@ -63,12 +63,13 @@ from typing import TYPE_CHECKING, cast
 from polylogue.config import Config
 from polylogue.logging import get_logger
 from polylogue.paths import render_root
+from polylogue.storage.index_generation import IndexGeneration
 from polylogue.storage.sqlite.connection_profile import BULK_BUILD_WRITE_CONNECTION_PRAGMA_STATEMENTS
 
 if TYPE_CHECKING:
     from polylogue.maintenance.rebuild_index import RebuildProvenanceContext
     from polylogue.sources.revision_backfill import RawParsePrefetchCache
-    from polylogue.storage.index_generation import IndexGeneration, IndexGenerationStore
+    from polylogue.storage.index_generation import IndexGenerationStore
 
 logger = get_logger(__name__)
 
@@ -460,6 +461,34 @@ def resolve_cross_shard_session_graph(
     return time.perf_counter() - started_at
 
 
+def _cleanup_shard_generations(
+    generation_store: IndexGenerationStore,
+    shard_generations: list[IndexGeneration],
+    provenance: RebuildProvenanceContext,
+) -> list[BaseException]:
+    """Attempt every shard cleanup and return failures without short-circuiting."""
+    errors: list[BaseException] = []
+    for shard_generation in shard_generations:
+        try:
+            provenance.validate_cleanup()
+            generation_store.discard_if_inactive(shard_generation)
+        except BaseException as exc:
+            cleanup_error = RuntimeError(f"{shard_generation.generation_id}: {exc}")
+            cleanup_error.__cause__ = exc
+            errors.append(cleanup_error)
+    return errors
+
+
+def _surface_shard_cleanup_failures(primary: BaseException | None, cleanup_errors: list[BaseException]) -> None:
+    """Preserve a primary failure while surfacing every cleanup failure."""
+    if not cleanup_errors:
+        return
+    detail = "; ".join(str(error) for error in cleanup_errors)
+    if primary is None:
+        raise RuntimeError(f"shard cleanup failed: {detail}") from cleanup_errors[0]
+    primary.add_note(f"shard cleanup also failed: {detail}")
+
+
 async def replay_selected_raw_ids_sharded(
     *,
     root: Path,
@@ -528,13 +557,10 @@ async def replay_selected_raw_ids_sharded(
     )
     failures = [result for result in build_results if isinstance(result, BaseException)]
     if failures:
-        for shard_generation in created_generations:
-            try:
-                provenance.validate()
-            except Exception:
-                provenance.validate_cleanup()
-            generation_store.discard_if_inactive(shard_generation)
-        raise failures[0]
+        primary = failures[0]
+        cleanup_errors = _cleanup_shard_generations(generation_store, created_generations, provenance)
+        _surface_shard_cleanup_failures(primary, cleanup_errors)
+        raise primary
     shard_generations = [cast(tuple[IndexGeneration, ShardBuildStats], result)[0] for result in build_results]
     shard_stats = [cast(tuple[IndexGeneration, ShardBuildStats], result)[1] for result in build_results]
     try:
@@ -544,13 +570,13 @@ async def replay_selected_raw_ids_sharded(
         )
         merge_s = time.perf_counter() - merge_started_at
         graph_resolve_s = resolve_cross_shard_session_graph(Path(generation.index_path), provenance=provenance)
-    finally:
-        for shard_generation in shard_generations:
-            try:
-                provenance.validate()
-            except Exception:
-                provenance.validate_cleanup()
-            generation_store.discard_if_inactive(shard_generation)
+    except BaseException as primary:
+        cleanup_errors = _cleanup_shard_generations(generation_store, shard_generations, provenance)
+        _surface_shard_cleanup_failures(primary, cleanup_errors)
+        raise
+    else:
+        cleanup_errors = _cleanup_shard_generations(generation_store, shard_generations, provenance)
+        _surface_shard_cleanup_failures(None, cleanup_errors)
     logger.info(
         "sharded_rebuild_merge_complete",
         generation_id=generation.generation_id,

--- a/polylogue/maintenance/sharded_rebuild.py
+++ b/polylogue/maintenance/sharded_rebuild.py
@@ -66,6 +66,7 @@ from polylogue.paths import render_root
 from polylogue.storage.sqlite.connection_profile import BULK_BUILD_WRITE_CONNECTION_PRAGMA_STATEMENTS
 
 if TYPE_CHECKING:
+    from polylogue.maintenance.rebuild_index import RebuildProvenanceContext
     from polylogue.sources.revision_backfill import RawParsePrefetchCache
     from polylogue.storage.index_generation import IndexGeneration, IndexGenerationStore
 
@@ -251,11 +252,16 @@ async def _build_one_shard(
     raw_ids: list[str],
     raw_batch_size: int,
     prefetch_cache: RawParsePrefetchCache | None,
+    provenance: RebuildProvenanceContext,
+    created_generations: list[IndexGeneration],
 ) -> tuple[IndexGeneration, ShardBuildStats]:
     """Replay one shard's raw ids into its own owned inactive generation."""
     from polylogue.maintenance.replay import rebuild_index_from_source as replay_source
 
+    provenance.validate()
     generation = generation_store.create(source_snapshot=source_snapshot)
+    created_generations.append(generation)
+    provenance.validate()
     generation_root = Path(generation.index_path).parent
     config = Config(
         archive_root=generation_root,
@@ -275,7 +281,9 @@ async def _build_one_shard(
         bulk_fts=True,
         bulk_build=True,
         prefetch_cache=prefetch_cache,
+        deadline_check=provenance.validate,
     )
+    provenance.validate()
     build_s = time.perf_counter() - started_at
     return generation, ShardBuildStats(
         generation_id=generation.generation_id,
@@ -325,7 +333,12 @@ def _non_generated_columns(conn: sqlite3.Connection, table: str) -> list[str]:
     return [str(row[1]) for row in conn.execute(f"PRAGMA table_xinfo({table})").fetchall() if int(row[6]) not in (2, 3)]
 
 
-def merge_shards_into_target(target_index_path: Path, shard_index_paths: list[Path]) -> dict[str, int]:
+def merge_shards_into_target(
+    target_index_path: Path,
+    shard_index_paths: list[Path],
+    *,
+    provenance: RebuildProvenanceContext,
+) -> dict[str, int]:
     """ATTACH every shard's ``index.db`` and fold its rows into the target.
 
     Returns per-table total row counts written (across all shards, before
@@ -339,6 +352,7 @@ def merge_shards_into_target(target_index_path: Path, shard_index_paths: list[Pa
 
     row_counts: dict[str, int] = dict.fromkeys(MERGE_TABLES, 0)
     aliases = [f"shard{i}" for i in range(len(shard_index_paths))]
+    provenance.validate()
     with contextlib.closing(_open_merge_connection(target_index_path, timeout=600)) as conn:
         conn.execute("PRAGMA busy_timeout = 600000")
         attached: list[str] = []
@@ -360,20 +374,25 @@ def merge_shards_into_target(target_index_path: Path, shard_index_paths: list[Pa
             # terminal `_repopulate_bulk_build_derived_state` stage), so that
             # stage's `resume_from_empty_message_index=True` precondition
             # holds for the sharded path too.
+            provenance.validate()
             conn.execute(
                 "INSERT OR IGNORE INTO derived_refresh_guard (guard_name) VALUES (?)", (FTS_BULK_SESSION_WRITE_GUARD,)
             )
             for alias, shard_path in zip(aliases, shard_index_paths, strict=True):
+                provenance.validate()
                 conn.execute(f"ATTACH DATABASE ? AS {alias}", (str(shard_path),))
                 attached.append(alias)
             for table in MERGE_TABLES:
                 columns = _non_generated_columns(conn, table)
                 column_list = ", ".join(columns)
                 for alias in aliases:
+                    provenance.validate()
                     cursor = conn.execute(
                         f"INSERT OR REPLACE INTO {table} ({column_list}) SELECT {column_list} FROM {alias}.{table}"
                     )
                     row_counts[table] += cursor.rowcount if cursor.rowcount > 0 else 0
+                    provenance.validate()
+            provenance.validate()
             conn.execute("DELETE FROM derived_refresh_guard WHERE guard_name = ?", (FTS_BULK_SESSION_WRITE_GUARD,))
             conn.commit()
             violations = conn.execute("PRAGMA foreign_key_check").fetchall()
@@ -391,7 +410,11 @@ def merge_shards_into_target(target_index_path: Path, shard_index_paths: list[Pa
     return row_counts
 
 
-def resolve_cross_shard_session_graph(target_index_path: Path) -> float:
+def resolve_cross_shard_session_graph(
+    target_index_path: Path,
+    *,
+    provenance: RebuildProvenanceContext,
+) -> float:
     """Re-run per-session graph resolution over every merged session.
 
     Each shard's own replay already resolved links whose OTHER endpoint
@@ -413,6 +436,7 @@ def resolve_cross_shard_session_graph(target_index_path: Path) -> float:
     """
     from polylogue.storage.sqlite.archive_tiers.write import _resolve_session_graph
 
+    provenance.validate()
     started_at = time.perf_counter()
     with contextlib.closing(_open_merge_connection(target_index_path, timeout=600)) as conn:
         conn.execute("PRAGMA busy_timeout = 600000")
@@ -420,6 +444,7 @@ def resolve_cross_shard_session_graph(target_index_path: Path) -> float:
         rows = conn.execute("SELECT session_id, native_id, origin FROM sessions ORDER BY session_id").fetchall()
         signature_cache: dict[str, list[tuple[str, str]]] = {}
         for session_id, native_id, origin in rows:
+            provenance.validate()
             _resolve_session_graph(
                 conn,
                 session_id,
@@ -430,6 +455,7 @@ def resolve_cross_shard_session_graph(target_index_path: Path) -> float:
                 bulk_fts=True,
                 bulk_build=True,
             )
+        provenance.validate()
         conn.commit()
     return time.perf_counter() - started_at
 
@@ -443,6 +469,7 @@ async def replay_selected_raw_ids_sharded(
     raw_batch_size: int,
     shard_count: int,
     prefetch_cache: RawParsePrefetchCache | None,
+    provenance: RebuildProvenanceContext,
 ) -> dict[str, object]:
     """Replay ``selected_raw_ids`` into ``generation`` via ``shard_count`` parallel shards.
 
@@ -483,6 +510,7 @@ async def replay_selected_raw_ids_sharded(
         shard_count=len(buckets),
         selected_raw_count=len(selected_raw_ids),
     )
+    created_generations: list[IndexGeneration] = []
     build_results = await asyncio.gather(
         *[
             _build_one_shard(
@@ -491,23 +519,38 @@ async def replay_selected_raw_ids_sharded(
                 raw_ids=bucket,
                 raw_batch_size=raw_batch_size,
                 prefetch_cache=prefetch_cache,
+                provenance=provenance,
+                created_generations=created_generations,
             )
             for bucket in buckets
-        ]
+        ],
+        return_exceptions=True,
     )
-    shard_generations = [pair[0] for pair in build_results]
-    shard_stats = [pair[1] for pair in build_results]
+    failures = [result for result in build_results if isinstance(result, BaseException)]
+    if failures:
+        for shard_generation in created_generations:
+            try:
+                provenance.validate()
+            except Exception:
+                provenance.validate_cleanup()
+            generation_store.discard_if_inactive(shard_generation)
+        raise failures[0]
+    shard_generations = [cast(tuple[IndexGeneration, ShardBuildStats], result)[0] for result in build_results]
+    shard_stats = [cast(tuple[IndexGeneration, ShardBuildStats], result)[1] for result in build_results]
     try:
         merge_started_at = time.perf_counter()
         row_counts = merge_shards_into_target(
-            Path(generation.index_path), [Path(sg.index_path) for sg in shard_generations]
+            Path(generation.index_path), [Path(sg.index_path) for sg in shard_generations], provenance=provenance
         )
         merge_s = time.perf_counter() - merge_started_at
-        graph_resolve_s = resolve_cross_shard_session_graph(Path(generation.index_path))
+        graph_resolve_s = resolve_cross_shard_session_graph(Path(generation.index_path), provenance=provenance)
     finally:
         for shard_generation in shard_generations:
-            with contextlib.suppress(Exception):
-                generation_store.discard_if_inactive(shard_generation)
+            try:
+                provenance.validate()
+            except Exception:
+                provenance.validate_cleanup()
+            generation_store.discard_if_inactive(shard_generation)
     logger.info(
         "sharded_rebuild_merge_complete",
         generation_id=generation.generation_id,

--- a/tests/benchmarks/test_rebuild_cost_model.py
+++ b/tests/benchmarks/test_rebuild_cost_model.py
@@ -41,6 +41,7 @@ from tests.infra.rebuild_cost_model import (
     run_cost_model,
     stage_proportions,
 )
+from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
 
 
 def test_default_sample_n_scales_inversely_with_size() -> None:
@@ -89,8 +90,16 @@ def test_structural_corpus_exercises_cohort_arbitration(tmp_path: Path) -> None:
     prior = os.environ.get("POLYLOGUE_ARCHIVE_ROOT")
     os.environ["POLYLOGUE_ARCHIVE_ROOT"] = str(archive_root)
     try:
+        receipt_path = write_valid_rebuild_receipt(
+            archive_root, archive_root.parent / "schema-inference-gate-receipt.json"
+        )
         receipt = rebuild_index_from_source_sync(
-            RebuildIndexRequest(archive_root=archive_root, promote=True, raw_batch_size=12)
+            RebuildIndexRequest(
+                archive_root=archive_root,
+                promote=True,
+                raw_batch_size=12,
+                schema_inference_receipt_path=receipt_path,
+            )
         )
     finally:
         if prior is None:

--- a/tests/benchmarks/test_sharded_rebuild.py
+++ b/tests/benchmarks/test_sharded_rebuild.py
@@ -45,6 +45,7 @@ import pytest
 from polylogue.core.enums import Provider
 from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
 from tests.infra.rebuild_cost_model import Stratum, build_stratum_sample_corpus
+from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
 
 #: The bead's named correctness surface, in composite-primary-key order so a
 #: row-for-row comparison is well-defined without depending on SQLite's
@@ -140,6 +141,9 @@ def _build_corpus(tmp_path: Path, *, sample_n: int) -> Path:
 
 def _rebuild(archive_root: Path, *, shard_count: int, raw_batch_size: int) -> float:
     with _archive_root_env(archive_root):
+        receipt_path = write_valid_rebuild_receipt(
+            archive_root, archive_root.parent / "schema-inference-gate-receipt.json"
+        )
         started_at = time.perf_counter()
         receipt = rebuild_index_from_source_sync(
             RebuildIndexRequest(
@@ -147,6 +151,7 @@ def _rebuild(archive_root: Path, *, shard_count: int, raw_batch_size: int) -> fl
                 promote=True,
                 raw_batch_size=raw_batch_size,
                 shard_count=shard_count,
+                schema_inference_receipt_path=receipt_path,
             )
         )
         elapsed_s = time.perf_counter() - started_at

--- a/tests/infra/rebuild_cost_model.py
+++ b/tests/infra/rebuild_cost_model.py
@@ -53,6 +53,7 @@ from polylogue.core.enums import Provider
 from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
 
 # ---------------------------------------------------------------------------
 # Population strata
@@ -788,9 +789,17 @@ def _run_one_rebuild_pass(
     prior_env = os.environ.get("POLYLOGUE_ARCHIVE_ROOT")
     os.environ["POLYLOGUE_ARCHIVE_ROOT"] = str(archive_root)
     try:
+        receipt_path = write_valid_rebuild_receipt(
+            archive_root, archive_root.parent / "schema-inference-gate-receipt.json"
+        )
         started = time.perf_counter()
         receipt = rebuild_index_from_source_sync(
-            RebuildIndexRequest(archive_root=archive_root, promote=True, raw_batch_size=max(n, 1))
+            RebuildIndexRequest(
+                archive_root=archive_root,
+                promote=True,
+                raw_batch_size=max(n, 1),
+                schema_inference_receipt_path=receipt_path,
+            )
         )
         wall_s = time.perf_counter() - started
     finally:

--- a/tests/infra/rebuild_receipt.py
+++ b/tests/infra/rebuild_receipt.py
@@ -48,11 +48,20 @@ def write_valid_rebuild_receipt(
             for raw_id, blob_hash in raw_rows:
                 (external_root / f"{raw_id}.bin").write_bytes(BlobStore(root / "blob").read_all(bytes(blob_hash).hex()))
             inventory = gate._external_inventory((external_root,))
+            inventory_records = [
+                {
+                    "root_index": item.root_index,
+                    "relative_path": item.relative_path,
+                    "hash": item.content_hash,
+                    "size": item.size,
+                }
+                for item in inventory
+            ]
             mapping = gate._raw_external_mapping(source, origin=origin, inventory=inventory, exempt=False)
             ground_truth_origins[origin] = {
                 "exempt": False,
                 "declared_roots": [str(external_root)],
-                "external_inventory": inventory,
+                "external_inventory": inventory_records,
                 "raw_external_mapping": mapping,
                 "passed": all(item["disposition"] == "matched-external" for item in mapping),
             }

--- a/tests/infra/rebuild_receipt.py
+++ b/tests/infra/rebuild_receipt.py
@@ -1,0 +1,100 @@
+"""Targeted schema-inference receipts for real rebuild-route tests."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import cast
+
+from polylogue.maintenance import schema_inference_gate as gate
+from polylogue.storage.archive_identity import ArchiveIdentity, ArchiveLocation
+from polylogue.storage.blob_store import BlobStore
+from polylogue.storage.index_generation import source_revision_snapshot
+from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+
+def write_valid_rebuild_receipt(
+    archive_root: Path,
+    receipt_path: Path,
+    *,
+    generated_at: datetime | None = None,
+) -> Path:
+    """Write a minimally complete, identity-bound PASS for a test archive."""
+
+    root = archive_root.absolute()
+    location = ArchiveLocation.resolve(root)
+    identity = ArchiveIdentity.resolve_location(location)
+    with sqlite3.connect(root / "source.db") as source:
+        origins = {str(row[0]) for row in source.execute("SELECT DISTINCT origin FROM raw_sessions ORDER BY origin")}
+        ground_truth_origins: dict[str, object] = {}
+        for origin in sorted(origins):
+            declared = gate.GROUND_TRUTH_INPUTS.get(origin, {"exempt": False})
+            if bool(declared.get("exempt")):
+                ground_truth_origins[origin] = {
+                    "exempt": True,
+                    "reason": declared.get("reason"),
+                    "raw_external_mapping": gate._raw_external_mapping(
+                        source, origin=origin, inventory=(), exempt=True
+                    ),
+                }
+                continue
+            external_root = root.parent / f"{root.name}-{origin}-ground-truth"
+            external_root.mkdir(parents=True, exist_ok=True)
+            raw_rows = source.execute(
+                "SELECT raw_id, blob_hash FROM raw_sessions WHERE origin = ? ORDER BY raw_id", (origin,)
+            ).fetchall()
+            for raw_id, blob_hash in raw_rows:
+                (external_root / f"{raw_id}.bin").write_bytes(BlobStore(root / "blob").read_all(bytes(blob_hash).hex()))
+            inventory = gate._external_inventory((external_root,))
+            mapping = gate._raw_external_mapping(source, origin=origin, inventory=inventory, exempt=False)
+            ground_truth_origins[origin] = {
+                "exempt": False,
+                "declared_roots": [str(external_root)],
+                "external_inventory": inventory,
+                "raw_external_mapping": mapping,
+                "passed": all(item["disposition"] == "matched-external" for item in mapping),
+            }
+
+    ground_truth = {
+        "passed": True,
+        "origins": ground_truth_origins,
+    }
+    digest = gate._canonical_external_ground_truth_digest(cast(dict[str, object], ground_truth_origins))
+    ground_truth["external_ground_truth_digest"] = digest
+    query_results = {
+        gate_id: {"gate": gate_id, "passed": True, "count": 0}
+        for gate_id in (*gate._HARD_GATE_SQL, "zero-unexplained-byte-duplicates")
+    }
+    source_entry = {
+        "expected_user_version": ARCHIVE_TIER_SPECS[ArchiveTier.SOURCE].version,
+        "actual_user_version": ARCHIVE_TIER_SPECS[ArchiveTier.SOURCE].version,
+        "matches_expected": True,
+    }
+    payload: dict[str, object] = {
+        "schema": gate.RECEIPT_SCHEMA,
+        "gate_version": gate.GATE_VERSION,
+        "generated_at": (generated_at or datetime.now(UTC)).astimezone(UTC).isoformat(),
+        "verdict": "PASS",
+        "archive_root": str(root),
+        "archive_identity": gate._archive_receipt_identity(location),
+        "source_identity": {
+            "durable_id": identity.durable_id,
+            "source_tier": identity.tier("source").as_dict(),
+        },
+        "source_snapshot": source_revision_snapshot(root),
+        "external_ground_truth_digest": digest,
+        "source_schema_identity": source_entry,
+        "query_results": query_results,
+        "ground_truth_inputs": ground_truth,
+        "corpus_fidelity": {"passed": True},
+        "full_blob_hash_verification": {"passed": True},
+    }
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    receipt_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return receipt_path
+
+
+__all__ = ["write_valid_rebuild_receipt"]

--- a/tests/infra/rebuild_receipt.py
+++ b/tests/infra/rebuild_receipt.py
@@ -6,7 +6,6 @@ import json
 import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import cast
 
 from polylogue.maintenance import schema_inference_gate as gate
 from polylogue.storage.archive_identity import ArchiveIdentity, ArchiveLocation
@@ -62,7 +61,7 @@ def write_valid_rebuild_receipt(
         "passed": True,
         "origins": ground_truth_origins,
     }
-    digest = gate._canonical_external_ground_truth_digest(cast(dict[str, object], ground_truth_origins))
+    digest = gate._canonical_external_ground_truth_digest(ground_truth_origins)
     ground_truth["external_ground_truth_digest"] = digest
     query_results = {
         gate_id: {"gate": gate_id, "passed": True, "count": 0}

--- a/tests/infra/rebuild_receipt.py
+++ b/tests/infra/rebuild_receipt.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from polylogue.maintenance import schema_inference_gate as gate
 from polylogue.storage.archive_identity import ArchiveIdentity, ArchiveLocation
 from polylogue.storage.blob_store import BlobStore
-from polylogue.storage.index_generation import source_revision_snapshot
 from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 
@@ -92,7 +91,7 @@ def write_valid_rebuild_receipt(
             "durable_id": identity.durable_id,
             "source_tier": identity.tier("source").as_dict(),
         },
-        "source_snapshot": source_revision_snapshot(root),
+        "source_snapshot": gate.rebuild_source_revision_snapshot(root),
         "external_ground_truth_digest": digest,
         "source_schema_identity": source_entry,
         "query_results": query_results,

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -34,6 +34,7 @@ from polylogue.storage.sqlite.archive_tiers.source_write import write_source_raw
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.user import USER_SCHEMA_VERSION
 from polylogue.storage.sqlite.archive_tiers.user_write import AssertionKind, upsert_assertion
+from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
 
 _ARCHIVE_TIERS = tuple(spec.filename for spec in ARCHIVE_TIER_SPECS.values())
 
@@ -1944,6 +1945,10 @@ def test_rebuild_index_source_replay_expands_every_execution_selection_to_author
     monkeypatch: pytest.MonkeyPatch,
     selection_args: list[str],
 ) -> None:
+    receipt_path = write_valid_rebuild_receipt(
+        cli_workspace["archive_root"], cli_workspace["archive_root"].parent / "schema-inference-gate-receipt.json"
+    )
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_INFERENCE_RECEIPT", str(receipt_path))
     monkeypatch.setattr("polylogue.maintenance.rebuild_index.count_source_raw_sessions", lambda _root: 4)
     monkeypatch.setattr(
         "polylogue.maintenance.rebuild_index.all_index_rebuild_raw_ids",
@@ -1989,6 +1994,9 @@ def test_rebuild_index_daemon_path_posts_the_real_selection_request(
     cli_workspace: dict[str, Path], cli_runner: CliRunner, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     captured: dict[str, object] = {}
+    receipt_path = write_valid_rebuild_receipt(
+        cli_workspace["archive_root"], cli_workspace["archive_root"].parent / "schema-inference-gate-receipt.json"
+    )
 
     class Response:
         def read(self) -> bytes:
@@ -2024,6 +2032,8 @@ def test_rebuild_index_daemon_path_posts_the_real_selection_request(
             "--daemon",
             "--daemon-url",
             "http://127.0.0.1:9876",
+            "--schema-inference-receipt",
+            str(receipt_path),
             "--raw-batch-size",
             "17",
             "--pass-byte-budget-mb",
@@ -2043,6 +2053,7 @@ def test_rebuild_index_daemon_path_posts_the_real_selection_request(
             "max_blob_mb": None,
             "promote": True,
             "operation_id": None,
+            "schema_inference_receipt_path": str(receipt_path),
             "raw_batch_size": 17,
             "pass_byte_budget_mb": 12.5,
             "pass_deadline_seconds": 45.0,
@@ -2100,7 +2111,7 @@ def test_all_index_rebuild_raw_ids_uses_source_acquisition_order(
 
 
 def test_rebuild_index_full_source_resumes_one_candidate_until_terminal_promotion(
-    cli_workspace: dict[str, Path], cli_runner: CliRunner
+    cli_workspace: dict[str, Path], cli_runner: CliRunner, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A bounded pass retains its generation; only the terminal resume promotes it."""
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -2118,6 +2129,8 @@ def test_rebuild_index_full_source_resumes_one_candidate_until_terminal_promotio
                 source_path=f"{native_id}.jsonl",
                 acquired_at_ms=acquired_at_ms,
             )
+    receipt_path = write_valid_rebuild_receipt(root, root.parent / "schema-inference-gate-receipt.json")
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_INFERENCE_RECEIPT", str(receipt_path))
 
     first = cli_runner.invoke(
         cli,
@@ -2171,7 +2184,7 @@ def test_rebuild_index_full_source_resumes_one_candidate_until_terminal_promotio
 
 
 def test_rebuild_index_persists_durable_pass_receipt_alongside_transaction(
-    cli_workspace: dict[str, Path], cli_runner: CliRunner
+    cli_workspace: dict[str, Path], cli_runner: CliRunner, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Every rebuild pass receipt survives on disk, not only on the CLI's stdout.
 
@@ -2196,6 +2209,8 @@ def test_rebuild_index_persists_durable_pass_receipt_alongside_transaction(
                 source_path=f"{native_id}.jsonl",
                 acquired_at_ms=acquired_at_ms,
             )
+    receipt_path = write_valid_rebuild_receipt(root, root.parent / "schema-inference-gate-receipt.json")
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_INFERENCE_RECEIPT", str(receipt_path))
 
     first = cli_runner.invoke(
         cli,
@@ -2249,7 +2264,7 @@ def test_rebuild_index_persists_durable_pass_receipt_alongside_transaction(
 
 
 def test_rebuild_index_byte_budget_defers_then_reaches_terminal_ready_candidate(
-    cli_workspace: dict[str, Path], cli_runner: CliRunner
+    cli_workspace: dict[str, Path], cli_runner: CliRunner, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The real CLI replays every raw over passes; byte budgeting never filters archive data."""
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -2267,6 +2282,8 @@ def test_rebuild_index_byte_budget_defers_then_reaches_terminal_ready_candidate(
                 source_path=f"{native_id}.jsonl",
                 acquired_at_ms=acquired_at_ms,
             )
+    receipt_path = write_valid_rebuild_receipt(root, root.parent / "schema-inference-gate-receipt.json")
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_INFERENCE_RECEIPT", str(receipt_path))
     first = cli_runner.invoke(
         cli,
         [
@@ -2336,6 +2353,11 @@ def test_rebuild_index_source_snapshot_drift_marks_candidate_stale_before_promot
             source_path="drift.jsonl",
             acquired_at_ms=1,
         )
+    receipt_path = write_valid_rebuild_receipt(root, root.parent / "schema-inference-gate-receipt.json")
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_INFERENCE_RECEIPT", str(receipt_path))
+    receipt_payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+    receipt_payload["source_snapshot"] = "source-v1"
+    receipt_path.write_text(json.dumps(receipt_payload), encoding="utf-8")
     snapshots = iter(("source-v1", "source-v1", "source-v2"))
     monkeypatch.setattr("polylogue.storage.index_generation.source_revision_snapshot", lambda _root: next(snapshots))
     result = cli_runner.invoke(
@@ -2368,6 +2390,8 @@ def test_rebuild_index_deadline_defers_postflight_until_resume(
             source_path="deadline.jsonl",
             acquired_at_ms=1,
         )
+    receipt_path = write_valid_rebuild_receipt(root, root.parent / "schema-inference-gate-receipt.json")
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_INFERENCE_RECEIPT", str(receipt_path))
     # `monkeypatch.setattr("polylogue.maintenance.rebuild_index.time.time", ...)`
     # patches the *stdlib* `time` module's `time` attribute (modules are
     # process-wide singletons), not a private copy scoped to rebuild_index.py.

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -2359,7 +2359,10 @@ def test_rebuild_index_source_snapshot_drift_marks_candidate_stale_before_promot
     receipt_payload["source_snapshot"] = "source-v1"
     receipt_path.write_text(json.dumps(receipt_payload), encoding="utf-8")
     snapshots = iter(("source-v1", "source-v1", "source-v2"))
-    monkeypatch.setattr("polylogue.storage.index_generation.source_revision_snapshot", lambda _root: next(snapshots))
+    monkeypatch.setattr(
+        "polylogue.maintenance.schema_inference_gate.rebuild_source_revision_snapshot",
+        lambda _root: next(snapshots),
+    )
     result = cli_runner.invoke(
         cli,
         ["--plain", "ops", "maintenance", "rebuild-index", "--output-format", "json"],

--- a/tests/unit/daemon/test_bulk_rebuild.py
+++ b/tests/unit/daemon/test_bulk_rebuild.py
@@ -50,6 +50,7 @@ from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_ind
 from polylogue.storage.index_generation import IndexGenerationStore, source_revision_snapshot
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
 
 _RAW_COUNT = 6
 
@@ -171,17 +172,18 @@ def test_resolve_or_start_creates_resumes_and_retires_transaction(
 ) -> None:
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path))
     _seed_corpus(tmp_path, count=2)
+    receipt_path = write_valid_rebuild_receipt(tmp_path, tmp_path / "receipt.json")
     store = IndexGenerationStore.for_archive_root(tmp_path)
 
     assert has_resumable_daemon_bulk_rebuild_transaction(tmp_path) is False
-    first = resolve_or_start_daemon_bulk_rebuild_transaction(tmp_path)
+    first = resolve_or_start_daemon_bulk_rebuild_transaction(tmp_path, schema_inference_receipt_path=receipt_path)
     assert first.operation_id == DAEMON_BULK_REBUILD_OPERATION_ID
     assert first.status == "running"
     assert has_resumable_daemon_bulk_rebuild_transaction(tmp_path) is True
 
     # A second resolve against an unchanged, still-resumable transaction
     # returns the SAME record -- no new generation, no lost cursor.
-    again = resolve_or_start_daemon_bulk_rebuild_transaction(tmp_path)
+    again = resolve_or_start_daemon_bulk_rebuild_transaction(tmp_path, schema_inference_receipt_path=receipt_path)
     assert again.generation_id == first.generation_id
     assert again.operation_id == first.operation_id
 
@@ -190,7 +192,7 @@ def test_resolve_or_start_creates_resumes_and_retires_transaction(
     # transaction/generation rather than colliding with the retired one.
     store.checkpoint_transaction(first, status="promoted")
     assert has_resumable_daemon_bulk_rebuild_transaction(tmp_path) is False
-    restarted = resolve_or_start_daemon_bulk_rebuild_transaction(tmp_path)
+    restarted = resolve_or_start_daemon_bulk_rebuild_transaction(tmp_path, schema_inference_receipt_path=receipt_path)
     assert restarted.operation_id == DAEMON_BULK_REBUILD_OPERATION_ID
     assert restarted.status == "running"
     assert restarted.generation_id != first.generation_id
@@ -210,6 +212,8 @@ def test_daemon_bulk_rebuild_pass_resumes_without_reprocessing_raw_ids(
     """
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path))
     _seed_corpus(tmp_path)
+    receipt_path = write_valid_rebuild_receipt(tmp_path, tmp_path / "receipt.json")
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_INFERENCE_RECEIPT", str(receipt_path))
     receipts = asyncio.run(_drive_daemon_bulk_rebuild_to_promotion(tmp_path, batch_size=2))
 
     assert len(receipts) >= 3  # 6 raws / batch 2 => at least 3 passes before promotion finalizes
@@ -237,8 +241,9 @@ def test_daemon_bulk_rebuild_pass_resumes_without_reprocessing_raw_ids(
 def test_daemon_bulk_rebuild_pass_next_page_excludes_already_scheduled_raws(tmp_path: Path) -> None:
     """Direct proof that a later page never reselects an earlier page's raws."""
     _seed_corpus(tmp_path)
+    receipt_path = write_valid_rebuild_receipt(tmp_path, tmp_path / "receipt.json")
     store = IndexGenerationStore.for_archive_root(tmp_path)
-    transaction = resolve_or_start_daemon_bulk_rebuild_transaction(tmp_path)
+    transaction = resolve_or_start_daemon_bulk_rebuild_transaction(tmp_path, schema_inference_receipt_path=receipt_path)
 
     first_page = store.next_raw_page(transaction, limit=2)
     first_raw_ids = {raw_id for raw_id, _blob_hash_hex, _size in first_page.rows}
@@ -267,6 +272,12 @@ def test_daemon_bulk_rebuild_equivalent_to_cli_rebuild(tmp_path: Path, monkeypat
     daemon_root = tmp_path / "daemon"
     _seed_corpus(cli_root)
     _seed_corpus(daemon_root)
+    cli_receipt_path = write_valid_rebuild_receipt(
+        cli_root, tmp_path / "cli-receipt" / "schema-inference-gate-receipt.json"
+    )
+    daemon_receipt_path = write_valid_rebuild_receipt(
+        daemon_root, tmp_path / "daemon-receipt" / "schema-inference-gate-receipt.json"
+    )
     assert source_revision_snapshot(cli_root) == source_revision_snapshot(daemon_root)
 
     # ArchiveStore.open_owned_inactive_generation validates generation
@@ -276,12 +287,15 @@ def test_daemon_bulk_rebuild_equivalent_to_cli_rebuild(tmp_path: Path, monkeypat
     # the daemon route share this same invariant in production (a real
     # daemon process only ever has one configured root at a time).
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(cli_root))
-    cli_receipt = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=cli_root, promote=True))
+    cli_receipt = rebuild_index_from_source_sync(
+        RebuildIndexRequest(archive_root=cli_root, promote=True, schema_inference_receipt_path=cli_receipt_path)
+    )
     assert cli_receipt.status == "replayed"
     assert cli_receipt.transaction is not None
     assert cli_receipt.transaction["status"] == "promoted"
 
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(daemon_root))
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_INFERENCE_RECEIPT", str(daemon_receipt_path))
     asyncio.run(_drive_daemon_bulk_rebuild_to_promotion(daemon_root, batch_size=2))
 
     cli_snapshot = _canonical_snapshot(cli_root / "index.db")

--- a/tests/unit/daemon/test_bulk_rebuild.py
+++ b/tests/unit/daemon/test_bulk_rebuild.py
@@ -31,6 +31,7 @@ Two claims this file proves:
 from __future__ import annotations
 
 import asyncio
+import json
 import sqlite3
 from pathlib import Path
 from typing import Any
@@ -47,7 +48,7 @@ from polylogue.daemon.bulk_rebuild import (
 )
 from polylogue.daemon.parse_prefetch import DaemonParseStage
 from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
-from polylogue.storage.index_generation import IndexGenerationStore, source_revision_snapshot
+from polylogue.storage.index_generation import IndexGeneration, IndexGenerationStore, source_revision_snapshot
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
 from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
@@ -198,6 +199,82 @@ def test_resolve_or_start_creates_resumes_and_retires_transaction(
     assert restarted.generation_id != first.generation_id
     assert restarted.last_raw_id is None
     assert restarted.processed_raw_count == 0
+
+
+def test_resumability_probe_is_pure_for_an_invalid_pointer(tmp_path: Path) -> None:
+    """A poisoned pointer cannot trigger lock acquisition, repair, or bootstrap."""
+    pointer = tmp_path / ".index-active-pointer"
+    poisoned_target = tmp_path / ".index-generations" / "gen-poison" / "index.db"
+    poisoned_target.parent.mkdir(parents=True)
+    poisoned_target.write_bytes(b"poison")
+    pointer.write_text(f"{poisoned_target}\n", encoding="utf-8")
+    before = pointer.read_bytes()
+
+    assert has_resumable_daemon_bulk_rebuild_transaction(tmp_path) is False
+    assert pointer.read_bytes() == before
+    assert not (tmp_path / ".archive-ownership.lock").exists()
+    assert [path.name for path in (tmp_path / ".index-generations").iterdir()] == ["gen-poison"]
+    assert not (tmp_path / ".index-rebuild-transactions").exists()
+
+
+def test_transaction_creation_cleans_candidate_when_receipt_expires_after_create(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A post-create receipt failure cannot strand a daemon candidate or cursor."""
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path))
+    _seed_corpus(tmp_path, count=1)
+    receipt_path = write_valid_rebuild_receipt(tmp_path, tmp_path / "receipt.json")
+    original_create = IndexGenerationStore.create
+
+    def expire_after_create(
+        store: IndexGenerationStore, *, owner_id: str | None = None, source_snapshot: str
+    ) -> IndexGeneration:
+        generation = original_create(store, owner_id=owner_id, source_snapshot=source_snapshot)
+        payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+        payload["generated_at"] = "2000-01-01T00:00:00Z"
+        receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+        return generation
+
+    monkeypatch.setattr(IndexGenerationStore, "create", expire_after_create)
+
+    with pytest.raises(RuntimeError, match="schema-inference preflight gate failed"):
+        resolve_or_start_daemon_bulk_rebuild_transaction(tmp_path, schema_inference_receipt_path=receipt_path)
+
+    assert not has_resumable_daemon_bulk_rebuild_transaction(tmp_path)
+    generations_root = tmp_path / ".index-generations"
+    if generations_root.exists():
+        assert not list(generations_root.glob("gen-*"))
+    assert not (tmp_path / ".index-rebuild-transactions" / f"{DAEMON_BULK_REBUILD_OPERATION_ID}.json").exists()
+
+
+def test_route_probe_rejects_expired_receipt_without_calling_stateful_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The daemon route validates evidence before asking the pure transaction probe."""
+    from polylogue.daemon import cli as daemon_cli
+
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path))
+    _seed_corpus(tmp_path, count=1)
+    receipt_path = write_valid_rebuild_receipt(tmp_path, tmp_path / "receipt.json")
+    payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+    payload["generated_at"] = "2000-01-01T00:00:00Z"
+    receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_INFERENCE_RECEIPT", str(receipt_path))
+    pointer = tmp_path / ".index-active-pointer"
+    pointer_before = pointer.read_bytes() if pointer.exists() else None
+    lock = tmp_path / ".archive-ownership.lock"
+    lock_before = lock.read_bytes() if lock.exists() else None
+
+    def fail_stateful_probe(_root: Path) -> bool:
+        pytest.fail("expired evidence must stop route probing before transaction inspection")
+
+    monkeypatch.setattr(
+        "polylogue.daemon.bulk_rebuild.has_resumable_daemon_bulk_rebuild_transaction", fail_stateful_probe
+    )
+
+    assert asyncio.run(daemon_cli._daemon_bulk_rebuild_transaction_in_flight()) is False
+    assert (pointer.read_bytes() if pointer.exists() else None) == pointer_before
+    assert (lock.read_bytes() if lock.exists() else None) == lock_before
 
 
 def test_daemon_bulk_rebuild_pass_resumes_without_reprocessing_raw_ids(

--- a/tests/unit/daemon/test_bulk_rebuild_ownership.py
+++ b/tests/unit/daemon/test_bulk_rebuild_ownership.py
@@ -15,12 +15,15 @@ could race the daemon's own bulk-rebuild bookkeeping undetected.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 
 from polylogue.daemon.bulk_rebuild import resolve_or_start_daemon_bulk_rebuild_transaction
+from polylogue.maintenance.schema_inference_gate import rebuild_source_revision_snapshot
 from polylogue.storage.archive_identity import ArchiveLocation, ArchiveOwnershipError, OwnedArchiveLocation
+from polylogue.storage.index_generation import IndexGenerationStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
@@ -29,6 +32,24 @@ from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
 def _init_empty_source(root: Path) -> None:
     root.mkdir(parents=True, exist_ok=True)
     initialize_archive_database(root / "source.db", ArchiveTier.SOURCE)
+
+
+def _interpose_receipt_mutation(monkeypatch: pytest.MonkeyPatch, receipt_path: Path, *, expire: bool) -> None:
+    original_acquire = OwnedArchiveLocation.acquire
+
+    def acquire_after_mutation(
+        cls: type[OwnedArchiveLocation], /, location: object, **kwargs: object
+    ) -> OwnedArchiveLocation:
+        owned = original_acquire(location, **kwargs)  # type: ignore[arg-type]
+        payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+        if expire:
+            payload["generated_at"] = "2000-01-01T00:00:00Z"
+        else:
+            payload["source_snapshot"] = "post-preflight-source-drift"
+        receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+        return owned
+
+    monkeypatch.setattr(OwnedArchiveLocation, "acquire", classmethod(acquire_after_mutation))
 
 
 def test_daemon_bulk_rebuild_refuses_when_archive_location_already_owned(tmp_path: Path) -> None:
@@ -55,6 +76,46 @@ def test_daemon_bulk_rebuild_refuses_when_archive_location_already_owned(tmp_pat
     # Releasing the concurrent holder's ownership lets the daemon proceed.
     transaction = resolve_or_start_daemon_bulk_rebuild_transaction(root, schema_inference_receipt_path=receipt_path)
     assert transaction.status == "running"
+
+
+@pytest.mark.parametrize("expire", [False, True], ids=["external-drift", "receipt-expiry"])
+def test_daemon_post_preflight_receipt_change_fails_before_candidate_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, expire: bool
+) -> None:
+    root = tmp_path / "archive"
+    _init_empty_source(root)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    _interpose_receipt_mutation(monkeypatch, receipt_path, expire=expire)
+
+    with pytest.raises(RuntimeError, match="daemon bulk rebuild schema-inference preflight gate failed"):
+        resolve_or_start_daemon_bulk_rebuild_transaction(root, schema_inference_receipt_path=receipt_path)
+
+    assert not (root / ".index-generations").exists()
+    assert not (root / ".index-rebuild-transactions").exists()
+
+
+def test_daemon_post_preflight_receipt_change_does_not_retire_terminal_candidate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "archive"
+    _init_empty_source(root)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    store = IndexGenerationStore.for_archive_root(root)
+    transaction = store.create_transaction(
+        source_snapshot=rebuild_source_revision_snapshot(root),
+        operation_id="daemon-bulk-rebuild",
+    )
+    store.checkpoint_transaction(transaction, status="failed")
+    generation_id = transaction.generation_id
+    _interpose_receipt_mutation(monkeypatch, receipt_path, expire=False)
+
+    with pytest.raises(RuntimeError, match="daemon bulk rebuild schema-inference preflight gate failed"):
+        resolve_or_start_daemon_bulk_rebuild_transaction(root, schema_inference_receipt_path=receipt_path)
+
+    retained_transaction = store.load_transaction("daemon-bulk-rebuild")
+    assert retained_transaction.status == "failed"
+    assert retained_transaction.generation_id == generation_id
+    assert store.load(generation_id).state == "inactive"
 
 
 def test_daemon_bulk_rebuild_releases_ownership_lock_after_resolving(tmp_path: Path) -> None:

--- a/tests/unit/daemon/test_bulk_rebuild_ownership.py
+++ b/tests/unit/daemon/test_bulk_rebuild_ownership.py
@@ -23,6 +23,7 @@ from polylogue.daemon.bulk_rebuild import resolve_or_start_daemon_bulk_rebuild_t
 from polylogue.storage.archive_identity import ArchiveLocation, ArchiveOwnershipError, OwnedArchiveLocation
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
 
 
 def _init_empty_source(root: Path) -> None:
@@ -39,11 +40,12 @@ def test_daemon_bulk_rebuild_refuses_when_archive_location_already_owned(tmp_pat
     """
     root = tmp_path / "archive"
     _init_empty_source(root)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
     location = ArchiveLocation.resolve(root)
     owned = OwnedArchiveLocation.acquire(location, owner_id="concurrent-campaign")
     try:
         with pytest.raises(ArchiveOwnershipError):
-            resolve_or_start_daemon_bulk_rebuild_transaction(root)
+            resolve_or_start_daemon_bulk_rebuild_transaction(root, schema_inference_receipt_path=receipt_path)
         # Failure happened before any generation/transaction bookkeeping was created.
         assert not (root / ".index-generations").exists()
         assert not (root / ".index-rebuild-transactions").exists()
@@ -51,7 +53,7 @@ def test_daemon_bulk_rebuild_refuses_when_archive_location_already_owned(tmp_pat
         owned.release()
 
     # Releasing the concurrent holder's ownership lets the daemon proceed.
-    transaction = resolve_or_start_daemon_bulk_rebuild_transaction(root)
+    transaction = resolve_or_start_daemon_bulk_rebuild_transaction(root, schema_inference_receipt_path=receipt_path)
     assert transaction.status == "running"
 
 
@@ -62,8 +64,9 @@ def test_daemon_bulk_rebuild_releases_ownership_lock_after_resolving(tmp_path: P
     """
     root = tmp_path / "archive"
     _init_empty_source(root)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
 
-    resolve_or_start_daemon_bulk_rebuild_transaction(root)
+    resolve_or_start_daemon_bulk_rebuild_transaction(root, schema_inference_receipt_path=receipt_path)
 
     location = ArchiveLocation.resolve(root)
     owned = OwnedArchiveLocation.acquire(location, owner_id="post-resolve-probe")

--- a/tests/unit/daemon/test_daemon_bulk_rebuild_responsiveness.py
+++ b/tests/unit/daemon/test_daemon_bulk_rebuild_responsiveness.py
@@ -58,6 +58,7 @@ from polylogue.daemon.parse_prefetch import DaemonParseStage
 from polylogue.daemon.write_coordinator import DaemonWriteCoordinator, DaemonWriteEvent
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
 
 _RAW_COUNT = 150
 _BULK_BATCH_SIZE = 8  # forces >= 10 bounded passes over the fixture corpus
@@ -200,6 +201,8 @@ def test_small_writer_actors_stay_responsive_during_bulk_rebuild_drain(
     """
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path))
     _seed_corpus(tmp_path)
+    receipt_path = write_valid_rebuild_receipt(tmp_path, tmp_path / "receipt.json")
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_INFERENCE_RECEIPT", str(receipt_path))
 
     events: list[DaemonWriteEvent] = []
     coordinator = DaemonWriteCoordinator(observer=events.append)

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -4117,9 +4117,11 @@ def test_bulk_rebuild_routing_resumable_transaction_drives_pass_even_below_thres
 
     monkeypatch.setattr("polylogue.paths.archive_root", lambda: tmp_path)
     monkeypatch.setattr("polylogue.paths.render_root", lambda: tmp_path / "render")
-    monkeypatch.setattr(
-        "polylogue.daemon.bulk_rebuild.has_resumable_daemon_bulk_rebuild_transaction", lambda _root: True
-    )
+
+    async def fake_in_flight() -> bool:
+        return True
+
+    monkeypatch.setattr(daemon_cli, "_daemon_bulk_rebuild_transaction_in_flight", fake_in_flight)
     monkeypatch.setattr("polylogue.daemon.bulk_rebuild.run_daemon_bulk_rebuild_pass", fake_run_pass)
 
     counts = RawMaterializationCounts(candidate_count=3, pending_blob_bytes=0)
@@ -4144,9 +4146,11 @@ def test_bulk_rebuild_routing_pass_failure_never_propagates(
 
     monkeypatch.setattr("polylogue.paths.archive_root", lambda: tmp_path)
     monkeypatch.setattr("polylogue.paths.render_root", lambda: tmp_path / "render")
-    monkeypatch.setattr(
-        "polylogue.daemon.bulk_rebuild.has_resumable_daemon_bulk_rebuild_transaction", lambda _root: True
-    )
+
+    async def fake_in_flight() -> bool:
+        return True
+
+    monkeypatch.setattr(daemon_cli, "_daemon_bulk_rebuild_transaction_in_flight", fake_in_flight)
     monkeypatch.setattr("polylogue.daemon.bulk_rebuild.run_daemon_bulk_rebuild_pass", fail_run_pass)
 
     counts = RawMaterializationCounts(candidate_count=3, pending_blob_bytes=0)
@@ -4168,6 +4172,14 @@ def test_daemon_bulk_rebuild_transaction_in_flight_delegates(
         return True
 
     monkeypatch.setattr("polylogue.paths.archive_root", lambda: tmp_path)
+    monkeypatch.setattr(
+        "polylogue.maintenance.schema_inference_gate.resolve_schema_inference_receipt_reference",
+        lambda _root: tmp_path / "receipt.json",
+    )
+    monkeypatch.setattr(
+        "polylogue.maintenance.schema_inference_gate.validate_schema_inference_receipt",
+        lambda _root, _receipt: {},
+    )
     monkeypatch.setattr(
         "polylogue.daemon.bulk_rebuild.has_resumable_daemon_bulk_rebuild_transaction", fake_has_resumable
     )

--- a/tests/unit/daemon/test_http_write_coordination.py
+++ b/tests/unit/daemon/test_http_write_coordination.py
@@ -133,7 +133,14 @@ def test_rebuild_index_route_uses_the_bridge_run_sync_with_timeout_writer_path(m
     timeline: list[str] = []
     handler = _handler(["api", "maintenance", "rebuild-index"], timeline)
     handler.server.write_bridge = _RecordingRebuildBridge(timeline)  # type: ignore[assignment]
-    body = json.dumps({"promote": False, "raw_ids": ["raw-1"]}).encode("utf-8")
+    receipt_path = tmp_path / "receipt.json"
+    body = json.dumps(
+        {
+            "promote": False,
+            "raw_ids": ["raw-1"],
+            "schema_inference_receipt_path": str(receipt_path),
+        }
+    ).encode("utf-8")
     handler.headers = {"Content-Length": str(len(body))}  # type: ignore[assignment]
     handler.rfile = BytesIO(body)
 
@@ -157,6 +164,7 @@ def test_rebuild_index_route_uses_the_bridge_run_sync_with_timeout_writer_path(m
     request = rebuild.call_args.args[0]
     assert request.raw_ids == ("raw-1",)
     assert request.promote is False
+    assert request.schema_inference_receipt_path == receipt_path
     assert send_json.call_args.args == (HTTPStatus.OK, receipt.to_dict())
 
 

--- a/tests/unit/daemon/test_maintenance_endpoints.py
+++ b/tests/unit/daemon/test_maintenance_endpoints.py
@@ -162,7 +162,15 @@ class TestMaintenanceAPIRoutes:
         from polylogue.maintenance.rebuild_index import RebuildIndexReceipt
 
         monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path))
-        handler = _make_handler("/api/maintenance/rebuild-index", body={"promote": False, "raw_ids": ["raw-1"]})
+        receipt_path = tmp_path / "receipt.json"
+        handler = _make_handler(
+            "/api/maintenance/rebuild-index",
+            body={
+                "promote": False,
+                "raw_ids": ["raw-1"],
+                "schema_inference_receipt_path": str(receipt_path),
+            },
+        )
         receipt = RebuildIndexReceipt(
             archive_root=str(tmp_path),
             raw_session_count=1,
@@ -191,6 +199,7 @@ class TestMaintenanceAPIRoutes:
         request = rebuild.call_args.args[0]
         assert request.raw_ids == ("raw-1",)
         assert request.promote is False
+        assert request.schema_inference_receipt_path == receipt_path
         assert send.call_args.args == (HTTPStatus.OK, receipt.to_dict())
 
     def test_rebuild_index_fails_closed_without_a_write_bridge(self, tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]

--- a/tests/unit/daemon/test_maintenance_endpoints.py
+++ b/tests/unit/daemon/test_maintenance_endpoints.py
@@ -9,8 +9,16 @@ import json
 from email.message import Message
 from http import HTTPStatus
 from io import BytesIO
+from pathlib import Path
 from typing import TYPE_CHECKING, cast
 from unittest.mock import patch
+
+import pytest
+
+from polylogue.storage.archive_identity import OwnedArchiveLocation
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
 
 if TYPE_CHECKING:
     from polylogue.daemon.http import DaemonAPIHandler, DaemonAPIHTTPServer
@@ -19,6 +27,24 @@ if TYPE_CHECKING:
 class MockServer:
     auth_token: str | None = None
     api_host = "127.0.0.1"
+
+
+def _interpose_receipt_mutation(monkeypatch: pytest.MonkeyPatch, receipt_path: Path, *, expire: bool) -> None:
+    original_acquire = OwnedArchiveLocation.acquire
+
+    def acquire_after_mutation(
+        cls: type[OwnedArchiveLocation], /, location: object, **kwargs: object
+    ) -> OwnedArchiveLocation:
+        owned = original_acquire(location, **kwargs)  # type: ignore[arg-type]
+        payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+        if expire:
+            payload["generated_at"] = "2000-01-01T00:00:00Z"
+        else:
+            payload["source_snapshot"] = "post-preflight-source-drift"
+        receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+        return owned
+
+    monkeypatch.setattr(OwnedArchiveLocation, "acquire", classmethod(acquire_after_mutation))
 
 
 class MockHeaders:
@@ -220,6 +246,38 @@ class TestMaintenanceAPIRoutes:
                 handler._handle_rebuild_index()
         rebuild.assert_not_called()
         send_error.assert_called_once_with(HTTPStatus.SERVICE_UNAVAILABLE, "write_coordinator_unavailable")
+
+    @pytest.mark.parametrize("expire", [False, True], ids=["external-drift", "receipt-expiry"])
+    def test_rebuild_index_route_rejects_post_preflight_receipt_change_before_mutation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, expire: bool
+    ) -> None:
+        root = tmp_path / "archive"
+        root.mkdir()
+        initialize_archive_database(root / "source.db", ArchiveTier.SOURCE)
+        receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+        _interpose_receipt_mutation(monkeypatch, receipt_path, expire=expire)
+        monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
+        handler = _make_handler(
+            "/api/maintenance/rebuild-index",
+            body={
+                "promote": False,
+                "schema_inference_receipt_path": str(receipt_path),
+            },
+        )
+        handler.server.write_bridge = type(
+            "Bridge",
+            (),
+            {"run_sync_with_timeout": lambda _self, _actor, _timeout, function, *args: function(*args)},
+        )()
+
+        with patch.object(handler, "_send_json") as send_json:
+            handler._handle_rebuild_index()
+
+        assert send_json.call_args.args[0] == HTTPStatus.INTERNAL_SERVER_ERROR
+        assert not (root / ".index-active-pointer").exists()
+        assert not (root / ".index-generations").exists()
+        assert not (root / ".index-rebuild-transactions").exists()
+        assert not (root / ".index-rebuild.lock").exists()
 
 
 class TestMaintenanceRegistryEndpoints:

--- a/tests/unit/daemon/test_route_contracts.py
+++ b/tests/unit/daemon/test_route_contracts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from http import HTTPStatus
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -101,6 +102,7 @@ def test_rebuild_index_handler_forwards_resumable_pass_options_through_writer_br
                 "pass_byte_budget_mb": 12.5,
                 "pass_deadline_seconds": 45,
                 "promote": False,
+                "schema_inference_receipt_path": "/tmp/schema-inference-receipt.json",
             }
         ).encode(),
         server=bridge,
@@ -118,6 +120,7 @@ def test_rebuild_index_handler_forwards_resumable_pass_options_through_writer_br
     assert request.pass_byte_budget_mb == 12.5
     assert request.pass_deadline_seconds == 45.0
     assert request.promote is False
+    assert request.schema_inference_receipt_path == Path("/tmp/schema-inference-receipt.json")
     send_json.assert_called_once_with(HTTPStatus.OK, receipt.to_dict())
 
 

--- a/tests/unit/maintenance/test_rebuild_index_candidate_promotion.py
+++ b/tests/unit/maintenance/test_rebuild_index_candidate_promotion.py
@@ -16,6 +16,7 @@ from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_ind
 from polylogue.storage.index_generation import IndexGenerationStore
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
 
 
 def _codex_session(native_id: str, text: str) -> bytes:
@@ -60,8 +61,11 @@ def test_stamp_corruption_blocks_real_candidate_promotion_without_touching_activ
     initialize_active_archive_root(root)
     _seed_raw(root, "active-session", "active generation remains exact")
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
 
-    initial = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+    initial = rebuild_index_from_source_sync(
+        RebuildIndexRequest(archive_root=root, promote=True, schema_inference_receipt_path=receipt_path)
+    )
     assert initial.status == "replayed"
 
     store = IndexGenerationStore.for_archive_root(root)
@@ -69,6 +73,7 @@ def test_stamp_corruption_blocks_real_candidate_promotion_without_touching_activ
     snapshot_before = _active_snapshot(root)
 
     _seed_raw(root, "candidate-session", "candidate must never become active")
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
     original_writer = cast(Callable[..., str], revision_governance.__dict__["write_parsed_session_to_archive"])
     corruption_calls = 0
 
@@ -82,7 +87,9 @@ def test_stamp_corruption_blocks_real_candidate_promotion_without_touching_activ
     monkeypatch.setattr(revision_governance, "write_parsed_session_to_archive", bypass_stamps)
 
     with pytest.raises(RuntimeError, match="reindex acceptance gate failed.*session-fingerprint-stamps"):
-        rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(archive_root=root, promote=True, schema_inference_receipt_path=receipt_path)
+        )
 
     assert corruption_calls > 0
     assert store.active_pointer.resolve(strict=True) == active_before

--- a/tests/unit/maintenance/test_rebuild_index_deadline.py
+++ b/tests/unit/maintenance/test_rebuild_index_deadline.py
@@ -51,6 +51,7 @@ from polylogue.sources.revision_backfill import (
 )
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
 
 
 def _codex_session(native_id: str, messages: tuple[tuple[str, str], ...]) -> bytes:
@@ -152,6 +153,7 @@ def test_rebuild_index_deadline_stops_mid_page_and_resumes_without_omission_or_d
     # lookups 404 against the wrong (default XDG) location.
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
     _seed_distinct_codex_sessions(root, 3)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
 
     call_state = {"first": True}
 
@@ -164,7 +166,12 @@ def test_rebuild_index_deadline_stops_mid_page_and_resumes_without_omission_or_d
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr("polylogue.maintenance.rebuild_index.time.time", fake_time)
         first_pass = rebuild_index_from_source_sync(
-            RebuildIndexRequest(archive_root=root, raw_batch_size=10, pass_deadline_seconds=30.0)
+            RebuildIndexRequest(
+                archive_root=root,
+                raw_batch_size=10,
+                pass_deadline_seconds=30.0,
+                schema_inference_receipt_path=receipt_path,
+            )
         )
 
     assert first_pass.status == "deferred"
@@ -186,7 +193,9 @@ def test_rebuild_index_deadline_stops_mid_page_and_resumes_without_omission_or_d
 
     # Real clock restored (the monkeypatch context exited above); the
     # transaction's durable 30s budget is ample for this tiny fixture.
-    final_pass = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, operation_id=operation_id))
+    final_pass = rebuild_index_from_source_sync(
+        RebuildIndexRequest(archive_root=root, operation_id=operation_id, schema_inference_receipt_path=receipt_path)
+    )
     assert final_pass.status == "replayed"
     assert final_pass.materialized is True
 

--- a/tests/unit/maintenance/test_rebuild_index_lease_lifecycle.py
+++ b/tests/unit/maintenance/test_rebuild_index_lease_lifecycle.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     from polylogue.storage.repair import RepairResult
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
 
 
 def _codex_session(native_id: str) -> bytes:
@@ -76,6 +77,7 @@ def test_rebuild_lease_blocks_a_concurrent_writer_deep_inside_the_pass(
     root = tmp_path / "archive"
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
     _seed_one_codex_session(root)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
 
     probe_result: dict[str, object] = {"attempted": False, "blocked": False}
 
@@ -117,7 +119,9 @@ def test_rebuild_lease_blocks_a_concurrent_writer_deep_inside_the_pass(
 
     monkeypatch.setattr(repair_module, "repair_session_insights", probing_repair_session_insights)
 
-    receipt = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root))
+    receipt = rebuild_index_from_source_sync(
+        RebuildIndexRequest(archive_root=root, schema_inference_receipt_path=receipt_path)
+    )
 
     assert receipt.status == "replayed"
     assert probe_result["attempted"] is True, "the probe never ran; the test setup itself is broken"

--- a/tests/unit/maintenance/test_rebuild_index_ownership.py
+++ b/tests/unit/maintenance/test_rebuild_index_ownership.py
@@ -20,6 +20,7 @@ from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_ind
 from polylogue.storage.archive_identity import ArchiveLocation, ArchiveOwnershipError, OwnedArchiveLocation
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
 
 
 def _init_empty_source(root: Path) -> None:
@@ -35,11 +36,14 @@ def test_rebuild_refuses_when_archive_location_already_owned(tmp_path: Path) -> 
     """
     root = tmp_path / "archive"
     _init_empty_source(root)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
     location = ArchiveLocation.resolve(root)
     owned = OwnedArchiveLocation.acquire(location, owner_id="concurrent-campaign")
     try:
         with pytest.raises(ArchiveOwnershipError):
-            rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root))
+            rebuild_index_from_source_sync(
+                RebuildIndexRequest(archive_root=root, schema_inference_receipt_path=receipt_path)
+            )
         # Failure happened before any generation bookkeeping was created.
         assert not (root / ".index-generations").exists()
         # The rebuild lease is now deliberately acquired before the general
@@ -49,13 +53,16 @@ def test_rebuild_refuses_when_archive_location_already_owned(tmp_path: Path) -> 
         owned.release()
 
     # Releasing the concurrent holder's ownership lets the rebuild proceed.
-    receipt = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root))
+    receipt = rebuild_index_from_source_sync(
+        RebuildIndexRequest(archive_root=root, schema_inference_receipt_path=receipt_path)
+    )
     assert receipt.status == "empty-source"
 
 
 def test_rebuild_source_preflight_rejects_orphaned_blob_refs_before_generation_creation(tmp_path: Path) -> None:
     root = tmp_path / "archive"
     _init_empty_source(root)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
     with sqlite3.connect(root / "source.db") as conn:
         conn.execute(
             """
@@ -66,7 +73,9 @@ def test_rebuild_source_preflight_rejects_orphaned_blob_refs_before_generation_c
         )
 
     with pytest.raises(RuntimeError, match="reindex source preflight gate failed: blob-refs-liveness"):
-        rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root))
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(archive_root=root, schema_inference_receipt_path=receipt_path)
+        )
 
     assert not (root / ".index-generations").exists()
 
@@ -74,6 +83,7 @@ def test_rebuild_source_preflight_rejects_orphaned_blob_refs_before_generation_c
 def test_rebuild_preflight_exposes_unreconciled_source_ref_types(tmp_path: Path) -> None:
     root = tmp_path / "archive"
     _init_empty_source(root)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
     with sqlite3.connect(root / "source.db") as conn:
         conn.executemany(
             """
@@ -88,7 +98,9 @@ def test_rebuild_preflight_exposes_unreconciled_source_ref_types(tmp_path: Path)
         )
 
     with pytest.raises(RuntimeError) as exc_info:
-        rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root))
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(archive_root=root, schema_inference_receipt_path=receipt_path)
+        )
 
     message = str(exc_info.value)
     assert "reindex source preflight gate failed: blob-refs-liveness" in message
@@ -108,8 +120,11 @@ def test_rebuild_releases_ownership_lock_after_completion(tmp_path: Path) -> Non
     """
     root = tmp_path / "archive"
     _init_empty_source(root)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
 
-    receipt = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root))
+    receipt = rebuild_index_from_source_sync(
+        RebuildIndexRequest(archive_root=root, schema_inference_receipt_path=receipt_path)
+    )
     assert receipt.status == "empty-source"
 
     location = ArchiveLocation.resolve(root)

--- a/tests/unit/maintenance/test_rebuild_index_phase_timing.py
+++ b/tests/unit/maintenance/test_rebuild_index_phase_timing.py
@@ -41,6 +41,7 @@ from polylogue.core.enums import Provider
 from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
 
 
 def _codex_session(native_id: str, messages: tuple[tuple[str, str], ...]) -> bytes:
@@ -85,8 +86,11 @@ def test_replayed_receipt_carries_selection_phase_timing(tmp_path: Path, monkeyp
     root = tmp_path / "archive"
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
     _seed_distinct_codex_sessions(root, 2)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
 
-    receipt = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+    receipt = rebuild_index_from_source_sync(
+        RebuildIndexRequest(archive_root=root, promote=True, schema_inference_receipt_path=receipt_path)
+    )
 
     assert receipt.status == "replayed"
     assert "selection_s" in receipt.timings_s
@@ -108,9 +112,17 @@ def test_partial_rebuild_cannot_complete_when_candidate_omits_source_document(
     root = tmp_path / "archive"
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
     raw_ids = _seed_distinct_codex_sessions(root, 2)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
 
     with pytest.raises(RuntimeError, match="reindex acceptance gate failed.*corpus-absences"):
-        rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, raw_ids=(raw_ids[0],), promote=False))
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(
+                archive_root=root,
+                raw_ids=(raw_ids[0],),
+                promote=False,
+                schema_inference_receipt_path=receipt_path,
+            )
+        )
 
     with sqlite3.connect(root / "index.db") as conn:
         assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 0
@@ -141,6 +153,7 @@ def test_rebuild_corpus_gate_blocks_mutated_inactive_candidate(
     root = tmp_path / "archive"
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
     _seed_distinct_codex_sessions(root, 1)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
     original_repopulate = rebuild_index._repopulate_bulk_build_derived_state
 
     def corrupt_candidate_before_acceptance(index_path: Path) -> dict[str, float]:
@@ -188,7 +201,9 @@ def test_rebuild_corpus_gate_blocks_mutated_inactive_candidate(
     monkeypatch.setattr(rebuild_index, "_repopulate_bulk_build_derived_state", corrupt_candidate_before_acceptance)
 
     with pytest.raises(RuntimeError, match=f"reindex acceptance gate failed.*{expected_check}"):
-        rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=False))
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(archive_root=root, promote=False, schema_inference_receipt_path=receipt_path)
+        )
 
     with sqlite3.connect(root / "index.db") as conn:
         assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 0
@@ -201,12 +216,18 @@ def test_deferred_pass_cost_carries_selection_phase_timing(tmp_path: Path, monke
     root = tmp_path / "archive"
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
     _seed_distinct_codex_sessions(root, 2)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
 
     # A sub-millisecond deadline truncates to pass_deadline_ms=0, so the
     # first between-cohorts check always trips deterministically (see
     # test_rebuild_index_deadline.py for the same technique in detail).
     receipt = rebuild_index_from_source_sync(
-        RebuildIndexRequest(archive_root=root, raw_batch_size=10, pass_deadline_seconds=0.0001)
+        RebuildIndexRequest(
+            archive_root=root,
+            raw_batch_size=10,
+            pass_deadline_seconds=0.0001,
+            schema_inference_receipt_path=receipt_path,
+        )
     )
 
     assert receipt.status == "deferred"

--- a/tests/unit/maintenance/test_rebuild_index_provenance_gate.py
+++ b/tests/unit/maintenance/test_rebuild_index_provenance_gate.py
@@ -19,7 +19,7 @@ from polylogue.maintenance.schema_inference_gate import rebuild_source_revision_
 from polylogue.maintenance.sharded_rebuild import shard_raw_ids
 from polylogue.sources.revision_backfill import RebuildDeadlineExceededError
 from polylogue.storage.archive_identity import OwnedArchiveLocation
-from polylogue.storage.index_generation import IndexGeneration, IndexGenerationStore
+from polylogue.storage.index_generation import IndexGeneration, IndexGenerationStore, IndexRebuildTransaction
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
 from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
@@ -341,59 +341,50 @@ def test_sharded_target_creation_cleans_candidate_when_receipt_expires_after_cre
 def test_full_source_transaction_creation_cleans_candidate_after_post_create_validation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """An absent raw-id filter still gets post-create cleanup on receipt failure."""
-    root = tmp_path / "archive"
-    _seed(root, count=1)
-    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
-    original_create = IndexGenerationStore.create
+    """Full-source setup cleans both durable records after post-create validation fails.
 
-    def expire_after_create(
-        store: IndexGenerationStore, *, owner_id: str | None = None, source_snapshot: str
-    ) -> IndexGeneration:
-        generation = original_create(store, owner_id=owner_id, source_snapshot=source_snapshot)
+    Anti-vacuity: the production full-source route creates both the inactive
+    candidate and its transaction before the receipt is expired. Removing the
+    post-create validation or either cleanup leaves the captured generation or
+    transaction record behind.
+    """
+    root = tmp_path / "archive"
+    _seed(root, count=2)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    original_create_transaction = IndexGenerationStore.create_transaction
+    created_records: list[tuple[str, str]] = []
+
+    def expire_after_transaction(
+        store: IndexGenerationStore,
+        *,
+        source_snapshot: str,
+        operation_id: str | None = None,
+        pass_byte_budget: int | None = None,
+        pass_deadline_ms: int | None = None,
+    ) -> IndexRebuildTransaction:
+        transaction = original_create_transaction(
+            store,
+            source_snapshot=source_snapshot,
+            operation_id=operation_id,
+            pass_byte_budget=pass_byte_budget,
+            pass_deadline_ms=pass_deadline_ms,
+        )
+        assert store.load(transaction.generation_id).state == "inactive"
+        assert store.load_transaction(transaction.operation_id).operation_id == transaction.operation_id
+        created_records.append((transaction.generation_id, transaction.operation_id))
         payload = json.loads(receipt_path.read_text(encoding="utf-8"))
         payload["generated_at"] = "2000-01-01T00:00:00Z"
         receipt_path.write_text(json.dumps(payload), encoding="utf-8")
-        return generation
+        return transaction
 
-    monkeypatch.setattr(IndexGenerationStore, "create", expire_after_create)
-
-    with pytest.raises(RuntimeError, match="schema-inference preflight gate failed"):
-        rebuild_index_from_source_sync(
-            RebuildIndexRequest(archive_root=root, schema_inference_receipt_path=receipt_path)
-        )
-
-    assert _generation_ids(root) == set()
-    assert not list((root / ".index-rebuild-transactions").glob("*.json"))
-
-
-def test_full_source_setup_validation_cleans_candidate_and_transaction(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A receipt failure after transaction creation still cleans before replay setup returns."""
-    root = tmp_path / "archive"
-    _seed(root, count=1)
-    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
-    original_validate = rebuild_index_module._validate_rebuild_provenance_receipt
-    validation_calls = 0
-
-    def expire_on_setup_validation(root_arg: Path, receipt_arg: Path | None) -> dict[str, object]:
-        nonlocal validation_calls
-        validation_calls += 1
-        if validation_calls == 3:
-            payload = json.loads(receipt_path.read_text(encoding="utf-8"))
-            payload["generated_at"] = "2000-01-01T00:00:00Z"
-            receipt_path.write_text(json.dumps(payload), encoding="utf-8")
-        return original_validate(root_arg, receipt_arg)
-
-    monkeypatch.setattr(rebuild_index_module, "_validate_rebuild_provenance_receipt", expire_on_setup_validation)
+    monkeypatch.setattr(IndexGenerationStore, "create_transaction", expire_after_transaction)
 
     with pytest.raises(RuntimeError, match="schema-inference preflight gate failed"):
         rebuild_index_from_source_sync(
             RebuildIndexRequest(archive_root=root, schema_inference_receipt_path=receipt_path)
         )
 
-    assert validation_calls == 3
+    assert len(created_records) == 1
     assert _generation_ids(root) == set()
     assert not list((root / ".index-rebuild-transactions").glob("*.json"))
 

--- a/tests/unit/maintenance/test_rebuild_index_provenance_gate.py
+++ b/tests/unit/maintenance/test_rebuild_index_provenance_gate.py
@@ -9,6 +9,8 @@ import pytest
 
 from polylogue.core.enums import Provider
 from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
+from polylogue.maintenance.schema_inference_gate import rebuild_source_revision_snapshot
+from polylogue.sources.revision_backfill import RebuildDeadlineExceededError
 from polylogue.storage.archive_identity import OwnedArchiveLocation
 from polylogue.storage.index_generation import IndexGenerationStore
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -187,3 +189,42 @@ def test_mapping_mutation_is_rejected_without_relying_on_aggregate_counts(tmp_pa
             RebuildIndexRequest(archive_root=root, schema_inference_receipt_path=receipt_path)
         )
     assert not (root / ".index-generations").exists()
+
+
+@pytest.mark.parametrize("expire", [False, True], ids=["external-drift", "receipt-expiry"])
+def test_deadline_checkpoint_revalidates_receipt_before_persisting_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, expire: bool
+) -> None:
+    root = tmp_path / "archive"
+    _seed(root, count=1)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    store = IndexGenerationStore.for_archive_root(root)
+    transaction = store.create_transaction(
+        source_snapshot=rebuild_source_revision_snapshot(root), operation_id="deadline-checkpoint"
+    )
+    transaction = store.checkpoint_transaction(transaction, status="running", derived_stores_cleared=True)
+    transaction_path = root / ".index-rebuild-transactions" / "deadline-checkpoint.json"
+    before = transaction_path.read_bytes()
+
+    async def fail_after_receipt_drift(*args: object, **kwargs: object) -> dict[str, object]:
+        payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+        if expire:
+            payload["generated_at"] = "2000-01-01T00:00:00Z"
+        else:
+            payload["source_snapshot"] = "post-preflight-source-drift"
+        receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+        raise RebuildDeadlineExceededError("synthetic deadline")
+
+    monkeypatch.setattr("polylogue.maintenance.replay.rebuild_index_from_source", fail_after_receipt_drift)
+
+    with pytest.raises(RuntimeError, match="schema-inference preflight gate failed"):
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(
+                archive_root=root,
+                operation_id="deadline-checkpoint",
+                schema_inference_receipt_path=receipt_path,
+                raw_batch_size=1,
+            )
+        )
+
+    assert transaction_path.read_bytes() == before

--- a/tests/unit/maintenance/test_rebuild_index_provenance_gate.py
+++ b/tests/unit/maintenance/test_rebuild_index_provenance_gate.py
@@ -108,7 +108,9 @@ def test_resume_revalidates_external_mapping_before_more_replay(tmp_path: Path) 
     assert first.status == "paused"
     assert first.transaction is not None
     operation_id = str(first.transaction["operation_id"])
-    processed_before = int(first.transaction["processed_raw_count"])
+    processed_value = first.transaction["processed_raw_count"]
+    assert isinstance(processed_value, int)
+    processed_before = processed_value
     active_before = _active_bytes(root)
 
     receipt = json.loads(receipt_path.read_text(encoding="utf-8"))

--- a/tests/unit/maintenance/test_rebuild_index_provenance_gate.py
+++ b/tests/unit/maintenance/test_rebuild_index_provenance_gate.py
@@ -10,6 +10,8 @@ from typing import Any, cast
 
 import pytest
 
+import polylogue.maintenance.rebuild_index as rebuild_index_module
+import polylogue.maintenance.sharded_rebuild as sharded_rebuild_module
 from polylogue.config import Config
 from polylogue.core.enums import Provider
 from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
@@ -333,4 +335,130 @@ def test_sharded_target_creation_cleans_candidate_when_receipt_expires_after_cre
         )
 
     assert create_count == 1
+    assert _generation_ids(root) == set()
+
+
+def test_full_source_transaction_creation_cleans_candidate_after_post_create_validation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An absent raw-id filter still gets post-create cleanup on receipt failure."""
+    root = tmp_path / "archive"
+    _seed(root, count=1)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    original_create = IndexGenerationStore.create
+
+    def expire_after_create(
+        store: IndexGenerationStore, *, owner_id: str | None = None, source_snapshot: str
+    ) -> IndexGeneration:
+        generation = original_create(store, owner_id=owner_id, source_snapshot=source_snapshot)
+        payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+        payload["generated_at"] = "2000-01-01T00:00:00Z"
+        receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+        return generation
+
+    monkeypatch.setattr(IndexGenerationStore, "create", expire_after_create)
+
+    with pytest.raises(RuntimeError, match="schema-inference preflight gate failed"):
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(archive_root=root, schema_inference_receipt_path=receipt_path)
+        )
+
+    assert _generation_ids(root) == set()
+    assert not list((root / ".index-rebuild-transactions").glob("*.json"))
+
+
+def test_full_source_setup_validation_cleans_candidate_and_transaction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A receipt failure after transaction creation still cleans before replay setup returns."""
+    root = tmp_path / "archive"
+    _seed(root, count=1)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    original_validate = rebuild_index_module._validate_rebuild_provenance_receipt
+    validation_calls = 0
+
+    def expire_on_setup_validation(root_arg: Path, receipt_arg: Path | None) -> dict[str, object]:
+        nonlocal validation_calls
+        validation_calls += 1
+        if validation_calls == 3:
+            payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+            payload["generated_at"] = "2000-01-01T00:00:00Z"
+            receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+        return original_validate(root_arg, receipt_arg)
+
+    monkeypatch.setattr(rebuild_index_module, "_validate_rebuild_provenance_receipt", expire_on_setup_validation)
+
+    with pytest.raises(RuntimeError, match="schema-inference preflight gate failed"):
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(archive_root=root, schema_inference_receipt_path=receipt_path)
+        )
+
+    assert validation_calls == 3
+    assert _generation_ids(root) == set()
+    assert not list((root / ".index-rebuild-transactions").glob("*.json"))
+
+
+def test_sharded_graph_drift_blocks_derived_stages_and_cleans_resumable_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Receipt drift after graph resolution cannot reach derived-state writers."""
+    root = tmp_path / "archive"
+    _seed(root, count=4)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    original_graph_resolution = sharded_rebuild_module.resolve_cross_shard_session_graph
+    original_create = IndexGenerationStore.create
+    original_discard = IndexGenerationStore.discard_if_inactive
+    created_generation_ids: list[str] = []
+    discard_calls: list[str] = []
+    repopulate_calls: list[Path] = []
+    insight_calls: list[object] = []
+
+    def drift_after_graph_resolution(*args: Any, **kwargs: Any) -> float:
+        graph_elapsed_s = original_graph_resolution(*args, **kwargs)
+        payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+        payload["generated_at"] = "2000-01-01T00:00:00Z"
+        receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+        return graph_elapsed_s
+
+    def record_create(
+        store: IndexGenerationStore, *, owner_id: str | None = None, source_snapshot: str
+    ) -> IndexGeneration:
+        generation = original_create(store, owner_id=owner_id, source_snapshot=source_snapshot)
+        created_generation_ids.append(generation.generation_id)
+        return generation
+
+    def record_discard(store: IndexGenerationStore, generation: IndexGeneration) -> bool:
+        discard_calls.append(generation.generation_id)
+        return original_discard(store, generation)
+
+    def unexpected_repopulate(index_path: Path) -> dict[str, float]:
+        repopulate_calls.append(index_path)
+        raise AssertionError("stale provenance reached bulk-derived repopulation")
+
+    def unexpected_insight_repair(*args: Any, **kwargs: Any) -> object:
+        insight_calls.append((args, kwargs))
+        raise AssertionError("stale provenance reached session insight repair")
+
+    monkeypatch.setattr(sharded_rebuild_module, "resolve_cross_shard_session_graph", drift_after_graph_resolution)
+    monkeypatch.setattr(IndexGenerationStore, "create", record_create)
+    monkeypatch.setattr(IndexGenerationStore, "discard_if_inactive", record_discard)
+    monkeypatch.setattr(rebuild_index_module, "_repopulate_bulk_build_derived_state", unexpected_repopulate)
+    monkeypatch.setattr("polylogue.storage.repair.repair_session_insights", unexpected_insight_repair)
+
+    with pytest.raises(RuntimeError, match="schema-inference preflight gate failed"):
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(
+                archive_root=root,
+                schema_inference_receipt_path=receipt_path,
+                shard_count=2,
+            )
+        )
+
+    assert repopulate_calls == []
+    assert insight_calls == []
+    assert not list((root / ".index-rebuild-transactions").glob("*.json"))
+    shard_ids = set(created_generation_ids[1:])
+    assert shard_ids
+    assert shard_ids <= set(discard_calls)
+    assert len([generation_id for generation_id in discard_calls if generation_id in shard_ids]) == len(shard_ids)
     assert _generation_ids(root) == set()

--- a/tests/unit/maintenance/test_rebuild_index_provenance_gate.py
+++ b/tests/unit/maintenance/test_rebuild_index_provenance_gate.py
@@ -3,16 +3,21 @@
 from __future__ import annotations
 
 import json
+import sqlite3
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 
+from polylogue.config import Config
 from polylogue.core.enums import Provider
 from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
 from polylogue.maintenance.schema_inference_gate import rebuild_source_revision_snapshot
+from polylogue.maintenance.sharded_rebuild import shard_raw_ids
 from polylogue.sources.revision_backfill import RebuildDeadlineExceededError
 from polylogue.storage.archive_identity import OwnedArchiveLocation
-from polylogue.storage.index_generation import IndexGenerationStore
+from polylogue.storage.index_generation import IndexGeneration, IndexGenerationStore
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
 from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
@@ -48,6 +53,17 @@ def _seed(root: Path, count: int = 2) -> None:
 
 def _active_bytes(root: Path) -> bytes:
     return root.joinpath("index.db").read_bytes()
+
+
+def _generation_ids(root: Path) -> set[str]:
+    generations = root / ".index-generations"
+    return {path.name for path in generations.glob("gen-*")} if generations.exists() else set()
+
+
+def _same_shard_raw_ids(root: Path) -> tuple[str, ...]:
+    with sqlite3.connect(root / "source.db") as conn:
+        raw_ids = [str(row[0]) for row in conn.execute("SELECT raw_id FROM raw_sessions ORDER BY raw_id")]
+    return tuple(next(bucket for bucket in shard_raw_ids(root, raw_ids, 2) if len(bucket) >= 2))
 
 
 def _interpose_receipt_mutation(monkeypatch: pytest.MonkeyPatch, receipt_path: Path, *, expire: bool) -> None:
@@ -228,3 +244,93 @@ def test_deadline_checkpoint_revalidates_receipt_before_persisting_state(
         )
 
     assert transaction_path.read_bytes() == before
+
+
+def test_sharded_replay_revalidates_expired_receipt_before_candidate_writes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Shard replay must fail before its first index write and clean scratch generations.
+
+    Anti-vacuity: the real sharded rebuild route calls the real replay engine. The
+    wrapper expires the receipt immediately before that engine starts. Removing
+    the shard replay provenance guard lets the engine write the shard candidate,
+    which makes ``replayed_rows`` nonzero before the route fails later.
+    """
+    root = tmp_path / "archive"
+    _seed(root, count=4)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_INFERENCE_RECEIPT", str(receipt_path))
+    raw_ids = _same_shard_raw_ids(root)
+    replayed_rows: list[int] = []
+
+    from polylogue.maintenance import replay as replay_module
+
+    original_replay = cast(Callable[..., Any], replay_module.rebuild_index_from_source)
+
+    async def expire_before_replay(*args: Any, **kwargs: Any) -> dict[str, object]:
+        payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+        payload["generated_at"] = "2000-01-01T00:00:00Z"
+        receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+        try:
+            return cast(dict[str, object], await original_replay(*args, **kwargs))
+        finally:
+            config = cast(Config, args[0])
+            index_path = Path(config.db_path)
+            with sqlite3.connect(index_path) as conn:
+                replayed_rows.append(int(conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]))
+
+    monkeypatch.setattr(replay_module, "rebuild_index_from_source", expire_before_replay)
+
+    with pytest.raises(RuntimeError, match="schema-inference preflight gate failed"):
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(
+                archive_root=root,
+                raw_ids=raw_ids,
+                promote=False,
+                shard_count=2,
+                schema_inference_receipt_path=receipt_path,
+            )
+        )
+
+    assert replayed_rows == [0]
+    assert _generation_ids(root) == set()
+
+
+def test_sharded_target_creation_cleans_candidate_when_receipt_expires_after_create(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Receipt failure immediately after target creation cannot strand the target."""
+    root = tmp_path / "archive"
+    _seed(root, count=4)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    raw_ids = _same_shard_raw_ids(root)
+    original_create = IndexGenerationStore.create
+    create_count = 0
+
+    def expire_after_target_create(
+        store: IndexGenerationStore, *, owner_id: str | None = None, source_snapshot: str
+    ) -> IndexGeneration:
+        nonlocal create_count
+        generation = original_create(store, owner_id=owner_id, source_snapshot=source_snapshot)
+        create_count += 1
+        if create_count == 1:
+            payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+            payload["generated_at"] = "2000-01-01T00:00:00Z"
+            receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+        return generation
+
+    monkeypatch.setattr(IndexGenerationStore, "create", expire_after_target_create)
+
+    with pytest.raises(RuntimeError, match="schema-inference preflight gate failed"):
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(
+                archive_root=root,
+                raw_ids=raw_ids,
+                promote=False,
+                shard_count=2,
+                schema_inference_receipt_path=receipt_path,
+            )
+        )
+
+    assert create_count == 1
+    assert _generation_ids(root) == set()

--- a/tests/unit/maintenance/test_rebuild_index_provenance_gate.py
+++ b/tests/unit/maintenance/test_rebuild_index_provenance_gate.py
@@ -9,6 +9,7 @@ import pytest
 
 from polylogue.core.enums import Provider
 from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
+from polylogue.storage.archive_identity import OwnedArchiveLocation
 from polylogue.storage.index_generation import IndexGenerationStore
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
@@ -47,6 +48,24 @@ def _active_bytes(root: Path) -> bytes:
     return root.joinpath("index.db").read_bytes()
 
 
+def _interpose_receipt_mutation(monkeypatch: pytest.MonkeyPatch, receipt_path: Path, *, expire: bool) -> None:
+    original_acquire = OwnedArchiveLocation.acquire
+
+    def acquire_after_mutation(
+        cls: type[OwnedArchiveLocation], /, location: object, **kwargs: object
+    ) -> OwnedArchiveLocation:
+        owned = original_acquire(location, **kwargs)  # type: ignore[arg-type]
+        payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+        if expire:
+            payload["generated_at"] = "2000-01-01T00:00:00Z"
+        else:
+            payload["source_snapshot"] = "post-preflight-source-drift"
+        receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+        return owned
+
+    monkeypatch.setattr(OwnedArchiveLocation, "acquire", classmethod(acquire_after_mutation))
+
+
 def test_missing_receipt_fails_before_lease_and_candidate_mutation(tmp_path: Path) -> None:
     root = tmp_path / "archive"
     _seed(root, count=1)
@@ -55,6 +74,27 @@ def test_missing_receipt_fails_before_lease_and_candidate_mutation(tmp_path: Pat
         rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
     assert _active_bytes(root) == active_before
     assert not (root / ".index-generations").exists()
+
+
+@pytest.mark.parametrize("expire", [False, True], ids=["external-drift", "receipt-expiry"])
+def test_offline_post_preflight_receipt_change_fails_before_lease_or_candidate_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, expire: bool
+) -> None:
+    root = tmp_path / "archive"
+    _seed(root, count=1)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    _interpose_receipt_mutation(monkeypatch, receipt_path, expire=expire)
+    lease_path = root / ".index-rebuild.lock"
+    lease_before = lease_path.read_bytes() if lease_path.exists() else None
+
+    with pytest.raises(RuntimeError, match="schema-inference preflight gate failed"):
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(archive_root=root, schema_inference_receipt_path=receipt_path)
+        )
+
+    assert (lease_path.read_bytes() if lease_path.exists() else None) == lease_before
+    assert not (root / ".index-generations").exists()
+    assert not (root / ".index-rebuild-transactions").exists()
 
 
 def test_forged_top_level_pass_cannot_bypass_a_failing_subgate(tmp_path: Path) -> None:

--- a/tests/unit/maintenance/test_rebuild_index_provenance_gate.py
+++ b/tests/unit/maintenance/test_rebuild_index_provenance_gate.py
@@ -1,0 +1,147 @@
+"""Real-route tests for the schema-inference rebuild hard gate."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from polylogue.core.enums import Provider
+from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
+from polylogue.storage.index_generation import IndexGenerationStore
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
+
+
+def _payload(native_id: str, text: str) -> bytes:
+    rows = [
+        {"type": "session_meta", "payload": {"id": native_id, "timestamp": "2026-08-05T10:00:00Z"}},
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "id": f"{native_id}-m0",
+                "role": "user",
+                "content": [{"type": "input_text", "text": text}],
+            },
+        },
+    ]
+    return b"".join(json.dumps(row, sort_keys=True).encode() + b"\n" for row in rows)
+
+
+def _seed(root: Path, count: int = 2) -> None:
+    initialize_active_archive_root(root)
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        for index in range(count):
+            archive.write_raw_payload(
+                provider=Provider.CODEX,
+                payload=_payload(f"gate-session-{index}", f"gate text {index}"),
+                source_path=f"current/{index}.jsonl",
+                acquired_at_ms=index + 1,
+            )
+
+
+def _active_bytes(root: Path) -> bytes:
+    return root.joinpath("index.db").read_bytes()
+
+
+def test_missing_receipt_fails_before_lease_and_candidate_mutation(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _seed(root, count=1)
+    active_before = _active_bytes(root)
+    with pytest.raises(RuntimeError, match="schema-inference preflight gate failed"):
+        rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+    assert _active_bytes(root) == active_before
+    assert not (root / ".index-generations").exists()
+
+
+def test_forged_top_level_pass_cannot_bypass_a_failing_subgate(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _seed(root, count=1)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+    payload["verdict"] = "PASS"
+    payload["query_results"]["zero-surviving-quarantine"]["passed"] = False
+    receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+    active_before = _active_bytes(root)
+
+    with pytest.raises(RuntimeError, match="zero-surviving-quarantine is not PASS"):
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(archive_root=root, schema_inference_receipt_path=receipt_path)
+        )
+    assert _active_bytes(root) == active_before
+    assert not (root / ".index-generations").exists()
+
+
+def test_valid_receipt_allows_real_candidate_acceptance_and_promotion(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _seed(root, count=1)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+
+    result = rebuild_index_from_source_sync(
+        RebuildIndexRequest(archive_root=root, schema_inference_receipt_path=receipt_path, promote=True)
+    )
+
+    assert result.status == "replayed"
+    assert result.transaction is not None
+    assert result.transaction["status"] == "promoted"
+    assert result.consumed_evidence["receipt_path"] == str(receipt_path)
+    assert result.consumed_evidence["source_snapshot"]
+    assert result.consumed_evidence["external_ground_truth_digest"]
+    assert IndexGenerationStore.for_archive_root(root).active_pointer.resolve().exists()
+
+
+def test_resume_revalidates_external_mapping_before_more_replay(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _seed(root, count=2)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    first = rebuild_index_from_source_sync(
+        RebuildIndexRequest(
+            archive_root=root,
+            schema_inference_receipt_path=receipt_path,
+            raw_batch_size=1,
+            promote=True,
+        )
+    )
+    assert first.status == "paused"
+    assert first.transaction is not None
+    operation_id = str(first.transaction["operation_id"])
+    processed_before = int(first.transaction["processed_raw_count"])
+    active_before = _active_bytes(root)
+
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    origin = receipt["ground_truth_inputs"]["origins"]["codex-session"]
+    external_path = Path(origin["declared_roots"][0]) / origin["external_inventory"][0]["relative_path"]
+    external_path.write_bytes(b"changed external corpus")
+
+    with pytest.raises(RuntimeError, match="external ground-truth corpus changed"):
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(
+                archive_root=root,
+                schema_inference_receipt_path=receipt_path,
+                operation_id=operation_id,
+                raw_batch_size=1,
+                promote=True,
+            )
+        )
+    transaction = IndexGenerationStore.for_archive_root(root).load_transaction(operation_id)
+    assert transaction.processed_raw_count == processed_before
+    assert _active_bytes(root) == active_before
+
+
+def test_mapping_mutation_is_rejected_without_relying_on_aggregate_counts(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _seed(root, count=1)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+    mapping = payload["ground_truth_inputs"]["origins"]["codex-session"]["raw_external_mapping"]
+    mapping[0]["source_path"] = "stale/source/path.jsonl"
+    receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="raw external mapping or inventory"):
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(archive_root=root, schema_inference_receipt_path=receipt_path)
+        )
+    assert not (root / ".index-generations").exists()

--- a/tests/unit/maintenance/test_rebuild_index_resume_correctness.py
+++ b/tests/unit/maintenance/test_rebuild_index_resume_correctness.py
@@ -22,6 +22,7 @@ from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_ind
 from polylogue.storage.index_generation import IndexGenerationStore
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
 
 
 class InjectedInterruptError(RuntimeError):
@@ -102,6 +103,7 @@ def test_committed_page_interrupt_resumes_only_suffix_and_matches_clean_rebuild(
     clean_root = tmp_path / "clean"
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
     _seed(root)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
 
     original_checkpoint = IndexGenerationStore.checkpoint_transaction
     interrupted = False
@@ -117,7 +119,9 @@ def test_committed_page_interrupt_resumes_only_suffix_and_matches_clean_rebuild(
     with monkeypatch.context() as scoped:
         scoped.setattr(IndexGenerationStore, "checkpoint_transaction", interrupt_after_committed_page)
         with pytest.raises(InjectedInterruptError, match="after committed page"):
-            rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, raw_batch_size=1))
+            rebuild_index_from_source_sync(
+                RebuildIndexRequest(archive_root=root, raw_batch_size=1, schema_inference_receipt_path=receipt_path)
+            )
 
     store = IndexGenerationStore.for_archive_root(root)
     operation_id = next(path.stem for path in store.transactions_root.glob("*.json"))
@@ -142,7 +146,12 @@ def test_committed_page_interrupt_resumes_only_suffix_and_matches_clean_rebuild(
     monkeypatch.setattr(replay_module, "rebuild_index_from_source", recording_replay)
     while True:
         receipt = rebuild_index_from_source_sync(
-            RebuildIndexRequest(archive_root=root, operation_id=operation_id, raw_batch_size=1)
+            RebuildIndexRequest(
+                archive_root=root,
+                operation_id=operation_id,
+                raw_batch_size=1,
+                schema_inference_receipt_path=receipt_path,
+            )
         )
         if receipt.status == "replayed":
             break
@@ -156,14 +165,24 @@ def test_committed_page_interrupt_resumes_only_suffix_and_matches_clean_rebuild(
 
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(clean_root))
     _seed(clean_root)
-    clean = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=clean_root, raw_batch_size=1))
+    clean_receipt_path = write_valid_rebuild_receipt(
+        clean_root, tmp_path / "clean-receipt" / "schema-inference-gate-receipt.json"
+    )
+    clean = rebuild_index_from_source_sync(
+        RebuildIndexRequest(archive_root=clean_root, raw_batch_size=1, schema_inference_receipt_path=clean_receipt_path)
+    )
     assert clean.status == "paused"
     assert clean.transaction is not None
     clean_operation = clean.transaction["operation_id"]
     assert isinstance(clean_operation, str)
     while clean.status != "replayed":
         clean = rebuild_index_from_source_sync(
-            RebuildIndexRequest(archive_root=clean_root, operation_id=clean_operation, raw_batch_size=1)
+            RebuildIndexRequest(
+                archive_root=clean_root,
+                operation_id=clean_operation,
+                raw_batch_size=1,
+                schema_inference_receipt_path=clean_receipt_path,
+            )
         )
 
     resumed_snapshot = _semantic_snapshot(root)

--- a/tests/unit/maintenance/test_rebuild_parse_apply_split.py
+++ b/tests/unit/maintenance/test_rebuild_parse_apply_split.py
@@ -37,6 +37,7 @@ from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_ind
 from polylogue.sources import revision_backfill
 from polylogue.sources.census_parse_stage import CensusParseStage
 from polylogue.sources.revision_backfill import split_parse_and_apply_seconds
+from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
 from tests.infra.revision_backfill_benchmark import build_independent_raw_corpus
 
 
@@ -79,12 +80,14 @@ def test_rebuild_records_parse_apply_split_summing_to_stage_total(
     # tests/unit/storage/test_rebuild_paging_content_order.py for the same
     # requirement on the same code path).
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
 
     receipt = rebuild_index_from_source_sync(
         RebuildIndexRequest(
             archive_root=root,
             promote=True,
             raw_batch_size=500,  # single page: whole corpus fits in one pass
+            schema_inference_receipt_path=receipt_path,
         )
     )
 
@@ -136,6 +139,7 @@ def test_rebuild_index_from_source_sync_warms_prefetch_cache_when_caller_omits_o
     root = tmp_path / "archive"
     raw_ids = build_independent_raw_corpus(root, raw_count=6, avg_payload_bytes=20_000)
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
 
     warmed_raw_id_batches: list[tuple[str, ...]] = []
     real_warm_raw_ids = CensusParseStage.warm_raw_ids
@@ -151,6 +155,7 @@ def test_rebuild_index_from_source_sync_warms_prefetch_cache_when_caller_omits_o
             archive_root=root,
             promote=True,
             raw_batch_size=500,  # single page: whole corpus fits in one pass
+            schema_inference_receipt_path=receipt_path,
         )
     )
 
@@ -223,12 +228,14 @@ def test_rebuild_index_from_source_sync_auto_engages_pipelined_decode(
     cohort_count = revision_backfill._PIPELINE_DECODE_MIN_COHORTS + 4
     raw_ids = build_independent_raw_corpus(root, raw_count=cohort_count, avg_payload_bytes=20_000)
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
 
     receipt = rebuild_index_from_source_sync(
         RebuildIndexRequest(
             archive_root=root,
             promote=True,
             raw_batch_size=500,  # single page: whole corpus fits in one pass
+            schema_inference_receipt_path=receipt_path,
         )
     )
 

--- a/tests/unit/maintenance/test_rebuild_status.py
+++ b/tests/unit/maintenance/test_rebuild_status.py
@@ -27,6 +27,7 @@ from polylogue.storage.index_generation import IndexGenerationStore, source_revi
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root, initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
 
 _DEFINITELY_DEAD_PID = 2**31 - 1
 
@@ -111,7 +112,10 @@ def test_reports_active_generation_and_schema_version_after_a_rebuild(
     root = tmp_path / "archive"
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
     _seed_one_real_codex_session(root)
-    receipt = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root))
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    receipt = rebuild_index_from_source_sync(
+        RebuildIndexRequest(archive_root=root, schema_inference_receipt_path=receipt_path)
+    )
     assert receipt.status == "replayed"
 
     status = rebuild_status(root, operation_id="none", include_daemon_bulk_rebuild=False)
@@ -192,7 +196,8 @@ def test_falls_back_to_the_daemon_well_known_operation_id_by_default(tmp_path: P
 
     root = tmp_path / "archive"
     _init_empty_source(root)
-    resolve_or_start_daemon_bulk_rebuild_transaction(root)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    resolve_or_start_daemon_bulk_rebuild_transaction(root, schema_inference_receipt_path=receipt_path)
 
     status = rebuild_status(root)
 

--- a/tests/unit/maintenance/test_rebuild_status.py
+++ b/tests/unit/maintenance/test_rebuild_status.py
@@ -23,7 +23,8 @@ import pytest
 
 from polylogue.core.enums import Provider
 from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync, rebuild_status
-from polylogue.storage.index_generation import IndexGenerationStore, source_revision_snapshot
+from polylogue.maintenance.schema_inference_gate import rebuild_source_revision_snapshot
+from polylogue.storage.index_generation import IndexGenerationStore
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root, initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
@@ -137,7 +138,7 @@ def test_reports_transaction_cursor_and_no_delta_when_source_unchanged(tmp_path:
         )
     store = IndexGenerationStore.for_archive_root(root)
     transaction = store.create_transaction(
-        source_snapshot=source_revision_snapshot(root), operation_id="status-probe-op"
+        source_snapshot=rebuild_source_revision_snapshot(root), operation_id="status-probe-op"
     )
     transaction = store.checkpoint_transaction(
         transaction, status="paused", last_raw_id="raw-a", last_blob_hash_hex="00" * 32, processed_raw_count=1

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -34,8 +34,10 @@ from polylogue.maintenance.reindex_canary import (
     select_canary_sessions,
     write_canary_report,
 )
+from polylogue.storage.archive_identity import OwnedArchiveLocation
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
 from tests.infra.workload_artifacts import build_seeded_archive, clone_seeded_archive
 
 
@@ -108,6 +110,24 @@ def _empty_comparison(current: Path, candidate: Path, session_ids: tuple[str, ..
         missing_columns=(),
         differences=(),
     )
+
+
+def _interpose_receipt_mutation(monkeypatch: pytest.MonkeyPatch, receipt_path: Path, *, expire: bool) -> None:
+    original_acquire = OwnedArchiveLocation.acquire
+
+    def acquire_after_mutation(
+        cls: type[OwnedArchiveLocation], /, location: object, **kwargs: object
+    ) -> OwnedArchiveLocation:
+        owned = original_acquire(location, **kwargs)  # type: ignore[arg-type]
+        payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+        if expire:
+            payload["generated_at"] = "2000-01-01T00:00:00Z"
+        else:
+            payload["source_snapshot"] = "post-preflight-source-drift"
+        receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+        return owned
+
+    monkeypatch.setattr(OwnedArchiveLocation, "acquire", classmethod(acquire_after_mutation))
 
 
 def test_equal_real_generations_ignore_only_materialization_metadata(tmp_path: Path) -> None:
@@ -389,6 +409,8 @@ def test_run_reindex_canary_accepts_split_root_active_pointer_through_real_valid
     shutil.move(root / "index.db", external_index)
     (root / ".index-active-pointer").write_text(str(external_index), encoding="utf-8")
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path / "configured-live"))
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "split-root-receipt.json")
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_INFERENCE_RECEIPT", str(receipt_path))
 
     result = run_reindex_canary(root, input_index=external_index, sessions_per_origin=1, no_promote=True)
 
@@ -425,6 +447,56 @@ def test_run_reindex_canary_accepts_split_root_active_pointer_through_real_valid
     assert operation_generation == {"generation_id": generation_id, "state": "inactive"}
     assert operation_delta["transaction_source_snapshot"] == source_snapshot
     assert operation_delta["source_snapshot_matches"] is True
+
+
+@pytest.mark.parametrize("expire", [False, True], ids=["external-drift", "receipt-expiry"])
+def test_run_reindex_canary_rejects_post_preflight_receipt_change_before_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, expire: bool
+) -> None:
+    artifact = build_seeded_archive(cache_root=tmp_path / "seeded-cache")
+    root = clone_seeded_archive(artifact, tmp_path / "archive").root
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "schema-inference-gate-receipt.json")
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path / "configured-live"))
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_INFERENCE_RECEIPT", str(receipt_path))
+    _interpose_receipt_mutation(monkeypatch, receipt_path, expire=expire)
+
+    pointer = root / ".index-active-pointer"
+    pointer_before = None
+    if pointer.exists() or pointer.is_symlink():
+        pointer_before = os.readlink(pointer) if pointer.is_symlink() else pointer.read_bytes()
+    generations_before = (
+        sorted(path.relative_to(root) for path in (root / ".index-generations").glob("**/*"))
+        if (root / ".index-generations").exists()
+        else []
+    )
+    transactions_before = (
+        sorted(path.relative_to(root) for path in (root / ".index-rebuild-transactions").glob("**/*"))
+        if (root / ".index-rebuild-transactions").exists()
+        else []
+    )
+    lease = root / ".index-rebuild.lock"
+    lease_before = lease.read_bytes() if lease.exists() else None
+
+    with pytest.raises(RuntimeError, match="schema-inference preflight gate failed"):
+        run_reindex_canary(root, input_index=root / "index.db", sessions_per_origin=1, no_promote=True)
+
+    pointer_after = None
+    if pointer.exists() or pointer.is_symlink():
+        pointer_after = os.readlink(pointer) if pointer.is_symlink() else pointer.read_bytes()
+    assert pointer_after == pointer_before
+    generations_after = (
+        sorted(path.relative_to(root) for path in (root / ".index-generations").glob("**/*"))
+        if (root / ".index-generations").exists()
+        else []
+    )
+    transactions_after = (
+        sorted(path.relative_to(root) for path in (root / ".index-rebuild-transactions").glob("**/*"))
+        if (root / ".index-rebuild-transactions").exists()
+        else []
+    )
+    assert generations_after == generations_before
+    assert transactions_after == transactions_before
+    assert (lease.read_bytes() if lease.exists() else None) == lease_before
 
 
 def test_run_reindex_canary_does_not_require_zoo_sessions_for_ordinary_archive(
@@ -578,6 +650,8 @@ def test_real_pathology_canary_rejects_cyclic_candidate_before_insight_repair(
     zoo = build_pathology_zoo(tmp_path / "zoo")
     active_index = zoo.archive_root / "index.db"
     active_digest = hashlib.sha256(active_index.read_bytes()).hexdigest()
+    receipt_path = write_valid_rebuild_receipt(zoo.archive_root, tmp_path / "pathology-receipt.json")
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_INFERENCE_RECEIPT", str(receipt_path))
     from polylogue.maintenance import rebuild_index
 
     real_repopulate = rebuild_index._repopulate_bulk_build_derived_state

--- a/tests/unit/maintenance/test_schema_inference_gate.py
+++ b/tests/unit/maintenance/test_schema_inference_gate.py
@@ -30,6 +30,7 @@ class _OriginGroundTruthReceipt(TypedDict):
     external_files: int
     unverified_source_blob_hashes: int
     provenance: list[_RawGroundTruthProvenance]
+    raw_external_mapping: list[dict[str, object]]
     unmatched_external_files: list[object]
     cross_origin_mismatches: list[object]
     count_discrepancy: bool

--- a/tests/unit/maintenance/test_schema_inference_gate.py
+++ b/tests/unit/maintenance/test_schema_inference_gate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import sqlite3
 from pathlib import Path
 from typing import TypedDict, cast
@@ -14,6 +15,7 @@ from polylogue.maintenance.schema_inference_gate import (
     RECEIPT_FILENAME,
     SchemaInferenceGateError,
     run_schema_inference_gate,
+    validate_schema_inference_receipt,
 )
 from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
@@ -170,6 +172,19 @@ def test_clean_archive_runs_actual_blobstore_verifier_and_external_reconciliatio
             "matched_external_hash": expected_hash,
             "matched_external_size": len(b"actual external codex raw"),
             "disposition": "materialized",
+        }
+    ]
+    mapping = payload["ground_truth_inputs"]["origins"]["codex-session"]["raw_external_mapping"]
+    assert mapping == [
+        {
+            "blob_hash": hashlib.sha256(b"actual external codex raw").hexdigest(),
+            "blob_size": len(b"actual external codex raw"),
+            "disposition": "matched-external",
+            "external_hash": hashlib.sha256(b"actual external codex raw").hexdigest(),
+            "external_relative_path": "session.jsonl",
+            "external_size": len(b"actual external codex raw"),
+            "raw_id": "raw-1",
+            "source_path": str(ground_truth / "session.jsonl"),
         }
     ]
     full = payload["full_blob_hash_verification"]
@@ -340,6 +355,39 @@ def test_full_blob_hash_evidence_is_not_a_caller_claim(tmp_path: Path) -> None:
     assert full["passed"] is False
     assert full["verifier"]["identity"] == "polylogue.storage.blob_store.BlobStore.verify_all"
     assert any(finding["reason"] == "hash_mismatch" for finding in full["failures"])
+
+
+def test_receipt_rejects_stale_source_path_even_when_blob_mapping_is_unchanged(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    ground_truth = _seed_archive(root)
+    receipt_path = tmp_path / RECEIPT_FILENAME
+    _run(root, tmp_path, ground_truth=ground_truth)
+    with sqlite3.connect(root / "source.db") as conn:
+        conn.execute("UPDATE raw_sessions SET source_path = ? WHERE raw_id = 'raw-1'", ("stale/path.jsonl",))
+    with pytest.raises(SchemaInferenceGateError, match="external ground-truth corpus changed"):
+        validate_schema_inference_receipt(root, receipt_path)
+
+
+def test_receipt_rejects_mutated_raw_external_mapping_and_aggregate_only_receipt(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    ground_truth = _seed_archive(root)
+    receipt_path = tmp_path / RECEIPT_FILENAME
+    _run(root, tmp_path, ground_truth=ground_truth)
+    payload = cast(dict[str, Any], json.loads(receipt_path.read_text(encoding="utf-8")))
+    original_payload = json.loads(json.dumps(payload))
+    mapping = cast(
+        list[dict[str, object]], payload["ground_truth_inputs"]["origins"]["codex-session"]["raw_external_mapping"]
+    )
+    mapping[0]["external_relative_path"] = "forged.jsonl"
+    receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(SchemaInferenceGateError, match="raw external mapping or inventory"):
+        validate_schema_inference_receipt(root, receipt_path)
+
+    aggregate_only = cast(dict[str, Any], original_payload)
+    aggregate_only["ground_truth_inputs"]["origins"]["codex-session"].pop("raw_external_mapping")
+    receipt_path.write_text(json.dumps(aggregate_only), encoding="utf-8")
+    with pytest.raises(SchemaInferenceGateError, match="raw external mapping"):
+        validate_schema_inference_receipt(root, receipt_path)
 
 
 def test_non_session_duplicate_requires_durable_content_bound_twin_receipt(tmp_path: Path) -> None:

--- a/tests/unit/maintenance/test_schema_inference_gate.py
+++ b/tests/unit/maintenance/test_schema_inference_gate.py
@@ -6,7 +6,7 @@ import hashlib
 import json
 import sqlite3
 from pathlib import Path
-from typing import TypedDict, cast
+from typing import Any, TypedDict, cast
 
 import pytest
 

--- a/tests/unit/maintenance/test_sharded_rebuild.py
+++ b/tests/unit/maintenance/test_sharded_rebuild.py
@@ -29,16 +29,20 @@ from typing import cast
 
 import pytest
 
+import polylogue.maintenance.rebuild_index as rebuild_index_module
+import polylogue.maintenance.sharded_rebuild as sharded_rebuild_module
 from polylogue.archive.message.roles import Role
 from polylogue.core.enums import BlockType, BranchType, Provider
-from polylogue.maintenance.rebuild_index import RebuildProvenanceContext
+from polylogue.maintenance.rebuild_index import (
+    RebuildIndexRequest,
+    RebuildProvenanceContext,
+    rebuild_index_from_source_sync,
+)
 from polylogue.maintenance.schema_inference_gate import (
     rebuild_source_revision_snapshot,
     validate_schema_inference_receipt,
 )
 from polylogue.maintenance.sharded_rebuild import (
-    _cleanup_shard_generations,
-    _surface_shard_cleanup_failures,
     merge_shards_into_target,
     resolve_cross_shard_session_graph,
     shard_raw_ids,
@@ -69,6 +73,36 @@ def _connect(path: Path) -> sqlite3.Connection:
     conn.execute("PRAGMA foreign_keys = ON")
     initialize_archive_tier(conn, ArchiveTier.INDEX)
     return conn
+
+
+def _raw_payload(native_id: str, text: str) -> bytes:
+    rows = [
+        {"type": "session_meta", "payload": {"id": native_id, "timestamp": "2026-08-05T10:00:00Z"}},
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "id": f"{native_id}-m0",
+                "role": "user",
+                "content": [{"type": "input_text", "text": text}],
+            },
+        },
+    ]
+    return b"".join(json.dumps(row, sort_keys=True).encode() + b"\n" for row in rows)
+
+
+def _seed_raw_archive(root: Path, count: int = 8) -> list[str]:
+    initialize_active_archive_root(root)
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        for index in range(count):
+            archive.write_raw_payload(
+                provider=Provider.CODEX,
+                payload=_raw_payload(f"sharded-route-{index}", f"sharded route text {index}"),
+                source_path=f"current/{index}.jsonl",
+                acquired_at_ms=index + 1,
+            )
+    with sqlite3.connect(root / "source.db") as conn:
+        return [str(row[0]) for row in conn.execute("SELECT raw_id FROM raw_sessions ORDER BY raw_id")]
 
 
 def test_shard_raw_ids_is_deterministic_exhaustive_and_disjoint(tmp_path: Path) -> None:
@@ -284,36 +318,93 @@ def test_merge_revalidates_external_evidence_before_target_mutation(tmp_path: Pa
         assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 0
 
 
-def test_shard_cleanup_attempts_all_candidates_and_preserves_primary_failure(
+def test_sharded_route_cleans_every_sibling_after_post_graph_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """One cleanup error cannot prevent sibling cleanup or replace the build error."""
+    """The real sharded route cleans every sibling after graph provenance fails.
+
+    Anti-vacuity: this drives ``rebuild_index_from_source_sync`` through
+    ``replay_selected_raw_ids_sharded`` with real source rows and real shard
+    replay. The real graph resolver completes before the receipt is expired;
+    the post-graph validation then fails. Removing sibling cleanup, the
+    independent-discard handling, or the primary-error preservation leaves
+    shard metadata behind, skips a sibling, or hides the graph failure.
+    """
     root = tmp_path / "archive"
-    initialize_active_archive_root(root)
-    store = IndexGenerationStore.for_archive_root(root)
-    generations = [store.create(source_snapshot="snapshot") for _ in range(3)]
-    failed_generation_id = generations[0].generation_id
-    discard_calls: list[str] = []
+    raw_ids = _seed_raw_archive(root)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    original_graph_resolution = sharded_rebuild_module.resolve_cross_shard_session_graph
+    original_create = IndexGenerationStore.create
     original_discard = IndexGenerationStore.discard_if_inactive
+    created_generation_ids: list[str] = []
+    failed_shard_id: str | None = None
+    discard_calls: list[str] = []
+    repopulate_calls: list[Path] = []
+    insight_calls: list[object] = []
+
+    def record_create(
+        store: IndexGenerationStore, *, owner_id: str | None = None, source_snapshot: str
+    ) -> IndexGeneration:
+        nonlocal failed_shard_id
+        generation = original_create(store, owner_id=owner_id, source_snapshot=source_snapshot)
+        created_generation_ids.append(generation.generation_id)
+        if len(created_generation_ids) == 2:
+            failed_shard_id = generation.generation_id
+        return generation
 
     def fail_one_discard(generation_store: IndexGenerationStore, generation: IndexGeneration) -> bool:
         generation_id = generation.generation_id
         discard_calls.append(generation_id)
-        if generation_id == failed_generation_id:
+        if generation_id == failed_shard_id:
             raise OSError("synthetic shard cleanup failure")
         return original_discard(generation_store, generation)
 
-    monkeypatch.setattr(IndexGenerationStore, "discard_if_inactive", fail_one_discard)
-    cleanup_errors = _cleanup_shard_generations(
-        store,
-        generations,
-        cast(RebuildProvenanceContext, _NOOP_PROVENANCE),
-    )
-    primary = RuntimeError("synthetic shard build failure")
-    _surface_shard_cleanup_failures(primary, cleanup_errors)
+    def fail_after_graph(target_index_path: Path, *, provenance: RebuildProvenanceContext) -> float:
+        graph_elapsed_s = original_graph_resolution(target_index_path, provenance=provenance)
+        payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+        payload["generated_at"] = "2000-01-01T00:00:00Z"
+        receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+        provenance.validate()
+        return graph_elapsed_s
 
-    assert discard_calls == [generation.generation_id for generation in generations]
-    assert len(cleanup_errors) == 1
-    assert str(primary) == "synthetic shard build failure"
-    assert primary.__notes__ and "synthetic shard cleanup failure" in primary.__notes__[0]
-    assert {path.name for path in (root / ".index-generations").glob("gen-*")} == {failed_generation_id}
+    def unexpected_repopulate(index_path: Path) -> dict[str, float]:
+        repopulate_calls.append(index_path)
+        raise AssertionError("post-graph provenance failure reached derived-state repopulation")
+
+    def unexpected_insight_repair(*args: object, **kwargs: object) -> object:
+        insight_calls.append((args, kwargs))
+        raise AssertionError("post-graph provenance failure reached insight repair")
+
+    monkeypatch.setattr(sharded_rebuild_module, "resolve_cross_shard_session_graph", fail_after_graph)
+    monkeypatch.setattr(IndexGenerationStore, "create", record_create)
+    monkeypatch.setattr(IndexGenerationStore, "discard_if_inactive", fail_one_discard)
+    monkeypatch.setattr(rebuild_index_module, "_repopulate_bulk_build_derived_state", unexpected_repopulate)
+    monkeypatch.setattr("polylogue.storage.repair.repair_session_insights", unexpected_insight_repair)
+
+    buckets = [bucket for bucket in shard_raw_ids(root, raw_ids, 2) if bucket]
+    assert len(buckets) == 2
+
+    with pytest.raises(RuntimeError, match="schema-inference preflight gate failed") as raised:
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(
+                archive_root=root,
+                schema_inference_receipt_path=receipt_path,
+                shard_count=2,
+            )
+        )
+
+    assert failed_shard_id is not None
+    shard_ids = set(created_generation_ids[1:])
+    assert len(shard_ids) == len(buckets)
+    assert failed_shard_id in shard_ids
+    assert shard_ids <= set(discard_calls)
+    assert all(discard_calls.count(generation_id) == 1 for generation_id in shard_ids)
+    assert {path.name for path in (root / ".index-generations").glob("gen-*")} == {failed_shard_id}
+    assert not list((root / ".index-rebuild-transactions").glob("*.json"))
+    assert repopulate_calls == []
+    assert insight_calls == []
+    assert str(raised.value).startswith("rebuild schema-inference preflight gate failed")
+    notes = "\n".join(raised.value.__notes__ or ())
+    assert "shard cleanup also failed" in notes
+    assert failed_shard_id in notes
+    assert "synthetic shard cleanup failure" in notes

--- a/tests/unit/maintenance/test_sharded_rebuild.py
+++ b/tests/unit/maintenance/test_sharded_rebuild.py
@@ -37,11 +37,14 @@ from polylogue.maintenance.schema_inference_gate import (
     validate_schema_inference_receipt,
 )
 from polylogue.maintenance.sharded_rebuild import (
+    _cleanup_shard_generations,
+    _surface_shard_cleanup_failures,
     merge_shards_into_target,
     resolve_cross_shard_session_graph,
     shard_raw_ids,
 )
 from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
+from polylogue.storage.index_generation import IndexGeneration, IndexGenerationStore
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root, initialize_archive_tier
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
@@ -279,3 +282,38 @@ def test_merge_revalidates_external_evidence_before_target_mutation(tmp_path: Pa
 
     with sqlite3.connect(target) as conn:
         assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 0
+
+
+def test_shard_cleanup_attempts_all_candidates_and_preserves_primary_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One cleanup error cannot prevent sibling cleanup or replace the build error."""
+    root = tmp_path / "archive"
+    initialize_active_archive_root(root)
+    store = IndexGenerationStore.for_archive_root(root)
+    generations = [store.create(source_snapshot="snapshot") for _ in range(3)]
+    failed_generation_id = generations[0].generation_id
+    discard_calls: list[str] = []
+    original_discard = IndexGenerationStore.discard_if_inactive
+
+    def fail_one_discard(generation_store: IndexGenerationStore, generation: IndexGeneration) -> bool:
+        generation_id = generation.generation_id
+        discard_calls.append(generation_id)
+        if generation_id == failed_generation_id:
+            raise OSError("synthetic shard cleanup failure")
+        return original_discard(generation_store, generation)
+
+    monkeypatch.setattr(IndexGenerationStore, "discard_if_inactive", fail_one_discard)
+    cleanup_errors = _cleanup_shard_generations(
+        store,
+        generations,
+        cast(RebuildProvenanceContext, _NOOP_PROVENANCE),
+    )
+    primary = RuntimeError("synthetic shard build failure")
+    _surface_shard_cleanup_failures(primary, cleanup_errors)
+
+    assert discard_calls == [generation.generation_id for generation in generations]
+    assert len(cleanup_errors) == 1
+    assert str(primary) == "synthetic shard build failure"
+    assert primary.__notes__ and "synthetic shard cleanup failure" in primary.__notes__[0]
+    assert {path.name for path in (root / ".index-generations").glob("gen-*")} == {failed_generation_id}

--- a/tests/unit/maintenance/test_sharded_rebuild.py
+++ b/tests/unit/maintenance/test_sharded_rebuild.py
@@ -22,20 +22,42 @@ both drive the real rebuild engine end to end and are slower.
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from pathlib import Path
+from typing import cast
+
+import pytest
 
 from polylogue.archive.message.roles import Role
 from polylogue.core.enums import BlockType, BranchType, Provider
+from polylogue.maintenance.rebuild_index import RebuildProvenanceContext
+from polylogue.maintenance.schema_inference_gate import (
+    rebuild_source_revision_snapshot,
+    validate_schema_inference_receipt,
+)
 from polylogue.maintenance.sharded_rebuild import (
     merge_shards_into_target,
     resolve_cross_shard_session_graph,
     shard_raw_ids,
 )
 from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
-from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root, initialize_archive_tier
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
+from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
+
+
+class _NoopProvenance:
+    def validate(self) -> None:
+        return
+
+    def validate_cleanup(self) -> None:
+        return
+
+
+_NOOP_PROVENANCE = _NoopProvenance()
 
 
 def _connect(path: Path) -> sqlite3.Connection:
@@ -146,8 +168,8 @@ def test_cross_shard_parent_child_resolves_after_merge(tmp_path: Path) -> None:
     conn_target.commit()
     conn_target.close()
 
-    merge_shards_into_target(target, [shard_a, shard_b])
-    resolve_cross_shard_session_graph(target)
+    merge_shards_into_target(target, [shard_a, shard_b], provenance=cast(RebuildProvenanceContext, _NOOP_PROVENANCE))
+    resolve_cross_shard_session_graph(target, provenance=cast(RebuildProvenanceContext, _NOOP_PROVENANCE))
 
     with sqlite3.connect(target) as conn:
         conn.row_factory = sqlite3.Row
@@ -206,4 +228,54 @@ def test_merge_shards_into_target_raises_on_foreign_key_violation(tmp_path: Path
     conn_target.close()
 
     with pytest.raises(RuntimeError, match="foreign-key violations"):
-        merge_shards_into_target(target, [shard_a])
+        merge_shards_into_target(target, [shard_a], provenance=cast(RebuildProvenanceContext, _NOOP_PROVENANCE))
+
+
+def test_merge_revalidates_external_evidence_before_target_mutation(tmp_path: Path) -> None:
+    """A source-evidence change at the merge boundary leaves the target empty.
+
+    Anti-vacuity: this invokes the production ``merge_shards_into_target`` with
+    real index rows and a real receipt context. Removing its pre-insert
+    provenance validation lets the shard row reach ``target`` before the
+    caller can observe the drift.
+    """
+    root = tmp_path / "archive"
+    initialize_active_archive_root(root)
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=b'{"type":"session_meta","payload":{"id":"receipt-source"}}\n',
+            source_path="receipt-source.jsonl",
+            acquired_at_ms=1,
+        )
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    evidence = validate_schema_inference_receipt(root, receipt_path)
+    provenance = RebuildProvenanceContext(
+        root=root,
+        receipt_path=receipt_path,
+        source_snapshot=rebuild_source_revision_snapshot(root),
+        consumed_evidence=evidence,
+    )
+
+    shard = tmp_path / "shard" / "index.db"
+    shard.parent.mkdir(parents=True)
+    conn = _connect(shard)
+    write_parsed_session_to_archive(conn, _parent_session(), bulk_fts=True, bulk_build=True)
+    conn.commit()
+    conn.close()
+    target = tmp_path / "target" / "index.db"
+    target.parent.mkdir(parents=True)
+    conn = _connect(target)
+    conn.commit()
+    conn.close()
+
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    origin = receipt["ground_truth_inputs"]["origins"]["codex-session"]
+    external_path = Path(origin["declared_roots"][0]) / origin["external_inventory"][0]["relative_path"]
+    external_path.write_bytes(b"drifted-before-merge")
+
+    with pytest.raises(RuntimeError, match="schema-inference preflight gate failed"):
+        merge_shards_into_target(target, [shard], provenance=provenance)
+
+    with sqlite3.connect(target) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 0

--- a/tests/unit/storage/test_rebuild_paging_content_order.py
+++ b/tests/unit/storage/test_rebuild_paging_content_order.py
@@ -79,6 +79,7 @@ from polylogue.sources.revision_backfill import RawParsePrefetchCache
 from polylogue.storage.index_generation import IndexGenerationStore
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
 
 
 def _codex_session(native_id: str, messages: tuple[tuple[str, str], ...]) -> bytes:
@@ -171,6 +172,7 @@ def _drive_rebuild_to_promotion(
     """
     receipts: list[Any] = []
     operation_id: str | None = None
+    receipt_path = write_valid_rebuild_receipt(root, root.parent / "schema-inference-gate-receipt.json")
     for _ in range(20):  # generous upper bound; promotion ends the loop early
         receipt = rebuild_index_from_source_sync(
             RebuildIndexRequest(
@@ -179,6 +181,7 @@ def _drive_rebuild_to_promotion(
                 raw_batch_size=raw_batch_size,
                 operation_id=operation_id,
                 prefetch_cache=prefetch_cache,
+                schema_inference_receipt_path=receipt_path,
             )
         )
         receipts.append(receipt)


### PR DESCRIPTION
## Summary

Add route-level regressions for the two remaining provenance cleanup gaps identified in the final non-delegating review.

## Problem

The full-source test expired the receipt before transaction creation, so it could pass without proving cleanup after both durable records existed. The shard cleanup test called private cleanup helpers directly, so it did not prove the production sharded replay route attempted every sibling after a post-graph provenance failure.

## Solution

The full-source regression calls the synchronous production rebuild route with `raw_ids` absent, lets the real generation store create the inactive candidate and transaction, expires the receipt after both records exist, and verifies both records are removed by setup cleanup. The sharded regression drives the production route through real shard replay, merge, and graph resolution, expires provenance after graph resolution, injects one real inactive-shard discard failure, and verifies sibling cleanup, primary-error preservation, cleanup diagnostics, and terminal-stage exclusion.

## Verification

- `env -u VIRTUAL_ENV direnv exec . devtools test tests/unit/maintenance/test_rebuild_index_provenance_gate.py tests/unit/maintenance/test_sharded_rebuild.py`: 19 passed in 49.79s.
- `env -u VIRTUAL_ENV direnv exec . devtools verify --quick`: passed at head `701c56754e38a78764f5fb5ca33ca5a512ad3b19`, exit 0.
- The pre-push quick verification repeated the same static gate at the pushed head and passed, including format, lint, mypy, generated surfaces, layering, policy labs, and schema promotion audit.

## Anti-vacuity evidence

- Full-source creation captures the real generation id and operation id only after `IndexGenerationStore.create_transaction` returns. It asserts the candidate metadata is inactive and the transaction JSON is readable before expiring the receipt, then asserts no generation directory or transaction JSON survives.
- The sharded case seeds eight temporary source rows and confirms two non-empty production shard buckets. The original shard replay, merge, and graph resolver execute before the test expires the receipt and invokes the real provenance validator. The test asserts every shard discard is attempted exactly once, all successful siblings are removed, only the deliberately failed discard remains, the parent transaction is removed, and `_repopulate_bulk_build_derived_state` plus `repair_session_insights` are never entered.
- The raised provenance error remains the primary exception. Its notes include the failed shard id and the synthetic discard diagnostic.

## Scope

Test coverage only. No production data, Beads state, or delegated agents were used.

Ref #3803
