### PR TITLE
test(storage): assert aggregate stats use public origins

### DIFF
--- a/tests/unit/storage/test_store_ops.py
+++ b/tests/unit/storage/test_store_ops.py
@@ -277,7 +277,7 @@ def _record_query(**kwargs: Unpack[RecordQueryKwargs]) -> SessionRecordQuery:
 
 
 @pytest.mark.asyncio
-async def test_aggregate_message_stats_reports_role_counts_and_words(workspace_env: dict[str, Path]) -> None:
+async def test_aggregate_message_stats_reports_public_contract(workspace_env: dict[str, Path]) -> None:
     from tests.infra.archive_scenarios import archive_for_scenario_db, native_session_id_for
     from tests.infra.storage_records import SessionBuilder, db_setup
 
@@ -313,7 +313,10 @@ async def test_aggregate_message_stats_reports_role_counts_and_words(workspace_e
     assert unfiltered["words_approx"] == 9
     assert unfiltered["attachment_refs"] == 1
     assert unfiltered["distinct_attachments"] == 1
-    assert unfiltered["origins"] == {"chatgpt-export": 1, "codex-session": 1}
+    assert unfiltered["origins"] == {
+        Origin.CHATGPT_EXPORT.value: 1,
+        Origin.CODEX_SESSION.value: 1,
+    }
 
     assert filtered["total"] == 2
     assert filtered["user"] == 1
@@ -322,7 +325,7 @@ async def test_aggregate_message_stats_reports_role_counts_and_words(workspace_e
     assert filtered["words_approx"] == 5
     assert filtered["attachment_refs"] == 1
     assert filtered["distinct_attachments"] == 1
-    assert filtered["origins"] == {"chatgpt-export": 1}
+    assert filtered["origins"] == {Origin.CHATGPT_EXPORT.value: 1}
 
 
 def _file_read_block(*, message_id: str, session_id: str, path: str, block_index: int = 0) -> BlockRecord:


### PR DESCRIPTION
## Summary
The aggregate message statistics regression test now names and asserts the complete public contract, including canonical Origin values for filtered and unfiltered rollups.

## Problem
The read-all stats path depends on SessionRepository.aggregate_message_stats, so the regression must exercise the async repository and SQLite implementation directly. Provider tokens are an internal vocabulary and must not become the public origin contract.

## Solution
The existing test continues to seed the real SQLite fixture and call archive.repository.aggregate_message_stats() for both scopes. It asserts exact role counts, word totals, attachment rollups, and Origin enum values, with no test-local SQL implementation.

## Verification
- `direnv exec . devtools test tests/unit/storage/test_store_ops.py::test_aggregate_message_stats_reports_public_contract`: 1 passed.
- `direnv exec . devtools verify --quick`: passed, including ruff, mypy, rendering, layering, policy labs, and schema promotion audit.
- Assistant-to-tool mutation: failed at the assistant count assertion (`0 != 1`).
- Word aggregate-to-zero mutation: failed at the unfiltered word assertion (`0 != 9`).

Ref polylogue-7qw4