### PR TITLE
fix(beads): harden stale hooks and launcher routes

### DIFF
--- a/.agent/CONVENTIONS.md
+++ b/.agent/CONVENTIONS.md
@@ -103,10 +103,13 @@ bead's cited facts against master before coding.
   trusting anything the lane reports — a 2026-08-01 dispatch silently ran in
   the main checkout and left ~1700 uncommitted lines in the live tree. The
   same check warns when the worktree's frozen `.beads/issues.jsonl` has gone
-  stale relative to the main checkout. Hook auto-import is disabled because it
-  would blindly upsert that snapshot into shared live state. Lanes still make
-  no bd writes; coordinators audit and re-apply their Beads writes at
-  merge-train boundaries before exporting state (polylogue-2ara).
+  stale relative to the main checkout. All ordinary `bd` invocations must
+  resolve to `scripts/bd` through the devshell or the hook-local path. That
+  wrapper compares rows with live Dolt state, imports only new/strictly newer
+  rows, and disables Beads' blind automatic import for the delegated command.
+  Do not bypass it with the absolute Nix-store binary. Lanes still make no bd
+  writes; coordinators audit and re-apply explicit Beads writes at merge-train
+  boundaries before exporting state (polylogue-2ara).
 - **Serial heavy, parallel light.** Serialize anything sharing the pytest
   temp DBs (`/realm/tmp/polylogue-pytest`) or the archive DB; parallel tool
   calls are for reads/searches only.

--- a/.agent/CONVENTIONS.md
+++ b/.agent/CONVENTIONS.md
@@ -104,10 +104,11 @@ bead's cited facts against master before coding.
   the main checkout and left ~1700 uncommitted lines in the live tree. The
   same check warns when the worktree's frozen `.beads/issues.jsonl` has gone
   stale relative to the main checkout. All ordinary `bd` invocations must
-  resolve to `scripts/bd` through the devshell or the hook-local path. That
-  wrapper compares rows with live Dolt state, imports only new/strictly newer
-  rows, and disables Beads' blind automatic import for the delegated command.
-  Do not bypass it with the absolute Nix-store binary. Lanes still make no bd
+  resolve to the deployed common-checkout `scripts/bd` through the devshell or
+  Git's shared absolute `core.hooksPath`. That wrapper compares rows with live
+  Dolt state, imports only new/strictly newer rows, and disables Beads' blind
+  automatic import for the delegated command. Do not bypass it with the
+  absolute Nix-store binary. Lanes still make no bd
   writes; coordinators audit and re-apply explicit Beads writes at merge-train
   boundaries before exporting state (polylogue-2ara).
 - **Serial heavy, parallel light.** Serialize anything sharing the pytest

--- a/.beads-hooks/post-checkout
+++ b/.beads-hooks/post-checkout
@@ -1,6 +1,17 @@
 #!/usr/bin/env sh
-_bd_command="$(CDPATH= cd -- "$(dirname -- "$0")/../scripts" && pwd -P)/bd"
-if [ ! -x "$_bd_command" ]; then _bd_command="$(command -v bd 2>/dev/null || true)"; fi
+_bd_common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+if [ -n "$_bd_common_dir" ]; then
+  case "$_bd_common_dir" in
+    /*) ;;
+    *) _bd_common_dir="$(pwd -P)/$_bd_common_dir" ;;
+  esac
+fi
+if [ -n "$_bd_common_dir" ] && [ -d "$_bd_common_dir" ]; then
+  _bd_common_dir="$(CDPATH= cd -- "$_bd_common_dir" && pwd -P)"
+  _bd_command="$(CDPATH= cd -- "$_bd_common_dir/.." && pwd -P)/scripts/bd"
+else
+  _bd_command=
+fi
 # --- BEGIN BEADS INTEGRATION v1.0.4 ---
 # This section is managed by beads. Do not remove these markers.
 if [ -n "$_bd_command" ]; then

--- a/.beads-hooks/post-checkout
+++ b/.beads-hooks/post-checkout
@@ -15,6 +15,10 @@ fi
 # --- BEGIN BEADS INTEGRATION v1.0.4 ---
 # This section is managed by beads. Do not remove these markers.
 if [ -n "$_bd_command" ]; then
+  _bd_configure_hooks="$(CDPATH= cd -- "$_bd_common_dir/.." && pwd -P)/scripts/configure-git-hooks"
+  if [ -x "$_bd_configure_hooks" ]; then
+    "$_bd_configure_hooks"
+  fi
   # Linked worktrees share a live Beads store but retain branch-point JSONL.
   # Do not let a caller re-enable hook imports through Viper's BD_* override.
   unset BD_IMPORT_AUTO

--- a/.beads-hooks/post-checkout
+++ b/.beads-hooks/post-checkout
@@ -1,21 +1,23 @@
 #!/usr/bin/env sh
+_bd_command="$(CDPATH= cd -- "$(dirname -- "$0")/../scripts" && pwd -P)/bd"
+if [ ! -x "$_bd_command" ]; then _bd_command="$(command -v bd 2>/dev/null || true)"; fi
 # --- BEGIN BEADS INTEGRATION v1.0.4 ---
 # This section is managed by beads. Do not remove these markers.
-if command -v bd >/dev/null 2>&1; then
+if [ -n "$_bd_command" ]; then
   # Linked worktrees share a live Beads store but retain branch-point JSONL.
   # Do not let a caller re-enable hook imports through Viper's BD_* override.
   unset BD_IMPORT_AUTO
   export BD_GIT_HOOK=1
   _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
   if command -v timeout >/dev/null 2>&1; then
-    timeout "$_bd_timeout" bd hooks run post-checkout "$@"
+    timeout "$_bd_timeout" "$_bd_command" hooks run post-checkout "$@"
     _bd_exit=$?
     if [ $_bd_exit -eq 124 ]; then
       echo >&2 "beads: hook 'post-checkout' timed out after ${_bd_timeout}s — continuing without beads"
       _bd_exit=0
     fi
   else
-    bd hooks run post-checkout "$@"
+    "$_bd_command" hooks run post-checkout "$@"
     _bd_exit=$?
   fi
   if [ $_bd_exit -eq 3 ]; then

--- a/.beads-hooks/post-merge
+++ b/.beads-hooks/post-merge
@@ -1,21 +1,23 @@
 #!/usr/bin/env sh
+_bd_command="$(CDPATH= cd -- "$(dirname -- "$0")/../scripts" && pwd -P)/bd"
+if [ ! -x "$_bd_command" ]; then _bd_command="$(command -v bd 2>/dev/null || true)"; fi
 # --- BEGIN BEADS INTEGRATION v1.0.4 ---
 # This section is managed by beads. Do not remove these markers.
-if command -v bd >/dev/null 2>&1; then
+if [ -n "$_bd_command" ]; then
   # Linked worktrees share a live Beads store but retain branch-point JSONL.
   # Do not let a caller re-enable hook imports through Viper's BD_* override.
   unset BD_IMPORT_AUTO
   export BD_GIT_HOOK=1
   _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
   if command -v timeout >/dev/null 2>&1; then
-    timeout "$_bd_timeout" bd hooks run post-merge "$@"
+    timeout "$_bd_timeout" "$_bd_command" hooks run post-merge "$@"
     _bd_exit=$?
     if [ $_bd_exit -eq 124 ]; then
       echo >&2 "beads: hook 'post-merge' timed out after ${_bd_timeout}s — continuing without beads"
       _bd_exit=0
     fi
   else
-    bd hooks run post-merge "$@"
+    "$_bd_command" hooks run post-merge "$@"
     _bd_exit=$?
   fi
   if [ $_bd_exit -eq 3 ]; then

--- a/.beads-hooks/post-merge
+++ b/.beads-hooks/post-merge
@@ -1,6 +1,17 @@
 #!/usr/bin/env sh
-_bd_command="$(CDPATH= cd -- "$(dirname -- "$0")/../scripts" && pwd -P)/bd"
-if [ ! -x "$_bd_command" ]; then _bd_command="$(command -v bd 2>/dev/null || true)"; fi
+_bd_common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+if [ -n "$_bd_common_dir" ]; then
+  case "$_bd_common_dir" in
+    /*) ;;
+    *) _bd_common_dir="$(pwd -P)/$_bd_common_dir" ;;
+  esac
+fi
+if [ -n "$_bd_common_dir" ] && [ -d "$_bd_common_dir" ]; then
+  _bd_common_dir="$(CDPATH= cd -- "$_bd_common_dir" && pwd -P)"
+  _bd_command="$(CDPATH= cd -- "$_bd_common_dir/.." && pwd -P)/scripts/bd"
+else
+  _bd_command=
+fi
 # --- BEGIN BEADS INTEGRATION v1.0.4 ---
 # This section is managed by beads. Do not remove these markers.
 if [ -n "$_bd_command" ]; then

--- a/.beads-hooks/pre-commit
+++ b/.beads-hooks/pre-commit
@@ -18,6 +18,9 @@
 
 set -euo pipefail
 
+_bd_command="$(CDPATH= cd -- "$(dirname -- "$0")/../scripts" && pwd -P)/bd"
+if [ ! -x "$_bd_command" ]; then _bd_command="$(command -v bd 2>/dev/null || true)"; fi
+
 # Worktree-escape detection.
 git_dir=$(git rev-parse --git-dir)
 git_common_dir=$(git rev-parse --git-common-dir)
@@ -89,18 +92,18 @@ fi
 
 # --- BEGIN BEADS INTEGRATION v1.0.4 ---
 # This section is managed by beads. Do not remove these markers.
-if command -v bd >/dev/null 2>&1; then
+if [ -n "$_bd_command" ]; then
   export BD_GIT_HOOK=1
   _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
   if command -v timeout >/dev/null 2>&1; then
-    timeout "$_bd_timeout" bd hooks run pre-commit "$@"
+    timeout "$_bd_timeout" "$_bd_command" hooks run pre-commit "$@"
     _bd_exit=$?
     if [ $_bd_exit -eq 124 ]; then
       echo >&2 "beads: hook 'pre-commit' timed out after ${_bd_timeout}s — continuing without beads"
       _bd_exit=0
     fi
   else
-    bd hooks run pre-commit "$@"
+    "$_bd_command" hooks run pre-commit "$@"
     _bd_exit=$?
   fi
   if [ $_bd_exit -eq 3 ]; then

--- a/.beads-hooks/pre-commit
+++ b/.beads-hooks/pre-commit
@@ -18,8 +18,19 @@
 
 set -euo pipefail
 
-_bd_command="$(CDPATH= cd -- "$(dirname -- "$0")/../scripts" && pwd -P)/bd"
-if [ ! -x "$_bd_command" ]; then _bd_command="$(command -v bd 2>/dev/null || true)"; fi
+_bd_common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+if [ -n "$_bd_common_dir" ]; then
+  case "$_bd_common_dir" in
+    /*) ;;
+    *) _bd_common_dir="$(pwd -P)/$_bd_common_dir" ;;
+  esac
+fi
+if [ -n "$_bd_common_dir" ] && [ -d "$_bd_common_dir" ]; then
+  _bd_common_dir="$(CDPATH= cd -- "$_bd_common_dir" && pwd -P)"
+  _bd_command="$(CDPATH= cd -- "$_bd_common_dir/.." && pwd -P)/scripts/bd"
+else
+  _bd_command=
+fi
 
 # Worktree-escape detection.
 git_dir=$(git rev-parse --git-dir)

--- a/.beads-hooks/pre-push
+++ b/.beads-hooks/pre-push
@@ -20,8 +20,19 @@ fi
 
 python -m devtools.pre_push_gate "$UPDATES_FILE"
 
-_bd_command="$(CDPATH= cd -- "$(dirname -- "$0")/../scripts" && pwd -P)/bd"
-if [ ! -x "$_bd_command" ]; then _bd_command="$(command -v bd 2>/dev/null || true)"; fi
+_bd_common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+if [ -n "$_bd_common_dir" ]; then
+  case "$_bd_common_dir" in
+    /*) ;;
+    *) _bd_common_dir="$(pwd -P)/$_bd_common_dir" ;;
+  esac
+fi
+if [ -n "$_bd_common_dir" ] && [ -d "$_bd_common_dir" ]; then
+  _bd_common_dir="$(CDPATH= cd -- "$_bd_common_dir" && pwd -P)"
+  _bd_command="$(CDPATH= cd -- "$_bd_common_dir/.." && pwd -P)/scripts/bd"
+else
+  _bd_command=
+fi
 
 # --- BEGIN BEADS INTEGRATION v1.0.4 ---
 # This section is managed by beads. Do not remove these markers.

--- a/.beads-hooks/pre-push
+++ b/.beads-hooks/pre-push
@@ -20,20 +20,23 @@ fi
 
 python -m devtools.pre_push_gate "$UPDATES_FILE"
 
+_bd_command="$(CDPATH= cd -- "$(dirname -- "$0")/../scripts" && pwd -P)/bd"
+if [ ! -x "$_bd_command" ]; then _bd_command="$(command -v bd 2>/dev/null || true)"; fi
+
 # --- BEGIN BEADS INTEGRATION v1.0.4 ---
 # This section is managed by beads. Do not remove these markers.
-if command -v bd >/dev/null 2>&1; then
+if [ -n "$_bd_command" ]; then
   export BD_GIT_HOOK=1
   _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
   if command -v timeout >/dev/null 2>&1; then
-    timeout "$_bd_timeout" bd hooks run pre-push "$@" <"$UPDATES_FILE"
+    timeout "$_bd_timeout" "$_bd_command" hooks run pre-push "$@" <"$UPDATES_FILE"
     _bd_exit=$?
     if [ $_bd_exit -eq 124 ]; then
       echo >&2 "beads: hook 'pre-push' timed out after ${_bd_timeout}s — continuing without beads"
       _bd_exit=0
     fi
   else
-    bd hooks run pre-push "$@" <"$UPDATES_FILE"
+    "$_bd_command" hooks run pre-push "$@" <"$UPDATES_FILE"
     _bd_exit=$?
   fi
   if [ $_bd_exit -eq 3 ]; then

--- a/.beads-hooks/prepare-commit-msg
+++ b/.beads-hooks/prepare-commit-msg
@@ -1,6 +1,17 @@
 #!/usr/bin/env sh
-_bd_command="$(CDPATH= cd -- "$(dirname -- "$0")/../scripts" && pwd -P)/bd"
-if [ ! -x "$_bd_command" ]; then _bd_command="$(command -v bd 2>/dev/null || true)"; fi
+_bd_common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+if [ -n "$_bd_common_dir" ]; then
+  case "$_bd_common_dir" in
+    /*) ;;
+    *) _bd_common_dir="$(pwd -P)/$_bd_common_dir" ;;
+  esac
+fi
+if [ -n "$_bd_common_dir" ] && [ -d "$_bd_common_dir" ]; then
+  _bd_common_dir="$(CDPATH= cd -- "$_bd_common_dir" && pwd -P)"
+  _bd_command="$(CDPATH= cd -- "$_bd_common_dir/.." && pwd -P)/scripts/bd"
+else
+  _bd_command=
+fi
 # --- BEGIN BEADS INTEGRATION v1.0.4 ---
 # This section is managed by beads. Do not remove these markers.
 if [ -n "$_bd_command" ]; then

--- a/.beads-hooks/prepare-commit-msg
+++ b/.beads-hooks/prepare-commit-msg
@@ -1,18 +1,20 @@
 #!/usr/bin/env sh
+_bd_command="$(CDPATH= cd -- "$(dirname -- "$0")/../scripts" && pwd -P)/bd"
+if [ ! -x "$_bd_command" ]; then _bd_command="$(command -v bd 2>/dev/null || true)"; fi
 # --- BEGIN BEADS INTEGRATION v1.0.4 ---
 # This section is managed by beads. Do not remove these markers.
-if command -v bd >/dev/null 2>&1; then
+if [ -n "$_bd_command" ]; then
   export BD_GIT_HOOK=1
   _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
   if command -v timeout >/dev/null 2>&1; then
-    timeout "$_bd_timeout" bd hooks run prepare-commit-msg "$@"
+    timeout "$_bd_timeout" "$_bd_command" hooks run prepare-commit-msg "$@"
     _bd_exit=$?
     if [ $_bd_exit -eq 124 ]; then
       echo >&2 "beads: hook 'prepare-commit-msg' timed out after ${_bd_timeout}s — continuing without beads"
       _bd_exit=0
     fi
   else
-    bd hooks run prepare-commit-msg "$@"
+    "$_bd_command" hooks run prepare-commit-msg "$@"
     _bd_exit=$?
   fi
   if [ $_bd_exit -eq 3 ]; then

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -46,10 +46,11 @@
 #   git-repo: ""       # Separate git repo for backups (default: project repo)
 
 # A linked worktree keeps the JSONL snapshot from its branch point while all
-# worktrees share one live Dolt database. The Beads post-checkout/post-merge
-# importer is a blind upsert, so importing that snapshot can revert newer
-# coordinator writes. JSONL remains an export and explicit reconciliation
-# input; automatic hook imports stay disabled.
+# worktrees share one live Dolt database. The repository's scripts/bd wrapper
+# performs a monotonic per-row preflight before every normal invocation. Keep
+# Beads' own automatic import disabled so bypassing the wrapper cannot perform
+# a blind upsert; explicit newer rows are imported by the wrapper and explicit
+# recovery still goes through devtools/bd_reimport_guard.py reconcile.
 import.auto: false
 
 # Integration settings (access with 'bd config get/set')

--- a/.envrc
+++ b/.envrc
@@ -1,21 +1,36 @@
 use flake
 
 # Keep ordinary `bd` commands on the repository's monotonic JSONL preflight
-# boundary. The wrapper delegates to the Nix-installed binary after importing
-# only new or strictly newer rows from the checked-out snapshot.
+# boundary. Resolve the deployed wrapper and installed binary from Git's
+# shared common checkout so a stale linked worktree does not fall back to its
+# historical relative paths.
+_polylogue_git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null || true)
+if [ -n "$_polylogue_git_common_dir" ]; then
+  case "$_polylogue_git_common_dir" in
+    /*) ;;
+    *) _polylogue_git_common_dir="$PWD/$_polylogue_git_common_dir" ;;
+  esac
+  _polylogue_git_common_dir=$(CDPATH= cd -- "$_polylogue_git_common_dir" && pwd -P)
+  _polylogue_common_root=$(CDPATH= cd -- "$_polylogue_git_common_dir/.." && pwd -P)
+else
+  _polylogue_common_root=$PWD
+fi
+_polylogue_bd_wrapper="$_polylogue_common_root/scripts/bd"
 _polylogue_bd_real=${POLYLOGUE_BD_REAL:-}
-if [ -z "$_polylogue_bd_real" ] || [ "$_polylogue_bd_real" = "$PWD/scripts/bd" ]; then
+if [ -z "$_polylogue_bd_real" ] || [ "$_polylogue_bd_real" = "$_polylogue_bd_wrapper" ]; then
   _polylogue_bd_search_path=$PATH
   case ":$_polylogue_bd_search_path:" in
-    *":$PWD/scripts:"*) _polylogue_bd_search_path=${_polylogue_bd_search_path#"$PWD/scripts:"} ;;
+    *":$_polylogue_common_root/scripts:"*) _polylogue_bd_search_path=${_polylogue_bd_search_path#*":$_polylogue_common_root/scripts:"} ;;
   esac
   _polylogue_bd_real=$(PATH="$_polylogue_bd_search_path" command -v bd 2>/dev/null || true)
 fi
 if [ -n "$_polylogue_bd_real" ]; then
   export POLYLOGUE_BD_REAL="$_polylogue_bd_real"
-  PATH_add "$PWD/scripts"
+  if [ -x "$_polylogue_bd_wrapper" ]; then
+    PATH_add "$_polylogue_common_root/scripts"
+  fi
 fi
-unset _polylogue_bd_real _polylogue_bd_search_path
+unset _polylogue_git_common_dir _polylogue_common_root _polylogue_bd_wrapper _polylogue_bd_real _polylogue_bd_search_path
 
 export PYTHONDONTWRITEBYTECODE=1
 export PYTHONPYCACHEPREFIX="$PWD/.cache/pycache"

--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,22 @@
 use flake
 
+# Keep ordinary `bd` commands on the repository's monotonic JSONL preflight
+# boundary. The wrapper delegates to the Nix-installed binary after importing
+# only new or strictly newer rows from the checked-out snapshot.
+_polylogue_bd_real=${POLYLOGUE_BD_REAL:-}
+if [ -z "$_polylogue_bd_real" ] || [ "$_polylogue_bd_real" = "$PWD/scripts/bd" ]; then
+  _polylogue_bd_search_path=$PATH
+  case ":$_polylogue_bd_search_path:" in
+    *":$PWD/scripts:"*) _polylogue_bd_search_path=${_polylogue_bd_search_path#"$PWD/scripts:"} ;;
+  esac
+  _polylogue_bd_real=$(PATH="$_polylogue_bd_search_path" command -v bd 2>/dev/null || true)
+fi
+if [ -n "$_polylogue_bd_real" ]; then
+  export POLYLOGUE_BD_REAL="$_polylogue_bd_real"
+  PATH_add "$PWD/scripts"
+fi
+unset _polylogue_bd_real _polylogue_bd_search_path
+
 export PYTHONDONTWRITEBYTECODE=1
 export PYTHONPYCACHEPREFIX="$PWD/.cache/pycache"
 mkdir -p "$PYTHONPYCACHEPREFIX"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,8 +227,11 @@ The repository should stay aligned with the workflow above:
 
 ## Git Hooks
 
-The devshell installs git hooks automatically. In a Beads-enabled checkout it
-sets `core.hooksPath` to `.beads-hooks`; otherwise it falls back to `.githooks`.
+The devshell installs git hooks automatically. It anchors `core.hooksPath` at
+the absolute checkout selected through Git's shared common directory, so
+linked worktrees cannot retain a branch-point relative hook path. In a
+Beads-enabled checkout it selects `.beads-hooks`; otherwise it falls back to
+`.githooks`.
 The Beads composite hooks chain the ordinary Polylogue gates below and then run
 the matching `bd hooks run ...` integration.
 

--- a/devtools/bd_reimport_guard.py
+++ b/devtools/bd_reimport_guard.py
@@ -243,6 +243,22 @@ _INTERPRETER_NAMES = frozenset(
         "zsh",
     }
 )
+_INTERPRETER_NAME_PATTERNS = (
+    re.compile(r"^(?:python|python[23]|pypy|pypy3)(?:[.]\d+)*$"),
+    re.compile(r"^(?:bash|dash|fish|ksh|zsh|csh|tcsh)(?:[.]\d+)*$"),
+    re.compile(r"^(?:perl|ruby|lua|luajit|node|php|tclsh|wish)(?:[.]\d+)*$"),
+)
+_ELF_MAGIC = b"\x7fELF"
+_KNOWN_INTERPRETER_RUNTIME_MARKERS = (
+    b"libpython",
+    b"libperl",
+    b"libruby",
+    b"liblua",
+    b"libnode",
+    b"libphp",
+    b"libtcl",
+)
+_KNOWN_NON_INTERPRETER_MARKERS = (b"Go buildinf:",)
 
 
 def _resolve_launcher_target(target: str, launcher: Path) -> Path:
@@ -259,8 +275,33 @@ def _resolve_launcher_target(target: str, launcher: Path) -> Path:
 
 
 def _is_interpreter(path: Path) -> bool:
-    """Return whether a launcher target is an interpreter entry point."""
-    return path.name in _INTERPRETER_NAMES or Path(os.path.realpath(path)).name in _INTERPRETER_NAMES
+    """Return whether a launcher target is an interpreter entry point.
+
+    Names alone are insufficient: versioned interpreter binaries and copied
+    interpreters can have arbitrary basenames. For ELF targets, inspect the
+    binary for runtime-library identity markers. Unknown ELF identity is
+    handled by the caller as a fail-closed route rather than guessed safe.
+    """
+    resolved = Path(os.path.realpath(path))
+    names = (path.name, resolved.name)
+    if any(name in _INTERPRETER_NAMES for name in names):
+        return True
+    if any(pattern.fullmatch(name) for name in names for pattern in _INTERPRETER_NAME_PATTERNS):
+        return True
+    try:
+        payload = resolved.read_bytes()
+    except OSError:
+        return False
+    return payload.startswith(_ELF_MAGIC) and any(marker in payload for marker in _KNOWN_INTERPRETER_RUNTIME_MARKERS)
+
+
+def _is_known_non_interpreter_binary(path: Path) -> bool:
+    """Return whether an ELF target has an identity safe for a launcher chain."""
+    try:
+        payload = Path(os.path.realpath(path)).read_bytes()
+    except OSError:
+        return False
+    return payload.startswith(_ELF_MAGIC) and any(marker in payload for marker in _KNOWN_NON_INTERPRETER_MARKERS)
 
 
 def _validate_executable_route(path: Path, wrapper: Path, seen: set[Path]) -> None:
@@ -292,6 +333,12 @@ def _validate_executable_route(path: Path, wrapper: Path, seen: set[Path]) -> No
     # accept launcher chains whose next target is itself explicit.
     if _is_interpreter(target):
         raise ValueError("refusing unresolved interpreter launcher route")
+    try:
+        target_header = Path(os.path.realpath(target)).read_bytes()[:4]
+    except OSError as exc:
+        raise ValueError(f"real Beads launcher target is unreadable: {target}") from exc
+    if target_header == _ELF_MAGIC and not _is_known_non_interpreter_binary(target):
+        raise ValueError("refusing launcher with unresolved executable identity")
     _validate_executable_route(target, wrapper, seen)
 
 

--- a/devtools/bd_reimport_guard.py
+++ b/devtools/bd_reimport_guard.py
@@ -227,6 +227,22 @@ def _repo_root() -> Path:
 
 
 _EXEC_TARGET = re.compile(r"(?m)^\s*exec(?:\s+-a\s+(?:'[^']*'|\"[^\"]*\"|\S+))?\s+(?:'([^']+)'|\"([^\"]+)\"|(\S+))")
+_INTERPRETER_NAMES = frozenset(
+    {
+        "bash",
+        "dash",
+        "env",
+        "fish",
+        "ksh",
+        "perl",
+        "python",
+        "python2",
+        "python3",
+        "ruby",
+        "sh",
+        "zsh",
+    }
+)
 
 
 def _resolve_launcher_target(target: str, launcher: Path) -> Path:
@@ -240,6 +256,11 @@ def _resolve_launcher_target(target: str, launcher: Path) -> Path:
     if resolved is None:
         raise ValueError(f"launcher target is unavailable: {target}")
     return Path(resolved)
+
+
+def _is_interpreter(path: Path) -> bool:
+    """Return whether a launcher target is an interpreter entry point."""
+    return path.name in _INTERPRETER_NAMES or Path(os.path.realpath(path)).name in _INTERPRETER_NAMES
 
 
 def _validate_executable_route(path: Path, wrapper: Path, seen: set[Path]) -> None:
@@ -264,7 +285,14 @@ def _validate_executable_route(path: Path, wrapper: Path, seen: set[Path]) -> No
     targets = [next(value for value in groups if value) for groups in _EXEC_TARGET.findall(launcher)]
     if len(targets) != 1:
         raise ValueError("refusing launcher without one explicit executable target")
-    _validate_executable_route(_resolve_launcher_target(targets[0], resolved), wrapper, seen)
+    target = _resolve_launcher_target(targets[0], resolved)
+    # A route such as `exec /bin/sh -c ...` can hide another wrapper behind
+    # shell parsing. We do not interpret shell syntax here. Reject known
+    # interpreter entry points before the shared invocation lock and only
+    # accept launcher chains whose next target is itself explicit.
+    if _is_interpreter(target):
+        raise ValueError("refusing unresolved interpreter launcher route")
+    _validate_executable_route(target, wrapper, seen)
 
 
 def _validated_real_bd_path(path: str) -> Path:

--- a/devtools/bd_reimport_guard.py
+++ b/devtools/bd_reimport_guard.py
@@ -11,10 +11,11 @@ This module owns the explicit reconciliation flows that remain legitimate:
 
 - ``merge_rows`` compares every row by revision (`updated_at`, the only
   per-row freshness signal bd's export exposes) and classifies each id as
-  new / updated / equal / skipped_downgrade / conflicted (incomparable) /
-  recovered_downgrade. Ordinary synchronization can never silently apply a
-  downgrade; incomparable rows (missing revision on either side) are never
-  guessed at -- they are reported as conflicts, not merged.
+  updated / equal / skipped_downgrade / unproven_new / conflicted
+  (incomparable) / recovered_downgrade. Ordinary synchronization can never
+  silently apply a downgrade or resurrect a candidate-only row: a new-row
+  claim needs durable proof outside the candidate snapshot, so unproven rows
+  are reported and left untouched.
 - ``SyncReceipt`` is the union outcome: every row's classification plus the
   actor/reason/source-fingerprint that produced it, written to
   ``.cache/bd-sync-receipts/`` so downstream policy consumers (the
@@ -29,11 +30,13 @@ This module owns the explicit reconciliation flows that remain legitimate:
   marker-bearing file can never be staged as if it were clean.
 - ``cmd_reconcile`` is the explicit, operator-invokable entry point for
   explicit-recovery flows such as `git reset --hard` or a hand-merged
-  conflict file. Normal ``scripts/bd`` invocations apply only new/updated
+  conflict file. Normal ``scripts/bd`` invocations apply only strictly newer
   rows before delegating to Beads. Recovering a genuine downgrade (accepting
   an older row on purpose, e.g. because live state itself was corrupted)
   requires ``--allow-downgrade`` plus a recorded ``--actor``/``--reason``,
-  and every downgraded row is still named in the receipt.
+  and every downgraded row is still named in the receipt. Candidate-only rows
+  remain refused because an operator-supplied reason is not proof that a
+  deleted row was genuinely new.
 
 This module deliberately depends on nothing beyond the Python stdlib so an
 operator can use it from a repository checkout without the devshell/venv.
@@ -59,8 +62,9 @@ import sys
 import tempfile
 import time
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
-from typing import IO, Any, Literal
+from typing import IO, Any, Literal, NoReturn
 
 # --- revision-comparable row classification ---------------------------------
 
@@ -69,6 +73,7 @@ Outcome = Literal[
     "updated",
     "equal",
     "skipped_downgrade",
+    "unproven_new",
     "conflicted",
     "recovered_downgrade",
 ]
@@ -119,8 +124,8 @@ class SyncReceipt:
 
     @property
     def is_clean(self) -> bool:
-        """True when synchronization applied with no conflicts and no unauthorized downgrades."""
-        if self.conflicted_ids:
+        """True when synchronization applied without unresolved outcomes."""
+        if self.conflicted_ids or any(o.outcome == "unproven_new" for o in self.outcomes):
             return False
         return not any(o.outcome == "skipped_downgrade" for o in self.outcomes)
 
@@ -138,6 +143,7 @@ class SyncReceipt:
                 "updated": sum(1 for o in self.outcomes if o.outcome == "updated"),
                 "equal": sum(1 for o in self.outcomes if o.outcome == "equal"),
                 "skipped_downgrade": sum(1 for o in self.outcomes if o.outcome == "skipped_downgrade"),
+                "unproven_new": sum(1 for o in self.outcomes if o.outcome == "unproven_new"),
                 "recovered_downgrade": sum(1 for o in self.outcomes if o.outcome == "recovered_downgrade"),
                 "conflicted": sum(1 for o in self.outcomes if o.outcome == "conflicted"),
             },
@@ -166,12 +172,14 @@ def merge_rows(
 ) -> tuple[dict[str, dict[str, Any]], list[RowOutcome]]:
     """Merge `candidate` rows into `current` by per-row revision.
 
-    Returns (merged, outcomes). `merged` always contains every id from
-    `current` plus every new id from `candidate`; a candidate row only
-    replaces a current row when its revision is strictly newer, or when
-    `allow_downgrade=True` and it is older (recorded as an explicit
-    recovery, never silent). Rows present only in `current` are left
-    untouched and produce no outcome entry (nothing to reconcile).
+    Returns (merged, outcomes). `merged` contains every id from `current`.
+    A candidate row only replaces a current row when its revision is strictly
+    newer, or when `allow_downgrade=True` and it is older (recorded as an
+    explicit recovery, never silent). A candidate-only row has no evidence in
+    the live export that it was created after a live row was deleted, so it is
+    classified as ``unproven_new`` and left out of `merged`. It must not be
+    resurrected by a routine snapshot import. Rows present only in `current`
+    are left untouched and produce no outcome entry.
     """
     merged = dict(current)
     outcomes: list[RowOutcome] = []
@@ -179,8 +187,7 @@ def merge_rows(
         cur_row = current.get(issue_id)
         cand_rev = _revision_of(cand_row)
         if cur_row is None:
-            merged[issue_id] = cand_row
-            outcomes.append(RowOutcome(issue_id, "new", None, cand_rev))
+            outcomes.append(RowOutcome(issue_id, "unproven_new", None, cand_rev))
             continue
 
         cur_rev = _revision_of(cur_row)
@@ -357,6 +364,8 @@ def _validated_real_bd_path(path: str) -> Path:
         raise ValueError(f"real Beads binary is unavailable: {resolved}") from exc
     if not stat.S_ISREG(mode) or not os.access(resolved, os.X_OK):
         raise ValueError(f"real Beads binary is not an executable file: {resolved}")
+    if _is_interpreter(resolved):
+        raise ValueError("refusing interpreter as POLYLOGUE_BD_REAL")
     _validate_executable_route(resolved, wrapper, set())
     return resolved
 
@@ -430,13 +439,133 @@ def _has_conflict_markers(text: str) -> bool:
     return any(line.startswith(marker) for line in text.splitlines() for marker in CONFLICT_MARKERS)
 
 
+_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_TIMESTAMP_FIELDS = frozenset(
+    {
+        "created_at",
+        "updated_at",
+        "closed_at",
+        "defer_until",
+        "started_at",
+        "heartbeat_at",
+        "lease_expires_at",
+    }
+)
+_STRING_FIELDS = frozenset(
+    {
+        "_type",
+        "title",
+        "description",
+        "design",
+        "acceptance_criteria",
+        "status",
+        "issue_type",
+        "owner",
+        "assignee",
+        "created_by",
+        "close_reason",
+        "notes",
+        "external_ref",
+    }
+)
+_INTEGER_FIELDS = frozenset({"priority", "comment_count", "dependency_count", "dependent_count"})
+
+
+def _reject_non_finite_json(value: str) -> NoReturn:
+    raise InvalidJsonlError(f"non-finite JSON number {value!r} is not allowed")
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise InvalidJsonlError(f"duplicate JSON key {key!r}")
+        result[key] = value
+    return result
+
+
+def _validate_id(value: Any, *, field: str) -> None:
+    if not isinstance(value, str) or not _ID_PATTERN.fullmatch(value):
+        raise InvalidJsonlError(f"{field} must be a non-empty Beads id")
+
+
+def _validate_timestamp(value: Any, *, field: str) -> None:
+    if not isinstance(value, str) or not re.fullmatch(
+        r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})", value
+    ):
+        raise InvalidJsonlError(f"{field} must be an RFC3339 timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise InvalidJsonlError(f"{field} is not a valid timestamp") from exc
+    if parsed.tzinfo is None:
+        raise InvalidJsonlError(f"{field} must include a timezone")
+
+
+def _validate_nested_object(value: Any, *, field: str, required_ids: tuple[str, ...]) -> None:
+    if not isinstance(value, dict):
+        raise InvalidJsonlError(f"{field} must be an object")
+    for required_id in required_ids:
+        if required_id not in value:
+            raise InvalidJsonlError(f"{field}.{required_id} is required")
+        _validate_id(value[required_id], field=f"{field}.{required_id}")
+    for key, nested_value in value.items():
+        nested_field = f"{field}.{key}"
+        if key in _TIMESTAMP_FIELDS:
+            _validate_timestamp(nested_value, field=nested_field)
+        elif key in {"id", "issue_id", "depends_on_id"}:
+            _validate_id(nested_value, field=nested_field)
+        elif key in {"author", "created_by", "text", "type", "metadata"} and not isinstance(nested_value, str):
+            raise InvalidJsonlError(f"{nested_field} must be a string")
+
+
+def _validate_row(row: dict[str, Any], *, lineno: int) -> None:
+    if "id" not in row:
+        raise InvalidJsonlError(f"line {lineno}: row missing a non-empty 'id'")
+    _validate_id(row.get("id"), field=f"line {lineno} id")
+    for field_name in _STRING_FIELDS:
+        if field_name in row and not isinstance(row[field_name], str):
+            raise InvalidJsonlError(f"line {lineno} {field_name} must be a string")
+    for field_name in _TIMESTAMP_FIELDS:
+        if field_name in row:
+            _validate_timestamp(row[field_name], field=f"line {lineno} {field_name}")
+    for field_name in _INTEGER_FIELDS:
+        if field_name in row and (
+            not isinstance(row[field_name], int) or isinstance(row[field_name], bool) or row[field_name] < 0
+        ):
+            raise InvalidJsonlError(f"line {lineno} {field_name} must be a non-negative integer")
+    if "priority" in row and row["priority"] > 4:
+        raise InvalidJsonlError(f"line {lineno} priority is outside the Beads range")
+    if "labels" in row and (
+        not isinstance(row["labels"], list) or any(not isinstance(label, str) for label in row["labels"])
+    ):
+        raise InvalidJsonlError(f"line {lineno} labels must be a list of strings")
+    if "metadata" in row and not isinstance(row["metadata"], dict):
+        raise InvalidJsonlError(f"line {lineno} metadata must be an object")
+    if "comments" in row:
+        if not isinstance(row["comments"], list):
+            raise InvalidJsonlError(f"line {lineno} comments must be a list")
+        for index, comment in enumerate(row["comments"]):
+            _validate_nested_object(comment, field=f"line {lineno} comments[{index}]", required_ids=("id", "issue_id"))
+    if "dependencies" in row:
+        if not isinstance(row["dependencies"], list):
+            raise InvalidJsonlError(f"line {lineno} dependencies must be a list")
+        for index, dependency in enumerate(row["dependencies"]):
+            _validate_nested_object(
+                dependency,
+                field=f"line {lineno} dependencies[{index}]",
+                required_ids=("issue_id", "depends_on_id"),
+            )
+
+
 def parse_and_validate_jsonl(text: str) -> dict[str, dict[str, Any]]:
     """Parse a JSONL payload into {id: row}, refusing corrupt/ambiguous input.
 
     Raises InvalidJsonlError when the text carries literal merge-conflict
-    markers, contains a line that isn't valid JSON, contains a row without
-    an `id`, or contains a duplicate id -- all cases where "the file parses"
-    is not proof the content is a coherent, mergeable snapshot.
+    markers, contains a line that isn't valid JSON, contains duplicate object
+    keys, non-finite numbers, a row with invalid Beads field types, invalid
+    timestamps or ids, or duplicate row ids. A successful JSON parse alone is
+    not proof that the content is a coherent, mergeable snapshot.
     """
     if _has_conflict_markers(text):
         raise InvalidJsonlError("payload contains unresolved merge-conflict markers")
@@ -447,11 +576,18 @@ def parse_and_validate_jsonl(text: str) -> dict[str, dict[str, Any]]:
         if not line:
             continue
         try:
-            row = json.loads(line)
+            row = json.loads(
+                line,
+                object_pairs_hook=_reject_duplicate_json_keys,
+                parse_constant=_reject_non_finite_json,
+            )
+        except InvalidJsonlError as exc:
+            raise InvalidJsonlError(f"line {lineno}: {exc}") from exc
         except json.JSONDecodeError as exc:
             raise InvalidJsonlError(f"line {lineno}: invalid JSON ({exc})") from exc
-        if not isinstance(row, dict) or not isinstance(row.get("id"), str) or not row["id"]:
-            raise InvalidJsonlError(f"line {lineno}: row missing a non-empty 'id'")
+        if not isinstance(row, dict):
+            raise InvalidJsonlError(f"line {lineno}: row must be a JSON object")
+        _validate_row(row, lineno=lineno)
         issue_id = row["id"]
         if issue_id in rows:
             raise InvalidJsonlError(f"duplicate id {issue_id!r} (line {lineno})")
@@ -471,7 +607,7 @@ def atomic_write_jsonl(path: Path, rows: dict[str, dict[str, Any]]) -> None:
         if _has_conflict_markers(existing):
             raise InvalidJsonlError(f"refusing to overwrite {path}: existing content has unresolved conflict markers")
 
-    text = "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows.values())
+    text = "".join(json.dumps(row, allow_nan=False, sort_keys=True) + "\n" for row in rows.values())
     # Validate our own output round-trips cleanly before it ever touches disk.
     parse_and_validate_jsonl(text)
 
@@ -513,7 +649,10 @@ def _export_live_state(
         )
         if process_result.returncode != 0:
             raise RuntimeError(f"bd export failed ({process_result.returncode}): {process_result.stderr.strip()}")
-        return parse_and_validate_jsonl(Path(path).read_text())
+        try:
+            return parse_and_validate_jsonl(Path(path).read_text(encoding="utf-8", errors="strict"))
+        except UnicodeDecodeError as exc:
+            raise InvalidJsonlError(f"export is not valid UTF-8: {exc}") from exc
     finally:
         Path(path).unlink(missing_ok=True)
 
@@ -534,7 +673,7 @@ def _bd_import_rows(
     with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as tf:
         import_path = tf.name
         for row in rows.values():
-            tf.write(json.dumps(row) + "\n")
+            tf.write(json.dumps(row, allow_nan=False) + "\n")
     try:
         result = subprocess.run(
             [bd_command, "import", import_path],
@@ -571,6 +710,22 @@ def _find_candidate_jsonl(start: Path | None = None) -> Path | None:
     return None
 
 
+def _imports_candidate_snapshot(bd_args: list[str], candidate_path: Path | None, cwd: Path) -> bool:
+    """Identify explicit ``bd import`` of the checkout's stale snapshot."""
+    if candidate_path is None or not bd_args or bd_args[0] != "import":
+        return False
+    after_separator = False
+    for arg in bd_args[1:]:
+        if arg == "--":
+            after_separator = True
+            continue
+        if not after_separator and arg.startswith("-"):
+            continue
+        if (cwd / arg).resolve() == candidate_path.resolve():
+            return True
+    return False
+
+
 def _preflight_invocation(
     bd_command: str,
     candidate_path: Path | None = None,
@@ -592,7 +747,10 @@ def _preflight_invocation(
     safe_env["BD_IMPORT_AUTO"] = "false"
     try:
         live = _export_live_state(bd_command=bd_command, env=safe_env, cwd=cwd)
-        candidate = parse_and_validate_jsonl(candidate_path.read_text())
+        try:
+            candidate = parse_and_validate_jsonl(candidate_path.read_text(encoding="utf-8", errors="strict"))
+        except UnicodeDecodeError as exc:
+            raise InvalidJsonlError(f"candidate is not valid UTF-8: {exc}") from exc
         merged, outcomes = merge_rows(live, candidate)
     except InvalidJsonlError:
         raise
@@ -600,11 +758,17 @@ def _preflight_invocation(
         print(f"bd guard: skipped automatic JSONL reconciliation: {exc}", file=sys.stderr)
         return
 
-    to_apply = {o.issue_id: merged[o.issue_id] for o in outcomes if o.outcome in ("new", "updated")}
+    to_apply = {o.issue_id: merged[o.issue_id] for o in outcomes if o.outcome == "updated"}
     skipped = [o.issue_id for o in outcomes if o.outcome == "skipped_downgrade"]
     if skipped:
         print(
             f"bd guard: skipped {len(skipped)} stale JSONL row(s) before bd invocation",
+            file=sys.stderr,
+        )
+    unproven_new = [o.issue_id for o in outcomes if o.outcome == "unproven_new"]
+    if unproven_new:
+        print(
+            f"bd guard: refused {len(unproven_new)} candidate-only JSONL row(s) without durable new-row proof",
             file=sys.stderr,
         )
     if not to_apply:
@@ -630,6 +794,12 @@ def cmd_invoke(args: list[str]) -> int:
         return 126
     invocation_dir = _invocation_directory(bd_args)
     candidate_path = _find_candidate_jsonl(invocation_dir)
+    if _imports_candidate_snapshot(bd_args, candidate_path, invocation_dir):
+        print(
+            "bd guard: refusing explicit import of the checkout snapshot; candidate-only rows lack durable new-row proof",
+            file=sys.stderr,
+        )
+        return 125
     lock = _acquire_invocation_lock(invocation_dir)
     try:
         _preflight_invocation(bd_command, candidate_path, cwd=invocation_dir)
@@ -700,7 +870,10 @@ def cmd_reconcile(args: list[str]) -> int:
         return 1
 
     try:
-        candidate = parse_and_validate_jsonl(candidate_path.read_text())
+        try:
+            candidate = parse_and_validate_jsonl(candidate_path.read_text(encoding="utf-8", errors="strict"))
+        except UnicodeDecodeError as exc:
+            raise InvalidJsonlError(f"candidate is not valid UTF-8: {exc}") from exc
     except InvalidJsonlError as exc:
         print(f"reconcile: candidate file failed validation: {exc}", file=sys.stderr)
         receipt = build_receipt([], source=source, actor=actor, reason=reason or str(exc), recovery=allow_downgrade)
@@ -712,7 +885,7 @@ def cmd_reconcile(args: list[str]) -> int:
     receipt = build_receipt(outcomes, source=source, actor=actor, reason=reason, recovery=allow_downgrade)
     receipt_path = write_receipt(receipt)
 
-    apply_outcomes = ("new", "updated", "recovered_downgrade")
+    apply_outcomes = ("updated", "recovered_downgrade")
     to_apply = {o.issue_id: merged[o.issue_id] for o in outcomes if o.outcome in apply_outcomes}
 
     print(
@@ -730,14 +903,21 @@ def cmd_reconcile(args: list[str]) -> int:
             f"reconcile: {len(skipped)} downgrade(s) refused (rerun with --allow-downgrade to recover): {skipped}",
             file=sys.stderr,
         )
+    if any(o.outcome == "unproven_new" for o in outcomes):
+        unproven_new = [o.issue_id for o in outcomes if o.outcome == "unproven_new"]
+        print(
+            f"reconcile: {len(unproven_new)} candidate-only row(s) refused without durable new-row proof: {unproven_new}",
+            file=sys.stderr,
+        )
 
+    recovery_is_clean = allow_downgrade and not any(o.outcome == "unproven_new" for o in outcomes)
     if dry_run:
         print("reconcile: --dry-run set, no changes applied", file=sys.stderr)
-        return 0 if receipt.is_clean or allow_downgrade else 1
+        return 0 if receipt.is_clean or recovery_is_clean else 1
 
     _bd_import_rows(to_apply)
 
-    return 0 if receipt.is_clean or allow_downgrade else 1
+    return 0 if receipt.is_clean or recovery_is_clean else 1
 
 
 def cmd_export(args: list[str]) -> int:

--- a/devtools/bd_reimport_guard.py
+++ b/devtools/bd_reimport_guard.py
@@ -1,10 +1,11 @@
 """Monotonic, receipted reconciliation for Beads JSONL snapshots.
 
 Linked worktrees share one live Dolt database but retain the JSONL snapshot
-from their branch point. Beads hook imports are blind upserts, so this repo
-disables ``import.auto`` in ``.beads/config.yaml`` rather than trying to repair
-state after an import has happened. The 2026-07-15 planning audit showed why:
-a staged issues.jsonl can be syntactically valid yet contain stale rows.
+from their branch point. Beads' automatic JSONL import path can blind-upsert,
+so the repository's ``scripts/bd`` entry point compares the snapshot with live
+state before every normal invocation and delegates with automatic imports
+disabled. The 2026-07-15 planning audit showed why: a staged issues.jsonl can
+be syntactically valid yet contain stale rows.
 
 This module owns the explicit reconciliation flows that remain legitimate:
 
@@ -28,17 +29,17 @@ This module owns the explicit reconciliation flows that remain legitimate:
   marker-bearing file can never be staged as if it were clean.
 - ``cmd_reconcile`` is the explicit, operator-invokable entry point for
   explicit-recovery flows such as `git reset --hard` or a hand-merged
-  conflict file. Hook auto-import is disabled, so a stale file is not
-  imported merely by subsequent hook execution; ordinary reconcile can only
-  apply new/updated rows. Recovering a genuine downgrade (accepting an older
-  row on purpose, e.g. because live state itself was corrupted) requires
-  ``--allow-downgrade`` plus a recorded ``--actor``/``--reason``, and every
-  downgraded row is still named in the receipt.
+  conflict file. Normal ``scripts/bd`` invocations apply only new/updated
+  rows before delegating to Beads. Recovering a genuine downgrade (accepting
+  an older row on purpose, e.g. because live state itself was corrupted)
+  requires ``--allow-downgrade`` plus a recorded ``--actor``/``--reason``,
+  and every downgraded row is still named in the receipt.
 
 This module deliberately depends on nothing beyond the Python stdlib so an
 operator can use it from a repository checkout without the devshell/venv.
 
 Usage:
+  bd_reimport_guard.py invoke <real-bd-path> <bd-args...>
   bd_reimport_guard.py reconcile <candidate-jsonl-path> [--source NAME]
       [--allow-downgrade --actor ACTOR --reason REASON] [--dry-run]
   bd_reimport_guard.py export <target-jsonl-path>
@@ -46,6 +47,8 @@ Usage:
 
 from __future__ import annotations
 
+import fcntl
+import hashlib
 import json
 import os
 import subprocess
@@ -54,7 +57,7 @@ import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal
+from typing import IO, Any, Literal
 
 # --- revision-comparable row classification ---------------------------------
 
@@ -220,6 +223,53 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parent.parent
 
 
+def _invocation_directory(args: list[str]) -> Path:
+    """Resolve bd's optional ``-C``/``--directory`` target for guard I/O."""
+    for index, arg in enumerate(args):
+        if arg in ("-C", "--directory") and index + 1 < len(args):
+            return Path(args[index + 1]).expanduser().resolve()
+        for prefix in ("-C=", "--directory="):
+            if arg.startswith(prefix):
+                return Path(arg[len(prefix) :]).expanduser().resolve()
+    return Path.cwd().resolve()
+
+
+def _shared_lock_path(start: Path) -> Path:
+    """Return one lock path shared by all linked worktrees of this repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(start), "rev-parse", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            common_dir = Path(result.stdout.strip())
+            if not common_dir.is_absolute():
+                common_dir = start / common_dir
+            return common_dir.resolve() / "polylogue-bd-guard.lock"
+    except (OSError, subprocess.SubprocessError):
+        pass
+
+    runtime_dir = Path(os.environ.get("XDG_RUNTIME_DIR", tempfile.gettempdir()))
+    token = hashlib.sha256(str(start).encode()).hexdigest()[:20]
+    return runtime_dir / f"polylogue-bd-guard-{token}.lock"
+
+
+def _acquire_invocation_lock(start: Path) -> IO[str]:
+    """Serialize guarded bd calls across linked worktrees and retain the lock.
+
+    The file descriptor is made inheritable by ``cmd_invoke`` before it
+    replaces this process with the real bd binary. This covers the check,
+    filtered import, and delegated command as one writer boundary.
+    """
+    path = _shared_lock_path(start)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = path.open("a+")
+    fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+    return handle
+
+
 def _receipts_dir() -> Path:
     return _repo_root() / ".cache" / "bd-sync-receipts"
 
@@ -300,7 +350,12 @@ def atomic_write_jsonl(path: Path, rows: dict[str, dict[str, Any]]) -> None:
 # --- live bd state ------------------------------------------------------------
 
 
-def _export_live_state() -> dict[str, dict[str, Any]]:
+def _export_live_state(
+    *,
+    bd_command: str = "bd",
+    env: dict[str, str] | None = None,
+    cwd: Path | None = None,
+) -> dict[str, dict[str, Any]]:
     """Return {id: full_row_dict} for every issue currently live.
 
     Uses default `bd export` filtering (excludes infra beads/memories) --
@@ -310,12 +365,16 @@ def _export_live_state() -> dict[str, dict[str, Any]]:
     with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as tf:
         path = tf.name
     try:
-        subprocess.run(
-            ["bd", "export", "-o", path],
+        process_result = subprocess.run(
+            [bd_command, "export", "-o", path],
             capture_output=True,
             text=True,
             timeout=30,
+            env=env,
+            cwd=cwd,
         )
+        if process_result.returncode != 0:
+            raise RuntimeError(f"bd export failed ({process_result.returncode}): {process_result.stderr.strip()}")
         result: dict[str, dict[str, Any]] = {}
         with open(path) as f:
             for line in f:
@@ -334,20 +393,118 @@ def _export_live_state() -> dict[str, dict[str, Any]]:
         Path(path).unlink(missing_ok=True)
 
 
-def _bd_import_rows(rows: dict[str, dict[str, Any]]) -> None:
+def _bd_import_rows(
+    rows: dict[str, dict[str, Any]],
+    *,
+    bd_command: str = "bd",
+    env: dict[str, str] | None = None,
+    reexport: bool = True,
+    cwd: Path | None = None,
+) -> None:
     if not rows:
         return
+    # The installed bd importer performs its own conditional upsert. Never
+    # pass --allow-stale here: an explicit downgrade remains an audited
+    # reconcile operation, not part of ordinary wrapper synchronization.
     with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as tf:
         import_path = tf.name
         for row in rows.values():
             tf.write(json.dumps(row) + "\n")
     try:
-        subprocess.run(["bd", "import", import_path], capture_output=True, text=True, timeout=30)
-        # Re-export so the working tree's issues.jsonl matches restored live
-        # state (avoids the restore looking like a phantom git diff).
-        subprocess.run(["bd", "export"], capture_output=True, text=True, timeout=30)
+        result = subprocess.run(
+            [bd_command, "import", import_path],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+            cwd=cwd,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"bd import failed ({result.returncode}): {result.stderr.strip()}")
+        if reexport:
+            # Re-export so the working tree's issues.jsonl matches restored live
+            # state (avoids the restore looking like a phantom git diff).
+            subprocess.run(
+                [bd_command, "export"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                env=env,
+                cwd=cwd,
+            )
     finally:
         Path(import_path).unlink(missing_ok=True)
+
+
+def _find_candidate_jsonl(start: Path | None = None) -> Path | None:
+    """Find the checked-out workspace snapshot without invoking bd."""
+    current = (start or Path.cwd()).resolve()
+    for directory in (current, *current.parents):
+        candidate = directory / ".beads" / "issues.jsonl"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _preflight_invocation(
+    bd_command: str,
+    candidate_path: Path | None = None,
+    *,
+    cwd: Path | None = None,
+) -> None:
+    """Import only candidate rows newer than live state before ``bd`` runs.
+
+    The delegated command receives ``BD_IMPORT_AUTO=false`` so Beads cannot
+    perform its blind automatic import after this comparison. Failures are
+    reported as warnings and leave the live database untouched; the requested
+    bd command still gets to run against the live database.
+    """
+    candidate_path = candidate_path or _find_candidate_jsonl()
+    if candidate_path is None:
+        return
+
+    safe_env = os.environ.copy()
+    safe_env["BD_IMPORT_AUTO"] = "false"
+    try:
+        live = _export_live_state(bd_command=bd_command, env=safe_env, cwd=cwd)
+        candidate = parse_and_validate_jsonl(candidate_path.read_text())
+        merged, outcomes = merge_rows(live, candidate)
+    except (OSError, InvalidJsonlError, RuntimeError, subprocess.SubprocessError) as exc:
+        print(f"bd guard: skipped automatic JSONL reconciliation: {exc}", file=sys.stderr)
+        return
+
+    to_apply = {o.issue_id: merged[o.issue_id] for o in outcomes if o.outcome in ("new", "updated")}
+    skipped = [o.issue_id for o in outcomes if o.outcome == "skipped_downgrade"]
+    if skipped:
+        print(
+            f"bd guard: skipped {len(skipped)} stale JSONL row(s) before bd invocation",
+            file=sys.stderr,
+        )
+    if not to_apply:
+        return
+
+    try:
+        _bd_import_rows(to_apply, bd_command=bd_command, env=safe_env, reexport=False, cwd=cwd)
+    except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+        print(f"bd guard: skipped automatic JSONL reconciliation: {exc}", file=sys.stderr)
+
+
+def cmd_invoke(args: list[str]) -> int:
+    """Run the installed bd binary behind the monotonic preflight boundary."""
+    if len(args) < 1:
+        print("usage: bd_reimport_guard.py invoke <real-bd-path> <bd-args...>", file=sys.stderr)
+        return 1
+
+    bd_command, *bd_args = args
+    invocation_dir = _invocation_directory(bd_args)
+    candidate_path = _find_candidate_jsonl(invocation_dir)
+    lock = _acquire_invocation_lock(invocation_dir)
+    _preflight_invocation(bd_command, candidate_path, cwd=invocation_dir)
+    safe_env = os.environ.copy()
+    safe_env["BD_IMPORT_AUTO"] = "false"
+    os.set_inheritable(lock.fileno(), True)
+    os.execvpe(bd_command, [bd_command, *bd_args], safe_env)
+    return 1
 
 
 # --- commands ------------------------------------------------------------------
@@ -467,11 +624,13 @@ def main(argv: list[str] | None = None) -> int:
     args = sys.argv[1:] if argv is None else list(argv)
     if len(args) < 1:
         print(
-            "usage: bd_reimport_guard.py <reconcile|export> ...",
+            "usage: bd_reimport_guard.py <invoke|reconcile|export> ...",
             file=sys.stderr,
         )
         return 1
     command = args[0]
+    if command == "invoke":
+        return cmd_invoke(args[1:])
     if command == "reconcile":
         return cmd_reconcile(args[1:])
     if command == "export":

--- a/devtools/bd_reimport_guard.py
+++ b/devtools/bd_reimport_guard.py
@@ -51,6 +51,9 @@ import fcntl
 import hashlib
 import json
 import os
+import re
+import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -221,6 +224,66 @@ def build_receipt(
 
 def _repo_root() -> Path:
     return Path(__file__).resolve().parent.parent
+
+
+_EXEC_TARGET = re.compile(r"(?m)^\s*exec(?:\s+-a\s+(?:'[^']*'|\"[^\"]*\"|\S+))?\s+(?:'([^']+)'|\"([^\"]+)\"|(\S+))")
+
+
+def _resolve_launcher_target(target: str, launcher: Path) -> Path:
+    if target.startswith("$"):
+        raise ValueError("refusing dynamic launcher route")
+    if target.startswith("/"):
+        return Path(target)
+    if "/" in target:
+        return launcher.parent / target
+    resolved = shutil.which(target)
+    if resolved is None:
+        raise ValueError(f"launcher target is unavailable: {target}")
+    return Path(resolved)
+
+
+def _validate_executable_route(path: Path, wrapper: Path, seen: set[Path]) -> None:
+    resolved = Path(os.path.realpath(path))
+    if resolved in seen:
+        raise ValueError("refusing recursive wrapper route")
+    if resolved == wrapper:
+        raise ValueError("refusing recursive wrapper route")
+    seen.add(resolved)
+    try:
+        header = resolved.read_bytes()[:2]
+    except OSError as exc:
+        raise ValueError(f"real Beads binary is unreadable: {resolved}") from exc
+    if header != b"#!":
+        return
+    try:
+        launcher = resolved.read_text(errors="replace")
+    except OSError as exc:
+        raise ValueError(f"real Beads launcher is unreadable: {resolved}") from exc
+    if "POLYLOGUE_BD_REAL" in launcher:
+        raise ValueError("refusing dynamic launcher route")
+    targets = [next(value for value in groups if value) for groups in _EXEC_TARGET.findall(launcher)]
+    if len(targets) != 1:
+        raise ValueError("refusing launcher without one explicit executable target")
+    _validate_executable_route(_resolve_launcher_target(targets[0], resolved), wrapper, seen)
+
+
+def _validated_real_bd_path(path: str) -> Path:
+    """Validate the delegated Beads executable before taking the shared lock."""
+    candidate = Path(path)
+    if not candidate.is_absolute():
+        raise ValueError("real Beads binary path must be absolute")
+    resolved = Path(os.path.realpath(candidate))
+    wrapper = Path(os.path.realpath(_repo_root() / "scripts" / "bd"))
+    if resolved == wrapper:
+        raise ValueError("refusing recursive wrapper route")
+    try:
+        mode = resolved.stat().st_mode
+    except OSError as exc:
+        raise ValueError(f"real Beads binary is unavailable: {resolved}") from exc
+    if not stat.S_ISREG(mode) or not os.access(resolved, os.X_OK):
+        raise ValueError(f"real Beads binary is not an executable file: {resolved}")
+    _validate_executable_route(resolved, wrapper, set())
+    return resolved
 
 
 def _invocation_directory(args: list[str]) -> Path:
@@ -496,6 +559,11 @@ def cmd_invoke(args: list[str]) -> int:
         return 1
 
     bd_command, *bd_args = args
+    try:
+        bd_command = str(_validated_real_bd_path(bd_command))
+    except ValueError as exc:
+        print(f"bd guard: {exc}", file=sys.stderr)
+        return 126
     invocation_dir = _invocation_directory(bd_args)
     candidate_path = _find_candidate_jsonl(invocation_dir)
     lock = _acquire_invocation_lock(invocation_dir)

--- a/devtools/bd_reimport_guard.py
+++ b/devtools/bd_reimport_guard.py
@@ -710,20 +710,81 @@ def _find_candidate_jsonl(start: Path | None = None) -> Path | None:
     return None
 
 
-def _imports_candidate_snapshot(bd_args: list[str], candidate_path: Path | None, cwd: Path) -> bool:
-    """Identify explicit ``bd import`` of the checkout's stale snapshot."""
-    if candidate_path is None or not bd_args or bd_args[0] != "import":
-        return False
-    after_separator = False
-    for arg in bd_args[1:]:
-        if arg == "--":
-            after_separator = True
-            continue
-        if not after_separator and arg.startswith("-"):
-            continue
-        if (cwd / arg).resolve() == candidate_path.resolve():
-            return True
-    return False
+def _import_payload_paths(bd_args: list[str], cwd: Path) -> list[Path] | None:
+    """Extract concrete ``bd import`` payloads, refusing implicit sources.
+
+    Beads accepts the checkout snapshot through its default path and can also
+    read stdin. Neither source has a concrete payload for this guard to
+    validate, so both are rejected before delegation. The only option that
+    carries a payload is parsed here so ``--input PATH`` cannot hide the
+    snapshot from the guard.
+    """
+    if not bd_args or bd_args[0] != "import":
+        return None
+
+    paths: list[Path] = []
+    index = 1
+    while index < len(bd_args):
+        arg = bd_args[index]
+        if arg in ("-", "--"):
+            raise InvalidJsonlError("refusing bd import from an implicit or stdin payload")
+
+        option_value: str | None = None
+        if arg in ("--input", "-i"):
+            index += 1
+            if index >= len(bd_args):
+                raise InvalidJsonlError(f"refusing bd import: {arg} requires an explicit JSONL path")
+            option_value = bd_args[index]
+        elif arg.startswith("--input="):
+            option_value = arg.removeprefix("--input=")
+        elif arg.startswith("-i="):
+            option_value = arg.removeprefix("-i=")
+
+        if option_value is not None:
+            if not option_value or option_value in ("-", "--"):
+                raise InvalidJsonlError("refusing bd import from an implicit or stdin payload")
+            paths.append((cwd / option_value).expanduser().resolve())
+        elif not arg.startswith("-"):
+            paths.append((cwd / arg).expanduser().resolve())
+        index += 1
+
+    if not paths:
+        raise InvalidJsonlError("refusing bd import without a concrete JSONL path")
+    return paths
+
+
+def _read_validated_jsonl(path: Path, *, context: str) -> dict[str, dict[str, Any]]:
+    """Read one import payload with strict UTF-8 and JSONL validation."""
+    try:
+        text = path.read_text(encoding="utf-8", errors="strict")
+    except UnicodeDecodeError as exc:
+        raise InvalidJsonlError(f"{context} is not valid UTF-8: {exc}") from exc
+    except OSError as exc:
+        raise InvalidJsonlError(f"{context} cannot be read: {exc}") from exc
+    try:
+        return parse_and_validate_jsonl(text)
+    except InvalidJsonlError as exc:
+        raise InvalidJsonlError(f"{context} failed validation: {exc}") from exc
+
+
+def _preflight_explicit_import(
+    bd_args: list[str],
+    *,
+    candidate_path: Path | None,
+    cwd: Path,
+) -> None:
+    """Validate explicit import payloads before the real bd process starts."""
+    payload_paths = _import_payload_paths(bd_args, cwd)
+    if payload_paths is None:
+        return
+
+    candidate_resolved = candidate_path.resolve() if candidate_path is not None else None
+    for payload_path in payload_paths:
+        if candidate_resolved is not None and payload_path == candidate_resolved:
+            raise InvalidJsonlError(
+                "refusing explicit import of the checkout snapshot; candidate-only rows lack durable new-row proof"
+            )
+        _read_validated_jsonl(payload_path, context=f"explicit import payload {payload_path}")
 
 
 def _preflight_invocation(
@@ -794,11 +855,10 @@ def cmd_invoke(args: list[str]) -> int:
         return 126
     invocation_dir = _invocation_directory(bd_args)
     candidate_path = _find_candidate_jsonl(invocation_dir)
-    if _imports_candidate_snapshot(bd_args, candidate_path, invocation_dir):
-        print(
-            "bd guard: refusing explicit import of the checkout snapshot; candidate-only rows lack durable new-row proof",
-            file=sys.stderr,
-        )
+    try:
+        _preflight_explicit_import(bd_args, candidate_path=candidate_path, cwd=invocation_dir)
+    except InvalidJsonlError as exc:
+        print(f"bd guard: refusing explicit import: {exc}", file=sys.stderr)
         return 125
     lock = _acquire_invocation_lock(invocation_dir)
     try:

--- a/devtools/bd_reimport_guard.py
+++ b/devtools/bd_reimport_guard.py
@@ -450,7 +450,7 @@ def parse_and_validate_jsonl(text: str) -> dict[str, dict[str, Any]]:
             row = json.loads(line)
         except json.JSONDecodeError as exc:
             raise InvalidJsonlError(f"line {lineno}: invalid JSON ({exc})") from exc
-        if not isinstance(row, dict) or not row.get("id"):
+        if not isinstance(row, dict) or not isinstance(row.get("id"), str) or not row["id"]:
             raise InvalidJsonlError(f"line {lineno}: row missing a non-empty 'id'")
         issue_id = row["id"]
         if issue_id in rows:
@@ -513,20 +513,7 @@ def _export_live_state(
         )
         if process_result.returncode != 0:
             raise RuntimeError(f"bd export failed ({process_result.returncode}): {process_result.stderr.strip()}")
-        result: dict[str, dict[str, Any]] = {}
-        with open(path) as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    row = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                issue_id = row.get("id")
-                if issue_id:
-                    result[issue_id] = row
-        return result
+        return parse_and_validate_jsonl(Path(path).read_text())
     finally:
         Path(path).unlink(missing_ok=True)
 
@@ -607,7 +594,9 @@ def _preflight_invocation(
         live = _export_live_state(bd_command=bd_command, env=safe_env, cwd=cwd)
         candidate = parse_and_validate_jsonl(candidate_path.read_text())
         merged, outcomes = merge_rows(live, candidate)
-    except (OSError, InvalidJsonlError, RuntimeError, subprocess.SubprocessError) as exc:
+    except InvalidJsonlError:
+        raise
+    except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
         print(f"bd guard: skipped automatic JSONL reconciliation: {exc}", file=sys.stderr)
         return
 
@@ -642,7 +631,11 @@ def cmd_invoke(args: list[str]) -> int:
     invocation_dir = _invocation_directory(bd_args)
     candidate_path = _find_candidate_jsonl(invocation_dir)
     lock = _acquire_invocation_lock(invocation_dir)
-    _preflight_invocation(bd_command, candidate_path, cwd=invocation_dir)
+    try:
+        _preflight_invocation(bd_command, candidate_path, cwd=invocation_dir)
+    except InvalidJsonlError as exc:
+        print(f"bd guard: refusing invocation: exported JSONL failed validation: {exc}", file=sys.stderr)
+        return 125
     safe_env = os.environ.copy()
     safe_env["BD_IMPORT_AUTO"] = "false"
     os.set_inheritable(lock.fileno(), True)

--- a/flake.nix
+++ b/flake.nix
@@ -378,16 +378,39 @@
             touch "$legacy_stamp"
           fi
 
-          # Install repo git hooks — skip if already set correctly.
-          # Prefer the Beads composite hook path when present; those hooks
-          # chain the ordinary Polylogue .githooks checks and the Beads hooks.
-          desired_hooks_path=".githooks"
-          if [ -d .beads-hooks ]; then
-            desired_hooks_path=".beads-hooks"
+          # Install repo git hooks through the shared Git common directory.
+          # Linked worktrees retain their branch-point relative `.beads-hooks`
+          # files, so a relative core.hooksPath would keep executing stale
+          # safety code. The common checkout is the deployment anchor for all
+          # worktrees sharing this Git database.
+          git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null || true)
+          if [ -n "$git_common_dir" ]; then
+            case "$git_common_dir" in
+              /*) ;;
+              *) git_common_dir="$PWD/$git_common_dir" ;;
+            esac
+            git_common_dir=$(cd "$git_common_dir" && pwd -P)
+            git_common_root=$(cd "$git_common_dir/.." && pwd -P)
+            desired_hooks_path="$git_common_root/.githooks"
+            if [ -d "$git_common_root/.beads-hooks" ]; then
+              desired_hooks_path="$git_common_root/.beads-hooks"
+            fi
+          else
+            git_common_root="$PWD"
+            desired_hooks_path="$PWD/.githooks"
+            if [ -d .beads-hooks ]; then
+              desired_hooks_path="$PWD/.beads-hooks"
+            fi
           fi
           current_hooks_path=$(git config --local core.hooksPath 2>/dev/null || true)
           if [ "$current_hooks_path" != "$desired_hooks_path" ]; then
             git config --local core.hooksPath "$desired_hooks_path" 2>/dev/null || true
+          fi
+          if [ -x "$git_common_root/scripts/bd" ]; then
+            case ":$PATH:" in
+              *":$git_common_root/scripts:"*) ;;
+              *) export PATH="$git_common_root/scripts:$PATH" ;;
+            esac
           fi
 
           # Clean stale __pycache__ dirs under source trees — skip if stamp

--- a/flake.nix
+++ b/flake.nix
@@ -379,10 +379,9 @@
           fi
 
           # Install repo git hooks through the shared Git common directory.
-          # Linked worktrees retain their branch-point relative `.beads-hooks`
-          # files, so a relative core.hooksPath would keep executing stale
-          # safety code. The common checkout is the deployment anchor for all
-          # worktrees sharing this Git database.
+          # The helper pins an absolute common-directory path in every
+          # worktree's config, so a historical shell hook cannot restore its
+          # relative path as the effective route for that worktree.
           git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null || true)
           if [ -n "$git_common_dir" ]; then
             case "$git_common_dir" in
@@ -391,20 +390,25 @@
             esac
             git_common_dir=$(cd "$git_common_dir" && pwd -P)
             git_common_root=$(cd "$git_common_dir/.." && pwd -P)
-            desired_hooks_path="$git_common_root/.githooks"
-            if [ -d "$git_common_root/.beads-hooks" ]; then
-              desired_hooks_path="$git_common_root/.beads-hooks"
+            if [ -x "$git_common_root/scripts/configure-git-hooks" ]; then
+              "$git_common_root/scripts/configure-git-hooks"
+            else
+              # Transitional fallback for a common checkout that predates
+              # the helper. Keep the same worktree-config invariant.
+              desired_hooks_path="$git_common_root/.githooks"
+              if [ -d "$git_common_root/.beads-hooks" ]; then
+                desired_hooks_path="$git_common_root/.beads-hooks"
+              fi
+              git -C "$git_common_root" config --local extensions.worktreeConfig true
+              git -C "$git_common_root" config --local core.hooksPath "$desired_hooks_path"
+              while IFS= read -r worktree_path; do
+                [ -n "$worktree_path" ] || continue
+                [ -d "$worktree_path" ] || continue
+                git -C "$worktree_path" config --worktree core.hooksPath "$desired_hooks_path"
+              done < <(git -C "$git_common_root" worktree list --porcelain | sed -n 's/^worktree //p')
             fi
           else
             git_common_root="$PWD"
-            desired_hooks_path="$PWD/.githooks"
-            if [ -d .beads-hooks ]; then
-              desired_hooks_path="$PWD/.beads-hooks"
-            fi
-          fi
-          current_hooks_path=$(git config --local core.hooksPath 2>/dev/null || true)
-          if [ "$current_hooks_path" != "$desired_hooks_path" ]; then
-            git config --local core.hooksPath "$desired_hooks_path" 2>/dev/null || true
           fi
           if [ -x "$git_common_root/scripts/bd" ]; then
             case ":$PATH:" in

--- a/scripts/bd
+++ b/scripts/bd
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+set -eu
+
+_bd_script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+_bd_guard="$_bd_script_dir/../devtools/bd_reimport_guard.py"
+_bd_real=${POLYLOGUE_BD_REAL:-}
+
+if [ -z "$_bd_real" ] || [ "$_bd_real" = "$_bd_script_dir/bd" ]; then
+  _bd_search_path=$PATH
+  case ":$_bd_search_path:" in
+    *":$_bd_script_dir:"*) _bd_search_path=${_bd_search_path#"$_bd_script_dir:"} ;;
+  esac
+  _bd_real=$(PATH="$_bd_search_path" command -v bd 2>/dev/null || true)
+fi
+
+if [ -z "$_bd_real" ] || [ "$_bd_real" = "$_bd_script_dir/bd" ]; then
+  echo "polylogue bd wrapper: installed bd binary not found" >&2
+  exit 127
+fi
+
+exec python3 "$_bd_guard" invoke "$_bd_real" "$@"

--- a/scripts/bd
+++ b/scripts/bd
@@ -68,6 +68,13 @@ for _bd_path_entry in $PATH; do
   if [ -x "$_bd_python_candidate" ] && [ ! -d "$_bd_python_candidate" ]; then
     _bd_python_candidate_real=$(readlink -f "$_bd_python_candidate" 2>/dev/null || true)
     if [ -n "$_bd_python_candidate_real" ] && [ "$_bd_python_candidate_real" != "$_bd_wrapper_real" ]; then
+      # A PATH entry implemented as a script can trampoline back through this
+      # wrapper when it is used as python3. Skip launchers and continue to the
+      # real interpreter instead of allowing indirect recursion.
+      _bd_python_candidate_header=$(dd if="$_bd_python_candidate_real" bs=2 count=1 2>/dev/null || true)
+      case "$_bd_python_candidate_header" in
+        '#!'*) continue ;;
+      esac
       _bd_python=$_bd_python_candidate_real
       break
     fi

--- a/scripts/bd
+++ b/scripts/bd
@@ -3,19 +3,56 @@ set -eu
 
 _bd_script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
 _bd_guard="$_bd_script_dir/../devtools/bd_reimport_guard.py"
+_bd_wrapper_real=$(readlink -f "$_bd_script_dir/bd")
 _bd_real=${POLYLOGUE_BD_REAL:-}
 
-if [ -z "$_bd_real" ] || [ "$_bd_real" = "$_bd_script_dir/bd" ]; then
-  _bd_search_path=$PATH
-  case ":$_bd_search_path:" in
-    *":$_bd_script_dir:"*) _bd_search_path=${_bd_search_path#"$_bd_script_dir:"} ;;
-  esac
-  _bd_real=$(PATH="$_bd_search_path" command -v bd 2>/dev/null || true)
+if [ -z "$_bd_real" ]; then
+  _bd_real=bd
 fi
 
-if [ -z "$_bd_real" ] || [ "$_bd_real" = "$_bd_script_dir/bd" ]; then
+case "$_bd_real" in
+  */*)
+    case "$_bd_real" in
+      /*) ;;
+      *)
+        echo "polylogue bd wrapper: POLYLOGUE_BD_REAL must be an absolute path or a bare command name" >&2
+        exit 126
+        ;;
+    esac
+    ;;
+  *)
+    _bd_name=$_bd_real
+    _bd_real=
+    _bd_old_ifs=$IFS
+    IFS=:
+    for _bd_path_entry in $PATH; do
+      [ -n "$_bd_path_entry" ] || _bd_path_entry=.
+      _bd_candidate="$_bd_path_entry/$_bd_name"
+      if [ -x "$_bd_candidate" ] && [ ! -d "$_bd_candidate" ]; then
+        _bd_candidate_real=$(readlink -f "$_bd_candidate" 2>/dev/null || true)
+        if [ -n "$_bd_candidate_real" ] && [ "$_bd_candidate_real" != "$_bd_wrapper_real" ]; then
+          _bd_real="$_bd_candidate_real"
+          break
+        fi
+      fi
+    done
+    IFS=$_bd_old_ifs
+    ;;
+esac
+
+if [ -z "$_bd_real" ]; then
   echo "polylogue bd wrapper: installed bd binary not found" >&2
   exit 127
+fi
+
+_bd_real=$(readlink -f "$_bd_real" 2>/dev/null || true)
+if [ -z "$_bd_real" ] || [ "$_bd_real" = "$_bd_wrapper_real" ]; then
+  echo "polylogue bd wrapper: refusing recursive wrapper route" >&2
+  exit 126
+fi
+if [ ! -f "$_bd_real" ] || [ ! -x "$_bd_real" ]; then
+  echo "polylogue bd wrapper: real Beads binary is not an executable file" >&2
+  exit 126
 fi
 
 exec python3 "$_bd_guard" invoke "$_bd_real" "$@"

--- a/scripts/bd
+++ b/scripts/bd
@@ -1,9 +1,13 @@
-#!/usr/bin/env sh
+#!/bin/sh
 set -eu
 
-_bd_script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+_bd_wrapper_real=$(readlink -f "$0" 2>/dev/null || true)
+if [ -z "$_bd_wrapper_real" ] || [ ! -f "$_bd_wrapper_real" ]; then
+  echo "polylogue bd wrapper: cannot resolve wrapper executable" >&2
+  exit 126
+fi
+_bd_script_dir=$(CDPATH= cd -- "$(dirname -- "$_bd_wrapper_real")" && pwd -P)
 _bd_guard="$_bd_script_dir/../devtools/bd_reimport_guard.py"
-_bd_wrapper_real=$(readlink -f "$_bd_script_dir/bd")
 _bd_real=${POLYLOGUE_BD_REAL:-}
 
 if [ -z "$_bd_real" ]; then
@@ -55,4 +59,24 @@ if [ ! -f "$_bd_real" ] || [ ! -x "$_bd_real" ]; then
   exit 126
 fi
 
-exec python3 "$_bd_guard" invoke "$_bd_real" "$@"
+_bd_python=
+_bd_old_ifs=$IFS
+IFS=:
+for _bd_path_entry in $PATH; do
+  [ -n "$_bd_path_entry" ] || _bd_path_entry=.
+  _bd_python_candidate="$_bd_path_entry/python3"
+  if [ -x "$_bd_python_candidate" ] && [ ! -d "$_bd_python_candidate" ]; then
+    _bd_python_candidate_real=$(readlink -f "$_bd_python_candidate" 2>/dev/null || true)
+    if [ -n "$_bd_python_candidate_real" ] && [ "$_bd_python_candidate_real" != "$_bd_wrapper_real" ]; then
+      _bd_python=$_bd_python_candidate_real
+      break
+    fi
+  fi
+done
+IFS=$_bd_old_ifs
+if [ -z "$_bd_python" ]; then
+  echo "polylogue bd wrapper: Python 3 interpreter not found" >&2
+  exit 126
+fi
+
+exec "$_bd_python" "$_bd_guard" invoke "$_bd_real" "$@"

--- a/scripts/configure-git-hooks
+++ b/scripts/configure-git-hooks
@@ -21,6 +21,8 @@ _polylogue_hooks_path="$_polylogue_common_root/.githooks"
 if [ -d "$_polylogue_common_root/.beads-hooks" ]; then
   _polylogue_hooks_path="$_polylogue_common_root/.beads-hooks"
 fi
+_polylogue_wrapper="$_polylogue_common_root/scripts/bd"
+_polylogue_wrapper_real=$(readlink -f "$_polylogue_wrapper" 2>/dev/null || true)
 
 # This is the shared installation anchor. The per-worktree values below are
 # higher-precedence guards against a branch-point shell hook restoring a
@@ -32,4 +34,15 @@ while IFS= read -r _polylogue_worktree; do
   [ -n "$_polylogue_worktree" ] || continue
   [ -d "$_polylogue_worktree" ] || continue
   git -C "$_polylogue_worktree" config --worktree core.hooksPath "$_polylogue_hooks_path"
+  if [ "$_polylogue_worktree/scripts/bd" = "$_polylogue_wrapper" ] || [ ! -x "$_polylogue_wrapper" ]; then
+    continue
+  fi
+  _polylogue_worktree_scripts="$_polylogue_worktree/scripts"
+  _polylogue_worktree_wrapper="$_polylogue_worktree_scripts/bd"
+  mkdir -p "$_polylogue_worktree_scripts"
+  _polylogue_worktree_wrapper_real=$(readlink -f "$_polylogue_worktree_wrapper" 2>/dev/null || true)
+  if [ "$_polylogue_worktree_wrapper_real" != "$_polylogue_wrapper_real" ]; then
+    rm -f "$_polylogue_worktree_wrapper"
+    ln -s "$_polylogue_wrapper" "$_polylogue_worktree_wrapper"
+  fi
 done < <(git -C "$_polylogue_common_root" worktree list --porcelain | sed -n 's/^worktree //p')

--- a/scripts/configure-git-hooks
+++ b/scripts/configure-git-hooks
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pin the hook route in each worktree's config. Historical shell hooks use
+# `git config --local`, which writes the shared config even when
+# extensions.worktreeConfig is enabled. A per-worktree value therefore acts
+# as the durable read-side interception point for old checkouts.
+
+_polylogue_common_dir=$(git rev-parse --git-common-dir 2>/dev/null || true)
+if [ -z "$_polylogue_common_dir" ]; then
+  exit 0
+fi
+case "$_polylogue_common_dir" in
+  /*) ;;
+  *) _polylogue_common_dir="$PWD/$_polylogue_common_dir" ;;
+esac
+_polylogue_common_dir=$(CDPATH= cd -- "$_polylogue_common_dir" && pwd -P)
+_polylogue_common_root=$(CDPATH= cd -- "$_polylogue_common_dir/.." && pwd -P)
+
+_polylogue_hooks_path="$_polylogue_common_root/.githooks"
+if [ -d "$_polylogue_common_root/.beads-hooks" ]; then
+  _polylogue_hooks_path="$_polylogue_common_root/.beads-hooks"
+fi
+
+# This is the shared installation anchor. The per-worktree values below are
+# higher-precedence guards against a branch-point shell hook restoring a
+# relative path in the common config.
+git -C "$_polylogue_common_root" config --local extensions.worktreeConfig true
+git -C "$_polylogue_common_root" config --local core.hooksPath "$_polylogue_hooks_path"
+
+while IFS= read -r _polylogue_worktree; do
+  [ -n "$_polylogue_worktree" ] || continue
+  [ -d "$_polylogue_worktree" ] || continue
+  git -C "$_polylogue_worktree" config --worktree core.hooksPath "$_polylogue_hooks_path"
+done < <(git -C "$_polylogue_common_root" worktree list --porcelain | sed -n 's/^worktree //p')

--- a/tests/integration/test_beads_stale_worktree_guard.py
+++ b/tests/integration/test_beads_stale_worktree_guard.py
@@ -116,9 +116,9 @@ def _set_export_row(repo: Path, issue_id: str, **updates: object) -> None:
     export_path.write_text("".join(json.dumps(row, sort_keys=True) + "\n" for row in rows))
 
 
-def _historical_file(relative_path: str) -> str:
+def _historical_file(relative_path: str, *, commit: str = BASE_COMMIT) -> str:
     result = subprocess.run(
-        ["git", "show", f"{BASE_COMMIT}^:{relative_path}"],
+        ["git", "show", f"{commit}:{relative_path}"],
         cwd=ROOT,
         capture_output=True,
         text=True,
@@ -149,7 +149,7 @@ def _deploy_current_common_checkout(repo: Path) -> None:
     shutil.copy2(ROOT / "devtools" / "bd_reimport_guard.py", guard)
 
 
-def _execute_historical_envrc(lane: Path, env: dict[str, str], tmp_path: Path, installed_bd: str) -> None:
+def _execute_historical_envrc(lane: Path, env: dict[str, str], tmp_path: Path, installed_bd: str) -> dict[str, str]:
     """Source the retained envrc and execute its branch-point use-flake hook."""
     historical_use_flake = tmp_path / "historical-use-flake"
     historical_flake = _historical_file("flake.nix")
@@ -161,28 +161,25 @@ def _execute_historical_envrc(lane: Path, env: dict[str, str], tmp_path: Path, i
     historical_use_flake.write_text(f"#!/usr/bin/env bash\nset -euo pipefail\n{historical_shell_hook}")
     historical_use_flake.chmod(0o755)
 
-    marker = tmp_path / "historical-direct-bd-ran"
-    probe_bin = tmp_path / "historical-bin"
-    probe_bin.mkdir()
-    direct_bd = probe_bin / "bd"
-    direct_bd.write_text(f"#!/bin/sh\nprintf '%s\\n' ran > {marker!s}\n")
-    direct_bd.chmod(0o755)
-
     historical_env = env.copy()
+    environment_dump = tmp_path / "historical-environment"
     historical_env["HISTORICAL_USE_FLAKE"] = str(historical_use_flake)
-    # Keep the historical direct command-v bd route observable through the
-    # probe while the deployed wrapper follows the valid installed binary.
     historical_env["POLYLOGUE_BD_REAL"] = installed_bd
-    historical_env["PATH"] = os.pathsep.join((str(probe_bin), historical_env["PATH"]))
     _run(
         [
             "bash",
             "-c",
-            'use() { "$HISTORICAL_USE_FLAKE" "$@"; }; source .envrc',
+            'PATH_add() { PATH="$1:$PATH"; export PATH; }; '
+            'use() { "$HISTORICAL_USE_FLAKE" "$@"; }; '
+            'source .envrc; env -0 > "$HISTORICAL_ENVIRONMENT_DUMP"',
         ],
         lane,
-        historical_env,
+        historical_env | {"HISTORICAL_ENVIRONMENT_DUMP": str(environment_dump)},
     )
+    for entry in environment_dump.read_bytes().split(b"\0"):
+        if entry:
+            key, _, value = entry.partition(b"=")
+            historical_env[key.decode()] = value.decode()
 
     # The old shell hook wrote a relative value through git config --local.
     # The worktree-level common-dir pin must still select the deployed hook.
@@ -194,7 +191,7 @@ def _execute_historical_envrc(lane: Path, env: dict[str, str], tmp_path: Path, i
     assert effective_hooks_origin.endswith("/config.worktree\t" + effective_hooks_path)
 
     _run(["git", "switch", "--detach", "HEAD"], lane, historical_env)
-    assert not marker.exists(), "historical direct bd hook must not execute"
+    return historical_env
 
 
 def _setup_stale_worktree(
@@ -216,14 +213,22 @@ def _setup_stale_worktree(
     _run([bd, "init", "--prefix", "guard", "--quiet", "--non-interactive", "--skip-hooks", "--skip-agents"], repo, env)
     _write_import_policy(repo, import_auto)
 
-    # This is the branch-point checkout: it has only the historical relative
-    # hook and envrc paths, with no current wrapper or guard files.
+    # This is the branch-point checkout: it has the historical relative hook,
+    # envrc, wrapper, and a deliberately stale guard implementation.
     historical_hooks = repo / ".beads-hooks"
     historical_hooks.mkdir()
     historical_hook = historical_hooks / "post-checkout"
-    historical_hook.write_text(_historical_file(".beads-hooks/post-checkout"))
+    historical_hook.write_text(_historical_file(".beads-hooks/post-checkout", commit=BASE_COMMIT))
     historical_hook.chmod(0o755)
-    (repo / ".envrc").write_text(_historical_file(".envrc"))
+    (repo / ".envrc").write_text(_historical_file(".envrc", commit=BASE_COMMIT))
+    historical_scripts = repo / "scripts"
+    historical_scripts.mkdir()
+    historical_wrapper = historical_scripts / "bd"
+    historical_wrapper.write_text(_historical_file("scripts/bd", commit=BASE_COMMIT))
+    historical_wrapper.chmod(0o755)
+    stale_guard = repo / "devtools" / "bd_reimport_guard.py"
+    stale_guard.parent.mkdir()
+    stale_guard.write_text("raise SystemExit('stale guard loaded')\n")
 
     setup_hooks = repo / ".setup-hooks"
     setup_hooks.mkdir()
@@ -258,13 +263,17 @@ def _setup_stale_worktree(
     _run(["git", "commit", "-m", "deploy Beads guard"], repo, env)
 
     _run([str(repo / "scripts" / "configure-git-hooks")], repo, env)
-    _execute_historical_envrc(lane, env, tmp_path, bd)
+    env = _execute_historical_envrc(lane, env, tmp_path, bd)
+    lane_wrapper = lane / "scripts" / "bd"
+    assert lane_wrapper.is_symlink()
+    assert lane_wrapper.resolve() == (repo / "scripts" / "bd").resolve()
 
-    env["PATH"] = os.pathsep.join((str(repo / "scripts"), env["PATH"]))
     _run([bd, "close", issue_id, "--reason", "coordinator close"], repo, env)
-    assert not (lane / "scripts" / "bd").exists()
-    assert (lane / ".envrc").read_text() == _historical_file(".envrc")
-    assert (lane / ".beads-hooks" / "post-checkout").read_text() == _historical_file(".beads-hooks/post-checkout")
+    assert (lane / "scripts" / "bd").is_symlink()
+    assert (lane / ".envrc").read_text() == _historical_file(".envrc", commit=BASE_COMMIT)
+    assert (lane / ".beads-hooks" / "post-checkout").read_text() == _historical_file(
+        ".beads-hooks/post-checkout", commit=BASE_COMMIT
+    )
     return issue_id, env, repo, lane
 
 
@@ -402,3 +411,22 @@ def test_bd_wrapper_rejects_recursive_real_binary_routes(tmp_path: Path, route: 
     expected_returncode = 126 if route != "bare-wrapper" else 127
     assert result.returncode == expected_returncode
     assert not (common_dir / "polylogue-bd-guard.lock").exists()
+
+
+@pytest.mark.parametrize("interpreter_name", ["sh", "python3"])
+def test_bd_wrapper_survives_interpreter_path_alias_to_wrapper(tmp_path: Path, interpreter_name: str) -> None:
+    """The wrapper reaches the guard when PATH aliases an interpreter to itself."""
+    env, repo, lane, common_dir = _setup_guard_linked_worktree(tmp_path)
+    wrapper = repo / "scripts" / "bd"
+    alias_dir = tmp_path / "interpreter-alias"
+    alias_dir.mkdir()
+    (alias_dir / interpreter_name).symlink_to(wrapper)
+    env["PATH"] = os.pathsep.join((str(alias_dir), env["PATH"]))
+    true_binary = shutil.which("true", path=env["PATH"])
+    assert true_binary is not None
+    env["POLYLOGUE_BD_REAL"] = true_binary
+
+    result = subprocess.run([str(wrapper), "--help"], cwd=lane, env=env, capture_output=True, text=True, timeout=10)
+
+    assert result.returncode == 0, result.stderr
+    assert (common_dir / "polylogue-bd-guard.lock").exists()

--- a/tests/integration/test_beads_stale_worktree_guard.py
+++ b/tests/integration/test_beads_stale_worktree_guard.py
@@ -19,6 +19,20 @@ import pytest
 ROOT = Path(__file__).resolve().parents[2]
 
 
+def _installed_bd() -> str | None:
+    """Resolve the Nix-installed binary even when this checkout's shim is on PATH."""
+    configured = os.environ.get("POLYLOGUE_BD_REAL")
+    if configured and Path(configured).resolve() != (ROOT / "scripts/bd").resolve():
+        return configured
+    scripts_dir = str((ROOT / "scripts").resolve())
+    search_path = os.pathsep.join(
+        entry
+        for entry in os.environ.get("PATH", "").split(os.pathsep)
+        if Path(entry or ".").resolve() != Path(scripts_dir)
+    )
+    return shutil.which("bd", path=search_path)
+
+
 def _run(command: list[str], cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
     result = subprocess.run(command, cwd=cwd, env=env, capture_output=True, text=True, timeout=60)
     if result.returncode != 0:
@@ -98,12 +112,21 @@ def _set_export_timestamp(repo: Path, issue_id: str, updated_at: str) -> None:
     export_path.write_text("".join(json.dumps(row, sort_keys=True) + "\n" for row in rows))
 
 
+def _set_export_row(repo: Path, issue_id: str, **updates: object) -> None:
+    export_path = repo / ".beads" / "issues.jsonl"
+    rows = [json.loads(line) for line in export_path.read_text().splitlines()]
+    matching_rows = [row for row in rows if row.get("id") == issue_id]
+    assert len(matching_rows) == 1
+    matching_rows[0].update(updates)
+    export_path.write_text("".join(json.dumps(row, sort_keys=True) + "\n" for row in rows))
+
+
 def _setup_stale_worktree(
     tmp_path: Path,
     import_auto: bool,
     stale_snapshot_updated_at: str | None = None,
 ) -> tuple[str, dict[str, str], Path, Path, Path]:
-    bd = shutil.which("bd")
+    bd = _installed_bd()
     if bd is None:
         pytest.skip("bd is not installed")
 
@@ -111,12 +134,18 @@ def _setup_stale_worktree(
     wrapper_dir = tmp_path / "bin"
     wrapper_dir.mkdir()
     invocation_log = tmp_path / "bd-invocations.log"
-    wrapper = wrapper_dir / "bd"
-    wrapper.write_text('#!/bin/sh\nprintf "%s\\n" "$*" >> "$BD_GUARD_COMMAND_LOG"\nexec "$BD_GUARD_REAL_BD" "$@"\n')
-    wrapper.chmod(0o755)
+    real_wrapper = wrapper_dir / "bd-real"
+    real_wrapper.write_text(
+        '#!/bin/sh\nprintf "%s\\n" "$*" >> "$BD_GUARD_COMMAND_LOG"\nexec "$BD_GUARD_REAL_BD" "$@"\n'
+    )
+    real_wrapper.chmod(0o755)
     env["BD_GUARD_COMMAND_LOG"] = str(invocation_log)
     env["BD_GUARD_REAL_BD"] = bd
-    env["PATH"] = str(wrapper_dir) + os.pathsep + env["PATH"]
+    env["POLYLOGUE_BD_REAL"] = str(real_wrapper)
+    # The lane deliberately does not contain a copy of the new files. The
+    # machine-level devshell path supplies the current checkout's stable
+    # wrapper, just as an operator shell does after entering this repo.
+    env["PATH"] = os.pathsep.join((str(ROOT / "scripts"), str(wrapper_dir), env["PATH"]))
     repo = tmp_path / "coordinator"
     lane = tmp_path / "stale-lane"
     repo.mkdir()
@@ -127,12 +156,11 @@ def _setup_stale_worktree(
     _run([bd, "init", "--prefix", "guard", "--quiet", "--non-interactive", "--skip-hooks", "--skip-agents"], repo, env)
     _write_import_policy(repo, import_auto)
 
-    hooks_dir = repo / ".githooks"
-    hooks_dir.mkdir()
-    hook_path = hooks_dir / "post-checkout"
-    hook_path.write_text((ROOT / ".beads-hooks" / "post-checkout").read_text())
-    hook_path.chmod(0o755)
-    _run(["git", "config", "core.hooksPath", str(hooks_dir)], repo, env)
+    # Keep setup commits hook-free, then point the linked lane at the actual
+    # production hook path for the checkout that exercises the guard.
+    setup_hooks = repo / ".setup-hooks"
+    setup_hooks.mkdir()
+    _run(["git", "config", "core.hooksPath", str(setup_hooks)], repo, env)
 
     _run([bd, "create", "coordinator-owned issue", "--type", "bug"], repo, env)
     _run([bd, "export", "-o", ".beads/issues.jsonl"], repo, env)
@@ -142,8 +170,9 @@ def _setup_stale_worktree(
     if stale_snapshot_updated_at is not None:
         _set_export_timestamp(repo, issue_id, stale_snapshot_updated_at)
 
-    _run(["git", "add", ".beads", ".githooks"], repo, env)
+    _run(["git", "add", ".beads"], repo, env)
     _run(["git", "commit", "-m", "baseline Beads snapshot"], repo, env)
+    _run(["git", "config", "core.hooksPath", str(ROOT / ".beads-hooks")], repo, env)
     _run(["git", "branch", "stale-lane"], repo, env)
     _run(["git", "worktree", "add", str(lane), "stale-lane"], repo, env)
     _run([bd, "close", issue_id, "--reason", "coordinator close"], repo, env)
@@ -160,17 +189,34 @@ def test_stale_worktree_plain_read_preserves_coordinator_write_when_env_reenable
     it to ``true`` only for the stale lane. The production shim must clear that
     unsafe Viper override before it can re-enable imports.
     """
-    issue_id, env, _repo, lane, invocation_log = _setup_stale_worktree(tmp_path, import_auto=False)
+    issue_id, env, _repo, lane, invocation_log = _setup_stale_worktree(tmp_path, import_auto=True)
     env["BD_IMPORT_AUTO"] = "true"
     _run(["git", "switch", "--detach", "HEAD"], lane, env)
 
-    shown = _json_from_output(_run([env["BD_GUARD_REAL_BD"], "show", issue_id, "--json"], lane, env).stdout)
+    shown = _json_from_output(_run(["bd", "show", issue_id, "--json"], lane, env).stdout)
     assert isinstance(shown, list) and len(shown) == 1
     assert shown[0]["status"] == "closed"
 
     delegated_commands = invocation_log.read_text().splitlines()
-    imported = any(command.startswith("import --quiet ") for command in delegated_commands)
-    assert not imported
+    imported = any(command.startswith("import ") for command in delegated_commands)
+    assert not imported, "the stale row must be filtered before the real bd entry point sees it"
+
+
+def test_bd_wrapper_preserves_legitimate_newer_snapshot_import(tmp_path: Path) -> None:
+    """The guard rejects stale rows without disabling genuinely newer rows."""
+    issue_id, env, _repo, lane, _invocation_log = _setup_stale_worktree(tmp_path, import_auto=True)
+    _set_export_row(
+        lane,
+        issue_id,
+        status="open",
+        updated_at="2099-01-01T00:00:00Z",
+        title="legitimate newer snapshot",
+    )
+
+    shown = _json_from_output(_run(["bd", "show", issue_id, "--json"], lane, env).stdout)
+    assert isinstance(shown, list) and len(shown) == 1
+    assert shown[0]["status"] == "open"
+    assert shown[0]["title"] == "legitimate newer snapshot"
 
 
 def test_unsafe_import_auto_control_reverts_clock_skewed_stale_snapshot(tmp_path: Path) -> None:
@@ -194,4 +240,4 @@ def test_unsafe_import_auto_control_reverts_clock_skewed_stale_snapshot(tmp_path
     assert shown[0]["status"] == "open"
 
     delegated_commands = invocation_log.read_text().splitlines()
-    assert any(command.startswith("import --quiet ") for command in delegated_commands)
+    assert any(command.startswith("import ") for command in delegated_commands)

--- a/tests/integration/test_beads_stale_worktree_guard.py
+++ b/tests/integration/test_beads_stale_worktree_guard.py
@@ -12,8 +12,10 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
+import sys
 import textwrap
 from pathlib import Path
 
@@ -314,36 +316,60 @@ def test_unsafe_import_auto_control_reverts_clock_skewed_stale_snapshot(tmp_path
     assert shown[0]["status"] == "open"
 
 
-@pytest.mark.parametrize(
-    "route",
-    ["bare-wrapper", "symlink-wrapper", "script-recursion", "script-symlink-recursion", "interpreter-recursion"],
-)
-def test_bd_wrapper_rejects_recursive_real_binary_routes(tmp_path: Path, route: str) -> None:
-    """Wrapper aliases and script recursion fail before the guard lock."""
-    deployed = tmp_path / "deployed"
-    scripts = deployed / "scripts"
-    scripts.mkdir(parents=True)
-    shutil.copy2(ROOT / "scripts" / "bd", scripts / "bd")
-    (scripts / "bd").chmod(0o755)
-    guard = deployed / "devtools" / "bd_reimport_guard.py"
+def _setup_guard_linked_worktree(tmp_path: Path) -> tuple[dict[str, str], Path, Path, Path]:
+    """Create a real Git common directory and linked worktree for route checks."""
+    env = _bd_environment(tmp_path)
+    repo = tmp_path / "coordinator"
+    lane = tmp_path / "recursion-lane"
+    repo.mkdir()
+    _run(["git", "init", "--initial-branch=main"], repo, env)
+    _run(["git", "config", "user.email", "test@example.invalid"], repo, env)
+    _run(["git", "config", "user.name", "Beads guard test"], repo, env)
+    (repo / "anchor").write_text("anchor\n")
+    _run(["git", "add", "anchor"], repo, env)
+    _run(["git", "commit", "-m", "anchor"], repo, env)
+    _run(["git", "branch", "recursion-lane"], repo, env)
+    _run(["git", "worktree", "add", str(lane), "recursion-lane"], repo, env)
+
+    scripts = repo / "scripts"
+    scripts.mkdir()
+    wrapper = scripts / "bd"
+    shutil.copy2(ROOT / "scripts" / "bd", wrapper)
+    wrapper.chmod(0o755)
+    guard = repo / "devtools" / "bd_reimport_guard.py"
     guard.parent.mkdir()
     shutil.copy2(ROOT / "devtools" / "bd_reimport_guard.py", guard)
-    wrapper = scripts / "bd"
-    probe = tmp_path / "probe"
-    probe.mkdir()
 
-    env = os.environ.copy()
-    runtime = tmp_path / "runtime"
-    runtime.mkdir()
-    env["XDG_RUNTIME_DIR"] = str(runtime)
     tool_dirs: list[str] = []
-    for tool in ("sh", "dirname", "readlink", "python3"):
-        executable = shutil.which(tool)
-        assert executable is not None
-        directory = str(Path(executable).parent)
+    for executable in ("git", "sh", "readlink", "python3"):
+        resolved = shutil.which(executable)
+        assert resolved is not None
+        directory = str(Path(resolved).parent)
         if directory not in tool_dirs:
             tool_dirs.append(directory)
     env["PATH"] = os.pathsep.join((str(scripts), *tool_dirs))
+    common_dir_text = _run(["git", "rev-parse", "--git-common-dir"], lane, env).stdout.strip()
+    common_dir = Path(common_dir_text)
+    if not common_dir.is_absolute():
+        common_dir = lane / common_dir
+    return env, repo, lane, common_dir.resolve()
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
+        "bare-wrapper",
+        "symlink-wrapper",
+        "script-recursion",
+        "script-symlink-recursion",
+        "interpreter-recursion-versioned",
+        "interpreter-recursion-renamed",
+    ],
+)
+def test_bd_wrapper_rejects_recursive_real_binary_routes(tmp_path: Path, route: str) -> None:
+    """Aliases and interpreter-mediated recursion fail before the common lock."""
+    env, _repo, lane, common_dir = _setup_guard_linked_worktree(tmp_path)
+    wrapper = lane.parent / "coordinator" / "scripts" / "bd"
     if route == "bare-wrapper":
         env["POLYLOGUE_BD_REAL"] = "bd"
     elif route == "symlink-wrapper":
@@ -363,12 +389,16 @@ def test_bd_wrapper_rejects_recursive_real_binary_routes(tmp_path: Path, route: 
         recursive.chmod(0o755)
         env["POLYLOGUE_BD_REAL"] = str(recursive)
     else:
-        recursive = tmp_path / "interpreter-recursive-bd"
-        recursive.write_text(f'#!/bin/sh\nexec /bin/sh -c \'exec {wrapper!s} "$@"\' sh "$@"\n')
+        interpreter = tmp_path / ("python3.14" if route.endswith("versioned") else "renamed-interpreter")
+        shutil.copy2(Path(sys.executable).resolve(), interpreter)
+        interpreter.chmod(0o755)
+        recursive = tmp_path / route
+        python_code = f"import os; os.execv({str(wrapper)!r}, [{str(wrapper)!r}, *os.sys.argv[1:]])"
+        recursive.write_text(f'#!/bin/sh\nexec {interpreter!s} -c {shlex.quote(python_code)} "$@"\n')
         recursive.chmod(0o755)
         env["POLYLOGUE_BD_REAL"] = str(recursive)
 
-    result = subprocess.run([str(wrapper), "--help"], cwd=probe, env=env, capture_output=True, text=True, timeout=10)
+    result = subprocess.run([str(wrapper), "--help"], cwd=lane, env=env, capture_output=True, text=True, timeout=10)
     expected_returncode = 126 if route != "bare-wrapper" else 127
     assert result.returncode == expected_returncode
-    assert not list(runtime.iterdir())
+    assert not (common_dir / "polylogue-bd-guard.lock").exists()

--- a/tests/integration/test_beads_stale_worktree_guard.py
+++ b/tests/integration/test_beads_stale_worktree_guard.py
@@ -1,8 +1,10 @@
 """Regression coverage for the linked-worktree Beads import guard.
 
-This exercises the production post-checkout hook and the installed ``bd``
-binary against a temporary git repository and temporary embedded Dolt store.
-It never opens the repository's shared Beads database.
+The fixture has a deployed coordinator checkout and a linked lane created
+before deployment. The lane therefore retains the historical relative
+``.beads-hooks`` and ``.envrc`` paths while Git routes hooks through the
+coordinator's shared common-directory installation. It never opens this
+checkout's Beads database.
 """
 
 from __future__ import annotations
@@ -17,18 +19,14 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
+BASE_COMMIT = "a516b3caa791ef84a1a4133d217e39c20123651a"
 
 
 def _installed_bd() -> str | None:
-    """Resolve the Nix-installed binary even when this checkout's shim is on PATH."""
-    configured = os.environ.get("POLYLOGUE_BD_REAL")
-    if configured and Path(configured).resolve() != (ROOT / "scripts/bd").resolve():
-        return configured
-    scripts_dir = str((ROOT / "scripts").resolve())
+    """Resolve the installed binary without using this checkout's wrapper."""
+    scripts_dir = (ROOT / "scripts").resolve()
     search_path = os.pathsep.join(
-        entry
-        for entry in os.environ.get("PATH", "").split(os.pathsep)
-        if Path(entry or ".").resolve() != Path(scripts_dir)
+        entry for entry in os.environ.get("PATH", "").split(os.pathsep) if Path(entry or ".").resolve() != scripts_dir
     )
     return shutil.which("bd", path=search_path)
 
@@ -58,6 +56,7 @@ def _bd_environment(tmp_path: Path) -> dict[str, str]:
         "BEADS_DIR",
         "BEADS_DOLT_SERVER_DATABASE",
         "BEADS_DOLT_SERVER_PORT",
+        "POLYLOGUE_BD_REAL",
     ):
         env.pop(key, None)
     env.update(
@@ -103,15 +102,6 @@ def _write_import_policy(repo: Path, import_auto: bool) -> None:
     config_path.write_text(updated)
 
 
-def _set_export_timestamp(repo: Path, issue_id: str, updated_at: str) -> None:
-    export_path = repo / ".beads" / "issues.jsonl"
-    rows = [json.loads(line) for line in export_path.read_text().splitlines()]
-    matching_rows = [row for row in rows if row.get("id") == issue_id]
-    assert len(matching_rows) == 1
-    matching_rows[0]["updated_at"] = updated_at
-    export_path.write_text("".join(json.dumps(row, sort_keys=True) + "\n" for row in rows))
-
-
 def _set_export_row(repo: Path, issue_id: str, **updates: object) -> None:
     export_path = repo / ".beads" / "issues.jsonl"
     rows = [json.loads(line) for line in export_path.read_text().splitlines()]
@@ -121,31 +111,45 @@ def _set_export_row(repo: Path, issue_id: str, **updates: object) -> None:
     export_path.write_text("".join(json.dumps(row, sort_keys=True) + "\n" for row in rows))
 
 
+def _historical_file(relative_path: str) -> str:
+    result = subprocess.run(
+        ["git", "show", f"{BASE_COMMIT}^:{relative_path}"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def _deploy_current_common_checkout(repo: Path) -> None:
+    hooks = repo / ".beads-hooks"
+    hooks.mkdir(parents=True, exist_ok=True)
+    for hook in ("post-checkout", "post-merge", "pre-commit", "pre-push", "prepare-commit-msg"):
+        target = hooks / hook
+        shutil.copy2(ROOT / ".beads-hooks" / hook, target)
+        target.chmod(0o755)
+
+    envrc = repo / ".envrc"
+    shutil.copy2(ROOT / ".envrc", envrc)
+    wrapper = repo / "scripts" / "bd"
+    wrapper.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(ROOT / "scripts" / "bd", wrapper)
+    wrapper.chmod(0o755)
+    guard = repo / "devtools" / "bd_reimport_guard.py"
+    guard.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(ROOT / "devtools" / "bd_reimport_guard.py", guard)
+
+
 def _setup_stale_worktree(
     tmp_path: Path,
     import_auto: bool,
-    stale_snapshot_updated_at: str | None = None,
-) -> tuple[str, dict[str, str], Path, Path, Path]:
+) -> tuple[str, dict[str, str], Path, Path]:
     bd = _installed_bd()
     if bd is None:
         pytest.skip("bd is not installed")
 
     env = _bd_environment(tmp_path)
-    wrapper_dir = tmp_path / "bin"
-    wrapper_dir.mkdir()
-    invocation_log = tmp_path / "bd-invocations.log"
-    real_wrapper = wrapper_dir / "bd-real"
-    real_wrapper.write_text(
-        '#!/bin/sh\nprintf "%s\\n" "$*" >> "$BD_GUARD_COMMAND_LOG"\nexec "$BD_GUARD_REAL_BD" "$@"\n'
-    )
-    real_wrapper.chmod(0o755)
-    env["BD_GUARD_COMMAND_LOG"] = str(invocation_log)
-    env["BD_GUARD_REAL_BD"] = bd
-    env["POLYLOGUE_BD_REAL"] = str(real_wrapper)
-    # The lane deliberately does not contain a copy of the new files. The
-    # machine-level devshell path supplies the current checkout's stable
-    # wrapper, just as an operator shell does after entering this repo.
-    env["PATH"] = os.pathsep.join((str(ROOT / "scripts"), str(wrapper_dir), env["PATH"]))
     repo = tmp_path / "coordinator"
     lane = tmp_path / "stale-lane"
     repo.mkdir()
@@ -156,55 +160,58 @@ def _setup_stale_worktree(
     _run([bd, "init", "--prefix", "guard", "--quiet", "--non-interactive", "--skip-hooks", "--skip-agents"], repo, env)
     _write_import_policy(repo, import_auto)
 
-    # Keep setup commits hook-free, then point the linked lane at the actual
-    # production hook path for the checkout that exercises the guard.
+    # This is the branch-point checkout: it has only the historical relative
+    # hook and envrc paths, with no current wrapper or guard files.
+    historical_hooks = repo / ".beads-hooks"
+    historical_hooks.mkdir()
+    historical_hook = historical_hooks / "post-checkout"
+    historical_hook.write_text(_historical_file(".beads-hooks/post-checkout"))
+    historical_hook.chmod(0o755)
+    (repo / ".envrc").write_text(_historical_file(".envrc"))
+
     setup_hooks = repo / ".setup-hooks"
     setup_hooks.mkdir()
     _run(["git", "config", "core.hooksPath", str(setup_hooks)], repo, env)
-
     _run([bd, "create", "coordinator-owned issue", "--type", "bug"], repo, env)
     _run([bd, "export", "-o", ".beads/issues.jsonl"], repo, env)
     issue_rows = _json_from_output(_run([bd, "list", "--json"], repo, env).stdout)
     assert isinstance(issue_rows, list) and len(issue_rows) == 1
     issue_id = issue_rows[0]["id"]
-    if stale_snapshot_updated_at is not None:
-        _set_export_timestamp(repo, issue_id, stale_snapshot_updated_at)
 
-    _run(["git", "add", ".beads"], repo, env)
-    _run(["git", "commit", "-m", "baseline Beads snapshot"], repo, env)
-    _run(["git", "config", "core.hooksPath", str(ROOT / ".beads-hooks")], repo, env)
+    _run(["git", "add", ".beads", ".beads-hooks", ".envrc"], repo, env)
+    _run(["git", "commit", "-m", "historical Beads snapshot"], repo, env)
     _run(["git", "branch", "stale-lane"], repo, env)
     _run(["git", "worktree", "add", str(lane), "stale-lane"], repo, env)
+
+    # Deployment happens only in the common coordinator checkout. The shared
+    # absolute hook path is what protects the stale lane's historical files.
+    _deploy_current_common_checkout(repo)
+    _run(["git", "add", ".beads-hooks", ".envrc", "scripts/bd", "devtools/bd_reimport_guard.py"], repo, env)
+    _run(["git", "commit", "-m", "deploy Beads guard"], repo, env)
+    _run(["git", "config", "core.hooksPath", str(repo / ".beads-hooks")], repo, env)
+
+    env["PATH"] = os.pathsep.join((str(repo / "scripts"), env["PATH"]))
     _run([bd, "close", issue_id, "--reason", "coordinator close"], repo, env)
-    invocation_log.write_text("")
-    return issue_id, env, repo, lane, invocation_log
+    assert not (lane / "scripts" / "bd").exists()
+    assert (lane / ".envrc").read_text() == _historical_file(".envrc")
+    assert (lane / ".beads-hooks" / "post-checkout").read_text() == _historical_file(".beads-hooks/post-checkout")
+    return issue_id, env, repo, lane
 
 
-def test_stale_worktree_plain_read_preserves_coordinator_write_when_env_reenables_import(tmp_path: Path) -> None:
-    """A stale branch cannot overwrite a coordinator close before its read.
-
-    Production dependency exercised: Git invokes the committed
-    ``.beads-hooks/post-checkout`` shim, which invokes Beads' real hook import
-    gate. The fixture clears ambient ``BD_IMPORT_AUTO`` before setup, then sets
-    it to ``true`` only for the stale lane. The production shim must clear that
-    unsafe Viper override before it can re-enable imports.
-    """
-    issue_id, env, _repo, lane, invocation_log = _setup_stale_worktree(tmp_path, import_auto=True)
+def test_stale_worktree_plain_read_preserves_coordinator_write(tmp_path: Path) -> None:
+    """A stale branch's historical hook path cannot overwrite a close."""
+    issue_id, env, _repo, lane = _setup_stale_worktree(tmp_path, import_auto=True)
     env["BD_IMPORT_AUTO"] = "true"
-    _run(["git", "switch", "--detach", "HEAD"], lane, env)
 
+    _run(["git", "switch", "--detach", "HEAD"], lane, env)
     shown = _json_from_output(_run(["bd", "show", issue_id, "--json"], lane, env).stdout)
     assert isinstance(shown, list) and len(shown) == 1
     assert shown[0]["status"] == "closed"
 
-    delegated_commands = invocation_log.read_text().splitlines()
-    imported = any(command.startswith("import ") for command in delegated_commands)
-    assert not imported, "the stale row must be filtered before the real bd entry point sees it"
-
 
 def test_bd_wrapper_preserves_legitimate_newer_snapshot_import(tmp_path: Path) -> None:
-    """The guard rejects stale rows without disabling genuinely newer rows."""
-    issue_id, env, _repo, lane, _invocation_log = _setup_stale_worktree(tmp_path, import_auto=True)
+    """The guard rejects stale rows without disabling newer rows."""
+    issue_id, env, _repo, lane = _setup_stale_worktree(tmp_path, import_auto=True)
     _set_export_row(
         lane,
         issue_id,
@@ -220,24 +227,72 @@ def test_bd_wrapper_preserves_legitimate_newer_snapshot_import(tmp_path: Path) -
 
 
 def test_unsafe_import_auto_control_reverts_clock_skewed_stale_snapshot(tmp_path: Path) -> None:
-    """The config mutation reaches the importer and reopens the stale issue.
+    """The installed Beads importer remains a causal unsafe control."""
+    issue_id, env, _repo, lane = _setup_stale_worktree(tmp_path, import_auto=True)
+    _set_export_row(lane, issue_id, status="open", updated_at="2099-01-01T00:00:00Z")
+    env["BD_IMPORT_AUTO"] = "true"
 
-    This is the causal negative control for the protected test. It removes the
-    production ``import.auto: false`` mutation while retaining the same actual
-    git checkout and installed Beads engine. A clock-skewed branch snapshot
-    has a later ``updated_at`` despite containing the old open status, so the
-    importer accepts it over the coordinator's close.
-    """
-    issue_id, env, _repo, lane, invocation_log = _setup_stale_worktree(
-        tmp_path,
-        import_auto=True,
-        stale_snapshot_updated_at="2099-01-01T00:00:00Z",
-    )
+    bd = _installed_bd()
+    assert bd is not None
+    unsafe_hooks = tmp_path / "unsafe-hooks"
+    unsafe_hooks.mkdir()
+    unsafe_hook = unsafe_hooks / "post-checkout"
+    unsafe_hook.write_text(f"#!/bin/sh\nexec {bd} import .beads/issues.jsonl\n")
+    unsafe_hook.chmod(0o755)
+    _run(["git", "config", "core.hooksPath", str(unsafe_hooks)], lane, env)
     _run(["git", "switch", "--detach", "HEAD"], lane, env)
-
-    shown = _json_from_output(_run([env["BD_GUARD_REAL_BD"], "show", issue_id, "--json"], lane, env).stdout)
+    shown = _json_from_output(_run([bd, "show", issue_id, "--json"], lane, env).stdout)
     assert isinstance(shown, list) and len(shown) == 1
     assert shown[0]["status"] == "open"
 
-    delegated_commands = invocation_log.read_text().splitlines()
-    assert any(command.startswith("import ") for command in delegated_commands)
+
+@pytest.mark.parametrize("route", ["bare-wrapper", "symlink-wrapper", "script-recursion", "script-symlink-recursion"])
+def test_bd_wrapper_rejects_recursive_real_binary_routes(tmp_path: Path, route: str) -> None:
+    """Wrapper aliases and script recursion fail before the guard lock."""
+    deployed = tmp_path / "deployed"
+    scripts = deployed / "scripts"
+    scripts.mkdir(parents=True)
+    shutil.copy2(ROOT / "scripts" / "bd", scripts / "bd")
+    (scripts / "bd").chmod(0o755)
+    guard = deployed / "devtools" / "bd_reimport_guard.py"
+    guard.parent.mkdir()
+    shutil.copy2(ROOT / "devtools" / "bd_reimport_guard.py", guard)
+    wrapper = scripts / "bd"
+    probe = tmp_path / "probe"
+    probe.mkdir()
+
+    env = os.environ.copy()
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    env["XDG_RUNTIME_DIR"] = str(runtime)
+    tool_dirs: list[str] = []
+    for tool in ("sh", "dirname", "readlink", "python3"):
+        executable = shutil.which(tool)
+        assert executable is not None
+        directory = str(Path(executable).parent)
+        if directory not in tool_dirs:
+            tool_dirs.append(directory)
+    env["PATH"] = os.pathsep.join((str(scripts), *tool_dirs))
+    if route == "bare-wrapper":
+        env["POLYLOGUE_BD_REAL"] = "bd"
+    elif route == "symlink-wrapper":
+        alias = tmp_path / "bd-alias"
+        alias.symlink_to(wrapper)
+        env["POLYLOGUE_BD_REAL"] = str(alias)
+    elif route == "script-recursion":
+        recursive = tmp_path / "recursive-bd"
+        recursive.write_text(f'#!/bin/sh\nexec {wrapper!s} "$@"\n')
+        recursive.chmod(0o755)
+        env["POLYLOGUE_BD_REAL"] = str(recursive)
+    else:
+        alias = tmp_path / "bd-alias"
+        alias.symlink_to(wrapper)
+        recursive = tmp_path / "recursive-bd"
+        recursive.write_text(f'#!/bin/sh\nexec {alias!s} "$@"\n')
+        recursive.chmod(0o755)
+        env["POLYLOGUE_BD_REAL"] = str(recursive)
+
+    result = subprocess.run([str(wrapper), "--help"], cwd=probe, env=env, capture_output=True, text=True, timeout=10)
+    expected_returncode = 126 if route != "bare-wrapper" else 127
+    assert result.returncode == expected_returncode
+    assert not list(runtime.iterdir())

--- a/tests/integration/test_beads_stale_worktree_guard.py
+++ b/tests/integration/test_beads_stale_worktree_guard.py
@@ -546,3 +546,125 @@ def test_bd_wrapper_does_not_resurrect_deleted_candidate_only_row(tmp_path: Path
     snapshot = tmp_path / "live.jsonl"
     _run([bd, "export", "-o", str(snapshot)], lane, safe_env)
     assert candidate_id not in snapshot.read_text()
+
+
+@pytest.mark.parametrize(
+    ("label", "import_args"),
+    [
+        ("default", ["import"]),
+        ("stdin-short", ["import", "-"]),
+        ("stdin-long", ["import", "--"]),
+        ("input-equals", ["import", "--input=.beads/issues.jsonl"]),
+        ("input-separate", ["import", "--input", ".beads/issues.jsonl"]),
+        ("positional", ["import", ".beads/issues.jsonl"]),
+    ],
+)
+def test_bd_wrapper_rejects_every_checkout_snapshot_import_form(
+    tmp_path: Path, label: str, import_args: list[str]
+) -> None:
+    """No launcher spelling can delegate the checked-out snapshot to Beads."""
+    env, repo, lane, _common_dir = _setup_guard_linked_worktree(tmp_path)
+    wrapper = repo / "scripts" / "bd"
+    bd = _installed_bd()
+    if bd is None:
+        pytest.skip("bd is not installed")
+    _run([bd, "init", "--prefix", "guard", "--quiet", "--non-interactive", "--skip-hooks", "--skip-agents"], lane, env)
+    candidate_id = f"guard-{label}"
+    (lane / ".beads").mkdir(exist_ok=True)
+    (lane / ".beads" / "issues.jsonl").write_text(
+        json.dumps(
+            {
+                "_type": "issue",
+                "id": candidate_id,
+                "title": "checkout snapshot candidate",
+                "description": "",
+                "status": "open",
+                "priority": 1,
+                "issue_type": "bug",
+                "owner": "",
+                "created_at": "2026-01-01T00:00:00Z",
+                "created_by": "test",
+                "updated_at": "2026-01-01T00:00:00Z",
+                "labels": [],
+                "comment_count": 0,
+                "dependency_count": 0,
+                "dependent_count": 0,
+            }
+        )
+        + "\n"
+    )
+    env["POLYLOGUE_BD_REAL"] = bd
+
+    result = subprocess.run(
+        [str(wrapper), *import_args],
+        cwd=lane,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 125, result.stderr
+    assert "refusing explicit import" in result.stderr
+    safe_env = env | {"BD_IMPORT_AUTO": "false"}
+    snapshot = tmp_path / "live.jsonl"
+    _run([bd, "export", "-o", str(snapshot)], lane, safe_env)
+    assert candidate_id not in snapshot.read_text()
+
+
+@pytest.mark.parametrize(
+    ("label", "payload"),
+    [
+        ("malformed", "not-json\n"),
+        ("duplicate-key", '{"id":"guard-a","id":"guard-b"}\n'),
+        ("non-finite", '{"id":"guard-a","priority":NaN}\n'),
+    ],
+)
+def test_bd_wrapper_rejects_invalid_explicit_import_payloads(tmp_path: Path, label: str, payload: str) -> None:
+    """The process boundary validates independently supplied JSONL too."""
+    env, repo, lane, _common_dir = _setup_guard_linked_worktree(tmp_path)
+    wrapper = repo / "scripts" / "bd"
+    bd = _installed_bd()
+    if bd is None:
+        pytest.skip("bd is not installed")
+    payload_path = tmp_path / f"{label}.jsonl"
+    payload_path.write_text(payload)
+    env["POLYLOGUE_BD_REAL"] = bd
+
+    result = subprocess.run(
+        [str(wrapper), "import", "--input", str(payload_path)],
+        cwd=lane,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 125, result.stderr
+    assert "explicit import" in result.stderr
+    assert label in result.stderr
+
+
+def test_bd_wrapper_preserves_valid_independent_explicit_import(tmp_path: Path) -> None:
+    """A strict, independently supplied snapshot still reaches real Beads."""
+    env, repo, lane, _common_dir = _setup_guard_linked_worktree(tmp_path)
+    wrapper = repo / "scripts" / "bd"
+    bd = _installed_bd()
+    if bd is None:
+        pytest.skip("bd is not installed")
+    _run([bd, "init", "--prefix", "guard", "--quiet", "--non-interactive", "--skip-hooks", "--skip-agents"], lane, env)
+    _run([bd, "create", "independent import", "--type", "bug"], lane, env)
+    safe_payload = tmp_path / "independent-safe.jsonl"
+    _run([bd, "export", "-o", str(safe_payload)], lane, env | {"BD_IMPORT_AUTO": "false"})
+    env["POLYLOGUE_BD_REAL"] = bd
+
+    result = subprocess.run(
+        [str(wrapper), "import", f"--input={safe_payload}"],
+        cwd=lane,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/tests/integration/test_beads_stale_worktree_guard.py
+++ b/tests/integration/test_beads_stale_worktree_guard.py
@@ -14,6 +14,7 @@ import os
 import re
 import shutil
 import subprocess
+import textwrap
 from pathlib import Path
 
 import pytest
@@ -26,7 +27,9 @@ def _installed_bd() -> str | None:
     """Resolve the installed binary without using this checkout's wrapper."""
     scripts_dir = (ROOT / "scripts").resolve()
     search_path = os.pathsep.join(
-        entry for entry in os.environ.get("PATH", "").split(os.pathsep) if Path(entry or ".").resolve() != scripts_dir
+        entry
+        for entry in os.environ.get("PATH", "").split(os.pathsep)
+        if (Path(entry or ".").resolve() / "bd").resolve().parent.name != scripts_dir.name
     )
     return shutil.which("bd", path=search_path)
 
@@ -136,9 +139,60 @@ def _deploy_current_common_checkout(repo: Path) -> None:
     wrapper.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(ROOT / "scripts" / "bd", wrapper)
     wrapper.chmod(0o755)
+    hook_configurator = repo / "scripts" / "configure-git-hooks"
+    shutil.copy2(ROOT / "scripts" / "configure-git-hooks", hook_configurator)
+    hook_configurator.chmod(0o755)
     guard = repo / "devtools" / "bd_reimport_guard.py"
     guard.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(ROOT / "devtools" / "bd_reimport_guard.py", guard)
+
+
+def _execute_historical_envrc(lane: Path, env: dict[str, str], tmp_path: Path, installed_bd: str) -> None:
+    """Source the retained envrc and execute its branch-point use-flake hook."""
+    historical_use_flake = tmp_path / "historical-use-flake"
+    historical_flake = _historical_file("flake.nix")
+    start_marker = "          # Install repo git hooks"
+    end_marker = "          # Clean stale __pycache__"
+    start = historical_flake.index(start_marker)
+    end = historical_flake.index(end_marker, start)
+    historical_shell_hook = textwrap.dedent(historical_flake[start:end])
+    historical_use_flake.write_text(f"#!/usr/bin/env bash\nset -euo pipefail\n{historical_shell_hook}")
+    historical_use_flake.chmod(0o755)
+
+    marker = tmp_path / "historical-direct-bd-ran"
+    probe_bin = tmp_path / "historical-bin"
+    probe_bin.mkdir()
+    direct_bd = probe_bin / "bd"
+    direct_bd.write_text(f"#!/bin/sh\nprintf '%s\\n' ran > {marker!s}\n")
+    direct_bd.chmod(0o755)
+
+    historical_env = env.copy()
+    historical_env["HISTORICAL_USE_FLAKE"] = str(historical_use_flake)
+    # Keep the historical direct command-v bd route observable through the
+    # probe while the deployed wrapper follows the valid installed binary.
+    historical_env["POLYLOGUE_BD_REAL"] = installed_bd
+    historical_env["PATH"] = os.pathsep.join((str(probe_bin), historical_env["PATH"]))
+    _run(
+        [
+            "bash",
+            "-c",
+            'use() { "$HISTORICAL_USE_FLAKE" "$@"; }; source .envrc',
+        ],
+        lane,
+        historical_env,
+    )
+
+    # The old shell hook wrote a relative value through git config --local.
+    # The worktree-level common-dir pin must still select the deployed hook.
+    effective_hooks_path = _run(["git", "config", "--get", "core.hooksPath"], lane, historical_env).stdout.strip()
+    assert effective_hooks_path == str((lane.parent / "coordinator" / ".beads-hooks").resolve())
+    effective_hooks_origin = _run(
+        ["git", "config", "--show-origin", "--get", "core.hooksPath"], lane, historical_env
+    ).stdout.strip()
+    assert effective_hooks_origin.endswith("/config.worktree\t" + effective_hooks_path)
+
+    _run(["git", "switch", "--detach", "HEAD"], lane, historical_env)
+    assert not marker.exists(), "historical direct bd hook must not execute"
 
 
 def _setup_stale_worktree(
@@ -186,9 +240,23 @@ def _setup_stale_worktree(
     # Deployment happens only in the common coordinator checkout. The shared
     # absolute hook path is what protects the stale lane's historical files.
     _deploy_current_common_checkout(repo)
-    _run(["git", "add", ".beads-hooks", ".envrc", "scripts/bd", "devtools/bd_reimport_guard.py"], repo, env)
+    _run(
+        [
+            "git",
+            "add",
+            ".beads-hooks",
+            ".envrc",
+            "scripts/bd",
+            "scripts/configure-git-hooks",
+            "devtools/bd_reimport_guard.py",
+        ],
+        repo,
+        env,
+    )
     _run(["git", "commit", "-m", "deploy Beads guard"], repo, env)
-    _run(["git", "config", "core.hooksPath", str(repo / ".beads-hooks")], repo, env)
+
+    _run([str(repo / "scripts" / "configure-git-hooks")], repo, env)
+    _execute_historical_envrc(lane, env, tmp_path, bd)
 
     env["PATH"] = os.pathsep.join((str(repo / "scripts"), env["PATH"]))
     _run([bd, "close", issue_id, "--reason", "coordinator close"], repo, env)
@@ -246,7 +314,10 @@ def test_unsafe_import_auto_control_reverts_clock_skewed_stale_snapshot(tmp_path
     assert shown[0]["status"] == "open"
 
 
-@pytest.mark.parametrize("route", ["bare-wrapper", "symlink-wrapper", "script-recursion", "script-symlink-recursion"])
+@pytest.mark.parametrize(
+    "route",
+    ["bare-wrapper", "symlink-wrapper", "script-recursion", "script-symlink-recursion", "interpreter-recursion"],
+)
 def test_bd_wrapper_rejects_recursive_real_binary_routes(tmp_path: Path, route: str) -> None:
     """Wrapper aliases and script recursion fail before the guard lock."""
     deployed = tmp_path / "deployed"
@@ -284,11 +355,16 @@ def test_bd_wrapper_rejects_recursive_real_binary_routes(tmp_path: Path, route: 
         recursive.write_text(f'#!/bin/sh\nexec {wrapper!s} "$@"\n')
         recursive.chmod(0o755)
         env["POLYLOGUE_BD_REAL"] = str(recursive)
-    else:
+    elif route == "script-symlink-recursion":
         alias = tmp_path / "bd-alias"
         alias.symlink_to(wrapper)
         recursive = tmp_path / "recursive-bd"
         recursive.write_text(f'#!/bin/sh\nexec {alias!s} "$@"\n')
+        recursive.chmod(0o755)
+        env["POLYLOGUE_BD_REAL"] = str(recursive)
+    else:
+        recursive = tmp_path / "interpreter-recursive-bd"
+        recursive.write_text(f'#!/bin/sh\nexec /bin/sh -c \'exec {wrapper!s} "$@"\' sh "$@"\n')
         recursive.chmod(0o755)
         env["POLYLOGUE_BD_REAL"] = str(recursive)
 

--- a/tests/integration/test_beads_stale_worktree_guard.py
+++ b/tests/integration/test_beads_stale_worktree_guard.py
@@ -164,7 +164,7 @@ def _execute_historical_envrc(lane: Path, env: dict[str, str], tmp_path: Path, i
     historical_env = env.copy()
     environment_dump = tmp_path / "historical-environment"
     historical_env["HISTORICAL_USE_FLAKE"] = str(historical_use_flake)
-    historical_env["POLYLOGUE_BD_REAL"] = installed_bd
+    historical_env["PATH"] = os.pathsep.join((str(Path(installed_bd).parent), historical_env["PATH"]))
     _run(
         [
             "bash",
@@ -180,6 +180,7 @@ def _execute_historical_envrc(lane: Path, env: dict[str, str], tmp_path: Path, i
         if entry:
             key, _, value = entry.partition(b"=")
             historical_env[key.decode()] = value.decode()
+    assert historical_env.get("POLYLOGUE_BD_REAL") == installed_bd
 
     # The old shell hook wrote a relative value through git config --local.
     # The worktree-level common-dir pin must still select the deployed hook.
@@ -430,3 +431,61 @@ def test_bd_wrapper_survives_interpreter_path_alias_to_wrapper(tmp_path: Path, i
 
     assert result.returncode == 0, result.stderr
     assert (common_dir / "polylogue-bd-guard.lock").exists()
+
+
+def test_bd_wrapper_skips_indirect_python3_trampoline(tmp_path: Path) -> None:
+    """A python3 launcher that invokes the wrapper cannot recurse indefinitely."""
+    env, repo, lane, common_dir = _setup_guard_linked_worktree(tmp_path)
+    wrapper = repo / "scripts" / "bd"
+    alias_dir = tmp_path / "interpreter-trampoline"
+    alias_dir.mkdir()
+    trampoline = alias_dir / "python3"
+    trampoline.write_text(f'#!/bin/sh\nexec {wrapper!s} "$@"\n')
+    trampoline.chmod(0o755)
+    env["PATH"] = os.pathsep.join((str(alias_dir), env["PATH"]))
+    true_binary = shutil.which("true", path=env["PATH"])
+    assert true_binary is not None
+    env["POLYLOGUE_BD_REAL"] = true_binary
+
+    result = subprocess.run([str(wrapper), "--help"], cwd=lane, env=env, capture_output=True, text=True, timeout=10)
+
+    assert result.returncode == 0, result.stderr
+    assert (common_dir / "polylogue-bd-guard.lock").exists()
+
+
+@pytest.mark.parametrize(
+    ("label", "export_payload"),
+    [
+        ("malformed", '{"id":"guard-a"}\nnot-json\n'),
+        ("missing-id", '{"title":"guard-a"}\n'),
+        ("duplicate", '{"id":"guard-a"}\n{"id":"guard-a"}\n'),
+    ],
+)
+def test_bd_wrapper_fails_closed_on_invalid_successful_export(tmp_path: Path, label: str, export_payload: str) -> None:
+    """The real wrapper refuses invalid successful exports before import or delegation."""
+    env, repo, lane, _common_dir = _setup_guard_linked_worktree(tmp_path)
+    wrapper = repo / "scripts" / "bd"
+    (lane / ".beads").mkdir()
+    (lane / ".beads" / "issues.jsonl").write_text('{"id":"candidate"}\n')
+
+    # Point the wrapper at the real Python ELF and provide command-named Python
+    # programs in the invocation directory. This exercises the wrapper and
+    # guard subprocess route without requiring a second installed Beads binary.
+    marker = tmp_path / f"{label}-delegated"
+    (lane / "export").write_text(
+        "from pathlib import Path\n"
+        "import os\n"
+        "import sys\n"
+        "output = sys.argv[sys.argv.index('-o') + 1]\n"
+        "Path(output).write_text(os.environ['FAKE_EXPORT_PAYLOAD'] + '\\n')\n"
+    )
+    for command in ("import", "show"):
+        (lane / command).write_text(f"from pathlib import Path\nPath({str(marker)!r}).write_text('delegated\\n')\n")
+    env["POLYLOGUE_BD_REAL"] = sys.executable
+    env["FAKE_EXPORT_PAYLOAD"] = export_payload
+
+    result = subprocess.run([str(wrapper), "show"], cwd=lane, env=env, capture_output=True, text=True, timeout=10)
+
+    assert result.returncode == 125, result.stderr
+    assert "failed validation" in result.stderr
+    assert not marker.exists(), "invalid export must stop before import or delegated bd execution"

--- a/tests/integration/test_beads_stale_worktree_guard.py
+++ b/tests/integration/test_beads_stale_worktree_guard.py
@@ -414,6 +414,19 @@ def test_bd_wrapper_rejects_recursive_real_binary_routes(tmp_path: Path, route: 
     assert not (common_dir / "polylogue-bd-guard.lock").exists()
 
 
+def test_bd_wrapper_rejects_direct_python_target_before_guard_lock(tmp_path: Path) -> None:
+    """POLYLOGUE_BD_REAL cannot turn the wrapper into a Python trampoline."""
+    env, _repo, lane, common_dir = _setup_guard_linked_worktree(tmp_path)
+    wrapper = lane.parent / "coordinator" / "scripts" / "bd"
+    env["POLYLOGUE_BD_REAL"] = sys.executable
+
+    result = subprocess.run([str(wrapper), "--help"], cwd=lane, env=env, capture_output=True, text=True, timeout=10)
+
+    assert result.returncode == 126
+    assert "interpreter" in result.stderr
+    assert not (common_dir / "polylogue-bd-guard.lock").exists()
+
+
 @pytest.mark.parametrize("interpreter_name", ["sh", "python3"])
 def test_bd_wrapper_survives_interpreter_path_alias_to_wrapper(tmp_path: Path, interpreter_name: str) -> None:
     """The wrapper reaches the guard when PATH aliases an interpreter to itself."""
@@ -454,38 +467,82 @@ def test_bd_wrapper_skips_indirect_python3_trampoline(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    ("label", "export_payload"),
+    ("label", "candidate_payload"),
     [
         ("malformed", '{"id":"guard-a"}\nnot-json\n'),
         ("missing-id", '{"title":"guard-a"}\n'),
         ("duplicate", '{"id":"guard-a"}\n{"id":"guard-a"}\n'),
+        ("non-finite", '{"id":"guard-a","priority":NaN}\n'),
+        ("duplicate-key", '{"id":"guard-a","id":"guard-b"}\n'),
+        ("invalid-type", '{"id":"guard-a","labels":"area:beads"}\n'),
+        ("invalid-timestamp", '{"id":"guard-a","updated_at":"tomorrow"}\n'),
+        ("invalid-id", '{"id":42}\n'),
     ],
 )
-def test_bd_wrapper_fails_closed_on_invalid_successful_export(tmp_path: Path, label: str, export_payload: str) -> None:
-    """The real wrapper refuses invalid successful exports before import or delegation."""
+def test_bd_wrapper_fails_closed_on_invalid_candidate_jsonl(tmp_path: Path, label: str, candidate_payload: str) -> None:
+    """The real wrapper rejects malicious candidate JSONL before delegation."""
     env, repo, lane, _common_dir = _setup_guard_linked_worktree(tmp_path)
     wrapper = repo / "scripts" / "bd"
-    (lane / ".beads").mkdir()
-    (lane / ".beads" / "issues.jsonl").write_text('{"id":"candidate"}\n')
+    bd = _installed_bd()
+    if bd is None:
+        pytest.skip("bd is not installed")
+    _run([bd, "init", "--prefix", "guard", "--quiet", "--non-interactive", "--skip-hooks", "--skip-agents"], lane, env)
+    (lane / ".beads").mkdir(exist_ok=True)
+    (lane / ".beads" / "issues.jsonl").write_text(candidate_payload)
+    env["POLYLOGUE_BD_REAL"] = bd
 
-    # Point the wrapper at the real Python ELF and provide command-named Python
-    # programs in the invocation directory. This exercises the wrapper and
-    # guard subprocess route without requiring a second installed Beads binary.
-    marker = tmp_path / f"{label}-delegated"
-    (lane / "export").write_text(
-        "from pathlib import Path\n"
-        "import os\n"
-        "import sys\n"
-        "output = sys.argv[sys.argv.index('-o') + 1]\n"
-        "Path(output).write_text(os.environ['FAKE_EXPORT_PAYLOAD'] + '\\n')\n"
-    )
-    for command in ("import", "show"):
-        (lane / command).write_text(f"from pathlib import Path\nPath({str(marker)!r}).write_text('delegated\\n')\n")
-    env["POLYLOGUE_BD_REAL"] = sys.executable
-    env["FAKE_EXPORT_PAYLOAD"] = export_payload
-
-    result = subprocess.run([str(wrapper), "show"], cwd=lane, env=env, capture_output=True, text=True, timeout=10)
+    result = subprocess.run([str(wrapper), "show"], cwd=lane, env=env, capture_output=True, text=True, timeout=30)
 
     assert result.returncode == 125, result.stderr
     assert "failed validation" in result.stderr
-    assert not marker.exists(), "invalid export must stop before import or delegated bd execution"
+
+
+def test_bd_wrapper_does_not_resurrect_deleted_candidate_only_row(tmp_path: Path) -> None:
+    """A row absent from live export is not treated as a newly-created row."""
+    env, repo, lane, _common_dir = _setup_guard_linked_worktree(tmp_path)
+    wrapper = repo / "scripts" / "bd"
+    bd = _installed_bd()
+    if bd is None:
+        pytest.skip("bd is not installed")
+    _run([bd, "init", "--prefix", "guard", "--quiet", "--non-interactive", "--skip-hooks", "--skip-agents"], lane, env)
+    candidate_id = "guard-deleted"
+    (lane / ".beads").mkdir(exist_ok=True)
+    (lane / ".beads" / "issues.jsonl").write_text(
+        json.dumps(
+            {
+                "_type": "issue",
+                "id": candidate_id,
+                "title": "deleted live row",
+                "description": "",
+                "status": "open",
+                "priority": 1,
+                "issue_type": "bug",
+                "owner": "",
+                "created_at": "2026-01-01T00:00:00Z",
+                "created_by": "test",
+                "updated_at": "2026-01-01T00:00:00Z",
+                "labels": [],
+                "comment_count": 0,
+                "dependency_count": 0,
+                "dependent_count": 0,
+            }
+        )
+        + "\n"
+    )
+    env["POLYLOGUE_BD_REAL"] = bd
+
+    result = subprocess.run(
+        [str(wrapper), "import", ".beads/issues.jsonl"],
+        cwd=lane,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 125
+    assert "durable new-row proof" in result.stderr
+    safe_env = env | {"BD_IMPORT_AUTO": "false"}
+    snapshot = tmp_path / "live.jsonl"
+    _run([bd, "export", "-o", str(snapshot)], lane, safe_env)
+    assert candidate_id not in snapshot.read_text()

--- a/tests/unit/devtools/test_bd_reimport_guard.py
+++ b/tests/unit/devtools/test_bd_reimport_guard.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
@@ -70,10 +71,15 @@ def test_validated_real_bd_path_rejects_interpreter_mediated_launcher(tmp_path: 
         guard._validated_real_bd_path(str(launcher))
 
 
+def test_validated_real_bd_path_rejects_direct_python_target() -> None:
+    with pytest.raises(ValueError, match="interpreter"):
+        guard._validated_real_bd_path(sys.executable)
+
+
 # --- merge_rows: the monotonic per-row merge engine --------------------------
 
 
-def test_merge_rows_classifies_new_updated_equal_and_skips_downgrade() -> None:
+def test_merge_rows_refuses_unproven_candidate_only_rows() -> None:
     current = {
         "polylogue-a": {"id": "polylogue-a", "updated_at": "2026-07-15T10:00:00Z", "title": "a-current"},
         "polylogue-b": {"id": "polylogue-b", "updated_at": "2026-07-15T10:00:00Z", "title": "b-current"},
@@ -86,7 +92,7 @@ def test_merge_rows_classifies_new_updated_equal_and_skips_downgrade() -> None:
         "polylogue-b": {"id": "polylogue-b", "updated_at": "2026-07-15T10:00:00Z", "title": "b-current"},
         # older than current -- a downgrade, must be refused by default
         "polylogue-c": {"id": "polylogue-c", "updated_at": "2026-07-14T10:00:00Z", "title": "c-stale"},
-        # not present in current at all -- a new row
+        # not present in current at all -- no durable proof of newness
         "polylogue-d": {"id": "polylogue-d", "updated_at": "2026-07-16T10:00:00Z", "title": "d-new"},
     }
 
@@ -96,7 +102,7 @@ def test_merge_rows_classifies_new_updated_equal_and_skips_downgrade() -> None:
     assert by_id["polylogue-a"].outcome == "updated"
     assert by_id["polylogue-b"].outcome == "equal"
     assert by_id["polylogue-c"].outcome == "skipped_downgrade"
-    assert by_id["polylogue-d"].outcome == "new"
+    assert by_id["polylogue-d"].outcome == "unproven_new"
 
     # The mutation that would make this fail: merging the stale candidate
     # for polylogue-c into `merged` (i.e. treating merge as a blind upsert,
@@ -104,7 +110,7 @@ def test_merge_rows_classifies_new_updated_equal_and_skips_downgrade() -> None:
     # is exactly the anti-regression property this bead exists to enforce.
     assert merged["polylogue-c"]["title"] == "c-current"
     assert merged["polylogue-a"]["title"] == "a-newer"
-    assert merged["polylogue-d"]["title"] == "d-new"
+    assert "polylogue-d" not in merged
 
 
 def test_merge_rows_incomparable_revision_is_conflicted_not_guessed() -> None:
@@ -156,6 +162,25 @@ def test_parse_and_validate_jsonl_rejects_missing_id() -> None:
 def test_parse_and_validate_jsonl_rejects_duplicate_id() -> None:
     text = '{"id": "polylogue-a", "title": "first"}\n{"id": "polylogue-a", "title": "second"}\n'
     with pytest.raises(guard.InvalidJsonlError, match="duplicate"):
+        guard.parse_and_validate_jsonl(text)
+
+
+@pytest.mark.parametrize(
+    ("text", "message"),
+    [
+        ('{"id":"polylogue-a","priority":NaN}\n', "non-finite"),
+        ('{"id":"polylogue-a","id":"polylogue-b"}\n', "duplicate JSON key"),
+        ('{"id":42}\n', "Beads id"),
+        ('{"id":"polylogue-a","updated_at":"tomorrow"}\n', "timestamp"),
+        ('{"id":"polylogue-a","labels":"area:beads"}\n', "list of strings"),
+        (
+            '{"id":"polylogue-a","dependencies":[{"issue_id":42,"depends_on_id":"polylogue-b"}]}\n',
+            "Beads id",
+        ),
+    ],
+)
+def test_parse_and_validate_jsonl_rejects_malicious_or_invalid_payload(text: str, message: str) -> None:
+    with pytest.raises(guard.InvalidJsonlError, match=message):
         guard.parse_and_validate_jsonl(text)
 
 
@@ -221,7 +246,7 @@ def test_reconcile_applies_new_and_updated_but_refuses_downgrade(
     # A skipped downgrade means the sync is not "clean" -- rc reports it
     # rather than silently succeeding.
     assert rc == 1
-    assert set(imported) == {"polylogue-a", "polylogue-d"}
+    assert set(imported) == {"polylogue-a"}
     assert "polylogue-c" not in imported, "the stale replacement for polylogue-c must never reach bd import"
 
     receipts = list((tmp_path / "receipts").glob("*.json"))
@@ -229,7 +254,7 @@ def test_reconcile_applies_new_and_updated_but_refuses_downgrade(
     receipt = json.loads(receipts[0].read_text())
     assert receipt["summary"]["skipped_downgrade"] == 1
     assert receipt["summary"]["updated"] == 1
-    assert receipt["summary"]["new"] == 1
+    assert receipt["summary"]["unproven_new"] == 1
     assert not receipt["is_clean"]
 
 

--- a/tests/unit/devtools/test_bd_reimport_guard.py
+++ b/tests/unit/devtools/test_bd_reimport_guard.py
@@ -51,8 +51,8 @@ def test_validated_real_bd_path_rejects_script_recursion(tmp_path: Path) -> None
 
 
 def test_validated_real_bd_path_accepts_explicit_launcher_target(tmp_path: Path) -> None:
-    binary = tmp_path / "bd-bin"
-    binary.write_bytes(b"\x7fELF\x02\x01")
+    binary = tmp_path / "bd"
+    binary.write_bytes(b"\x7fELF\x02\x01Go buildinf:")
     binary.chmod(0o755)
     launcher = tmp_path / "bd-launcher"
     launcher.write_text(f'#!/bin/sh\nexec {binary!s} "$@"\n')

--- a/tests/unit/devtools/test_bd_reimport_guard.py
+++ b/tests/unit/devtools/test_bd_reimport_guard.py
@@ -184,6 +184,74 @@ def test_parse_and_validate_jsonl_rejects_malicious_or_invalid_payload(text: str
         guard.parse_and_validate_jsonl(text)
 
 
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["import"],
+        ["import", "-"],
+        ["import", "--"],
+        ["import", "--input"],
+        ["import", "--input", "-"],
+        ["import", "--input=--"],
+        ["import", "--allow-stale"],
+    ],
+)
+def test_import_payload_paths_rejects_implicit_and_missing_payloads(tmp_path: Path, args: list[str]) -> None:
+    with pytest.raises(guard.InvalidJsonlError, match="refusing bd import"):
+        guard._import_payload_paths(args, tmp_path)
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["import", "candidate.jsonl"],
+        ["import", "--input", "candidate.jsonl"],
+        ["import", "--input=candidate.jsonl"],
+        ["import", "-i", "candidate.jsonl"],
+        ["import", "-i=candidate.jsonl"],
+    ],
+)
+def test_import_payload_paths_extracts_explicit_forms(tmp_path: Path, args: list[str]) -> None:
+    assert guard._import_payload_paths(args, tmp_path) == [(tmp_path / "candidate.jsonl").resolve()]
+
+
+def test_preflight_explicit_import_rejects_checkout_snapshot_alias_and_accepts_safe_input(tmp_path: Path) -> None:
+    candidate = tmp_path / ".beads" / "issues.jsonl"
+    candidate.parent.mkdir()
+    candidate.write_text('{"id":"polylogue-candidate"}\n')
+    safe = tmp_path / "independent.jsonl"
+    safe.write_text('{"id":"polylogue-safe","updated_at":"2026-07-15T10:00:00Z"}\n')
+
+    with pytest.raises(guard.InvalidJsonlError, match="checkout snapshot"):
+        guard._preflight_explicit_import(
+            ["import", "--input=./.beads/issues.jsonl"],
+            candidate_path=candidate,
+            cwd=tmp_path,
+        )
+
+    guard._preflight_explicit_import(
+        ["import", "--input", str(safe)],
+        candidate_path=candidate,
+        cwd=tmp_path,
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "not-json\n",
+        '{"id":"polylogue-a","id":"polylogue-b"}\n',
+        '{"id":"polylogue-a","priority":NaN}\n',
+    ],
+)
+def test_preflight_explicit_import_rejects_invalid_independent_input(tmp_path: Path, payload: str) -> None:
+    path = tmp_path / "invalid.jsonl"
+    path.write_text(payload)
+
+    with pytest.raises(guard.InvalidJsonlError, match="explicit import payload"):
+        guard._preflight_explicit_import(["import", str(path)], candidate_path=None, cwd=tmp_path)
+
+
 def test_atomic_write_jsonl_writes_valid_rows(tmp_path: Path) -> None:
     target = tmp_path / "issues.jsonl"
     rows = {"polylogue-a": {"id": "polylogue-a", "updated_at": "2026-07-15T10:00:00Z"}}

--- a/tests/unit/devtools/test_bd_reimport_guard.py
+++ b/tests/unit/devtools/test_bd_reimport_guard.py
@@ -25,6 +25,42 @@ def test_main_rejects_unknown_command() -> None:
     assert guard.main(["frobnicate", "post-checkout"]) == 1
 
 
+def test_validated_real_bd_path_accepts_absolute_binary(tmp_path: Path) -> None:
+    binary = tmp_path / "bd"
+    binary.write_bytes(b"\x7fELF\x02\x01")
+    binary.chmod(0o755)
+
+    assert guard._validated_real_bd_path(str(binary)) == binary
+
+
+def test_validated_real_bd_path_rejects_wrapper_symlink() -> None:
+    wrapper = Path(__file__).resolve().parents[3] / "scripts" / "bd"
+
+    with pytest.raises(ValueError, match="recursive wrapper"):
+        guard._validated_real_bd_path(str(wrapper))
+
+
+def test_validated_real_bd_path_rejects_script_recursion(tmp_path: Path) -> None:
+    recursive = tmp_path / "bd-recursive"
+    wrapper = Path(__file__).resolve().parents[3] / "scripts" / "bd"
+    recursive.write_text(f'#!/bin/sh\nexec {wrapper!s} "$@"\n')
+    recursive.chmod(0o755)
+
+    with pytest.raises(ValueError, match="recursive wrapper"):
+        guard._validated_real_bd_path(str(recursive))
+
+
+def test_validated_real_bd_path_accepts_explicit_launcher_target(tmp_path: Path) -> None:
+    binary = tmp_path / "bd-bin"
+    binary.write_bytes(b"\x7fELF\x02\x01")
+    binary.chmod(0o755)
+    launcher = tmp_path / "bd-launcher"
+    launcher.write_text(f'#!/bin/sh\nexec {binary!s} "$@"\n')
+    launcher.chmod(0o755)
+
+    assert guard._validated_real_bd_path(str(launcher)) == launcher
+
+
 # --- merge_rows: the monotonic per-row merge engine --------------------------
 
 

--- a/tests/unit/devtools/test_bd_reimport_guard.py
+++ b/tests/unit/devtools/test_bd_reimport_guard.py
@@ -61,6 +61,15 @@ def test_validated_real_bd_path_accepts_explicit_launcher_target(tmp_path: Path)
     assert guard._validated_real_bd_path(str(launcher)) == launcher
 
 
+def test_validated_real_bd_path_rejects_interpreter_mediated_launcher(tmp_path: Path) -> None:
+    launcher = tmp_path / "bd-shell-launcher"
+    launcher.write_text('#!/bin/sh\nexec /bin/sh -c \'exec /tmp/hidden-bd "$@"\' sh "$@"\n')
+    launcher.chmod(0o755)
+
+    with pytest.raises(ValueError, match="interpreter launcher"):
+        guard._validated_real_bd_path(str(launcher))
+
+
 # --- merge_rows: the monotonic per-row merge engine --------------------------
 
 


### PR DESCRIPTION
## Summary

Route every ordinary `bd` invocation from a linked worktree through the deployed common-checkout wrapper and guard, including worktrees that retain the historical shell environment and wrapper. Harden the wrapper bootstrap so symlinked invocation and interpreter aliases cannot select stale code or recurse before the guard.

## Problem

A stale linked worktree could retain its branch-point `scripts/bd` and `.envrc` route while sharing the coordinator's live Beads store. The previous regression setup prepended the common `scripts` directory itself, so it did not prove that a real stale checkout invocation reached the guard. The wrapper also derived `devtools/bd_reimport_guard.py` from the path used to invoke it, allowing a symlink route to load a stale guard. Its `/usr/bin/env sh` and PATH-resolved `python3` bootstrap could be redirected to a wrapper alias before the guard ran.

## Solution

- `scripts/configure-git-hooks` installs the common-checkout `scripts/bd` as the reserved `scripts/bd` route in every linked worktree, replacing the historical wrapper route while leaving the common checkout's executable in place.
- `scripts/bd` resolves its own executable before deriving the guard path, uses `/bin/sh` for the shell bootstrap, and resolves `python3` candidates while rejecting candidates whose real path is the wrapper itself. Direct invocation remains supported.
- The integration fixture creates a real temporary Git repository with `git worktree add`, preserves the historical wrapper and `.envrc`, adds a stale guard witness, runs the common deployment, captures the environment produced by sourcing the historical `.envrc`, and invokes `bd` through that environment. The common wrapper is proven to be the route and the stale guard is never loaded.
- The rejection matrix covers bare wrapper lookup, wrapper symlink, direct shell recursion, shell recursion through a wrapper symlink, versioned copied Python, arbitrarily renamed copied Python, and both `sh` and `python3` PATH aliases to the wrapper. Every rejected route is checked against the actual linked-worktree Git common directory and the common lock remains absent before delegation.

## Verification

- `sh -n scripts/bd scripts/configure-git-hooks`: passed.
- `git diff --check`: passed.
- `direnv exec . devtools test tests/unit/devtools/test_bd_reimport_guard.py`: 24 passed.
- `direnv exec . devtools test tests/integration/test_beads_stale_worktree_guard.py`: 11 passed, including the real historical-environment direct invocation and common-lock assertions.
- `direnv exec . devtools verify --quick`: exit 0. Ruff format, Ruff check, mypy, generated-surface rendering, layering, policy, manifest, workflow, and schema-promotion steps all passed.
- Full suite and `devtools verify --all` were not run. No production paths or databases were accessed.

Ref polylogue-2ara
