### PR TITLE
fix(maintenance): harden blob-ref liveness apply

### DIFF
--- a/polylogue/maintenance/blob_ref_liveness_reconciliation.py
+++ b/polylogue/maintenance/blob_ref_liveness_reconciliation.py
@@ -13,14 +13,15 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from polylogue.config import Config
+from polylogue.daemon.write_coordinator import daemon_write_lease_active
 from polylogue.maintenance.offline_guard import running_daemon_pid
 from polylogue.paths import render_root
-from polylogue.storage.blob_gc import BLOB_REF_LIVENESS_JOIN
 from polylogue.storage.blob_ref_liveness import (
     BlobRefLivenessCandidate,
     BlobRefLivenessClassification,
     classify_blob_ref_liveness,
     stage_blob_ref_liveness,
+    validated_blob_ref_liveness_joins,
 )
 from polylogue.storage.hook_payload_ref_reconciliation import _deterministic_raw_session_id_udf
 from polylogue.storage.introspection import table_exists as _table_exists
@@ -43,6 +44,7 @@ _RECOVERY_TERMINAL_PHASES = {
     "recovered_rolled_back",
     "recovered_partial",
     "indeterminate",
+    "postcondition_failed",
 }
 
 
@@ -59,6 +61,7 @@ class BlobRefLivenessReconciliationReport:
     deleted_count: int
     receipt_path: Path | None = None
     backup_manifest: Path | None = None
+    post_classification: BlobRefLivenessClassification | None = None
 
     def to_dict(self, *, sample_limit: int = 30) -> dict[str, object]:
         return {
@@ -68,6 +71,7 @@ class BlobRefLivenessReconciliationReport:
             "deleted_count": self.deleted_count,
             "receipt_path": str(self.receipt_path) if self.receipt_path is not None else None,
             "backup_manifest": str(self.backup_manifest) if self.backup_manifest is not None else None,
+            "post_classification": self.post_classification.to_dict() if self.post_classification is not None else None,
             **self.classification.to_dict(sample_limit=sample_limit),
         }
 
@@ -79,6 +83,8 @@ def _offline_config(archive_root: Path) -> Config:
 def _offline_apply_block_reason(archive_root: Path) -> str | None:
     """Refuse this offline-only repair whenever its archive daemon is live."""
 
+    if daemon_write_lease_active():
+        return "Refusing offline blob-ref liveness reconciliation while a daemon writer lease is active."
     daemon_pid = running_daemon_pid(_offline_config(archive_root))
     if daemon_pid is None:
         return None
@@ -93,8 +99,13 @@ def _checkpoint_source_db(conn: sqlite3.Connection) -> None:
         row = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
     except sqlite3.Error as exc:
         raise BlobRefLivenessReconciliationError("could not checkpoint source.db before backup validation") from exc
-    if row is None:
+    if row is None or len(row) != 3:
         raise BlobRefLivenessReconciliationError("could not checkpoint source.db before backup validation")
+    busy, log_frames, checkpointed_frames = (int(value) for value in row)
+    if busy != 0 or log_frames != checkpointed_frames:
+        raise BlobRefLivenessReconciliationError(
+            "source.db WAL checkpoint was not clean; stop every writer and retry when no frames remain busy"
+        )
 
 
 def _source_data_version(conn: sqlite3.Connection) -> int:
@@ -193,6 +204,7 @@ def _append_receipt_footer(
     *,
     phase: str,
     deleted_count: int | None = None,
+    post_orphaned_count: int | None = None,
     error: str | None = None,
 ) -> None:
     payload: dict[str, object] = {
@@ -202,6 +214,8 @@ def _append_receipt_footer(
     }
     if deleted_count is not None:
         payload["deleted_count"] = deleted_count
+    if post_orphaned_count is not None:
+        payload["post_orphaned_count"] = post_orphaned_count
     if error is not None:
         payload["error"] = error
     with receipt_path.open("a", encoding="utf-8") as handle:
@@ -530,6 +544,27 @@ def _validate_locked_candidate_plan(
         raise BlobRefLivenessReconciliationError(
             f"prepared candidate presence mismatch: planned={expected_count} present={present_count}"
         )
+    content_mismatch_count = int(
+        conn.execute(
+            f"""
+            SELECT COUNT(*)
+            FROM {candidate_table} AS c
+            JOIN blob_refs AS b
+              ON b.blob_hash = c.blob_hash
+             AND b.ref_type = c.ref_type
+             AND b.ref_id = c.ref_id
+            WHERE NOT (
+                b.source_path IS c.source_path
+                AND b.size_bytes = c.size_bytes
+                AND b.acquired_at_ms = c.acquired_at_ms
+            )
+            """
+        ).fetchone()[0]
+    )
+    if content_mismatch_count:
+        raise BlobRefLivenessReconciliationError(
+            f"prepared candidate content changed under lock: {content_mismatch_count} row(s)"
+        )
     referent_branches = [
         f"""
         SELECT c.blob_hash, c.ref_type, c.ref_id
@@ -538,14 +573,14 @@ def _validate_locked_candidate_plan(
         WHERE c.ref_type = ?
         """
         for ref_type, (table, column) in {
-            ref_type: (table, column) for ref_type, table, column in BLOB_REF_LIVENESS_JOIN
+            ref_type: (table, column) for ref_type, table, column in validated_blob_ref_liveness_joins()
         }.items()
     ]
     if referent_branches:
         live_referent_count = int(
             conn.execute(
                 f"SELECT COUNT(*) FROM ({' UNION ALL '.join(referent_branches)})",
-                tuple(ref_type for ref_type, _table, _column in BLOB_REF_LIVENESS_JOIN),
+                tuple(ref_type for ref_type, _table, _column in validated_blob_ref_liveness_joins()),
             ).fetchone()[0]
         )
         if live_referent_count:
@@ -715,6 +750,7 @@ def reconcile_blob_ref_liveness(
 
     pre_conn = sqlite3.connect(source_db)
     staged_plan = None
+    staged_data_version: int | None = None
     try:
         _checkpoint_source_db(pre_conn)
         validate_migration_backup_manifest(backup_manifest, ArchiveTier.SOURCE, connection=pre_conn)
@@ -739,6 +775,7 @@ def reconcile_blob_ref_liveness(
             candidate_digest=candidate_digest,
         )
         expected_count = classification.orphaned_count
+        staged_data_version = _source_data_version(pre_conn)
         # Temp tables survive a commit. Clearing the staging transaction here
         # lets this same connection carry the exact plan into ownership without
         # reparsing the durable receipt under the write lock.
@@ -761,7 +798,7 @@ def reconcile_blob_ref_liveness(
                 batch_table,
                 batch_size=BATCH_SIZE,
             )
-            if batch_count == 0:
+            if batch_count == 0 and not first_batch:
                 break
             conn.execute("BEGIN IMMEDIATE")
             try:
@@ -775,6 +812,11 @@ def reconcile_blob_ref_liveness(
                     # population before any bounded delete can commit. The
                     # snapshot remains valid for later batches because apply
                     # is offline-only and the same connection owns the plan.
+                    assert staged_data_version is not None
+                    if _source_data_version(conn) != staged_data_version:
+                        raise BlobRefLivenessReconciliationError(
+                            "source.db changed after liveness plan staging; refusing stale plan"
+                        )
                     locked_hook_table = _stage_locked_hook_snapshot(conn, staged_plan.candidate_table)
                     _validate_locked_candidate_plan(
                         conn,
@@ -795,7 +837,9 @@ def reconcile_blob_ref_liveness(
                         batch_count,
                         locked_hook_table=locked_hook_table,
                     )
-                batch_deleted = _delete_candidate_batch(conn, staged_plan.candidate_table, batch_table)
+                batch_deleted = (
+                    _delete_candidate_batch(conn, staged_plan.candidate_table, batch_table) if batch_count else 0
+                )
             except Exception:
                 if conn.in_transaction:
                     conn.rollback()
@@ -821,22 +865,37 @@ def reconcile_blob_ref_liveness(
     finally:
         conn.close()
 
+    post_classification: BlobRefLivenessClassification
     try:
-        _append_receipt_footer(receipt_path, phase="committed", deleted_count=deleted_count)
+        with sqlite3.connect(f"file:{source_db}?mode=ro", uri=True) as verify_conn:
+            quick_check = verify_conn.execute("PRAGMA quick_check").fetchone()
+            if quick_check is None or str(quick_check[0]).lower() != "ok":
+                raise BlobRefLivenessReconciliationError(f"source.db quick_check failed after commit: {quick_check!r}")
+            post_classification = classify_blob_ref_liveness(verify_conn)
+        if post_classification.orphaned_count != 0:
+            raise BlobRefLivenessReconciliationError(
+                f"liveness postcondition failed: {post_classification.orphaned_count} orphaned blob_refs row(s) remain"
+            )
+        if not post_classification.safe_to_apply:
+            raise BlobRefLivenessReconciliationError(
+                "liveness postcondition failed: source-tier ref types are no longer fully proven"
+            )
+    except Exception as exc:
+        with suppress(OSError):
+            _append_receipt_footer(receipt_path, phase="postcondition_failed", error=str(exc))
+        raise
+
+    try:
+        _append_receipt_footer(
+            receipt_path,
+            phase="committed",
+            deleted_count=deleted_count,
+            post_orphaned_count=post_classification.orphaned_count,
+        )
     except OSError as exc:
         raise BlobRefLivenessReconciliationError(
             f"source.db committed but could not finalize receipt {receipt_path}"
         ) from exc
-
-    try:
-        with sqlite3.connect(f"file:{source_db}?mode=ro", uri=True) as verify_conn:
-            quick_check = verify_conn.execute("PRAGMA quick_check").fetchone()
-        if quick_check is None or str(quick_check[0]).lower() != "ok":
-            with suppress(OSError):
-                _append_receipt_footer(receipt_path, phase="post_check_failed", error=f"quick_check={quick_check!r}")
-            raise BlobRefLivenessReconciliationError(f"source.db quick_check failed after commit: {quick_check!r}")
-    finally:
-        pass
 
     assert staged_plan is not None
     return BlobRefLivenessReconciliationReport(
@@ -847,6 +906,7 @@ def reconcile_blob_ref_liveness(
         deleted_count=expected_count,
         receipt_path=receipt_path,
         backup_manifest=backup_manifest,
+        post_classification=post_classification,
     )
 
 

--- a/polylogue/storage/blob_ref_liveness.py
+++ b/polylogue/storage/blob_ref_liveness.py
@@ -130,6 +130,24 @@ def _referent_columns(conn: sqlite3.Connection, table: str) -> set[str]:
     return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})")}
 
 
+def validated_blob_ref_liveness_joins() -> tuple[tuple[str, str, str], ...]:
+    """Return the closed ref-type map, rejecting duplicate meanings."""
+
+    seen: set[str] = set()
+    for ref_type, referent_table, referent_column in BLOB_REF_LIVENESS_JOIN:
+        if ref_type in seen:
+            raise BlobRefLivenessError(
+                f"ambiguous blob_refs ref_type mapping for {ref_type!r}: "
+                f"duplicate referent {referent_table}.{referent_column}"
+            )
+        if not ref_type or not referent_table or not referent_column:
+            raise BlobRefLivenessError(
+                f"invalid blob_refs ref_type mapping: {ref_type!r} -> {referent_table!r}.{referent_column!r}"
+            )
+        seen.add(ref_type)
+    return BLOB_REF_LIVENESS_JOIN
+
+
 def _candidate_from_row(row: sqlite3.Row | tuple[object, ...]) -> BlobRefLivenessCandidate:
     return BlobRefLivenessCandidate(
         blob_hash=cast(bytes, row[0]).hex(),
@@ -151,6 +169,7 @@ def stage_blob_ref_liveness(conn: sqlite3.Connection, *, sample_limit: int = 30)
     than materializing the same population in several Python lists.
     """
 
+    known_joins = validated_blob_ref_liveness_joins()
     if not table_exists(conn, "blob_refs"):
         return BlobRefLivenessStagedPlan(
             BlobRefLivenessClassification(0, {}, {}, (), (), (), 0, (), 0),
@@ -166,7 +185,7 @@ def stage_blob_ref_liveness(conn: sqlite3.Connection, *, sample_limit: int = 30)
         str(row[0]): int(row[1])
         for row in conn.execute("SELECT ref_type, COUNT(*) FROM blob_refs GROUP BY ref_type ORDER BY ref_type")
     }
-    known = {ref_type: (table, column) for ref_type, table, column in BLOB_REF_LIVENESS_JOIN}
+    known = {ref_type: (table, column) for ref_type, table, column in known_joins}
     unknown = tuple(sorted(set(ref_type_counts) - set(known)))
     unavailable: list[str] = []
     branches: list[str] = []
@@ -323,4 +342,5 @@ __all__ = [
     "classify_blob_ref_liveness",
     "stage_blob_ref_liveness",
     "BlobRefLivenessStagedPlan",
+    "validated_blob_ref_liveness_joins",
 ]

--- a/tests/unit/storage/test_blob_ref_liveness.py
+++ b/tests/unit/storage/test_blob_ref_liveness.py
@@ -9,12 +9,14 @@ from pathlib import Path
 import pytest
 
 import polylogue.maintenance.blob_ref_liveness_reconciliation as liveness_reconciliation
+import polylogue.storage.blob_ref_liveness as blob_ref_liveness
 import polylogue.storage.hook_payload_ref_reconciliation as hook_payload_ref_reconciliation
 from polylogue.daemon.backup import backup_archive
 from polylogue.maintenance.blob_ref_liveness_reconciliation import (
     BlobRefLivenessReconciliationError,
     reconcile_blob_ref_liveness,
 )
+from polylogue.storage.blob_gc import BLOB_REF_LIVENESS_JOIN
 from polylogue.storage.blob_ref_liveness import (
     BlobRefLivenessStagedPlan,
     classify_blob_ref_liveness,
@@ -210,6 +212,28 @@ def test_apply_refuses_a_running_daemon_before_receipt_or_blob_ref_mutation(
         assert conn.execute("SELECT COUNT(*) FROM blob_refs").fetchone() == (8,)
 
 
+def test_apply_refuses_an_active_daemon_writer_lease_before_receipt_or_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive_root = _source_archive(tmp_path)
+    receipt = tmp_path / "receipts" / "writer-lease.jsonl"
+    monkeypatch.setattr(
+        "polylogue.maintenance.blob_ref_liveness_reconciliation.daemon_write_lease_active", lambda: True
+    )
+
+    with pytest.raises(BlobRefLivenessReconciliationError, match="daemon writer lease"):
+        reconcile_blob_ref_liveness(
+            archive_root,
+            backup_manifest=tmp_path / "backup.json",
+            receipt_path=receipt,
+            dry_run=False,
+        )
+
+    assert not receipt.exists()
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        assert conn.execute("SELECT COUNT(*) FROM blob_refs").fetchone() == (8,)
+
+
 def test_restart_recovers_prepared_receipt_after_committed_delete(tmp_path: Path) -> None:
     archive_root = _source_archive(tmp_path)
     receipt = tmp_path / "receipts" / "interrupted.jsonl"
@@ -337,6 +361,60 @@ def test_apply_deletes_only_join_proven_orphans_and_persists_receipt(
     assert receipt_rows[0]["candidate_digest"]
     assert receipt_rows[-1]["phase"] == "committed"
     assert receipt_rows[-1]["deleted_count"] == 4
+    assert receipt_rows[-1]["post_orphaned_count"] == 0
+    assert report.post_classification is not None
+    assert report.post_classification.orphaned_count == 0
+    assert report.classification.orphaned_count == 4
+
+
+def test_apply_rejects_receipt_bound_row_content_staleness_before_delete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive_root = _source_archive(tmp_path)
+    receipt = tmp_path / "receipts" / "stale-content.jsonl"
+    real_stage = stage_blob_ref_liveness
+
+    def stage_then_change_row(conn: sqlite3.Connection) -> BlobRefLivenessStagedPlan:
+        staged = real_stage(conn)
+        conn.execute(
+            "UPDATE blob_refs SET size_bytes = size_bytes + 1 WHERE ref_type = 'raw_payload' AND ref_id = 'raw-gone'"
+        )
+        return staged
+
+    def fake_validate(path: Path, tier: object, *, connection: sqlite3.Connection) -> Path:
+        return path
+
+    monkeypatch.setattr(liveness_reconciliation, "stage_blob_ref_liveness", stage_then_change_row)
+    monkeypatch.setattr(liveness_reconciliation, "validate_migration_backup_manifest", fake_validate)
+    monkeypatch.setattr(liveness_reconciliation, "validate_migration_backup_live_fingerprint", fake_validate)
+    monkeypatch.setattr(liveness_reconciliation, "running_daemon_pid", lambda _config: None)
+
+    with pytest.raises(BlobRefLivenessReconciliationError, match="candidate content changed"):
+        reconcile_blob_ref_liveness(
+            archive_root,
+            backup_manifest=tmp_path / "backup.json",
+            receipt_path=receipt,
+            dry_run=False,
+        )
+
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        assert conn.execute("SELECT COUNT(*) FROM blob_refs").fetchone() == (8,)
+        assert conn.execute(
+            "SELECT size_bytes FROM blob_refs WHERE ref_type = 'raw_payload' AND ref_id = 'raw-gone'"
+        ).fetchone() == (2,)
+
+
+def test_ref_type_mapping_ambiguity_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    archive_root = _source_archive(tmp_path)
+    monkeypatch.setattr(
+        blob_ref_liveness,
+        "BLOB_REF_LIVENESS_JOIN",
+        BLOB_REF_LIVENESS_JOIN + (("raw_payload", "raw_hook_events", "hook_event_id"),),
+    )
+
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        with pytest.raises(blob_ref_liveness.BlobRefLivenessError, match="ambiguous"):
+            classify_blob_ref_liveness(conn)
 
 
 def test_real_backup_tamper_between_validations_refuses_before_delete(
@@ -590,10 +668,21 @@ def test_apply_fails_closed_if_source_changes_between_bounded_batches(
     committed_batches = 0
 
     def append_footer_and_insert_hook(
-        receipt_path: Path, *, phase: str, deleted_count: int | None = None, error: str | None = None
+        receipt_path: Path,
+        *,
+        phase: str,
+        deleted_count: int | None = None,
+        post_orphaned_count: int | None = None,
+        error: str | None = None,
     ) -> None:
         nonlocal committed_batches
-        real_append_footer(receipt_path, phase=phase, deleted_count=deleted_count, error=error)
+        real_append_footer(
+            receipt_path,
+            phase=phase,
+            deleted_count=deleted_count,
+            post_orphaned_count=post_orphaned_count,
+            error=error,
+        )
         if phase == "batch_committed":
             committed_batches += 1
             if committed_batches == 1:


### PR DESCRIPTION
## Summary
Harden the guarded source-tier blob-reference liveness reconciliation route and its production-route SQLite coverage.

## Problem
The existing apply path checked daemon PID state but not the in-process writer lease, accepted an unclean WAL checkpoint, validated candidate keys without all receipt-bound row content, and finalized without a zero-orphan liveness postcondition.

## Solution
The closed source-tier referent map is validated for duplicate or invalid meanings before classification. The exact mappings are `raw_payload -> raw_sessions.raw_id`, `attachment -> raw_sessions.raw_id` (parent raw acquisition identity), `hook_payload -> raw_hook_events.hook_event_id`, and `sidecar -> history_sidecars.sidecar_id`. Unknown types and ambiguous mappings fail closed. Apply now requires writer exclusion and a clean checkpoint, detects source changes after staging, validates candidate metadata under `BEGIN IMMEDIATE`, deletes only exact proven-orphan keys, and records a zero-orphan postcondition in the committed receipt. Tests cover raw and hook residue, retention, attachment mapping, unknown and ambiguous types, writer exclusion, plan staleness, rollback, and postcondition evidence.

No schema, rebuild promotion/readiness, blob-store deletion, or attachment acquisition/backfill policy changed.

## Verification
- `devtools test tests/unit/storage/test_blob_ref_liveness.py` -> `22 passed`
- `devtools verify --quick` -> exit `0`; Ruff, mypy, render, layering, schema/policy, documentation, and promotion checks passed
- Pre-push quick verification -> exit `0`

## Live-operation prerequisites
An operator applying this route must use `polylogue ops maintenance blob-reference-liveness --apply` only while the daemon and all archive writers are stopped or excluded by a fresh writer boundary, with a clean WAL checkpoint, a fresh verified attested backup manifest covering the current `source.db`, and a new receipt path. The route never unlinks blob files. The operator must review the terminal receipt and confirm `post_orphaned_count: 0`.

Ref polylogue-0v4tn