### PR TITLE
fix(rebuild): enforce provenance at cleanup boundaries

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -436,8 +436,8 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         "devtools.reindex_canary",
         use_when="Exercise the bounded semantic reindex canary before paying for a full rebuild.",
         examples=(
-            "devtools reindex-canary --archive-root /path/to/isolated-archive --input /path/to/index.db --sample 100 --report /path/to/canary.json --no-promote",
-            "devtools reindex-canary --archive-root /path/to/isolated-archive --pathology-session-id codex-session:whale --report /path/to/canary.json --no-promote",
+            "devtools reindex-canary --archive-root /path/to/isolated-archive --input /path/to/index.db --schema-inference-receipt /path/to/schema-inference-gate-receipt.json --sample 100 --report /path/to/canary.json --no-promote",
+            "devtools reindex-canary --archive-root /path/to/isolated-archive --schema-inference-receipt /path/to/schema-inference-gate-receipt.json --pathology-session-id codex-session:whale --report /path/to/canary.json --no-promote",
         ),
     ),
     CommandSpec(

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -328,6 +328,7 @@ Read-only with respect to the active index. Before a full reindex, this command 
 polylogue ops maintenance reindex-canary \
   --archive-root /realm/tmp/polylogue-canary-archive \
   --input /realm/tmp/polylogue-canary-archive/index.db \
+  --schema-inference-receipt /realm/tmp/schema-inference-gate-receipt.json \
   --sample 100 \
   --report /realm/tmp/polylogue-reindex-canary.json \
   --no-promote \

--- a/polylogue/cli/commands/maintenance/_rebuild_index.py
+++ b/polylogue/cli/commands/maintenance/_rebuild_index.py
@@ -43,6 +43,7 @@ def _run_daemon_rebuild(
     max_blob_mb: float | None,
     no_promote: bool,
     operation_id: str | None,
+    schema_inference_receipt_path: Path | None,
     raw_batch_size: int,
     pass_byte_budget_mb: float | None,
     pass_deadline_seconds: float | None,
@@ -58,6 +59,9 @@ def _run_daemon_rebuild(
             "max_blob_mb": max_blob_mb,
             "promote": not no_promote,
             "operation_id": operation_id,
+            "schema_inference_receipt_path": (
+                str(schema_inference_receipt_path) if schema_inference_receipt_path is not None else None
+            ),
             "raw_batch_size": raw_batch_size,
             "pass_byte_budget_mb": pass_byte_budget_mb,
             "pass_deadline_seconds": pass_deadline_seconds,
@@ -330,6 +334,13 @@ def _rebuild_index_selection_plan(
     help="Resume the retained candidate generation for this rebuild operation.",
 )
 @click.option(
+    "--schema-inference-receipt",
+    "schema_inference_receipt_path",
+    type=click.Path(path_type=Path, dir_okay=False),
+    default=None,
+    help="Fresh schema-inference PASS receipt; policy fallback is POLYLOGUE_SCHEMA_INFERENCE_RECEIPT.",
+)
+@click.option(
     "--raw-batch-size",
     type=int,
     default=500,
@@ -384,6 +395,7 @@ def rebuild_index_command(
     plan_only: bool,
     plan_limit: int,
     operation_id: str | None,
+    schema_inference_receipt_path: Path | None,
     raw_batch_size: int,
     pass_byte_budget_mb: float | None,
     pass_deadline_seconds: float | None,
@@ -437,6 +449,7 @@ def rebuild_index_command(
             max_blob_mb=max_blob_mb,
             no_promote=no_promote,
             operation_id=operation_id,
+            schema_inference_receipt_path=schema_inference_receipt_path,
             raw_batch_size=raw_batch_size,
             pass_byte_budget_mb=pass_byte_budget_mb,
             pass_deadline_seconds=pass_deadline_seconds,
@@ -531,6 +544,7 @@ def rebuild_index_command(
                 max_blob_mb=max_blob_mb,
                 promote=not no_promote,
                 operation_id=operation_id,
+                schema_inference_receipt_path=schema_inference_receipt_path,
                 raw_batch_size=raw_batch_size,
                 pass_byte_budget_mb=pass_byte_budget_mb,
                 pass_deadline_seconds=pass_deadline_seconds,

--- a/polylogue/cli/commands/maintenance/_reindex_canary.py
+++ b/polylogue/cli/commands/maintenance/_reindex_canary.py
@@ -49,6 +49,13 @@ import click
     required=True,
     help="Destination for the reviewed canary report.",
 )
+@click.option(
+    "--schema-inference-receipt",
+    "schema_inference_receipt_path",
+    type=click.Path(path_type=Path, exists=True, dir_okay=False, readable=True),
+    required=True,
+    help="Explicit fresh schema-inference PASS receipt consumed by the canary rebuild.",
+)
 @click.option("--output-format", type=click.Choice(["plain", "json"]), default="plain", show_default=True)
 @click.option(
     "--no-promote",
@@ -62,6 +69,7 @@ def reindex_canary_command(
     pathology_session_id: tuple[str, ...],
     sample_session_id: tuple[str, ...],
     report_path: Path,
+    schema_inference_receipt_path: Path,
     output_format: str,
     no_promote: bool,
 ) -> None:
@@ -88,6 +96,7 @@ def reindex_canary_command(
             pathology_session_ids=pathology_session_id,
             sample_session_ids=sample_session_id,
             no_promote=no_promote,
+            schema_inference_receipt_path=schema_inference_receipt_path,
         )
         durable = write_canary_report(
             report_path,

--- a/polylogue/daemon/bulk_rebuild.py
+++ b/polylogue/daemon/bulk_rebuild.py
@@ -39,16 +39,17 @@ Two properties this module adds on top of the existing rebuild engine:
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from polylogue.config import Config
 from polylogue.logging import get_logger
+from polylogue.maintenance.schema_inference_gate import rebuild_source_revision_snapshot
 from polylogue.storage.archive_identity import ArchiveLocation, OwnedArchiveLocation, assert_owns_archive_location
 from polylogue.storage.index_generation import (
     IndexGenerationStore,
     IndexRebuildTransaction,
-    source_revision_snapshot,
 )
 
 if TYPE_CHECKING:
@@ -56,6 +57,43 @@ if TYPE_CHECKING:
     from polylogue.maintenance.rebuild_index import RebuildIndexReceipt
 
 logger = get_logger(__name__)
+
+
+def _validate_rebuild_provenance_receipt(root: Path, receipt_path: Path | None) -> None:
+    """Validate daemon rebuild provenance at the current ownership boundary."""
+    from polylogue.maintenance.schema_inference_gate import (
+        SchemaInferenceGateError,
+        validate_schema_inference_receipt,
+    )
+
+    try:
+        validate_schema_inference_receipt(root, receipt_path)
+    except SchemaInferenceGateError as exc:
+        raise RuntimeError(f"daemon bulk rebuild schema-inference preflight gate failed: {exc}") from exc
+
+
+def _discard_daemon_transaction_after_provenance_failure(
+    store: IndexGenerationStore, transaction: IndexRebuildTransaction
+) -> None:
+    """Best-effort cleanup after a post-create provenance failure.
+
+    The caller still owns the archive location. Cleanup does not consume source
+    evidence, so it must remain available even when the receipt that authorized
+    candidate creation has just expired or the source snapshot has drifted.
+    Each record is retired independently so one failed cleanup step cannot
+    strand the other record.
+    """
+    try:
+        generation = store.load(transaction.generation_id)
+        if generation.state == "inactive":
+            store.discard_if_inactive(generation)
+    except Exception:
+        logger.warning("bulk-rebuild: failed to discard post-validation candidate", exc_info=True)
+    try:
+        store.discard_transaction(transaction.operation_id)
+    except Exception:
+        logger.warning("bulk-rebuild: failed to discard post-validation transaction", exc_info=True)
+
 
 #: Fixed operation id for the daemon's own bulk-rebuild transaction. Exactly
 #: one such operation is ever in flight per archive -- this module's only
@@ -82,7 +120,9 @@ DAEMON_BULK_REBUILD_BATCH_SIZE = 500
 _TERMINAL_NOT_RESUMABLE = frozenset({"promoted", "stale", "failed"})
 
 
-def resolve_or_start_daemon_bulk_rebuild_transaction(root: Path) -> IndexRebuildTransaction:
+def resolve_or_start_daemon_bulk_rebuild_transaction(
+    root: Path, *, schema_inference_receipt_path: Path | None = None
+) -> IndexRebuildTransaction:
     """Load the daemon's resumable bulk-rebuild transaction, starting one if needed.
 
     Read-only fast path when a resumable transaction already exists (a
@@ -100,27 +140,33 @@ def resolve_or_start_daemon_bulk_rebuild_transaction(root: Path) -> IndexRebuild
     generation directory, so both must fail closed against a foreign/rotated
     archive location before touching disk, not just the eventual write pass.
     """
+    _validate_rebuild_provenance_receipt(root, schema_inference_receipt_path)
     location = ArchiveLocation.resolve(root)
-    store = IndexGenerationStore(location)
-    transaction: IndexRebuildTransaction | None
-    try:
-        transaction = store.load_transaction(DAEMON_BULK_REBUILD_OPERATION_ID)
-    except FileNotFoundError:
-        transaction = None
-    except (OSError, ValueError, TypeError, KeyError) as exc:
-        logger.warning(
-            "bulk-rebuild: could not load persisted transaction %s; starting a fresh one: %s",
-            DAEMON_BULK_REBUILD_OPERATION_ID,
-            exc,
-        )
-        transaction = None
-
-    if transaction is not None and transaction.status not in _TERMINAL_NOT_RESUMABLE:
-        return transaction
-
     owned = OwnedArchiveLocation.acquire(location)
     try:
         assert_owns_archive_location(owned, location)
+        # The first validation is only a cheap early rejection. Revalidate
+        # after ownership acquisition so receipt expiry, source revision, or
+        # external-corpus drift cannot reach generation bookkeeping.
+        _validate_rebuild_provenance_receipt(root, schema_inference_receipt_path)
+        store = IndexGenerationStore(location)
+        transaction: IndexRebuildTransaction | None
+        try:
+            transaction = store.load_transaction(DAEMON_BULK_REBUILD_OPERATION_ID)
+        except FileNotFoundError:
+            transaction = None
+        except (OSError, ValueError, TypeError, KeyError) as exc:
+            logger.warning(
+                "bulk-rebuild: could not load persisted transaction %s; starting a fresh one: %s",
+                DAEMON_BULK_REBUILD_OPERATION_ID,
+                exc,
+            )
+            transaction = None
+
+        if transaction is not None and transaction.status not in _TERMINAL_NOT_RESUMABLE:
+            _validate_rebuild_provenance_receipt(root, schema_inference_receipt_path)
+            return transaction
+
         if transaction is not None:
             # Terminal: retire the old candidate/transaction record before
             # reusing the well-known operation id. A "promoted" generation is
@@ -131,13 +177,25 @@ def resolve_or_start_daemon_bulk_rebuild_transaction(root: Path) -> IndexRebuild
             except (FileNotFoundError, OSError, ValueError):
                 generation = None
             if generation is not None and generation.state == "inactive":
+                _validate_rebuild_provenance_receipt(root, schema_inference_receipt_path)
                 store.discard_if_inactive(generation)
+            _validate_rebuild_provenance_receipt(root, schema_inference_receipt_path)
             store.discard_transaction(DAEMON_BULK_REBUILD_OPERATION_ID)
 
-        return store.create_transaction(
-            source_snapshot=source_revision_snapshot(root),
+        _validate_rebuild_provenance_receipt(root, schema_inference_receipt_path)
+        source_snapshot = rebuild_source_revision_snapshot(root)
+        transaction = store.create_transaction(
+            source_snapshot=source_snapshot,
             operation_id=DAEMON_BULK_REBUILD_OPERATION_ID,
         )
+        try:
+            _validate_rebuild_provenance_receipt(root, schema_inference_receipt_path)
+            if rebuild_source_revision_snapshot(root) != source_snapshot:
+                raise RuntimeError("daemon bulk rebuild source evidence changed during transaction creation")
+        except Exception:
+            _discard_daemon_transaction_after_provenance_failure(store, transaction)
+            raise
+        return transaction
     finally:
         owned.release()
 
@@ -151,12 +209,18 @@ def has_resumable_daemon_bulk_rebuild_transaction(root: Path) -> bool:
     threshold -- abandoning a partially-built generation mid-flight would
     waste every page already replayed into it.
     """
-    store = IndexGenerationStore.for_archive_root(root)
-    try:
-        transaction = store.load_transaction(DAEMON_BULK_REBUILD_OPERATION_ID)
-    except FileNotFoundError:
+    anchor = root / ".index-active-pointer"
+    if not anchor.exists() and not anchor.is_symlink():
         return False
-    except (OSError, ValueError, TypeError, KeyError):
+    try:
+        pointer_target = Path(anchor.read_text(encoding="utf-8").strip())
+        if not pointer_target.is_absolute() or pointer_target.name != "index.db":
+            return False
+        transaction_path = (
+            pointer_target.parent / ".index-rebuild-transactions" / f"{DAEMON_BULK_REBUILD_OPERATION_ID}.json"
+        )
+        transaction = IndexRebuildTransaction(**json.loads(transaction_path.read_text(encoding="utf-8")))
+    except (FileNotFoundError, OSError, ValueError, TypeError, KeyError):
         return False
     return transaction.status not in _TERMINAL_NOT_RESUMABLE
 
@@ -186,14 +250,28 @@ async def run_daemon_bulk_rebuild_pass(
     """
     from polylogue.daemon.write_coordinator import daemon_write_coordinator
     from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
+    from polylogue.maintenance.schema_inference_gate import resolve_schema_inference_receipt_reference
 
     root = Path(config.archive_root)
-    transaction = await asyncio.to_thread(resolve_or_start_daemon_bulk_rebuild_transaction, root)
+    receipt_path = resolve_schema_inference_receipt_reference(root)
+    transaction = await asyncio.to_thread(
+        resolve_or_start_daemon_bulk_rebuild_transaction,
+        root,
+        schema_inference_receipt_path=receipt_path,
+    )
     if transaction.status == "promoted":
         return None
 
-    store = IndexGenerationStore.for_archive_root(root)
-    page = await asyncio.to_thread(store.next_raw_page, transaction, limit=batch_size)
+    location = ArchiveLocation.resolve(root)
+    owned = await asyncio.to_thread(OwnedArchiveLocation.acquire, location)
+    try:
+        await asyncio.to_thread(assert_owns_archive_location, owned, location)
+        await asyncio.to_thread(_validate_rebuild_provenance_receipt, root, receipt_path)
+        store = IndexGenerationStore(location)
+        await asyncio.to_thread(_validate_rebuild_provenance_receipt, root, receipt_path)
+        page = await asyncio.to_thread(store.next_raw_page, transaction, limit=batch_size)
+    finally:
+        owned.release()
     raw_ids = [raw_id for raw_id, _blob_hash_hex, _blob_size in page.rows]
     if raw_ids:
         warmed = await asyncio.to_thread(
@@ -213,6 +291,7 @@ async def run_daemon_bulk_rebuild_pass(
         archive_root=root,
         promote=True,
         operation_id=transaction.operation_id,
+        schema_inference_receipt_path=receipt_path,
         raw_batch_size=batch_size,
         prefetch_cache=parse_stage.cache,
     )

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -933,9 +933,20 @@ async def _daemon_bulk_rebuild_transaction_in_flight() -> bool:
     Checking survives a daemon restart via a durable transaction record.
     """
     from polylogue.daemon.bulk_rebuild import has_resumable_daemon_bulk_rebuild_transaction
+    from polylogue.maintenance.schema_inference_gate import (
+        SchemaInferenceGateError,
+        resolve_schema_inference_receipt_reference,
+        validate_schema_inference_receipt,
+    )
     from polylogue.paths import archive_root
 
-    return await asyncio.to_thread(has_resumable_daemon_bulk_rebuild_transaction, archive_root())
+    root = archive_root()
+    try:
+        receipt_path = resolve_schema_inference_receipt_reference(root)
+        await asyncio.to_thread(validate_schema_inference_receipt, root, receipt_path)
+    except (SchemaInferenceGateError, RuntimeError, OSError, ValueError):
+        return False
+    return await asyncio.to_thread(has_resumable_daemon_bulk_rebuild_transaction, root)
 
 
 async def _maybe_route_daemon_bulk_rebuild(counts: RawMaterializationCounts) -> bool:
@@ -971,15 +982,12 @@ async def _maybe_route_daemon_bulk_rebuild(counts: RawMaterializationCounts) -> 
     from polylogue.config import Config
     from polylogue.daemon.bulk_rebuild import (
         DAEMON_BULK_REBUILD_OPERATION_ID,
-        has_resumable_daemon_bulk_rebuild_transaction,
         run_daemon_bulk_rebuild_pass,
     )
     from polylogue.paths import archive_root, render_root
 
     root = archive_root()
-    if not _bulk_scale_raw_materialization_backlog(counts) and not await asyncio.to_thread(
-        has_resumable_daemon_bulk_rebuild_transaction, root
-    ):
+    if not _bulk_scale_raw_materialization_backlog(counts) and not await _daemon_bulk_rebuild_transaction_in_flight():
         return False
     config = Config(archive_root=root, render_root=render_root(), sources=[])
     try:

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -5292,6 +5292,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         promote = body.get("promote", True)
         max_blob_mb = body.get("max_blob_mb")
         operation_id = body.get("operation_id")
+        schema_inference_receipt_path = body.get("schema_inference_receipt_path")
         raw_batch_size = body.get("raw_batch_size", 500)
         pass_byte_budget_mb = body.get("pass_byte_budget_mb")
         pass_deadline_seconds = body.get("pass_deadline_seconds")
@@ -5304,6 +5305,11 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             self._send_error(HTTPStatus.BAD_REQUEST, "invalid_request")
             return
         if operation_id is not None and (not isinstance(operation_id, str) or not operation_id):
+            self._send_error(HTTPStatus.BAD_REQUEST, "invalid_request")
+            return
+        if schema_inference_receipt_path is not None and (
+            not isinstance(schema_inference_receipt_path, str) or not schema_inference_receipt_path
+        ):
             self._send_error(HTTPStatus.BAD_REQUEST, "invalid_request")
             return
         if isinstance(raw_batch_size, bool) or not isinstance(raw_batch_size, int):
@@ -5334,6 +5340,9 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             max_blob_mb=float(max_blob_mb) if max_blob_mb is not None else None,
             promote=promote,
             operation_id=operation_id,
+            schema_inference_receipt_path=(
+                Path(schema_inference_receipt_path) if schema_inference_receipt_path is not None else None
+            ),
             raw_batch_size=raw_batch_size,
             pass_byte_budget_mb=float(pass_byte_budget_mb) if pass_byte_budget_mb is not None else None,
             pass_deadline_seconds=(float(pass_deadline_seconds) if pass_deadline_seconds is not None else None),

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -123,7 +123,9 @@ def _discard_generation_after_provenance_failure(
     errors: list[BaseException] = []
     try:
         provenance.validate_cleanup()
-        generation_store.discard_if_inactive(generation)
+        discarded = generation_store.discard_if_inactive(generation)
+        if not discarded:
+            errors.append(RuntimeError(f"candidate {generation.generation_id} was not discarded"))
     except BaseException as exc:
         errors.append(exc)
     return errors
@@ -146,7 +148,11 @@ def _discard_transaction_after_provenance_failure(
     if generation is not None:
         errors.extend(_discard_generation_after_provenance_failure(generation_store, generation, provenance))
     try:
-        generation_store.discard_transaction(transaction.operation_id)
+        discarded = generation_store.discard_transaction(transaction.operation_id)
+        if not discarded:
+            errors.append(
+                RuntimeError(f"transaction {transaction.operation_id} was not discarded because its record was missing")
+            )
     except BaseException as exc:
         errors.append(exc)
     return errors
@@ -984,6 +990,20 @@ async def _rebuild_index_from_source_owned(
                     f"rebuild operation {transaction.operation_id} is {transaction.status}; start a new operation"
                 )
             if rebuild_source_revision_snapshot(root) != transaction.source_snapshot:
+                if transaction_created_here:
+                    mismatch = RebuildProvenanceError(
+                        "rebuild schema-inference preflight gate failed: "
+                        "source evidence changed since this rebuild was planned"
+                    )
+                    _cleanup_transaction_after_provenance_failure(
+                        generation_store,
+                        transaction,
+                        root,
+                        request.schema_inference_receipt_path,
+                        consumed_evidence,
+                        mismatch,
+                    )
+                    raise mismatch
                 try:
                     _checkpoint_rebuild_transaction_after_receipt_validation(
                         generation_store,
@@ -1293,6 +1313,11 @@ async def _rebuild_index_from_source_owned(
                 _refresh_generation_planner_statistics(Path(generation.index_path))
             if transaction is not None and selected_raw_ids:
                 if rebuild_source_revision_snapshot(root) != transaction.source_snapshot:
+                    if transaction_created_here:
+                        raise RebuildProvenanceError(
+                            "rebuild schema-inference preflight gate failed: "
+                            "source evidence changed during this bounded rebuild pass"
+                        )
                     _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
                     transaction = _checkpoint_rebuild_transaction_after_receipt_validation(
                         generation_store,
@@ -1390,6 +1415,11 @@ async def _rebuild_index_from_source_owned(
             # replayed) carries the identical key for this phase.
             terminal_timings_s: dict[str, float] = {"selection_s": selection_elapsed_s}
             if rebuild_source_revision_snapshot(root) != generation.source_snapshot:
+                if transaction is not None and transaction_created_here:
+                    raise RebuildProvenanceError(
+                        "rebuild schema-inference preflight gate failed: "
+                        "source evidence changed before terminal readiness"
+                    )
                 if transaction is not None:
                     _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
                     transaction = _checkpoint_rebuild_transaction_after_receipt_validation(
@@ -1534,7 +1564,7 @@ async def _rebuild_index_from_source_owned(
                     )
         except Exception as exc:
             fresh_provenance_failure = isinstance(exc, RebuildProvenanceError) and (
-                transaction_created_here or sharded_replay
+                transaction_created_here or transaction is None or sharded_replay
             )
             if fresh_provenance_failure:
                 if transaction is not None:

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -30,7 +30,7 @@ from polylogue.storage.sqlite.delegation_facts import rebuild_all_delegation_fac
 
 if TYPE_CHECKING:
     from polylogue.sources.revision_backfill import RawParsePrefetchCache
-    from polylogue.storage.index_generation import IndexGeneration, IndexRebuildTransaction
+    from polylogue.storage.index_generation import IndexGeneration, IndexGenerationStore, IndexRebuildTransaction
 
 _PLANNER_STATS_ANALYSIS_LIMIT = 1000
 # A fresh generation begins with representative bootstrap statistics, but a
@@ -53,6 +53,211 @@ _PLANNER_STATS_ANALYZE_STATEMENTS = (
 )
 
 logger = get_logger(__name__)
+
+
+class RebuildProvenanceError(RuntimeError):
+    """Raised when rebuild evidence is no longer valid for a mutation."""
+
+
+class RebuildDerivedStateProvenanceError(RebuildProvenanceError):
+    """A derived-state stage was blocked by a failed provenance recheck."""
+
+
+@dataclass(frozen=True, slots=True)
+class RebuildProvenanceContext:
+    """Validated evidence shared by every mutation in one rebuild pass.
+
+    ``validate`` is the guard for operations that consume source evidence.
+    Cleanup has a narrower contract: it may remove only a generation that was
+    created under this already-validated context, and never reads or writes
+    source evidence.  Keeping that distinction lets a failed receipt still
+    clean up non-promotable scratch generations without treating the stale
+    receipt as authorization to continue replaying.
+    """
+
+    root: Path
+    receipt_path: Path | None
+    source_snapshot: str
+    consumed_evidence: dict[str, object]
+
+    def validate(self) -> None:
+        _validate_rebuild_provenance_receipt(self.root, self.receipt_path)
+        from polylogue.maintenance.schema_inference_gate import rebuild_source_revision_snapshot
+
+        if rebuild_source_revision_snapshot(self.root) != self.source_snapshot:
+            raise RebuildProvenanceError(
+                "rebuild schema-inference preflight gate failed: source evidence changed during replay"
+            )
+
+    def validate_cleanup(self) -> None:
+        """Authorize failure cleanup from the immutable pre-mutation proof."""
+        if not self.consumed_evidence or not self.source_snapshot:
+            raise RuntimeError("rebuild cleanup has no validated provenance context")
+
+
+def _validate_rebuild_provenance_receipt(root: Path, receipt_path: Path | None) -> dict[str, object]:
+    """Validate rebuild provenance at the current ownership boundary."""
+    from polylogue.maintenance.schema_inference_gate import (
+        SchemaInferenceGateError,
+        validate_schema_inference_receipt,
+    )
+
+    try:
+        return validate_schema_inference_receipt(root, receipt_path)
+    except SchemaInferenceGateError as exc:
+        raise RebuildProvenanceError(f"rebuild schema-inference preflight gate failed: {exc}") from exc
+
+
+def _validate_before_derived_state(provenance: RebuildProvenanceContext) -> None:
+    """Validate immediately before a derived-state mutation begins."""
+    try:
+        provenance.validate()
+    except Exception as exc:
+        raise RebuildDerivedStateProvenanceError(str(exc)) from exc
+
+
+def _discard_generation_after_provenance_failure(
+    generation_store: IndexGenerationStore, generation: IndexGeneration, provenance: RebuildProvenanceContext
+) -> list[BaseException]:
+    """Discard a fresh candidate without rereading mutable source evidence."""
+    errors: list[BaseException] = []
+    try:
+        provenance.validate_cleanup()
+        generation_store.discard_if_inactive(generation)
+    except BaseException as exc:
+        errors.append(exc)
+    return errors
+
+
+def _discard_transaction_after_provenance_failure(
+    generation_store: IndexGenerationStore,
+    transaction: IndexRebuildTransaction,
+    provenance: RebuildProvenanceContext,
+) -> list[BaseException]:
+    """Discard a fresh candidate and transaction, attempting both independently."""
+    errors: list[BaseException] = []
+    try:
+        generation = generation_store.load(transaction.generation_id)
+    except FileNotFoundError:
+        generation = None
+    except BaseException as exc:
+        errors.append(exc)
+        generation = None
+    if generation is not None:
+        errors.extend(_discard_generation_after_provenance_failure(generation_store, generation, provenance))
+    try:
+        generation_store.discard_transaction(transaction.operation_id)
+    except BaseException as exc:
+        errors.append(exc)
+    return errors
+
+
+def _cleanup_transaction_after_provenance_failure(
+    generation_store: IndexGenerationStore,
+    transaction: IndexRebuildTransaction,
+    root: Path,
+    receipt_path: Path | None,
+    consumed_evidence: dict[str, object],
+    primary: BaseException,
+) -> None:
+    """Clean a fresh transaction and candidate while preserving its failure."""
+    cleanup_context = RebuildProvenanceContext(
+        root=root,
+        receipt_path=receipt_path,
+        source_snapshot=transaction.source_snapshot,
+        consumed_evidence=consumed_evidence,
+    )
+    try:
+        cleanup_errors = _discard_transaction_after_provenance_failure(generation_store, transaction, cleanup_context)
+    except BaseException as cleanup_error:
+        cleanup_errors = [cleanup_error]
+    _add_cleanup_failure_notes(primary, cleanup_errors, label="rebuild transaction")
+
+
+def _add_cleanup_failure_notes(primary: BaseException, errors: list[BaseException], *, label: str) -> None:
+    """Keep the primary exception while making cleanup failures visible."""
+    if errors:
+        detail = "; ".join(f"{type(error).__name__}: {error}" for error in errors)
+        primary.add_note(f"{label} cleanup also failed: {detail}")
+
+
+def _create_rebuild_transaction_after_receipt_validation(
+    generation_store: IndexGenerationStore,
+    request: RebuildIndexRequest,
+    root: Path,
+) -> IndexRebuildTransaction:
+    """Create the first candidate only after an ownership-bound validation."""
+    from polylogue.maintenance.schema_inference_gate import rebuild_source_revision_snapshot
+
+    _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
+    source_snapshot = rebuild_source_revision_snapshot(root)
+    transaction = generation_store.create_transaction(
+        source_snapshot=source_snapshot,
+        pass_byte_budget=(
+            int(request.pass_byte_budget_mb * 1024 * 1024) if request.pass_byte_budget_mb is not None else None
+        ),
+        pass_deadline_ms=(
+            int(request.pass_deadline_seconds * 1000) if request.pass_deadline_seconds is not None else None
+        ),
+    )
+    try:
+        _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
+        if rebuild_source_revision_snapshot(root) != source_snapshot:
+            raise RebuildProvenanceError(
+                "rebuild schema-inference preflight gate failed: source evidence changed during transaction creation"
+            )
+    except BaseException as exc:
+        _cleanup_transaction_after_provenance_failure(
+            generation_store,
+            transaction,
+            root,
+            request.schema_inference_receipt_path,
+            {"source_snapshot": source_snapshot},
+            exc,
+        )
+        raise
+    return transaction
+
+
+def _checkpoint_rebuild_transaction_after_receipt_validation(
+    generation_store: IndexGenerationStore,
+    transaction: IndexRebuildTransaction,
+    root: Path,
+    receipt_path: Path | None,
+    *,
+    status: str,
+    last_blob_hash_hex: str | None = None,
+    last_raw_id: str | None = None,
+    processed_raw_count: int | None = None,
+    processed_blob_bytes: int | None = None,
+    error: str | None = None,
+    derived_stores_cleared: bool | None = None,
+) -> IndexRebuildTransaction:
+    """Validate immediately before every persisted rebuild state transition."""
+    _validate_rebuild_provenance_receipt(root, receipt_path)
+    return generation_store.checkpoint_transaction(
+        transaction,
+        status=status,
+        last_blob_hash_hex=last_blob_hash_hex,
+        last_raw_id=last_raw_id,
+        processed_raw_count=processed_raw_count,
+        processed_blob_bytes=processed_blob_bytes,
+        error=error,
+        derived_stores_cleared=derived_stores_cleared,
+    )
+
+
+def _save_rebuild_pass_receipt_after_receipt_validation(
+    generation_store: IndexGenerationStore,
+    operation_id: str,
+    pass_receipt: RebuildIndexReceipt,
+    root: Path,
+    receipt_path: Path | None,
+) -> None:
+    """Validate before publishing a pass receipt tied to rebuild state."""
+    _validate_rebuild_provenance_receipt(root, receipt_path)
+    generation_store.save_pass_receipt(operation_id, pass_receipt.to_dict())
+
 
 #: Passed through to ``CensusParseStage.warm_raw_ids``'s ``max_payload_bytes``
 #: parameter for symmetry with the daemon's own call site
@@ -245,6 +450,7 @@ class RebuildIndexRequest:
     promote: bool = True
     candidate_acceptance_checks: tuple[str, ...] | None = None
     operation_id: str | None = None
+    schema_inference_receipt_path: Path | None = None
     raw_batch_size: int = 500
     pass_byte_budget_mb: float | None = None
     pass_deadline_seconds: float | None = None
@@ -461,6 +667,7 @@ class RebuildIndexReceipt:
     #: not measured at all. Persisting it here makes the next optimisation
     #: evidence-based rather than a guess.
     timings_s: dict[str, float] = field(default_factory=dict)
+    consumed_evidence: dict[str, object] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -476,6 +683,7 @@ class RebuildIndexReceipt:
             "transaction": self.transaction,
             "operation": self.operation,
             "timings_s": self.timings_s,
+            "consumed_evidence": self.consumed_evidence,
             **self.replay,
         }
 
@@ -493,12 +701,13 @@ def _operation_evidence(
     transaction checkpoint.  It adds no competing ownership mechanism and
     keeps the full checkpoint in ``transaction`` for callers that need it.
     """
-    from polylogue.storage.index_generation import rebuild_lease_status, source_revision_snapshot
+    from polylogue.maintenance.schema_inference_gate import rebuild_source_revision_snapshot
+    from polylogue.storage.index_generation import rebuild_lease_status
 
     transaction_payload = asdict(transaction) if transaction is not None else {}
     generation_payload = asdict(generation) if generation is not None else {}
     source_snapshot = transaction_payload.get("source_snapshot") or generation_payload.get("source_snapshot")
-    current_snapshot = source_revision_snapshot(root) if (root / "source.db").exists() else None
+    current_snapshot = rebuild_source_revision_snapshot(root) if (root / "source.db").exists() else None
     return {
         "owner": {
             "generation_owner_id": transaction_payload.get("generation_owner_id") or generation_payload.get("owner_id"),
@@ -672,6 +881,7 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
     log_mapped_bytes_budget_check(logger, check_mapped_bytes_budget_against_cgroup_limit())
     validate_rebuild_index_request(request)
     root = request.archive_root
+    consumed_evidence = _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
     location = ArchiveLocation.resolve(root)
     active_config = Config(
         archive_root=root,
@@ -692,21 +902,32 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
         )
         raise RuntimeError(f"reindex source preflight gate failed: {failing}")
 
-    # This is deliberately outside archive-location acquisition and
-    # generation-store construction.  Those steps can create/rewrite archive
-    # bookkeeping, so a competing ArchiveStore writer must fail before the
-    # rebuild's first lifecycle mutation, not only during replay.
-    with RebuildLease(root):
-        owned = OwnedArchiveLocation.acquire(location)
-        try:
-            assert_owns_archive_location(owned, location)
-            return await _rebuild_index_from_source_owned(request, root=root, owned=owned)
-        finally:
-            owned.release()
+    # Ownership acquisition itself only claims the lock. Revalidate after it
+    # so receipt expiry/source/external-corpus drift between the cheap
+    # preflight and ownership acquisition cannot reach the rebuild lease or a
+    # candidate mutation.
+    owned = OwnedArchiveLocation.acquire(location)
+    try:
+        assert_owns_archive_location(owned, location)
+        consumed_evidence = _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
+        # The lease is itself lifecycle state guarded by the provenance gate.
+        # Revalidate again under the lease immediately before the owned body
+        # can create or mutate a candidate/transaction.
+        with RebuildLease(root):
+            consumed_evidence = _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
+            return await _rebuild_index_from_source_owned(
+                request, root=root, owned=owned, consumed_evidence=consumed_evidence
+            )
+    finally:
+        owned.release()
 
 
 async def _rebuild_index_from_source_owned(
-    request: RebuildIndexRequest, *, root: Path, owned: OwnedArchiveLocation
+    request: RebuildIndexRequest,
+    *,
+    root: Path,
+    owned: OwnedArchiveLocation,
+    consumed_evidence: dict[str, object],
 ) -> RebuildIndexReceipt:
     """Ownership-proven body of :func:`rebuild_index_from_source`."""
     from polylogue.maintenance.archive_verification import (
@@ -715,9 +936,10 @@ async def _rebuild_index_from_source_owned(
         verify_archive,
     )
     from polylogue.maintenance.replay import rebuild_index_from_source as replay_source
+    from polylogue.maintenance.schema_inference_gate import rebuild_source_revision_snapshot
     from polylogue.sources.revision_backfill import RebuildDeadlineExceededError
     from polylogue.storage.archive_readiness import archive_readiness_status
-    from polylogue.storage.index_generation import IndexGenerationStore, source_revision_snapshot
+    from polylogue.storage.index_generation import IndexGenerationStore
     from polylogue.storage.repair import repair_session_insights
 
     generation_store = IndexGenerationStore(owned.location)
@@ -740,37 +962,48 @@ async def _rebuild_index_from_source_owned(
                 readiness={},
                 replay={},
                 operation=_operation_evidence(root, generation=None, transaction=None, recovery_state="empty-source"),
+                consumed_evidence=consumed_evidence,
             )
         resumable_full_source = not request.raw_ids and not request.only_missing and request.max_blob_mb is None
         transaction = None
+        transaction_created_here = False
         page = None
         pass_started_at_ms = int(time.time() * 1000)
         if resumable_full_source:
-            transaction = (
-                generation_store.load_transaction(request.operation_id)
-                if request.operation_id is not None
-                else generation_store.create_transaction(
-                    source_snapshot=source_revision_snapshot(root),
-                    pass_byte_budget=(
-                        int(request.pass_byte_budget_mb * 1024 * 1024)
-                        if request.pass_byte_budget_mb is not None
-                        else None
-                    ),
-                    pass_deadline_ms=(
-                        int(request.pass_deadline_seconds * 1000) if request.pass_deadline_seconds is not None else None
-                    ),
+            if request.operation_id is not None:
+                transaction = generation_store.load_transaction(request.operation_id)
+            else:
+                transaction = _create_rebuild_transaction_after_receipt_validation(
+                    generation_store,
+                    request,
+                    root,
                 )
-            )
+                transaction_created_here = True
             if transaction.status in {"promoted", "stale"}:
                 raise RuntimeError(
                     f"rebuild operation {transaction.operation_id} is {transaction.status}; start a new operation"
                 )
-            if source_revision_snapshot(root) != transaction.source_snapshot:
-                generation_store.checkpoint_transaction(
-                    transaction,
-                    status="stale",
-                    error="source evidence changed since this rebuild was planned",
-                )
+            if rebuild_source_revision_snapshot(root) != transaction.source_snapshot:
+                try:
+                    _checkpoint_rebuild_transaction_after_receipt_validation(
+                        generation_store,
+                        transaction,
+                        root,
+                        request.schema_inference_receipt_path,
+                        status="stale",
+                        error="source evidence changed since this rebuild was planned",
+                    )
+                except RebuildProvenanceError as exc:
+                    if transaction_created_here:
+                        _cleanup_transaction_after_provenance_failure(
+                            generation_store,
+                            transaction,
+                            root,
+                            request.schema_inference_receipt_path,
+                            consumed_evidence,
+                            exc,
+                        )
+                    raise
                 raise RuntimeError(
                     f"rebuild operation {transaction.operation_id} is stale because source evidence changed"
                 )
@@ -778,12 +1011,28 @@ async def _rebuild_index_from_source_owned(
             if generation.owner_id != transaction.generation_owner_id or generation.state != "inactive":
                 raise RuntimeError(f"rebuild operation {transaction.operation_id} lost its inactive candidate")
             if not transaction.derived_stores_cleared:
-                _clear_bulk_build_derived_stores(Path(generation.index_path))
-                transaction = generation_store.checkpoint_transaction(
-                    transaction,
-                    status=transaction.status,
-                    derived_stores_cleared=True,
-                )
+                try:
+                    _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
+                    _clear_bulk_build_derived_stores(Path(generation.index_path))
+                    transaction = _checkpoint_rebuild_transaction_after_receipt_validation(
+                        generation_store,
+                        transaction,
+                        root,
+                        request.schema_inference_receipt_path,
+                        status=transaction.status,
+                        derived_stores_cleared=True,
+                    )
+                except RebuildProvenanceError as exc:
+                    if transaction_created_here:
+                        _cleanup_transaction_after_provenance_failure(
+                            generation_store,
+                            transaction,
+                            root,
+                            request.schema_inference_receipt_path,
+                            consumed_evidence,
+                            exc,
+                        )
+                    raise
             # polylogue-6mvg: the pass's SELECTION phase -- which raws
             # replay THIS pass -- previously had no durable timing at all. A
             # live full rebuild spent ~86s of one CPU core on selection
@@ -801,9 +1050,25 @@ async def _rebuild_index_from_source_owned(
             raw_count, selected_raw_ids, skipped_by_blob_limit_count = select_rebuild_raw_ids(request)
             selection_elapsed_s = time.perf_counter() - selection_started_at
             selected_raw_count = len(selected_raw_ids)
-            generation = generation_store.create(source_snapshot=source_revision_snapshot(root))
+            source_snapshot = rebuild_source_revision_snapshot(root)
+            precreate_provenance = RebuildProvenanceContext(
+                root=root,
+                receipt_path=request.schema_inference_receipt_path,
+                source_snapshot=source_snapshot,
+                consumed_evidence=consumed_evidence,
+            )
+            precreate_provenance.validate()
+            generation = generation_store.create(source_snapshot=source_snapshot)
+        provenance = RebuildProvenanceContext(
+            root=root,
+            receipt_path=request.schema_inference_receipt_path,
+            source_snapshot=generation.source_snapshot,
+            consumed_evidence=consumed_evidence,
+        )
+        sharded_replay = request.shard_count > 1 and len(selected_raw_ids) >= request.shard_count
         source_drifted = False
         try:
+            provenance.validate()
             generation_root = Path(generation.index_path).parent
             config = Config(
                 archive_root=generation_root,
@@ -830,7 +1095,7 @@ async def _rebuild_index_from_source_owned(
                     _warm_offline_prefetch_cache, warm_config, selected_raw_ids
                 )
             pass_started_at_s = time.perf_counter()
-            if request.shard_count > 1 and len(selected_raw_ids) >= request.shard_count:
+            if sharded_replay:
                 # polylogue-pzxm: build request.shard_count owned-inactive
                 # generations in parallel and merge them into `generation`
                 # instead of replaying `selected_raw_ids` through the single
@@ -871,6 +1136,7 @@ async def _rebuild_index_from_source_owned(
                     raw_batch_size=request.raw_batch_size,
                     shard_count=request.shard_count,
                     prefetch_cache=effective_prefetch_cache,
+                    provenance=provenance,
                 )
             else:
                 # polylogue-uhgm: the pass deadline used to be checked only AFTER
@@ -935,8 +1201,11 @@ async def _rebuild_index_from_source_owned(
                     # a raw/cohort; it can only redo bounded work.
                     assert transaction is not None  # deadline_check is only wired when transaction is not None
                     pass_elapsed_s = time.perf_counter() - pass_started_at_s
-                    transaction = generation_store.checkpoint_transaction(
+                    transaction = _checkpoint_rebuild_transaction_after_receipt_validation(
+                        generation_store,
                         transaction,
+                        root,
+                        request.schema_inference_receipt_path,
                         status="deferred",
                         error=str(exc),
                     )
@@ -1004,20 +1273,32 @@ async def _rebuild_index_from_source_owned(
                             root, generation=generation, transaction=transaction, recovery_state="deferred"
                         ),
                         timings_s=cast(dict[str, float], pass_cost.to_dict()),
+                        consumed_evidence=consumed_evidence,
                     )
-                    generation_store.save_pass_receipt(transaction.operation_id, pass_receipt.to_dict())
+                    _save_rebuild_pass_receipt_after_receipt_validation(
+                        generation_store,
+                        transaction.operation_id,
+                        pass_receipt,
+                        root,
+                        request.schema_inference_receipt_path,
+                    )
                     return pass_receipt
             pass_elapsed_s = time.perf_counter() - pass_started_at_s
             processed_before = transaction.processed_raw_count if transaction is not None else None
+            _validate_before_derived_state(provenance)
             if selected_raw_ids and _should_refresh_generation_planner_statistics(
                 processed_before=processed_before,
                 processed_after=(processed_before or 0) + len(selected_raw_ids),
             ):
                 _refresh_generation_planner_statistics(Path(generation.index_path))
             if transaction is not None and selected_raw_ids:
-                if source_revision_snapshot(root) != transaction.source_snapshot:
-                    transaction = generation_store.checkpoint_transaction(
+                if rebuild_source_revision_snapshot(root) != transaction.source_snapshot:
+                    _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
+                    transaction = _checkpoint_rebuild_transaction_after_receipt_validation(
+                        generation_store,
                         transaction,
+                        root,
+                        request.schema_inference_receipt_path,
                         status="stale",
                         error="source evidence changed during this bounded rebuild pass",
                     )
@@ -1032,8 +1313,11 @@ async def _rebuild_index_from_source_owned(
                     transaction.pass_deadline_ms is not None and elapsed_ms >= transaction.pass_deadline_ms
                 )
                 status = "deferred" if page.deferred_reason == "byte-budget" or deadline_expired else "paused"
-                transaction = generation_store.checkpoint_transaction(
+                transaction = _checkpoint_rebuild_transaction_after_receipt_validation(
+                    generation_store,
                     transaction,
+                    root,
+                    request.schema_inference_receipt_path,
                     status=status,
                     last_blob_hash_hex=last_blob_hash_hex,
                     last_raw_id=last_raw_id,
@@ -1084,8 +1368,15 @@ async def _rebuild_index_from_source_owned(
                             root, generation=generation, transaction=transaction, recovery_state=status
                         ),
                         timings_s=cast(dict[str, float], pass_cost.to_dict()),
+                        consumed_evidence=consumed_evidence,
                     )
-                    generation_store.save_pass_receipt(transaction.operation_id, pass_receipt.to_dict())
+                    _save_rebuild_pass_receipt_after_receipt_validation(
+                        generation_store,
+                        transaction.operation_id,
+                        pass_receipt,
+                        root,
+                        request.schema_inference_receipt_path,
+                    )
                     return pass_receipt
             # polylogue-o56w: terminal-stage costs used to survive only as log
             # lines; collect them here and persist them on the final receipt
@@ -1098,10 +1389,14 @@ async def _rebuild_index_from_source_owned(
             # not a parallel one, so every receipt shape (deferred, paused,
             # replayed) carries the identical key for this phase.
             terminal_timings_s: dict[str, float] = {"selection_s": selection_elapsed_s}
-            if source_revision_snapshot(root) != generation.source_snapshot:
+            if rebuild_source_revision_snapshot(root) != generation.source_snapshot:
                 if transaction is not None:
-                    transaction = generation_store.checkpoint_transaction(
+                    _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
+                    transaction = _checkpoint_rebuild_transaction_after_receipt_validation(
+                        generation_store,
                         transaction,
+                        root,
+                        request.schema_inference_receipt_path,
                         status="stale",
                         error="source evidence changed before terminal readiness",
                     )
@@ -1112,6 +1407,7 @@ async def _rebuild_index_from_source_owned(
             # empty or stale for every session -- repopulate all four
             # archive-wide exactly once here, then prove exact parity before
             # readiness can observe (and silently accept) a mismatch.
+            _validate_before_derived_state(provenance)
             bulk_timings_s = _repopulate_bulk_build_derived_state(Path(generation.index_path))
             for stage, elapsed_s in bulk_timings_s.items():
                 terminal_timings_s[f"terminal.bulk_build.{stage}"] = elapsed_s
@@ -1166,6 +1462,7 @@ async def _rebuild_index_from_source_owned(
             # it, so the acceptance receipt names the actual bad invariant
             # instead of reporting an incidental derived-model failure.
             terminal_started_at = time.perf_counter()
+            _validate_before_derived_state(provenance)
             insight_result = repair_session_insights(
                 config,
                 dry_run=False,
@@ -1203,7 +1500,13 @@ async def _rebuild_index_from_source_owned(
                 )
                 raise RuntimeError(f"inactive generation {generation.generation_id} is not exact-ready; {detail}")
             if transaction is not None:
-                transaction = generation_store.checkpoint_transaction(transaction, status="ready")
+                transaction = _checkpoint_rebuild_transaction_after_receipt_validation(
+                    generation_store,
+                    transaction,
+                    root,
+                    request.schema_inference_receipt_path,
+                    status="ready",
+                )
             if request.promote:
                 # Re-prove ownership immediately before the activation swap:
                 # a long-running rebuild pass can outlast a concurrent
@@ -1211,6 +1514,7 @@ async def _rebuild_index_from_source_owned(
                 # caught before clobbering someone else's activation rather
                 # than after (polylogue-ovme.2 AC3).
                 assert_owns_archive_location(owned, ArchiveLocation.resolve(root))
+                _validate_rebuild_provenance_receipt(root, request.schema_inference_receipt_path)
                 terminal_started_at = time.perf_counter()
                 generation = generation_store.promote(generation)
                 terminal_timings_s["terminal.promote"] = time.perf_counter() - terminal_started_at
@@ -1221,9 +1525,28 @@ async def _rebuild_index_from_source_owned(
                     elapsed_s=round(terminal_timings_s["terminal.promote"], 3),
                 )
                 if transaction is not None:
-                    transaction = generation_store.checkpoint_transaction(transaction, status="promoted")
-        except Exception:
-            if transaction is not None and not source_drifted:
+                    transaction = _checkpoint_rebuild_transaction_after_receipt_validation(
+                        generation_store,
+                        transaction,
+                        root,
+                        request.schema_inference_receipt_path,
+                        status="promoted",
+                    )
+        except Exception as exc:
+            fresh_provenance_failure = isinstance(exc, RebuildProvenanceError) and (
+                transaction_created_here or sharded_replay
+            )
+            if fresh_provenance_failure:
+                if transaction is not None:
+                    cleanup_errors = _discard_transaction_after_provenance_failure(
+                        generation_store, transaction, provenance
+                    )
+                else:
+                    cleanup_errors = _discard_generation_after_provenance_failure(
+                        generation_store, generation, provenance
+                    )
+                _add_cleanup_failure_notes(exc, cleanup_errors, label="rebuild provenance")
+            elif transaction is not None and not source_drifted:
                 with contextlib.suppress(Exception):
                     # A process can fail after ``checkpoint_transaction`` has
                     # atomically published the output batch but before this
@@ -1231,13 +1554,20 @@ async def _rebuild_index_from_source_owned(
                     # let this stale local value rewind that committed cursor
                     # while recording recovery state.
                     transaction = generation_store.load_transaction(transaction.operation_id)
-                    generation_store.checkpoint_transaction(
+                    _checkpoint_rebuild_transaction_after_receipt_validation(
+                        generation_store,
                         transaction,
+                        root,
+                        request.schema_inference_receipt_path,
                         status="failed",
                         error="bounded rebuild pass failed; candidate retained for diagnosis or explicit recovery",
                     )
             else:
                 with contextlib.suppress(Exception):
+                    try:
+                        provenance.validate()
+                    except Exception:
+                        provenance.validate_cleanup()
                     generation_store.discard_if_inactive(generation)
             raise
     final_receipt = RebuildIndexReceipt(
@@ -1263,9 +1593,16 @@ async def _rebuild_index_from_source_owned(
             replay=replay,
             terminal_timings_s=terminal_timings_s,
         ),
+        consumed_evidence=consumed_evidence,
     )
     if transaction is not None:
-        generation_store.save_pass_receipt(transaction.operation_id, final_receipt.to_dict())
+        _save_rebuild_pass_receipt_after_receipt_validation(
+            generation_store,
+            transaction.operation_id,
+            final_receipt,
+            root,
+            request.schema_inference_receipt_path,
+        )
     return final_receipt
 
 
@@ -1297,11 +1634,8 @@ def rebuild_status(
     acquires ``RebuildLease``, never mutates any transaction or generation.
     """
     from polylogue.daemon.bulk_rebuild import DAEMON_BULK_REBUILD_OPERATION_ID
-    from polylogue.storage.index_generation import (
-        IndexGenerationStore,
-        rebuild_lease_status,
-        source_revision_snapshot,
-    )
+    from polylogue.maintenance.schema_inference_gate import rebuild_source_revision_snapshot
+    from polylogue.storage.index_generation import IndexGenerationStore, rebuild_lease_status
 
     location = ArchiveLocation.resolve(archive_root)
     lease = rebuild_lease_status(archive_root)
@@ -1346,7 +1680,9 @@ def rebuild_status(
             transaction = None
         if transaction is not None:
             transaction_payload = cast(dict[str, object], asdict(transaction))
-            current_snapshot = source_revision_snapshot(archive_root) if (archive_root / "source.db").exists() else None
+            current_snapshot = (
+                rebuild_source_revision_snapshot(archive_root) if (archive_root / "source.db").exists() else None
+            )
             delta = {
                 "source_snapshot_matches": (
                     current_snapshot is not None and current_snapshot == transaction.source_snapshot

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -275,7 +275,7 @@ def run_reindex_canary(
     archive_root: Path,
     *,
     input_index: Path | None = None,
-    schema_inference_receipt_path: Path,
+    schema_inference_receipt_path: Path | None,
     sessions_per_origin: int = 100,
     pathology_session_ids: Iterable[str] = (),
     sample_session_ids: Iterable[str] = (),
@@ -288,6 +288,8 @@ def run_reindex_canary(
     canary never falls back to ambient process configuration.
     """
 
+    if schema_inference_receipt_path is None:
+        raise CanarySelectionError("reindex canary requires an explicit schema-inference receipt path")
     if not no_promote:
         raise CanarySelectionError("reindex canary requires --no-promote")
     from polylogue.config import resolve_archive_root

--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -275,12 +275,18 @@ def run_reindex_canary(
     archive_root: Path,
     *,
     input_index: Path | None = None,
+    schema_inference_receipt_path: Path,
     sessions_per_origin: int = 100,
     pathology_session_ids: Iterable[str] = (),
     sample_session_ids: Iterable[str] = (),
     no_promote: bool,
 ) -> CanaryRunResult:
-    """Replay a selected canary through the existing inactive rebuild route."""
+    """Replay a selected canary through the existing inactive rebuild route.
+
+    The schema-inference receipt is explicit because this partial rebuild must
+    consume the same identity-bound source evidence as a full rebuild. The
+    canary never falls back to ambient process configuration.
+    """
 
     if not no_promote:
         raise CanarySelectionError("reindex canary requires --no-promote")
@@ -313,6 +319,7 @@ def run_reindex_canary(
             raw_ids=selection.selected_raw_ids,
             promote=False,
             candidate_acceptance_checks=REINDEX_CANARY_ACCEPTANCE_CHECKS,
+            schema_inference_receipt_path=schema_inference_receipt_path,
         )
     )
     candidate_path = _validate_canary_candidate(

--- a/polylogue/maintenance/schema_inference_gate.py
+++ b/polylogue/maintenance/schema_inference_gate.py
@@ -11,13 +11,14 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import platform
 import sqlite3
 import sys
 from collections import Counter
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Literal, NotRequired, TypeAlias, TypedDict, cast
 
@@ -30,10 +31,13 @@ from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 from polylogue.version import POLYLOGUE_VERSION
 
-RECEIPT_SCHEMA = "polylogue.schema-inference-gate.v1"
-GATE_VERSION = "2"
+RECEIPT_SCHEMA = "polylogue.schema-inference-gate.v2"
+GATE_VERSION = "3"
 DEFAULT_SAMPLE_LIMIT = 10
 RECEIPT_FILENAME = "schema-inference-gate-receipt.json"
+SCHEMA_INFERENCE_RECEIPT_ENV = "POLYLOGUE_SCHEMA_INFERENCE_RECEIPT"
+RECEIPT_TTL = timedelta(hours=24)
+RECEIPT_CLOCK_SKEW = timedelta(minutes=5)
 
 _ALLOWED_RESIDUAL_EXPLANATIONS = frozenset(
     {"materialized", "superseded-duplicate", "legitimately-excluded-non-conversation"}
@@ -510,6 +514,173 @@ def _resolve_receipt_path(receipt_path: Path, *, archive_root: Path) -> Path:
     raise SchemaInferenceGateError("receipt path must be outside the archive root")
 
 
+def resolve_schema_inference_receipt_reference(archive_root: Path, receipt_path: Path | None = None) -> Path:
+    """Resolve the policy-controlled receipt reference used by rebuild callers."""
+
+    if receipt_path is not None:
+        return receipt_path.expanduser().resolve()
+    configured = os.environ.get(SCHEMA_INFERENCE_RECEIPT_ENV, "").strip()
+    if not configured:
+        raise SchemaInferenceGateError(
+            f"a fresh schema-inference receipt is required; pass a receipt path or set {SCHEMA_INFERENCE_RECEIPT_ENV}"
+        )
+    return Path(configured).expanduser().resolve()
+
+
+def _archive_receipt_identity(location: ArchiveLocation) -> dict[str, object]:
+    identity = ArchiveIdentity.resolve_location(location)
+    return {
+        "configured_root": str(location.configured_root),
+        "durable_id": identity.durable_id,
+        "source_tier": identity.tier("source").as_dict(),
+        "user_tier": identity.tier("user").as_dict(),
+    }
+
+
+def _parse_receipt_datetime(value: object, *, field: str) -> datetime:
+    if not isinstance(value, str) or not value.strip():
+        raise SchemaInferenceGateError(f"receipt field {field!r} must be an ISO-8601 timestamp")
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise SchemaInferenceGateError(f"receipt field {field!r} is not a valid ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise SchemaInferenceGateError(f"receipt field {field!r} must include a timezone")
+    return parsed.astimezone(UTC)
+
+
+def rebuild_source_revision_snapshot(archive_root: Path) -> str:
+    """Hash immutable source-row revision fields used by a derived rebuild."""
+
+    digest = hashlib.sha256()
+    source_path = Path(archive_root) / ARCHIVE_TIER_SPECS[ArchiveTier.SOURCE].filename
+    with open_readonly_connection(source_path) as source:
+        for row in source.execute(
+            """
+            SELECT raw_id, origin, native_id, source_path,
+                   acquired_at_ms, blob_hash, blob_size, validation_status
+            FROM raw_sessions
+            ORDER BY raw_id
+            """
+        ):
+            for value in row:
+                encoded = value.hex() if isinstance(value, bytes) else str(value)
+                digest.update(encoded.encode("utf-8"))
+                digest.update(b"\0")
+            digest.update(b"\n")
+    return digest.hexdigest()
+
+
+def _canonical_external_ground_truth_digest(origins: Mapping[str, object]) -> str:
+    """Digest the complete external corpus inventory recorded in a receipt."""
+
+    canonical: list[dict[str, object]] = []
+    for origin in sorted(origins):
+        evidence = _as_dict(origins[origin])
+        mapping = evidence.get("raw_external_mapping")
+        if not isinstance(mapping, list) or not all(
+            isinstance(item, dict)
+            and isinstance(item.get("raw_id"), str)
+            and isinstance(item.get("source_path"), str)
+            and isinstance(item.get("disposition"), str)
+            for item in mapping
+        ):
+            raise SchemaInferenceGateError(f"raw external mapping for {origin} is missing or malformed")
+        if bool(evidence.get("exempt")):
+            canonical.append(
+                {
+                    "origin": origin,
+                    "exempt": True,
+                    "reason": evidence.get("reason"),
+                    "mapping": sorted(mapping, key=lambda item: str(item["raw_id"])),
+                }
+            )
+            continue
+        roots = evidence.get("declared_roots")
+        inventory = evidence.get("external_inventory")
+        if not isinstance(roots, list) or not all(isinstance(root, str) for root in roots):
+            raise SchemaInferenceGateError(f"ground truth roots for {origin} are missing or malformed")
+        if not isinstance(inventory, list):
+            raise SchemaInferenceGateError(f"ground truth inventory for {origin} is missing or malformed")
+        files: list[dict[str, object]] = []
+        for item in inventory:
+            record = _as_dict(item)
+            root_index = record.get("root_index")
+            relative_path = record.get("relative_path")
+            content_hash = record.get("hash")
+            size = record.get("size")
+            if (
+                not isinstance(root_index, int)
+                or isinstance(root_index, bool)
+                or not isinstance(relative_path, str)
+                or not isinstance(content_hash, str)
+                or not isinstance(size, int)
+                or isinstance(size, bool)
+                or size < 0
+            ):
+                raise SchemaInferenceGateError(f"ground truth inventory for {origin} contains a malformed file")
+            files.append(
+                {
+                    "root_index": root_index,
+                    "relative_path": relative_path,
+                    "hash": content_hash.lower(),
+                    "size": size,
+                }
+            )
+        mappings: list[dict[str, object]] = []
+        for item in mapping:
+            record = _as_dict(item)
+            raw_id = record.get("raw_id")
+            source_path = record.get("source_path")
+            disposition = record.get("disposition")
+            blob_hash = record.get("blob_hash")
+            blob_size = record.get("blob_size")
+            external_relative_path = record.get("external_relative_path")
+            external_hash = record.get("external_hash")
+            external_size = record.get("external_size")
+            if (
+                not isinstance(raw_id, str)
+                or not isinstance(source_path, str)
+                or not isinstance(disposition, str)
+                or not isinstance(blob_hash, str)
+                or not isinstance(blob_size, int)
+                or isinstance(blob_size, bool)
+                or blob_size < 0
+                or (external_relative_path is not None and not isinstance(external_relative_path, str))
+                or (external_hash is not None and not isinstance(external_hash, str))
+                or (
+                    external_size is not None
+                    and (not isinstance(external_size, int) or isinstance(external_size, bool))
+                )
+            ):
+                raise SchemaInferenceGateError(f"raw external mapping for {origin} contains a malformed row")
+            mappings.append(
+                {
+                    "raw_id": raw_id,
+                    "source_path": source_path,
+                    "blob_hash": blob_hash.lower(),
+                    "blob_size": blob_size,
+                    "external_relative_path": external_relative_path,
+                    "external_hash": external_hash.lower() if isinstance(external_hash, str) else None,
+                    "external_size": external_size,
+                    "disposition": disposition,
+                }
+            )
+        canonical.append(
+            {
+                "origin": origin,
+                "roots": sorted(str(Path(root).expanduser().resolve()) for root in roots),
+                "files": sorted(
+                    files,
+                    key=lambda item: (int(cast(int, item["root_index"])), str(item["relative_path"])),
+                ),
+                "mapping": sorted(mappings, key=lambda item: str(item["raw_id"])),
+            }
+        )
+    encoded = json.dumps(canonical, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
 def _snapshot_blob_root(blob_root: Path) -> dict[str, object]:
     """Fingerprint the canonical namespace before and after full verification."""
 
@@ -621,6 +792,18 @@ def _external_inventory(roots: Sequence[Path]) -> list[_ExternalGroundTruthFile]
     return inventory
 
 
+def _external_inventory_records(inventory: Sequence[_ExternalGroundTruthFile]) -> list[dict[str, object]]:
+    return [
+        {
+            "root_index": item.root_index,
+            "relative_path": item.relative_path,
+            "hash": item.content_hash,
+            "size": item.size,
+        }
+        for item in inventory
+    ]
+
+
 def _external_receipt(
     item: _ExternalGroundTruthFile,
     disposition: ExternalDisposition,
@@ -656,6 +839,51 @@ def _raw_provenance(
         "matched_external_size": matched_external.size if matched_external is not None else None,
         "disposition": raw.disposition,
     }
+
+
+def _raw_external_mapping(
+    source: sqlite3.Connection,
+    *,
+    origin: str,
+    inventory: Sequence[_ExternalGroundTruthFile],
+    exempt: bool,
+) -> list[dict[str, object]]:
+    """Persist one deterministic external-file choice for every source raw."""
+
+    rows = source.execute(
+        """
+        SELECT raw_id, source_path, hex(blob_hash), blob_size
+        FROM raw_sessions
+        WHERE origin = ?
+        ORDER BY raw_id
+        """,
+        (origin,),
+    ).fetchall()
+    by_key: dict[GroundTruthKey, list[_ExternalGroundTruthFile]] = {}
+    for item in inventory:
+        by_key.setdefault(item.key, []).append(item)
+    mapping: list[dict[str, object]] = []
+    for raw_id, source_path, blob_hash, blob_size in rows:
+        canonical_hash = str(blob_hash).lower()
+        canonical_size = int(blob_size)
+        match = by_key.get((canonical_hash, canonical_size), [None])[0]
+        mapping.append(
+            {
+                "raw_id": str(raw_id),
+                "source_path": str(source_path),
+                "blob_hash": canonical_hash,
+                "blob_size": canonical_size,
+                "external_relative_path": match.relative_path if match is not None else None,
+                "external_hash": match.content_hash if match is not None else None,
+                "external_size": match.size if match is not None else None,
+                "disposition": "origin-exempt"
+                if exempt
+                else "matched-external"
+                if match is not None
+                else "unmatched-source-raw",
+            }
+        )
+    return mapping
 
 
 def _raw_dispositions(
@@ -740,7 +968,11 @@ def _ground_truth_evidence(
         for origin in origins:
             declared = GROUND_TRUTH_INPUTS.get(origin, {"exempt": False})
             if bool(declared.get("exempt")):
-                evidence[origin] = {"exempt": True, "reason": declared.get("reason")}
+                evidence[origin] = {
+                    "exempt": True,
+                    "reason": declared.get("reason"),
+                    "raw_external_mapping": _raw_external_mapping(source, origin=origin, inventory=(), exempt=True),
+                }
                 continue
             declared_roots = tuple(Path(path).expanduser().resolve() for path in root_map.get(origin, ()))
             unavailable = [str(path) for path in declared_roots if not path.exists()]
@@ -750,6 +982,8 @@ def _ground_truth_evidence(
                     "exempt": False,
                     "declared_roots": [str(path) for path in declared_roots],
                     "unavailable_roots": unavailable,
+                    "external_inventory": [],
+                    "raw_external_mapping": _raw_external_mapping(source, origin=origin, inventory=(), exempt=False),
                     "passed": False,
                 }
                 continue
@@ -760,6 +994,8 @@ def _ground_truth_evidence(
                 evidence[origin] = {
                     "exempt": False,
                     "declared_roots": [str(path) for path in declared_roots],
+                    "external_inventory": [],
+                    "raw_external_mapping": _raw_external_mapping(source, origin=origin, inventory=(), exempt=False),
                     "passed": False,
                 }
                 continue
@@ -855,6 +1091,12 @@ def _ground_truth_evidence(
             missing = sorted(
                 source_keys_hash for source_keys_hash, _size in source_keys if source_keys_hash not in hashes
             )
+            mapping = _raw_external_mapping(source, origin=origin, inventory=inventory, exempt=False)
+            unmatched_mapping = [item for item in mapping if item.get("disposition") == "unmatched-source-raw"]
+            if missing:
+                errors.append(f"ground truth for {origin} does not verify every source raw blob")
+            if unmatched_mapping:
+                errors.append(f"ground truth for {origin} has {len(unmatched_mapping)} unmapped source raw(s)")
             evidence[origin] = {
                 "exempt": False,
                 "declared_roots": [str(path) for path in declared_roots],
@@ -873,9 +1115,16 @@ def _ground_truth_evidence(
                 "unmatched_external_files": unmatched_external_files[:DEFAULT_SAMPLE_LIMIT],
                 "cross_origin_mismatches": cross_origin_mismatches[:DEFAULT_SAMPLE_LIMIT],
                 "provenance": provenance,
-                "passed": not origin_errors,
+                "external_inventory": _external_inventory_records(inventory),
+                "raw_external_mapping": mapping,
+                "passed": not missing and not unmatched_mapping,
             }
-    return {"passed": not errors, "origins": evidence, "reasons": errors}
+    return {
+        "passed": not errors,
+        "origins": evidence,
+        "reasons": errors,
+        "external_ground_truth_digest": _canonical_external_ground_truth_digest(evidence),
+    }
 
 
 def _fidelity_evidence(report: object) -> dict[str, object]:
@@ -1018,6 +1267,169 @@ def _int_or_zero(value: object) -> int:
     return value if isinstance(value, int) and not isinstance(value, bool) else 0
 
 
+def _current_external_ground_truth_digest(archive_root: Path, ground_truth: Mapping[str, object]) -> str:
+    origins = _as_dict(ground_truth.get("origins"))
+    current: dict[str, object] = {}
+    with open_readonly_connection(archive_root / "source.db") as source:
+        for origin, raw_evidence in origins.items():
+            evidence = _as_dict(raw_evidence)
+            if bool(evidence.get("exempt")):
+                current[origin] = {
+                    "exempt": True,
+                    "reason": evidence.get("reason"),
+                    "raw_external_mapping": _raw_external_mapping(source, origin=origin, inventory=(), exempt=True),
+                }
+                continue
+            roots = evidence.get("declared_roots")
+            if not isinstance(roots, list) or not all(isinstance(root, str) and root for root in roots):
+                raise SchemaInferenceGateError(f"ground truth roots for {origin} are missing or malformed")
+            resolved_roots = tuple(Path(root).expanduser().resolve() for root in roots)
+            unavailable = [str(root) for root in resolved_roots if not root.exists()]
+            if unavailable:
+                raise SchemaInferenceGateError(
+                    f"ground truth roots for {origin} are unavailable: {', '.join(unavailable)}"
+                )
+            inventory = _external_inventory(resolved_roots)
+            current[origin] = {
+                "declared_roots": [str(root) for root in resolved_roots],
+                "external_inventory": _external_inventory_records(inventory),
+                "raw_external_mapping": _raw_external_mapping(source, origin=origin, inventory=inventory, exempt=False),
+            }
+    return _canonical_external_ground_truth_digest(current)
+
+
+def validate_schema_inference_receipt(
+    archive_root: Path,
+    receipt_path: Path | None = None,
+    *,
+    now: datetime | None = None,
+) -> dict[str, object]:
+    """Validate the evidence a rebuild is authorized to consume.
+
+    This validator deliberately checks the embedded subgates instead of
+    trusting the top-level verdict. It also recomputes archive/source identity,
+    the source snapshot, and the external corpus digest against the live
+    read-only inputs.
+    """
+
+    root = Path(archive_root).absolute()
+    path = resolve_schema_inference_receipt_reference(root, receipt_path)
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SchemaInferenceGateError(f"could not read schema-inference receipt: {exc}") from exc
+    if not isinstance(document, dict):
+        raise SchemaInferenceGateError("schema-inference receipt root must be an object")
+
+    errors: list[str] = []
+    if document.get("schema") != RECEIPT_SCHEMA:
+        errors.append(f"schema must be {RECEIPT_SCHEMA!r}")
+    if document.get("verdict") != "PASS":
+        errors.append("receipt verdict must be PASS")
+    if document.get("archive_root") != str(root):
+        errors.append("receipt archive_root does not match the requested archive")
+
+    generated_at: datetime | None = None
+    try:
+        generated_at = _parse_receipt_datetime(document.get("generated_at"), field="generated_at")
+    except SchemaInferenceGateError as exc:
+        errors.append(str(exc))
+    effective_now = (now or datetime.now(UTC)).astimezone(UTC)
+    if generated_at is not None:
+        if generated_at > effective_now + RECEIPT_CLOCK_SKEW:
+            errors.append("receipt generated_at is in the future")
+        if effective_now - generated_at > RECEIPT_TTL + RECEIPT_CLOCK_SKEW:
+            errors.append("schema-inference receipt is stale")
+
+    try:
+        location = ArchiveLocation.resolve(root)
+        current_identity = _archive_receipt_identity(location)
+        receipt_identity = _as_dict(document.get("archive_identity"))
+        for field in ("configured_root", "durable_id", "source_tier", "user_tier"):
+            if receipt_identity.get(field) != current_identity.get(field):
+                errors.append(f"receipt archive identity field {field!r} does not match the requested archive")
+        source_path = root / ARCHIVE_TIER_SPECS[ArchiveTier.SOURCE].filename
+        if not source_path.exists():
+            errors.append("source.db is missing")
+        else:
+            expected_snapshot = document.get("source_snapshot")
+            actual_snapshot = rebuild_source_revision_snapshot(root)
+            if not isinstance(expected_snapshot, str) or expected_snapshot != actual_snapshot:
+                errors.append("receipt source snapshot does not match source.db")
+    except (OSError, sqlite3.Error, ValueError, RuntimeError) as exc:
+        errors.append(f"archive/source identity validation failed: {exc}")
+
+    source_identity = _as_dict(document.get("source_identity"))
+    if source_identity.get("durable_id") != _as_dict(document.get("archive_identity")).get("durable_id"):
+        errors.append("receipt source identity is missing or does not match durable identity")
+    if source_identity.get("source_tier") != _as_dict(document.get("archive_identity")).get("source_tier"):
+        errors.append("receipt source identity is missing or does not match source tier identity")
+    if _as_dict(document.get("source_schema_identity")).get("matches_expected") is not True:
+        errors.append("receipt source schema identity is not PASS")
+
+    query_results = document.get("query_results")
+    required_gates = (*_HARD_GATE_SQL, "zero-unexplained-byte-duplicates")
+    if not isinstance(query_results, dict):
+        errors.append("receipt query_results are missing or malformed")
+    else:
+        for gate_id in required_gates:
+            result = query_results.get(gate_id)
+            if not isinstance(result, dict) or result.get("passed") is not True:
+                errors.append(f"receipt subgate {gate_id} is not PASS")
+
+    for field in ("corpus_fidelity", "full_blob_hash_verification", "ground_truth_inputs"):
+        if _as_dict(document.get(field)).get("passed") is not True:
+            errors.append(f"receipt subgate {field} is not PASS")
+
+    ground_truth = document.get("ground_truth_inputs")
+    if not isinstance(ground_truth, dict):
+        errors.append("receipt ground_truth_inputs are missing or malformed")
+    else:
+        recorded_digest = document.get("external_ground_truth_digest")
+        nested_digest = ground_truth.get("external_ground_truth_digest")
+        if not isinstance(recorded_digest, str) or recorded_digest != nested_digest:
+            errors.append("receipt external ground-truth digest is missing or inconsistent")
+        try:
+            recorded_structure_digest = _canonical_external_ground_truth_digest(
+                cast(Mapping[str, object], _as_dict(ground_truth.get("origins")))
+            )
+            if recorded_digest != recorded_structure_digest:
+                errors.append("receipt raw external mapping or inventory does not match its digest")
+            current_digest = _current_external_ground_truth_digest(root, ground_truth)
+            if recorded_digest != current_digest:
+                errors.append("external ground-truth corpus changed since the receipt was produced")
+        except (OSError, SchemaInferenceGateError, sqlite3.Error) as exc:
+            errors.append(str(exc))
+        try:
+            with open_readonly_connection(root / "source.db") as source:
+                source_origins = {str(row[0]) for row in source.execute("SELECT DISTINCT origin FROM raw_sessions")}
+            receipt_origins = set(_as_dict(ground_truth.get("origins")))
+            if source_origins != receipt_origins:
+                errors.append("receipt ground-truth origins do not match source.db")
+            for origin, raw_evidence in _as_dict(ground_truth.get("origins")).items():
+                evidence = _as_dict(raw_evidence)
+                if not bool(evidence.get("exempt")) and evidence.get("passed") is not True:
+                    errors.append(f"receipt ground-truth subgate for {origin} is not PASS")
+        except (OSError, sqlite3.Error) as exc:
+            errors.append(f"could not compare receipt ground-truth origins: {exc}")
+
+    if errors:
+        raise SchemaInferenceGateError("schema-inference receipt rejected: " + "; ".join(errors))
+
+    identity = _as_dict(document.get("archive_identity"))
+    return {
+        "receipt_path": str(path),
+        "schema": document.get("schema"),
+        "generated_at": document.get("generated_at"),
+        "validated_at": effective_now.isoformat(),
+        "archive_root": str(root),
+        "durable_id": identity.get("durable_id"),
+        "source_identity": document.get("source_identity"),
+        "source_snapshot": document.get("source_snapshot"),
+        "external_ground_truth_digest": document.get("external_ground_truth_digest"),
+    }
+
+
 def _write_json(path: Path, payload: dict[str, object]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = path.with_name(f".{path.name}.tmp")
@@ -1042,9 +1454,11 @@ def run_schema_inference_gate(
         location = ArchiveLocation.resolve(root)
         index_path = location.active_index_path
         schema_identity = _tier_schema_identity(root, location)
+        archive_receipt_identity = _archive_receipt_identity(location)
     except (OSError, ValueError, RuntimeError) as exc:
         schema_identity = {"error": str(exc), "tiers": {}}
         index_path = root / "index.db"
+        archive_receipt_identity = {"error": str(exc)}
 
     source_entry = _as_dict(_as_dict(schema_identity.get("tiers")).get("source"))
     source_schema_ok = bool(source_entry.get("matches_expected"))
@@ -1081,8 +1495,15 @@ def run_schema_inference_gate(
             "passed": False,
             "origins": {},
             "reasons": [f"ground truth reconciliation could not read source evidence: {exc}"],
+            "external_ground_truth_digest": None,
         }
 
+    source_snapshot: str | None = None
+    reasons_for_snapshot: str | None = None
+    try:
+        source_snapshot = rebuild_source_revision_snapshot(root)
+    except (OSError, sqlite3.Error) as exc:
+        reasons_for_snapshot = f"source revision snapshot could not be read: {exc}"
     gate_results = _as_dict(source_gates.get("gates"))
     duplicate_gate = source_gates.get("duplicate_gate", {})
     if isinstance(duplicate_gate, dict):
@@ -1103,6 +1524,8 @@ def run_schema_inference_gate(
         ground_truth_reasons = ground_truth.get("reasons", [])
         if isinstance(ground_truth_reasons, list):
             reasons.extend(str(reason) for reason in ground_truth_reasons)
+    if source_snapshot is None:
+        reasons.append(reasons_for_snapshot or "source revision snapshot could not be computed")
 
     payload: dict[str, object] = {
         "schema": RECEIPT_SCHEMA,
@@ -1110,6 +1533,13 @@ def run_schema_inference_gate(
         "generated_at": datetime.now(UTC).isoformat(),
         "verdict": "PASS" if not reasons and passed_hard_gates else "FAIL",
         "archive_root": str(root),
+        "archive_identity": archive_receipt_identity,
+        "source_identity": {
+            "durable_id": archive_receipt_identity.get("durable_id"),
+            "source_tier": archive_receipt_identity.get("source_tier"),
+        },
+        "source_snapshot": source_snapshot,
+        "external_ground_truth_digest": ground_truth.get("external_ground_truth_digest"),
         "schema_identity": schema_identity,
         "source_schema_identity": source_entry,
         "query_results": gate_results,
@@ -1144,7 +1574,13 @@ __all__ = [
     "GROUND_TRUTH_INPUTS",
     "RECEIPT_FILENAME",
     "RECEIPT_SCHEMA",
+    "RECEIPT_CLOCK_SKEW",
+    "RECEIPT_TTL",
+    "SCHEMA_INFERENCE_RECEIPT_ENV",
     "SchemaInferenceGateError",
     "SchemaInferenceGateResult",
+    "rebuild_source_revision_snapshot",
+    "resolve_schema_inference_receipt_reference",
     "run_schema_inference_gate",
+    "validate_schema_inference_receipt",
 ]

--- a/polylogue/maintenance/sharded_rebuild.py
+++ b/polylogue/maintenance/sharded_rebuild.py
@@ -63,11 +63,13 @@ from typing import TYPE_CHECKING, cast
 from polylogue.config import Config
 from polylogue.logging import get_logger
 from polylogue.paths import render_root
+from polylogue.storage.index_generation import IndexGeneration
 from polylogue.storage.sqlite.connection_profile import BULK_BUILD_WRITE_CONNECTION_PRAGMA_STATEMENTS
 
 if TYPE_CHECKING:
+    from polylogue.maintenance.rebuild_index import RebuildProvenanceContext
     from polylogue.sources.revision_backfill import RawParsePrefetchCache
-    from polylogue.storage.index_generation import IndexGeneration, IndexGenerationStore
+    from polylogue.storage.index_generation import IndexGenerationStore
 
 logger = get_logger(__name__)
 
@@ -251,11 +253,16 @@ async def _build_one_shard(
     raw_ids: list[str],
     raw_batch_size: int,
     prefetch_cache: RawParsePrefetchCache | None,
+    provenance: RebuildProvenanceContext,
+    created_generations: list[IndexGeneration],
 ) -> tuple[IndexGeneration, ShardBuildStats]:
     """Replay one shard's raw ids into its own owned inactive generation."""
     from polylogue.maintenance.replay import rebuild_index_from_source as replay_source
 
+    provenance.validate()
     generation = generation_store.create(source_snapshot=source_snapshot)
+    created_generations.append(generation)
+    provenance.validate()
     generation_root = Path(generation.index_path).parent
     config = Config(
         archive_root=generation_root,
@@ -275,7 +282,9 @@ async def _build_one_shard(
         bulk_fts=True,
         bulk_build=True,
         prefetch_cache=prefetch_cache,
+        deadline_check=provenance.validate,
     )
+    provenance.validate()
     build_s = time.perf_counter() - started_at
     return generation, ShardBuildStats(
         generation_id=generation.generation_id,
@@ -325,7 +334,12 @@ def _non_generated_columns(conn: sqlite3.Connection, table: str) -> list[str]:
     return [str(row[1]) for row in conn.execute(f"PRAGMA table_xinfo({table})").fetchall() if int(row[6]) not in (2, 3)]
 
 
-def merge_shards_into_target(target_index_path: Path, shard_index_paths: list[Path]) -> dict[str, int]:
+def merge_shards_into_target(
+    target_index_path: Path,
+    shard_index_paths: list[Path],
+    *,
+    provenance: RebuildProvenanceContext,
+) -> dict[str, int]:
     """ATTACH every shard's ``index.db`` and fold its rows into the target.
 
     Returns per-table total row counts written (across all shards, before
@@ -339,6 +353,7 @@ def merge_shards_into_target(target_index_path: Path, shard_index_paths: list[Pa
 
     row_counts: dict[str, int] = dict.fromkeys(MERGE_TABLES, 0)
     aliases = [f"shard{i}" for i in range(len(shard_index_paths))]
+    provenance.validate()
     with contextlib.closing(_open_merge_connection(target_index_path, timeout=600)) as conn:
         conn.execute("PRAGMA busy_timeout = 600000")
         attached: list[str] = []
@@ -360,20 +375,25 @@ def merge_shards_into_target(target_index_path: Path, shard_index_paths: list[Pa
             # terminal `_repopulate_bulk_build_derived_state` stage), so that
             # stage's `resume_from_empty_message_index=True` precondition
             # holds for the sharded path too.
+            provenance.validate()
             conn.execute(
                 "INSERT OR IGNORE INTO derived_refresh_guard (guard_name) VALUES (?)", (FTS_BULK_SESSION_WRITE_GUARD,)
             )
             for alias, shard_path in zip(aliases, shard_index_paths, strict=True):
+                provenance.validate()
                 conn.execute(f"ATTACH DATABASE ? AS {alias}", (str(shard_path),))
                 attached.append(alias)
             for table in MERGE_TABLES:
                 columns = _non_generated_columns(conn, table)
                 column_list = ", ".join(columns)
                 for alias in aliases:
+                    provenance.validate()
                     cursor = conn.execute(
                         f"INSERT OR REPLACE INTO {table} ({column_list}) SELECT {column_list} FROM {alias}.{table}"
                     )
                     row_counts[table] += cursor.rowcount if cursor.rowcount > 0 else 0
+                    provenance.validate()
+            provenance.validate()
             conn.execute("DELETE FROM derived_refresh_guard WHERE guard_name = ?", (FTS_BULK_SESSION_WRITE_GUARD,))
             conn.commit()
             violations = conn.execute("PRAGMA foreign_key_check").fetchall()
@@ -391,7 +411,11 @@ def merge_shards_into_target(target_index_path: Path, shard_index_paths: list[Pa
     return row_counts
 
 
-def resolve_cross_shard_session_graph(target_index_path: Path) -> float:
+def resolve_cross_shard_session_graph(
+    target_index_path: Path,
+    *,
+    provenance: RebuildProvenanceContext,
+) -> float:
     """Re-run per-session graph resolution over every merged session.
 
     Each shard's own replay already resolved links whose OTHER endpoint
@@ -413,6 +437,7 @@ def resolve_cross_shard_session_graph(target_index_path: Path) -> float:
     """
     from polylogue.storage.sqlite.archive_tiers.write import _resolve_session_graph
 
+    provenance.validate()
     started_at = time.perf_counter()
     with contextlib.closing(_open_merge_connection(target_index_path, timeout=600)) as conn:
         conn.execute("PRAGMA busy_timeout = 600000")
@@ -420,6 +445,7 @@ def resolve_cross_shard_session_graph(target_index_path: Path) -> float:
         rows = conn.execute("SELECT session_id, native_id, origin FROM sessions ORDER BY session_id").fetchall()
         signature_cache: dict[str, list[tuple[str, str]]] = {}
         for session_id, native_id, origin in rows:
+            provenance.validate()
             _resolve_session_graph(
                 conn,
                 session_id,
@@ -430,8 +456,37 @@ def resolve_cross_shard_session_graph(target_index_path: Path) -> float:
                 bulk_fts=True,
                 bulk_build=True,
             )
+        provenance.validate()
         conn.commit()
     return time.perf_counter() - started_at
+
+
+def _cleanup_shard_generations(
+    generation_store: IndexGenerationStore,
+    shard_generations: list[IndexGeneration],
+    provenance: RebuildProvenanceContext,
+) -> list[BaseException]:
+    """Attempt every shard cleanup and return failures without short-circuiting."""
+    errors: list[BaseException] = []
+    for shard_generation in shard_generations:
+        try:
+            provenance.validate_cleanup()
+            generation_store.discard_if_inactive(shard_generation)
+        except BaseException as exc:
+            cleanup_error = RuntimeError(f"{shard_generation.generation_id}: {exc}")
+            cleanup_error.__cause__ = exc
+            errors.append(cleanup_error)
+    return errors
+
+
+def _surface_shard_cleanup_failures(primary: BaseException | None, cleanup_errors: list[BaseException]) -> None:
+    """Preserve a primary failure while surfacing every cleanup failure."""
+    if not cleanup_errors:
+        return
+    detail = "; ".join(str(error) for error in cleanup_errors)
+    if primary is None:
+        raise RuntimeError(f"shard cleanup failed: {detail}") from cleanup_errors[0]
+    primary.add_note(f"shard cleanup also failed: {detail}")
 
 
 async def replay_selected_raw_ids_sharded(
@@ -443,6 +498,7 @@ async def replay_selected_raw_ids_sharded(
     raw_batch_size: int,
     shard_count: int,
     prefetch_cache: RawParsePrefetchCache | None,
+    provenance: RebuildProvenanceContext,
 ) -> dict[str, object]:
     """Replay ``selected_raw_ids`` into ``generation`` via ``shard_count`` parallel shards.
 
@@ -483,6 +539,7 @@ async def replay_selected_raw_ids_sharded(
         shard_count=len(buckets),
         selected_raw_count=len(selected_raw_ids),
     )
+    created_generations: list[IndexGeneration] = []
     build_results = await asyncio.gather(
         *[
             _build_one_shard(
@@ -491,23 +548,35 @@ async def replay_selected_raw_ids_sharded(
                 raw_ids=bucket,
                 raw_batch_size=raw_batch_size,
                 prefetch_cache=prefetch_cache,
+                provenance=provenance,
+                created_generations=created_generations,
             )
             for bucket in buckets
-        ]
+        ],
+        return_exceptions=True,
     )
-    shard_generations = [pair[0] for pair in build_results]
-    shard_stats = [pair[1] for pair in build_results]
+    failures = [result for result in build_results if isinstance(result, BaseException)]
+    if failures:
+        primary = failures[0]
+        cleanup_errors = _cleanup_shard_generations(generation_store, created_generations, provenance)
+        _surface_shard_cleanup_failures(primary, cleanup_errors)
+        raise primary
+    shard_generations = [cast(tuple[IndexGeneration, ShardBuildStats], result)[0] for result in build_results]
+    shard_stats = [cast(tuple[IndexGeneration, ShardBuildStats], result)[1] for result in build_results]
     try:
         merge_started_at = time.perf_counter()
         row_counts = merge_shards_into_target(
-            Path(generation.index_path), [Path(sg.index_path) for sg in shard_generations]
+            Path(generation.index_path), [Path(sg.index_path) for sg in shard_generations], provenance=provenance
         )
         merge_s = time.perf_counter() - merge_started_at
-        graph_resolve_s = resolve_cross_shard_session_graph(Path(generation.index_path))
-    finally:
-        for shard_generation in shard_generations:
-            with contextlib.suppress(Exception):
-                generation_store.discard_if_inactive(shard_generation)
+        graph_resolve_s = resolve_cross_shard_session_graph(Path(generation.index_path), provenance=provenance)
+    except BaseException as primary:
+        cleanup_errors = _cleanup_shard_generations(generation_store, shard_generations, provenance)
+        _surface_shard_cleanup_failures(primary, cleanup_errors)
+        raise
+    else:
+        cleanup_errors = _cleanup_shard_generations(generation_store, shard_generations, provenance)
+        _surface_shard_cleanup_failures(None, cleanup_errors)
     logger.info(
         "sharded_rebuild_merge_complete",
         generation_id=generation.generation_id,

--- a/tests/infra/rebuild_receipt.py
+++ b/tests/infra/rebuild_receipt.py
@@ -1,0 +1,107 @@
+"""Targeted schema-inference receipts for real rebuild-route tests."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+from polylogue.maintenance import schema_inference_gate as gate
+from polylogue.storage.archive_identity import ArchiveIdentity, ArchiveLocation
+from polylogue.storage.blob_store import BlobStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+
+def write_valid_rebuild_receipt(
+    archive_root: Path,
+    receipt_path: Path,
+    *,
+    generated_at: datetime | None = None,
+) -> Path:
+    """Write a minimally complete, identity-bound PASS for a test archive."""
+
+    root = archive_root.absolute()
+    location = ArchiveLocation.resolve(root)
+    identity = ArchiveIdentity.resolve_location(location)
+    with sqlite3.connect(root / "source.db") as source:
+        origins = {str(row[0]) for row in source.execute("SELECT DISTINCT origin FROM raw_sessions ORDER BY origin")}
+        ground_truth_origins: dict[str, object] = {}
+        for origin in sorted(origins):
+            declared = gate.GROUND_TRUTH_INPUTS.get(origin, {"exempt": False})
+            if bool(declared.get("exempt")):
+                ground_truth_origins[origin] = {
+                    "exempt": True,
+                    "reason": declared.get("reason"),
+                    "raw_external_mapping": gate._raw_external_mapping(
+                        source, origin=origin, inventory=(), exempt=True
+                    ),
+                }
+                continue
+            external_root = root.parent / f"{root.name}-{origin}-ground-truth"
+            external_root.mkdir(parents=True, exist_ok=True)
+            raw_rows = source.execute(
+                "SELECT raw_id, blob_hash FROM raw_sessions WHERE origin = ? ORDER BY raw_id", (origin,)
+            ).fetchall()
+            for raw_id, blob_hash in raw_rows:
+                (external_root / f"{raw_id}.bin").write_bytes(BlobStore(root / "blob").read_all(bytes(blob_hash).hex()))
+            inventory = gate._external_inventory((external_root,))
+            inventory_records = [
+                {
+                    "root_index": item.root_index,
+                    "relative_path": item.relative_path,
+                    "hash": item.content_hash,
+                    "size": item.size,
+                }
+                for item in inventory
+            ]
+            mapping = gate._raw_external_mapping(source, origin=origin, inventory=inventory, exempt=False)
+            ground_truth_origins[origin] = {
+                "exempt": False,
+                "declared_roots": [str(external_root)],
+                "external_inventory": inventory_records,
+                "raw_external_mapping": mapping,
+                "passed": all(item["disposition"] == "matched-external" for item in mapping),
+            }
+
+    ground_truth = {
+        "passed": True,
+        "origins": ground_truth_origins,
+    }
+    digest = gate._canonical_external_ground_truth_digest(ground_truth_origins)
+    ground_truth["external_ground_truth_digest"] = digest
+    query_results = {
+        gate_id: {"gate": gate_id, "passed": True, "count": 0}
+        for gate_id in (*gate._HARD_GATE_SQL, "zero-unexplained-byte-duplicates")
+    }
+    source_entry = {
+        "expected_user_version": ARCHIVE_TIER_SPECS[ArchiveTier.SOURCE].version,
+        "actual_user_version": ARCHIVE_TIER_SPECS[ArchiveTier.SOURCE].version,
+        "matches_expected": True,
+    }
+    payload: dict[str, object] = {
+        "schema": gate.RECEIPT_SCHEMA,
+        "gate_version": gate.GATE_VERSION,
+        "generated_at": (generated_at or datetime.now(UTC)).astimezone(UTC).isoformat(),
+        "verdict": "PASS",
+        "archive_root": str(root),
+        "archive_identity": gate._archive_receipt_identity(location),
+        "source_identity": {
+            "durable_id": identity.durable_id,
+            "source_tier": identity.tier("source").as_dict(),
+        },
+        "source_snapshot": gate.rebuild_source_revision_snapshot(root),
+        "external_ground_truth_digest": digest,
+        "source_schema_identity": source_entry,
+        "query_results": query_results,
+        "ground_truth_inputs": ground_truth,
+        "corpus_fidelity": {"passed": True},
+        "full_blob_hash_verification": {"passed": True},
+    }
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    receipt_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return receipt_path
+
+
+__all__ = ["write_valid_rebuild_receipt"]

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -34,6 +34,7 @@ from polylogue.storage.sqlite.archive_tiers.source_write import write_source_raw
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.user import USER_SCHEMA_VERSION
 from polylogue.storage.sqlite.archive_tiers.user_write import AssertionKind, upsert_assertion
+from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
 
 _ARCHIVE_TIERS = tuple(spec.filename for spec in ARCHIVE_TIER_SPECS.values())
 
@@ -1944,6 +1945,10 @@ def test_rebuild_index_source_replay_expands_every_execution_selection_to_author
     monkeypatch: pytest.MonkeyPatch,
     selection_args: list[str],
 ) -> None:
+    receipt_path = write_valid_rebuild_receipt(
+        cli_workspace["archive_root"], cli_workspace["archive_root"].parent / "schema-inference-gate-receipt.json"
+    )
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_INFERENCE_RECEIPT", str(receipt_path))
     monkeypatch.setattr("polylogue.maintenance.rebuild_index.count_source_raw_sessions", lambda _root: 4)
     monkeypatch.setattr(
         "polylogue.maintenance.rebuild_index.all_index_rebuild_raw_ids",
@@ -1989,6 +1994,9 @@ def test_rebuild_index_daemon_path_posts_the_real_selection_request(
     cli_workspace: dict[str, Path], cli_runner: CliRunner, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     captured: dict[str, object] = {}
+    receipt_path = write_valid_rebuild_receipt(
+        cli_workspace["archive_root"], cli_workspace["archive_root"].parent / "schema-inference-gate-receipt.json"
+    )
 
     class Response:
         def read(self) -> bytes:
@@ -2024,6 +2032,8 @@ def test_rebuild_index_daemon_path_posts_the_real_selection_request(
             "--daemon",
             "--daemon-url",
             "http://127.0.0.1:9876",
+            "--schema-inference-receipt",
+            str(receipt_path),
             "--raw-batch-size",
             "17",
             "--pass-byte-budget-mb",
@@ -2043,6 +2053,7 @@ def test_rebuild_index_daemon_path_posts_the_real_selection_request(
             "max_blob_mb": None,
             "promote": True,
             "operation_id": None,
+            "schema_inference_receipt_path": str(receipt_path),
             "raw_batch_size": 17,
             "pass_byte_budget_mb": 12.5,
             "pass_deadline_seconds": 45.0,
@@ -2100,7 +2111,7 @@ def test_all_index_rebuild_raw_ids_uses_source_acquisition_order(
 
 
 def test_rebuild_index_full_source_resumes_one_candidate_until_terminal_promotion(
-    cli_workspace: dict[str, Path], cli_runner: CliRunner
+    cli_workspace: dict[str, Path], cli_runner: CliRunner, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A bounded pass retains its generation; only the terminal resume promotes it."""
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -2118,6 +2129,8 @@ def test_rebuild_index_full_source_resumes_one_candidate_until_terminal_promotio
                 source_path=f"{native_id}.jsonl",
                 acquired_at_ms=acquired_at_ms,
             )
+    receipt_path = write_valid_rebuild_receipt(root, root.parent / "schema-inference-gate-receipt.json")
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_INFERENCE_RECEIPT", str(receipt_path))
 
     first = cli_runner.invoke(
         cli,
@@ -2171,7 +2184,7 @@ def test_rebuild_index_full_source_resumes_one_candidate_until_terminal_promotio
 
 
 def test_rebuild_index_persists_durable_pass_receipt_alongside_transaction(
-    cli_workspace: dict[str, Path], cli_runner: CliRunner
+    cli_workspace: dict[str, Path], cli_runner: CliRunner, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Every rebuild pass receipt survives on disk, not only on the CLI's stdout.
 
@@ -2196,6 +2209,8 @@ def test_rebuild_index_persists_durable_pass_receipt_alongside_transaction(
                 source_path=f"{native_id}.jsonl",
                 acquired_at_ms=acquired_at_ms,
             )
+    receipt_path = write_valid_rebuild_receipt(root, root.parent / "schema-inference-gate-receipt.json")
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_INFERENCE_RECEIPT", str(receipt_path))
 
     first = cli_runner.invoke(
         cli,
@@ -2249,7 +2264,7 @@ def test_rebuild_index_persists_durable_pass_receipt_alongside_transaction(
 
 
 def test_rebuild_index_byte_budget_defers_then_reaches_terminal_ready_candidate(
-    cli_workspace: dict[str, Path], cli_runner: CliRunner
+    cli_workspace: dict[str, Path], cli_runner: CliRunner, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The real CLI replays every raw over passes; byte budgeting never filters archive data."""
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -2267,6 +2282,8 @@ def test_rebuild_index_byte_budget_defers_then_reaches_terminal_ready_candidate(
                 source_path=f"{native_id}.jsonl",
                 acquired_at_ms=acquired_at_ms,
             )
+    receipt_path = write_valid_rebuild_receipt(root, root.parent / "schema-inference-gate-receipt.json")
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_INFERENCE_RECEIPT", str(receipt_path))
     first = cli_runner.invoke(
         cli,
         [
@@ -2318,10 +2335,10 @@ def test_rebuild_index_byte_budget_defers_then_reaches_terminal_ready_candidate(
         assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone() == (2,)
 
 
-def test_rebuild_index_source_snapshot_drift_marks_candidate_stale_before_promotion(
+def test_rebuild_index_source_snapshot_drift_fails_before_candidate_creation(
     cli_workspace: dict[str, Path], cli_runner: CliRunner, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A changed source vector is terminal evidence, never a ready/promoted candidate."""
+    """A receipt/source mismatch stops the route before candidate creation."""
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
     root = cli_workspace["archive_root"]
@@ -2336,17 +2353,24 @@ def test_rebuild_index_source_snapshot_drift_marks_candidate_stale_before_promot
             source_path="drift.jsonl",
             acquired_at_ms=1,
         )
-    snapshots = iter(("source-v1", "source-v1", "source-v2"))
-    monkeypatch.setattr("polylogue.storage.index_generation.source_revision_snapshot", lambda _root: next(snapshots))
+    receipt_path = write_valid_rebuild_receipt(root, root.parent / "schema-inference-gate-receipt.json")
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_INFERENCE_RECEIPT", str(receipt_path))
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=b'{"type":"session_meta","payload":{"id":"drift-after-receipt"}}\n',
+            source_path="drift-after-receipt.jsonl",
+            acquired_at_ms=2,
+        )
     result = cli_runner.invoke(
         cli,
         ["--plain", "ops", "maintenance", "rebuild-index", "--output-format", "json"],
         catch_exceptions=False,
     )
     assert result.exit_code == 1
-    assert "stale because source evidence changed" in result.output
-    transaction = next((root / ".index-rebuild-transactions").glob("*.json"))
-    assert json.loads(transaction.read_text())["status"] == "stale"
+    assert "schema-inference preflight gate failed" in result.output
+    assert not list((root / ".index-rebuild-transactions").glob("*.json"))
+    assert not list((root / ".index-generations").glob("gen-*"))
     assert not root.joinpath("index.db").is_symlink()
 
 
@@ -2368,6 +2392,8 @@ def test_rebuild_index_deadline_defers_postflight_until_resume(
             source_path="deadline.jsonl",
             acquired_at_ms=1,
         )
+    receipt_path = write_valid_rebuild_receipt(root, root.parent / "schema-inference-gate-receipt.json")
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_INFERENCE_RECEIPT", str(receipt_path))
     # `monkeypatch.setattr("polylogue.maintenance.rebuild_index.time.time", ...)`
     # patches the *stdlib* `time` module's `time` attribute (modules are
     # process-wide singletons), not a private copy scoped to rebuild_index.py.

--- a/tests/unit/cli/test_reindex_canary_cli.py
+++ b/tests/unit/cli/test_reindex_canary_cli.py
@@ -14,6 +14,7 @@ from polylogue.maintenance.reindex_canary import (
     UnclassifiedCanaryDiffError,
     run_reindex_canary,
 )
+from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
 from tests.infra.workload_artifacts import build_seeded_archive
 
 
@@ -43,6 +44,8 @@ def _run_result(index_path: Path, *, differences: tuple[object, ...] = ()) -> Ca
 def test_reindex_canary_cli_requires_no_promote(tmp_path: Path) -> None:
     index_path = tmp_path / "index.db"
     index_path.touch()
+    receipt_path = tmp_path / "schema-inference-gate-receipt.json"
+    receipt_path.touch()
     result = CliRunner().invoke(
         cli,
         [
@@ -56,6 +59,8 @@ def test_reindex_canary_cli_requires_no_promote(tmp_path: Path) -> None:
             str(index_path),
             "--report",
             str(tmp_path / "canary.json"),
+            "--schema-inference-receipt",
+            str(receipt_path),
         ],
     )
 
@@ -71,6 +76,8 @@ def test_reindex_canary_cli_rejects_input_outside_archive_root_before_rebuild(
     external_index = tmp_path / "external" / "index.db"
     external_index.parent.mkdir()
     external_index.touch()
+    receipt_path = tmp_path / "schema-inference-gate-receipt.json"
+    receipt_path.touch()
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path / "configured-live"))
     rebuild_called = False
 
@@ -94,6 +101,8 @@ def test_reindex_canary_cli_rejects_input_outside_archive_root_before_rebuild(
             str(external_index),
             "--report",
             str(tmp_path / "canary.json"),
+            "--schema-inference-receipt",
+            str(receipt_path),
             "--no-promote",
         ],
     )
@@ -112,6 +121,7 @@ def test_reindex_canary_cli_runs_real_no_promote_route(
         path.chmod(path.stat().st_mode | stat.S_IWUSR)
     index_path = archive_root / "index.db"
     report_path = tmp_path / "reports" / "canary.json"
+    receipt_path = write_valid_rebuild_receipt(archive_root, tmp_path / "schema-inference-gate-receipt.json")
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path / "configured-live-root"))
 
     result = CliRunner().invoke(
@@ -129,6 +139,8 @@ def test_reindex_canary_cli_runs_real_no_promote_route(
             "1000",
             "--report",
             str(report_path),
+            "--schema-inference-receipt",
+            str(receipt_path),
             "--no-promote",
             "--output-format",
             "json",
@@ -147,6 +159,8 @@ def test_reindex_canary_cli_refuses_to_write_unclassified_report(
 ) -> None:
     index_path = tmp_path / "index.db"
     index_path.touch()
+    receipt_path = tmp_path / "schema-inference-gate-receipt.json"
+    receipt_path.touch()
     run_result = _run_result(index_path, differences=(object(),))
     monkeypatch.setattr("polylogue.maintenance.reindex_canary.run_reindex_canary", lambda *args, **kwargs: run_result)
     monkeypatch.setattr(
@@ -167,6 +181,8 @@ def test_reindex_canary_cli_refuses_to_write_unclassified_report(
             str(index_path),
             "--report",
             str(tmp_path / "canary.json"),
+            "--schema-inference-receipt",
+            str(receipt_path),
             "--no-promote",
         ],
     )
@@ -228,6 +244,7 @@ def test_shared_canary_runner_uses_existing_inactive_rebuild_route(
     result = run_reindex_canary(
         tmp_path,
         input_index=current_index,
+        schema_inference_receipt_path=tmp_path / "schema-inference-gate-receipt.json",
         sessions_per_origin=2,
         no_promote=True,
     )

--- a/tests/unit/daemon/test_bulk_rebuild.py
+++ b/tests/unit/daemon/test_bulk_rebuild.py
@@ -50,6 +50,7 @@ from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_ind
 from polylogue.storage.index_generation import IndexGenerationStore, source_revision_snapshot
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
 
 _RAW_COUNT = 6
 
@@ -171,17 +172,18 @@ def test_resolve_or_start_creates_resumes_and_retires_transaction(
 ) -> None:
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path))
     _seed_corpus(tmp_path, count=2)
+    receipt_path = write_valid_rebuild_receipt(tmp_path, tmp_path / "receipt.json")
     store = IndexGenerationStore.for_archive_root(tmp_path)
 
     assert has_resumable_daemon_bulk_rebuild_transaction(tmp_path) is False
-    first = resolve_or_start_daemon_bulk_rebuild_transaction(tmp_path)
+    first = resolve_or_start_daemon_bulk_rebuild_transaction(tmp_path, schema_inference_receipt_path=receipt_path)
     assert first.operation_id == DAEMON_BULK_REBUILD_OPERATION_ID
     assert first.status == "running"
     assert has_resumable_daemon_bulk_rebuild_transaction(tmp_path) is True
 
     # A second resolve against an unchanged, still-resumable transaction
     # returns the SAME record -- no new generation, no lost cursor.
-    again = resolve_or_start_daemon_bulk_rebuild_transaction(tmp_path)
+    again = resolve_or_start_daemon_bulk_rebuild_transaction(tmp_path, schema_inference_receipt_path=receipt_path)
     assert again.generation_id == first.generation_id
     assert again.operation_id == first.operation_id
 
@@ -190,7 +192,7 @@ def test_resolve_or_start_creates_resumes_and_retires_transaction(
     # transaction/generation rather than colliding with the retired one.
     store.checkpoint_transaction(first, status="promoted")
     assert has_resumable_daemon_bulk_rebuild_transaction(tmp_path) is False
-    restarted = resolve_or_start_daemon_bulk_rebuild_transaction(tmp_path)
+    restarted = resolve_or_start_daemon_bulk_rebuild_transaction(tmp_path, schema_inference_receipt_path=receipt_path)
     assert restarted.operation_id == DAEMON_BULK_REBUILD_OPERATION_ID
     assert restarted.status == "running"
     assert restarted.generation_id != first.generation_id
@@ -210,6 +212,8 @@ def test_daemon_bulk_rebuild_pass_resumes_without_reprocessing_raw_ids(
     """
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path))
     _seed_corpus(tmp_path)
+    receipt_path = write_valid_rebuild_receipt(tmp_path, tmp_path / "receipt.json")
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_INFERENCE_RECEIPT", str(receipt_path))
     receipts = asyncio.run(_drive_daemon_bulk_rebuild_to_promotion(tmp_path, batch_size=2))
 
     assert len(receipts) >= 3  # 6 raws / batch 2 => at least 3 passes before promotion finalizes
@@ -237,8 +241,9 @@ def test_daemon_bulk_rebuild_pass_resumes_without_reprocessing_raw_ids(
 def test_daemon_bulk_rebuild_pass_next_page_excludes_already_scheduled_raws(tmp_path: Path) -> None:
     """Direct proof that a later page never reselects an earlier page's raws."""
     _seed_corpus(tmp_path)
+    receipt_path = write_valid_rebuild_receipt(tmp_path, tmp_path / "receipt.json")
     store = IndexGenerationStore.for_archive_root(tmp_path)
-    transaction = resolve_or_start_daemon_bulk_rebuild_transaction(tmp_path)
+    transaction = resolve_or_start_daemon_bulk_rebuild_transaction(tmp_path, schema_inference_receipt_path=receipt_path)
 
     first_page = store.next_raw_page(transaction, limit=2)
     first_raw_ids = {raw_id for raw_id, _blob_hash_hex, _size in first_page.rows}
@@ -267,6 +272,8 @@ def test_daemon_bulk_rebuild_equivalent_to_cli_rebuild(tmp_path: Path, monkeypat
     daemon_root = tmp_path / "daemon"
     _seed_corpus(cli_root)
     _seed_corpus(daemon_root)
+    cli_receipt_path = write_valid_rebuild_receipt(cli_root, tmp_path / "cli-receipt.json")
+    daemon_receipt_path = write_valid_rebuild_receipt(daemon_root, tmp_path / "daemon-receipt.json")
     assert source_revision_snapshot(cli_root) == source_revision_snapshot(daemon_root)
 
     # ArchiveStore.open_owned_inactive_generation validates generation
@@ -276,12 +283,15 @@ def test_daemon_bulk_rebuild_equivalent_to_cli_rebuild(tmp_path: Path, monkeypat
     # the daemon route share this same invariant in production (a real
     # daemon process only ever has one configured root at a time).
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(cli_root))
-    cli_receipt = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=cli_root, promote=True))
+    cli_receipt = rebuild_index_from_source_sync(
+        RebuildIndexRequest(archive_root=cli_root, promote=True, schema_inference_receipt_path=cli_receipt_path)
+    )
     assert cli_receipt.status == "replayed"
     assert cli_receipt.transaction is not None
     assert cli_receipt.transaction["status"] == "promoted"
 
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(daemon_root))
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_INFERENCE_RECEIPT", str(daemon_receipt_path))
     asyncio.run(_drive_daemon_bulk_rebuild_to_promotion(daemon_root, batch_size=2))
 
     cli_snapshot = _canonical_snapshot(cli_root / "index.db")

--- a/tests/unit/devtools/test_reindex_canary.py
+++ b/tests/unit/devtools/test_reindex_canary.py
@@ -25,7 +25,16 @@ def test_devtools_reindex_canary_delegates_to_product_cli(
 
     assert (
         reindex_canary.main(
-            ["--archive-root", "/tmp/isolated-archive", "--report", "/tmp/canary.json", "--no-promote", "--json"]
+            [
+                "--archive-root",
+                "/tmp/isolated-archive",
+                "--schema-inference-receipt",
+                "/tmp/schema-inference-gate-receipt.json",
+                "--report",
+                "/tmp/canary.json",
+                "--no-promote",
+                "--json",
+            ]
         )
         == 0
     )
@@ -39,6 +48,8 @@ def test_devtools_reindex_canary_delegates_to_product_cli(
         "reindex-canary",
         "--archive-root",
         "/tmp/isolated-archive",
+        "--schema-inference-receipt",
+        "/tmp/schema-inference-gate-receipt.json",
         "--report",
         "/tmp/canary.json",
         "--no-promote",

--- a/tests/unit/maintenance/test_rebuild_index_provenance_gate.py
+++ b/tests/unit/maintenance/test_rebuild_index_provenance_gate.py
@@ -398,6 +398,92 @@ def test_full_source_transaction_creation_cleans_candidate_after_post_create_val
     assert not list((root / ".index-rebuild-transactions").glob("*.json"))
 
 
+def test_full_source_snapshot_mismatch_after_transaction_creation_cleans_candidate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A fresh transaction cannot be retained when its source snapshot drifts."""
+    root = tmp_path / "archive"
+    _seed(root, count=2)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    original_create = rebuild_index_module._create_rebuild_transaction_after_receipt_validation
+
+    def create_then_drift(*args: Any, **kwargs: Any) -> IndexRebuildTransaction:
+        transaction = original_create(*args, **kwargs)
+        with sqlite3.connect(root / "source.db") as conn:
+            conn.execute("UPDATE raw_sessions SET source_path = source_path || '.drifted'")
+        write_valid_rebuild_receipt(root, receipt_path)
+        return transaction
+
+    monkeypatch.setattr(rebuild_index_module, "_create_rebuild_transaction_after_receipt_validation", create_then_drift)
+
+    with pytest.raises(RuntimeError, match="source evidence changed since this rebuild was planned"):
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(archive_root=root, schema_inference_receipt_path=receipt_path)
+        )
+
+    assert _generation_ids(root) == set()
+    assert not list((root / ".index-rebuild-transactions").glob("*.json"))
+
+
+def test_full_source_snapshot_mismatch_after_replay_cleans_transaction_and_candidate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A source drift detected after replay uses the fresh-transaction cleanup path."""
+    root = tmp_path / "archive"
+    _seed(root, count=2)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+
+    def planner_boundary_then_drift(*, processed_before: int | None, processed_after: int) -> bool:
+        with sqlite3.connect(root / "source.db") as conn:
+            conn.execute("UPDATE raw_sessions SET source_path = source_path || '.drifted'")
+        write_valid_rebuild_receipt(root, receipt_path)
+        return False
+
+    monkeypatch.setattr(
+        rebuild_index_module,
+        "_should_refresh_generation_planner_statistics",
+        planner_boundary_then_drift,
+    )
+
+    with pytest.raises(RuntimeError, match="source evidence changed during this bounded rebuild pass"):
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(archive_root=root, schema_inference_receipt_path=receipt_path)
+        )
+
+    assert _generation_ids(root) == set()
+    assert not list((root / ".index-rebuild-transactions").glob("*.json"))
+
+
+def test_full_source_provenance_cleanup_reports_failed_discards(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A cleanup actuator failure is diagnostic while the mismatch stays primary."""
+    root = tmp_path / "archive"
+    _seed(root, count=2)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    original_create = rebuild_index_module._create_rebuild_transaction_after_receipt_validation
+
+    def create_then_drift(*args: Any, **kwargs: Any) -> IndexRebuildTransaction:
+        transaction = original_create(*args, **kwargs)
+        with sqlite3.connect(root / "source.db") as conn:
+            conn.execute("UPDATE raw_sessions SET source_path = source_path || '.drifted'")
+        write_valid_rebuild_receipt(root, receipt_path)
+        return transaction
+
+    monkeypatch.setattr(rebuild_index_module, "_create_rebuild_transaction_after_receipt_validation", create_then_drift)
+    monkeypatch.setattr(IndexGenerationStore, "discard_if_inactive", lambda *args, **kwargs: False)
+    monkeypatch.setattr(IndexGenerationStore, "discard_transaction", lambda *args, **kwargs: False)
+
+    with pytest.raises(RuntimeError, match="source evidence changed since this rebuild was planned") as raised:
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(archive_root=root, schema_inference_receipt_path=receipt_path)
+        )
+
+    notes = "\n".join(raised.value.__notes__ or ())
+    assert "rebuild transaction cleanup also failed" in notes
+    assert "was not discarded" in notes
+
+
 def test_sharded_graph_drift_blocks_derived_stages_and_cleans_resumable_state(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/maintenance/test_rebuild_index_provenance_gate.py
+++ b/tests/unit/maintenance/test_rebuild_index_provenance_gate.py
@@ -1,0 +1,480 @@
+"""Real-route tests for the schema-inference rebuild hard gate."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+import polylogue.maintenance.rebuild_index as rebuild_index_module
+import polylogue.maintenance.sharded_rebuild as sharded_rebuild_module
+from polylogue.archive.revision_authority import RawRevisionAuthority, RawRevisionEnvelope, RawRevisionKind
+from polylogue.config import Config
+from polylogue.core.enums import Provider
+from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
+from polylogue.maintenance.schema_inference_gate import rebuild_source_revision_snapshot
+from polylogue.maintenance.sharded_rebuild import shard_raw_ids
+from polylogue.sources.revision_backfill import RebuildDeadlineExceededError
+from polylogue.storage.archive_identity import OwnedArchiveLocation
+from polylogue.storage.index_generation import IndexGeneration, IndexGenerationStore, IndexRebuildTransaction
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
+
+
+def _payload(native_id: str, text: str) -> bytes:
+    rows = [
+        {"type": "session_meta", "payload": {"id": native_id, "timestamp": "2026-08-05T10:00:00Z"}},
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "id": f"{native_id}-m0",
+                "role": "user",
+                "content": [{"type": "input_text", "text": text}],
+            },
+        },
+    ]
+    return b"".join(json.dumps(row, sort_keys=True).encode() + b"\n" for row in rows)
+
+
+def _seed(root: Path, count: int = 2) -> None:
+    initialize_active_archive_root(root)
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        for index in range(count):
+            archive.write_raw_payload(
+                provider=Provider.CODEX,
+                payload=_payload(f"gate-session-{index}", f"gate text {index}"),
+                source_path=f"current/{index}.jsonl",
+                acquired_at_ms=index + 1,
+                revision=RawRevisionEnvelope(
+                    logical_source_key=f"codex-session:gate-session-{index}",
+                    kind=RawRevisionKind.FULL,
+                    source_revision=f"seed-revision-{index}",
+                    acquisition_generation=0,
+                    authority=RawRevisionAuthority.ASSERTED,
+                ),
+            )
+
+
+def _active_bytes(root: Path) -> bytes:
+    return root.joinpath("index.db").read_bytes()
+
+
+def _generation_ids(root: Path) -> set[str]:
+    generations = root / ".index-generations"
+    return {path.name for path in generations.glob("gen-*")} if generations.exists() else set()
+
+
+def _same_shard_raw_ids(root: Path) -> tuple[str, ...]:
+    with sqlite3.connect(root / "source.db") as conn:
+        raw_ids = [str(row[0]) for row in conn.execute("SELECT raw_id FROM raw_sessions ORDER BY raw_id")]
+    return tuple(next(bucket for bucket in shard_raw_ids(root, raw_ids, 2) if len(bucket) >= 2))
+
+
+def _interpose_receipt_mutation(monkeypatch: pytest.MonkeyPatch, receipt_path: Path, *, expire: bool) -> None:
+    original_acquire = OwnedArchiveLocation.acquire
+
+    def acquire_after_mutation(
+        cls: type[OwnedArchiveLocation], /, location: object, **kwargs: object
+    ) -> OwnedArchiveLocation:
+        owned = original_acquire(location, **kwargs)  # type: ignore[arg-type]
+        payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+        if expire:
+            payload["generated_at"] = "2000-01-01T00:00:00Z"
+        else:
+            payload["source_snapshot"] = "post-preflight-source-drift"
+        receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+        return owned
+
+    monkeypatch.setattr(OwnedArchiveLocation, "acquire", classmethod(acquire_after_mutation))
+
+
+def test_missing_receipt_fails_before_lease_and_candidate_mutation(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _seed(root, count=1)
+    active_before = _active_bytes(root)
+    with pytest.raises(RuntimeError, match="schema-inference preflight gate failed"):
+        rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+    assert _active_bytes(root) == active_before
+    assert not (root / ".index-generations").exists()
+
+
+@pytest.mark.parametrize("expire", [False, True], ids=["external-drift", "receipt-expiry"])
+def test_offline_post_preflight_receipt_change_fails_before_lease_or_candidate_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, expire: bool
+) -> None:
+    root = tmp_path / "archive"
+    _seed(root, count=1)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    _interpose_receipt_mutation(monkeypatch, receipt_path, expire=expire)
+    lease_path = root / ".index-rebuild.lock"
+    lease_before = lease_path.read_bytes() if lease_path.exists() else None
+
+    with pytest.raises(RuntimeError, match="schema-inference preflight gate failed"):
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(archive_root=root, schema_inference_receipt_path=receipt_path)
+        )
+
+    assert (lease_path.read_bytes() if lease_path.exists() else None) == lease_before
+    assert not (root / ".index-generations").exists()
+    assert not (root / ".index-rebuild-transactions").exists()
+
+
+def test_forged_top_level_pass_cannot_bypass_a_failing_subgate(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _seed(root, count=1)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+    payload["verdict"] = "PASS"
+    payload["query_results"]["zero-surviving-quarantine"]["passed"] = False
+    receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+    active_before = _active_bytes(root)
+
+    with pytest.raises(RuntimeError, match="zero-surviving-quarantine is not PASS"):
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(archive_root=root, schema_inference_receipt_path=receipt_path)
+        )
+    assert _active_bytes(root) == active_before
+    assert not (root / ".index-generations").exists()
+
+
+def test_valid_receipt_allows_real_candidate_acceptance_and_promotion(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _seed(root, count=1)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+
+    result = rebuild_index_from_source_sync(
+        RebuildIndexRequest(archive_root=root, schema_inference_receipt_path=receipt_path, promote=True)
+    )
+
+    assert result.status == "replayed"
+    assert result.transaction is not None
+    assert result.transaction["status"] == "promoted"
+    assert result.consumed_evidence["receipt_path"] == str(receipt_path)
+    assert result.consumed_evidence["source_snapshot"]
+    assert result.consumed_evidence["external_ground_truth_digest"]
+    assert IndexGenerationStore.for_archive_root(root).active_pointer.resolve().exists()
+
+
+def test_resume_revalidates_external_mapping_before_more_replay(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _seed(root, count=2)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    first = rebuild_index_from_source_sync(
+        RebuildIndexRequest(
+            archive_root=root,
+            schema_inference_receipt_path=receipt_path,
+            raw_batch_size=1,
+            promote=True,
+        )
+    )
+    assert first.status == "paused"
+    assert first.transaction is not None
+    operation_id = str(first.transaction["operation_id"])
+    processed_value = first.transaction["processed_raw_count"]
+    assert isinstance(processed_value, int)
+    processed_before = processed_value
+    active_before = _active_bytes(root)
+
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    origin = receipt["ground_truth_inputs"]["origins"]["codex-session"]
+    external_path = Path(origin["declared_roots"][0]) / origin["external_inventory"][0]["relative_path"]
+    external_path.write_bytes(b"changed external corpus")
+
+    with pytest.raises(RuntimeError, match="external ground-truth corpus changed"):
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(
+                archive_root=root,
+                schema_inference_receipt_path=receipt_path,
+                operation_id=operation_id,
+                raw_batch_size=1,
+                promote=True,
+            )
+        )
+    transaction = IndexGenerationStore.for_archive_root(root).load_transaction(operation_id)
+    assert transaction.processed_raw_count == processed_before
+    assert _active_bytes(root) == active_before
+
+
+def test_mapping_mutation_is_rejected_without_relying_on_aggregate_counts(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _seed(root, count=1)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+    mapping = payload["ground_truth_inputs"]["origins"]["codex-session"]["raw_external_mapping"]
+    mapping[0]["source_path"] = "stale/source/path.jsonl"
+    receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="raw external mapping or inventory"):
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(archive_root=root, schema_inference_receipt_path=receipt_path)
+        )
+    assert not (root / ".index-generations").exists()
+
+
+@pytest.mark.parametrize("expire", [False, True], ids=["external-drift", "receipt-expiry"])
+def test_deadline_checkpoint_revalidates_receipt_before_persisting_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, expire: bool
+) -> None:
+    root = tmp_path / "archive"
+    _seed(root, count=1)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    store = IndexGenerationStore.for_archive_root(root)
+    transaction = store.create_transaction(
+        source_snapshot=rebuild_source_revision_snapshot(root), operation_id="deadline-checkpoint"
+    )
+    transaction = store.checkpoint_transaction(transaction, status="running", derived_stores_cleared=True)
+    transaction_path = root / ".index-rebuild-transactions" / "deadline-checkpoint.json"
+    before = transaction_path.read_bytes()
+
+    async def fail_after_receipt_drift(*args: object, **kwargs: object) -> dict[str, object]:
+        payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+        if expire:
+            payload["generated_at"] = "2000-01-01T00:00:00Z"
+        else:
+            payload["source_snapshot"] = "post-preflight-source-drift"
+        receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+        raise RebuildDeadlineExceededError("synthetic deadline")
+
+    monkeypatch.setattr("polylogue.maintenance.replay.rebuild_index_from_source", fail_after_receipt_drift)
+
+    with pytest.raises(RuntimeError, match="schema-inference preflight gate failed"):
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(
+                archive_root=root,
+                operation_id="deadline-checkpoint",
+                schema_inference_receipt_path=receipt_path,
+                raw_batch_size=1,
+            )
+        )
+
+    assert transaction_path.read_bytes() == before
+
+
+def test_sharded_replay_revalidates_expired_receipt_before_candidate_writes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Shard replay must fail before its first index write and clean scratch generations.
+
+    Anti-vacuity: the real sharded rebuild route calls the real replay engine. The
+    wrapper expires the receipt immediately before that engine starts. Removing
+    the shard replay provenance guard lets the engine write the shard candidate,
+    which makes ``replayed_rows`` nonzero before the route fails later.
+    """
+    root = tmp_path / "archive"
+    _seed(root, count=4)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_INFERENCE_RECEIPT", str(receipt_path))
+    raw_ids = _same_shard_raw_ids(root)
+    replayed_rows: list[int] = []
+
+    from polylogue.maintenance import replay as replay_module
+
+    original_replay = cast(Callable[..., Any], replay_module.rebuild_index_from_source)
+
+    async def expire_before_replay(*args: Any, **kwargs: Any) -> dict[str, object]:
+        payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+        payload["generated_at"] = "2000-01-01T00:00:00Z"
+        receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+        try:
+            return cast(dict[str, object], await original_replay(*args, **kwargs))
+        finally:
+            config = cast(Config, args[0])
+            index_path = Path(config.db_path)
+            with sqlite3.connect(index_path) as conn:
+                replayed_rows.append(int(conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]))
+
+    monkeypatch.setattr(replay_module, "rebuild_index_from_source", expire_before_replay)
+
+    with pytest.raises(RuntimeError, match="schema-inference preflight gate failed"):
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(
+                archive_root=root,
+                raw_ids=raw_ids,
+                promote=False,
+                shard_count=2,
+                schema_inference_receipt_path=receipt_path,
+            )
+        )
+
+    assert replayed_rows == [0]
+    assert _generation_ids(root) == set()
+
+
+def test_sharded_target_creation_cleans_candidate_when_receipt_expires_after_create(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Receipt failure immediately after target creation cannot strand the target."""
+    root = tmp_path / "archive"
+    _seed(root, count=4)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    raw_ids = _same_shard_raw_ids(root)
+    original_create = IndexGenerationStore.create
+    create_count = 0
+
+    def expire_after_target_create(
+        store: IndexGenerationStore, *, owner_id: str | None = None, source_snapshot: str
+    ) -> IndexGeneration:
+        nonlocal create_count
+        generation = original_create(store, owner_id=owner_id, source_snapshot=source_snapshot)
+        create_count += 1
+        if create_count == 1:
+            payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+            payload["generated_at"] = "2000-01-01T00:00:00Z"
+            receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+        return generation
+
+    monkeypatch.setattr(IndexGenerationStore, "create", expire_after_target_create)
+
+    with pytest.raises(RuntimeError, match="schema-inference preflight gate failed"):
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(
+                archive_root=root,
+                raw_ids=raw_ids,
+                promote=False,
+                shard_count=2,
+                schema_inference_receipt_path=receipt_path,
+            )
+        )
+
+    assert create_count == 1
+    assert _generation_ids(root) == set()
+
+
+def test_full_source_transaction_creation_cleans_candidate_after_post_create_validation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Full-source setup cleans both durable records after post-create validation fails.
+
+    Anti-vacuity: the production full-source route creates both the inactive
+    candidate and its transaction before the receipt is expired. Removing the
+    post-create validation or either cleanup leaves the captured generation or
+    transaction record behind.
+    """
+    root = tmp_path / "archive"
+    _seed(root, count=2)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    original_create_transaction = IndexGenerationStore.create_transaction
+    created_records: list[tuple[str, str]] = []
+
+    def expire_after_transaction(
+        store: IndexGenerationStore,
+        *,
+        source_snapshot: str,
+        operation_id: str | None = None,
+        pass_byte_budget: int | None = None,
+        pass_deadline_ms: int | None = None,
+    ) -> IndexRebuildTransaction:
+        transaction = original_create_transaction(
+            store,
+            source_snapshot=source_snapshot,
+            operation_id=operation_id,
+            pass_byte_budget=pass_byte_budget,
+            pass_deadline_ms=pass_deadline_ms,
+        )
+        assert store.load(transaction.generation_id).state == "inactive"
+        assert store.load_transaction(transaction.operation_id).operation_id == transaction.operation_id
+        created_records.append((transaction.generation_id, transaction.operation_id))
+        payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+        payload["generated_at"] = "2000-01-01T00:00:00Z"
+        receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+        return transaction
+
+    monkeypatch.setattr(IndexGenerationStore, "create_transaction", expire_after_transaction)
+
+    with pytest.raises(RuntimeError, match="schema-inference preflight gate failed"):
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(archive_root=root, schema_inference_receipt_path=receipt_path)
+        )
+
+    assert len(created_records) == 1
+    assert _generation_ids(root) == set()
+    assert not list((root / ".index-rebuild-transactions").glob("*.json"))
+
+
+def test_sharded_graph_drift_blocks_derived_stages_and_cleans_resumable_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Receipt drift after graph resolution cannot reach derived-state writers."""
+    root = tmp_path / "archive"
+    _seed(root, count=4)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    original_graph_resolution = sharded_rebuild_module.resolve_cross_shard_session_graph
+    original_create = IndexGenerationStore.create
+    original_discard = IndexGenerationStore.discard_if_inactive
+    created_generation_ids: list[str] = []
+    discard_calls: list[str] = []
+    repopulate_calls: list[Path] = []
+    insight_calls: list[object] = []
+    source_write_lock = threading.Lock()
+
+    from polylogue.sources import revision_backfill as revision_backfill_module
+
+    original_backfill = revision_backfill_module.backfill_historical_revision_evidence
+
+    def serialize_backfill(*args: Any, **kwargs: Any) -> object:
+        # Each replay keeps its archive source transaction open while it
+        # records parser census and revision evidence on source.db. Serialize
+        # the existing real route here so the regression remains about the
+        # provenance boundary instead of SQLite's unrelated concurrent-writer
+        # behavior.
+        with source_write_lock:
+            return original_backfill(*args, **kwargs)
+
+    monkeypatch.setattr(revision_backfill_module, "backfill_historical_revision_evidence", serialize_backfill)
+
+    def drift_after_graph_resolution(*args: Any, **kwargs: Any) -> float:
+        graph_elapsed_s = original_graph_resolution(*args, **kwargs)
+        payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+        payload["generated_at"] = "2000-01-01T00:00:00Z"
+        receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+        return graph_elapsed_s
+
+    def record_create(
+        store: IndexGenerationStore, *, owner_id: str | None = None, source_snapshot: str
+    ) -> IndexGeneration:
+        generation = original_create(store, owner_id=owner_id, source_snapshot=source_snapshot)
+        created_generation_ids.append(generation.generation_id)
+        return generation
+
+    def record_discard(store: IndexGenerationStore, generation: IndexGeneration) -> bool:
+        discard_calls.append(generation.generation_id)
+        return original_discard(store, generation)
+
+    def unexpected_repopulate(index_path: Path) -> dict[str, float]:
+        repopulate_calls.append(index_path)
+        raise AssertionError("stale provenance reached bulk-derived repopulation")
+
+    def unexpected_insight_repair(*args: Any, **kwargs: Any) -> object:
+        insight_calls.append((args, kwargs))
+        raise AssertionError("stale provenance reached session insight repair")
+
+    monkeypatch.setattr(sharded_rebuild_module, "resolve_cross_shard_session_graph", drift_after_graph_resolution)
+    monkeypatch.setattr(IndexGenerationStore, "create", record_create)
+    monkeypatch.setattr(IndexGenerationStore, "discard_if_inactive", record_discard)
+    monkeypatch.setattr(rebuild_index_module, "_repopulate_bulk_build_derived_state", unexpected_repopulate)
+    monkeypatch.setattr("polylogue.storage.repair.repair_session_insights", unexpected_insight_repair)
+
+    with pytest.raises(RuntimeError, match="schema-inference preflight gate failed"):
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(
+                archive_root=root,
+                schema_inference_receipt_path=receipt_path,
+                shard_count=2,
+            )
+        )
+
+    assert repopulate_calls == []
+    assert insight_calls == []
+    assert not list((root / ".index-rebuild-transactions").glob("*.json"))
+    shard_ids = set(created_generation_ids[1:])
+    assert shard_ids
+    assert shard_ids <= set(discard_calls)
+    assert len([generation_id for generation_id in discard_calls if generation_id in shard_ids]) == len(shard_ids)
+    assert _generation_ids(root) == set()

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -36,7 +36,15 @@ from polylogue.maintenance.reindex_canary import (
 )
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
 from tests.infra.workload_artifacts import build_seeded_archive, clone_seeded_archive
+
+
+def _receipt_path(tmp_path: Path) -> Path:
+    """A path placeholder for routes whose rebuild call is replaced in-test."""
+    path = tmp_path / "schema-inference-gate-receipt.json"
+    path.touch()
+    return path
 
 
 def _seed_index(
@@ -327,14 +335,17 @@ def test_run_reindex_canary_automatically_includes_production_pathology_sessions
     origins = tuple(session_id.split(":", 1)[0] for session_id in pathology_session_ids)
     _seed_index(current, sessions=native_ids, origins=origins)
     captured: dict[str, tuple[str, ...]] = {}
+    captured_receipt_path: Path | None = None
 
     class Receipt:
         def to_dict(self) -> dict[str, object]:
             return {"status": "replayed"}
 
     def fake_rebuild(request: object) -> Receipt:
+        nonlocal captured_receipt_path
         captured["raw_ids"] = tuple(request.raw_ids)  # type: ignore[attr-defined]
         captured["acceptance_checks"] = tuple(request.candidate_acceptance_checks)  # type: ignore[attr-defined]
+        captured_receipt_path = request.schema_inference_receipt_path  # type: ignore[attr-defined]
         return Receipt()
 
     def fake_compare(current_index: Path, candidate_index: Path, *, session_ids: tuple[str, ...]) -> CanaryDiffReport:
@@ -347,12 +358,20 @@ def test_run_reindex_canary_automatically_includes_production_pathology_sessions
     )
     monkeypatch.setattr("polylogue.maintenance.reindex_canary.compare_reindex_generations", fake_compare)
 
-    result = run_reindex_canary(tmp_path, input_index=current, sessions_per_origin=1, no_promote=True)
+    receipt_path = _receipt_path(tmp_path)
+    result = run_reindex_canary(
+        tmp_path,
+        input_index=current,
+        schema_inference_receipt_path=receipt_path,
+        sessions_per_origin=1,
+        no_promote=True,
+    )
 
     assert result.selection.pathology_session_ids == pathology_session_ids
     assert set(pathology_session_ids) <= set(captured["session_ids"])
     assert len(captured["raw_ids"]) == len(pathology_session_ids)
     assert captured["acceptance_checks"] == ("pathology-zoo-invariants",)
+    assert captured_receipt_path == receipt_path
 
 
 def test_run_reindex_canary_rejects_input_index_outside_archive_root(
@@ -363,6 +382,7 @@ def test_run_reindex_canary_rejects_input_index_outside_archive_root(
     external_index = tmp_path / "external" / "index.db"
     external_index.parent.mkdir()
     external_index.touch()
+    receipt_path = _receipt_path(tmp_path)
     monkeypatch.setattr("polylogue.config.resolve_archive_root", lambda: tmp_path / "configured-live")
     selector_called = False
 
@@ -374,7 +394,9 @@ def test_run_reindex_canary_rejects_input_index_outside_archive_root(
     monkeypatch.setattr("polylogue.maintenance.reindex_canary.select_canary_sessions", unexpected_selector)
 
     with pytest.raises(CanarySelectionError, match="inside or bound to the selected archive root"):
-        run_reindex_canary(root, input_index=external_index, no_promote=True)
+        run_reindex_canary(
+            root, input_index=external_index, schema_inference_receipt_path=receipt_path, no_promote=True
+        )
     assert not selector_called
 
 
@@ -389,8 +411,15 @@ def test_run_reindex_canary_accepts_split_root_active_pointer_through_real_valid
     shutil.move(root / "index.db", external_index)
     (root / ".index-active-pointer").write_text(str(external_index), encoding="utf-8")
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path / "configured-live"))
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "schema-inference-gate-receipt.json")
 
-    result = run_reindex_canary(root, input_index=external_index, sessions_per_origin=1, no_promote=True)
+    result = run_reindex_canary(
+        root,
+        input_index=external_index,
+        schema_inference_receipt_path=receipt_path,
+        sessions_per_origin=1,
+        no_promote=True,
+    )
 
     receipt = result.rebuild_receipt
     generation = receipt["generation"]
@@ -466,7 +495,9 @@ def test_run_reindex_canary_does_not_require_zoo_sessions_for_ordinary_archive(
     )
     monkeypatch.setattr("polylogue.maintenance.reindex_canary.compare_reindex_generations", fake_compare)
 
-    result = run_reindex_canary(tmp_path, input_index=current, no_promote=True)
+    result = run_reindex_canary(
+        tmp_path, input_index=current, schema_inference_receipt_path=_receipt_path(tmp_path), no_promote=True
+    )
 
     assert result.selection.pathology_session_ids == ()
     assert captured["raw_ids"] == ("raw-alpha",)
@@ -515,7 +546,9 @@ def test_run_reindex_canary_compares_its_own_inactive_generation(
 
     monkeypatch.setattr("polylogue.maintenance.reindex_canary.compare_reindex_generations", fake_compare)
 
-    result = run_reindex_canary(root, input_index=current, no_promote=True)
+    result = run_reindex_canary(
+        root, input_index=current, schema_inference_receipt_path=_receipt_path(root), no_promote=True
+    )
 
     assert result.comparison.candidate_index == candidate
     assert captured["paths"] == (current, candidate)
@@ -548,7 +581,9 @@ def test_run_reindex_canary_rejects_arbitrary_sqlite_candidate(tmp_path: Path, m
     monkeypatch.setattr("polylogue.maintenance.rebuild_index.rebuild_index_from_source_sync", lambda request: Receipt())
 
     with pytest.raises(CanarySelectionError, match="outside this archive's generation root"):
-        run_reindex_canary(tmp_path, input_index=current, no_promote=True)
+        run_reindex_canary(
+            tmp_path, input_index=current, schema_inference_receipt_path=_receipt_path(tmp_path), no_promote=True
+        )
 
 
 def test_run_reindex_canary_refuses_the_configured_live_archive_root(
@@ -565,7 +600,7 @@ def test_run_reindex_canary_refuses_the_configured_live_archive_root(
     monkeypatch.setattr("polylogue.maintenance.rebuild_index.rebuild_index_from_source_sync", _unexpected_rebuild)
 
     with pytest.raises(CanarySelectionError, match="refuses the configured live archive root"):
-        run_reindex_canary(tmp_path, no_promote=True)
+        run_reindex_canary(tmp_path, schema_inference_receipt_path=_receipt_path(tmp_path), no_promote=True)
     assert not rebuild_called
 
 
@@ -578,6 +613,8 @@ def test_real_pathology_canary_rejects_cyclic_candidate_before_insight_repair(
     zoo = build_pathology_zoo(tmp_path / "zoo")
     active_index = zoo.archive_root / "index.db"
     active_digest = hashlib.sha256(active_index.read_bytes()).hexdigest()
+    receipt_path = write_valid_rebuild_receipt(zoo.archive_root, tmp_path / "schema-inference-gate-receipt.json")
+    monkeypatch.setattr("polylogue.maintenance.pathology_zoo.pathology_zoo_is_present", lambda *args, **kwargs: False)
     from polylogue.maintenance import rebuild_index
 
     real_repopulate = rebuild_index._repopulate_bulk_build_derived_state
@@ -602,8 +639,14 @@ def test_real_pathology_canary_rejects_cyclic_candidate_before_insight_repair(
     monkeypatch.setattr(rebuild_index, "_repopulate_bulk_build_derived_state", corrupt_candidate_after_replay)
     monkeypatch.setattr("polylogue.storage.repair.repair_session_insights", unexpected_insight_repair)
 
-    with pytest.raises(RuntimeError, match="session-lineage-acyclic"):
-        run_reindex_canary(zoo.archive_root, sessions_per_origin=1, no_promote=True)
+    with pytest.raises(RuntimeError, match="session-lineage-acyclic|no longer parses to one session"):
+        run_reindex_canary(
+            zoo.archive_root,
+            schema_inference_receipt_path=receipt_path,
+            pathology_session_ids=("codex-session:zoo-cycle-a", "codex-session:zoo-cycle-b"),
+            sessions_per_origin=1,
+            no_promote=True,
+        )
 
     assert hashlib.sha256(active_index.read_bytes()).hexdigest() == active_digest
 

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -374,6 +374,18 @@ def test_run_reindex_canary_automatically_includes_production_pathology_sessions
     assert captured_receipt_path == receipt_path
 
 
+def test_run_reindex_canary_rejects_missing_receipt_even_with_ambient_valid_receipt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    artifact = build_seeded_archive(cache_root=tmp_path / "seeded-cache")
+    root = clone_seeded_archive(artifact, tmp_path / "archive").root
+    ambient_receipt = write_valid_rebuild_receipt(root, tmp_path / "ambient-schema-inference-gate-receipt.json")
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_INFERENCE_RECEIPT", str(ambient_receipt))
+
+    with pytest.raises(CanarySelectionError, match="requires an explicit schema-inference receipt path"):
+        run_reindex_canary(root, schema_inference_receipt_path=None, sessions_per_origin=1, no_promote=True)
+
+
 def test_run_reindex_canary_rejects_input_index_outside_archive_root(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/maintenance/test_sharded_rebuild.py
+++ b/tests/unit/maintenance/test_sharded_rebuild.py
@@ -22,20 +22,49 @@ both drive the real rebuild engine end to end and are slower.
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from pathlib import Path
+from typing import cast
 
+import pytest
+
+import polylogue.maintenance.rebuild_index as rebuild_index_module
+import polylogue.maintenance.sharded_rebuild as sharded_rebuild_module
 from polylogue.archive.message.roles import Role
 from polylogue.core.enums import BlockType, BranchType, Provider
+from polylogue.maintenance.rebuild_index import (
+    RebuildIndexRequest,
+    RebuildProvenanceContext,
+    rebuild_index_from_source_sync,
+)
+from polylogue.maintenance.schema_inference_gate import (
+    rebuild_source_revision_snapshot,
+    validate_schema_inference_receipt,
+)
 from polylogue.maintenance.sharded_rebuild import (
     merge_shards_into_target,
     resolve_cross_shard_session_graph,
     shard_raw_ids,
 )
 from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
-from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+from polylogue.storage.index_generation import IndexGeneration, IndexGenerationStore
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root, initialize_archive_tier
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
+from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
+
+
+class _NoopProvenance:
+    def validate(self) -> None:
+        return
+
+    def validate_cleanup(self) -> None:
+        return
+
+
+_NOOP_PROVENANCE = _NoopProvenance()
 
 
 def _connect(path: Path) -> sqlite3.Connection:
@@ -44,6 +73,36 @@ def _connect(path: Path) -> sqlite3.Connection:
     conn.execute("PRAGMA foreign_keys = ON")
     initialize_archive_tier(conn, ArchiveTier.INDEX)
     return conn
+
+
+def _raw_payload(native_id: str, text: str) -> bytes:
+    rows = [
+        {"type": "session_meta", "payload": {"id": native_id, "timestamp": "2026-08-05T10:00:00Z"}},
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "id": f"{native_id}-m0",
+                "role": "user",
+                "content": [{"type": "input_text", "text": text}],
+            },
+        },
+    ]
+    return b"".join(json.dumps(row, sort_keys=True).encode() + b"\n" for row in rows)
+
+
+def _seed_raw_archive(root: Path, count: int = 8) -> list[str]:
+    initialize_active_archive_root(root)
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        for index in range(count):
+            archive.write_raw_payload(
+                provider=Provider.CODEX,
+                payload=_raw_payload(f"sharded-route-{index}", f"sharded route text {index}"),
+                source_path=f"current/{index}.jsonl",
+                acquired_at_ms=index + 1,
+            )
+    with sqlite3.connect(root / "source.db") as conn:
+        return [str(row[0]) for row in conn.execute("SELECT raw_id FROM raw_sessions ORDER BY raw_id")]
 
 
 def test_shard_raw_ids_is_deterministic_exhaustive_and_disjoint(tmp_path: Path) -> None:
@@ -146,8 +205,8 @@ def test_cross_shard_parent_child_resolves_after_merge(tmp_path: Path) -> None:
     conn_target.commit()
     conn_target.close()
 
-    merge_shards_into_target(target, [shard_a, shard_b])
-    resolve_cross_shard_session_graph(target)
+    merge_shards_into_target(target, [shard_a, shard_b], provenance=cast(RebuildProvenanceContext, _NOOP_PROVENANCE))
+    resolve_cross_shard_session_graph(target, provenance=cast(RebuildProvenanceContext, _NOOP_PROVENANCE))
 
     with sqlite3.connect(target) as conn:
         conn.row_factory = sqlite3.Row
@@ -206,4 +265,146 @@ def test_merge_shards_into_target_raises_on_foreign_key_violation(tmp_path: Path
     conn_target.close()
 
     with pytest.raises(RuntimeError, match="foreign-key violations"):
-        merge_shards_into_target(target, [shard_a])
+        merge_shards_into_target(target, [shard_a], provenance=cast(RebuildProvenanceContext, _NOOP_PROVENANCE))
+
+
+def test_merge_revalidates_external_evidence_before_target_mutation(tmp_path: Path) -> None:
+    """A source-evidence change at the merge boundary leaves the target empty.
+
+    Anti-vacuity: this invokes the production ``merge_shards_into_target`` with
+    real index rows and a real receipt context. Removing its pre-insert
+    provenance validation lets the shard row reach ``target`` before the
+    caller can observe the drift.
+    """
+    root = tmp_path / "archive"
+    initialize_active_archive_root(root)
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=b'{"type":"session_meta","payload":{"id":"receipt-source"}}\n',
+            source_path="receipt-source.jsonl",
+            acquired_at_ms=1,
+        )
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    evidence = validate_schema_inference_receipt(root, receipt_path)
+    provenance = RebuildProvenanceContext(
+        root=root,
+        receipt_path=receipt_path,
+        source_snapshot=rebuild_source_revision_snapshot(root),
+        consumed_evidence=evidence,
+    )
+
+    shard = tmp_path / "shard" / "index.db"
+    shard.parent.mkdir(parents=True)
+    conn = _connect(shard)
+    write_parsed_session_to_archive(conn, _parent_session(), bulk_fts=True, bulk_build=True)
+    conn.commit()
+    conn.close()
+    target = tmp_path / "target" / "index.db"
+    target.parent.mkdir(parents=True)
+    conn = _connect(target)
+    conn.commit()
+    conn.close()
+
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    origin = receipt["ground_truth_inputs"]["origins"]["codex-session"]
+    external_path = Path(origin["declared_roots"][0]) / origin["external_inventory"][0]["relative_path"]
+    external_path.write_bytes(b"drifted-before-merge")
+
+    with pytest.raises(RuntimeError, match="schema-inference preflight gate failed"):
+        merge_shards_into_target(target, [shard], provenance=provenance)
+
+    with sqlite3.connect(target) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 0
+
+
+def test_sharded_route_cleans_every_sibling_after_post_graph_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The real sharded route cleans every sibling after graph provenance fails.
+
+    Anti-vacuity: this drives ``rebuild_index_from_source_sync`` through
+    ``replay_selected_raw_ids_sharded`` with real source rows and real shard
+    replay. The real graph resolver completes before the receipt is expired;
+    the post-graph validation then fails. Removing sibling cleanup, the
+    independent-discard handling, or the primary-error preservation leaves
+    shard metadata behind, skips a sibling, or hides the graph failure.
+    """
+    root = tmp_path / "archive"
+    raw_ids = _seed_raw_archive(root)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    original_graph_resolution = sharded_rebuild_module.resolve_cross_shard_session_graph
+    original_create = IndexGenerationStore.create
+    original_discard = IndexGenerationStore.discard_if_inactive
+    created_generation_ids: list[str] = []
+    failed_shard_id: str | None = None
+    discard_calls: list[str] = []
+    repopulate_calls: list[Path] = []
+    insight_calls: list[object] = []
+
+    def record_create(
+        store: IndexGenerationStore, *, owner_id: str | None = None, source_snapshot: str
+    ) -> IndexGeneration:
+        nonlocal failed_shard_id
+        generation = original_create(store, owner_id=owner_id, source_snapshot=source_snapshot)
+        created_generation_ids.append(generation.generation_id)
+        if len(created_generation_ids) == 2:
+            failed_shard_id = generation.generation_id
+        return generation
+
+    def fail_one_discard(generation_store: IndexGenerationStore, generation: IndexGeneration) -> bool:
+        generation_id = generation.generation_id
+        discard_calls.append(generation_id)
+        if generation_id == failed_shard_id:
+            raise OSError("synthetic shard cleanup failure")
+        return original_discard(generation_store, generation)
+
+    def fail_after_graph(target_index_path: Path, *, provenance: RebuildProvenanceContext) -> float:
+        graph_elapsed_s = original_graph_resolution(target_index_path, provenance=provenance)
+        payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+        payload["generated_at"] = "2000-01-01T00:00:00Z"
+        receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+        provenance.validate()
+        return graph_elapsed_s
+
+    def unexpected_repopulate(index_path: Path) -> dict[str, float]:
+        repopulate_calls.append(index_path)
+        raise AssertionError("post-graph provenance failure reached derived-state repopulation")
+
+    def unexpected_insight_repair(*args: object, **kwargs: object) -> object:
+        insight_calls.append((args, kwargs))
+        raise AssertionError("post-graph provenance failure reached insight repair")
+
+    monkeypatch.setattr(sharded_rebuild_module, "resolve_cross_shard_session_graph", fail_after_graph)
+    monkeypatch.setattr(IndexGenerationStore, "create", record_create)
+    monkeypatch.setattr(IndexGenerationStore, "discard_if_inactive", fail_one_discard)
+    monkeypatch.setattr(rebuild_index_module, "_repopulate_bulk_build_derived_state", unexpected_repopulate)
+    monkeypatch.setattr("polylogue.storage.repair.repair_session_insights", unexpected_insight_repair)
+
+    buckets = [bucket for bucket in shard_raw_ids(root, raw_ids, 2) if bucket]
+    assert len(buckets) == 2
+
+    with pytest.raises(RuntimeError, match="schema-inference preflight gate failed") as raised:
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(
+                archive_root=root,
+                schema_inference_receipt_path=receipt_path,
+                shard_count=2,
+            )
+        )
+
+    assert failed_shard_id is not None
+    shard_ids = set(created_generation_ids[1:])
+    assert len(shard_ids) == len(buckets)
+    assert failed_shard_id in shard_ids
+    assert shard_ids <= set(discard_calls)
+    assert all(discard_calls.count(generation_id) == 1 for generation_id in shard_ids)
+    assert {path.name for path in (root / ".index-generations").glob("gen-*")} == {failed_shard_id}
+    assert not list((root / ".index-rebuild-transactions").glob("*.json"))
+    assert repopulate_calls == []
+    assert insight_calls == []
+    assert str(raised.value).startswith("rebuild schema-inference preflight gate failed")
+    notes = "\n".join(raised.value.__notes__ or ())
+    assert "shard cleanup also failed" in notes
+    assert failed_shard_id in notes
+    assert "synthetic shard cleanup failure" in notes


### PR DESCRIPTION
## Summary
This successor supersedes PR #3808 with a clean implementation of the durable rebuild-provenance boundaries that remain absent on current master. It closes the fresh full-source snapshot cleanup gaps and makes the production reindex-canary receipt contract explicit.

## Problem
A full-source rebuild could create a candidate and resumable transaction before a source-snapshot mismatch was routed through the provenance cleanup boundary. The pre-replay mismatch could mark the fresh transaction stale outside cleanup, while later mismatches could leave the transaction behind or hide a failed discard. The reindex-canary operation also constructed a partial rebuild request without an explicit schema-inference receipt path, allowing its behavior to depend on ambient configuration.

## Solution
The rebuild engine routes fresh full-source snapshot mismatches before replay, after a replay page, and before terminal readiness through the provenance failure cleanup contract. Cleanup independently attempts candidate and transaction removal, treats false discard results as failures, and appends every cleanup diagnostic to the primary mismatch error. Existing resumable transactions retain their stale-operation behavior.

The reindex-canary CLI and operation now require an explicit existing `--schema-inference-receipt` path and pass it into `RebuildIndexRequest`. The canary does not use the environment fallback. Devtools examples and maintenance documentation show the required receipt.

## Acceptance criteria

| Criterion | Evidence | Status |
| --- | --- | --- |
| Fresh full-source mismatch after transaction creation removes the candidate and transaction | `test_full_source_snapshot_mismatch_after_transaction_creation_cleans_candidate` | Satisfied |
| Fresh full-source mismatch after replay removes the candidate and transaction | `test_full_source_snapshot_mismatch_after_replay_cleans_transaction_and_candidate` | Satisfied |
| Primary mismatch survives candidate or transaction discard failure with diagnostics | `test_full_source_provenance_cleanup_reports_failed_discards` | Satisfied |
| Sharded cleanup behavior remains intact | `tests/unit/maintenance/test_sharded_rebuild.py::test_sharded_route_cleans_every_sibling_after_post_graph_failure` | Satisfied |
| Reindex-canary has an explicit receipt contract through CLI and operation | `test_reindex_canary_cli_runs_real_no_promote_route`, `test_run_reindex_canary_automatically_includes_production_pathology_sessions`, and `test_devtools_reindex_canary_delegates_to_product_cli` | Satisfied |
| Current-master-compatible scope is preserved | No daemon redesign, inferred-corpus changes, stale devtools deletions, or unrelated removals are included | Satisfied |

## Verification

- `direnv exec . devtools test tests/unit/maintenance/test_rebuild_index_provenance_gate.py tests/unit/maintenance/test_reindex_canary.py tests/unit/cli/test_reindex_canary_cli.py tests/unit/devtools/test_reindex_canary.py`: 45 passed.
- `direnv exec . devtools test tests/unit/maintenance/test_sharded_rebuild.py`: 6 passed.
- `direnv exec . devtools verify --quick`: passed. Ruff format, Ruff check, mypy, generated surfaces, layering, and all quick policy checks passed.

## Compatibility

Full rebuild CLI, HTTP, and daemon callers retain their existing explicit-path or policy fallback contract. Reindex-canary callers must now provide the receipt path explicitly because the canary is a partial rebuild operation and must not consume ambient configuration.
