### PR TITLE
fix(reindex): gate on raw failure lifecycle evidence

### DIFF
--- a/devtools/preflight_ledger.py
+++ b/devtools/preflight_ledger.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from polylogue.config import Config
 from polylogue.storage.archive_readiness import probe_archive_tier, raw_materialization_readiness_snapshot
 from polylogue.storage.fts.fts_lifecycle import fts_invariant_snapshot_sync
+from polylogue.storage.raw_failure_lifecycle import read_raw_failure_lifecycle
 from polylogue.storage.raw_retention import raw_frontier_integrity_projection
 from polylogue.storage.repair import raw_materialization_replay_backlog
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
@@ -496,6 +497,31 @@ def _convergence_preflight(root: Path) -> dict[str, object]:
     )
 
 
+def _raw_failure_preflight(root: Path, *, limit: int) -> dict[str, object]:
+    """Project typed lifecycle evidence into the stopped-daemon ledger."""
+    snapshot = read_raw_failure_lifecycle(root / "source.db", sample_limit=limit)
+    if not snapshot.available:
+        return _status(
+            state="unknown",
+            reason=snapshot.reason or "raw failure lifecycle unavailable",
+            available=False,
+            evidence=snapshot.to_dict(),
+        )
+    state = "fail" if snapshot.unexplained else "warn" if snapshot.deferred or snapshot.terminal else "pass"
+    return _status(
+        state=state,
+        reason=(
+            "raw failures lack typed lifecycle evidence"
+            if snapshot.unexplained
+            else "raw failures are classified as deferred or terminal"
+            if snapshot.deferred or snapshot.terminal
+            else None
+        ),
+        available=True,
+        evidence=snapshot.to_dict(),
+    )
+
+
 def build_preflight_ledger(root: Path, *, limit: int = 10, now: datetime | None = None) -> dict[str, object]:
     """Build a read-only preflight ledger from the deployed archive relations."""
     checks = {
@@ -506,6 +532,7 @@ def build_preflight_ledger(root: Path, *, limit: int = 10, now: datetime | None 
         "source_frontier": _frontier_preflight(root),
         "replay_backlog": _replay_preflight(root, limit=limit),
         "cursor_failures": _cursor_preflight(root, now=now, limit=limit),
+        "raw_failure_lifecycle": _raw_failure_preflight(root, limit=limit),
         "convergence_debt": _convergence_preflight(root),
     }
     states = [str(value.get("state")) for value in checks.values()]

--- a/docs/plans/degrade-loudly-allowlist.yaml
+++ b/docs/plans/degrade-loudly-allowlist.yaml
@@ -263,13 +263,6 @@ entries:
   reason: 'Internal fallback: None triggers the local-DB query in the caller (_live_ingest_attempt_summary_info),
     which now logs on its own failure (fixed in this sweep).'
 - path: polylogue/daemon/status.py
-  function: <module>._archive_raw_failure_info
-  exceptions:
-  - Error
-  occurrence: 0
-  reason: 'Internal fallback: None triggers the local-DB query in the caller (_raw_failure_info), which
-    now logs on its own failure (fixed in this sweep).'
-- path: polylogue/daemon/status.py
   function: <module>._raw_replay_backlog_info
   exceptions:
   - Exception

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -1199,9 +1199,11 @@ def status_command(
             obs.attributes["daemon_reachable"] = True
             obs.daemon_path = "daemon"
             if output_format == "json":
-                _show_status_json(env, result, full=full_payload)
+                status_ok = _show_status_json(env, result, full=full_payload)
             else:
-                _show_daemon_status(env, result)
+                status_ok = _show_daemon_status(env, result)
+            if not status_ok:
+                raise click.exceptions.Exit(1)
             return
 
         obs.attributes["daemon_reachable"] = False
@@ -1210,14 +1212,20 @@ def status_command(
             if any(_daemon_live(url, timeout=_FAST_TIMEOUT_S) for url in candidate_urls):
                 obs.status = "degraded"
                 _show_daemon_status_unavailable_json(env)
+                raise click.exceptions.Exit(1)
             else:
-                _show_direct_json(env, full=full_payload, include_archive_readiness=exact_archive_readiness)
+                status_ok = _show_direct_json(env, full=full_payload, include_archive_readiness=exact_archive_readiness)
+                if not status_ok:
+                    raise click.exceptions.Exit(1)
         else:
             if any(_daemon_live(url, timeout=_FAST_TIMEOUT_S) for url in candidate_urls):
                 obs.status = "degraded"
                 _show_daemon_status_unavailable(env)
+                raise click.exceptions.Exit(1)
             else:
-                _show_direct_status(env, include_archive_readiness=exact_archive_readiness)
+                status_ok = _show_direct_status(env, include_archive_readiness=exact_archive_readiness)
+                if not status_ok:
+                    raise click.exceptions.Exit(1)
     return
 
 
@@ -1249,7 +1257,7 @@ def show_fast_status(env: AppEnv, *, daemon_url: str | None = None) -> None:
         _show_direct_status(env, compact=True)
 
 
-def _show_daemon_status(env: AppEnv, status: dict[str, Any], *, compact: bool = False) -> None:
+def _show_daemon_status(env: AppEnv, status: dict[str, Any], *, compact: bool = False) -> bool:
     """Render daemon status from the real DaemonStatus payload."""
     status = normalize_raw_frontier_status_payload(status, require_fresh_snapshot=True)
     liveness = status.get("daemon_liveness", False)
@@ -1353,17 +1361,25 @@ def _show_daemon_status(env: AppEnv, status: dict[str, Any], *, compact: bool = 
             f" [{fail_color}]({raw_parse} parse + {raw_val} validation)[/{fail_color}]"
         )
 
+    if not _raw_failure_lifecycle_is_healthy(status):
+        lifecycle_state = str(status.get("raw_failure_lifecycle_state") or "unavailable")
+        lifecycle_reason = str(status.get("raw_failure_lifecycle_reason") or "source.db evidence is unavailable")
+        if total_raw == 0 or lifecycle_state in {"unavailable", "blocked"}:
+            env.ui.console.print(f"  Raw failure lifecycle: [{lifecycle_state}] {lifecycle_reason}")
+
     if not compact:
         checked = status.get("checked_at", "")
         if checked:
             env.ui.console.print(f"\n  [dim]Checked: {checked}[/dim]")
+    return overall_ok
 
 
-def _show_status_json(env: AppEnv, status: dict[str, Any], *, full: bool = False) -> None:
+def _show_status_json(env: AppEnv, status: dict[str, Any], *, full: bool = False) -> bool:
     """Machine-readable JSON status output."""
     normalized = normalize_raw_frontier_status_payload(status, require_fresh_snapshot=True)
     payload = normalized if full else _compact_status_payload(normalized, source="daemon")
     env.ui.console.print(json.dumps(payload, indent=2, default=str))
+    return _status_ok(normalized, require_fresh_snapshot=True)
 
 
 def _compact_status_payload(status: dict[str, Any], *, source: str) -> dict[str, Any]:
@@ -1482,7 +1498,7 @@ def _status_ok(status: dict[str, Any], *, require_fresh_snapshot: bool = False) 
         return False
     if isinstance(snapshot, dict) and snapshot.get("state") not in {None, "fresh"}:
         return False
-    if status.get("raw_failure_lifecycle_available") is False:
+    if not _raw_failure_lifecycle_is_healthy(status):
         return False
     return ok and raw_frontier_integrity_is_proven_healthy(status.get("raw_frontier_integrity"))
 
@@ -1600,6 +1616,17 @@ def _compact_raw_failure_status(status: dict[str, Any]) -> dict[str, Any]:
     return failures
 
 
+def _raw_failure_lifecycle_is_healthy(status: dict[str, Any]) -> bool:
+    """Require explicit, clean source-tier lifecycle evidence for green status."""
+    return (
+        status.get("raw_failure_lifecycle_available") is True
+        and status.get("raw_failure_lifecycle_state") == "healthy"
+        and status.get("raw_parse_failures") == 0
+        and status.get("raw_validation_failures") == 0
+        and status.get("raw_unexplained_failures") == 0
+    )
+
+
 def _direct_raw_failure_status(root: Path) -> dict[str, Any]:
     """Adapt the archive raw-failure ledger for the stopped-daemon surface."""
     from polylogue.daemon.status import raw_failure_info_for_root
@@ -1653,7 +1680,7 @@ def _show_direct_json(
     *,
     full: bool = False,
     include_archive_readiness: bool = False,
-) -> None:
+) -> bool:
     """Machine-readable JSON fallback when daemon is not running."""
     from polylogue.cli.commands.init import starter_config_path
     from polylogue.cli.commands.status_diagnostics import (
@@ -1690,8 +1717,7 @@ def _show_direct_json(
     )
     schema_drift = schema_drift_status(active_root, now_ms=int(time.time() * 1000))
     payload: dict[str, Any] = {
-        "ok": _direct_status_ok(component_readiness)
-        and raw_failure_status.get("raw_failure_lifecycle_available") is not False,
+        "ok": _direct_status_ok(component_readiness) and _raw_failure_lifecycle_is_healthy(raw_failure_status),
         "daemon_liveness": False,
         "archive_root": str(root),
         "active_archive_root": str(active_root),
@@ -1745,6 +1771,7 @@ def _show_direct_json(
         else _compact_status_payload(normalized_payload, source="direct")
     )
     env.ui.console.print(json.dumps(output, indent=2, default=str))
+    return _status_ok(normalized_payload)
 
 
 def _component_computation_failure(component: str, exc: Exception, *, scope: str = "archive") -> dict[str, Any]:
@@ -2246,7 +2273,7 @@ def _show_direct_status(
     *,
     compact: bool = False,
     include_archive_readiness: bool = False,
-) -> None:
+) -> bool:
     """Fallback status when daemon is not running."""
     from polylogue.cli.commands.status_diagnostics import diagnose_first_run
     from polylogue.paths import archive_root, db_path
@@ -2257,7 +2284,7 @@ def _show_direct_status(
     if active_db is None or not active_db.exists():
         diag = diagnose_first_run(daemon_alive=False)
         _render_diagnostic(env, diag)
-        return
+        return False
     # An index-only external generation's active_db can live outside the
     # configured root (polylogue-yla8.1 split-root contract); source.db must
     # then resolve against the active db's own directory, not the configured
@@ -2271,7 +2298,7 @@ def _show_direct_status(
         diag = diagnose_first_run(daemon_alive=False)
         if diag.kind in {"schema_mismatch", "locked_db", "stale_pidfile"}:
             _render_diagnostic(env, diag)
-            return
+            return False
 
     try:
         from polylogue.storage.sqlite.connection_profile import open_readonly_connection
@@ -2355,6 +2382,7 @@ def _show_direct_status(
         env.ui.console.print(f"  Messages: {msgs:,}")
         env.ui.console.print(f"  Raw records: {raw:,}")
         raw_failure_status = _direct_raw_failure_status(root)
+        raw_lifecycle_healthy = _raw_failure_lifecycle_is_healthy(raw_failure_status)
         raw_total = (
             raw_failure_status["raw_parse_failures"]
             + raw_failure_status["raw_validation_failures"]
@@ -2367,6 +2395,12 @@ def _show_direct_status(
                 f"{raw_failure_status['raw_terminal_rejections']:,} terminal, "
                 f"{raw_failure_status['raw_unexplained_failures']:,} unexplained"
             )
+        if not raw_lifecycle_healthy and (
+            not raw_total or raw_failure_status["raw_failure_lifecycle_state"] in {"unavailable", "blocked"}
+        ):
+            lifecycle_state = raw_failure_status["raw_failure_lifecycle_state"] or "unavailable"
+            lifecycle_reason = raw_failure_status["raw_failure_lifecycle_reason"] or "source.db evidence is unavailable"
+            env.ui.console.print(f"  Raw failure lifecycle: [{lifecycle_state}] {lifecycle_reason}")
         if unidentified:
             env.ui.console.print(
                 f"  Unidentified artifacts: [yellow]{unidentified:,}[/yellow] "
@@ -2395,10 +2429,11 @@ def _show_direct_status(
             diag = diagnose_first_run(daemon_alive=False)
             if diag.kind in {"no_sources", "no_daemon", "missing_optional_dep"}:
                 _render_diagnostic(env, diag)
-                return
+                return raw_lifecycle_healthy
 
         if not compact and not actively_ingesting:
             env.ui.console.print("\n  [dim]Run [bold]polylogued run[/bold] to start the daemon.[/dim]")
+        return raw_lifecycle_healthy
     except Exception as exc:
         # markup=False: raw exception text may contain [brackets] Rich would
         # otherwise parse as style tags and crash on, hiding the error.
@@ -2407,6 +2442,7 @@ def _show_direct_status(
             style="yellow",
             markup=False,
         )
+        return False
 
 
 def _render_archive_readiness(env: AppEnv, readiness: dict[str, Any]) -> None:

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -1482,6 +1482,8 @@ def _status_ok(status: dict[str, Any], *, require_fresh_snapshot: bool = False) 
         return False
     if isinstance(snapshot, dict) and snapshot.get("state") not in {None, "fresh"}:
         return False
+    if status.get("raw_failure_lifecycle_available") is False:
+        return False
     return ok and raw_frontier_integrity_is_proven_healthy(status.get("raw_frontier_integrity"))
 
 
@@ -1587,6 +1589,9 @@ def _compact_raw_failure_status(status: dict[str, Any]) -> dict[str, Any]:
         "terminal_rejections": "raw_terminal_rejections",
         "unexplained": "raw_unexplained_failures",
         "detection_warnings": "raw_detection_warnings",
+        "lifecycle_available": "raw_failure_lifecycle_available",
+        "lifecycle_state": "raw_failure_lifecycle_state",
+        "lifecycle_reason": "raw_failure_lifecycle_reason",
     }
     failures = {label: status[key] for label, key in keys.items() if key in status}
     samples = status.get("raw_failure_samples")
@@ -1608,6 +1613,9 @@ def _direct_raw_failure_status(root: Path) -> dict[str, Any]:
         "raw_deferred_failures": _safe_int(info.get("deferred_failures")),
         "raw_terminal_rejections": _safe_int(info.get("terminal_rejections")),
         "raw_unexplained_failures": _safe_int(info.get("unexplained_failures")),
+        "raw_failure_lifecycle_available": info.get("raw_failure_lifecycle_available"),
+        "raw_failure_lifecycle_state": info.get("raw_failure_lifecycle_state"),
+        "raw_failure_lifecycle_reason": info.get("raw_failure_lifecycle_reason"),
         "raw_failure_samples": info.get("samples", []),
     }
 
@@ -1666,6 +1674,7 @@ def _show_direct_json(
     )
     raw_materialization_readiness = _direct_raw_materialization_readiness(active_root)
     raw_frontier_integrity = _direct_raw_frontier_integrity(active_root, raw_materialization_readiness)
+    raw_failure_status = _direct_raw_failure_status(root)
     component_readiness = _direct_component_readiness(
         env,
         active_root=active_root,
@@ -1681,7 +1690,8 @@ def _show_direct_json(
     )
     schema_drift = schema_drift_status(active_root, now_ms=int(time.time() * 1000))
     payload: dict[str, Any] = {
-        "ok": _direct_status_ok(component_readiness),
+        "ok": _direct_status_ok(component_readiness)
+        and raw_failure_status.get("raw_failure_lifecycle_available") is not False,
         "daemon_liveness": False,
         "archive_root": str(root),
         "active_archive_root": str(active_root),
@@ -1714,7 +1724,7 @@ def _show_direct_json(
         "next_action": diag.next_action,
         "diagnostic": diagnostic_payload(diag),
     }
-    payload.update(_direct_raw_failure_status(root))
+    payload.update(raw_failure_status)
     if active_db is not None and active_db.exists():
         payload["active_db_path"] = str(active_db)
         try:

--- a/polylogue/daemon/bulk_rebuild.py
+++ b/polylogue/daemon/bulk_rebuild.py
@@ -44,6 +44,7 @@ from typing import TYPE_CHECKING
 
 from polylogue.config import Config
 from polylogue.logging import get_logger
+from polylogue.maintenance.archive_verification import read_raw_failure_lifecycle
 from polylogue.storage.archive_identity import ArchiveLocation, OwnedArchiveLocation, assert_owns_archive_location
 from polylogue.storage.index_generation import (
     IndexGenerationStore,
@@ -82,6 +83,18 @@ DAEMON_BULK_REBUILD_BATCH_SIZE = 500
 _TERMINAL_NOT_RESUMABLE = frozenset({"promoted", "stale", "failed"})
 
 
+def _preflight_raw_failure_lifecycle(root: Path) -> None:
+    """Refuse daemon rebuild mutation while raw failures are unexplained."""
+    snapshot = read_raw_failure_lifecycle(root / "source.db", sample_limit=10)
+    if not snapshot.blocking:
+        return
+    if snapshot.available:
+        reason = f"{snapshot.unexplained} raw failure(s) lack matching typed lifecycle evidence"
+    else:
+        reason = snapshot.reason or "raw failure lifecycle is unavailable"
+    raise RuntimeError(f"daemon bulk-rebuild raw failure lifecycle preflight failed: {reason}")
+
+
 def resolve_or_start_daemon_bulk_rebuild_transaction(root: Path) -> IndexRebuildTransaction:
     """Load the daemon's resumable bulk-rebuild transaction, starting one if needed.
 
@@ -100,6 +113,12 @@ def resolve_or_start_daemon_bulk_rebuild_transaction(root: Path) -> IndexRebuild
     generation directory, so both must fail closed against a foreign/rotated
     archive location before touching disk, not just the eventual write pass.
     """
+    # This must precede transaction resolution, because retiring a terminal
+    # transaction and creating its replacement also creates generation state.
+    # It must also precede the caller's page selection for a resumed
+    # transaction, so no raw is selected while the source failure universe is
+    # not in a known lifecycle state.
+    _preflight_raw_failure_lifecycle(root)
     location = ArchiveLocation.resolve(root)
     store = IndexGenerationStore(location)
     transaction: IndexRebuildTransaction | None

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -2865,11 +2865,14 @@ def status_command(spool_path: Path | None, output_format: str | None) -> None:
                 browser_capture_spool_path=spool_path,
                 include_browser_capture_spool_path=spool_path is not None,
             )
+    status_ok = payload.get("ok") is True
     if output_format == "json":
         click.echo(dumps(payload))
-        return
-    for line in format_daemon_status_lines(payload):
-        click.echo(line)
+    else:
+        for line in format_daemon_status_lines(payload):
+            click.echo(line)
+    if not status_ok:
+        raise SystemExit(1)
 
 
 @main.command("health", help="Run tiered daemon health checks.")

--- a/polylogue/daemon/health.py
+++ b/polylogue/daemon/health.py
@@ -670,6 +670,16 @@ def _check_raw_failures_medium() -> HealthAlert:
         from polylogue.daemon.status import _raw_failure_info
 
         info = _raw_failure_info()
+        if info.get("raw_failure_lifecycle_available") is False:
+            reason = str(info.get("raw_failure_lifecycle_reason") or "source.db evidence is unavailable")
+            return HealthAlert(
+                check_name="raw_failures",
+                tier=HealthTier.MEDIUM,
+                severity=HealthSeverity.ERROR,
+                message=f"raw failure lifecycle unavailable: {reason}",
+                checked_at=now,
+                consecutive_failures=_record_failure("raw_failures", False),
+            )
         raw_parse = info.get("parse_failures", 0)
         parse = int(raw_parse) if isinstance(raw_parse, (int, float)) else 0
         raw_val = info.get("validation_failures", 0)

--- a/polylogue/daemon/health.py
+++ b/polylogue/daemon/health.py
@@ -670,13 +670,26 @@ def _check_raw_failures_medium() -> HealthAlert:
         from polylogue.daemon.status import _raw_failure_info
 
         info = _raw_failure_info()
-        if info.get("raw_failure_lifecycle_available") is False:
+        lifecycle_available = info.get("raw_failure_lifecycle_available") is True
+        lifecycle_state = info.get("raw_failure_lifecycle_state")
+        if not lifecycle_available or lifecycle_state not in {"healthy", "degraded", "blocked"}:
             reason = str(info.get("raw_failure_lifecycle_reason") or "source.db evidence is unavailable")
             return HealthAlert(
                 check_name="raw_failures",
                 tier=HealthTier.MEDIUM,
                 severity=HealthSeverity.ERROR,
                 message=f"raw failure lifecycle unavailable: {reason}",
+                checked_at=now,
+                consecutive_failures=_record_failure("raw_failures", False),
+            )
+        if lifecycle_state == "blocked":
+            unexplained = info.get("unexplained_failures")
+            reason = str(info.get("raw_failure_lifecycle_reason") or f"{unexplained or 0} unexplained raw failures")
+            return HealthAlert(
+                check_name="raw_failures",
+                tier=HealthTier.MEDIUM,
+                severity=HealthSeverity.ERROR,
+                message=f"raw failure lifecycle blocked: {reason}",
                 checked_at=now,
                 consecutive_failures=_record_failure("raw_failures", False),
             )

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -2692,21 +2692,40 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         except (OSError, sqlite3.Error):
             quick_check_ok = False
 
+        from polylogue.daemon.status import raw_failure_lifecycle_for_root
+
+        raw_lifecycle = raw_failure_lifecycle_for_root(archive_root())
+        raw_lifecycle_payload = {
+            "available": raw_lifecycle.available,
+            "state": raw_lifecycle.state,
+            "reason": raw_lifecycle.reason,
+            "parse_failures": raw_lifecycle.parse_failures,
+            "validation_failures": raw_lifecycle.validation_failures,
+            "deferred": raw_lifecycle.deferred,
+            "terminal": raw_lifecycle.terminal,
+            "unexplained": raw_lifecycle.unexplained,
+        }
+        archive_health_ok = quick_check_ok and raw_lifecycle.healthy
+
         overview: dict[str, object] = {
-            "ok": quick_check_ok,
+            "ok": archive_health_ok,
             "db_size_bytes": db_size,
             "wal_size_bytes": wal_size,
             "disk_free_bytes": disk_free,
             "blob_dir_size_bytes": 0,
             "quick_check": "pass" if quick_check_ok else "error",
             "quick_check_age_s": None,
+            "raw_failure_lifecycle_available": raw_lifecycle.available,
+            "raw_failure_lifecycle_state": raw_lifecycle.state,
+            "raw_failure_lifecycle_reason": raw_lifecycle.reason,
+            "raw_failure_lifecycle": raw_lifecycle_payload,
             "archive_root": str(load_polylogue_config().archive_root),
             "index_schema_version": INDEX_SCHEMA_VERSION,
             "daemon_version": POLYLOGUE_VERSION,
             "commit": VERSION_INFO.commit,
             "started_at": getattr(self.server, "started_at", None),
         }
-        self._send_json(HTTPStatus.OK, overview)
+        self._send_json(HTTPStatus.OK if archive_health_ok else HTTPStatus.SERVICE_UNAVAILABLE, overview)
 
     # ------------------------------------------------------------------
     # Handlers: status

--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import contextlib
 import json
 import os
 import re
@@ -493,6 +492,9 @@ class DaemonStatus(BaseModel):
     raw_deferred_failures: int = 0
     raw_terminal_rejections: int = 0
     raw_unexplained_failures: int = 0
+    raw_failure_lifecycle_available: bool | None = None
+    raw_failure_lifecycle_state: Literal["healthy", "degraded", "blocked", "unavailable"] | None = None
+    raw_failure_lifecycle_reason: str | None = None
     raw_failure_samples: list[RawFailureSample] = Field(default_factory=list)
     raw_detection_warnings: int = 0
     health: DaemonHealth = Field(default_factory=DaemonHealth)
@@ -838,149 +840,37 @@ def _raw_failure_info() -> dict[str, object]:
     re-querying.
     """
     root = archive_root()
-    dbf = _active_status_db_path()
     source_db = root / "source.db"
     maintenance_samples, maintenance_count = _maintenance_failure_info()
-    if not dbf.exists():
-        archive_info = _archive_raw_failure_info(
-            source_db,
-            maintenance_samples=maintenance_samples,
-            maintenance_count=maintenance_count,
-        )
-        if archive_info is not None:
-            return archive_info
-        return {
-            "parse_failures": 0,
-            "validation_failures": 0,
-            "quarantined": 0,
-            "maintenance_failures": maintenance_count,
-            "deferred_failures": 0,
-            "terminal_rejections": 0,
-            "unexplained_failures": 0,
-            "samples": maintenance_samples,
-        }
     archive_info = _archive_raw_failure_info(
         source_db,
         maintenance_samples=maintenance_samples,
         maintenance_count=maintenance_count,
     )
-    if source_db.exists() and archive_info is not None:
-        return archive_info
+    return archive_info
 
-    try:
-        conn = open_readonly_connection(dbf)
-        try:
-            tables = {
-                row[0]
-                for row in conn.execute(
-                    "SELECT name FROM sqlite_master WHERE type='table' AND name='raw_sessions'"
-                ).fetchall()
-            }
-            if "raw_sessions" not in tables:
-                return {
-                    "parse_failures": 0,
-                    "validation_failures": 0,
-                    "quarantined": 0,
-                    "detection_warnings": 0,
-                    "maintenance_failures": maintenance_count,
-                    "deferred_failures": 0,
-                    "terminal_rejections": 0,
-                    "unexplained_failures": 0,
-                    "samples": maintenance_samples,
-                }
 
-            parse_fail = int(
-                conn.execute("SELECT COUNT(*) FROM raw_sessions WHERE parse_error IS NOT NULL").fetchone()[0] or 0
-            )
-            validation_fail = int(
-                conn.execute("SELECT COUNT(*) FROM raw_sessions WHERE validation_status = 'FAILED'").fetchone()[0] or 0
-            )
-            quarantined = int(
-                conn.execute(
-                    "SELECT COUNT(*) FROM raw_sessions WHERE parsed_at IS NULL AND (parse_error IS NOT NULL OR validation_status = 'FAILED')"
-                ).fetchone()[0]
-                or 0
-            )
-            detection_warnings_count = 0
-            try:
-                with contextlib.suppress(sqlite3.OperationalError):
-                    detection_warnings_count = int(
-                        conn.execute(
-                            "SELECT COUNT(*) FROM raw_sessions WHERE detection_warnings IS NOT NULL"
-                        ).fetchone()[0]
-                        or 0
-                    )
-            except Exception as exc:
-                # contextlib.suppress above already covers the expected
-                # "detection_warnings column not on this schema yet" case;
-                # anything reaching here is unexpected and previously
-                # vanished silently behind a 0 count.
-                logger.warning("detection-warnings count query failed: %s", exc, exc_info=True)
-            # Bounded failure samples (most recent 50), typed.
-            samples: list[RawFailureSample] = []
-            raw_columns = {str(row[1]) for row in conn.execute("PRAGMA table_info(raw_sessions)").fetchall()}
-            acquired_order_column = "acquired_at_ms" if "acquired_at_ms" in raw_columns else "acquired_at"
-            for row in conn.execute(
-                "SELECT raw_id, source_name, parse_error, validation_status, validation_error "
-                "FROM raw_sessions "
-                "WHERE parse_error IS NOT NULL OR validation_status = 'FAILED' "
-                f"ORDER BY {acquired_order_column} DESC LIMIT 50"
-            ).fetchall():
-                parse_err = str(row[2] or "") if row[2] else ""
-                val_status = str(row[3] or "") if row[3] else ""
-                val_err = str(row[4] or "") if row[4] else ""
-                provider = str(row[1]) if row[1] else None
-
-                # Classify failure kind from the available error signals.
-                if "JSONDecodeError" in parse_err or "decode error" in parse_err.lower():
-                    kind: Literal["decode_error", "parse_error", "schema_violation", "unknown"] = "decode_error"
-                elif val_status == "FAILED":
-                    kind = "schema_violation"
-                elif parse_err:
-                    kind = "parse_error"
-                else:
-                    kind = "unknown"
-
-                # Redacted error text: prefer parse_error, fall back to validation_error.
-                error_text = parse_err or val_err
-
-                samples.append(
-                    RawFailureSample(
-                        failure_kind=kind,
-                        provider_hint=provider,
-                        redacted_error=error_text,
-                    )
-                )
-        finally:
-            conn.close()
-        combined: list[RawFailureSample] = list(samples)
-        combined.extend(maintenance_samples)
-        if len(combined) > 50:
-            combined = combined[:50]
-        return {
-            "parse_failures": parse_fail,
-            "validation_failures": validation_fail,
-            "quarantined": quarantined,
-            "detection_warnings": detection_warnings_count,
-            "maintenance_failures": maintenance_count,
-            "deferred_failures": 0,
-            "terminal_rejections": 0,
-            "unexplained_failures": parse_fail + validation_fail,
-            "samples": combined,
-        }
-    except sqlite3.Error as exc:
-        logger.warning("status: raw-failure query failed for %s: %s", dbf, exc, exc_info=True)
-        return {
-            "parse_failures": 0,
-            "validation_failures": 0,
-            "quarantined": 0,
-            "detection_warnings": 0,
-            "maintenance_failures": maintenance_count,
-            "deferred_failures": 0,
-            "terminal_rejections": 0,
-            "unexplained_failures": 0,
-            "samples": maintenance_samples,
-        }
+def _unavailable_raw_failure_info(
+    *,
+    reason: str,
+    maintenance_samples: list[RawFailureSample],
+    maintenance_count: int,
+) -> dict[str, object]:
+    """Represent missing source evidence without manufacturing zero counts."""
+    return {
+        "parse_failures": 0,
+        "validation_failures": 0,
+        "quarantined": 0,
+        "detection_warnings": 0,
+        "maintenance_failures": maintenance_count,
+        "deferred_failures": 0,
+        "terminal_rejections": 0,
+        "unexplained_failures": 0,
+        "raw_failure_lifecycle_available": False,
+        "raw_failure_lifecycle_state": "unavailable",
+        "raw_failure_lifecycle_reason": reason,
+        "samples": maintenance_samples,
+    }
 
 
 def _archive_raw_failure_info(
@@ -988,29 +878,29 @@ def _archive_raw_failure_info(
     *,
     maintenance_samples: list[RawFailureSample],
     maintenance_count: int,
-) -> dict[str, object] | None:
+) -> dict[str, object]:
     if not archive_db.exists():
-        return None
+        return _unavailable_raw_failure_info(
+            reason=f"source.db not found: {archive_db}",
+            maintenance_samples=maintenance_samples,
+            maintenance_count=maintenance_count,
+        )
     lifecycle_snapshot = read_raw_failure_lifecycle(archive_db, sample_limit=50)
     if not lifecycle_snapshot.available:
-        return {
-            "parse_failures": 0,
-            "validation_failures": 0,
-            "quarantined": 0,
-            "detection_warnings": 0,
-            "maintenance_failures": maintenance_count,
-            "deferred_failures": 0,
-            "terminal_rejections": 0,
-            "unexplained_failures": 1,
-            "raw_failure_lifecycle_available": False,
-            "raw_failure_lifecycle_reason": lifecycle_snapshot.reason,
-            "samples": maintenance_samples,
-        }
+        return _unavailable_raw_failure_info(
+            reason=lifecycle_snapshot.reason or "raw failure lifecycle is unavailable",
+            maintenance_samples=maintenance_samples,
+            maintenance_count=maintenance_count,
+        )
     try:
         conn = open_readonly_connection(archive_db)
         try:
             if not conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='raw_sessions'").fetchone():
-                return None
+                return _unavailable_raw_failure_info(
+                    reason="source.db is missing raw_sessions",
+                    maintenance_samples=maintenance_samples,
+                    maintenance_count=maintenance_count,
+                )
             parse_fail = lifecycle_snapshot.parse_failures
             validation_fail = lifecycle_snapshot.validation_failures
             quarantined = int(
@@ -1089,10 +979,22 @@ def _archive_raw_failure_info(
             "terminal_rejections": lifecycle_snapshot.terminal,
             "unexplained_failures": lifecycle_snapshot.unexplained,
             "raw_failure_lifecycle_available": True,
+            "raw_failure_lifecycle_state": (
+                "blocked"
+                if lifecycle_snapshot.unexplained
+                else "degraded"
+                if lifecycle_snapshot.deferred or lifecycle_snapshot.terminal
+                else "healthy"
+            ),
             "samples": combined,
         }
-    except sqlite3.Error:
-        return None
+    except (OSError, sqlite3.Error) as exc:
+        logger.warning("status: raw-failure query failed for %s: %s", archive_db, exc, exc_info=True)
+        return _unavailable_raw_failure_info(
+            reason=f"could not read source.db raw failure relations: {exc}",
+            maintenance_samples=maintenance_samples,
+            maintenance_count=maintenance_count,
+        )
 
 
 def raw_failure_info_for_root(root: Path) -> dict[str, object]:
@@ -1103,18 +1005,7 @@ def raw_failure_info_for_root(root: Path) -> dict[str, object]:
         maintenance_samples=maintenance_samples,
         maintenance_count=maintenance_count,
     )
-    if archive_info is not None:
-        return archive_info
-    return {
-        "parse_failures": 0,
-        "validation_failures": 0,
-        "quarantined": 0,
-        "maintenance_failures": maintenance_count,
-        "deferred_failures": 0,
-        "terminal_rejections": 0,
-        "unexplained_failures": 0,
-        "samples": maintenance_samples,
-    }
+    return archive_info
 
 
 def _maintenance_failure_info(root: Path | None = None) -> tuple[list[RawFailureSample], int]:
@@ -2664,6 +2555,7 @@ def build_daemon_status(
         ops_db=archive_root() / "ops.db",
     )
     raw_failures: dict[str, object] = _v("raw_failures", {})
+    raw_lifecycle_available = raw_failures.get("raw_failure_lifecycle_available")
     blob_publication_reservations = _v("blob_publication_reservations", BlobPublicationReservationStatus())
     embedding_info: dict[str, object] = _v("embedding_readiness", {})
     health = _v("health", _checked_health())
@@ -2761,6 +2653,16 @@ def build_daemon_status(
         raw_deferred_failures=_safe_int(raw_failures.get("deferred_failures", 0)),
         raw_terminal_rejections=_safe_int(raw_failures.get("terminal_rejections", 0)),
         raw_unexplained_failures=_safe_int(raw_failures.get("unexplained_failures", 0)),
+        raw_failure_lifecycle_available=raw_lifecycle_available if isinstance(raw_lifecycle_available, bool) else None,
+        raw_failure_lifecycle_state=cast(
+            Literal["healthy", "degraded", "blocked", "unavailable"] | None,
+            raw_failures.get("raw_failure_lifecycle_state"),
+        ),
+        raw_failure_lifecycle_reason=(
+            str(raw_failures["raw_failure_lifecycle_reason"])
+            if raw_failures.get("raw_failure_lifecycle_reason") is not None
+            else None
+        ),
         raw_failure_samples=_typed_failure_samples(raw_failures.get("samples")),
         raw_detection_warnings=_safe_int(raw_failures.get("detection_warnings", 0)),
         daemon_liveness=_check_daemon_liveness(daemon_lifecycle),
@@ -2899,7 +2801,10 @@ def daemon_status_payload(
 
     return json_document(
         {
-            "ok": status.raw_frontier_integrity.overall_status == "healthy",
+            "ok": (
+                status.raw_frontier_integrity.overall_status == "healthy"
+                and status.raw_failure_lifecycle_available is not False
+            ),
             "daemon": "polylogued",
             "daemon_liveness": status.daemon_liveness,
             "daemon_lifecycle": status.daemon_lifecycle,
@@ -2963,6 +2868,9 @@ def daemon_status_payload(
             "raw_deferred_failures": status.raw_deferred_failures,
             "raw_terminal_rejections": status.raw_terminal_rejections,
             "raw_unexplained_failures": status.raw_unexplained_failures,
+            "raw_failure_lifecycle_available": status.raw_failure_lifecycle_available,
+            "raw_failure_lifecycle_state": status.raw_failure_lifecycle_state,
+            "raw_failure_lifecycle_reason": status.raw_failure_lifecycle_reason,
             "raw_detection_warnings": status.raw_detection_warnings,
             "raw_failure_samples": [s.model_dump() for s in status.raw_failure_samples],
         }
@@ -3374,8 +3282,13 @@ def format_daemon_status_lines(payload: JSONDocument) -> list[str]:
     raw_deferred = _safe_int(payload.get("raw_deferred_failures"))
     raw_terminal = _safe_int(payload.get("raw_terminal_rejections"))
     raw_unexplained = _safe_int(payload.get("raw_unexplained_failures"))
+    raw_lifecycle_unavailable = payload.get("raw_failure_lifecycle_available") is False
+    if raw_lifecycle_unavailable:
+        lifecycle_state = str(payload.get("raw_failure_lifecycle_state") or "unavailable")
+        lifecycle_reason = str(payload.get("raw_failure_lifecycle_reason") or "source.db evidence is unavailable")
+        lines.append(f"Raw failures: {lifecycle_state} ({lifecycle_reason})")
     total_raw = raw_parse + raw_val + raw_maintenance
-    if total_raw > 0:
+    if not raw_lifecycle_unavailable and total_raw > 0:
         breakdown = f"{raw_parse} parse + {raw_val} validation"
         if raw_maintenance > 0:
             breakdown += f" + {raw_maintenance} maintenance"

--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -22,10 +22,6 @@ from polylogue.core.payload_coercion import optional_str as _optional_str
 from polylogue.core.payload_coercion import required_str as _required_str
 from polylogue.core.payload_coercion import row_float as _row_float
 from polylogue.core.payload_coercion import row_int as _row_int
-from polylogue.core.raw_failure_evidence import (
-    RAW_FAILURE_DEFERRED_EVIDENCE_KINDS,
-    RAW_FAILURE_TERMINAL_EVIDENCE_KINDS,
-)
 from polylogue.core.stats import percentile
 from polylogue.daemon.catchup_status import (
     CatchupStatus as CatchupStatus,
@@ -65,6 +61,7 @@ from polylogue.daemon.live_ingest_attempt_workload import (
 )
 from polylogue.daemon.slo import IngestSloStatus, slo_status_info
 from polylogue.logging import get_logger
+from polylogue.maintenance.archive_verification import read_raw_failure_lifecycle
 from polylogue.operations.status_protocol import ComponentSnapshot, StatusComponentRegistry, StatusComponentSpec
 from polylogue.paths import archive_root, index_db_path
 from polylogue.readiness.capability import CapabilityReadinessState, ComponentReadiness
@@ -994,24 +991,35 @@ def _archive_raw_failure_info(
 ) -> dict[str, object] | None:
     if not archive_db.exists():
         return None
+    lifecycle_snapshot = read_raw_failure_lifecycle(archive_db, sample_limit=50)
+    if not lifecycle_snapshot.available:
+        return {
+            "parse_failures": 0,
+            "validation_failures": 0,
+            "quarantined": 0,
+            "detection_warnings": 0,
+            "maintenance_failures": maintenance_count,
+            "deferred_failures": 0,
+            "terminal_rejections": 0,
+            "unexplained_failures": 1,
+            "raw_failure_lifecycle_available": False,
+            "raw_failure_lifecycle_reason": lifecycle_snapshot.reason,
+            "samples": maintenance_samples,
+        }
     try:
         conn = open_readonly_connection(archive_db)
         try:
             if not conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='raw_sessions'").fetchone():
                 return None
-            parse_fail = int(
-                conn.execute("SELECT COUNT(*) FROM raw_sessions WHERE parse_error IS NOT NULL").fetchone()[0] or 0
-            )
-            validation_fail = int(
-                conn.execute("SELECT COUNT(*) FROM raw_sessions WHERE validation_status = 'failed'").fetchone()[0] or 0
-            )
+            parse_fail = lifecycle_snapshot.parse_failures
+            validation_fail = lifecycle_snapshot.validation_failures
             quarantined = int(
                 conn.execute(
                     """
                     SELECT COUNT(*)
                     FROM raw_sessions
                     WHERE parsed_at_ms IS NULL
-                      AND (parse_error IS NOT NULL OR validation_status = 'failed')
+                      AND ((parse_error IS NOT NULL AND TRIM(parse_error) != '') OR validation_status = 'failed')
                     """
                 ).fetchone()[0]
                 or 0
@@ -1027,51 +1035,18 @@ def _archive_raw_failure_info(
                 ).fetchone()[0]
                 or 0
             )
-            deferred_kinds = tuple(sorted(RAW_FAILURE_DEFERRED_EVIDENCE_KINDS))
-            terminal_kinds = tuple(sorted(RAW_FAILURE_TERMINAL_EVIDENCE_KINDS))
-            known_kinds = deferred_kinds + terminal_kinds
-            deferred_placeholders = ", ".join("?" for _ in deferred_kinds)
-            terminal_placeholders = ", ".join("?" for _ in terminal_kinds)
-            known_placeholders = ", ".join("?" for _ in known_kinds)
-            lifecycle_totals = conn.execute(
-                f"""
-                WITH raw_failures AS (
-                    SELECT (
-                        SELECT a.artifact_kind
-                        FROM raw_artifacts AS a
-                        WHERE a.raw_id = r.raw_id
-                        ORDER BY a.last_observed_at_ms DESC, a.artifact_id DESC
-                        LIMIT 1
-                    ) AS artifact_kind
-                    FROM raw_sessions AS r
-                    WHERE r.parse_error IS NOT NULL OR r.validation_status = 'failed'
-                )
-                SELECT
-                    COALESCE(SUM(artifact_kind IN ({deferred_placeholders})), 0),
-                    COALESCE(SUM(artifact_kind IN ({terminal_placeholders})), 0),
-                    COALESCE(SUM(artifact_kind IS NULL OR artifact_kind NOT IN ({known_placeholders})), 0)
-                FROM raw_failures
-                """,
-                (*deferred_kinds, *terminal_kinds, *known_kinds),
-            ).fetchone()
-            assert lifecycle_totals is not None
-            deferred_failures = int(lifecycle_totals[0] or 0)
-            terminal_rejections = int(lifecycle_totals[1] or 0)
-            unexplained_failures = int(lifecycle_totals[2] or 0)
+            lifecycle_by_raw_id = {
+                str(sample["raw_id"]): str(sample["lifecycle"])
+                for sample in lifecycle_snapshot.samples
+                if sample.get("raw_id") is not None and sample.get("lifecycle") is not None
+            }
             samples: list[RawFailureSample] = []
             for row in conn.execute(
                 """
-                SELECT r.raw_id, r.origin, r.parse_error, r.validation_status, r.validation_error,
-                       (
-                           SELECT a.artifact_kind
-                           FROM raw_artifacts AS a
-                           WHERE a.raw_id = r.raw_id
-                           ORDER BY a.last_observed_at_ms DESC, a.artifact_id DESC
-                           LIMIT 1
-                       ) AS artifact_kind
+                SELECT r.raw_id, r.origin, r.parse_error, r.validation_status, r.validation_error
                 FROM raw_sessions AS r
-                WHERE parse_error IS NOT NULL OR validation_status = 'failed'
-                ORDER BY acquired_at_ms DESC
+                WHERE (parse_error IS NOT NULL AND TRIM(parse_error) != '') OR validation_status = 'failed'
+                ORDER BY acquired_at_ms DESC, raw_id DESC
                 LIMIT 50
                 """
             ):
@@ -1079,8 +1054,6 @@ def _archive_raw_failure_info(
                 val_status = str(row[3] or "") if row[3] else ""
                 val_err = str(row[4] or "") if row[4] else ""
                 origin = str(row[1]) if row[1] else None
-                artifact_kind = str(row[5]) if row[5] is not None else None
-                lifecycle = _raw_failure_lifecycle(artifact_kind)
                 if "JSONDecodeError" in parse_err or "decode error" in parse_err.lower():
                     kind: Literal["decode_error", "parse_error", "schema_violation", "unknown"] = "decode_error"
                 elif val_status == "failed":
@@ -1094,7 +1067,10 @@ def _archive_raw_failure_info(
                         failure_kind=kind,
                         provider_hint=origin,
                         redacted_error=parse_err or val_err,
-                        lifecycle=lifecycle,
+                        lifecycle=cast(
+                            Literal["deferred", "terminal", "unexplained"],
+                            lifecycle_by_raw_id.get(str(row[0]), "unexplained"),
+                        ),
                     )
                 )
         finally:
@@ -1109,22 +1085,14 @@ def _archive_raw_failure_info(
             "quarantined": quarantined,
             "detection_warnings": detection_warnings_count,
             "maintenance_failures": maintenance_count,
-            "deferred_failures": deferred_failures,
-            "terminal_rejections": terminal_rejections,
-            "unexplained_failures": unexplained_failures,
+            "deferred_failures": lifecycle_snapshot.deferred,
+            "terminal_rejections": lifecycle_snapshot.terminal,
+            "unexplained_failures": lifecycle_snapshot.unexplained,
+            "raw_failure_lifecycle_available": True,
             "samples": combined,
         }
     except sqlite3.Error:
         return None
-
-
-def _raw_failure_lifecycle(artifact_kind: str | None) -> Literal["deferred", "terminal", "unexplained"]:
-    """Classify only closed source-tier evidence, never a diagnostic string."""
-    if artifact_kind in RAW_FAILURE_DEFERRED_EVIDENCE_KINDS:
-        return "deferred"
-    if artifact_kind in RAW_FAILURE_TERMINAL_EVIDENCE_KINDS:
-        return "terminal"
-    return "unexplained"
 
 
 def raw_failure_info_for_root(root: Path) -> dict[str, object]:

--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -492,8 +492,8 @@ class DaemonStatus(BaseModel):
     raw_deferred_failures: int = 0
     raw_terminal_rejections: int = 0
     raw_unexplained_failures: int = 0
-    raw_failure_lifecycle_available: bool | None = None
-    raw_failure_lifecycle_state: Literal["healthy", "degraded", "blocked", "unavailable"] | None = None
+    raw_failure_lifecycle_available: bool = False
+    raw_failure_lifecycle_state: Literal["healthy", "degraded", "blocked", "unavailable"] = "unavailable"
     raw_failure_lifecycle_reason: str | None = None
     raw_failure_samples: list[RawFailureSample] = Field(default_factory=list)
     raw_detection_warnings: int = 0
@@ -979,13 +979,7 @@ def _archive_raw_failure_info(
             "terminal_rejections": lifecycle_snapshot.terminal,
             "unexplained_failures": lifecycle_snapshot.unexplained,
             "raw_failure_lifecycle_available": True,
-            "raw_failure_lifecycle_state": (
-                "blocked"
-                if lifecycle_snapshot.unexplained
-                else "degraded"
-                if lifecycle_snapshot.deferred or lifecycle_snapshot.terminal
-                else "healthy"
-            ),
+            "raw_failure_lifecycle_state": lifecycle_snapshot.state,
             "samples": combined,
         }
     except (OSError, sqlite3.Error) as exc:
@@ -1006,6 +1000,11 @@ def raw_failure_info_for_root(root: Path) -> dict[str, object]:
         maintenance_count=maintenance_count,
     )
     return archive_info
+
+
+def raw_failure_lifecycle_for_root(root: Path) -> Any:
+    """Return the bounded source-tier lifecycle snapshot for a status route."""
+    return read_raw_failure_lifecycle(root / "source.db", sample_limit=0)
 
 
 def _maintenance_failure_info(root: Path | None = None) -> tuple[list[RawFailureSample], int]:
@@ -2555,7 +2554,13 @@ def build_daemon_status(
         ops_db=archive_root() / "ops.db",
     )
     raw_failures: dict[str, object] = _v("raw_failures", {})
-    raw_lifecycle_available = raw_failures.get("raw_failure_lifecycle_available")
+    raw_lifecycle_available = raw_failures.get("raw_failure_lifecycle_available") is True
+    raw_lifecycle_state = raw_failures.get("raw_failure_lifecycle_state")
+    if raw_lifecycle_state not in {"healthy", "degraded", "blocked", "unavailable"}:
+        raw_lifecycle_state = "unavailable"
+    raw_lifecycle_reason = raw_failures.get("raw_failure_lifecycle_reason")
+    if not raw_lifecycle_available and not raw_lifecycle_reason:
+        raw_lifecycle_reason = "raw failure lifecycle evidence is unavailable"
     blob_publication_reservations = _v("blob_publication_reservations", BlobPublicationReservationStatus())
     embedding_info: dict[str, object] = _v("embedding_readiness", {})
     health = _v("health", _checked_health())
@@ -2653,16 +2658,9 @@ def build_daemon_status(
         raw_deferred_failures=_safe_int(raw_failures.get("deferred_failures", 0)),
         raw_terminal_rejections=_safe_int(raw_failures.get("terminal_rejections", 0)),
         raw_unexplained_failures=_safe_int(raw_failures.get("unexplained_failures", 0)),
-        raw_failure_lifecycle_available=raw_lifecycle_available if isinstance(raw_lifecycle_available, bool) else None,
-        raw_failure_lifecycle_state=cast(
-            Literal["healthy", "degraded", "blocked", "unavailable"] | None,
-            raw_failures.get("raw_failure_lifecycle_state"),
-        ),
-        raw_failure_lifecycle_reason=(
-            str(raw_failures["raw_failure_lifecycle_reason"])
-            if raw_failures.get("raw_failure_lifecycle_reason") is not None
-            else None
-        ),
+        raw_failure_lifecycle_available=raw_lifecycle_available,
+        raw_failure_lifecycle_state=cast(Literal["healthy", "degraded", "blocked", "unavailable"], raw_lifecycle_state),
+        raw_failure_lifecycle_reason=str(raw_lifecycle_reason) if raw_lifecycle_reason is not None else None,
         raw_failure_samples=_typed_failure_samples(raw_failures.get("samples")),
         raw_detection_warnings=_safe_int(raw_failures.get("detection_warnings", 0)),
         daemon_liveness=_check_daemon_liveness(daemon_lifecycle),
@@ -2803,7 +2801,8 @@ def daemon_status_payload(
         {
             "ok": (
                 status.raw_frontier_integrity.overall_status == "healthy"
-                and status.raw_failure_lifecycle_available is not False
+                and status.raw_failure_lifecycle_available
+                and status.raw_failure_lifecycle_state == "healthy"
             ),
             "daemon": "polylogued",
             "daemon_liveness": status.daemon_liveness,
@@ -3282,9 +3281,10 @@ def format_daemon_status_lines(payload: JSONDocument) -> list[str]:
     raw_deferred = _safe_int(payload.get("raw_deferred_failures"))
     raw_terminal = _safe_int(payload.get("raw_terminal_rejections"))
     raw_unexplained = _safe_int(payload.get("raw_unexplained_failures"))
-    raw_lifecycle_unavailable = payload.get("raw_failure_lifecycle_available") is False
-    if raw_lifecycle_unavailable:
-        lifecycle_state = str(payload.get("raw_failure_lifecycle_state") or "unavailable")
+    raw_lifecycle_available = payload.get("raw_failure_lifecycle_available") is True
+    lifecycle_state = str(payload.get("raw_failure_lifecycle_state") or "unavailable")
+    raw_lifecycle_unavailable = not raw_lifecycle_available or lifecycle_state == "unavailable"
+    if raw_lifecycle_unavailable or lifecycle_state == "blocked":
         lifecycle_reason = str(payload.get("raw_failure_lifecycle_reason") or "source.db evidence is unavailable")
         lines.append(f"Raw failures: {lifecycle_state} ({lifecycle_reason})")
     total_raw = raw_parse + raw_val + raw_maintenance

--- a/polylogue/daemon/status_snapshot.py
+++ b/polylogue/daemon/status_snapshot.py
@@ -302,6 +302,9 @@ def _minimal_status_payload(*, refresh_in_progress: bool = False, refresh_error:
         "raw_deferred_failures": 0,
         "raw_terminal_rejections": 0,
         "raw_unexplained_failures": 0,
+        "raw_failure_lifecycle_available": False,
+        "raw_failure_lifecycle_state": "unavailable",
+        "raw_failure_lifecycle_reason": frontier_reason,
         "raw_detection_warnings": 0,
         "raw_failure_samples": [],
         "status_snapshot": {

--- a/polylogue/maintenance/archive_verification.py
+++ b/polylogue/maintenance/archive_verification.py
@@ -2557,5 +2557,6 @@ __all__ = [
     "ArchiveVerificationReport",
     "ArchiveVerificationWaiver",
     "DEFAULT_SAMPLE_LIMIT",
+    "read_raw_failure_lifecycle",
     "verify_archive",
 ]

--- a/polylogue/maintenance/archive_verification.py
+++ b/polylogue/maintenance/archive_verification.py
@@ -52,6 +52,7 @@ from polylogue.maintenance.corpus_fidelity import (
 from polylogue.sources.origin_specs import lowering_fingerprint, parser_fingerprint_for_origin
 from polylogue.storage.blob_gc import BLOB_REF_LIVENESS_JOIN
 from polylogue.storage.introspection import table_exists
+from polylogue.storage.raw_failure_lifecycle import read_raw_failure_lifecycle
 from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.connection_profile import open_readonly_connection
@@ -193,9 +194,17 @@ def archive_verification_check_json(check: OutcomeCheck) -> JSONDocument:
     return payload
 
 
-def _error_check(name: str, summary: str, *, exc: Exception | None = None) -> ArchiveVerificationCheck:
-    evidence: dict[str, Any] = {"error": str(exc)} if exc is not None else {}
-    return ArchiveVerificationCheck(name=name, status=OutcomeStatus.ERROR, summary=summary, count=1, evidence=evidence)
+def _error_check(
+    name: str,
+    summary: str,
+    *,
+    exc: Exception | None = None,
+    evidence: dict[str, Any] | None = None,
+) -> ArchiveVerificationCheck:
+    payload = dict(evidence or {})
+    if exc is not None:
+        payload["error"] = str(exc)
+    return ArchiveVerificationCheck(name=name, status=OutcomeStatus.ERROR, summary=summary, count=1, evidence=payload)
 
 
 def _skip_check(name: str, summary: str) -> ArchiveVerificationCheck:
@@ -996,6 +1005,53 @@ def _check_blob_refs_liveness(archive_root: Path, sample_limit: int) -> ArchiveV
         count=total_orphans,
         details=[f"{ref_type}:{ref_id}" for ref_type, ids in samples_by_type.items() for ref_id in ids],
         evidence={"orphans_by_ref_type": orphans_by_type, "orphan_samples_by_ref_type": samples_by_type},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Check: raw failure lifecycle
+# ---------------------------------------------------------------------------
+
+
+def _check_raw_failure_lifecycle(archive_root: Path, sample_limit: int) -> ArchiveVerificationCheck:
+    """Require typed evidence for every retained raw parse/validation failure."""
+    snapshot = read_raw_failure_lifecycle(_tier_path(archive_root, ArchiveTier.SOURCE), sample_limit=sample_limit)
+    evidence = snapshot.to_dict()
+    if not snapshot.available:
+        return _error_check(
+            "raw-failure-lifecycle",
+            str(snapshot.reason or "raw failure lifecycle is unavailable"),
+            evidence=evidence,
+        )
+    if snapshot.unexplained:
+        return ArchiveVerificationCheck(
+            name="raw-failure-lifecycle",
+            status=OutcomeStatus.ERROR,
+            summary=(
+                f"{snapshot.unexplained:,} raw failure(s) lack typed deferred/terminal evidence; "
+                "reindex is unsafe until each is classified"
+            ),
+            count=snapshot.unexplained,
+            details=[
+                f"{sample.get('origin', 'unknown')}:{sample.get('artifact_kind') or '<none>'}"
+                for sample in snapshot.samples
+                if sample.get("lifecycle") == "unexplained"
+            ],
+            evidence=evidence,
+        )
+    known = snapshot.deferred + snapshot.terminal
+    status = OutcomeStatus.WARNING if known else OutcomeStatus.OK
+    summary = (
+        f"{known:,} raw failure(s) classified ({snapshot.deferred:,} deferred, {snapshot.terminal:,} terminal)"
+        if known
+        else "no raw parse or validation failures"
+    )
+    return ArchiveVerificationCheck(
+        name="raw-failure-lifecycle",
+        status=status,
+        summary=summary,
+        count=known,
+        evidence=evidence,
     )
 
 
@@ -2256,6 +2312,12 @@ ARCHIVE_VERIFICATION_CHECKS: tuple[ArchiveVerificationCheckSpec, ...] = (
         "not membership in blob_refs itself (polylogue-t0m73 I3).",
         _check_blob_refs_liveness,
         ArchiveVerificationCheckClass.LIVENESS,
+    ),
+    ArchiveVerificationCheckSpec(
+        "raw-failure-lifecycle",
+        "Every retained raw parse or validation failure has typed deferred or terminal lifecycle evidence.",
+        _check_raw_failure_lifecycle,
+        ArchiveVerificationCheckClass.STATE_INVARIANT,
     ),
     ArchiveVerificationCheckSpec(
         "pathology-zoo-invariants",

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -819,7 +819,7 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
         raise RuntimeError(reason)
     from polylogue.maintenance.archive_verification import verify_archive
 
-    source_liveness = verify_archive(root, checks=("blob-refs-liveness",))
+    source_liveness = verify_archive(root, checks=("blob-refs-liveness", "raw-failure-lifecycle"))
     if source_liveness.blocking:
         failing = "; ".join(
             f"{check.name}: {check.summary}"

--- a/polylogue/storage/raw_failure_lifecycle.py
+++ b/polylogue/storage/raw_failure_lifecycle.py
@@ -16,8 +16,7 @@ from pathlib import Path
 from typing import Literal
 
 from polylogue.core.raw_failure_evidence import (
-    RAW_FAILURE_DEFERRED_EVIDENCE_KINDS,
-    RAW_FAILURE_TERMINAL_EVIDENCE_KINDS,
+    RawFailureEvidenceKind,
 )
 from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 
@@ -60,15 +59,28 @@ class RawFailureLifecycleSnapshot:
         }
 
 
-def _lifecycle(artifact_kind: object, *, validation_failed: bool) -> RawFailureLifecycle:
+def _lifecycle(
+    artifact_kind: object,
+    support_status: object,
+    *,
+    validation_failed: bool,
+) -> RawFailureLifecycle:
+    """Classify an artifact only when its closed evidence is self-consistent."""
     if validation_failed:
         return "unexplained"
-    kind = str(artifact_kind) if artifact_kind is not None else None
-    if kind in RAW_FAILURE_DEFERRED_EVIDENCE_KINDS:
-        return "deferred"
-    if kind in RAW_FAILURE_TERMINAL_EVIDENCE_KINDS:
-        return "terminal"
-    return "unexplained"
+    if artifact_kind is None or support_status is None:
+        return "unexplained"
+    kind = str(artifact_kind)
+    support = str(support_status)
+    try:
+        evidence_kind = RawFailureEvidenceKind(kind)
+    except ValueError:
+        return "unexplained"
+    if evidence_kind.lifecycle not in {"deferred", "terminal"}:
+        return "unexplained"
+    if evidence_kind.support_status.value != support:
+        return "unexplained"
+    return "deferred" if evidence_kind.lifecycle == "deferred" else "terminal"
 
 
 def read_raw_failure_lifecycle(source_db: Path, *, sample_limit: int = 10) -> RawFailureLifecycleSnapshot:
@@ -106,21 +118,34 @@ def read_raw_failure_lifecycle(source_db: Path, *, sample_limit: int = 10) -> Ra
                        SELECT a.artifact_kind
                        FROM raw_artifacts AS a
                        WHERE a.raw_id = r.raw_id
+                         AND a.origin = r.origin
+                         AND a.source_path = r.source_path
+                         AND a.source_index = r.source_index
                        ORDER BY a.last_observed_at_ms DESC, a.artifact_id DESC
                        LIMIT 1
                    ) AS artifact_kind
+                   ,(
+                       SELECT a.support_status
+                       FROM raw_artifacts AS a
+                       WHERE a.raw_id = r.raw_id
+                         AND a.origin = r.origin
+                         AND a.source_path = r.source_path
+                         AND a.source_index = r.source_index
+                       ORDER BY a.last_observed_at_ms DESC, a.artifact_id DESC
+                       LIMIT 1
+                   ) AS support_status
             FROM raw_sessions AS r
             WHERE (r.parse_error IS NOT NULL AND TRIM(r.parse_error) != '')
                OR r.validation_status = 'failed'
-            ORDER BY r.acquired_at_ms, r.raw_id
+            ORDER BY r.acquired_at_ms DESC, r.raw_id DESC
             """
         else:
             failure_query = """
-            SELECT r.raw_id, r.origin, r.validation_status, NULL AS artifact_kind
+            SELECT r.raw_id, r.origin, r.validation_status, NULL AS artifact_kind, NULL AS support_status
             FROM raw_sessions AS r
             WHERE (r.parse_error IS NOT NULL AND TRIM(r.parse_error) != '')
                OR r.validation_status = 'failed'
-            ORDER BY r.acquired_at_ms, r.raw_id
+            ORDER BY r.acquired_at_ms DESC, r.raw_id DESC
             """
         failed_rows = conn.execute(failure_query).fetchall()
     except sqlite3.Error as exc:
@@ -136,8 +161,9 @@ def read_raw_failure_lifecycle(source_db: Path, *, sample_limit: int = 10) -> Ra
     for row in failed_rows:
         origin = str(row[1] or "unknown")
         artifact_kind = str(row[3]) if row[3] is not None else None
+        support_status = str(row[4]) if row[4] is not None else None
         validation_failed = str(row[2] or "") == "failed"
-        lifecycle = _lifecycle(artifact_kind, validation_failed=validation_failed)
+        lifecycle = _lifecycle(artifact_kind, support_status, validation_failed=validation_failed)
         counts[lifecycle] += 1
         by_origin[origin] += 1
         by_artifact_kind[artifact_kind or "<none>"] += 1
@@ -147,6 +173,7 @@ def read_raw_failure_lifecycle(source_db: Path, *, sample_limit: int = 10) -> Ra
                     "raw_id": str(row[0]),
                     "origin": origin,
                     "artifact_kind": artifact_kind,
+                    "support_status": support_status,
                     "lifecycle": lifecycle,
                 }
             )

--- a/polylogue/storage/raw_failure_lifecycle.py
+++ b/polylogue/storage/raw_failure_lifecycle.py
@@ -21,6 +21,7 @@ from polylogue.core.raw_failure_evidence import (
 from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 
 RawFailureLifecycle = Literal["deferred", "terminal", "unexplained"]
+RawFailureLifecycleState = Literal["healthy", "degraded", "blocked", "unavailable"]
 logger = logging.getLogger(__name__)
 
 
@@ -44,6 +45,22 @@ class RawFailureLifecycleSnapshot:
         """Whether failed source evidence lacks a typed lifecycle explanation."""
         return not self.available or self.unexplained > 0
 
+    @property
+    def state(self) -> RawFailureLifecycleState:
+        """Return the public claim state for this source-tier evidence."""
+        if not self.available:
+            return "unavailable"
+        if self.unexplained > 0:
+            return "blocked"
+        if self.parse_failures > 0 or self.validation_failures > 0:
+            return "degraded"
+        return "healthy"
+
+    @property
+    def healthy(self) -> bool:
+        """Whether the source proves a clean, zero-failure lifecycle."""
+        return self.state == "healthy"
+
     def to_dict(self) -> dict[str, object]:
         return {
             "available": self.available,
@@ -56,6 +73,7 @@ class RawFailureLifecycleSnapshot:
             "by_artifact_kind": dict(self.by_artifact_kind),
             "samples": [dict(sample) for sample in self.samples],
             "reason": self.reason,
+            "state": self.state,
         }
 
 
@@ -190,4 +208,4 @@ def read_raw_failure_lifecycle(source_db: Path, *, sample_limit: int = 10) -> Ra
     )
 
 
-__all__ = ["RawFailureLifecycleSnapshot", "read_raw_failure_lifecycle"]
+__all__ = ["RawFailureLifecycleSnapshot", "RawFailureLifecycleState", "read_raw_failure_lifecycle"]

--- a/polylogue/storage/raw_failure_lifecycle.py
+++ b/polylogue/storage/raw_failure_lifecycle.py
@@ -1,0 +1,166 @@
+"""Read-only lifecycle projection for retained raw failures.
+
+``raw_sessions`` is the ground-truth failure universe.  A parser diagnostic is
+not a lifecycle decision: only a matching ``raw_artifacts`` observation can
+explain a failed raw as deferred or terminal.  This module keeps that rule in
+one substrate helper so status, preflight, and maintenance gates cannot drift.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from polylogue.core.raw_failure_evidence import (
+    RAW_FAILURE_DEFERRED_EVIDENCE_KINDS,
+    RAW_FAILURE_TERMINAL_EVIDENCE_KINDS,
+)
+from polylogue.storage.sqlite.connection_profile import open_readonly_connection
+
+RawFailureLifecycle = Literal["deferred", "terminal", "unexplained"]
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class RawFailureLifecycleSnapshot:
+    """Counts and bounded evidence from one source-tier read snapshot."""
+
+    available: bool
+    parse_failures: int = 0
+    validation_failures: int = 0
+    deferred: int = 0
+    terminal: int = 0
+    unexplained: int = 0
+    by_origin: tuple[tuple[str, int], ...] = ()
+    by_artifact_kind: tuple[tuple[str, int], ...] = ()
+    samples: tuple[dict[str, str | None], ...] = ()
+    reason: str | None = None
+
+    @property
+    def blocking(self) -> bool:
+        """Whether failed source evidence lacks a typed lifecycle explanation."""
+        return not self.available or self.unexplained > 0
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "available": self.available,
+            "parse_failures": self.parse_failures,
+            "validation_failures": self.validation_failures,
+            "deferred": self.deferred,
+            "terminal": self.terminal,
+            "unexplained": self.unexplained,
+            "by_origin": dict(self.by_origin),
+            "by_artifact_kind": dict(self.by_artifact_kind),
+            "samples": [dict(sample) for sample in self.samples],
+            "reason": self.reason,
+        }
+
+
+def _lifecycle(artifact_kind: object, *, validation_failed: bool) -> RawFailureLifecycle:
+    if validation_failed:
+        return "unexplained"
+    kind = str(artifact_kind) if artifact_kind is not None else None
+    if kind in RAW_FAILURE_DEFERRED_EVIDENCE_KINDS:
+        return "deferred"
+    if kind in RAW_FAILURE_TERMINAL_EVIDENCE_KINDS:
+        return "terminal"
+    return "unexplained"
+
+
+def read_raw_failure_lifecycle(source_db: Path, *, sample_limit: int = 10) -> RawFailureLifecycleSnapshot:
+    """Read and classify every failed raw without opening a write connection."""
+    if not source_db.exists():
+        return RawFailureLifecycleSnapshot(False, reason=f"source.db not found: {source_db}")
+    try:
+        conn = open_readonly_connection(source_db)
+    except (OSError, sqlite3.Error) as exc:
+        logger.warning("could not open source.db read-only", exc_info=exc)
+        return RawFailureLifecycleSnapshot(False, reason=f"could not open source.db read-only: {exc}")
+    try:
+        raw_table = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'raw_sessions'"
+        ).fetchone()
+        if raw_table is None:
+            return RawFailureLifecycleSnapshot(False, reason="source.db is missing raw_sessions")
+        parse_failures = int(
+            conn.execute(
+                "SELECT COUNT(*) FROM raw_sessions WHERE parse_error IS NOT NULL AND TRIM(parse_error) != ''"
+            ).fetchone()[0]
+            or 0
+        )
+        validation_failures = int(
+            conn.execute("SELECT COUNT(*) FROM raw_sessions WHERE validation_status = 'failed'").fetchone()[0] or 0
+        )
+        has_artifacts = (
+            conn.execute("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'raw_artifacts'").fetchone()
+            is not None
+        )
+        if has_artifacts:
+            failure_query = """
+            SELECT r.raw_id, r.origin, r.validation_status,
+                   (
+                       SELECT a.artifact_kind
+                       FROM raw_artifacts AS a
+                       WHERE a.raw_id = r.raw_id
+                       ORDER BY a.last_observed_at_ms DESC, a.artifact_id DESC
+                       LIMIT 1
+                   ) AS artifact_kind
+            FROM raw_sessions AS r
+            WHERE (r.parse_error IS NOT NULL AND TRIM(r.parse_error) != '')
+               OR r.validation_status = 'failed'
+            ORDER BY r.acquired_at_ms, r.raw_id
+            """
+        else:
+            failure_query = """
+            SELECT r.raw_id, r.origin, r.validation_status, NULL AS artifact_kind
+            FROM raw_sessions AS r
+            WHERE (r.parse_error IS NOT NULL AND TRIM(r.parse_error) != '')
+               OR r.validation_status = 'failed'
+            ORDER BY r.acquired_at_ms, r.raw_id
+            """
+        failed_rows = conn.execute(failure_query).fetchall()
+    except sqlite3.Error as exc:
+        logger.warning("could not read raw failure lifecycle", exc_info=exc)
+        return RawFailureLifecycleSnapshot(False, reason=f"could not read raw failure lifecycle: {exc}")
+    finally:
+        conn.close()
+
+    by_origin: Counter[str] = Counter()
+    by_artifact_kind: Counter[str] = Counter()
+    counts: Counter[str] = Counter()
+    samples: list[dict[str, str | None]] = []
+    for row in failed_rows:
+        origin = str(row[1] or "unknown")
+        artifact_kind = str(row[3]) if row[3] is not None else None
+        validation_failed = str(row[2] or "") == "failed"
+        lifecycle = _lifecycle(artifact_kind, validation_failed=validation_failed)
+        counts[lifecycle] += 1
+        by_origin[origin] += 1
+        by_artifact_kind[artifact_kind or "<none>"] += 1
+        if len(samples) < max(0, sample_limit):
+            samples.append(
+                {
+                    "raw_id": str(row[0]),
+                    "origin": origin,
+                    "artifact_kind": artifact_kind,
+                    "lifecycle": lifecycle,
+                }
+            )
+    return RawFailureLifecycleSnapshot(
+        available=True,
+        parse_failures=parse_failures,
+        validation_failures=validation_failures,
+        deferred=counts["deferred"],
+        terminal=counts["terminal"],
+        unexplained=counts["unexplained"],
+        by_origin=tuple(sorted(by_origin.items())),
+        by_artifact_kind=tuple(sorted(by_artifact_kind.items())),
+        samples=tuple(samples),
+    )
+
+
+__all__ = ["RawFailureLifecycleSnapshot", "read_raw_failure_lifecycle"]

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -13,6 +13,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from click.exceptions import Exit as ClickExit
 from click.testing import CliRunner
 
 from polylogue.api import Polylogue
@@ -148,14 +149,15 @@ def test_status_command_reads_a_real_daemon_http_status_route() -> None:
         env = _make_app_env()
         callback = getattr(status_command.callback, "__wrapped__", None)
         assert callable(callback)
-        callback(
-            env,
-            daemon_url=f"http://127.0.0.1:{server.server_port}",
-            output_format="json",
-            json_alias=False,
-            full_payload=False,
-            exact_archive_readiness=False,
-        )
+        with pytest.raises(ClickExit):
+            callback(
+                env,
+                daemon_url=f"http://127.0.0.1:{server.server_port}",
+                output_format="json",
+                json_alias=False,
+                full_payload=False,
+                exact_archive_readiness=False,
+            )
     finally:
         server.shutdown()
         worker.join()
@@ -195,14 +197,15 @@ def test_status_command_reports_live_daemon_with_unavailable_status_snapshot() -
         env = _make_app_env()
         callback = getattr(status_command.callback, "__wrapped__", None)
         assert callable(callback)
-        callback(
-            env,
-            daemon_url=f"http://127.0.0.1:{server.server_port}",
-            output_format="json",
-            json_alias=False,
-            full_payload=False,
-            exact_archive_readiness=False,
-        )
+        with pytest.raises(ClickExit):
+            callback(
+                env,
+                daemon_url=f"http://127.0.0.1:{server.server_port}",
+                output_format="json",
+                json_alias=False,
+                full_payload=False,
+                exact_archive_readiness=False,
+            )
     finally:
         server.shutdown()
         worker.join()
@@ -653,6 +656,9 @@ class TestNoArchiveStatus:
             "deferred_retryable": 1,
             "terminal_rejections": 0,
             "unexplained": 0,
+            "lifecycle_available": True,
+            "lifecycle_state": "degraded",
+            "lifecycle_reason": None,
             "sample_count": 1,
         }
 
@@ -2046,10 +2052,53 @@ class TestNoArchiveStatus:
         assert payload["component_readiness"]["raw_frontier_integrity"]["state"] == "unknown"
 
     @pytest.mark.frozen_clock_modules("polylogue.readiness.capability")
+    @pytest.mark.parametrize(
+        ("lifecycle_available", "lifecycle_state", "unexplained", "expected_exit"),
+        [
+            (False, "unavailable", 0, 1),
+            (True, "blocked", 1, 1),
+            (True, "degraded", 0, 1),
+            (True, "healthy", 0, 0),
+        ],
+    )
+    def test_root_status_json_exit_matches_raw_failure_lifecycle(
+        self,
+        lifecycle_available: bool,
+        lifecycle_state: str,
+        unexplained: int,
+        expected_exit: int,
+        frozen_clock: FrozenClock,
+    ) -> None:
+        env = _make_app_env()
+        daemon_payload = {
+            "ok": True,
+            "daemon_liveness": True,
+            "status_snapshot": _fresh_status_snapshot(frozen_clock),
+            "raw_frontier_integrity": _healthy_raw_frontier_integrity(),
+            "raw_failure_lifecycle_available": lifecycle_available,
+            "raw_failure_lifecycle_state": lifecycle_state,
+            "raw_failure_lifecycle_reason": "source evidence test state",
+            "raw_parse_failures": 1 if lifecycle_state == "degraded" else 0,
+            "raw_validation_failures": 0,
+            "raw_unexplained_failures": unexplained,
+        }
+        with patch("polylogue.cli.commands.status.urlopen", return_value=_FakeDaemonResponse(daemon_payload)):
+            result = CliRunner().invoke(
+                status_command,
+                ["--daemon-url", "http://127.0.0.1:8765", "--json"],
+                obj=env,
+            )
+
+        assert result.exit_code == expected_exit
+        rendered = _combined_calls(env)
+        payload = json.loads(rendered)
+        assert payload["ok"] is (expected_exit == 0)
+
+    @pytest.mark.frozen_clock_modules("polylogue.readiness.capability")
     def test_status_ok_requires_complete_fresh_frontier_authority(self, frozen_clock: FrozenClock) -> None:
         assert _status_ok({"ok": True, "daemon_liveness": True}) is False
         healthy = _healthy_raw_frontier_integrity()
-        assert _status_ok({"ok": True, "raw_frontier_integrity": healthy}) is True
+        assert _status_ok({"ok": True, "raw_frontier_integrity": healthy}) is False
         assert (
             _status_ok(
                 {"ok": True, "raw_frontier_integrity": healthy},
@@ -2063,6 +2112,11 @@ class TestNoArchiveStatus:
                     "ok": True,
                     "status_snapshot": _fresh_status_snapshot(frozen_clock),
                     "raw_frontier_integrity": healthy,
+                    "raw_failure_lifecycle_available": True,
+                    "raw_failure_lifecycle_state": "healthy",
+                    "raw_parse_failures": 0,
+                    "raw_validation_failures": 0,
+                    "raw_unexplained_failures": 0,
                 },
                 require_fresh_snapshot=True,
             )
@@ -2075,6 +2129,11 @@ class TestNoArchiveStatus:
                     "daemon_liveness": True,
                     "status_snapshot": {"state": "stale"},
                     "raw_frontier_integrity": healthy,
+                    "raw_failure_lifecycle_available": True,
+                    "raw_failure_lifecycle_state": "healthy",
+                    "raw_parse_failures": 0,
+                    "raw_validation_failures": 0,
+                    "raw_unexplained_failures": 0,
                 }
             )
             is False
@@ -2196,7 +2255,7 @@ class TestNoArchiveStatus:
                 obj=env,
             )
 
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         payload = json.loads(_combined_calls(env))
         assert payload["daemon_liveness"] is True
         assert payload["live_cursor"] == full_payload["live_cursor"]
@@ -2220,7 +2279,7 @@ class TestNoArchiveStatus:
                 obj=env,
             )
 
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         payload = json.loads(_combined_calls(env))
         assert payload["source"] == "daemon"
         assert "live_cursor" not in payload
@@ -2253,7 +2312,7 @@ class TestNoArchiveStatus:
                     obj=env,
                 )
 
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         assert requested_urls == [
             "http://127.0.0.1:8766/api/status",
             "http://127.0.0.1:8786/api/status",

--- a/tests/unit/daemon/test_bulk_rebuild.py
+++ b/tests/unit/daemon/test_bulk_rebuild.py
@@ -34,6 +34,7 @@ import asyncio
 import sqlite3
 from pathlib import Path
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
 
@@ -107,6 +108,38 @@ def _connect(path: Path) -> sqlite3.Connection:
     conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
     conn.row_factory = sqlite3.Row
     return conn
+
+
+def test_daemon_bulk_rebuild_refuses_unexplained_failures_before_generation_or_page_selection(
+    tmp_path: Path,
+) -> None:
+    """The real daemon route fails before creating state or selecting raws."""
+    initialize_active_archive_root(tmp_path)
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_sessions(
+                raw_id, origin, native_id, source_path, blob_hash, blob_size,
+                acquired_at_ms, parse_error
+            ) VALUES ('raw-failed', 'codex-session', 'failed', '/x', ?, 10, 100, 'parser failed')
+            """,
+            (b"f" * 32,),
+        )
+        conn.commit()
+
+    parse_stage = Mock()
+    with pytest.raises(RuntimeError, match="raw failure lifecycle preflight"):
+        asyncio.run(
+            run_daemon_bulk_rebuild_pass(
+                config=_config(tmp_path),
+                parse_stage=parse_stage,  # preflight must make this unreachable
+                batch_size=1,
+                max_payload_bytes=10_000,
+            )
+        )
+
+    assert not (tmp_path / ".index-generations").exists()
+    parse_stage.warm_raw_ids.assert_not_called()
 
 
 def _table_rows(conn: sqlite3.Connection, table: str) -> tuple[tuple[Any, ...], ...]:

--- a/tests/unit/daemon/test_daemon_http_contracts.py
+++ b/tests/unit/daemon/test_daemon_http_contracts.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import sqlite3
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from email.message import Message
@@ -95,6 +96,9 @@ REQUIRED_STATUS_KEYS: frozenset[str] = frozenset(
         "raw_quarantined",
         "raw_detection_warnings",
         "raw_failure_samples",
+        "raw_failure_lifecycle_available",
+        "raw_failure_lifecycle_state",
+        "raw_failure_lifecycle_reason",
         "last_event_id",
     }
 )
@@ -108,6 +112,10 @@ REQUIRED_HEALTH_KEYS: frozenset[str] = frozenset(
         "blob_dir_size_bytes",
         "quick_check",
         "quick_check_age_s",
+        "raw_failure_lifecycle_available",
+        "raw_failure_lifecycle_state",
+        "raw_failure_lifecycle_reason",
+        "raw_failure_lifecycle",
     }
 )
 
@@ -382,6 +390,58 @@ class TestStatusEnvelopeContract:
         assert status == HTTPStatus.OK
         assert payload["quick_check"] == "pass"
         assert payload["ok"] is True
+
+    @pytest.mark.parametrize("source_state", ["missing", "malformed", "unreadable", "unexplained"])
+    def test_fast_health_fails_closed_for_every_raw_lifecycle_failure_shape(
+        self,
+        workspace_env: dict[str, Path],
+        source_state: str,
+    ) -> None:
+        """The fast route cannot turn absent source evidence into a healthy archive."""
+        _init_archive(workspace_env["archive_root"])
+        source_db = workspace_env["archive_root"] / "source.db"
+        if source_state == "missing":
+            source_db.unlink()
+        elif source_state == "malformed":
+            source_db.write_bytes(b"not sqlite")
+        elif source_state == "unreadable":
+            source_db.unlink()
+            source_db.mkdir()
+        else:
+            with sqlite3.connect(source_db) as conn:
+                conn.execute(
+                    """
+                    INSERT INTO raw_sessions (
+                        raw_id, origin, native_id, source_path, blob_hash,
+                        blob_size, acquired_at_ms, parse_error
+                    ) VALUES ('raw-failed', 'codex-session', 'failed', '/bad', ?, 1, 1, 'parser failed')
+                    """,
+                    (b"f" * 32,),
+                )
+                conn.commit()
+
+        handler = _make_handler("GET", "/api/health")
+        _, send_json = _capture_responses(handler)
+        handler.do_GET()
+
+        status, payload = send_json.call_args.args
+        assert status == HTTPStatus.SERVICE_UNAVAILABLE
+        assert payload["ok"] is False
+        assert payload["raw_failure_lifecycle_state"] in {"unavailable", "blocked"}
+        assert payload["raw_failure_lifecycle_available"] is (source_state == "unexplained")
+
+    def test_fast_health_accepts_only_a_clean_zero_failure_source(self, workspace_env: dict[str, Path]) -> None:
+        _init_archive(workspace_env["archive_root"])
+        handler = _make_handler("GET", "/api/health")
+        _, send_json = _capture_responses(handler)
+        handler.do_GET()
+
+        status, payload = send_json.call_args.args
+        assert status == HTTPStatus.OK
+        assert payload["ok"] is True
+        assert payload["raw_failure_lifecycle_available"] is True
+        assert payload["raw_failure_lifecycle_state"] == "healthy"
+        assert payload["raw_failure_lifecycle"]["unexplained"] == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -8,10 +8,12 @@ from typing import Any, Literal, cast
 from unittest.mock import Mock, patch
 
 import pytest
+from click.testing import CliRunner
 
 from polylogue.browser_capture.receiver import BrowserCaptureReceiverConfig
 from polylogue.core.json import JSONDocument
 from polylogue.daemon import status as status_module
+from polylogue.daemon.cli import status_command as daemon_status_command
 from polylogue.daemon.fts_status import FTSReadiness
 from polylogue.daemon.health import DaemonHealth, HealthAlert, HealthSeverity, HealthTier
 from polylogue.daemon.status import (
@@ -140,6 +142,21 @@ def test_daemon_status_plain_output_reports_schema_and_cursor_debt() -> None:
         in lines
     )
     assert "Failing files: 1 shown, 2 omitted" in lines
+
+
+@pytest.mark.parametrize(("payload_ok", "expected_exit"), [(False, 1), (True, 0)])
+def test_daemon_status_command_exit_matches_json_health_claim(payload_ok: bool, expected_exit: int) -> None:
+    """``polylogued status`` exposes JSON and shell status consistently."""
+    with (
+        patch("polylogue.daemon.cli.configure_logging"),
+        patch(
+            "polylogue.daemon.cli._live_daemon_status_payload",
+            return_value={"ok": payload_ok, "raw_failure_lifecycle_state": "healthy" if payload_ok else "blocked"},
+        ),
+    ):
+        result = CliRunner().invoke(daemon_status_command, ["--format", "json"])
+
+    assert result.exit_code == expected_exit
 
 
 def test_status_snapshot_stale_healthy_authority_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1923,6 +1940,45 @@ def test_daemon_status_payload_marks_unproven_raw_frontier_non_green(
     frontier = cast(dict[str, object], payload["raw_frontier_integrity"])
     assert frontier["overall_status"] == overall_status
     assert payload["ok"] is False
+
+
+@pytest.mark.parametrize(
+    ("available", "lifecycle_state", "expected_ok"),
+    [
+        (False, "unavailable", False),
+        (True, "blocked", False),
+        (True, "degraded", False),
+        (True, "healthy", True),
+    ],
+)
+def test_daemon_status_route_requires_explicit_clean_raw_failure_lifecycle(
+    available: bool,
+    lifecycle_state: Literal["healthy", "degraded", "blocked", "unavailable"],
+    expected_ok: bool,
+) -> None:
+    """Root status JSON never promotes missing or non-clean source evidence."""
+    status = status_module.DaemonStatus(
+        daemon_liveness=True,
+        raw_failure_lifecycle_available=available,
+        raw_failure_lifecycle_state=lifecycle_state,
+        raw_failure_lifecycle_reason="source evidence test state",
+        raw_frontier_integrity=status_module.RawFrontierIntegrity(overall_status="healthy"),
+        raw_parse_failures=1 if lifecycle_state == "degraded" else 0,
+        raw_unexplained_failures=1 if lifecycle_state == "blocked" else 0,
+    )
+    with (
+        patch("polylogue.daemon.status.build_daemon_status", return_value=status),
+        patch("polylogue.daemon.status._archive_debt_status_summary", return_value={}),
+        patch("polylogue.daemon.events.get_last_ingestion_batch", return_value=None),
+    ):
+        payload = daemon_status_payload(sources=())
+
+    assert payload["ok"] is expected_ok
+    lines = format_daemon_status_lines(payload)
+    if expected_ok:
+        assert not any("Raw failures: unavailable" in line for line in lines)
+    else:
+        assert any("Raw failures:" in line for line in lines)
 
 
 def test_daemon_and_direct_claim_guard_share_mixed_frontier_summary(tmp_path: Path) -> None:

--- a/tests/unit/daemon/test_health_contract.py
+++ b/tests/unit/daemon/test_health_contract.py
@@ -30,7 +30,7 @@ from http import HTTPStatus
 from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -648,6 +648,74 @@ class TestReadinessProbeContract:
 # ---------------------------------------------------------------------------
 # 5. JSON-shape sanity for downstream consumers (#1236 OCI HEALTHCHECK)
 # ---------------------------------------------------------------------------
+
+
+class TestArchiveHealthRouteRawFailureLifecycle:
+    """The health route preserves source-tier lifecycle failures as errors."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_failures(self) -> Iterator[None]:
+        health_module._failure_counts.clear()
+        yield
+        health_module._failure_counts.clear()
+
+    def _patch_route_checks(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(health_module, "resolve_health_tiers", lambda _value: {HealthTier.MEDIUM})
+        monkeypatch.setattr(health_module, "_run_fast_checks", lambda: [])
+        monkeypatch.setattr(
+            health_module,
+            "_run_medium_checks",
+            lambda: [health_module._check_raw_failures_medium()],
+        )
+        monkeypatch.setattr(health_module, "_run_expensive_checks", lambda: [])
+
+    def _call_health_route(self) -> tuple[HTTPStatus, dict[str, object]]:
+        handler = _make_handler("GET", "/api/health/check")
+        _, send_json = _capture_responses(handler)
+        handler._handle_health_check()
+        status, payload = send_json.call_args.args
+        return status, cast(dict[str, object], payload)
+
+    @pytest.mark.parametrize("source_state", ["missing", "malformed", "unreadable"])
+    def test_health_route_blocks_unavailable_source_lifecycle(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        source_state: str,
+    ) -> None:
+        root = tmp_path / "archive"
+        root.mkdir()
+        source_db = root / "source.db"
+        if source_state == "malformed":
+            source_db.write_bytes(b"not a sqlite database")
+        elif source_state == "unreadable":
+            source_db.mkdir()
+        self._patch_route_checks(monkeypatch)
+
+        with patch("polylogue.daemon.status.archive_root", return_value=root):
+            status, payload = self._call_health_route()
+
+        assert status == HTTPStatus.SERVICE_UNAVAILABLE
+        assert payload["ok"] is False
+        assert payload["status"] == "error"
+        assert payload["alerts"] == 1
+
+    def test_health_route_reports_healthy_zero_failure_source(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = tmp_path / "archive"
+        root.mkdir()
+        from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+        from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+        initialize_archive_database(root / "source.db", ArchiveTier.SOURCE)
+        self._patch_route_checks(monkeypatch)
+
+        with patch("polylogue.daemon.status.archive_root", return_value=root):
+            status, payload = self._call_health_route()
+
+        assert status == HTTPStatus.OK
+        assert payload == {"ok": True, "status": "healthy"}
 
 
 @pytest.mark.contract

--- a/tests/unit/daemon/test_health_contract.py
+++ b/tests/unit/daemon/test_health_contract.py
@@ -676,7 +676,7 @@ class TestArchiveHealthRouteRawFailureLifecycle:
         status, payload = send_json.call_args.args
         return status, cast(dict[str, object], payload)
 
-    @pytest.mark.parametrize("source_state", ["missing", "malformed", "unreadable"])
+    @pytest.mark.parametrize("source_state", ["missing", "malformed", "unreadable", "unexplained"])
     def test_health_route_blocks_unavailable_source_lifecycle(
         self,
         tmp_path: Path,
@@ -690,6 +690,22 @@ class TestArchiveHealthRouteRawFailureLifecycle:
             source_db.write_bytes(b"not a sqlite database")
         elif source_state == "unreadable":
             source_db.mkdir()
+        elif source_state == "unexplained":
+            from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+            from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+            initialize_archive_database(source_db, ArchiveTier.SOURCE)
+            with sqlite3.connect(source_db) as conn:
+                conn.execute(
+                    """
+                    INSERT INTO raw_sessions (
+                        raw_id, origin, native_id, source_path, blob_hash,
+                        blob_size, acquired_at_ms, parse_error
+                    ) VALUES ('raw-failed', 'codex-session', 'failed', '/bad', ?, 1, 1, 'parser failed')
+                    """,
+                    (b"f" * 32,),
+                )
+                conn.commit()
         self._patch_route_checks(monkeypatch)
 
         with patch("polylogue.daemon.status.archive_root", return_value=root):

--- a/tests/unit/daemon/test_raw_failure_sample.py
+++ b/tests/unit/daemon/test_raw_failure_sample.py
@@ -16,6 +16,7 @@ from polylogue.daemon.status import (
     RawFailureSample,
     _raw_failure_info,
 )
+from polylogue.storage.raw_failure_lifecycle import read_raw_failure_lifecycle
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.source_write import ArchiveSourceArtifact, upsert_raw_artifact
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
@@ -436,6 +437,135 @@ class TestRawFailureInfoProducesTypedSamples:
 
         assert info["parse_failures"] == 1
         assert info["terminal_rejections"] == 1
+
+    def test_raw_failure_lifecycle_rejects_mismatched_or_malformed_artifacts(self, tmp_path: Path) -> None:
+        """Status cannot bless evidence with the wrong support or raw identity."""
+        index_db = _seed_archive_raw_session(
+            tmp_path,
+            raw_id="raw-malformed",
+            origin="codex-session",
+            native_id="malformed",
+            source_path="/data/malformed.jsonl",
+            parse_error="parser failed",
+        )
+        _seed_archive_raw_session(
+            tmp_path,
+            raw_id="raw-target",
+            origin="codex-session",
+            native_id="target",
+            source_path="/data/target.jsonl",
+            parse_error="parser failed",
+        )
+        _seed_archive_raw_session(
+            tmp_path,
+            raw_id="raw-other",
+            origin="codex-session",
+            native_id="other",
+            source_path="/data/other.jsonl",
+        )
+        with sqlite3.connect(tmp_path / "source.db") as conn:
+            # The evidence kind is terminal_corrupt_input, but its support
+            # status belongs to terminal_unsupported_shape.
+            upsert_raw_artifact(
+                conn,
+                "raw-malformed",
+                ArchiveSourceArtifact(
+                    artifact_id="malformed-evidence",
+                    origin="codex-session",
+                    source_path="/data/malformed.jsonl",
+                    source_index=0,
+                    artifact_kind="terminal_corrupt_input",
+                    classification_reason="terminal_corrupt_input",
+                    support_status=ArtifactSupportStatus.UNSUPPORTED_PARSEABLE,
+                ),
+            )
+            # A source-identity match is insufficient when the durable raw_id
+            # points at a different retained payload.
+            upsert_raw_artifact(
+                conn,
+                "raw-other",
+                ArchiveSourceArtifact(
+                    artifact_id="mismatched-evidence",
+                    origin="codex-session",
+                    source_path="/data/target.jsonl",
+                    source_index=0,
+                    artifact_kind="terminal_corrupt_input",
+                    classification_reason="terminal_corrupt_input",
+                    support_status=ArtifactSupportStatus.DECODE_FAILED,
+                ),
+            )
+            conn.commit()
+
+        snapshot = read_raw_failure_lifecycle(tmp_path / "source.db")
+        with (
+            patch("polylogue.daemon.status.archive_root", return_value=tmp_path),
+            patch("polylogue.daemon.status._active_status_db_path", return_value=index_db),
+        ):
+            info = _raw_failure_info()
+
+        assert snapshot.terminal == 0
+        assert snapshot.unexplained == 2
+        assert info["terminal_rejections"] == snapshot.terminal
+        assert info["unexplained_failures"] == snapshot.unexplained
+
+    def test_daemon_status_lifecycle_counts_match_the_shared_projection(self, tmp_path: Path) -> None:
+        """The health/status source is the same lifecycle projection as preflight."""
+        index_db = _seed_archive_raw_session(
+            tmp_path,
+            raw_id="raw-terminal",
+            origin="codex-session",
+            native_id="terminal",
+            source_path="/data/terminal.jsonl",
+            parse_error="bad input",
+        )
+        _seed_archive_raw_session(
+            tmp_path,
+            raw_id="raw-deferred",
+            origin="codex-session",
+            native_id="deferred",
+            source_path="/data/deferred.jsonl",
+            parse_error="hot capture",
+            acquired_at_ms=1_770_000_000_001,
+        )
+        with sqlite3.connect(tmp_path / "source.db") as conn:
+            upsert_raw_artifact(
+                conn,
+                "raw-terminal",
+                ArchiveSourceArtifact(
+                    artifact_id="terminal-evidence",
+                    origin="codex-session",
+                    source_path="/data/terminal.jsonl",
+                    source_index=0,
+                    artifact_kind="terminal_corrupt_input",
+                    classification_reason="terminal_corrupt_input",
+                    support_status=ArtifactSupportStatus.DECODE_FAILED,
+                ),
+            )
+            upsert_raw_artifact(
+                conn,
+                "raw-deferred",
+                ArchiveSourceArtifact(
+                    artifact_id="deferred-evidence",
+                    origin="codex-session",
+                    source_path="/data/deferred.jsonl",
+                    source_index=0,
+                    artifact_kind="deferred_hot_jsonl_capture",
+                    classification_reason="deferred_hot_jsonl_capture",
+                    support_status=ArtifactSupportStatus.PARTIAL_DECODE,
+                ),
+            )
+            conn.commit()
+
+        snapshot = read_raw_failure_lifecycle(tmp_path / "source.db")
+        with (
+            patch("polylogue.daemon.status.archive_root", return_value=tmp_path),
+            patch("polylogue.daemon.status._active_status_db_path", return_value=index_db),
+        ):
+            info = _raw_failure_info()
+
+        assert info["deferred_failures"] == snapshot.deferred == 1
+        assert info["terminal_rejections"] == snapshot.terminal == 1
+        assert info["unexplained_failures"] == snapshot.unexplained == 0
 
     def test_raw_failure_info_streams_lifecycle_counts_beyond_sample_cap(self, tmp_path: Path) -> None:
         """Lifecycle counts cover every failed raw without bulk-fetching rows."""

--- a/tests/unit/daemon/test_raw_failure_sample.py
+++ b/tests/unit/daemon/test_raw_failure_sample.py
@@ -11,10 +11,13 @@ import pytest
 from pydantic import ValidationError
 
 from polylogue.core.enums import ArtifactSupportStatus
+from polylogue.core.json import JSONDocument
 from polylogue.daemon.status import (
     DaemonStatus,
     RawFailureSample,
     _raw_failure_info,
+    format_daemon_status_lines,
+    raw_failure_info_for_root,
 )
 from polylogue.storage.raw_failure_lifecycle import read_raw_failure_lifecycle
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
@@ -566,6 +569,52 @@ class TestRawFailureInfoProducesTypedSamples:
         assert info["deferred_failures"] == snapshot.deferred == 1
         assert info["terminal_rejections"] == snapshot.terminal == 1
         assert info["unexplained_failures"] == snapshot.unexplained == 0
+
+    @pytest.mark.parametrize("source_state", ["missing", "malformed"])
+    def test_status_fails_closed_when_source_lifecycle_is_unavailable(
+        self,
+        tmp_path: Path,
+        source_state: str,
+    ) -> None:
+        """An index fallback cannot turn unavailable source evidence into zero failures."""
+        source_db = tmp_path / "source.db"
+        if source_state == "malformed":
+            source_db.write_bytes(b"not a sqlite database")
+
+        with patch("polylogue.daemon.status.archive_root", return_value=tmp_path):
+            info = _raw_failure_info()
+            root_info = raw_failure_info_for_root(tmp_path)
+
+        for status in (info, root_info):
+            assert status["raw_failure_lifecycle_available"] is False
+            assert status["raw_failure_lifecycle_state"] == "unavailable"
+            assert status["raw_failure_lifecycle_reason"]
+            rendered = "\n".join(
+                format_daemon_status_lines(
+                    cast(
+                        JSONDocument,
+                        {
+                            "raw_failure_lifecycle_available": status["raw_failure_lifecycle_available"],
+                            "raw_failure_lifecycle_state": status["raw_failure_lifecycle_state"],
+                            "raw_failure_lifecycle_reason": status["raw_failure_lifecycle_reason"],
+                        },
+                    )
+                )
+            )
+            assert "unavailable" in rendered
+            assert "no raw failures" not in rendered
+
+    def test_status_reports_healthy_zero_failure_lifecycle_for_valid_source(self, tmp_path: Path) -> None:
+        initialize_archive_database(tmp_path / "source.db", ArchiveTier.SOURCE)
+
+        with patch("polylogue.daemon.status.archive_root", return_value=tmp_path):
+            info = raw_failure_info_for_root(tmp_path)
+
+        assert info["raw_failure_lifecycle_available"] is True
+        assert info["raw_failure_lifecycle_state"] == "healthy"
+        assert info["parse_failures"] == 0
+        assert info["validation_failures"] == 0
+        assert info["unexplained_failures"] == 0
 
     def test_raw_failure_info_streams_lifecycle_counts_beyond_sample_cap(self, tmp_path: Path) -> None:
         """Lifecycle counts cover every failed raw without bulk-fetching rows."""

--- a/tests/unit/devtools/test_preflight_ledger.py
+++ b/tests/unit/devtools/test_preflight_ledger.py
@@ -229,6 +229,30 @@ def test_preflight_ignores_blank_parse_errors_in_origin_and_totals(tmp_path: Pat
     assert eligibility["actionable_count"] == 1
 
 
+def test_preflight_blocks_unexplained_raw_failure_lifecycle(tmp_path: Path) -> None:
+    _initialize_all_tiers(tmp_path)
+    _insert_raws(
+        tmp_path,
+        origin="codex-session",
+        quarantined_count=1,
+        missing_census=0,
+        missing_quarantine_count=0,
+        quarantined_bytes=1,
+        missing_census_bytes=0,
+    )
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        conn.execute("UPDATE raw_sessions SET parse_error = 'unexpected parser failure'")
+        conn.commit()
+
+    report = build_preflight_ledger(tmp_path)
+    lifecycle = _mapping(_mapping(report["checks"])["raw_failure_lifecycle"])
+
+    assert lifecycle["state"] == "fail"
+    assert "raw_failure_lifecycle" in _list(report["blocking_checks"])
+    evidence = _mapping(lifecycle["evidence"])
+    assert evidence["unexplained"] == 1
+
+
 def test_preflight_exposes_schema_and_convergence_failures_without_writing(tmp_path: Path) -> None:
     _initialize_all_tiers(tmp_path)
     with sqlite3.connect(tmp_path / "source.db") as conn:

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import pytest
 
+from polylogue.core.enums import ArtifactSupportStatus, Origin
 from polylogue.core.outcomes import OutcomeStatus
 from polylogue.maintenance.archive_verification import (
     ARCHIVE_VERIFICATION_CHECK_NAMES,
@@ -29,6 +30,7 @@ from polylogue.maintenance.archive_verification import (
 )
 from polylogue.sources.origin_specs import lowering_fingerprint, parser_fingerprint_for_origin
 from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS, initialize_active_archive_root
+from polylogue.storage.sqlite.archive_tiers.source_write import ArchiveSourceArtifact, upsert_raw_artifact
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from tests.infra.pathology_zoo import build_pathology_zoo, make_pathology_zoo_member_red
 from tests.infra.workload_artifacts import SeededArchiveArtifact
@@ -111,6 +113,74 @@ def test_coherent_archive_is_all_ok(tmp_path: Path) -> None:
     assert {check.name for check in report.checks} == set(ARCHIVE_VERIFICATION_CHECK_NAMES)
     for check in report.checks:
         assert check.status is OutcomeStatus.OK, f"{check.name}: {check.summary}"
+
+
+def test_raw_failure_lifecycle_accepts_only_typed_deferred_or_terminal_evidence(tmp_path: Path) -> None:
+    """A real source-tier failure without its closed outcome blocks reindex."""
+    _seed_coherent_archive(tmp_path)
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        conn.execute("UPDATE raw_sessions SET parse_error = 'parser failed' WHERE raw_id = 'raw-1'")
+        upsert_raw_artifact(
+            conn,
+            "raw-1",
+            ArchiveSourceArtifact(
+                artifact_id="failure-evidence",
+                origin=Origin.CODEX_SESSION,
+                source_path="/x",
+                source_index=0,
+                artifact_kind="terminal_corrupt_input",
+                classification_reason="terminal_corrupt_input",
+                support_status=ArtifactSupportStatus.DECODE_FAILED,
+                first_observed_at_ms=100,
+                last_observed_at_ms=100,
+            ),
+        )
+        conn.commit()
+
+    typed = verify_archive(tmp_path, checks=("raw-failure-lifecycle",))
+    typed_check = _check(typed, "raw-failure-lifecycle")
+    assert typed_check.status is OutcomeStatus.WARNING
+    assert not typed.blocking
+    assert typed_check.evidence["terminal"] == 1
+
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        conn.execute("DELETE FROM raw_artifacts WHERE raw_id = 'raw-1'")
+        conn.commit()
+
+    untyped = verify_archive(tmp_path, checks=("raw-failure-lifecycle",))
+    untyped_check = _check(untyped, "raw-failure-lifecycle")
+    assert untyped_check.status is OutcomeStatus.ERROR
+    assert untyped.blocking
+    assert untyped_check.evidence["unexplained"] == 1
+
+
+def test_raw_failure_lifecycle_mutation_red_twin_for_validation_failures(tmp_path: Path) -> None:
+    """Validation failures cannot be hidden by a parse-outcome artifact label."""
+    _seed_coherent_archive(tmp_path)
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        conn.execute("UPDATE raw_sessions SET validation_status = 'failed' WHERE raw_id = 'raw-1'")
+        upsert_raw_artifact(
+            conn,
+            "raw-1",
+            ArchiveSourceArtifact(
+                artifact_id="validation-evidence",
+                origin=Origin.CODEX_SESSION,
+                source_path="/x",
+                source_index=0,
+                artifact_kind="terminal_unsupported_shape",
+                classification_reason="terminal_unsupported_shape",
+                support_status=ArtifactSupportStatus.UNSUPPORTED_PARSEABLE,
+                first_observed_at_ms=100,
+                last_observed_at_ms=100,
+            ),
+        )
+        conn.commit()
+
+    report = verify_archive(tmp_path, checks=("raw-failure-lifecycle",))
+    check = _check(report, "raw-failure-lifecycle")
+    assert check.status is OutcomeStatus.ERROR
+    assert check.evidence["validation_failures"] == 1
+    assert check.evidence["unexplained"] == 1
 
 
 def test_missing_tier_trips_tier_schema_check(tmp_path: Path) -> None:
@@ -1394,6 +1464,7 @@ RED_TWIN_TESTS: dict[str, str] = {
     "lineage-sanity": "test_dangling_resolved_dst_trips_lineage_sanity",
     "enum-superset-check": "test_missing_enum_value_trips_enum_superset_check",
     "blob-refs-liveness": "test_blob_ref_with_no_referent_trips_blob_refs_liveness",
+    "raw-failure-lifecycle": "test_raw_failure_lifecycle_mutation_red_twin_for_validation_failures",
     "pathology-zoo-invariants": "test_pathology_zoo_invariants_red_twin",
     "embeddings-refs-liveness": "test_orphaned_embedding_ref_trips_embeddings_refs_liveness",
     "session-lineage-acyclic": "test_parent_session_id_cycle_trips_session_lineage_acyclic",

--- a/tests/unit/maintenance/test_rebuild_index_ownership.py
+++ b/tests/unit/maintenance/test_rebuild_index_ownership.py
@@ -71,6 +71,27 @@ def test_rebuild_source_preflight_rejects_orphaned_blob_refs_before_generation_c
     assert not (root / ".index-generations").exists()
 
 
+def test_rebuild_source_preflight_rejects_unexplained_raw_failure(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _init_empty_source(root)
+    with sqlite3.connect(root / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_sessions(
+                raw_id, origin, native_id, source_path, blob_hash, blob_size,
+                acquired_at_ms, parse_error
+            ) VALUES ('raw-failed', 'codex-session', 'failed', '/x', ?, 10, 100, 'unexpected parser failure')
+            """,
+            (b"u" * 32,),
+        )
+        conn.commit()
+
+    with pytest.raises(RuntimeError, match="raw-failure-lifecycle"):
+        rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root))
+
+    assert not (root / ".index-generations").exists()
+
+
 def test_rebuild_preflight_exposes_unreconciled_source_ref_types(tmp_path: Path) -> None:
     root = tmp_path / "archive"
     _init_empty_source(root)


### PR DESCRIPTION
## Summary

Make stopped-daemon raw failure evidence an explicit pre-reindex readiness decision. Every retained parse or validation failure is classified as deferred, terminal, or unexplained, and unexplained failures block a full index rebuild before candidate generation.

## Problem

The 2026-08-04 read-only census found 112 stopped-daemon failures: 111 raw parse failures and one maintenance failure. Only 59 raw parse failures had typed artifact observations. The remaining 52 failures had no durable lifecycle explanation, so a converged-archive claim could hide unresolved parser errors.

## Solution

Add a read-only source-tier lifecycle projection over `raw_sessions` and the latest `raw_artifacts` observation. Wire it into the preflight ledger and archive verification. Full rebuilds now run this production verification path before creating an index generation and stop loudly when unexplained failures remain. Mutation-sensitive tests cover typed terminal evidence, validation-failure red twins, preflight blocking, and rebuild refusal.

## Verification

- `direnv exec . devtools verify --quick` passed with all 24 steps exiting 0, including format, lint, mypy, generated surfaces, layering, degradation policy, and schema/promotion checks.
- `direnv exec . devtools test tests/unit/maintenance/test_archive_verification.py` passed: 91 tests.
- `direnv exec . devtools test tests/unit/devtools/test_preflight_ledger.py` passed: 6 tests.
- `direnv exec . devtools test tests/unit/maintenance/test_rebuild_index_ownership.py` passed: 5 tests.
- Read-only live census reproduced 43,124 raw sessions, 111 parse failures, 0 validation failures, 59 typed artifact observations, and 52 unexplained failures. No live remediation or reindex was run.

## Acceptance matrix

| Acceptance criterion | Status | Evidence |
| --- | --- | --- |
| 1. Classify every current raw failure into deferred, terminal, or unexpected state with bounded preflight evidence. | Satisfied | `raw_failure_lifecycle` reports counts, origins, artifact kinds, and samples. Current unexplained rows remain visible as unexpected instead of being silently accepted. |
| 2. Add production-route regression tests for parser or lifecycle defects. | Satisfied | Archive verification, preflight ledger, and full rebuild tests exercise real source-tier relations and the reindex gate, including mutation-sensitive red twins. |
| 3. Stopped-daemon status distinguishes deferred work, terminal evidence, and unexplained failures, with unexplained failures critical before reindex. | Satisfied | The preflight ledger reports `warn` for typed deferred/terminal evidence and `fail` for unexplained or unavailable lifecycle data. `rebuild_index_from_source` rejects the failing verification result before generation creation. |
| 4. Post-deploy backup-gated dry-run/apply receipt reduces known defect failures without hiding truncated hot files. | Deferred by explicit scope | This implementation performs no production mutation. The post-deploy backup, dry-run, and apply receipt remain an operator boundary after deployment. |

Ref polylogue-dyica