### PR TITLE
fix(storage): retain raw census predecessors during pruning

### DIFF
--- a/polylogue/maintenance/raw_authority_reset.py
+++ b/polylogue/maintenance/raw_authority_reset.py
@@ -2,8 +2,10 @@
 
 The raw-authority census tables (``raw_authority_censuses`` and its
 ``plans``/``blockers``/``census_plans``/``census_post_plans`` children) are
-DERIVED convergence bookkeeping: each census chains to its predecessor
-(``sequence_no + 1``) and carries unresolved plans forward. The ACCEPTED
+DERIVED convergence bookkeeping: each census normally chains to its predecessor
+(``sequence_no + 1``), while bounded header retention may set the oldest
+retained header's predecessor to NULL as the explicit compaction boundary.
+The ledger also carries unresolved plans forward. The ACCEPTED
 materialization state — ``raw_sessions.revision_authority`` and the index's
 ``raw_revision_heads`` / ``raw_revision_applications`` — lives OUTSIDE these
 tables and is untouched here.

--- a/polylogue/storage/raw_authority.py
+++ b/polylogue/storage/raw_authority.py
@@ -59,12 +59,14 @@ RAW_AUTHORITY_DETAIL_CHUNK_CHARS = 16_384
 #: ~990 MB/day (polylogue-wkc6).
 RAW_AUTHORITY_CENSUS_PLAN_RETENTION = 8
 
-#: How many census HEADERS (``raw_authority_censuses``) to keep.
+#: Minimum number of census HEADERS (``raw_authority_censuses``) to keep.
 #:
 #: Deliberately much larger than the plan-row window: headers carry the
 #: convergence history that is actually worth reading back -- sequence,
 #: digests, ``fixed_point``, and the ``predecessor_census_id`` chain -- and a
-#: header is far cheaper than a plan set. They are not free, though:
+#: header is far cheaper than a plan set. An intact predecessor chain may
+#: extend this floor while its retained edges still require the older headers.
+#: Headers are not free, though:
 #: ``residual_json`` and ``post_residual_json`` embed the full quarantined-raw
 #: id arrays and average ~144 KB each, so headers alone accrue ~28 MB/day at
 #: the observed ~97 censuses/day.
@@ -880,7 +882,9 @@ def unresolved_raw_replay_blockers(archive_root: Path) -> int:
 
 
 def prune_raw_authority_census_history(conn: sqlite3.Connection) -> tuple[int, int]:
-    """Bound census history to its retention windows. Returns (plan_rows, headers) deleted.
+    """Prune census history without breaking retained lineage.
+
+    Returns (plan_rows, headers) deleted.
 
     Runs inside the caller's transaction, immediately after a census is
     recorded, so growth is bounded at the point of growth rather than by a
@@ -961,17 +965,46 @@ def prune_raw_authority_census_history(conn: sqlite3.Connection) -> tuple[int, i
     headers = 0
     if header_floor_row is not None:
         # Same obligation guard, and additionally an FK guard:
-        # raw_authority_blockers references raw_authority_censuses(census_id),
-        # so a header may only go once nothing references it.
-        cursor = conn.execute(
-            """
-            DELETE FROM raw_authority_censuses
-            WHERE sequence_no < ?
-              AND census_id NOT IN (SELECT census_id FROM raw_authority_blockers)
-            """,
-            (int(header_floor_row[0]),),
-        )
-        headers = cursor.rowcount if cursor.rowcount and cursor.rowcount > 0 else 0
+        # raw_authority_blockers and predecessor_census_id both reference
+        # raw_authority_censuses(census_id). Keep the full predecessor closure
+        # of every header that survives the retention floor or remains pinned
+        # by a blocker. A direct predecessor check is insufficient: a stale
+        # header can itself survive because a newer retained header points to
+        # it, while still naming an older header as its predecessor.
+        floor = int(header_floor_row[0])
+        stale = [
+            str(row[0])
+            for row in conn.execute(
+                """
+                WITH RECURSIVE retained(census_id) AS (
+                    SELECT census_id
+                    FROM raw_authority_censuses
+                    WHERE sequence_no >= ?
+                    UNION
+                    SELECT census_id FROM raw_authority_blockers
+                    UNION
+                    SELECT c.predecessor_census_id
+                    FROM raw_authority_censuses AS c
+                    JOIN retained AS r ON r.census_id = c.census_id
+                    WHERE c.predecessor_census_id IS NOT NULL
+                )
+                SELECT c.census_id
+                FROM raw_authority_censuses AS c
+                WHERE c.sequence_no < ?
+                  AND c.census_id NOT IN (SELECT census_id FROM retained)
+                ORDER BY c.sequence_no DESC
+                """,
+                (floor, floor),
+            )
+        ]
+        # Delete newest-to-oldest so a stale predecessor chain is removed from
+        # the leaves upward while immediate foreign-key enforcement remains on.
+        for census_id in stale:
+            cursor = conn.execute(
+                "DELETE FROM raw_authority_censuses WHERE census_id = ?",
+                (census_id,),
+            )
+            headers += cursor.rowcount if cursor.rowcount and cursor.rowcount > 0 else 0
     return plan_rows, headers
 
 

--- a/polylogue/storage/raw_authority.py
+++ b/polylogue/storage/raw_authority.py
@@ -59,13 +59,14 @@ RAW_AUTHORITY_DETAIL_CHUNK_CHARS = 16_384
 #: ~990 MB/day (polylogue-wkc6).
 RAW_AUTHORITY_CENSUS_PLAN_RETENTION = 8
 
-#: Minimum number of census HEADERS (``raw_authority_censuses``) to keep.
+#: Target number of newest census HEADERS (``raw_authority_censuses``) to keep.
 #:
 #: Deliberately much larger than the plan-row window: headers carry the
 #: convergence history that is actually worth reading back -- sequence,
-#: digests, ``fixed_point``, and the ``predecessor_census_id`` chain -- and a
-#: header is far cheaper than a plan set. An intact predecessor chain may
-#: extend this floor while its retained edges still require the older headers.
+#: digests, ``fixed_point``, and the retained portion of the
+#: ``predecessor_census_id`` chain -- and a header is far cheaper than a plan
+#: set. The oldest retained header has a NULL predecessor when compaction cuts
+#: the chain boundary. Open blocker references may retain additional headers.
 #: Headers are not free, though:
 #: ``residual_json`` and ``post_residual_json`` embed the full quarantined-raw
 #: id arrays and average ~144 KB each, so headers alone accrue ~28 MB/day at
@@ -895,7 +896,10 @@ def prune_raw_authority_census_history(conn: sqlite3.Connection) -> tuple[int, i
     see ``RAW_AUTHORITY_CENSUS_PLAN_RETENTION`` and
     ``RAW_AUTHORITY_CENSUS_HEADER_RETENTION``. Plan membership is dropped for
     older censuses while their headers survive, so convergence history stays
-    readable after the per-plan detail behind it is gone.
+    readable after the per-plan detail behind it is gone. Header compaction
+    cuts the predecessor edge at the oldest retained header by setting it to
+    NULL before deleting older headers. NULL is the explicit retained-lineage
+    boundary, not an unresolved reference.
 
     Deletes are keyed on ``sequence_no``, which is monotonic per archive, so
     this cannot race a concurrently-recorded newer census into deletion.
@@ -966,39 +970,52 @@ def prune_raw_authority_census_history(conn: sqlite3.Connection) -> tuple[int, i
     if header_floor_row is not None:
         # Same obligation guard, and additionally an FK guard:
         # raw_authority_blockers and predecessor_census_id both reference
-        # raw_authority_censuses(census_id). Keep the full predecessor closure
-        # of every header that survives the retention floor or remains pinned
-        # by a blocker. A direct predecessor check is insufficient: a stale
-        # header can itself survive because a newer retained header points to
-        # it, while still naming an older header as its predecessor.
+        # raw_authority_censuses(census_id). Keep the newest headers and every
+        # header named by a blocker. The predecessor chain is a bounded
+        # read-history convenience, so cut any surviving edge into the delete
+        # set before deleting it. The NULL edge is the compacted boundary.
         floor = int(header_floor_row[0])
         stale = [
             str(row[0])
             for row in conn.execute(
                 """
-                WITH RECURSIVE retained(census_id) AS (
-                    SELECT census_id
-                    FROM raw_authority_censuses
-                    WHERE sequence_no >= ?
-                    UNION
-                    SELECT census_id FROM raw_authority_blockers
-                    UNION
-                    SELECT c.predecessor_census_id
-                    FROM raw_authority_censuses AS c
-                    JOIN retained AS r ON r.census_id = c.census_id
-                    WHERE c.predecessor_census_id IS NOT NULL
-                )
                 SELECT c.census_id
                 FROM raw_authority_censuses AS c
                 WHERE c.sequence_no < ?
-                  AND c.census_id NOT IN (SELECT census_id FROM retained)
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM raw_authority_blockers AS b
+                      WHERE b.census_id = c.census_id
+                  )
                 ORDER BY c.sequence_no DESC
                 """,
-                (floor, floor),
+                (floor,),
             )
         ]
-        # Delete newest-to-oldest so a stale predecessor chain is removed from
-        # the leaves upward while immediate foreign-key enforcement remains on.
+        # Cut only edges from surviving headers. Stale headers can still point
+        # at one another and are deleted newest-to-oldest below, preserving
+        # immediate foreign-key enforcement throughout the mutation.
+        conn.execute(
+            """
+            WITH stale(census_id) AS (
+                SELECT c.census_id
+                FROM raw_authority_censuses AS c
+                WHERE c.sequence_no < ?
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM raw_authority_blockers AS b
+                      WHERE b.census_id = c.census_id
+                  )
+            )
+            UPDATE raw_authority_censuses
+            SET predecessor_census_id = NULL
+            WHERE predecessor_census_id IN (SELECT census_id FROM stale)
+              AND census_id NOT IN (SELECT census_id FROM stale)
+            """,
+            (floor,),
+        )
+        # Delete newest-to-oldest so stale predecessor chains are removed from
+        # the leaves upward after surviving edges have been compacted.
         for census_id in stale:
             cursor = conn.execute(
                 "DELETE FROM raw_authority_censuses WHERE census_id = ?",
@@ -1030,6 +1047,10 @@ def record_raw_authority_census(
     scope_json = _canonical_json(scope)
     residual_json = _canonical_json(residual)
     with closing(sqlite3.connect(archive_root / "source.db")) as conn, conn:
+        # SQLite scopes foreign-key enforcement to each connection. Enable it
+        # before the transaction so header compaction preserves the declared
+        # self-FK and cascades its census-detail children as declared.
+        conn.execute("PRAGMA foreign_keys = ON")
         # A frontier preview authorizes an immutable execution exactly once.
         # Reserve the write transaction before reading existing claims.  A
         # deferred transaction would let two callers both observe no claim,

--- a/tests/unit/storage/test_raw_authority_ledger.py
+++ b/tests/unit/storage/test_raw_authority_ledger.py
@@ -1793,6 +1793,93 @@ def test_census_retention_keeps_the_newest_censuses_readable(tmp_path: Path, mon
     assert surviving == {receipts[-1].census_id, receipts[-2].census_id}
 
 
+def test_census_header_retention_preserves_predecessor_fk_and_prunes_safe_history(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The production census route must keep a retained child's predecessor.
+
+    A direct header filter deleted census 687 while retained census 688 still
+    named it as ``predecessor_census_id``, leaving the source tier with an FK
+    violation. The production route below builds that boundary shape, checks
+    the retained edge and foreign-key audit, then proves the same pruning
+    routine still removes an older header once no surviving census names it.
+    """
+    monkeypatch.setattr(raw_authority_mod, "RAW_AUTHORITY_CENSUS_PLAN_RETENTION", 2)
+    monkeypatch.setattr(raw_authority_mod, "RAW_AUTHORITY_CENSUS_HEADER_RETENTION", 2)
+    initialize_active_archive_root(tmp_path)
+    raw_id = _write_codex_raw(tmp_path, native_id="predecessor", source_path="predecessor.jsonl", acquired_at_ms=1)
+    census_historical_revision_evidence(tmp_path, selected_raw_ids=[raw_id])
+    plan = build_raw_replay_plans(tmp_path, ((raw_id,),))[0]
+
+    receipts = [
+        record_raw_authority_census(
+            tmp_path,
+            (plan,),
+            selected_plan_ids=set(),
+            mode="dry_run",
+            quiescent=True,
+            scope={"test": f"predecessor-{index}"},
+            residual={},
+        )
+        for index in range(3)
+    ]
+
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        conn.execute("PRAGMA foreign_keys = ON")
+        child_predecessor = conn.execute(
+            "SELECT predecessor_census_id FROM raw_authority_censuses WHERE census_id = ?",
+            (receipts[1].census_id,),
+        ).fetchone()[0]
+        retained_headers = {str(row[0]) for row in conn.execute("SELECT census_id FROM raw_authority_censuses")}
+        assert child_predecessor == receipts[0].census_id
+        assert retained_headers == {receipt.census_id for receipt in receipts}
+        assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+
+    # A disconnected older header is safe to retire on the next production
+    # prune cycle. It exercises the bounded-delete path without severing the
+    # predecessor chain under test above.
+    safe_root = tmp_path / "safe-prune"
+    initialize_active_archive_root(safe_root)
+    with sqlite3.connect(safe_root / "source.db") as conn:
+        conn.executemany(
+            """
+            INSERT INTO raw_authority_censuses (
+                census_id, sequence_no, scope_json, residual_json,
+                parser_fingerprint, mode, lifecycle_status, quiescent,
+                inventory_digest, residual_digest, plan_count,
+                post_inventory_digest, post_residual_json, post_residual_digest,
+                post_plan_count, postflight_at_ms, executable_plan_count,
+                residual_plan_count, predecessor_census_id, fixed_point,
+                created_at_ms, completed_at_ms
+            ) VALUES (?, ?, '{}', '{}', 'test', 'dry_run', 'completed', 1,
+                      ?, ?, 0, ?, '{}', ?, 0, 1, 0, 0, NULL, 0, 1, 1)
+            """,
+            (
+                ("census:detached:1", 1, "a" * 64, "b" * 64, "a" * 64, "b" * 64),
+                ("census:detached:2", 2, "c" * 64, "d" * 64, "c" * 64, "d" * 64),
+            ),
+        )
+        conn.commit()
+
+    later = record_raw_authority_census(
+        safe_root,
+        (),
+        selected_plan_ids=set(),
+        mode="dry_run",
+        quiescent=True,
+        scope={"test": "predecessor-safe-prune"},
+        residual={},
+    )
+
+    with sqlite3.connect(safe_root / "source.db") as conn:
+        conn.execute("PRAGMA foreign_keys = ON")
+        surviving = {str(row[0]) for row in conn.execute("SELECT census_id FROM raw_authority_censuses")}
+        assert "census:detached:1" not in surviving
+        assert "census:detached:2" in surviving
+        assert later.census_id in surviving
+        assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+
+
 def test_census_plan_rows_prune_past_retention_even_with_an_unresolved_blocker(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/storage/test_raw_authority_ledger.py
+++ b/tests/unit/storage/test_raw_authority_ledger.py
@@ -1796,13 +1796,12 @@ def test_census_retention_keeps_the_newest_censuses_readable(tmp_path: Path, mon
 def test_census_header_retention_preserves_predecessor_fk_and_prunes_safe_history(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The production census route must keep a retained child's predecessor.
+    """The production census route compacts lineage without breaking its FK.
 
-    A direct header filter deleted census 687 while retained census 688 still
-    named it as ``predecessor_census_id``, leaving the source tier with an FK
-    violation. The production route below builds that boundary shape, checks
-    the retained edge and foreign-key audit, then proves the same pruning
-    routine still removes an older header once no surviving census names it.
+    The production route below builds a retention boundary, keeps the newest
+    retained child-to-parent edge, cuts the oldest retained header's
+    predecessor to NULL, and proves that disconnected history is pruned while
+    foreign-key enforcement remains enabled.
     """
     monkeypatch.setattr(raw_authority_mod, "RAW_AUTHORITY_CENSUS_PLAN_RETENTION", 2)
     monkeypatch.setattr(raw_authority_mod, "RAW_AUTHORITY_CENSUS_HEADER_RETENTION", 2)
@@ -1828,11 +1827,16 @@ def test_census_header_retention_preserves_predecessor_fk_and_prunes_safe_histor
         conn.execute("PRAGMA foreign_keys = ON")
         child_predecessor = conn.execute(
             "SELECT predecessor_census_id FROM raw_authority_censuses WHERE census_id = ?",
+            (receipts[2].census_id,),
+        ).fetchone()[0]
+        boundary_predecessor = conn.execute(
+            "SELECT predecessor_census_id FROM raw_authority_censuses WHERE census_id = ?",
             (receipts[1].census_id,),
         ).fetchone()[0]
         retained_headers = {str(row[0]) for row in conn.execute("SELECT census_id FROM raw_authority_censuses")}
-        assert child_predecessor == receipts[0].census_id
-        assert retained_headers == {receipt.census_id for receipt in receipts}
+        assert child_predecessor == receipts[1].census_id
+        assert boundary_predecessor is None
+        assert retained_headers == {receipt.census_id for receipt in receipts[1:]}
         assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
 
     # A disconnected older header is safe to retire on the next production
@@ -1877,6 +1881,48 @@ def test_census_header_retention_preserves_predecessor_fk_and_prunes_safe_histor
         assert "census:detached:1" not in surviving
         assert "census:detached:2" in surviving
         assert later.census_id in surviving
+        assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+
+
+def test_census_header_retention_bounds_a_long_contiguous_production_chain(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A continuous census chain stays bounded at an explicit NULL boundary."""
+    retention = 4
+    monkeypatch.setattr(raw_authority_mod, "RAW_AUTHORITY_CENSUS_HEADER_RETENTION", retention)
+    initialize_active_archive_root(tmp_path)
+    raw_id = _write_codex_raw(tmp_path, native_id="long-chain", source_path="long-chain.jsonl", acquired_at_ms=1)
+    census_historical_revision_evidence(tmp_path, selected_raw_ids=[raw_id])
+    plan = build_raw_replay_plans(tmp_path, ((raw_id,),))[0]
+    census_count = retention + 12
+
+    receipts = [
+        record_raw_authority_census(
+            tmp_path,
+            (plan,),
+            selected_plan_ids=set(),
+            mode="dry_run",
+            quiescent=True,
+            scope={"test": f"long-chain-{index}"},
+            residual={},
+        )
+        for index in range(census_count)
+    ]
+
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        conn.execute("PRAGMA foreign_keys = ON")
+        rows = conn.execute(
+            """
+            SELECT sequence_no, census_id, predecessor_census_id
+            FROM raw_authority_censuses
+            ORDER BY sequence_no
+            """
+        ).fetchall()
+        assert len(rows) == retention
+        assert [int(row[0]) for row in rows] == list(range(census_count - retention + 1, census_count + 1))
+        assert rows[0][1] == receipts[census_count - retention].census_id
+        assert rows[0][2] is None
+        assert [row[2] for row in rows[1:]] == [rows[index][1] for index in range(retention - 1)]
         assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
 
 


### PR DESCRIPTION
## Summary
Bound raw-authority census header retention while preserving source-tier foreign-key integrity and the readable lineage within the retained window.

## Problem
The recursive predecessor closure in c1c32553e retained every ancestor of a continuously linked census chain, so normal production history never reached the configured header bound. A long chain also exposed that the census writer connection did not enable SQLite foreign keys, leaving census-detail child rows dangling when header retention was narrower than plan retention.

## Solution
`prune_raw_authority_census_history` now retains the newest configured header window plus headers pinned by blocker references. Before deleting stale headers, it sets any surviving `predecessor_census_id` edge into the deletion set to NULL, making NULL the explicit retained-lineage compaction boundary, then deletes stale headers newest-first. `record_raw_authority_census` enables `PRAGMA foreign_keys = ON` before its transaction so the declared census-detail cascades run and the declared self-FK remains enforced. No schema or FK constraint was changed.

## Retention invariant
With `RAW_AUTHORITY_CENSUS_HEADER_RETENTION = N`, a production chain with no blocker pins retains at most the newest N census headers. The oldest retained header has `predecessor_census_id IS NULL`; each newer retained header points to the immediately preceding retained header. Blocker-pinned headers are the explicit exception and may retain additional headers. No surviving predecessor or census-detail FK points to a deleted row.

## Verification
- `direnv exec . devtools test tests/unit/storage/test_raw_authority_ledger.py`: 43 passed in 15.92s.
- `direnv exec . devtools verify --quick`: exit 0, all 24 steps passed, run `20260805T130720Z-quick-1791424-75ac43a4`.
- Pre-push quick verification: exit 0, all 24 steps passed, run `20260805T130953Z-quick-1795283-379b1f0f`.
- The long contiguous production-chain regression creates 16 linked censuses with retention set to 4, observes exactly 4 retained headers, checks the NULL boundary and three retained predecessor links, and gets an empty `PRAGMA foreign_key_check` result.

## Anti-vacuity
Removing the production `prune_raw_authority_census_history` call makes the long-chain regression retain 16 headers instead of 4. Removing the boundary UPDATE makes production deletion fail under enforced foreign keys because a retained child still references a deleted predecessor. Removing the writer `PRAGMA foreign_keys = ON` leaves census-detail rows dangling when header retention is narrower than plan retention, which the same regression detects with `PRAGMA foreign_key_check`.

Ref #3810
