### PR TITLE
fix(daemon): gate unsafe cursor authority selection

### DIFF
--- a/docs/evidence/polylogue-xeck9-cursor-authority-census-2026-08-04.md
+++ b/docs/evidence/polylogue-xeck9-cursor-authority-census-2026-08-04.md
@@ -44,7 +44,7 @@ The existing status DTO renders these separately from the proven violation: `cur
 
 ## Root-cause conclusion
 
-No demonstrated defect was found in the cursor write path, comparison predicate, or state model on the current branch. The comparison is strict `cursor_offset > accepted_frontier`, consumes the durable accepted head, and its regression coverage already exercises the real `raw_frontier_integrity_snapshot()` route. Reclassifying the true violation as incomparable or comparing against a non-accepted raw would contradict the current projection and its existing tests.
+No demonstrated defect was found in the cursor write path or comparison predicate on the current branch. The comparison is strict `cursor_offset > accepted_frontier`, consumes the durable accepted head, and its regression coverage already exercises the real `raw_frontier_integrity_snapshot()` route. The production defect was at the readiness consumers: raw convergence and reindex did not consume this proof before selecting source rows. Reclassifying the true violation as incomparable or comparing against a non-accepted raw would contradict the current projection and its existing tests.
 
 The live cursor is ahead of its accepted full-head frontier. That is production reconciliation work, not evidence for a code change. The 725 source-backed incomparables are deferred authority states that must remain visible. The 2 source-absent cursor paths likewise must remain explicit until their durable history is reconciled; this report does not authorize a cursor reset or source-row edit.
 

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -1241,8 +1241,14 @@ def _drain_raw_materialization_once(
     function is ever scheduled onto the writer hold; passing ``None``
     (the flag-off default) reproduces the exact unmodified in-hold parse.
     """
+    from polylogue.paths import archive_root
+    from polylogue.readiness.capability import raw_frontier_source_selection_block_reason
+
+    if reason := raw_frontier_source_selection_block_reason(archive_root()):
+        raise RuntimeError(f"raw materialization source-selection gate blocked: {reason}")
+
     from polylogue.config import Config
-    from polylogue.paths import archive_root, render_root
+    from polylogue.paths import render_root
     from polylogue.product import raw_authority
     from polylogue.storage.blob_integrity import restore_direct_blob_reference_debt
 

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -1342,8 +1342,14 @@ def _run_raw_materialization_whale_pass_once(*, raw_artifact_id: str, max_payloa
     specific to this one escalated component, and the ordinary pass already
     runs them on its own cadence.
     """
+    from polylogue.paths import archive_root
+    from polylogue.readiness.capability import raw_frontier_source_selection_block_reason
+
+    if reason := raw_frontier_source_selection_block_reason(archive_root()):
+        raise RuntimeError(f"raw whale materialization source-selection gate blocked: {reason}")
+
     from polylogue.config import Config
-    from polylogue.paths import archive_root, render_root
+    from polylogue.paths import render_root
     from polylogue.product import raw_authority
 
     archive = archive_root()

--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -938,8 +938,16 @@ def make_raw_parse_recovery_stage(db_path: Path) -> ConvergenceStage:
     def execute(path: Path) -> StageExecuteReturn:
         from polylogue.config import Config
         from polylogue.product.raw_authority import repair_materialization
+        from polylogue.readiness.capability import raw_frontier_source_selection_block_reason
 
         archive_root = db_path.parent
+        if reason := raw_frontier_source_selection_block_reason(archive_root):
+            logger.warning(
+                "raw_parse_recovery: source-selection gate blocked for %s: %s",
+                path,
+                reason,
+            )
+            return False
         config = Config(archive_root=archive_root, render_root=archive_root, sources=[])
         try:
             repair_materialization(

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -808,6 +808,11 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
     log_mapped_bytes_budget_check(logger, check_mapped_bytes_budget_against_cgroup_limit())
     validate_rebuild_index_request(request)
     root = request.archive_root
+    if count_source_raw_sessions(root):
+        from polylogue.readiness.capability import raw_frontier_source_selection_block_reason
+
+        if reason := raw_frontier_source_selection_block_reason(root):
+            raise RuntimeError(f"reindex source preflight gate failed: raw frontier integrity: {reason}")
     location = ArchiveLocation.resolve(root)
     active_config = Config(
         archive_root=root,

--- a/polylogue/readiness/capability.py
+++ b/polylogue/readiness/capability.py
@@ -467,6 +467,38 @@ def raw_frontier_integrity_is_proven_healthy(payload: object) -> bool:
     return error is None and normalized is not None and normalized.get("overall_status") == "healthy"
 
 
+def raw_frontier_source_selection_block_reason(
+    archive_root: Path,
+    raw_materialization_readiness: Mapping[str, object] | None = None,
+) -> str | None:
+    """Return the readiness reason that must block unsafe source selection.
+
+    Raw convergence and reindex both select source rows before they write an
+    index. They therefore require the same complete, healthy frontier proof
+    exposed by the diagnostic/readiness route. ``None`` means every authority
+    comparison was proven healthy. A deferred or incomparable cursor is a
+    deliberate terminal exception to the byte comparison, but it remains a
+    blocking unknown until its authority can be resolved.
+    """
+
+    projection = raw_frontier_integrity_projection(
+        archive_root,
+        raw_materialization_readiness
+        if raw_materialization_readiness is not None
+        else _raw_materialization_readiness_for_source_selection(archive_root),
+    )
+    payload = projection.to_dict()
+    if raw_frontier_integrity_is_proven_healthy(payload):
+        return None
+    return raw_frontier_integrity_summary(payload)
+
+
+def _raw_materialization_readiness_for_source_selection(archive_root: Path) -> Mapping[str, object]:
+    from polylogue.storage.archive_readiness import raw_materialization_readiness_snapshot
+
+    return raw_materialization_readiness_snapshot(archive_root)
+
+
 def status_snapshot_has_fresh_provenance(payload: Mapping[str, Any]) -> bool:
     """Return whether a daemon payload carries a complete fresh-cache marker."""
 
@@ -874,6 +906,7 @@ __all__ = [
     "normalize_raw_frontier_status_payload",
     "raw_frontier_integrity_projection",
     "raw_frontier_integrity_is_proven_healthy",
+    "raw_frontier_source_selection_block_reason",
     "raw_frontier_integrity_summary",
     "status_snapshot_has_fresh_provenance",
     "unknown_raw_frontier_integrity_projection",

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -158,6 +158,11 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+
+class CursorAuthorityBlockedError(RuntimeError):
+    """The canonical raw frontier proof did not authorize live source selection."""
+
+
 # polylogue-0jf4: known ~/.codex live SQLite state filenames, matched by name
 # first (cheap, no I/O) before the structural table-shape check in
 # ``codex_state.is_in_scope_codex_sqlite_path`` decides whether to acquire.
@@ -492,6 +497,27 @@ class LiveBatchProcessor:
         # argument (identical shape to ``DaemonParseStage``).
         self._parse_stage = parse_stage
 
+    def cursor_authority_block_reason(self) -> str | None:
+        """Return the canonical frontier reason that blocks live ingestion.
+
+        Small unit tests may exercise the batch processor before an active
+        archive has been bootstrapped. The real watcher cannot write without
+        these tiers, so the preflight is intentionally deferred until they
+        exist. Once they do, the readiness proof is fail-closed and shared
+        with raw convergence, recovery, and reindex.
+        """
+        archive_root = Path(getattr(self._polylogue, "archive_root", self._cursor._db_path.parent))
+        if not (archive_root / "source.db").is_file() or not (archive_root / "index.db").is_file():
+            return None
+        from polylogue.readiness.capability import raw_frontier_source_selection_block_reason
+
+        return raw_frontier_source_selection_block_reason(archive_root)
+
+    def require_cursor_authority(self) -> None:
+        """Fail closed before a live batch can create attempts or write data."""
+        if reason := self.cursor_authority_block_reason():
+            raise CursorAuthorityBlockedError(f"live watcher source-selection gate blocked: {reason}")
+
     async def ingest_files(
         self,
         paths: list[Path],
@@ -502,6 +528,7 @@ class LiveBatchProcessor:
         max_pass_seconds: float | None = None,
     ) -> LiveBatchMetrics:
         """Ingest files in batch, run post-ingest convergence, and return metrics."""
+        self.require_cursor_authority()
         if is_fully_degraded():
             # The daemon has been marked structurally unable to ingest (e.g.
             # schema mismatch detected at preflight or on the first batch).

--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -436,11 +436,21 @@ class LiveWatcher:
         plan_holder: list[CatchUpPlan] = []
 
         async def prepare_catch_up() -> None:
+            # The preflight must precede both cursor initialization and the
+            # planning pass. ``_plan_catch_up`` can reconcile missing cursors
+            # and rebase matching filesystem observations before ingestion has
+            # a chance to apply its own gate.
+            self._batch_processor.require_cursor_authority()
             await self._run_writer_sync("watcher.catch_up.cursor_initialize", self._cursor.initialize)
+            self._batch_processor.require_cursor_authority()
             logger.info("live.watcher: catch-up scan over %d file(s)", len(candidates))
             plan_holder.append(self._plan_catch_up(candidates))
 
-        await self._run_coordinated("watcher.catch_up.prefilter", prepare_catch_up)
+        try:
+            await self._run_coordinated("watcher.catch_up.prefilter", prepare_catch_up)
+        except CursorAuthorityBlockedError as exc:
+            logger.warning("live.watcher: catch-up planning refused by cursor authority: %s", exc)
+            return
         plan = plan_holder[0]
         if not plan.needed:
             return
@@ -802,7 +812,12 @@ class LiveWatcher:
             self._pending_paths.clear()
 
         async def flush_batch() -> None:
+            # Filtering a changed-file batch invokes cursor reconciliation and
+            # lifecycle actuators, so the source-selection proof must be
+            # consumed before initialization or any stateful decision.
+            self._batch_processor.require_cursor_authority()
             await self._run_writer_sync("watcher.live_batch.cursor_initialize", self._cursor.initialize)
+            self._batch_processor.require_cursor_authority()
             # Filter to files that actually need work.
             cursor_records = self._cursor.get_records(paths)
             needed = []

--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -31,7 +31,12 @@ from polylogue.core.sources import provider_from_origin
 from polylogue.logging import get_logger
 from polylogue.sources.hooks import drain_hook_event_spool, hook_spool_root, pending_hook_spool_dir
 from polylogue.sources.live.acquisition_log import log_unclaimed_file
-from polylogue.sources.live.batch import LiveBatchEventEmitter, LiveBatchProcessor, fingerprint_file
+from polylogue.sources.live.batch import (
+    CursorAuthorityBlockedError,
+    LiveBatchEventEmitter,
+    LiveBatchProcessor,
+    fingerprint_file,
+)
 from polylogue.sources.live.batch_support import (
     _archive_blob_exists,
     cursor_ctime_ns,
@@ -545,6 +550,9 @@ class LiveWatcher:
                 operation_id, "cancelled", plan, attempted, ingested, failed, stage_timings_s, cycle_started
             )
             raise
+        except CursorAuthorityBlockedError as exc:
+            logger.warning("live.watcher: catch-up refused by cursor authority: %s", exc)
+            return
         except BaseException:
             await self._emit_catch_up_terminal(
                 operation_id, "failure", plan, attempted, ingested, failed, stage_timings_s, cycle_started
@@ -558,6 +566,12 @@ class LiveWatcher:
         large spool backlog cannot monopolize the single writer against
         live ingest and catch-up chunks.
         """
+
+        try:
+            self._batch_processor.require_cursor_authority()
+        except CursorAuthorityBlockedError as exc:
+            logger.warning("live.watcher: hook-spool drain refused by cursor authority: %s", exc)
+            return
 
         total_acknowledged = 0
         while True:
@@ -822,6 +836,9 @@ class LiveWatcher:
 
         try:
             await self._run_coordinated("watcher.live_batch", flush_batch)
+        except CursorAuthorityBlockedError as exc:
+            logger.warning("live.watcher: changed-file batch refused by cursor authority: %s", exc)
+            return True
         except sqlite3.OperationalError as exc:
             if not _is_database_locked(exc):
                 raise
@@ -1409,6 +1426,7 @@ class LiveWatcher:
         skipped_file_count: int = 0,
     ) -> LiveBatchMetrics:
         """Ingest files through the reusable daemon live batch processor."""
+        self._batch_processor.require_cursor_authority()
         async with self._ingest_lock:
 
             async def ingest() -> LiveBatchMetrics:

--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -853,6 +853,12 @@ class LiveWatcher:
             await self._run_coordinated("watcher.live_batch", flush_batch)
         except CursorAuthorityBlockedError as exc:
             logger.warning("live.watcher: changed-file batch refused by cursor authority: %s", exc)
+            # Authority denial must leave both durable cursor state and the
+            # in-memory work queue intact.  Otherwise the source is invisible
+            # until a later catch-up scan instead of retrying on the next
+            # authorized debounce flush.
+            async with self._batch_lock:
+                self._pending_paths.update(paths)
             return True
         except sqlite3.OperationalError as exc:
             if not _is_database_locked(exc):

--- a/polylogue/storage/raw_retention.py
+++ b/polylogue/storage/raw_retention.py
@@ -897,6 +897,12 @@ def reissue_stale_supersession_receipts(
 # it counts and samples it, so readiness and retention safety cannot drift.
 
 RawFrontierIntegrityStatus = Literal["healthy", "unknown", "violated"]
+CursorAuthorityGapState = Literal[
+    "deferred",
+    "source_raws_without_accepted_head",
+    "cursor_path_absent_from_source",
+    "accepted_head_missing_source",
+]
 """Typed check outcome. ``"unknown"`` means the check's authority tier could
 not be read — it is never collapsed into a false ``"healthy"`` zero."""
 
@@ -930,10 +936,22 @@ class CursorAheadSample:
 class CursorAuthorityGapSample:
     """One cursor/head that cannot be joined to comparable byte authority."""
 
+    state: CursorAuthorityGapState
     source_path: str | None
     logical_source_key: str | None
     cursor_byte_offset: int | None
     reason: str
+
+
+@dataclass(frozen=True)
+class _OpsCursorAuthority:
+    source_path: str
+    byte_offset: int
+    deferred_end_offset: int | None
+
+    @property
+    def is_deferred(self) -> bool:
+        return self.deferred_end_offset is not None and self.deferred_end_offset > self.byte_offset
 
 
 @dataclass(frozen=True)
@@ -1040,6 +1058,7 @@ class RawFrontierIntegrityProjection:
             "cursor_authority_gap_count": self.cursor_authority_gap_count,
             "cursor_authority_gap_samples": [
                 {
+                    "state": sample.state,
                     "source_path": sample.source_path,
                     "logical_source_key": sample.logical_source_key,
                     "cursor_byte_offset": sample.cursor_byte_offset,
@@ -1438,6 +1457,7 @@ def _check_cursor_ahead_of_accepted(
                 if len(gaps) < sample_limit:
                     gaps.append(
                         CursorAuthorityGapSample(
+                            state="accepted_head_missing_source",
                             source_path=None,
                             logical_source_key=head.logical_source_key,
                             cursor_byte_offset=None,
@@ -1454,7 +1474,29 @@ def _check_cursor_ahead_of_accepted(
     checked = 0
     comparison_count = 0
     ahead_comparison_count = 0
-    for path, cursor_offset in cursor_map.items():
+    try:
+        source_paths = _source_paths_for_paths(conn, set(cursor_map))
+    except sqlite3.Error as exc:
+        logger.warning("raw frontier integrity: cursor source path lookup failed: %s", exc)
+        return "unknown", 0, 0, 0, 0, (), 0, (), f"cursor source path lookup failed: {exc}"
+    for path, cursor in cursor_map.items():
+        cursor_offset = cursor.byte_offset
+        if cursor.is_deferred:
+            gap_count += 1
+            if len(gaps) < sample_limit:
+                gaps.append(
+                    CursorAuthorityGapSample(
+                        state="deferred",
+                        source_path=path,
+                        logical_source_key=None,
+                        cursor_byte_offset=cursor_offset,
+                        reason=(
+                            "ingest cursor has durably captured material awaiting authority resolution "
+                            f"through byte {cursor.deferred_end_offset}"
+                        ),
+                    )
+                )
+            continue
         comparable_heads = byte_heads_by_path.get(path)
         if not comparable_heads:
             # A path governed exclusively by membership authority has no
@@ -1465,10 +1507,19 @@ def _check_cursor_ahead_of_accepted(
             if len(gaps) < sample_limit:
                 gaps.append(
                     CursorAuthorityGapSample(
+                        state=(
+                            "source_raws_without_accepted_head"
+                            if path in source_paths
+                            else "cursor_path_absent_from_source"
+                        ),
                         source_path=path,
                         logical_source_key=None,
                         cursor_byte_offset=cursor_offset,
-                        reason="ingest cursor has no accepted byte head",
+                        reason=(
+                            "source tier has raw evidence but index has no accepted byte head"
+                            if path in source_paths
+                            else "ingest cursor path is absent from source tier"
+                        ),
                     )
                 )
             continue
@@ -1528,7 +1579,21 @@ def _source_paths_for_raw_ids(conn: sqlite3.Connection, raw_ids: set[str]) -> di
     return result
 
 
-def _ops_cursor_byte_offsets(ops_db_path: Path) -> dict[str, int]:
+def _source_paths_for_paths(conn: sqlite3.Connection, source_paths: set[str]) -> set[str]:
+    result: set[str] = set()
+    pending = set(source_paths)
+    while pending:
+        batch = tuple(sorted(pending)[:500])
+        pending.difference_update(batch)
+        placeholders = ", ".join("?" for _ in batch)
+        rows = conn.execute(
+            f"SELECT DISTINCT source_path FROM raw_sessions WHERE source_path IN ({placeholders})", batch
+        ).fetchall()
+        result.update(str(row[0]) for row in rows if row[0] is not None)
+    return result
+
+
+def _ops_cursor_byte_offsets(ops_db_path: Path) -> dict[str, _OpsCursorAuthority]:
     if not ops_db_path.is_file():
         raise RawRetentionSafetyError(f"ops tier is unavailable: {ops_db_path}")
     try:
@@ -1544,11 +1609,23 @@ def _ops_cursor_byte_offsets(ops_db_path: Path) -> dict[str, int]:
             # ingest authority. Their exclusion/failure state is surfaced by
             # the ordinary cursor workload status instead of frontier parity.
             rows = conn.execute(
-                "SELECT source_path, byte_offset FROM ingest_cursor WHERE excluded = 0 AND byte_offset IS NOT NULL",
+                """
+                SELECT source_path, byte_offset, deferred_end_offset
+                FROM ingest_cursor
+                WHERE COALESCE(excluded, 0) = 0 AND byte_offset IS NOT NULL
+                """,
             ).fetchall()
     except (OSError, sqlite3.Error) as exc:
         raise RawRetentionSafetyError(f"ops tier raw cursor authority is unreadable: {exc}") from exc
-    return {str(row[0]): int(row[1]) for row in rows if row[1] is not None}
+    return {
+        str(row[0]): _OpsCursorAuthority(
+            source_path=str(row[0]),
+            byte_offset=int(row[1]),
+            deferred_end_offset=int(row[2]) if row[2] is not None else None,
+        )
+        for row in rows
+        if row[1] is not None
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -1922,6 +1999,7 @@ __all__ = [
     "BrokenAppendHeadSample",
     "CursorAheadSample",
     "CursorAuthorityGapSample",
+    "CursorAuthorityGapState",
     "RawFrontierIntegrityProjection",
     "RawFrontierIntegritySnapshot",
     "RawFrontierIntegrityStatus",

--- a/tests/unit/core/test_health_core.py
+++ b/tests/unit/core/test_health_core.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sqlite3
 from collections.abc import Mapping
 from pathlib import Path
+from typing import cast
 from unittest.mock import patch
 
 import pytest
@@ -133,6 +134,95 @@ def test_raw_frontier_readiness_check_errors_on_missing_source_evidence(tmp_path
     assert check.status is VerifyStatus.ERROR
     assert check.count == 1
     assert check.breakdown["missing_source_raw_count"] == 1
+
+
+def test_public_readiness_route_blocks_cursor_ahead_source_selection(tmp_path: Path) -> None:
+    """The real readiness report must carry the cursor violation to convergence state."""
+
+    from polylogue.config import Config
+    from polylogue.readiness import run_archive_readiness
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+    from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+    for tier in (ArchiveTier.SOURCE, ArchiveTier.INDEX, ArchiveTier.OPS):
+        initialize_archive_database(tmp_path / f"{tier.value}.db", tier)
+    source_path = tmp_path / "session.jsonl"
+    unmaterialized_path = tmp_path / "unmaterialized.jsonl"
+    source_path.write_text("{}\n", encoding="utf-8")
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, source_index, blob_hash,
+                blob_size, acquired_at_ms, logical_source_key, revision_kind,
+                source_revision, acquisition_generation, revision_authority
+            ) VALUES ('raw-baseline', 'codex-session', 'session-1', ?, 0, ?,
+                      10, 1, 'codex:session-1', 'full', 'revision-0', 0, 'byte_proven')
+            """,
+            (str(source_path), bytes(32)),
+        )
+        conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, source_index, blob_hash,
+                blob_size, acquired_at_ms, logical_source_key, revision_kind,
+                source_revision, acquisition_generation, revision_authority
+            ) VALUES ('raw-unmaterialized', 'codex-session', 'session-2', ?, 0, ?,
+                      10, 2, 'codex:session-2', 'full', 'revision-0', 0, 'byte_proven')
+            """,
+            (str(unmaterialized_path), bytes(31) + b"x"),
+        )
+        conn.commit()
+    with sqlite3.connect(tmp_path / "index.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO sessions (native_id, origin, raw_id, title, content_hash)
+            VALUES ('session-1', 'codex-session', 'raw-baseline', 'session', ?)
+            """,
+            (bytes(32),),
+        )
+        conn.execute(
+            """
+            INSERT INTO raw_revision_heads (
+                logical_source_key, session_id, accepted_raw_id,
+                accepted_source_revision, accepted_content_hash,
+                accepted_frontier_kind, accepted_frontier,
+                acquisition_generation, append_end_offset, decided_at_ms
+            ) VALUES ('codex:session-1', 'codex-session:session-1', 'raw-baseline',
+                      'revision-0', ?, 'byte', 10, 0, NULL, 2)
+            """,
+            (bytes(32),),
+        )
+        conn.commit()
+    with sqlite3.connect(tmp_path / "ops.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO ingest_cursor (source_path, byte_offset, updated_at_ms)
+            VALUES (?, 20, 1)
+            """,
+            (str(source_path),),
+        )
+        conn.execute(
+            """
+            INSERT INTO ingest_cursor (source_path, byte_offset, updated_at_ms)
+            VALUES (?, 42, 2)
+            """,
+            (str(unmaterialized_path),),
+        )
+        conn.commit()
+
+    report = run_archive_readiness(
+        Config(archive_root=tmp_path, render_root=tmp_path, sources=[], db_path=tmp_path / "index.db")
+    )
+
+    check = next(check for check in report.checks if check.name == "raw_frontier_integrity")
+    assert check.status.value == "error"
+    assert check.breakdown["cursor_ahead_count"] == 1
+    assert report.raw_frontier_integrity["cursor_ahead_status"] == "violated"
+    assert report.raw_frontier_integrity["cursor_authority_gap_count"] == 1
+    gap_samples = cast(list[dict[str, object]], report.raw_frontier_integrity["cursor_authority_gap_samples"])
+    assert gap_samples[0]["state"] == "source_raws_without_accepted_head"
+    assert report.archive_convergence["converging"] is True
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -639,6 +639,42 @@ def test_drain_raw_materialization_once_blocks_unsafe_cursor_authority(
     assert not archive.exists()
 
 
+@pytest.mark.parametrize("authority_state", ["violated", "unknown"])
+def test_whale_writer_route_blocks_unproven_cursor_authority(
+    authority_state: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The real whale writer callback must not mutate under unproven authority."""
+    from polylogue.daemon import cli as daemon_cli
+
+    archive = tmp_path / "archive"
+    mutations: list[str] = []
+
+    monkeypatch.setattr("polylogue.paths.archive_root", lambda: archive)
+    monkeypatch.setattr(
+        "polylogue.readiness.capability.raw_frontier_source_selection_block_reason",
+        lambda _root: f"{authority_state} cursor authority",
+    )
+
+    def fake_repair(*_args: object, **_kwargs: object) -> object:
+        mutations.append("repair_materialization")
+        (archive / "writer-mutated").write_text("unsafe", encoding="utf-8")
+        return SimpleNamespace(success=True, repaired_count=1, detail="unexpected writer call")
+
+    monkeypatch.setattr("polylogue.product.raw_authority.repair_materialization", fake_repair)
+    monkeypatch.setattr(daemon_cli, "_close_raw_materialization_fts", lambda _path: None)
+    monkeypatch.setattr(daemon_cli, "_emit_raw_materialization_pass", lambda _result: None)
+
+    with pytest.raises(RuntimeError, match="source-selection gate blocked"):
+        daemon_cli._run_raw_materialization_whale_pass_once(
+            raw_artifact_id="whale-seed-raw-id",
+            max_payload_bytes=daemon_cli._RAW_MATERIALIZATION_WHALE_BLOB_LIMIT_BYTES,
+        )
+    assert mutations == []
+    assert not (archive / "writer-mutated").exists()
+
+
 def test_maybe_recommend_bulk_rebuild_silent_below_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
     """A backlog under both thresholds must not trigger the bulk-rebuild
     recommendation: this exercises the real threshold predicate

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -576,6 +576,7 @@ def test_drain_raw_materialization_once_uses_bounded_daemon_batch(
 
     monkeypatch.setattr("polylogue.paths.archive_root", lambda: tmp_path / "archive")
     monkeypatch.setattr("polylogue.paths.render_root", lambda: tmp_path / "render")
+    monkeypatch.setattr("polylogue.readiness.capability.raw_frontier_source_selection_block_reason", lambda _root: None)
     monkeypatch.setattr(
         "polylogue.storage.blob_integrity.restore_direct_blob_reference_debt",
         fake_restore_direct_blob_reference_debt,
@@ -617,6 +618,25 @@ def test_drain_raw_materialization_once_uses_bounded_daemon_batch(
         "frontier_limit": 8,
         "max_pass_seconds": daemon_cli._RAW_MATERIALIZATION_MAX_PASS_SECONDS,
     }
+
+
+def test_drain_raw_materialization_once_blocks_unsafe_cursor_authority(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from polylogue.daemon import cli as daemon_cli
+
+    archive = tmp_path / "archive"
+    monkeypatch.setattr("polylogue.paths.archive_root", lambda: archive)
+    monkeypatch.setattr(
+        "polylogue.readiness.capability.raw_frontier_source_selection_block_reason",
+        lambda _root: "1 ingest cursor row committed past accepted raw material",
+    )
+
+    with pytest.raises(RuntimeError, match="source-selection gate blocked"):
+        daemon_cli._drain_raw_materialization_once()
+
+    assert not archive.exists()
 
 
 def test_maybe_recommend_bulk_rebuild_silent_below_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -940,6 +960,7 @@ def test_raw_materialization_closes_fts_on_cancellation(
 
     monkeypatch.setattr("polylogue.paths.archive_root", lambda: archive)
     monkeypatch.setattr("polylogue.paths.render_root", lambda: tmp_path / "render")
+    monkeypatch.setattr("polylogue.readiness.capability.raw_frontier_source_selection_block_reason", lambda _root: None)
     monkeypatch.setattr(
         "polylogue.storage.blob_integrity.restore_direct_blob_reference_debt",
         lambda *_args, **_kwargs: FakeRestoreResult(),

--- a/tests/unit/daemon/test_raw_parse_recovery.py
+++ b/tests/unit/daemon/test_raw_parse_recovery.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
+import pytest
+
 from polylogue.core.enums import Provider
 from polylogue.daemon.convergence import DaemonConverger
 from polylogue.daemon.convergence_stages import make_raw_parse_recovery_stage
@@ -138,6 +140,27 @@ def test_raw_parse_recovery_stage_drains_a_stuck_raw_row(tmp_path: Path) -> None
     rows = _sessions_for_raw(tmp_path, raw_id)
     assert len(rows) == 1
     assert rows[0][0] == "conv-stuck"
+
+
+@pytest.mark.parametrize("authority_state", ["violated", "unknown"])
+def test_raw_parse_recovery_stage_blocks_unproven_cursor_authority(
+    authority_state: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    initialize_active_archive_root(tmp_path)
+    path = tmp_path / "stuck.json"
+    raw_id = _write_stuck_raw(tmp_path, source_path=str(path))
+    monkeypatch.setattr(
+        "polylogue.readiness.capability.raw_frontier_source_selection_block_reason",
+        lambda _root: f"{authority_state} cursor authority",
+    )
+
+    stage = make_raw_parse_recovery_stage(tmp_path / "index.db")
+
+    assert stage.execute(path) is False
+    assert stage.check(path) is True
+    assert _sessions_for_raw(tmp_path, raw_id) == []
 
 
 def test_raw_parse_recovery_stage_is_false_means_pending() -> None:

--- a/tests/unit/maintenance/test_rebuild_index_ownership.py
+++ b/tests/unit/maintenance/test_rebuild_index_ownership.py
@@ -53,6 +53,36 @@ def test_rebuild_refuses_when_archive_location_already_owned(tmp_path: Path) -> 
     assert receipt.status == "empty-source"
 
 
+def test_rebuild_blocks_unsafe_cursor_authority_before_generation_creation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "archive"
+    _init_empty_source(root)
+    with sqlite3.connect(root / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, source_index, blob_hash,
+                blob_size, acquired_at_ms, logical_source_key, revision_kind,
+                source_revision, acquisition_generation, revision_authority
+            ) VALUES ('raw-1', 'codex-session', 'session-1', 'source.jsonl', 0, ?,
+                      1, 1, 'codex:session-1', 'full', 'revision-0', 0, 'byte_proven')
+            """,
+            (bytes(32),),
+        )
+        conn.commit()
+    monkeypatch.setattr(
+        "polylogue.readiness.capability.raw_frontier_source_selection_block_reason",
+        lambda _root: "1 ingest cursor row committed past accepted raw material",
+    )
+
+    with pytest.raises(RuntimeError, match="raw frontier integrity"):
+        rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root))
+
+    assert not (root / ".index-generations").exists()
+
+
 def test_rebuild_source_preflight_rejects_orphaned_blob_refs_before_generation_creation(tmp_path: Path) -> None:
     root = tmp_path / "archive"
     _init_empty_source(root)

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -248,6 +248,81 @@ async def test_live_watcher_refuses_ahead_cursor_before_append_or_full_write(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("force_full_fallback", [False, True], ids=["append-route", "full-fallback-route"])
+async def test_live_watcher_catch_up_refuses_ahead_cursor_before_cursor_planning(
+    tmp_path: Path,
+    force_full_fallback: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Catch-up must stop before initialize or planning can mutate cursor state."""
+    _processor, watcher, cursor, source_path = _seed_live_cursor_authority_case(
+        tmp_path,
+        force_full_fallback=force_full_fallback,
+    )
+    candidates = watcher._scan_catch_up_candidates([source_path.parent])
+    before = _live_archive_snapshot(tmp_path)
+    initialize_calls = 0
+    plan_calls = 0
+
+    def track_initialize() -> None:
+        nonlocal initialize_calls
+        initialize_calls += 1
+
+    def track_plan(_candidates: tuple[live_watcher.CandidateSourceFile, ...]) -> live_watcher.CatchUpPlan:
+        nonlocal plan_calls
+        plan_calls += 1
+        raise AssertionError("cursor authority must gate catch-up before planning")
+
+    monkeypatch.setattr(cursor, "initialize", track_initialize)
+    monkeypatch.setattr(watcher, "_plan_catch_up", track_plan)
+
+    await watcher._catch_up_candidates(candidates)
+
+    assert initialize_calls == 0
+    assert plan_calls == 0
+    assert _live_archive_snapshot(tmp_path) == before
+    watcher.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("force_full_fallback", [False, True], ids=["append-route", "full-fallback-route"])
+async def test_live_watcher_flush_refuses_ahead_cursor_before_cursor_filtering(
+    tmp_path: Path,
+    force_full_fallback: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Flush must stop before initialize or cursor lifecycle decisions can run."""
+    _processor, watcher, cursor, source_path = _seed_live_cursor_authority_case(
+        tmp_path,
+        force_full_fallback=force_full_fallback,
+    )
+    watcher._pending_paths.add(source_path)
+    before = _live_archive_snapshot(tmp_path)
+    initialize_calls = 0
+    filter_calls = 0
+
+    def track_initialize() -> None:
+        nonlocal initialize_calls
+        initialize_calls += 1
+
+    def fail_filter(*args: object, **kwargs: object) -> bool:
+        del args, kwargs
+        nonlocal filter_calls
+        filter_calls += 1
+        raise AssertionError("cursor authority must gate flush before cursor filtering")
+
+    monkeypatch.setattr(cursor, "initialize", track_initialize)
+    monkeypatch.setattr(watcher, "_needs_work_from_state", fail_filter)
+
+    assert await watcher._flush_pending() is True
+
+    assert initialize_calls == 0
+    assert filter_calls == 0
+    assert _live_archive_snapshot(tmp_path) == before
+    watcher.stop()
+
+
+@pytest.mark.asyncio
 async def test_live_watcher_allows_append_at_authoritative_frontier(tmp_path: Path) -> None:
     """An exact accepted frontier retains the real append success path."""
     processor, watcher, _cursor, source_path = _seed_live_cursor_authority_case(

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -319,6 +319,7 @@ async def test_live_watcher_flush_refuses_ahead_cursor_before_cursor_filtering(
     assert initialize_calls == 0
     assert filter_calls == 0
     assert _live_archive_snapshot(tmp_path) == before
+    assert watcher._pending_paths == {source_path}
     watcher.stop()
 
 

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -21,6 +21,9 @@ import pytest
 
 import polylogue.sources.live.watcher as live_watcher
 from polylogue import Polylogue
+from polylogue.archive.message.roles import Role
+from polylogue.archive.revision_authority import RawRevisionAuthority, RawRevisionEnvelope, RawRevisionKind
+from polylogue.core.enums import Provider
 from polylogue.daemon.events import emit_catch_up_cycle, query_daemon_events
 from polylogue.daemon.write_coordinator import DaemonWriteCoordinator, DaemonWriteEvent
 from polylogue.sources.live import LiveWatcher, WatchSource
@@ -28,6 +31,7 @@ from polylogue.sources.live.batch import (
     _SMALL_FULL_PARSE_PROGRESS_MAX_BYTES,
     _SMALL_FULL_PARSE_PROGRESS_MAX_FILES,
     _STREAMING_FULL_INGEST_BYTES,
+    CursorAuthorityBlockedError,
     LiveBatchProcessor,
     _full_ingest_worker_count,
     _full_parse_progress_groups,
@@ -40,9 +44,12 @@ from polylogue.sources.live.batch_support import (
 )
 from polylogue.sources.live.cursor import CursorRecord, CursorStore
 from polylogue.sources.live.metrics import LiveBatchMetrics
+from polylogue.sources.parsers.base import ParsedMessage, ParsedSession
 from polylogue.sources.sqlite_snapshot import sqlite_source_revision
 from polylogue.storage.blob_store import BlobStore, PreparedBlob
 from polylogue.storage.runtime import RawSessionRecord
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
 from tests.infra.frozen_clock import FrozenClock
 
 
@@ -100,6 +107,162 @@ class _FailingSecondPathConverger:
                 {"fake": 0.001},
             )
         return ({path: SimpleNamespace(converged=True) for path in paths}, {"fake": 0.001})
+
+
+def _sqlite_snapshot(path: Path) -> tuple[tuple[str, tuple[tuple[object, ...], ...]], ...]:
+    with sqlite3.connect(path) as conn:
+        tables = tuple(
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+            )
+        )
+        return tuple((table, tuple(conn.execute(f'SELECT * FROM "{table}"').fetchall())) for table in tables)
+
+
+def _seed_live_cursor_authority_case(
+    root: Path,
+    *,
+    force_full_fallback: bool = False,
+    exact_frontier: bool = False,
+) -> tuple[LiveBatchProcessor, LiveWatcher, CursorStore, Path]:
+    source_root = root / "sessions"
+    source_root.mkdir(parents=True)
+    source_path = source_root / "session.jsonl"
+    prefix = (
+        json.dumps(_codex_session_meta("session-1")).encode()
+        + b"\n"
+        + json.dumps(
+            _codex_message(message_id="m1", role="user", text="hello", timestamp="2026-05-01T00:00:00Z")
+        ).encode()
+        + b"\n"
+    )
+    tail = (
+        json.dumps(
+            _codex_message(message_id="m2", role="assistant", text="reply", timestamp="2026-05-01T00:00:01Z")
+        ).encode()
+        + b"\n"
+    )
+    source_path.write_bytes(prefix + tail)
+    initialize_active_archive_root(root)
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        raw_id = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=prefix,
+            source_path=str(source_path),
+            acquired_at_ms=1,
+            native_id="session-1",
+        )
+        archive.bind_raw_revision(
+            raw_id,
+            RawRevisionEnvelope(
+                "codex:session-1",
+                RawRevisionKind.FULL,
+                "revision-0",
+                0,
+                authority=RawRevisionAuthority.BYTE_PROVEN,
+            ),
+        )
+        archive.apply_raw_revision_replay(
+            archive.raw_revision_replay_plan("codex:session-1"),
+            {
+                raw_id: ParsedSession(
+                    source_name=Provider.CODEX,
+                    provider_session_id="session-1",
+                    messages=[ParsedMessage(provider_message_id="m1", role=Role.USER, text="hello")],
+                )
+            },
+            acquired_at_ms=1,
+        )
+
+    cursor = CursorStore(root / "ops.db")
+    stat = source_path.stat()
+    cursor_offset = len(prefix) if exact_frontier else len(prefix) + 1
+    local_prefix_hash = sha256(source_path.read_bytes()[:cursor_offset]).hexdigest()
+    cursor.set(
+        source_path,
+        cursor_offset,
+        byte_offset=cursor_offset,
+        last_complete_newline=len(prefix),
+        parser_fingerprint="stale-parser" if force_full_fallback else live_watcher._PARSER_FINGERPRINT,
+        content_fingerprint="revision-0",
+        tail_hash=encode_cursor_hash_authority(local_prefix_hash, local_prefix_hash, ctime_ns=stat.st_ctime_ns),
+        source_name="codex",
+        st_dev=stat.st_dev,
+        st_ino=stat.st_ino,
+        mtime_ns=stat.st_mtime_ns,
+    )
+    polylogue = SimpleNamespace(archive_root=root, backend=SimpleNamespace(db_path=root / "index.db"))
+    processor = LiveBatchProcessor(
+        cast(Any, polylogue),
+        (WatchSource(name="codex", root=source_root),),
+        cursor=cursor,
+        parser_fingerprint=live_watcher._PARSER_FINGERPRINT,
+    )
+    watcher = LiveWatcher(
+        cast(Any, polylogue),
+        (WatchSource(name="codex", root=source_root),),
+        cursor=cursor,
+        parse_stage=None,
+    )
+    watcher._batch_processor = processor
+    return processor, watcher, cursor, source_path
+
+
+def _live_archive_snapshot(root: Path) -> tuple[object, ...]:
+    return (
+        _sqlite_snapshot(root / "source.db"),
+        _sqlite_snapshot(root / "index.db"),
+        _sqlite_snapshot(root / "ops.db"),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "force_full_fallback",
+    [False, True],
+    ids=["append-route", "full-fallback-route"],
+)
+async def test_live_watcher_refuses_ahead_cursor_before_append_or_full_write(
+    tmp_path: Path,
+    force_full_fallback: bool,
+) -> None:
+    """An ahead cursor with a locally matching prefix cannot select either live route."""
+    processor, watcher, cursor, source_path = _seed_live_cursor_authority_case(
+        tmp_path,
+        force_full_fallback=force_full_fallback,
+    )
+    record = cursor.get_record(source_path)
+    assert record is not None
+    if force_full_fallback:
+        assert processor._append_plan(source_path, cursor=record) is None
+    else:
+        assert processor._append_plan(source_path, cursor=record) is not None
+    before = _live_archive_snapshot(tmp_path)
+
+    with pytest.raises(CursorAuthorityBlockedError, match="source-selection gate blocked"):
+        await watcher._ingest_files([source_path])
+
+    assert _live_archive_snapshot(tmp_path) == before
+    watcher.stop()
+
+
+@pytest.mark.asyncio
+async def test_live_watcher_allows_append_at_authoritative_frontier(tmp_path: Path) -> None:
+    """An exact accepted frontier retains the real append success path."""
+    processor, watcher, _cursor, source_path = _seed_live_cursor_authority_case(
+        tmp_path,
+        exact_frontier=True,
+    )
+
+    metrics = await processor.ingest_files([source_path], emit_event=False)
+
+    assert metrics.succeeded_file_count == 1
+    assert metrics.append_file_count == 1
+    assert metrics.full_file_count == 0
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        assert conn.execute("SELECT COUNT(*) FROM raw_sessions").fetchone() == (2,)
+    watcher.stop()
 
 
 def test_live_ingest_metrics_log_separates_read_bytes_from_candidate_size(

--- a/tests/unit/storage/test_raw_retention.py
+++ b/tests/unit/storage/test_raw_retention.py
@@ -1130,7 +1130,13 @@ def test_archive_cleanup_compacts_append_snapshot_without_session_events(tmp_pat
     assert conn.execute("SELECT 1 FROM blob_refs WHERE ref_id = ?", (current_raw,)).fetchone() is not None
 
 
-def _seed_ops_cursor(ops_db_path: Path, *, source_path: Path, byte_offset: int) -> None:
+def _seed_ops_cursor(
+    ops_db_path: Path,
+    *,
+    source_path: Path,
+    byte_offset: int,
+    deferred_end_offset: int | None = None,
+) -> None:
     initialize_archive_database(ops_db_path, ArchiveTier.OPS)
     with sqlite3.connect(ops_db_path) as conn:
         upsert_ingest_cursor(
@@ -1138,6 +1144,7 @@ def _seed_ops_cursor(ops_db_path: Path, *, source_path: Path, byte_offset: int) 
             source_path=str(source_path),
             updated_at_ms=1,
             byte_offset=byte_offset,
+            deferred_end_offset=deferred_end_offset,
         )
         conn.commit()
 
@@ -1837,6 +1844,18 @@ def test_raw_frontier_integrity_snapshot_surfaces_cursor_without_accepted_head(t
     source_path = tmp_path / "unmaterialized.jsonl"
     initialize_archive_database(source_db, ArchiveTier.SOURCE)
     initialize_archive_database(index_db, ArchiveTier.INDEX)
+    with sqlite3.connect(source_db) as conn:
+        _insert_revision_raw(
+            conn,
+            raw_id="raw-unmaterialized",
+            source_path=source_path,
+            acquired_at_ms=1,
+            kind="full",
+            source_revision="revision-0",
+            generation=0,
+            blob_size=10,
+        )
+        conn.commit()
     _seed_ops_cursor(ops_db, source_path=source_path, byte_offset=42)
 
     with sqlite3.connect(source_db) as conn:
@@ -1847,7 +1866,57 @@ def test_raw_frontier_integrity_snapshot_surfaces_cursor_without_accepted_head(t
     assert snapshot.cursor_authority_gap_count == 1
     assert snapshot.cursor_authority_gap_samples[0].source_path == str(source_path)
     assert snapshot.cursor_authority_gap_samples[0].cursor_byte_offset == 42
-    assert "no accepted byte head" in snapshot.cursor_authority_gap_samples[0].reason
+    assert snapshot.cursor_authority_gap_samples[0].state == "source_raws_without_accepted_head"
+    assert "source tier has raw evidence" in snapshot.cursor_authority_gap_samples[0].reason
+    assert snapshot.overall_status == "unknown"
+
+
+def test_raw_frontier_integrity_snapshot_classifies_deferred_cursor_separately_from_ahead(
+    tmp_path: Path,
+) -> None:
+    """A captured-but-unresolved cursor is blocking deferred authority, not a false violation."""
+
+    source_db = tmp_path / "source.db"
+    index_db = tmp_path / "index.db"
+    ops_db = tmp_path / "ops.db"
+    source_path = tmp_path / "deferred.jsonl"
+    source_path.write_text("{}\n", encoding="utf-8")
+    initialize_archive_database(source_db, ArchiveTier.SOURCE)
+    initialize_archive_database(index_db, ArchiveTier.INDEX)
+    with sqlite3.connect(source_db) as conn:
+        _insert_revision_raw(
+            conn,
+            raw_id="raw-baseline",
+            source_path=source_path,
+            acquired_at_ms=1,
+            kind="full",
+            source_revision="revision-0",
+            generation=0,
+            blob_size=10,
+        )
+        conn.commit()
+    _seed_index_authority(
+        index_db,
+        session_raw_id="raw-baseline",
+        accepted_raw_id="raw-baseline",
+        accepted_revision="revision-0",
+        generation=0,
+        frontier=10,
+        append_end_offset=None,
+    )
+    _seed_ops_cursor(ops_db, source_path=source_path, byte_offset=10, deferred_end_offset=20)
+
+    with sqlite3.connect(source_db) as conn:
+        snapshot = raw_frontier_integrity_snapshot(conn, index_db_path=index_db, ops_db_path=ops_db)
+
+    assert snapshot.cursor_ahead_status == "unknown"
+    assert snapshot.cursor_ahead_count == 0
+    assert snapshot.cursor_head_comparison_count == 0
+    assert snapshot.cursor_authority_gap_count == 1
+    sample = snapshot.cursor_authority_gap_samples[0]
+    assert sample.state == "deferred"
+    assert sample.cursor_byte_offset == 10
+    assert "awaiting authority resolution" in sample.reason
     assert snapshot.overall_status == "unknown"
 
 


### PR DESCRIPTION
## Summary
Repair cursor authority readiness by classifying incomparable cursor states and consuming the canonical frontier proof before raw convergence, recovery, or reindex source selection.

## Problem
The read-only 2026-08-04 census found one cursor 254 bytes ahead of its accepted raw frontier and 727 incomparable cursor/head rows. The diagnostic projection detected these facts, but raw convergence and reindex did not use the proof as a source-selection safety gate. Deferred cursor authority was also not represented as a typed state.

## Solution
Add typed `deferred`, `source_raws_without_accepted_head`, `cursor_path_absent_from_source`, and `accepted_head_missing_source` states to the readiness projection. Add one shared fail-closed source-selection gate to the raw materialization drain, raw parse recovery stage, and reindex entry point. Preserve excluded cursor rows and semantic-only accepted heads as deliberate terminal exceptions. Add mutation-sensitive public readiness, convergence, reindex, exact-frontier, and deferred-state tests. Update the durable census with the route-level root cause.

## Verification
- `direnv exec . devtools test tests/unit/storage/test_raw_retention.py tests/unit/core/test_health_core.py tests/unit/core/test_readiness_capability.py tests/unit/daemon/test_daemon_status.py tests/unit/daemon/test_daemon_cli.py tests/unit/daemon/test_raw_parse_recovery.py tests/unit/maintenance/test_rebuild_index_ownership.py tests/unit/maintenance/test_rebuild_parse_apply_split.py` -> 324 passed.
- Final focused rerun -> 206 passed.
- `direnv exec . devtools verify --quick` -> exit 0. Ruff format, ruff check, mypy, generated surfaces, layering, and policy checks passed.
- Read-only live projection -> one cursor-ahead row, 16,881 comparisons, 727 gaps classified as 725 source raws without accepted heads and 2 cursor paths absent from source.

## Acceptance criteria
1. Satisfied. The read-only root-cause census is recorded in `docs/evidence/polylogue-xeck9-cursor-authority-census-2026-08-04.md`.
2. Satisfied. The missing production source-selection gate has public readiness coverage and red twin route tests for raw convergence and reindex.
3. Satisfied. Readiness now emits typed incomparable and deferred states separately from cursor-ahead samples.
4. Satisfied for this change. No live reconciliation was performed. Accepted heads and source rows were preserved, and the remaining live violation is explicitly surfaced. Any future reconciliation remains subject to the receipt-backed contract in the census.

Ref polylogue-xeck9