### PR TITLE
fix(embeddings): reconcile refs without provider configuration

### DIFF
--- a/polylogue/daemon/embedding_backlog.py
+++ b/polylogue/daemon/embedding_backlog.py
@@ -119,12 +119,6 @@ async def periodic_embedding_orphan_reconcile_check(
 
 def reconcile_embedding_orphans_once(db_path: Path) -> EmbeddingOrphanReconcileReport | None:
     """Run one bounded daemon orphan-reconciliation pass, or ``None`` if inapplicable."""
-
-    from polylogue.daemon.convergence_stages import _embedding_config_enabled
-
-    if not _embedding_config_enabled():
-        return None
-
     index_db = _active_archive_index_path(db_path)
     if index_db is None:
         return None

--- a/polylogue/storage/embeddings/reconcile.py
+++ b/polylogue/storage/embeddings/reconcile.py
@@ -454,7 +454,10 @@ def _orphan_message_rows(conn: sqlite3.Connection) -> list[sqlite3.Row]:
                1 AS has_vector
         FROM message_embedding_refs AS r
         WHERE NOT EXISTS (
-            SELECT 1 FROM idx.messages AS indexed WHERE indexed.message_id = r.message_id
+            SELECT 1
+            FROM idx.messages AS indexed
+            WHERE indexed.message_id = r.message_id
+              AND indexed.session_id = r.session_id
         )
         ORDER BY r.message_id
         """
@@ -467,7 +470,10 @@ def _delete_if_still_orphan_ref(conn: sqlite3.Connection, message_id: str) -> in
         DELETE FROM message_embedding_refs
         WHERE message_id = ?
           AND NOT EXISTS (
-              SELECT 1 FROM idx.messages WHERE idx.messages.message_id = message_embedding_refs.message_id
+              SELECT 1
+              FROM idx.messages
+              WHERE idx.messages.message_id = message_embedding_refs.message_id
+                AND idx.messages.session_id = message_embedding_refs.session_id
           )
         """,
         (message_id,),

--- a/polylogue/storage/embeddings/reconcile.py
+++ b/polylogue/storage/embeddings/reconcile.py
@@ -270,39 +270,25 @@ def reconcile_embedding_orphans(
         scanned_vector_rows = _scalar(conn, "SELECT COUNT(*) FROM message_embeddings")
         scanned_status_rows = _scalar(conn, "SELECT COUNT(*) FROM embedding_status")
 
-        message_rows = _orphan_message_rows(conn)
+        work_limit = None if max_count is None else max(0, max_count)
+        orphan_message_rows = _orphan_message_count(conn)
+        skipped_recent_message = _recent_orphan_message_count(conn, resolved_now_ms, quiet_window_ms)
+        limited_message = _orphan_message_rows(
+            conn,
+            now_ms=resolved_now_ms,
+            quiet_window_ms=quiet_window_ms,
+            limit=work_limit,
+        )
 
-        message_candidates: list[sqlite3.Row] = []
-        skipped_recent_message = 0
-        for row in message_rows:
-            if _is_recent(row["embedded_at_ms"], resolved_now_ms, quiet_window_ms):
-                skipped_recent_message += 1
-                continue
-            message_candidates.append(row)
-
-        limited_message = message_candidates if max_count is None else message_candidates[: max(0, max_count)]
-
-        status_rows = conn.execute(
-            """
-            SELECT session_id, last_embedded_at_ms
-            FROM embedding_status
-            WHERE NOT EXISTS (
-                SELECT 1 FROM idx.sessions AS ims WHERE ims.session_id = embedding_status.session_id
-            )
-            ORDER BY session_id
-            """
-        ).fetchall()
-
-        status_candidates: list[sqlite3.Row] = []
-        skipped_recent_status = 0
-        for row in status_rows:
-            if _is_recent(row["last_embedded_at_ms"], resolved_now_ms, quiet_window_ms):
-                skipped_recent_status += 1
-                continue
-            status_candidates.append(row)
-
-        status_budget = None if max_count is None else max(0, max_count - len(limited_message))
-        limited_status = status_candidates if status_budget is None else status_candidates[:status_budget]
+        status_budget = None if work_limit is None else max(0, work_limit - len(limited_message))
+        skipped_recent_status = _recent_orphan_status_count(conn, resolved_now_ms, quiet_window_ms)
+        orphan_status_rows = _orphan_status_count(conn)
+        limited_status = _orphan_status_rows(
+            conn,
+            now_ms=resolved_now_ms,
+            quiet_window_ms=quiet_window_ms,
+            limit=status_budget,
+        )
         candidate_message_rows = len(limited_message)
         candidate_message_meta_rows = sum(int(row["has_meta"]) for row in limited_message)
         candidate_vector_rows = sum(int(row["has_vector"]) for row in limited_message)
@@ -382,25 +368,13 @@ def reconcile_embedding_orphans(
             for row in limited_status[:remaining_sample_budget]
         )
 
-        orphan_message_rows = len(message_candidates) + skipped_recent_message
-        orphan_message_meta_rows = sum(int(row["has_meta"]) for row in message_rows)
-        orphan_vector_rows = sum(int(row["has_vector"]) for row in message_rows)
-        orphan_status_rows = len(status_candidates) + skipped_recent_status
+        orphan_message_meta_rows = orphan_message_rows
+        orphan_vector_rows = orphan_message_rows
         if dry_run:
             more_pending = orphan_message_rows > 0 or orphan_status_rows > 0
             conn.rollback()
         else:
-            more_pending = bool(_orphan_message_rows(conn)) or bool(
-                conn.execute(
-                    """
-                    SELECT 1 FROM embedding_status
-                    WHERE NOT EXISTS (
-                        SELECT 1 FROM idx.sessions WHERE idx.sessions.session_id = embedding_status.session_id
-                    )
-                    LIMIT 1
-                    """
-                ).fetchone()
-            )
+            more_pending = _has_orphan_message_rows(conn) or _has_orphan_status_rows(conn)
 
         return EmbeddingOrphanReconcileReport(
             index_db=str(index_path),
@@ -435,7 +409,13 @@ def reconcile_embedding_orphans(
         conn.close()
 
 
-def _orphan_message_rows(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+def _orphan_message_rows(
+    conn: sqlite3.Connection,
+    *,
+    now_ms: int,
+    quiet_window_ms: int,
+    limit: int | None,
+) -> list[sqlite3.Row]:
     """Return orphan ``message_embedding_refs`` rows.
 
     ``content_hash`` is reported as ``NULL`` -- refs carry no content-hash
@@ -444,8 +424,7 @@ def _orphan_message_rows(conn: sqlite3.Connection) -> list[sqlite3.Row]:
     since a ref only ever points at a hash that has both (write-once,
     atomic), even though this reconciler does not delete either.
     """
-    return conn.execute(
-        """
+    sql = """
         SELECT r.message_id AS message_id,
                r.session_id AS session_id,
                NULL AS content_hash,
@@ -459,9 +438,146 @@ def _orphan_message_rows(conn: sqlite3.Connection) -> list[sqlite3.Row]:
             WHERE indexed.message_id = r.message_id
               AND indexed.session_id = r.session_id
         )
+          AND (
+              r.embedded_at_ms IS NULL
+              OR (? - r.embedded_at_ms) >= ?
+          )
         ORDER BY r.message_id
+    """
+    params: list[object] = [now_ms, quiet_window_ms]
+    if limit == 0:
+        return []
+    if limit is not None:
+        sql += "\nLIMIT ?"
+        params.append(limit)
+    return conn.execute(sql, tuple(params)).fetchall()
+
+
+def _orphan_status_rows(
+    conn: sqlite3.Connection,
+    *,
+    now_ms: int,
+    quiet_window_ms: int,
+    limit: int | None,
+) -> list[sqlite3.Row]:
+    sql = """
+        SELECT session_id, last_embedded_at_ms
+        FROM embedding_status
+        WHERE NOT EXISTS (
+            SELECT 1 FROM idx.sessions AS ims WHERE ims.session_id = embedding_status.session_id
+        )
+          AND (
+              last_embedded_at_ms IS NULL
+              OR (? - last_embedded_at_ms) >= ?
+          )
+        ORDER BY session_id
+    """
+    params: list[object] = [now_ms, quiet_window_ms]
+    if limit is not None:
+        sql += "\nLIMIT ?"
+        params.append(limit)
+    if limit == 0:
+        return []
+    return conn.execute(sql, tuple(params)).fetchall()
+
+
+def _orphan_message_count(conn: sqlite3.Connection) -> int:
+    return _scalar(
+        conn,
         """
-    ).fetchall()
+        SELECT COUNT(*)
+        FROM message_embedding_refs AS r
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM idx.messages AS indexed
+            WHERE indexed.message_id = r.message_id
+              AND indexed.session_id = r.session_id
+        )
+        """,
+    )
+
+
+def _recent_orphan_message_count(conn: sqlite3.Connection, now_ms: int, quiet_window_ms: int) -> int:
+    return _scalar(
+        conn,
+        """
+        SELECT COUNT(*)
+        FROM message_embedding_refs AS r
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM idx.messages AS indexed
+            WHERE indexed.message_id = r.message_id
+              AND indexed.session_id = r.session_id
+        )
+          AND r.embedded_at_ms IS NOT NULL
+          AND (? - r.embedded_at_ms) < ?
+        """,
+        (now_ms, quiet_window_ms),
+    )
+
+
+def _orphan_status_count(conn: sqlite3.Connection) -> int:
+    return _scalar(
+        conn,
+        """
+        SELECT COUNT(*)
+        FROM embedding_status
+        WHERE NOT EXISTS (
+            SELECT 1 FROM idx.sessions AS ims WHERE ims.session_id = embedding_status.session_id
+        )
+        """,
+    )
+
+
+def _recent_orphan_status_count(conn: sqlite3.Connection, now_ms: int, quiet_window_ms: int) -> int:
+    return _scalar(
+        conn,
+        """
+        SELECT COUNT(*)
+        FROM embedding_status
+        WHERE NOT EXISTS (
+            SELECT 1 FROM idx.sessions AS ims WHERE ims.session_id = embedding_status.session_id
+        )
+          AND last_embedded_at_ms IS NOT NULL
+          AND (? - last_embedded_at_ms) < ?
+        """,
+        (now_ms, quiet_window_ms),
+    )
+
+
+def _has_orphan_message_rows(conn: sqlite3.Connection) -> bool:
+    return (
+        conn.execute(
+            """
+            SELECT 1
+            FROM message_embedding_refs AS r
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM idx.messages AS indexed
+                WHERE indexed.message_id = r.message_id
+                  AND indexed.session_id = r.session_id
+            )
+            LIMIT 1
+            """
+        ).fetchone()
+        is not None
+    )
+
+
+def _has_orphan_status_rows(conn: sqlite3.Connection) -> bool:
+    return (
+        conn.execute(
+            """
+            SELECT 1
+            FROM embedding_status
+            WHERE NOT EXISTS (
+                SELECT 1 FROM idx.sessions WHERE idx.sessions.session_id = embedding_status.session_id
+            )
+            LIMIT 1
+            """
+        ).fetchone()
+        is not None
+    )
 
 
 def _delete_if_still_orphan_ref(conn: sqlite3.Connection, message_id: str) -> int:
@@ -546,12 +662,6 @@ def _assert_active_index_generation(index_path: Path) -> None:
                 return
             raise RuntimeError("embedding orphan reconciliation requires an active source-snapshotted index generation")
     raise RuntimeError("embedding orphan reconciliation active index is missing generation readiness evidence")
-
-
-def _is_recent(timestamp_ms: int | None, now_ms: int, quiet_window_ms: int) -> bool:
-    if timestamp_ms is None:
-        return False
-    return (now_ms - int(timestamp_ms)) < quiet_window_ms
 
 
 def _scalar(conn: sqlite3.Connection, sql: str, params: tuple[object, ...] = ()) -> int:

--- a/tests/unit/daemon/test_embedding_orphan_reconcile_daemon.py
+++ b/tests/unit/daemon/test_embedding_orphan_reconcile_daemon.py
@@ -85,15 +85,16 @@ def _build_fixture(tmp_path: Path) -> tuple[Path, Path, str, str]:
     return index_db, embeddings_db, session_id, orphan_message_id
 
 
-def test_reconcile_embedding_orphans_once_noop_when_config_disabled(tmp_path: Path) -> None:
+def test_reconcile_embedding_orphans_once_runs_without_embedding_provider(tmp_path: Path) -> None:
     index_db, _embeddings_db, _session_id, _orphan_id = _build_fixture(tmp_path)
 
     with patch("polylogue.daemon.convergence_stages.load_polylogue_config") as mock_cfg:
         mock_cfg.return_value.embedding_enabled = False
-        mock_cfg.return_value.voyage_api_key = "test-key"
+        mock_cfg.return_value.voyage_api_key = None
         result = reconcile_embedding_orphans_once(index_db)
 
-    assert result is None
+    assert result is not None
+    assert result.removed_message_rows == 1
 
 
 def test_reconcile_embedding_orphans_once_noop_when_index_missing(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_embedding_orphan_reconcile.py
+++ b/tests/unit/storage/test_embedding_orphan_reconcile.py
@@ -243,6 +243,47 @@ def test_reconcile_removes_message_orphaned_by_index_rebuild(tmp_path: Path) -> 
     assert [item.session_id for item in pending] == [session_id]
 
 
+def test_reconcile_removes_ref_with_stale_session_identity_but_preserves_live_ref(tmp_path: Path) -> None:
+    """A ref is live only when both duplicated identities match the index row.
+
+    The session_id is denormalized in ``message_embedding_refs`` so the
+    cross-tier reconciler must validate it rather than treating message_id
+    presence alone as sufficient.
+    """
+    session_id = "codex-session:session-identity"
+    live_message_id = f"{session_id}:m1"
+    preserved_message_id = f"{session_id}:m2"
+    stale_session_id = "codex-session:deleted-session"
+
+    _connect_index(
+        tmp_path / "index.db",
+        sessions=[session_id],
+        messages={session_id: [live_message_id, preserved_message_id]},
+    )
+    embeddings_db = tmp_path / "embeddings.db"
+    conn = _connect_embeddings(embeddings_db)
+    _write_embedding(conn, message_id=preserved_message_id, session_id=session_id, embedded_at_ms=_OLD_MS)
+    _write_embedding(conn, message_id=live_message_id, session_id=stale_session_id, embedded_at_ms=_OLD_MS)
+    conn.close()
+
+    report = reconcile_embedding_orphans(
+        tmp_path / "index.db",
+        embeddings_db,
+        dry_run=False,
+        now_ms=_NOW_MS,
+        quiet_window_ms=0,
+        mutation_authority="offline-exclusive",
+    )
+
+    assert report.orphan_message_rows == 1
+    assert report.removed_message_rows == 1
+    with _connect_embeddings(embeddings_db) as verify:
+        refs = verify.execute(
+            "SELECT message_id, session_id FROM message_embedding_refs ORDER BY session_id"
+        ).fetchall()
+    assert [(row["message_id"], row["session_id"]) for row in refs] == [(preserved_message_id, session_id)]
+
+
 def test_apply_accepts_generation_metadata_beside_external_pointer_anchor(tmp_path: Path) -> None:
     """A public archive symlink must use the anchor tier's generation metadata.
 

--- a/tests/unit/storage/test_embedding_orphan_reconcile.py
+++ b/tests/unit/storage/test_embedding_orphan_reconcile.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import hashlib
 import json
 import sqlite3
+from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import patch
 
@@ -172,6 +173,17 @@ def _write_status(
 
 _OLD_MS = 1_700_000_000_000  # far outside any quiet window relative to _NOW_MS
 _NOW_MS = 1_800_000_000_000
+
+
+def _traced_reconcile_connect(traced_sql: list[str]) -> Callable[..., sqlite3.Connection]:
+    real_connect = sqlite3.connect
+
+    def traced_connect(database: str | Path, *, timeout: float) -> sqlite3.Connection:
+        connection = real_connect(database, timeout=timeout)
+        connection.set_trace_callback(traced_sql.append)
+        return connection
+
+    return traced_connect
 
 
 def test_reconcile_removes_message_orphaned_by_index_rebuild(tmp_path: Path) -> None:
@@ -567,6 +579,99 @@ def test_reconcile_is_bounded_and_resumable(tmp_path: Path) -> None:
     assert clean.orphan_message_rows == 0
     assert clean.removed_message_rows == 0
     assert clean.ok is True
+
+
+def test_reconcile_max_count_limits_message_query_and_deletion_count(tmp_path: Path) -> None:
+    """The message candidate query is bounded before Python receives rows.
+
+    Anti-vacuity: removing the SQL LIMIT makes the trace assertion fail, while
+    deleting more than the requested work unit makes the remaining-ref count
+    and report mutation count fail. The fixture uses the real embeddings DDL,
+    sqlite-vec loader, and content-addressed writer route.
+    """
+    session_id = "codex-session:bounded-messages"
+    message_ids = [f"{session_id}:m{i}" for i in range(4)]
+    _connect_index(tmp_path / "index.db", sessions=[session_id], messages={session_id: []})
+
+    embeddings_db = tmp_path / "embeddings.db"
+    conn = _connect_embeddings(embeddings_db)
+    for message_id in message_ids:
+        _write_embedding(conn, message_id=message_id, session_id=session_id, embedded_at_ms=_OLD_MS)
+    conn.close()
+
+    traced_sql: list[str] = []
+    with patch(
+        "polylogue.storage.embeddings.reconcile.sqlite3.connect",
+        side_effect=_traced_reconcile_connect(traced_sql),
+    ):
+        report = reconcile_embedding_orphans(
+            tmp_path / "index.db",
+            embeddings_db,
+            dry_run=False,
+            max_count=1,
+            now_ms=_NOW_MS,
+            quiet_window_ms=0,
+            mutation_authority="offline-exclusive",
+        )
+
+    candidate_queries = [sql for sql in traced_sql if "SELECT r.message_id AS message_id" in sql]
+    assert len(candidate_queries) == 1
+    assert "LIMIT 1" in candidate_queries[0]
+    assert any(
+        "SELECT 1" in sql and "FROM message_embedding_refs AS r" in sql and "LIMIT 1" in sql for sql in traced_sql
+    )
+    assert report.orphan_message_rows == 4
+    assert report.candidate_message_rows == 1
+    assert report.removed_message_rows == 1
+    assert report.more_pending is True
+
+    with _connect_embeddings(embeddings_db) as verify:
+        assert verify.execute("SELECT COUNT(*) FROM message_embedding_refs").fetchone()[0] == 3
+
+
+def test_reconcile_max_count_limits_status_query_and_deletion_count(tmp_path: Path) -> None:
+    """The status candidate query is bounded when the message queue is empty."""
+    _connect_index(tmp_path / "index.db", sessions=[], messages={})
+
+    embeddings_db = tmp_path / "embeddings.db"
+    conn = _connect_embeddings(embeddings_db)
+    status_ids = [f"codex-session:bounded-status-{i}" for i in range(4)]
+    for session_id in status_ids:
+        _write_status(
+            conn,
+            session_id=session_id,
+            message_count_embedded=0,
+            last_embedded_at_ms=_OLD_MS,
+        )
+    conn.close()
+
+    traced_sql: list[str] = []
+    with patch(
+        "polylogue.storage.embeddings.reconcile.sqlite3.connect",
+        side_effect=_traced_reconcile_connect(traced_sql),
+    ):
+        report = reconcile_embedding_orphans(
+            tmp_path / "index.db",
+            embeddings_db,
+            dry_run=False,
+            max_count=1,
+            now_ms=_NOW_MS,
+            quiet_window_ms=0,
+            mutation_authority="offline-exclusive",
+        )
+
+    candidate_queries = [sql for sql in traced_sql if "SELECT session_id, last_embedded_at_ms" in sql]
+    assert len(candidate_queries) == 1
+    assert "LIMIT 1" in candidate_queries[0]
+    assert any("SELECT 1" in sql and "FROM embedding_status" in sql and "LIMIT 1" in sql for sql in traced_sql)
+    assert report.orphan_status_rows == 4
+    assert report.candidate_status_rows == 1
+    assert report.removed_status_rows == 1
+    assert report.more_pending is True
+
+    with _connect_embeddings(embeddings_db) as verify:
+        remaining = verify.execute("SELECT session_id FROM embedding_status ORDER BY session_id").fetchall()
+    assert [row[0] for row in remaining] == status_ids[1:]
 
 
 def test_reconcile_dry_run_does_not_mutate(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Reconcile dangling embedding references even when embedding generation is disabled or no provider key is available.

## Problem

The live archive has stale `message_embedding_refs` whose indexed messages no longer exist. The cleanup path skipped this derived-data repair unless provider-backed generation was configured, and it did not validate the ref session identity.

## Solution

Run bounded reconciliation whenever active index and embeddings tiers are available. Require both message and session identities to match the authoritative index before retaining a reference.

## Verification

`devtools verify --quick` passed: format, lint, mypy, generated surfaces, layering, policies, and promotion audit all exited 0. Focused SQLite regressions cover provider-independent cleanup, stale session-identity removal, and preservation of a valid reference.

Ref polylogue-feu0