### PR TITLE
test(devtools): harden corpus fidelity gate output

### DIFF
--- a/devtools/corpus_fidelity.py
+++ b/devtools/corpus_fidelity.py
@@ -80,6 +80,7 @@ def main(argv: list[str] | None = None, *, stdout: TextIO | None = None) -> int:
     if args.json:
         payload = dict(report.to_json())
         payload["blocking"] = blocking
+        payload["verdict"] = "FAIL" if blocking else "PASS"
         json.dump(payload, output, indent=2, sort_keys=True)
         print(file=output)
     else:

--- a/tests/unit/devtools/test_corpus_fidelity.py
+++ b/tests/unit/devtools/test_corpus_fidelity.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from devtools import corpus_fidelity
+from devtools import click_dispatch, corpus_fidelity
 from tests.infra.workload_artifacts import SeededArchiveArtifact, clone_seeded_archive
 
 
@@ -28,6 +28,32 @@ def test_command_runs_registered_gate_against_real_seeded_archive(
     assert "clear" in output
 
 
+def test_registered_click_route_emits_verdict_and_preserves_archive(
+    corpus_fidelity_archive: SeededArchiveArtifact,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("POLYLOGUE_TASK_HISTORY_DISABLE", "1")
+    paths = (corpus_fidelity_archive.root / "source.db", corpus_fidelity_archive.root / "index.db")
+    before = tuple(hashlib.sha256(path.read_bytes()).digest() for path in paths)
+
+    exit_code = click_dispatch.main(
+        [
+            "verify",
+            "corpus-fidelity",
+            "--archive-root",
+            str(corpus_fidelity_archive.root),
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["verdict"] == "PASS"
+    assert payload["blocking"] is False
+    assert tuple(hashlib.sha256(path.read_bytes()).digest() for path in paths) == before
+
+
 def _clone(artifact: SeededArchiveArtifact, destination: Path) -> Path:
     return clone_seeded_archive(artifact, destination).root
 
@@ -44,6 +70,7 @@ def test_command_blocks_real_seeded_archive_fidelity_violations(
     corpus_fidelity_archive: SeededArchiveArtifact,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
     violation: str,
     expected_check: str,
 ) -> None:
@@ -99,8 +126,10 @@ def test_command_blocks_real_seeded_archive_fidelity_violations(
                 ),
             )
 
-    exit_code = corpus_fidelity.main(["--archive-root", str(root), "--json"])
+    monkeypatch.setenv("POLYLOGUE_TASK_HISTORY_DISABLE", "1")
+    exit_code = click_dispatch.main(["verify", "corpus-fidelity", "--archive-root", str(root), "--json"])
     assert exit_code == 1
     payload = json.loads(capsys.readouterr().out)
+    assert payload["verdict"] == "FAIL"
     assert payload["blocking"] is True
     assert {check["name"]: check["status"] for check in payload["checks"]}[expected_check] == "error"

--- a/tests/unit/devtools/test_corpus_fidelity.py
+++ b/tests/unit/devtools/test_corpus_fidelity.py
@@ -9,49 +9,60 @@ from pathlib import Path
 
 import pytest
 
-from devtools import click_dispatch, corpus_fidelity
+from devtools import click_dispatch
+from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS
 from tests.infra.workload_artifacts import SeededArchiveArtifact, clone_seeded_archive
 
 
-def test_command_runs_registered_gate_against_real_seeded_archive(
-    corpus_fidelity_archive: SeededArchiveArtifact,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    exit_code = corpus_fidelity.main(["--archive-root", str(corpus_fidelity_archive.root)])
-
-    assert exit_code == 0
-    output = capsys.readouterr().out
-    assert "Corpus fidelity:" in output
-    assert "[OK] corpus-absences:" in output
-    assert "[OK] corpus-attachment-fidelity:" in output
-    assert "[OK] corpus-revision-fidelity:" in output
-    assert "clear" in output
+def _archive_tier_bytes(root: Path) -> dict[str, bytes]:
+    """Capture exact bytes for every registered tier file present in a fixture."""
+    snapshots: dict[str, bytes] = {}
+    for spec in ARCHIVE_TIER_SPECS.values():
+        path = root / spec.filename
+        if path.is_file():
+            snapshots[spec.filename] = path.read_bytes()
+    assert snapshots, f"expected at least one archive tier under {root}"
+    return snapshots
 
 
-def test_registered_click_route_emits_verdict_and_preserves_archive(
+def _run_registered_route(root: Path, *, json_output: bool) -> int:
+    argv = ["verify", "corpus-fidelity", "--archive-root", str(root)]
+    if json_output:
+        argv.append("--json")
+    return click_dispatch.main(argv)
+
+
+@pytest.mark.parametrize("json_output", (False, True), ids=("plain", "json"))
+def test_registered_route_preserves_all_existing_archive_tiers(
     corpus_fidelity_archive: SeededArchiveArtifact,
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
+    json_output: bool,
 ) -> None:
-    monkeypatch.setenv("POLYLOGUE_TASK_HISTORY_DISABLE", "1")
-    paths = (corpus_fidelity_archive.root / "source.db", corpus_fidelity_archive.root / "index.db")
-    before = tuple(hashlib.sha256(path.read_bytes()).digest() for path in paths)
+    """Run the real registered route and prove it is read-only across tiers.
 
-    exit_code = click_dispatch.main(
-        [
-            "verify",
-            "corpus-fidelity",
-            "--archive-root",
-            str(corpus_fidelity_archive.root),
-            "--json",
-        ]
-    )
+    Anti-vacuity: mutating the command to write ``user.db``, ``ops.db``, or
+    ``embeddings.db`` would fail the exact-byte assertion below. The previous
+    source/index-only snapshot left those unchecked-tier mutations green.
+    """
+    monkeypatch.setenv("POLYLOGUE_TASK_HISTORY_DISABLE", "1")
+    before = _archive_tier_bytes(corpus_fidelity_archive.root)
+
+    exit_code = _run_registered_route(corpus_fidelity_archive.root, json_output=json_output)
 
     assert exit_code == 0
-    payload = json.loads(capsys.readouterr().out)
-    assert payload["verdict"] == "PASS"
-    assert payload["blocking"] is False
-    assert tuple(hashlib.sha256(path.read_bytes()).digest() for path in paths) == before
+    output = capsys.readouterr().out
+    if json_output:
+        payload = json.loads(output)
+        assert payload["verdict"] == "PASS"
+        assert payload["blocking"] is False
+    else:
+        assert "Corpus fidelity:" in output
+        assert "[OK] corpus-absences:" in output
+        assert "[OK] corpus-attachment-fidelity:" in output
+        assert "[OK] corpus-revision-fidelity:" in output
+        assert "clear" in output
+    assert _archive_tier_bytes(corpus_fidelity_archive.root) == before
 
 
 def _clone(artifact: SeededArchiveArtifact, destination: Path) -> Path:
@@ -59,11 +70,14 @@ def _clone(artifact: SeededArchiveArtifact, destination: Path) -> Path:
 
 
 @pytest.mark.parametrize(
-    ("violation", "expected_check"),
+    ("violation", "expected_check", "json_output"),
     (
-        ("absent", "corpus-absences"),
-        ("attachment", "corpus-attachment-fidelity"),
-        ("revision", "corpus-revision-fidelity"),
+        ("absent", "corpus-absences", False),
+        ("absent", "corpus-absences", True),
+        ("attachment", "corpus-attachment-fidelity", False),
+        ("attachment", "corpus-attachment-fidelity", True),
+        ("revision", "corpus-revision-fidelity", False),
+        ("revision", "corpus-revision-fidelity", True),
     ),
 )
 def test_command_blocks_real_seeded_archive_fidelity_violations(
@@ -73,6 +87,7 @@ def test_command_blocks_real_seeded_archive_fidelity_violations(
     monkeypatch: pytest.MonkeyPatch,
     violation: str,
     expected_check: str,
+    json_output: bool,
 ) -> None:
     """The command drives the production registry over a writable clone of
     the real seeded SQLite archive. Removing its ``verify_archive`` call or
@@ -127,9 +142,16 @@ def test_command_blocks_real_seeded_archive_fidelity_violations(
             )
 
     monkeypatch.setenv("POLYLOGUE_TASK_HISTORY_DISABLE", "1")
-    exit_code = click_dispatch.main(["verify", "corpus-fidelity", "--archive-root", str(root), "--json"])
+    before = _archive_tier_bytes(root)
+    exit_code = _run_registered_route(root, json_output=json_output)
     assert exit_code == 1
-    payload = json.loads(capsys.readouterr().out)
-    assert payload["verdict"] == "FAIL"
-    assert payload["blocking"] is True
-    assert {check["name"]: check["status"] for check in payload["checks"]}[expected_check] == "error"
+    output = capsys.readouterr().out
+    if json_output:
+        payload = json.loads(output)
+        assert payload["verdict"] == "FAIL"
+        assert payload["blocking"] is True
+        assert {check["name"]: check["status"] for check in payload["checks"]}[expected_check] == "error"
+    else:
+        assert f"[FAIL] {expected_check}:" in output
+        assert "BLOCKING" in output
+    assert _archive_tier_bytes(root) == before

--- a/tests/unit/devtools/test_render_devtools_reference.py
+++ b/tests/unit/devtools/test_render_devtools_reference.py
@@ -36,6 +36,7 @@ def test_build_command_catalog_includes_discovery_and_commands() -> None:
         "| `.github/workflows/mutation-testing.yml` | `registered` | `devtools verify mutation-freshness` |" in rendered
     )
     assert "| `devtools verify pytest-timeout-overrides` |" in rendered
+    assert "| `devtools verify corpus-fidelity` | Run the production corpus-fidelity acceptance gate" in rendered
     assert "Common forms: `devtools status`" in rendered
 
 


### PR DESCRIPTION
## Summary
Adds an explicit machine-readable PASS/FAIL verdict to the corpus-fidelity acceptance command and proves the registered devtools route against a real seeded archive.

## Problem
The promoted command exposed only a blocking boolean in JSON, leaving future promotion or reindex automation without a stable verdict token. The focused tests also called the implementation module directly, so they did not prove catalog and Click dispatch wiring.

## Solution
- Emit `verdict` as `PASS` or `FAIL` alongside the existing `blocking` field.
- Invoke `devtools verify corpus-fidelity` through `devtools.click_dispatch.main` in the green and mutation paths.
- Assert the green route leaves source.db and index.db byte-identical.
- Pin the generated devtools reference entry in its renderer test.

## Verification
- `direnv exec . devtools test tests/unit/devtools/test_corpus_fidelity.py tests/unit/devtools/test_render_devtools_reference.py tests/unit/devtools/test_command_catalog.py`: 16 passed.
- `direnv exec . devtools render devtools-reference --check`: sync OK.
- `direnv exec . devtools verify --quick`: exit 0; strict mypy, render-all, layering, schema/policy, manifest, catalog, documentation, and promotion checks passed.
- The mutation cases cover absent documents, unfetched attachments, and revision shortfalls. No production data was accessed or changed.

## Residual scope
The live corpus result remains a post-rebuild operator gate. This change does not run a reindex or alter the active archive.

Ref polylogue-f1vg