### PR TITLE
fix(storage): probe source hook event writer

### DIFF
--- a/polylogue/storage/sqlite/durable_change_train.py
+++ b/polylogue/storage/sqlite/durable_change_train.py
@@ -342,12 +342,19 @@ def _runtime_consumer_results(
                 ) from exc
             if not callable(value):
                 raise DurableChangeTrainError(f"runtime consumer {consumer.consumer_id} is not callable: {reference}")
+            detail = f"resolved {reference}"
             try:
                 if reference.endswith(":initialize_archive_database"):
                     value(archive_root / f"{train.tier.value}.db", train.tier, allow_create=False)
                 elif reference.endswith(":initialize_archive_tier"):
                     with sqlite3.connect(":memory:") as probe:
                         value(probe, train.tier)
+                elif reference.endswith(":write_source_hook_event"):
+                    if train.tier is not ArchiveTier.SOURCE:
+                        raise DurableChangeTrainError(
+                            f"runtime consumer {consumer.consumer_id} is source-tier-only: {reference}"
+                        )
+                    detail = _probe_source_hook_event_writer(cast(Callable[..., object], value))
                 elif not any(
                     parameter.default is inspect.Parameter.empty
                     and parameter.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
@@ -369,10 +376,82 @@ def _runtime_consumer_results(
                     consumer_id=consumer.consumer_id,
                     behavior_proof_ref=consumer.behavior_proof_ref,
                     passed=True,
-                    detail=f"resolved {reference}",
+                    detail=detail,
                 )
             )
     return tuple(results)
+
+
+def _probe_source_hook_event_writer(writer: Callable[..., object]) -> str:
+    """Exercise the source hook writer against an isolated fresh source tier."""
+    from polylogue.core.enums import Origin
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+    from polylogue.storage.sqlite.archive_tiers.source_write import (
+        ArchiveHookEvent,
+        deterministic_blob_hash,
+    )
+
+    source_path = "/durable-change-train/source-v27-probe.jsonl"
+    payload = b'{"event":"PostToolUse","probe":"source-v27"}'
+    hook_event = ArchiveHookEvent(
+        hook_event_id="durable-change-train-source-v27-hook",
+        origin=Origin.CODEX_SESSION,
+        source_path=source_path,
+        event_type="PostToolUse",
+        payload={"event": "PostToolUse", "probe": "source-v27"},
+        observed_at_ms=1_780_000_000_000,
+        native_id="durable-change-train-source-v27-native",
+        session_native_id="durable-change-train-source-v27-session",
+    )
+    expected_blob_hash = deterministic_blob_hash(payload)
+    with sqlite3.connect(":memory:") as probe:
+        initialize_archive_tier(probe, ArchiveTier.SOURCE)
+        returned_raw_id = writer(
+            probe,
+            origin=hook_event.origin,
+            source_path=source_path,
+            payload=payload,
+            acquired_at_ms=hook_event.observed_at_ms,
+            raw_id="durable-change-train-source-v27-raw",
+            hook_event=hook_event,
+        )
+        hook_row = probe.execute(
+            """
+            SELECT origin, native_id, session_native_id, source_path, event_type,
+                   payload_json, observed_at_ms, blob_hash
+            FROM raw_hook_events
+            WHERE hook_event_id = ?
+            """,
+            (hook_event.hook_event_id,),
+        ).fetchone()
+        blob_ref_row = probe.execute(
+            "SELECT blob_hash, ref_type, ref_id, source_path, size_bytes, acquired_at_ms FROM blob_refs"
+        ).fetchone()
+        raw_session_count = probe.execute("SELECT COUNT(*) FROM raw_sessions").fetchone()
+
+    expected_hook_row = (
+        Origin.CODEX_SESSION.value,
+        hook_event.native_id,
+        hook_event.session_native_id,
+        source_path,
+        hook_event.event_type,
+        '{"event":"PostToolUse","probe":"source-v27"}',
+        hook_event.observed_at_ms,
+        expected_blob_hash,
+    )
+    expected_blob_ref_row = (
+        expected_blob_hash,
+        "hook_payload",
+        hook_event.hook_event_id,
+        source_path,
+        len(payload),
+        hook_event.observed_at_ms,
+    )
+    if returned_raw_id != "durable-change-train-source-v27-raw":
+        raise DurableChangeTrainError("source hook writer probe returned the wrong raw identity")
+    if hook_row != expected_hook_row or blob_ref_row != expected_blob_ref_row or raw_session_count != (0,):
+        raise DurableChangeTrainError("source hook writer probe did not persist the expected hook payload contract")
+    return "wrote and read back a hook payload in a fresh source tier"
 
 
 def _open_existing_tier(tier_path: Path) -> sqlite3.Connection:

--- a/tests/unit/storage/test_durable_change_train.py
+++ b/tests/unit/storage/test_durable_change_train.py
@@ -19,8 +19,10 @@ from polylogue.storage.sqlite.archive_tiers import ARCHIVE_DDL_BY_TIER, ARCHIVE_
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.durable_change_train import (
     DURABLE_MIGRATION_ADOPTION_FLOORS,
+    _runtime_consumer_results,
     durable_change_train_manifest_path,
     durable_change_train_policy_report,
+    durable_migration_sidecar_for_slot,
     execute_durable_change_train,
     validate_durable_migration_sidecars,
 )
@@ -137,6 +139,29 @@ def _production_rider() -> DurableChangeRider:
             ),
         ),
         behavior_proof_refs=("proof:bootstrap", "proof:daemon-health"),
+    )
+
+
+def _source_hook_event_production_rider() -> DurableChangeRider:
+    return DurableChangeRider(
+        rider_id="rider:source-hook-event",
+        owner_ref="owner:source-hook-event",
+        schema_objects=("table:raw_hook_events",),
+        runtime_consumers=(
+            DurableRuntimeConsumer(
+                "source-hook-event-writer",
+                "polylogue/storage/sqlite/archive_tiers/source_write.py:write_source_hook_event",
+                "proof:source-v27:raw-hook-events-origin-repair",
+                ("write",),
+            ),
+            DurableRuntimeConsumer(
+                "source-hook-event-bootstrap",
+                "polylogue/storage/sqlite/archive_tiers/bootstrap.py:initialize_archive_tier",
+                "proof:source-v27:raw-hook-events-origin-repair",
+                ("read",),
+            ),
+        ),
+        behavior_proof_refs=("proof:source-v27:raw-hook-events-origin-repair",),
     )
 
 
@@ -260,6 +285,62 @@ def _runtime_results() -> tuple[DurableRuntimeConsumerResult, ...]:
         DurableRuntimeConsumerResult("consumer-0", "proof:behavior:0", True),
         DurableRuntimeConsumerResult("consumer-1", "proof:behavior:1", True),
     )
+
+
+def test_source_v27_sidecar_proves_the_real_hook_event_writer_against_fresh_schema(tmp_path: Path) -> None:
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+
+    sidecar = durable_migration_sidecar_for_slot(ArchiveTier.SOURCE, 27)
+    assert sidecar is not None
+    initialize_archive_database(tmp_path / "source.db", ArchiveTier.SOURCE)
+
+    results = _runtime_consumer_results(sidecar.train, tmp_path)
+
+    hook_writer = next(result for result in results if result.consumer_id == "source-hook-event-writer")
+    assert hook_writer.passed is True
+    assert hook_writer.behavior_proof_ref == "proof:source-v27:raw-hook-events-origin-repair"
+    assert hook_writer.detail == "wrote and read back a hook payload in a fresh source tier"
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        assert conn.execute("SELECT COUNT(*) FROM raw_hook_events").fetchone() == (0,)
+        assert conn.execute("SELECT COUNT(*) FROM blob_refs").fetchone() == (0,)
+
+
+def test_applied_train_release_requires_the_source_hook_event_writer_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "source.db"
+    _create_current_database(db_path)
+    _install_synthetic_migration(tmp_path, monkeypatch, ArchiveTier.SOURCE)
+    train = _admitted(ArchiveTier.SOURCE, rider=_source_hook_event_production_rider())
+    with sqlite3.connect(db_path) as conn:
+        train = _reserve_and_authorize(conn, train, archive_root=tmp_path)
+        train = apply_durable_change_train(conn, train)
+
+    train = record_durable_writer_release(train, evidence_ref="proof:source-hook-event-writer-release")
+    with sqlite3.connect(db_path) as restarted:
+        actual_parity = _parity(ArchiveTier.SOURCE)
+        runtime_results = _runtime_consumer_results(train, tmp_path)
+        restart = capture_durable_restart_convergence(
+            restarted,
+            train,
+            runtime_consumers=runtime_results,
+            evidence_ref="proof:source-hook-event-restart",
+        )
+    train = prove_durable_change_train(
+        train,
+        fresh_ddl_parity=actual_parity,
+        runtime_consumers=runtime_results,
+        restart_convergence=restart,
+    )
+    released = release_durable_change_train(train, evidence_ref="proof:source-hook-event-release")
+
+    assert released.state is DurableChangeTrainState.RELEASED
+    assert released.proof is not None
+    hook_writer = next(
+        result for result in released.proof.runtime_consumers if result.consumer_id == "source-hook-event-writer"
+    )
+    assert hook_writer.passed is True
 
 
 @pytest.mark.parametrize("tier", (ArchiveTier.SOURCE, ArchiveTier.USER))


### PR DESCRIPTION
## Summary
Add the missing durable runtime probe adapter for source v27 consumer `source-hook-event-writer`.

## Problem
Source v27 declares `polylogue/storage/sqlite/archive_tiers/source_write.py:write_source_hook_event` as a production consumer. Its required keyword-only runtime contract had no adapter in `_runtime_consumer_results`, so an applied durable train could not receive complete behavior proof or reach release.

## Solution
Extend the existing reference-based probe dispatcher with an explicit source-tier adapter. The adapter initializes a fresh in-memory source schema, invokes the production writer, validates the persisted hook row and `hook_payload` blob reference, and confirms that no `raw_sessions` row is created. Add direct durable-change-train regressions for the shipped v27 sidecar and the APPLIED-to-RELEASED proof path.

## Verification
- `direnv exec . devtools test tests/unit/storage/test_durable_change_train.py -k 'source_v27 or applied_train_release_requires'`: 2 passed, 35 deselected.
- `direnv exec . devtools verify --quick`: exit 0.
- Pre-push quick verification: exit 0.
- `git diff --check`: passed.

## Compatibility
The probe writes only to an in-memory SQLite connection. It does not alter production archive records or require migration changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Improved validation of durable storage upgrades for source hook events.
  * Confirmed hook-event data, identifiers, payload integrity, and blob references are persisted correctly.
  * Added safeguards to prevent an upgrade from being released until runtime validation succeeds.
  * Expanded coverage for fresh database setup and initially empty storage scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->