### PR TITLE
fix(daemon): gate unsafe cursor authority selection

### DIFF
--- a/docs/evidence/polylogue-xeck9-cursor-authority-census-2026-08-04.md
+++ b/docs/evidence/polylogue-xeck9-cursor-authority-census-2026-08-04.md
@@ -44,7 +44,7 @@ The existing status DTO renders these separately from the proven violation: `cur
 
 ## Root-cause conclusion
 
-No demonstrated defect was found in the cursor write path, comparison predicate, or state model on the current branch. The comparison is strict `cursor_offset > accepted_frontier`, consumes the durable accepted head, and its regression coverage already exercises the real `raw_frontier_integrity_snapshot()` route. Reclassifying the true violation as incomparable or comparing against a non-accepted raw would contradict the current projection and its existing tests.
+No demonstrated defect was found in the cursor write path or comparison predicate on the current branch. The comparison is strict `cursor_offset > accepted_frontier`, consumes the durable accepted head, and its regression coverage already exercises the real `raw_frontier_integrity_snapshot()` route. The production defect was at the readiness consumers: raw convergence and reindex did not consume this proof before selecting source rows. Reclassifying the true violation as incomparable or comparing against a non-accepted raw would contradict the current projection and its existing tests.
 
 The live cursor is ahead of its accepted full-head frontier. That is production reconciliation work, not evidence for a code change. The 725 source-backed incomparables are deferred authority states that must remain visible. The 2 source-absent cursor paths likewise must remain explicit until their durable history is reconciled; this report does not authorize a cursor reset or source-row edit.
 

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -1241,8 +1241,14 @@ def _drain_raw_materialization_once(
     function is ever scheduled onto the writer hold; passing ``None``
     (the flag-off default) reproduces the exact unmodified in-hold parse.
     """
+    from polylogue.paths import archive_root
+    from polylogue.readiness.capability import raw_frontier_source_selection_block_reason
+
+    if reason := raw_frontier_source_selection_block_reason(archive_root()):
+        raise RuntimeError(f"raw materialization source-selection gate blocked: {reason}")
+
     from polylogue.config import Config
-    from polylogue.paths import archive_root, render_root
+    from polylogue.paths import render_root
     from polylogue.product import raw_authority
     from polylogue.storage.blob_integrity import restore_direct_blob_reference_debt
 

--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -938,8 +938,16 @@ def make_raw_parse_recovery_stage(db_path: Path) -> ConvergenceStage:
     def execute(path: Path) -> StageExecuteReturn:
         from polylogue.config import Config
         from polylogue.product.raw_authority import repair_materialization
+        from polylogue.readiness.capability import raw_frontier_source_selection_block_reason
 
         archive_root = db_path.parent
+        if reason := raw_frontier_source_selection_block_reason(archive_root):
+            logger.warning(
+                "raw_parse_recovery: source-selection gate blocked for %s: %s",
+                path,
+                reason,
+            )
+            return False
         config = Config(archive_root=archive_root, render_root=archive_root, sources=[])
         try:
             repair_materialization(

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -808,6 +808,11 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
     log_mapped_bytes_budget_check(logger, check_mapped_bytes_budget_against_cgroup_limit())
     validate_rebuild_index_request(request)
     root = request.archive_root
+    if count_source_raw_sessions(root):
+        from polylogue.readiness.capability import raw_frontier_source_selection_block_reason
+
+        if reason := raw_frontier_source_selection_block_reason(root):
+            raise RuntimeError(f"reindex source preflight gate failed: raw frontier integrity: {reason}")
     location = ArchiveLocation.resolve(root)
     active_config = Config(
         archive_root=root,

--- a/polylogue/readiness/capability.py
+++ b/polylogue/readiness/capability.py
@@ -467,6 +467,38 @@ def raw_frontier_integrity_is_proven_healthy(payload: object) -> bool:
     return error is None and normalized is not None and normalized.get("overall_status") == "healthy"
 
 
+def raw_frontier_source_selection_block_reason(
+    archive_root: Path,
+    raw_materialization_readiness: Mapping[str, object] | None = None,
+) -> str | None:
+    """Return the readiness reason that must block unsafe source selection.
+
+    Raw convergence and reindex both select source rows before they write an
+    index. They therefore require the same complete, healthy frontier proof
+    exposed by the diagnostic/readiness route. ``None`` means every authority
+    comparison was proven healthy. A deferred or incomparable cursor is a
+    deliberate terminal exception to the byte comparison, but it remains a
+    blocking unknown until its authority can be resolved.
+    """
+
+    projection = raw_frontier_integrity_projection(
+        archive_root,
+        raw_materialization_readiness
+        if raw_materialization_readiness is not None
+        else _raw_materialization_readiness_for_source_selection(archive_root),
+    )
+    payload = projection.to_dict()
+    if raw_frontier_integrity_is_proven_healthy(payload):
+        return None
+    return raw_frontier_integrity_summary(payload)
+
+
+def _raw_materialization_readiness_for_source_selection(archive_root: Path) -> Mapping[str, object]:
+    from polylogue.storage.archive_readiness import raw_materialization_readiness_snapshot
+
+    return raw_materialization_readiness_snapshot(archive_root)
+
+
 def status_snapshot_has_fresh_provenance(payload: Mapping[str, Any]) -> bool:
     """Return whether a daemon payload carries a complete fresh-cache marker."""
 
@@ -874,6 +906,7 @@ __all__ = [
     "normalize_raw_frontier_status_payload",
     "raw_frontier_integrity_projection",
     "raw_frontier_integrity_is_proven_healthy",
+    "raw_frontier_source_selection_block_reason",
     "raw_frontier_integrity_summary",
     "status_snapshot_has_fresh_provenance",
     "unknown_raw_frontier_integrity_projection",

--- a/polylogue/storage/raw_retention.py
+++ b/polylogue/storage/raw_retention.py
@@ -897,6 +897,12 @@ def reissue_stale_supersession_receipts(
 # it counts and samples it, so readiness and retention safety cannot drift.
 
 RawFrontierIntegrityStatus = Literal["healthy", "unknown", "violated"]
+CursorAuthorityGapState = Literal[
+    "deferred",
+    "source_raws_without_accepted_head",
+    "cursor_path_absent_from_source",
+    "accepted_head_missing_source",
+]
 """Typed check outcome. ``"unknown"`` means the check's authority tier could
 not be read — it is never collapsed into a false ``"healthy"`` zero."""
 
@@ -930,10 +936,22 @@ class CursorAheadSample:
 class CursorAuthorityGapSample:
     """One cursor/head that cannot be joined to comparable byte authority."""
 
+    state: CursorAuthorityGapState
     source_path: str | None
     logical_source_key: str | None
     cursor_byte_offset: int | None
     reason: str
+
+
+@dataclass(frozen=True)
+class _OpsCursorAuthority:
+    source_path: str
+    byte_offset: int
+    deferred_end_offset: int | None
+
+    @property
+    def is_deferred(self) -> bool:
+        return self.deferred_end_offset is not None and self.deferred_end_offset > self.byte_offset
 
 
 @dataclass(frozen=True)
@@ -1040,6 +1058,7 @@ class RawFrontierIntegrityProjection:
             "cursor_authority_gap_count": self.cursor_authority_gap_count,
             "cursor_authority_gap_samples": [
                 {
+                    "state": sample.state,
                     "source_path": sample.source_path,
                     "logical_source_key": sample.logical_source_key,
                     "cursor_byte_offset": sample.cursor_byte_offset,
@@ -1438,6 +1457,7 @@ def _check_cursor_ahead_of_accepted(
                 if len(gaps) < sample_limit:
                     gaps.append(
                         CursorAuthorityGapSample(
+                            state="accepted_head_missing_source",
                             source_path=None,
                             logical_source_key=head.logical_source_key,
                             cursor_byte_offset=None,
@@ -1454,7 +1474,29 @@ def _check_cursor_ahead_of_accepted(
     checked = 0
     comparison_count = 0
     ahead_comparison_count = 0
-    for path, cursor_offset in cursor_map.items():
+    try:
+        source_paths = _source_paths_for_paths(conn, set(cursor_map))
+    except sqlite3.Error as exc:
+        logger.warning("raw frontier integrity: cursor source path lookup failed: %s", exc)
+        return "unknown", 0, 0, 0, 0, (), 0, (), f"cursor source path lookup failed: {exc}"
+    for path, cursor in cursor_map.items():
+        cursor_offset = cursor.byte_offset
+        if cursor.is_deferred:
+            gap_count += 1
+            if len(gaps) < sample_limit:
+                gaps.append(
+                    CursorAuthorityGapSample(
+                        state="deferred",
+                        source_path=path,
+                        logical_source_key=None,
+                        cursor_byte_offset=cursor_offset,
+                        reason=(
+                            "ingest cursor has durably captured material awaiting authority resolution "
+                            f"through byte {cursor.deferred_end_offset}"
+                        ),
+                    )
+                )
+            continue
         comparable_heads = byte_heads_by_path.get(path)
         if not comparable_heads:
             # A path governed exclusively by membership authority has no
@@ -1465,10 +1507,19 @@ def _check_cursor_ahead_of_accepted(
             if len(gaps) < sample_limit:
                 gaps.append(
                     CursorAuthorityGapSample(
+                        state=(
+                            "source_raws_without_accepted_head"
+                            if path in source_paths
+                            else "cursor_path_absent_from_source"
+                        ),
                         source_path=path,
                         logical_source_key=None,
                         cursor_byte_offset=cursor_offset,
-                        reason="ingest cursor has no accepted byte head",
+                        reason=(
+                            "source tier has raw evidence but index has no accepted byte head"
+                            if path in source_paths
+                            else "ingest cursor path is absent from source tier"
+                        ),
                     )
                 )
             continue
@@ -1528,7 +1579,21 @@ def _source_paths_for_raw_ids(conn: sqlite3.Connection, raw_ids: set[str]) -> di
     return result
 
 
-def _ops_cursor_byte_offsets(ops_db_path: Path) -> dict[str, int]:
+def _source_paths_for_paths(conn: sqlite3.Connection, source_paths: set[str]) -> set[str]:
+    result: set[str] = set()
+    pending = set(source_paths)
+    while pending:
+        batch = tuple(sorted(pending)[:500])
+        pending.difference_update(batch)
+        placeholders = ", ".join("?" for _ in batch)
+        rows = conn.execute(
+            f"SELECT DISTINCT source_path FROM raw_sessions WHERE source_path IN ({placeholders})", batch
+        ).fetchall()
+        result.update(str(row[0]) for row in rows if row[0] is not None)
+    return result
+
+
+def _ops_cursor_byte_offsets(ops_db_path: Path) -> dict[str, _OpsCursorAuthority]:
     if not ops_db_path.is_file():
         raise RawRetentionSafetyError(f"ops tier is unavailable: {ops_db_path}")
     try:
@@ -1544,11 +1609,23 @@ def _ops_cursor_byte_offsets(ops_db_path: Path) -> dict[str, int]:
             # ingest authority. Their exclusion/failure state is surfaced by
             # the ordinary cursor workload status instead of frontier parity.
             rows = conn.execute(
-                "SELECT source_path, byte_offset FROM ingest_cursor WHERE excluded = 0 AND byte_offset IS NOT NULL",
+                """
+                SELECT source_path, byte_offset, deferred_end_offset
+                FROM ingest_cursor
+                WHERE COALESCE(excluded, 0) = 0 AND byte_offset IS NOT NULL
+                """,
             ).fetchall()
     except (OSError, sqlite3.Error) as exc:
         raise RawRetentionSafetyError(f"ops tier raw cursor authority is unreadable: {exc}") from exc
-    return {str(row[0]): int(row[1]) for row in rows if row[1] is not None}
+    return {
+        str(row[0]): _OpsCursorAuthority(
+            source_path=str(row[0]),
+            byte_offset=int(row[1]),
+            deferred_end_offset=int(row[2]) if row[2] is not None else None,
+        )
+        for row in rows
+        if row[1] is not None
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -1922,6 +1999,7 @@ __all__ = [
     "BrokenAppendHeadSample",
     "CursorAheadSample",
     "CursorAuthorityGapSample",
+    "CursorAuthorityGapState",
     "RawFrontierIntegrityProjection",
     "RawFrontierIntegritySnapshot",
     "RawFrontierIntegrityStatus",

--- a/tests/unit/core/test_health_core.py
+++ b/tests/unit/core/test_health_core.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sqlite3
 from collections.abc import Mapping
 from pathlib import Path
+from typing import cast
 from unittest.mock import patch
 
 import pytest
@@ -133,6 +134,95 @@ def test_raw_frontier_readiness_check_errors_on_missing_source_evidence(tmp_path
     assert check.status is VerifyStatus.ERROR
     assert check.count == 1
     assert check.breakdown["missing_source_raw_count"] == 1
+
+
+def test_public_readiness_route_blocks_cursor_ahead_source_selection(tmp_path: Path) -> None:
+    """The real readiness report must carry the cursor violation to convergence state."""
+
+    from polylogue.config import Config
+    from polylogue.readiness import run_archive_readiness
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+    from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+    for tier in (ArchiveTier.SOURCE, ArchiveTier.INDEX, ArchiveTier.OPS):
+        initialize_archive_database(tmp_path / f"{tier.value}.db", tier)
+    source_path = tmp_path / "session.jsonl"
+    unmaterialized_path = tmp_path / "unmaterialized.jsonl"
+    source_path.write_text("{}\n", encoding="utf-8")
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, source_index, blob_hash,
+                blob_size, acquired_at_ms, logical_source_key, revision_kind,
+                source_revision, acquisition_generation, revision_authority
+            ) VALUES ('raw-baseline', 'codex-session', 'session-1', ?, 0, ?,
+                      10, 1, 'codex:session-1', 'full', 'revision-0', 0, 'byte_proven')
+            """,
+            (str(source_path), bytes(32)),
+        )
+        conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, source_index, blob_hash,
+                blob_size, acquired_at_ms, logical_source_key, revision_kind,
+                source_revision, acquisition_generation, revision_authority
+            ) VALUES ('raw-unmaterialized', 'codex-session', 'session-2', ?, 0, ?,
+                      10, 2, 'codex:session-2', 'full', 'revision-0', 0, 'byte_proven')
+            """,
+            (str(unmaterialized_path), bytes(31) + b"x"),
+        )
+        conn.commit()
+    with sqlite3.connect(tmp_path / "index.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO sessions (native_id, origin, raw_id, title, content_hash)
+            VALUES ('session-1', 'codex-session', 'raw-baseline', 'session', ?)
+            """,
+            (bytes(32),),
+        )
+        conn.execute(
+            """
+            INSERT INTO raw_revision_heads (
+                logical_source_key, session_id, accepted_raw_id,
+                accepted_source_revision, accepted_content_hash,
+                accepted_frontier_kind, accepted_frontier,
+                acquisition_generation, append_end_offset, decided_at_ms
+            ) VALUES ('codex:session-1', 'codex-session:session-1', 'raw-baseline',
+                      'revision-0', ?, 'byte', 10, 0, NULL, 2)
+            """,
+            (bytes(32),),
+        )
+        conn.commit()
+    with sqlite3.connect(tmp_path / "ops.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO ingest_cursor (source_path, byte_offset, updated_at_ms)
+            VALUES (?, 20, 1)
+            """,
+            (str(source_path),),
+        )
+        conn.execute(
+            """
+            INSERT INTO ingest_cursor (source_path, byte_offset, updated_at_ms)
+            VALUES (?, 42, 2)
+            """,
+            (str(unmaterialized_path),),
+        )
+        conn.commit()
+
+    report = run_archive_readiness(
+        Config(archive_root=tmp_path, render_root=tmp_path, sources=[], db_path=tmp_path / "index.db")
+    )
+
+    check = next(check for check in report.checks if check.name == "raw_frontier_integrity")
+    assert check.status.value == "error"
+    assert check.breakdown["cursor_ahead_count"] == 1
+    assert report.raw_frontier_integrity["cursor_ahead_status"] == "violated"
+    assert report.raw_frontier_integrity["cursor_authority_gap_count"] == 1
+    gap_samples = cast(list[dict[str, object]], report.raw_frontier_integrity["cursor_authority_gap_samples"])
+    assert gap_samples[0]["state"] == "source_raws_without_accepted_head"
+    assert report.archive_convergence["converging"] is True
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -576,6 +576,7 @@ def test_drain_raw_materialization_once_uses_bounded_daemon_batch(
 
     monkeypatch.setattr("polylogue.paths.archive_root", lambda: tmp_path / "archive")
     monkeypatch.setattr("polylogue.paths.render_root", lambda: tmp_path / "render")
+    monkeypatch.setattr("polylogue.readiness.capability.raw_frontier_source_selection_block_reason", lambda _root: None)
     monkeypatch.setattr(
         "polylogue.storage.blob_integrity.restore_direct_blob_reference_debt",
         fake_restore_direct_blob_reference_debt,
@@ -617,6 +618,25 @@ def test_drain_raw_materialization_once_uses_bounded_daemon_batch(
         "frontier_limit": 8,
         "max_pass_seconds": daemon_cli._RAW_MATERIALIZATION_MAX_PASS_SECONDS,
     }
+
+
+def test_drain_raw_materialization_once_blocks_unsafe_cursor_authority(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from polylogue.daemon import cli as daemon_cli
+
+    archive = tmp_path / "archive"
+    monkeypatch.setattr("polylogue.paths.archive_root", lambda: archive)
+    monkeypatch.setattr(
+        "polylogue.readiness.capability.raw_frontier_source_selection_block_reason",
+        lambda _root: "1 ingest cursor row committed past accepted raw material",
+    )
+
+    with pytest.raises(RuntimeError, match="source-selection gate blocked"):
+        daemon_cli._drain_raw_materialization_once()
+
+    assert not archive.exists()
 
 
 def test_maybe_recommend_bulk_rebuild_silent_below_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -940,6 +960,7 @@ def test_raw_materialization_closes_fts_on_cancellation(
 
     monkeypatch.setattr("polylogue.paths.archive_root", lambda: archive)
     monkeypatch.setattr("polylogue.paths.render_root", lambda: tmp_path / "render")
+    monkeypatch.setattr("polylogue.readiness.capability.raw_frontier_source_selection_block_reason", lambda _root: None)
     monkeypatch.setattr(
         "polylogue.storage.blob_integrity.restore_direct_blob_reference_debt",
         lambda *_args, **_kwargs: FakeRestoreResult(),

--- a/tests/unit/maintenance/test_rebuild_index_ownership.py
+++ b/tests/unit/maintenance/test_rebuild_index_ownership.py
@@ -53,6 +53,36 @@ def test_rebuild_refuses_when_archive_location_already_owned(tmp_path: Path) -> 
     assert receipt.status == "empty-source"
 
 
+def test_rebuild_blocks_unsafe_cursor_authority_before_generation_creation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "archive"
+    _init_empty_source(root)
+    with sqlite3.connect(root / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, source_index, blob_hash,
+                blob_size, acquired_at_ms, logical_source_key, revision_kind,
+                source_revision, acquisition_generation, revision_authority
+            ) VALUES ('raw-1', 'codex-session', 'session-1', 'source.jsonl', 0, ?,
+                      1, 1, 'codex:session-1', 'full', 'revision-0', 0, 'byte_proven')
+            """,
+            (bytes(32),),
+        )
+        conn.commit()
+    monkeypatch.setattr(
+        "polylogue.readiness.capability.raw_frontier_source_selection_block_reason",
+        lambda _root: "1 ingest cursor row committed past accepted raw material",
+    )
+
+    with pytest.raises(RuntimeError, match="raw frontier integrity"):
+        rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root))
+
+    assert not (root / ".index-generations").exists()
+
+
 def test_rebuild_source_preflight_rejects_orphaned_blob_refs_before_generation_creation(tmp_path: Path) -> None:
     root = tmp_path / "archive"
     _init_empty_source(root)

--- a/tests/unit/storage/test_raw_retention.py
+++ b/tests/unit/storage/test_raw_retention.py
@@ -1130,7 +1130,13 @@ def test_archive_cleanup_compacts_append_snapshot_without_session_events(tmp_pat
     assert conn.execute("SELECT 1 FROM blob_refs WHERE ref_id = ?", (current_raw,)).fetchone() is not None
 
 
-def _seed_ops_cursor(ops_db_path: Path, *, source_path: Path, byte_offset: int) -> None:
+def _seed_ops_cursor(
+    ops_db_path: Path,
+    *,
+    source_path: Path,
+    byte_offset: int,
+    deferred_end_offset: int | None = None,
+) -> None:
     initialize_archive_database(ops_db_path, ArchiveTier.OPS)
     with sqlite3.connect(ops_db_path) as conn:
         upsert_ingest_cursor(
@@ -1138,6 +1144,7 @@ def _seed_ops_cursor(ops_db_path: Path, *, source_path: Path, byte_offset: int) 
             source_path=str(source_path),
             updated_at_ms=1,
             byte_offset=byte_offset,
+            deferred_end_offset=deferred_end_offset,
         )
         conn.commit()
 
@@ -1837,6 +1844,18 @@ def test_raw_frontier_integrity_snapshot_surfaces_cursor_without_accepted_head(t
     source_path = tmp_path / "unmaterialized.jsonl"
     initialize_archive_database(source_db, ArchiveTier.SOURCE)
     initialize_archive_database(index_db, ArchiveTier.INDEX)
+    with sqlite3.connect(source_db) as conn:
+        _insert_revision_raw(
+            conn,
+            raw_id="raw-unmaterialized",
+            source_path=source_path,
+            acquired_at_ms=1,
+            kind="full",
+            source_revision="revision-0",
+            generation=0,
+            blob_size=10,
+        )
+        conn.commit()
     _seed_ops_cursor(ops_db, source_path=source_path, byte_offset=42)
 
     with sqlite3.connect(source_db) as conn:
@@ -1847,7 +1866,57 @@ def test_raw_frontier_integrity_snapshot_surfaces_cursor_without_accepted_head(t
     assert snapshot.cursor_authority_gap_count == 1
     assert snapshot.cursor_authority_gap_samples[0].source_path == str(source_path)
     assert snapshot.cursor_authority_gap_samples[0].cursor_byte_offset == 42
-    assert "no accepted byte head" in snapshot.cursor_authority_gap_samples[0].reason
+    assert snapshot.cursor_authority_gap_samples[0].state == "source_raws_without_accepted_head"
+    assert "source tier has raw evidence" in snapshot.cursor_authority_gap_samples[0].reason
+    assert snapshot.overall_status == "unknown"
+
+
+def test_raw_frontier_integrity_snapshot_classifies_deferred_cursor_separately_from_ahead(
+    tmp_path: Path,
+) -> None:
+    """A captured-but-unresolved cursor is blocking deferred authority, not a false violation."""
+
+    source_db = tmp_path / "source.db"
+    index_db = tmp_path / "index.db"
+    ops_db = tmp_path / "ops.db"
+    source_path = tmp_path / "deferred.jsonl"
+    source_path.write_text("{}\n", encoding="utf-8")
+    initialize_archive_database(source_db, ArchiveTier.SOURCE)
+    initialize_archive_database(index_db, ArchiveTier.INDEX)
+    with sqlite3.connect(source_db) as conn:
+        _insert_revision_raw(
+            conn,
+            raw_id="raw-baseline",
+            source_path=source_path,
+            acquired_at_ms=1,
+            kind="full",
+            source_revision="revision-0",
+            generation=0,
+            blob_size=10,
+        )
+        conn.commit()
+    _seed_index_authority(
+        index_db,
+        session_raw_id="raw-baseline",
+        accepted_raw_id="raw-baseline",
+        accepted_revision="revision-0",
+        generation=0,
+        frontier=10,
+        append_end_offset=None,
+    )
+    _seed_ops_cursor(ops_db, source_path=source_path, byte_offset=10, deferred_end_offset=20)
+
+    with sqlite3.connect(source_db) as conn:
+        snapshot = raw_frontier_integrity_snapshot(conn, index_db_path=index_db, ops_db_path=ops_db)
+
+    assert snapshot.cursor_ahead_status == "unknown"
+    assert snapshot.cursor_ahead_count == 0
+    assert snapshot.cursor_head_comparison_count == 0
+    assert snapshot.cursor_authority_gap_count == 1
+    sample = snapshot.cursor_authority_gap_samples[0]
+    assert sample.state == "deferred"
+    assert sample.cursor_byte_offset == 10
+    assert "awaiting authority resolution" in sample.reason
     assert snapshot.overall_status == "unknown"
 
 


### PR DESCRIPTION
## Summary

Block convergence and reindex before source selection when cursor authority is unsafe.

## Problem

Readiness detected an ahead cursor and 727 incomparable rows, but raw convergence and reindex did not consume that proof before selecting source rows. Deferred cursors were indistinguishable from other authority gaps.

## Solution

Classify cursor authority gaps with typed states, preserve excluded and semantic terminal exceptions, expose deferred authority as blocking unknown state, and use one shared readiness gate in raw materialization, recovery, and reindex before their first write.

## Verification

The worker completed its quick verification baseline, and focused public-readiness plus route-level mutation regressions cover unsafe blocking and valid exact-frontier progression.

Ref polylogue-xeck9