### PR TITLE
fix(storage): preserve blob namespace during raw inspection

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -155,6 +155,9 @@ not classify orphaned canonical blobs and never runs GC.
 
 ```bash
 polylogue ops maintenance blob-namespace-quarantine --output-format json
+polylogue ops maintenance blob-namespace-quarantine --plan \
+  --backup-manifest /path/to/verified-source-backup/manifest.json \
+  --output-format json
 polylogue ops maintenance blob-namespace-quarantine --apply \
   --backup-manifest /path/to/verified-source-backup/manifest.json \
   --receipt-dir /path/to/new/namespace-quarantine-receipt \
@@ -162,6 +165,13 @@ polylogue ops maintenance blob-namespace-quarantine --apply \
 polylogue ops maintenance blob-namespace-quarantine --recover \
   --receipt-dir /path/to/existing/namespace-quarantine-receipt
 ```
+
+`--plan` is the backup-gated operator audit. It authenticates the supplied
+source-tier backup against an immutable read of `source.db`, then emits a
+typed census of canonical blobs, SQLite `-wal`/`-shm` sidecars, `.blob.*`
+temporary files, and other invalid entries. It does not create receipts,
+checkpoint SQLite, move files, delete files, or change archive rows. Run this
+plan before any later offline quarantine decision.
 
 Apply requires the daemon stopped, no archive writer lease, the archive-wide
 exclusive maintenance lease, a successful attested source-tier backup manifest

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -173,6 +173,11 @@ temporary files, and other invalid entries. It does not create receipts,
 checkpoint SQLite, move files, delete files, or change archive rows. Run this
 plan before any later offline quarantine decision.
 
+This plan is an offline safety prerequisite, not a production cleanup receipt
+or a complete bead-closure claim. The full-hash pristine receipt required by
+`r9xsj` remains a separate residual dependency, and production cleanup remains
+a separate operator-authorized residual dependency. No receipt is claimed here.
+
 Apply requires the daemon stopped, no archive writer lease, the archive-wide
 exclusive maintenance lease, a successful attested source-tier backup manifest
 whose live identity still matches `source.db`, and a clean WAL checkpoint. The

--- a/polylogue/archive/raw_payload/decode.py
+++ b/polylogue/archive/raw_payload/decode.py
@@ -330,9 +330,15 @@ def build_raw_payload_envelope(
     fallback_provider: str | Provider,
     payload_provider: str | Provider | None = None,
     jsonl_dict_only: bool = False,
-    sqlite_immutable: bool = False,
+    sqlite_immutable: bool = True,
 ) -> RawPayloadEnvelope:
     """Decode raw payload and attach canonical provider/wire-format identity.
+
+    Path-backed SQLite inspection defaults to SQLite's immutable read mode.
+    Callers that inspect retained content-addressed blobs therefore cannot
+    accidentally create ``-wal`` or ``-shm`` namespace entries by omitting a
+    safety flag. Live-source discovery keeps its separate parser path because
+    it may need the source database's active WAL.
 
     When *raw_content* is a :class:`~pathlib.Path`, JSONL payloads are
     decoded line-by-line from disk before being materialized into a

--- a/polylogue/archive/raw_payload/decode.py
+++ b/polylogue/archive/raw_payload/decode.py
@@ -330,15 +330,14 @@ def build_raw_payload_envelope(
     fallback_provider: str | Provider,
     payload_provider: str | Provider | None = None,
     jsonl_dict_only: bool = False,
-    sqlite_immutable: bool = True,
+    sqlite_immutable: bool = False,
 ) -> RawPayloadEnvelope:
     """Decode raw payload and attach canonical provider/wire-format identity.
 
-    Path-backed SQLite inspection defaults to SQLite's immutable read mode.
-    Callers that inspect retained content-addressed blobs therefore cannot
-    accidentally create ``-wal`` or ``-shm`` namespace entries by omitting a
-    safety flag. Live-source discovery keeps its separate parser path because
-    it may need the source database's active WAL.
+    The default preserves live-source marker semantics, where an active SQLite
+    database may need its WAL. Callers inspecting retained content-addressed
+    blobs must pass ``sqlite_immutable=True`` so SQLite cannot create ``-wal``
+    or ``-shm`` namespace entries beside the blob.
 
     When *raw_content* is a :class:`~pathlib.Path`, JSONL payloads are
     decoded line-by-line from disk before being materialized into a

--- a/polylogue/cli/commands/maintenance/_blob_namespace_quarantine.py
+++ b/polylogue/cli/commands/maintenance/_blob_namespace_quarantine.py
@@ -12,13 +12,19 @@ from polylogue.paths import archive_root
 
 @click.command("blob-namespace-quarantine")
 @click.option(
+    "--plan",
+    "plan_only",
+    is_flag=True,
+    help="Build a backup-attested, read-only cleanup plan without moving or deleting entries.",
+)
+@click.option(
     "--apply", "apply_changes", is_flag=True, help="Move the proven invalid namespace entries into quarantine."
 )
 @click.option(
     "--backup-manifest",
     type=click.Path(dir_okay=False, path_type=Path),
     default=None,
-    help="Verified, attested source-tier backup manifest required with --apply.",
+    help="Verified, attested source-tier backup manifest required with --plan or --apply.",
 )
 @click.option(
     "--receipt-dir",
@@ -36,26 +42,55 @@ from polylogue.paths import archive_root
     show_default=True,
 )
 def blob_namespace_quarantine_command(
+    plan_only: bool,
     apply_changes: bool,
     backup_manifest: Path | None,
     receipt_dir: Path | None,
     recover: bool,
     output_format: str,
 ) -> None:
-    """Census invalid blob namespace entries; apply only as offline quarantine.
+    """Plan or census invalid blob namespace entries; apply only as offline quarantine.
 
-    The default is a complete, read-only census. ``--apply`` requires the
-    daemon stopped, the archive writer lease to be clear, a verified attested
-    source backup, a clean WAL checkpoint, and a fresh explicit receipt
-    directory. It only uses atomic same-filesystem moves and never deletes,
-    garbage-collects, changes SQLite rows, or moves canonical blobs.
+    The default is a complete, read-only census. ``--plan`` additionally
+    authenticates a supplied backup manifest and remains fully non-mutating.
+    ``--apply`` requires the daemon stopped, the archive writer lease to be
+    clear, a verified attested source backup, a clean WAL checkpoint, and a
+    fresh explicit receipt directory. It only uses atomic same-filesystem
+    moves and never deletes, garbage-collects, changes SQLite rows, or moves
+    canonical blobs.
     """
 
     from polylogue.operations.blob_namespace_quarantine import (
         BlobNamespaceQuarantineError,
         classify_blob_namespace_quarantine_recovery,
+        plan_blob_namespace_cleanup,
         quarantine_blob_namespace,
     )
+
+    if plan_only:
+        if apply_changes or recover:
+            raise click.UsageError("--plan cannot be combined with --apply or --recover")
+        if backup_manifest is None:
+            raise click.UsageError("--plan requires --backup-manifest")
+        try:
+            plan = plan_blob_namespace_cleanup(archive_root(), backup_manifest=backup_manifest)
+        except BlobNamespaceQuarantineError as exc:
+            raise click.ClickException(str(exc)) from exc
+        payload = {"mode": "blob_namespace_cleanup_plan", **plan.to_dict()}
+        if output_format == "json":
+            click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            click.echo("Blob namespace cleanup plan")
+            click.echo(f"Blob root:  {plan.blob_root}")
+            click.echo(f"Canonical: {len(plan.census.canonical):,}")
+            click.echo(f"Candidates: {len(plan.census.candidates):,}")
+            click.echo(f"Blockers:   {len(plan.census.blockers):,}")
+            click.echo("Moves:      no")
+            click.echo("Deletes:    no")
+            click.echo("SQLite writes: no")
+            for blocker in plan.census.blockers:
+                click.echo(f"  blocker: {blocker}")
+        return
 
     if recover:
         if apply_changes or backup_manifest is not None:

--- a/polylogue/maintenance/blob_namespace_quarantine.py
+++ b/polylogue/maintenance/blob_namespace_quarantine.py
@@ -23,6 +23,7 @@ import stat
 import time
 import uuid
 from dataclasses import asdict, dataclass
+from enum import StrEnum
 from pathlib import Path
 
 from polylogue.config import Config
@@ -36,6 +37,12 @@ from polylogue.storage.sqlite.migration_runner import validate_migration_backup_
 TOOL_VERSION = "blob-namespace-quarantine-v1"
 _CHUNK_SIZE = 1024 * 1024
 _QUARANTINE_DIRNAME = "blob-namespace-quarantine"
+
+
+class BlobNamespaceMoveCapability(StrEnum):
+    """Filesystem movement capability granted by a namespace cleanup plan."""
+
+    NONE = "none"
 
 
 class BlobNamespaceQuarantineError(RuntimeError):
@@ -123,6 +130,7 @@ class BlobNamespaceCleanupPlan:
     backup_manifest: Path
     backup_verification_receipt: Path
     census: BlobNamespaceCensus
+    move_capability: BlobNamespaceMoveCapability = BlobNamespaceMoveCapability.NONE
     deletes_files: bool = False
     moves_files: bool = False
     mutates_sqlite: bool = False
@@ -133,6 +141,7 @@ class BlobNamespaceCleanupPlan:
             "blob_root": str(self.blob_root),
             "backup_manifest": str(self.backup_manifest),
             "backup_verification_receipt": str(self.backup_verification_receipt),
+            "move_capability": self.move_capability.value,
             "deletes_files": self.deletes_files,
             "moves_files": self.moves_files,
             "mutates_sqlite": self.mutates_sqlite,
@@ -895,6 +904,7 @@ __all__ = [
     "BlobNamespaceCanonicalEntry",
     "BlobNamespaceCensus",
     "BlobNamespaceCleanupPlan",
+    "BlobNamespaceMoveCapability",
     "BlobNamespaceQuarantineEntry",
     "BlobNamespaceQuarantineError",
     "BlobNamespaceQuarantineReport",

--- a/polylogue/maintenance/blob_namespace_quarantine.py
+++ b/polylogue/maintenance/blob_namespace_quarantine.py
@@ -109,6 +109,38 @@ class BlobNamespaceCensus:
 
 
 @dataclass(frozen=True, slots=True)
+class BlobNamespaceCleanupPlan:
+    """Backup-attested, read-only plan for invalid namespace entries.
+
+    The plan is deliberately separate from the quarantine report. Producing
+    it never creates a receipt, moves a filesystem entry, checkpoints SQLite,
+    or changes an archive row. The later quarantine actuator may consume the
+    same census only after its own offline and lock-held revalidation.
+    """
+
+    archive_root: Path
+    blob_root: Path
+    backup_manifest: Path
+    backup_verification_receipt: Path
+    census: BlobNamespaceCensus
+    deletes_files: bool = False
+    moves_files: bool = False
+    mutates_sqlite: bool = False
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "archive_root": str(self.archive_root),
+            "blob_root": str(self.blob_root),
+            "backup_manifest": str(self.backup_manifest),
+            "backup_verification_receipt": str(self.backup_verification_receipt),
+            "deletes_files": self.deletes_files,
+            "moves_files": self.moves_files,
+            "mutates_sqlite": self.mutates_sqlite,
+            **self.census.to_dict(),
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class BlobNamespaceQuarantineReport:
     """Dry-run or applied namespace-quarantine outcome."""
 
@@ -436,6 +468,52 @@ def _census(blob_root: Path, *, quarantine_root: Path) -> BlobNamespaceCensus:
     canonical.sort(key=lambda item: item.relative_path)
     candidates.sort(key=lambda item: item.relative_path)
     return BlobNamespaceCensus(canonical=tuple(canonical), candidates=tuple(candidates), blockers=tuple(blockers))
+
+
+def plan_blob_namespace_cleanup(
+    archive_root: Path,
+    *,
+    backup_manifest: Path | None,
+) -> BlobNamespaceCleanupPlan:
+    """Build a backup-gated, non-mutating plan for invalid blob entries.
+
+    This command is intentionally usable before any cleanup decision. The
+    backup manifest is authenticated against an immutable source-tier read,
+    and the namespace census records existing sidecars, ``.blob.*`` temps,
+    malformed shards, and other invalid entries without deleting or moving
+    them.
+    """
+    if backup_manifest is None:
+        raise BlobNamespaceQuarantineError(
+            "planning blob namespace cleanup requires a verified source backup manifest (--backup-manifest)"
+        )
+
+    archive_root = _absolute(archive_root)
+    backup_manifest = _absolute(backup_manifest)
+    _require_offline(archive_root)
+    source_db = archive_root / "source.db"
+    try:
+        source_uri = source_db.resolve().as_uri() + "?mode=ro&immutable=1"
+        with sqlite3.connect(source_uri, uri=True) as source_conn:
+            verification_receipt = validate_migration_backup_manifest(
+                backup_manifest,
+                ArchiveTier.SOURCE,
+                connection=source_conn,
+            )
+    except Exception as exc:
+        raise BlobNamespaceQuarantineError(f"backup manifest validation failed: {exc}") from exc
+
+    census = _census(
+        archive_root / "blob",
+        quarantine_root=archive_root / _QUARANTINE_DIRNAME / "plan",
+    )
+    return BlobNamespaceCleanupPlan(
+        archive_root=archive_root,
+        blob_root=archive_root / "blob",
+        backup_manifest=backup_manifest,
+        backup_verification_receipt=verification_receipt,
+        census=census,
+    )
 
 
 def _same_census(left: BlobNamespaceCensus, right: BlobNamespaceCensus) -> bool:
@@ -816,10 +894,12 @@ __all__ = [
     "TOOL_VERSION",
     "BlobNamespaceCanonicalEntry",
     "BlobNamespaceCensus",
+    "BlobNamespaceCleanupPlan",
     "BlobNamespaceQuarantineEntry",
     "BlobNamespaceQuarantineError",
     "BlobNamespaceQuarantineReport",
     "BlobNamespaceRecoveryReport",
     "classify_blob_namespace_quarantine_recovery",
+    "plan_blob_namespace_cleanup",
     "quarantine_blob_namespace",
 ]

--- a/polylogue/operations/blob_namespace_quarantine.py
+++ b/polylogue/operations/blob_namespace_quarantine.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from polylogue.maintenance.blob_namespace_quarantine import (
     BlobNamespaceCleanupPlan,
+    BlobNamespaceMoveCapability,
     BlobNamespaceQuarantineError,
     BlobNamespaceQuarantineReport,
     BlobNamespaceRecoveryReport,
@@ -14,6 +15,7 @@ from polylogue.maintenance.blob_namespace_quarantine import (
 
 __all__ = [
     "BlobNamespaceCleanupPlan",
+    "BlobNamespaceMoveCapability",
     "BlobNamespaceQuarantineError",
     "BlobNamespaceQuarantineReport",
     "BlobNamespaceRecoveryReport",

--- a/polylogue/operations/blob_namespace_quarantine.py
+++ b/polylogue/operations/blob_namespace_quarantine.py
@@ -3,17 +3,21 @@
 from __future__ import annotations
 
 from polylogue.maintenance.blob_namespace_quarantine import (
+    BlobNamespaceCleanupPlan,
     BlobNamespaceQuarantineError,
     BlobNamespaceQuarantineReport,
     BlobNamespaceRecoveryReport,
     classify_blob_namespace_quarantine_recovery,
+    plan_blob_namespace_cleanup,
     quarantine_blob_namespace,
 )
 
 __all__ = [
+    "BlobNamespaceCleanupPlan",
     "BlobNamespaceQuarantineError",
     "BlobNamespaceQuarantineReport",
     "BlobNamespaceRecoveryReport",
     "classify_blob_namespace_quarantine_recovery",
+    "plan_blob_namespace_cleanup",
     "quarantine_blob_namespace",
 ]

--- a/polylogue/schemas/sampling_db.py
+++ b/polylogue/schemas/sampling_db.py
@@ -205,6 +205,7 @@ def _build_raw_payload_envelope_for_row(
             source_path=row.source_path,
             fallback_provider=row.provider_token or str(source_name),
             jsonl_dict_only=config.sample_granularity == "record",
+            sqlite_immutable=True,
         ),
         compacted_payload is not None,
     )

--- a/polylogue/storage/artifacts/inspection.py
+++ b/polylogue/storage/artifacts/inspection.py
@@ -50,7 +50,7 @@ def _build_payload_envelope(
     raw_content: Path | bytes,
     record: RawSessionRecord,
     *,
-    sqlite_immutable: bool = False,
+    sqlite_immutable: bool = True,
 ) -> RawPayloadEnvelope:
     return build_raw_payload_envelope(
         raw_content,

--- a/tests/unit/core/test_sampling.py
+++ b/tests/unit/core/test_sampling.py
@@ -6,8 +6,10 @@ and load_samples_from_sessions with JSON/JSONL fixtures.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
+import sqlite3
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
@@ -581,6 +583,77 @@ class TestLoadSamplesFromDb:
                 "reason": "artifact_taxonomy:Hermes SQLite evidence sidecar",
             }
         ]
+
+    def test_hermes_sqlite_schema_sampling_keeps_blob_namespace_pristine(self, tmp_path: Path) -> None:
+        """Schema sampling decodes retained SQLite blobs through an immutable URI."""
+        from polylogue.storage.blob_store import get_blob_store
+
+        db = _archive_index_db(tmp_path)
+        sqlite_path = tmp_path / "state.db"
+        with sqlite3.connect(sqlite_path) as conn:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.executescript(
+                """
+                CREATE TABLE schema_version(version INTEGER NOT NULL);
+                INSERT INTO schema_version(version) VALUES (16);
+                CREATE TABLE sessions (
+                    id TEXT PRIMARY KEY,
+                    source TEXT,
+                    model_config TEXT,
+                    parent_session_id TEXT,
+                    started_at REAL
+                );
+                CREATE TABLE messages (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    session_id TEXT NOT NULL,
+                    role TEXT NOT NULL,
+                    content TEXT,
+                    tool_calls TEXT,
+                    timestamp REAL NOT NULL,
+                    observed INTEGER DEFAULT 0,
+                    active INTEGER NOT NULL DEFAULT 1,
+                    compacted INTEGER NOT NULL DEFAULT 0
+                );
+                INSERT INTO sessions(id, model_config, started_at) VALUES ('hermes-root', '{}', 1.0);
+                INSERT INTO messages(session_id, role, content, timestamp)
+                VALUES ('hermes-root', 'assistant', 'hello', 2.0);
+                """
+            )
+            conn.commit()
+        content = sqlite_path.read_bytes()
+        raw_id = _insert_raw_session(
+            db_path=db,
+            origin="hermes-session",
+            source_path="/original/profile/state.db",
+            raw_content=content,
+        )
+
+        outcomes: list[dict[str, object]] = []
+        units = list(
+            iter_schema_units(
+                "hermes",
+                db_path=db,
+                full_corpus=True,
+                terminal_recorder=lambda **outcome: outcomes.append(outcome),
+            )
+        )
+        verification = get_blob_store().verify_all()
+
+        assert units == []
+        assert outcomes == [
+            {
+                "raw_id": raw_id,
+                "status": "unsupported",
+                "artifact_kind": None,
+                "source_path": "/original/profile/state.db",
+                "reason": "no_schema_eligible_units",
+            }
+        ]
+        assert verification.passed, verification.failures
+        assert verification.checked == 1
+        blob_path = get_blob_store().blob_path(hashlib.sha256(content).hexdigest())
+        assert not blob_path.with_name(blob_path.name + "-wal").exists()
+        assert not blob_path.with_name(blob_path.name + "-shm").exists()
 
     def test_explicit_db_path_zero_units_does_not_scan_session_dir(
         self,

--- a/tests/unit/maintenance/test_blob_namespace_quarantine.py
+++ b/tests/unit/maintenance/test_blob_namespace_quarantine.py
@@ -6,14 +6,19 @@ import hashlib
 import json
 import os
 import sqlite3
+import stat
 from pathlib import Path
 
 import pytest
+from click.testing import CliRunner
 
+from polylogue.cli.click_app import cli
 from polylogue.config import Source
 from polylogue.maintenance.blob_namespace_quarantine import (
+    BlobNamespaceCleanupPlan,
     BlobNamespaceQuarantineError,
     classify_blob_namespace_quarantine_recovery,
+    plan_blob_namespace_cleanup,
     quarantine_blob_namespace,
 )
 from polylogue.sources.source_parsing import iter_source_sessions_with_raw
@@ -56,6 +61,25 @@ def _inject_invalid_entries(blob_root: Path) -> dict[str, bytes]:
     return entries
 
 
+def _filesystem_snapshot(root: Path) -> tuple[tuple[str, int, int, str | None, str | None], ...]:
+    snapshot: list[tuple[str, int, int, str | None, str | None]] = []
+    for directory, dirnames, filenames in os.walk(root, followlinks=False):
+        directory_path = Path(directory)
+        names = sorted((*dirnames, *filenames))
+        for name in names:
+            path = directory_path / name
+            details = os.lstat(path)
+            mode = stat.S_IFMT(details.st_mode)
+            digest: str | None = None
+            link_target: str | None = None
+            if stat.S_ISREG(details.st_mode):
+                digest = hashlib.sha256(path.read_bytes()).hexdigest()
+            elif stat.S_ISLNK(details.st_mode):
+                link_target = os.readlink(path)
+            snapshot.append((path.relative_to(root).as_posix(), mode, details.st_size, digest, link_target))
+    return tuple(snapshot)
+
+
 def test_dry_run_classifies_mixed_namespace_without_mutating(tmp_path: Path) -> None:
     archive_root = _archive(tmp_path)
     store = BlobStore(archive_root / "blob")
@@ -75,6 +99,100 @@ def test_dry_run_classifies_mixed_namespace_without_mutating(tmp_path: Path) -> 
     assert store.blob_path(canonical_hash).read_bytes() == b"canonical payload"
     assert all((store.root / relative).exists() for relative in invalid)
     assert (store.root / "cd" / "link").is_symlink()
+
+
+def test_backup_gated_cleanup_plan_is_typed_and_read_only(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    archive_root = _archive(tmp_path)
+    store = BlobStore(archive_root / "blob")
+    canonical_hash, _ = store.write_from_bytes(b"canonical payload")
+    invalid = _inject_invalid_entries(store.root)
+    source_before = hashlib.sha256((archive_root / "source.db").read_bytes()).hexdigest()
+    manifest = _verified_source_backup(archive_root, tmp_path, monkeypatch)
+    before = _filesystem_snapshot(archive_root)
+
+    plan = plan_blob_namespace_cleanup(archive_root, backup_manifest=manifest)
+
+    assert isinstance(plan, BlobNamespaceCleanupPlan)
+    assert plan.census.safe_to_apply
+    assert plan.deletes_files is False
+    assert plan.moves_files is False
+    assert plan.mutates_sqlite is False
+    assert [entry.hash_hex for entry in plan.census.canonical] == [canonical_hash]
+    assert {entry.relative_path for entry in plan.census.candidates} == {
+        *invalid,
+        "cd/link",
+        "cd/nested",
+    }
+    assert hashlib.sha256((archive_root / "source.db").read_bytes()).hexdigest() == source_before
+    assert _filesystem_snapshot(archive_root) == before
+    assert not (archive_root / "blob-namespace-quarantine").exists()
+    assert all((store.root / relative).exists() for relative in invalid)
+    assert (store.root / "cd" / "link").is_symlink()
+
+
+def test_cleanup_plan_requires_backup_without_touching_namespace(tmp_path: Path) -> None:
+    archive_root = _archive(tmp_path)
+    store = BlobStore(archive_root / "blob")
+    store.write_from_bytes(b"canonical payload")
+    invalid = _inject_invalid_entries(store.root)
+
+    with pytest.raises(BlobNamespaceQuarantineError, match="verified source backup manifest"):
+        plan_blob_namespace_cleanup(archive_root, backup_manifest=None)
+
+    assert all((store.root / relative).exists() for relative in invalid)
+
+
+def test_cleanup_plan_refuses_online_archive_without_touching_namespace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive_root = _archive(tmp_path)
+    store = BlobStore(archive_root / "blob")
+    store.write_from_bytes(b"canonical payload")
+    invalid = _inject_invalid_entries(store.root)
+    manifest = _verified_source_backup(archive_root, tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        "polylogue.maintenance.blob_namespace_quarantine.running_daemon_pid",
+        lambda _config: 4242,
+    )
+
+    with pytest.raises(BlobNamespaceQuarantineError, match="PID 4242"):
+        plan_blob_namespace_cleanup(archive_root, backup_manifest=manifest)
+
+    assert all((store.root / relative).exists() for relative in invalid)
+    assert not (archive_root / "blob-namespace-quarantine").exists()
+
+
+def test_cleanup_plan_cli_emits_typed_non_mutation_contract(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    archive_root = _archive(tmp_path)
+    store = BlobStore(archive_root / "blob")
+    store.write_from_bytes(b"canonical payload")
+    _inject_invalid_entries(store.root)
+    manifest = _verified_source_backup(archive_root, tmp_path, monkeypatch)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "blob-namespace-quarantine",
+            "--plan",
+            "--backup-manifest",
+            str(manifest),
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.stdout or result.stderr, repr(result)
+    payload = json.loads(result.stdout)
+    assert payload["mode"] == "blob_namespace_cleanup_plan"
+    assert payload["deletes_files"] is False
+    assert payload["moves_files"] is False
+    assert payload["mutates_sqlite"] is False
+    assert payload["invalid_namespace_entries"] == 6
 
 
 def test_apply_moves_only_invalid_entries_and_writes_immutable_receipts(

--- a/tests/unit/maintenance/test_blob_namespace_quarantine.py
+++ b/tests/unit/maintenance/test_blob_namespace_quarantine.py
@@ -16,6 +16,7 @@ from polylogue.cli.click_app import cli
 from polylogue.config import Source
 from polylogue.maintenance.blob_namespace_quarantine import (
     BlobNamespaceCleanupPlan,
+    BlobNamespaceMoveCapability,
     BlobNamespaceQuarantineError,
     classify_blob_namespace_quarantine_recovery,
     plan_blob_namespace_cleanup,
@@ -61,8 +62,8 @@ def _inject_invalid_entries(blob_root: Path) -> dict[str, bytes]:
     return entries
 
 
-def _filesystem_snapshot(root: Path) -> tuple[tuple[str, int, int, str | None, str | None], ...]:
-    snapshot: list[tuple[str, int, int, str | None, str | None]] = []
+def _filesystem_snapshot(root: Path) -> tuple[tuple[str, int, int, int, int, int, str | None, str | None], ...]:
+    snapshot: list[tuple[str, int, int, int, int, int, str | None, str | None]] = []
     for directory, dirnames, filenames in os.walk(root, followlinks=False):
         directory_path = Path(directory)
         names = sorted((*dirnames, *filenames))
@@ -76,7 +77,18 @@ def _filesystem_snapshot(root: Path) -> tuple[tuple[str, int, int, str | None, s
                 digest = hashlib.sha256(path.read_bytes()).hexdigest()
             elif stat.S_ISLNK(details.st_mode):
                 link_target = os.readlink(path)
-            snapshot.append((path.relative_to(root).as_posix(), mode, details.st_size, digest, link_target))
+            snapshot.append(
+                (
+                    path.relative_to(root).as_posix(),
+                    mode,
+                    details.st_dev,
+                    details.st_ino,
+                    details.st_mtime_ns,
+                    details.st_size,
+                    digest,
+                    link_target,
+                )
+            )
     return tuple(snapshot)
 
 
@@ -108,11 +120,16 @@ def test_backup_gated_cleanup_plan_is_typed_and_read_only(tmp_path: Path, monkey
     invalid = _inject_invalid_entries(store.root)
     source_before = hashlib.sha256((archive_root / "source.db").read_bytes()).hexdigest()
     manifest = _verified_source_backup(archive_root, tmp_path, monkeypatch)
-    before = _filesystem_snapshot(archive_root)
+    backup_root = manifest.parent
+    for suffix in ("-wal", "-shm", "-journal"):
+        (archive_root / f"source.db{suffix}").touch()
+    archive_before = _filesystem_snapshot(archive_root)
+    backup_before = _filesystem_snapshot(backup_root)
 
     plan = plan_blob_namespace_cleanup(archive_root, backup_manifest=manifest)
 
     assert isinstance(plan, BlobNamespaceCleanupPlan)
+    assert plan.move_capability is BlobNamespaceMoveCapability.NONE
     assert plan.census.safe_to_apply
     assert plan.deletes_files is False
     assert plan.moves_files is False
@@ -124,7 +141,11 @@ def test_backup_gated_cleanup_plan_is_typed_and_read_only(tmp_path: Path, monkey
         "cd/nested",
     }
     assert hashlib.sha256((archive_root / "source.db").read_bytes()).hexdigest() == source_before
-    assert _filesystem_snapshot(archive_root) == before
+    assert _filesystem_snapshot(archive_root) == archive_before
+    assert _filesystem_snapshot(backup_root) == backup_before
+    assert manifest.relative_to(backup_root).as_posix() == "manifest.json"
+    assert plan.backup_verification_receipt.relative_to(backup_root).as_posix() == "verification-receipt.json"
+    assert all((archive_root / f"source.db{suffix}").exists() for suffix in ("-wal", "-shm", "-journal"))
     assert not (archive_root / "blob-namespace-quarantine").exists()
     assert all((store.root / relative).exists() for relative in invalid)
     assert (store.root / "cd" / "link").is_symlink()
@@ -150,6 +171,9 @@ def test_cleanup_plan_refuses_online_archive_without_touching_namespace(
     store.write_from_bytes(b"canonical payload")
     invalid = _inject_invalid_entries(store.root)
     manifest = _verified_source_backup(archive_root, tmp_path, monkeypatch)
+    backup_root = manifest.parent
+    archive_before = _filesystem_snapshot(archive_root)
+    backup_before = _filesystem_snapshot(backup_root)
     monkeypatch.setattr(
         "polylogue.maintenance.blob_namespace_quarantine.running_daemon_pid",
         lambda _config: 4242,
@@ -160,6 +184,8 @@ def test_cleanup_plan_refuses_online_archive_without_touching_namespace(
 
     assert all((store.root / relative).exists() for relative in invalid)
     assert not (archive_root / "blob-namespace-quarantine").exists()
+    assert _filesystem_snapshot(archive_root) == archive_before
+    assert _filesystem_snapshot(backup_root) == backup_before
 
 
 def test_cleanup_plan_cli_emits_typed_non_mutation_contract(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -192,6 +218,7 @@ def test_cleanup_plan_cli_emits_typed_non_mutation_contract(tmp_path: Path, monk
     assert payload["deletes_files"] is False
     assert payload["moves_files"] is False
     assert payload["mutates_sqlite"] is False
+    assert payload["move_capability"] == "none"
     assert payload["invalid_namespace_entries"] == 6
 
 

--- a/tests/unit/sources/test_parsers_local_agent.py
+++ b/tests/unit/sources/test_parsers_local_agent.py
@@ -915,11 +915,27 @@ def test_hermes_state_db_raw_payload_envelope_uses_marker(tmp_path: Path) -> Non
     db_path = tmp_path / "state.db"
     _write_hermes_state_db(db_path)
 
-    envelope = build_raw_payload_envelope(db_path, source_path=db_path, fallback_provider="inbox")
+    envelope = build_raw_payload_envelope(
+        db_path,
+        source_path=db_path,
+        fallback_provider="inbox",
+        sqlite_immutable=False,
+    )
 
     assert envelope.provider is Provider.HERMES
     assert envelope.artifact.parse_as_session is True
-    assert envelope.payload == hermes_state.marker_payload(db_path, profile_root=db_path.parent)
+    assert envelope.payload == hermes_state.marker_payload(db_path, profile_root=db_path.parent, immutable=False)
+    assert "sqlite_immutable" not in envelope.payload
+
+
+def test_hermes_state_db_raw_payload_envelope_default_keeps_live_marker_semantics(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    _write_hermes_state_db(db_path)
+
+    envelope = build_raw_payload_envelope(db_path, source_path=db_path, fallback_provider="inbox")
+
+    assert envelope.payload == hermes_state.marker_payload(db_path, profile_root=db_path.parent, immutable=False)
+    assert "sqlite_immutable" not in envelope.payload
 
 
 def test_hermes_state_db_live_batch_classifies_as_session_artifact(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_blob_store.py
+++ b/tests/unit/storage/test_blob_store.py
@@ -431,16 +431,25 @@ def test_stats_with_blobs(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_iter_all_skips_temp_files(tmp_path: Path) -> None:
+def test_iter_namespace_classifies_interrupted_temp_file_deterministically(tmp_path: Path) -> None:
     blob_store = BlobStore(tmp_path / "blobs")
-    blob_store.write_from_bytes(b"real blob")
+    blob_hash, _ = blob_store.write_from_bytes(b"real blob")
+    prepared = blob_store.prepare_from_bytes(b"interrupted write")
+    try:
+        entries = tuple(blob_store.iter_namespace())
+        verified = blob_store.verify_all()
 
-    # Create a fake temp file (like ones during writes)
-    temp_file = blob_store.root / ".blob.temp123"
-    temp_file.write_bytes(b"temp content")
-
-    hashes = list(blob_store.iter_all())
-    assert len(hashes) == 1  # Only the real blob, not .blob.* temp
+        assert [(entry.relative_path, entry.issue) for entry in entries] == [
+            (prepared.temporary_path.name, BlobNamespaceIssue.INVALID_SHARD_NAME),
+            (blob_hash[:2] + "/" + blob_hash[2:], None),
+        ]
+        assert [(failure.reason, failure.path) for failure in verified.failures] == [
+            ("invalid_namespace_entry", prepared.temporary_path.name),
+        ]
+        assert list(blob_store.iter_all()) == [blob_hash]
+    finally:
+        blob_store.discard_prepared(prepared)
+    assert not prepared.temporary_path.exists()
 
 
 def test_iter_all_skips_non_prefix_dirs(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_hermes_artifact_inspection.py
+++ b/tests/unit/storage/test_hermes_artifact_inspection.py
@@ -134,18 +134,25 @@ def test_retained_wal_snapshot_marker_reopen_keeps_blob_namespace_pristine(
     """Inspection reopens the marker path for schema support, so both opens must be immutable."""
     snapshot = tmp_path / "retained-wal.sqlite3"
     _write_hermes_v16(snapshot, wal_mode=True)
-
-    observation = inspect_raw_artifact(
-        _record(
-            blob_store,
-            snapshot,
-            raw_id="hermes:profile-a:wal-revision",
-            source_path="/original/profile/state.db",
-        )
+    record = _record(
+        blob_store,
+        snapshot,
+        raw_id="hermes:profile-a:wal-revision",
+        source_path="/original/profile/state.db",
     )
 
+    observation = inspect_raw_artifact(record)
+
     assert observation.support_status is ArtifactSupportStatus.SUPPORTED_PARSEABLE
-    assert blob_store.verify_all().passed
+    assert record.blob_hash is not None
+    expected_path = f"{record.blob_hash[:2]}/{record.blob_hash[2:]}"
+    namespace = tuple(blob_store.iter_namespace())
+    assert [entry.relative_path for entry in namespace] == [expected_path]
+    assert all(not entry.relative_path.endswith(("-wal", "-shm")) for entry in namespace)
+    assert not tuple(blob_store.root.rglob("*-wal"))
+    assert not tuple(blob_store.root.rglob("*-shm"))
+    verification = blob_store.verify_all()
+    assert verification.passed, verification.failures
 
 
 def test_retained_structurally_compatible_v17_snapshot_is_parseable(


### PR DESCRIPTION
## Summary

Make retained content-addressed SQLite inspection explicitly immutable while preserving the existing live Hermes marker semantics.

## Problem

The shared raw-payload decoder was changed to default `sqlite_immutable=True`. That protected retained blobs, but it also changed the marker payload emitted by the existing live-source helper route by adding `sqlite_immutable: true`. The marker model and its consumers were not intentionally migrated to that new meaning.

## Solution

The shared decoder default is restored to `sqlite_immutable=False`, which preserves the live marker contract. Every retained content-addressed caller remains explicit with `sqlite_immutable=True`, including retained-artifact inspection, validation, and sampling. The Hermes parser regression now checks both explicit live mode and the default live marker, while the retained WAL-mode inspection regression continues to prove a canonical blob namespace, no `-wal` or `-shm` sidecars, and a passing `BlobStore.verify_all()` result.

## Acceptance matrix

- Retained immutable SQLite inspection: satisfied. Retained callers explicitly request immutable reads, so their content-addressed blobs cannot acquire SQLite sidecars.
- Live Hermes marker semantics: satisfied. The default and explicit live paths emit the unflagged marker expected by the existing parser consumers.
- Retained Hermes WAL namespace proof: satisfied. The real retained-artifact regression checks the complete namespace and `BlobStore.verify_all()`.
- Backup-gated offline plan: satisfied as a non-mutating safety prerequisite. The plan validates the immutable source-tier backup, exposes typed movement capability, and its tests prove no archive or backup inventory changes.
- Active-daemon refusal: satisfied. The plan refuses a reported daemon PID before creating quarantine state and leaves both inventories unchanged.
- `r9xsj` full-hash pristine receipt: residual dependency. This PR does not produce or claim that receipt.
- Production cleanup: residual dependency. This PR does not move, delete, or garbage-collect production entries.
- Bead closure: not claimed. Bead state was not accessed or mutated.

## Verification

- `direnv exec . devtools test tests/unit/sources/test_parsers_local_agent.py tests/unit/storage/test_hermes_artifact_inspection.py tests/unit/pipeline/test_binary_payload_parse_parity.py tests/unit/core/test_raw_payload_decode.py` -> `52 passed`
- `direnv exec . devtools verify --quick` -> exit `0`; all 24 quick-gate steps passed, including format, lint, mypy, generated surfaces, layering, policy checks, and schema promotion audit.
- Devshell-backed pre-push quick verification on commit `132d355e4` -> exit `0`.
- `git diff --check` -> clean.

No production archive or daemon was accessed or mutated.
