### PR TITLE
test(reindex): cover all archive origins

### DIFF
--- a/polylogue/archive/artifact_taxonomy/runtime.py
+++ b/polylogue/archive/artifact_taxonomy/runtime.py
@@ -519,6 +519,7 @@ def _classify_dict(
 ) -> ArtifactClassification:
     # Keep this deferred to avoid the artifact-taxonomy/sources bootstrap
     # cycle described below. List streams import the same pair locally.
+    from polylogue.sources.parsers.grok import looks_like_export as looks_like_grok_export
     from polylogue.sources.parsers.hermes_spans import looks_like_atif_payload
 
     if provider is Provider.CHATGPT:
@@ -550,6 +551,16 @@ def _classify_dict(
             schema_eligible=False,
             default_priority=120,
             reason="Beads interaction-history record",
+        )
+
+    if provider is Provider.GROK and looks_like_grok_export(payload):
+        return ArtifactClassification(
+            provider=provider,
+            kind=ArtifactKind.SESSION_DOCUMENT,
+            parse_as_session=True,
+            schema_eligible=True,
+            default_priority=120,
+            reason="Grok account-data export document",
         )
 
     if provider is Provider.ANTIGRAVITY and _is_antigravity_markdown_export(payload):

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -52,7 +52,7 @@ from polylogue.sources.dispatch import (
     require_positive_conversational_evidence,
 )
 from polylogue.sources.origin_specs import artifact_rule_for_path
-from polylogue.sources.parsers import hermes_state, hermes_verification
+from polylogue.sources.parsers import antigravity, hermes_state, hermes_verification
 from polylogue.sources.parsers.base import ParsedSession
 from polylogue.sources.sqlite_snapshot import looks_like_sqlite_bytes
 from polylogue.storage.raw_authority import (
@@ -2577,6 +2577,21 @@ def _parse_one_raw(
     archive_root: Path | None = None,
     fallback_id_override: str | None = None,
 ) -> list[ParsedSession]:
+    if provider is Provider.ANTIGRAVITY and Path(source_path).suffix.lower() == ".pb":
+        trajectory_path = Path(source_path)
+        root = trajectory_path.parent.parent
+        if trajectory_path.parent.name != "conversations" or not trajectory_path.is_file():
+            raise RuntimeError(
+                f"Antigravity raw replay requires its original conversations/<cascade_id>.pb trajectory: {source_path}"
+            )
+        cascade_id = trajectory_path.stem
+        sessions = list(antigravity.iter_language_server_exports(root, only_cascade_ids=frozenset({cascade_id})))
+        if len(sessions) != 1 or sessions[0].provider_session_id != cascade_id:
+            raise RuntimeError(
+                "Antigravity raw replay did not reproduce exactly one requested trajectory "
+                f"{cascade_id!r} from {source_path}"
+            )
+        return sessions
     source_name = Path(source_path).name
     fallback_id = fallback_id_override or Path(source_path).stem
     if is_stream_record_provider(source_path, str(provider)):

--- a/polylogue/storage/raw_byte_duplicate_supersession.py
+++ b/polylogue/storage/raw_byte_duplicate_supersession.py
@@ -113,6 +113,7 @@ def plan_byte_duplicate_supersession(
             FROM raw_sessions
             WHERE revision_authority = 'quarantined'
               AND logical_source_key IS NULL
+              AND parse_error IS NULL
             ORDER BY raw_id
         """
         params: tuple[object, ...] = ()

--- a/tests/infra/convergence_harness.py
+++ b/tests/infra/convergence_harness.py
@@ -717,14 +717,23 @@ def set_debt_retry_at(
 def make_messages_fts_stale(index_db: Path, *, session_id: str) -> int:
     """Delete only this session's real FTS rows to create unrelated stage debt."""
     with open_connection(index_db) as conn:
-        row_ids = [
-            int(row[0])
-            for row in conn.execute(
-                "SELECT rowid FROM blocks WHERE session_id = ? ORDER BY rowid",
-                (session_id,),
-            ).fetchall()
-        ]
+        block_ids = tuple(
+            str(row[0])
+            for row in conn.execute("SELECT block_id FROM blocks WHERE session_id = ? ORDER BY rowid", (session_id,))
+        )
+        row_ids = (
+            tuple(
+                int(row[0])
+                for row in conn.execute(
+                    f"SELECT rowid FROM messages_fts_identity WHERE block_id IN ({','.join('?' for _ in block_ids)})",
+                    block_ids,
+                )
+            )
+            if block_ids
+            else ()
+        )
         conn.executemany("DELETE FROM messages_fts WHERE rowid = ?", ((row_id,) for row_id in row_ids))
+        conn.executemany("DELETE FROM messages_fts_identity WHERE rowid = ?", ((row_id,) for row_id in row_ids))
         conn.commit()
     if not row_ids:
         raise AssertionError(f"session {session_id!r} has no indexed blocks")

--- a/tests/infra/reindex_campaign.py
+++ b/tests/infra/reindex_campaign.py
@@ -1,0 +1,370 @@
+"""Real-pipeline corpus and manifest for the reindex campaign tranche.
+
+The campaign deliberately starts with provider-shaped wire artifacts.  The
+archive is populated by ``parse_sources_archive`` and converged by the same
+daemon stages used by the product.  The parser-failure fixture is then written
+through ``ArchiveStore`` and finalized through its typed parse-state route.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+from polylogue.config import Source
+from polylogue.core.enums import Provider
+from polylogue.daemon.convergence import DaemonConverger
+from polylogue.daemon.convergence_stages import make_fts_stage, make_insights_stage
+from polylogue.pipeline.services.archive_ingest import parse_sources_archive
+from polylogue.scenarios import CorpusSpec
+from polylogue.schemas.synthetic import SyntheticCorpus
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+REINDEX_CAMPAIGN_MINIMUMS: dict[str, int] = {
+    "lineage_edges": 1,
+    "attachment_refs": 1,
+    "attachment_blob_refs": 1,
+    "attachment_blob_bytes": 1,
+    "structured_tool_failures": 1,
+    "materialized_insight_sessions": 1,
+    "fts_documents": 1,
+    "parser_failure_residuals": 1,
+    "duplicate_raw_rows": 1,
+    "restart_debt_sessions": 1,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ReindexCampaignManifest:
+    """Stable campaign evidence, including positive class denominators."""
+
+    specs: tuple[CorpusSpec, ...]
+    session_ids: tuple[str, ...]
+    lineage_session_ids: tuple[str, ...]
+    attachment_session_ids: tuple[str, ...]
+    restart_session_ids: tuple[str, ...]
+    parser_failure_raw_ids: tuple[str, ...]
+    duplicate_raw_ids: tuple[str, ...]
+    fts_queries: tuple[str, ...]
+    denominators: tuple[tuple[str, int], ...]
+
+    def denominator(self, name: str) -> int:
+        try:
+            return dict(self.denominators)[name]
+        except KeyError as exc:
+            raise AssertionError(f"campaign manifest has no denominator {name!r}") from exc
+
+    def assert_positive(self) -> None:
+        for name, minimum in REINDEX_CAMPAIGN_MINIMUMS.items():
+            actual = self.denominator(name)
+            if actual < minimum:
+                raise AssertionError(f"campaign denominator {name!r} is {actual}, expected at least {minimum}")
+
+
+@dataclass(frozen=True, slots=True)
+class ReindexCampaignCorpus:
+    root: Path
+    manifest: ReindexCampaignManifest
+
+
+def reindex_campaign_corpus_specs() -> tuple[CorpusSpec, ...]:
+    """Return authored provider specs used by the campaign corpus."""
+
+    return (
+        CorpusSpec.for_provider(
+            "codex",
+            count=3,
+            messages_min=4,
+            messages_max=4,
+            seed=801,
+            style="tool-heavy",
+            session_native_ids=("campaign-codex-a", "campaign-codex-b", "campaign-codex-c"),
+            origin="test.reindex-campaign",
+            tags=("reindex", "campaign", "tool-results"),
+        ),
+        CorpusSpec.for_provider(
+            "claude-code",
+            count=4,
+            messages_min=4,
+            messages_max=4,
+            seed=802,
+            style="demo-tool-heavy",
+            session_native_ids=(
+                "campaign-claude-failure-a",
+                "campaign-claude-failure-b",
+                "campaign-claude-stable-a",
+                "campaign-claude-stable-b",
+            ),
+            origin="test.reindex-campaign",
+            tags=("reindex", "campaign", "structured-failures"),
+        ),
+        CorpusSpec.for_provider(
+            "gemini",
+            count=1,
+            messages_min=3,
+            messages_max=3,
+            seed=803,
+            style="demo-attachments",
+            session_native_ids=("campaign-attachment",),
+            origin="test.reindex-campaign",
+            tags=("reindex", "campaign", "attachments"),
+        ),
+    )
+
+
+def _codex_records(
+    session_id: str, texts: tuple[str, ...], *, parent: str | None = None
+) -> tuple[dict[str, object], ...]:
+    meta: dict[str, object] = {"id": session_id, "timestamp": "2026-08-05T00:00:00Z"}
+    if parent is not None:
+        meta["forked_from_id"] = parent
+    records: list[dict[str, object]] = [{"type": "session_meta", "payload": meta}]
+    for position, text in enumerate(texts):
+        records.append(
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "id": f"{session_id}-m{position}",
+                    "role": "user" if position % 2 == 0 else "assistant",
+                    "content": [{"type": "input_text", "text": text}],
+                },
+            }
+        )
+    return tuple(records)
+
+
+def _write_jsonl(path: Path, records: tuple[dict[str, object], ...]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(record, sort_keys=True) + "\n" for record in records), encoding="utf-8")
+    return path
+
+
+def _campaign_session_ids(root: Path) -> tuple[str, ...]:
+    with sqlite3.connect(root / "index.db") as conn:
+        return tuple(str(row[0]) for row in conn.execute("SELECT session_id FROM sessions ORDER BY session_id"))
+
+
+def _campaign_manifest(
+    root: Path,
+    *,
+    specs: tuple[CorpusSpec, ...],
+    parser_failure_raw_ids: tuple[str, ...],
+    duplicate_raw_ids: tuple[str, ...],
+) -> ReindexCampaignManifest:
+    with sqlite3.connect(root / "index.db") as index_conn:
+        session_ids = _campaign_session_ids(root)
+        lineage_session_ids = tuple(
+            str(row[0])
+            for row in index_conn.execute(
+                "SELECT DISTINCT src_session_id FROM session_links WHERE link_type = 'branch' ORDER BY src_session_id"
+            )
+        )
+        attachment_session_ids = tuple(
+            str(row[0])
+            for row in index_conn.execute(
+                "SELECT DISTINCT session_id FROM attachment_refs WHERE session_id IS NOT NULL ORDER BY session_id"
+            )
+        )
+        structured_tool_failures = int(
+            index_conn.execute(
+                """
+                SELECT COUNT(*) FROM blocks
+                WHERE block_type = 'tool_result'
+                  AND (tool_result_is_error = 1 OR tool_result_exit_code != 0)
+                """
+            ).fetchone()[0]
+        )
+        materialized_insight_sessions = int(
+            index_conn.execute("SELECT COUNT(DISTINCT session_id) FROM insight_materialization").fetchone()[0]
+        )
+        fts_documents = int(index_conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0])
+        attachment_refs = int(index_conn.execute("SELECT COUNT(*) FROM attachment_refs").fetchone()[0])
+        attachment_blob_bytes = int(
+            index_conn.execute(
+                "SELECT COALESCE(SUM(byte_count), 0) FROM attachments WHERE blob_hash IS NOT NULL"
+            ).fetchone()[0]
+        )
+        restart_session_ids = tuple(
+            str(row[0])
+            for row in index_conn.execute(
+                "SELECT session_id FROM sessions WHERE origin = 'claude-code-session' ORDER BY session_id LIMIT 1"
+            )
+        )
+    with sqlite3.connect(root / "source.db") as source_conn:
+        attachment_blob_refs = int(
+            source_conn.execute("SELECT COUNT(*) FROM blob_refs WHERE ref_type = 'attachment'").fetchone()[0]
+        )
+        duplicate_rows = int(
+            source_conn.execute(
+                """
+                SELECT COUNT(*) FROM raw_sessions
+                WHERE blob_hash IN (
+                    SELECT blob_hash FROM raw_sessions GROUP BY blob_hash HAVING COUNT(*) > 1
+                )
+                """
+            ).fetchone()[0]
+        )
+        parser_failure_residuals = int(
+            source_conn.execute(
+                "SELECT COUNT(*) FROM raw_sessions WHERE parsed_at_ms IS NULL AND parse_error IS NOT NULL"
+            ).fetchone()[0]
+        )
+    denominators = (
+        ("lineage_edges", len(lineage_session_ids)),
+        ("attachment_refs", attachment_refs),
+        ("attachment_blob_refs", attachment_blob_refs),
+        ("attachment_blob_bytes", attachment_blob_bytes),
+        ("structured_tool_failures", structured_tool_failures),
+        ("materialized_insight_sessions", materialized_insight_sessions),
+        ("fts_documents", fts_documents),
+        ("parser_failure_residuals", parser_failure_residuals),
+        ("duplicate_raw_rows", duplicate_rows),
+        ("restart_debt_sessions", len(restart_session_ids)),
+    )
+    manifest = ReindexCampaignManifest(
+        specs=specs,
+        session_ids=session_ids,
+        lineage_session_ids=lineage_session_ids,
+        attachment_session_ids=attachment_session_ids,
+        restart_session_ids=restart_session_ids,
+        parser_failure_raw_ids=parser_failure_raw_ids,
+        duplicate_raw_ids=duplicate_raw_ids,
+        fts_queries=("generated", "fixture", "failed"),
+        denominators=denominators,
+    )
+    manifest.assert_positive()
+    if parser_failure_residuals < len(parser_failure_raw_ids):
+        raise AssertionError("campaign parser-failure manifest exceeds source residuals")
+    if duplicate_rows < len(duplicate_raw_ids):
+        raise AssertionError("campaign duplicate manifest exceeds duplicate source rows")
+    return manifest
+
+
+def build_reindex_campaign_corpus(root: Path) -> ReindexCampaignCorpus:
+    """Build and converge the campaign corpus through production routes."""
+
+    root = Path(root)
+    initialize_active_archive_root(root)
+    specs = reindex_campaign_corpus_specs()
+    wire_root = root / "wire"
+    sources: list[Source] = []
+    first_payload: bytes | None = None
+    for index, spec in enumerate(specs):
+        written = SyntheticCorpus.write_spec_artifacts(spec, wire_root / spec.provider, prefix=f"campaign-{index:02d}")
+        if first_payload is None:
+            first_payload = written.files[0].read_bytes()
+        sources.extend(Source(name=spec.provider, path=path) for path in written.files)
+
+    lineage_dir = wire_root / "lineage"
+    sources.append(
+        Source(
+            name="codex",
+            path=_write_jsonl(
+                lineage_dir / "campaign-lineage-parent.jsonl",
+                _codex_records("campaign-lineage-parent", ("shared campaign prefix", "parent tail")),
+            ),
+        )
+    )
+    sources.append(
+        Source(
+            name="codex",
+            path=_write_jsonl(
+                lineage_dir / "campaign-lineage-child.jsonl",
+                _codex_records(
+                    "campaign-lineage-child",
+                    ("child tail",),
+                    parent="campaign-lineage-parent",
+                ),
+            ),
+        )
+    )
+    assert first_payload is not None
+    parse_result = asyncio.run(parse_sources_archive(root, sources, parse_workers=1))
+    if parse_result.parse_failures != 0:
+        raise AssertionError(f"campaign provider ingest unexpectedly failed: {parse_result.parse_failures}")
+
+    with sqlite3.connect(root / "source.db") as source_conn:
+        restart_native_id = source_conn.execute(
+            """
+            SELECT m.provider_session_id
+            FROM raw_session_memberships AS m
+            JOIN raw_sessions AS r USING (raw_id)
+            WHERE r.origin = 'claude-code-session'
+            ORDER BY m.provider_session_id
+            LIMIT 1
+            """
+        ).fetchone()
+        restart_native_id = str(restart_native_id[0])
+
+    duplicate_paths = tuple(wire_root / "duplicates" / f"campaign-duplicate-{suffix}.jsonl" for suffix in ("a", "b"))
+    duplicate_sources = [Source(name="codex", path=path) for path in duplicate_paths]
+    for path in duplicate_paths:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(first_payload)
+    duplicate_parse_result = asyncio.run(parse_sources_archive(root, duplicate_sources, parse_workers=1))
+    if duplicate_parse_result.parse_failures != 0:
+        raise AssertionError(f"campaign duplicate ingest unexpectedly failed: {duplicate_parse_result.parse_failures}")
+    with sqlite3.connect(root / "source.db") as source_conn:
+        duplicate_raw_ids = tuple(
+            str(row[0])
+            for row in source_conn.execute(
+                "SELECT raw_id FROM raw_sessions WHERE source_path IN (?, ?) ORDER BY source_path",
+                tuple(str(path) for path in duplicate_paths),
+            )
+        )
+    if len(duplicate_raw_ids) != len(duplicate_paths):
+        raise AssertionError("campaign duplicate ingest did not retain both raw acquisitions")
+
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        parser_failure_raw_id = archive.write_raw_payload(
+            provider=Provider.CLAUDE_CODE,
+            payload=b"not-json\nparser-failure-residual\n",
+            source_path="campaign-parser-failure.jsonl",
+            native_id=restart_native_id,
+            acquired_at_ms=3,
+        )
+        from polylogue.core.raw_failure_evidence import RawFailureEvidenceKind
+
+        archive.record_raw_failure_evidence(
+            parser_failure_raw_id,
+            provider=Provider.CLAUDE_CODE,
+            source_path="campaign-parser-failure.jsonl",
+            source_index=0,
+            acquired_at_ms=3,
+            kind=RawFailureEvidenceKind.TERMINAL_CORRUPT_INPUT,
+        )
+        archive.mark_raw_parse_failed(
+            parser_failure_raw_id,
+            provider=Provider.CLAUDE_CODE,
+            error=ValueError("campaign parser failure"),
+        )
+
+    session_ids = _campaign_session_ids(root)
+    states, _timings = DaemonConverger(
+        (make_fts_stage(root / "index.db"), make_insights_stage(root / "index.db"))
+    ).converge_sessions(session_ids)
+    not_converged = {session_id: state.last_error for session_id, state in states.items() if not state.converged}
+    if not_converged:
+        raise AssertionError(f"campaign corpus did not converge: {not_converged}")
+
+    manifest = _campaign_manifest(
+        root,
+        specs=specs,
+        parser_failure_raw_ids=(parser_failure_raw_id,),
+        duplicate_raw_ids=duplicate_raw_ids,
+    )
+    return ReindexCampaignCorpus(root=root, manifest=manifest)
+
+
+__all__ = [
+    "REINDEX_CAMPAIGN_MINIMUMS",
+    "ReindexCampaignCorpus",
+    "ReindexCampaignManifest",
+    "build_reindex_campaign_corpus",
+    "reindex_campaign_corpus_specs",
+]

--- a/tests/infra/reindex_campaign.py
+++ b/tests/infra/reindex_campaign.py
@@ -323,7 +323,7 @@ def build_reindex_campaign_corpus(root: Path) -> ReindexCampaignCorpus:
     with ArchiveStore.open_existing(root, read_only=False) as archive:
         parser_failure_raw_id = archive.write_raw_payload(
             provider=Provider.CLAUDE_CODE,
-            payload=b"not-json\nparser-failure-residual\n",
+            payload=first_payload,
             source_path="campaign-parser-failure.jsonl",
             native_id=restart_native_id,
             acquired_at_ms=3,

--- a/tests/infra/reindex_campaign.py
+++ b/tests/infra/reindex_campaign.py
@@ -13,6 +13,7 @@ import json
 import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
+from unittest.mock import patch
 
 from polylogue.config import Source
 from polylogue.core.enums import Provider
@@ -23,6 +24,21 @@ from polylogue.scenarios import CorpusSpec
 from polylogue.schemas.synthetic import SyntheticCorpus
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from tests.infra.source_builders import SyntheticAntigravityLanguageServerClient
+
+REINDEX_CAMPAIGN_REQUIRED_ORIGINS = frozenset(
+    {
+        "aistudio-drive",
+        "antigravity-session",
+        "chatgpt-export",
+        "claude-ai-export",
+        "claude-code-session",
+        "codex-session",
+        "gemini-cli-session",
+        "grok-export",
+        "hermes-session",
+    }
+)
 
 REINDEX_CAMPAIGN_MINIMUMS: dict[str, int] = {
     "lineage_edges": 1,
@@ -50,6 +66,7 @@ class ReindexCampaignManifest:
     parser_failure_raw_ids: tuple[str, ...]
     duplicate_raw_ids: tuple[str, ...]
     fts_queries: tuple[str, ...]
+    origin_session_counts: tuple[tuple[str, int], ...]
     denominators: tuple[tuple[str, int], ...]
 
     def denominator(self, name: str) -> int:
@@ -63,6 +80,11 @@ class ReindexCampaignManifest:
             actual = self.denominator(name)
             if actual < minimum:
                 raise AssertionError(f"campaign denominator {name!r} is {actual}, expected at least {minimum}")
+        actual_origins = {origin for origin, count in self.origin_session_counts if count > 0}
+        if actual_origins != REINDEX_CAMPAIGN_REQUIRED_ORIGINS:
+            missing = sorted(REINDEX_CAMPAIGN_REQUIRED_ORIGINS - actual_origins)
+            unexpected = sorted(actual_origins - REINDEX_CAMPAIGN_REQUIRED_ORIGINS)
+            raise AssertionError(f"campaign origin coverage mismatch: missing={missing}, unexpected={unexpected}")
 
 
 @dataclass(frozen=True, slots=True)
@@ -75,6 +97,28 @@ def reindex_campaign_corpus_specs() -> tuple[CorpusSpec, ...]:
     """Return authored provider specs used by the campaign corpus."""
 
     return (
+        CorpusSpec.for_provider(
+            "chatgpt",
+            count=2,
+            messages_min=4,
+            messages_max=4,
+            seed=800,
+            style="tool-heavy",
+            session_native_ids=("campaign-chatgpt-a", "campaign-chatgpt-b"),
+            origin="test.reindex-campaign",
+            tags=("reindex", "campaign", "chatgpt-tool-results"),
+        ),
+        CorpusSpec.for_provider(
+            "claude-ai",
+            count=2,
+            messages_min=4,
+            messages_max=4,
+            seed=801,
+            style="tool-heavy",
+            session_native_ids=("campaign-claude-ai-a", "campaign-claude-ai-b"),
+            origin="test.reindex-campaign",
+            tags=("reindex", "campaign", "claude-ai-tool-results"),
+        ),
         CorpusSpec.for_provider(
             "codex",
             count=3,
@@ -144,6 +188,83 @@ def _write_jsonl(path: Path, records: tuple[dict[str, object], ...]) -> Path:
     return path
 
 
+def _write_json(path: Path, payload: object) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _gemini_cli_payload() -> dict[str, object]:
+    return {
+        "sessionId": "campaign-gemini-cli",
+        "projectHash": "campaign-project",
+        "startTime": "2026-08-05T00:00:00.000Z",
+        "lastUpdated": "2026-08-05T00:01:00.000Z",
+        "kind": "chat",
+        "summary": "Campaign Gemini CLI witness",
+        "messages": [
+            {"id": "u1", "timestamp": "2026-08-05T00:00:01.000Z", "type": "user", "content": ["inspect archive"]},
+            {
+                "id": "a1",
+                "timestamp": "2026-08-05T00:00:02.000Z",
+                "type": "gemini",
+                "content": "I will inspect the archive.",
+                "thoughts": [{"text": "Need a native checkpoint witness."}],
+                "toolCalls": [{"id": "read-1", "name": "read_file", "arguments": {"path": "source.db"}}],
+            },
+        ],
+    }
+
+
+def _hermes_payload() -> dict[str, object]:
+    return {
+        "session_id": "campaign-hermes",
+        "model": "hermes-campaign",
+        "platform": "linux",
+        "session_start": "2026-08-05T00:00:00.000000",
+        "last_updated": "2026-08-05T00:01:00.000000",
+        "messages": [
+            {"role": "user", "content": "run integrity checks"},
+            {
+                "role": "assistant",
+                "content": "Running integrity checks.",
+                "reasoning_content": "Use the native local-agent tool shape.",
+                "tool_calls": [{"id": "integrity-1", "function": {"name": "shell", "arguments": '{"cmd": "check"}'}}],
+            },
+            {"role": "tool", "tool_call_id": "integrity-1", "content": "0 anomalies"},
+        ],
+    }
+
+
+def _grok_payload() -> dict[str, object]:
+    return {
+        "conversation": {
+            "title": "Campaign Grok witness",
+            "create_time": {"$date": {"$numberLong": "1754352000000"}},
+        },
+        "responses": [
+            {
+                "response": {
+                    "sender": "human",
+                    "message": "Summarize the archive state.",
+                    "create_time": {"$date": {"$numberLong": "1754352001000"}},
+                }
+            },
+            {
+                "response": {
+                    "sender": "assistant",
+                    "message": "The archive is being reindexed.",
+                    "create_time": {"$date": {"$numberLong": "1754352002000"}},
+                }
+            },
+        ],
+    }
+
+
+def _grok_export_payload() -> dict[str, object]:
+    return {"conversations": [_grok_payload()]}
+
+
 def _campaign_session_ids(root: Path) -> tuple[str, ...]:
     with sqlite3.connect(root / "index.db") as conn:
         return tuple(str(row[0]) for row in conn.execute("SELECT session_id FROM sessions ORDER BY session_id"))
@@ -195,6 +316,12 @@ def _campaign_manifest(
                 "SELECT session_id FROM sessions WHERE origin = 'claude-code-session' ORDER BY session_id LIMIT 1"
             )
         )
+        origin_session_counts = tuple(
+            (str(origin), int(count))
+            for origin, count in index_conn.execute(
+                "SELECT origin, COUNT(*) FROM sessions GROUP BY origin ORDER BY origin"
+            )
+        )
     with sqlite3.connect(root / "source.db") as source_conn:
         attachment_blob_refs = int(
             source_conn.execute("SELECT COUNT(*) FROM blob_refs WHERE ref_type = 'attachment'").fetchone()[0]
@@ -235,6 +362,7 @@ def _campaign_manifest(
         parser_failure_raw_ids=parser_failure_raw_ids,
         duplicate_raw_ids=duplicate_raw_ids,
         fts_queries=("generated", "fixture", "failed"),
+        origin_session_counts=origin_session_counts,
         denominators=denominators,
     )
     manifest.assert_positive()
@@ -256,9 +384,22 @@ def build_reindex_campaign_corpus(root: Path) -> ReindexCampaignCorpus:
     first_payload: bytes | None = None
     for index, spec in enumerate(specs):
         written = SyntheticCorpus.write_spec_artifacts(spec, wire_root / spec.provider, prefix=f"campaign-{index:02d}")
-        if first_payload is None:
+        if spec.provider == "codex":
             first_payload = written.files[0].read_bytes()
         sources.extend(Source(name=spec.provider, path=path) for path in written.files)
+
+    native_dir = wire_root / "native"
+    sources.extend(
+        (
+            Source(name="gemini-cli", path=_write_json(native_dir / "gemini-cli.json", _gemini_cli_payload())),
+            Source(name="hermes", path=_write_json(native_dir / "hermes.json", _hermes_payload())),
+            Source(name="grok", path=_write_json(native_dir / "grok.json", _grok_export_payload())),
+        )
+    )
+    antigravity_path = native_dir / "antigravity" / "conversations" / "campaign-antigravity.pb"
+    antigravity_path.parent.mkdir(parents=True, exist_ok=True)
+    antigravity_path.write_bytes(b"campaign-antigravity-protobuf")
+    sources.append(Source(name="antigravity", path=antigravity_path.parent.parent))
 
     lineage_dir = wire_root / "lineage"
     sources.append(
@@ -284,7 +425,11 @@ def build_reindex_campaign_corpus(root: Path) -> ReindexCampaignCorpus:
         )
     )
     assert first_payload is not None
-    parse_result = asyncio.run(parse_sources_archive(root, sources, parse_workers=1))
+    with patch(
+        "polylogue.sources.parsers.antigravity.AntigravityLanguageServerClient",
+        SyntheticAntigravityLanguageServerClient,
+    ):
+        parse_result = asyncio.run(parse_sources_archive(root, sources, parse_workers=1))
     if parse_result.parse_failures != 0:
         raise AssertionError(f"campaign provider ingest unexpectedly failed: {parse_result.parse_failures}")
 
@@ -363,6 +508,7 @@ def build_reindex_campaign_corpus(root: Path) -> ReindexCampaignCorpus:
 
 __all__ = [
     "REINDEX_CAMPAIGN_MINIMUMS",
+    "REINDEX_CAMPAIGN_REQUIRED_ORIGINS",
     "ReindexCampaignCorpus",
     "ReindexCampaignManifest",
     "build_reindex_campaign_corpus",

--- a/tests/infra/reindex_differential.py
+++ b/tests/infra/reindex_differential.py
@@ -17,6 +17,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
+from polylogue.storage.fts.sql import FTS_INDEXABLE_MESSAGE_COUNT_SQL
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.index import FTS_FRESHNESS_STATE_DDL, INDEX_DDL
 
@@ -136,7 +137,7 @@ def snapshot_derived_model(
         tables = tuple((table, _project_table(conn, table)) for table in census)
         markers = _marker_rows(conn)
         fts_ledger = _fts_ledger_rows(conn)
-        source_rows = int(conn.execute("SELECT COUNT(*) FROM blocks").fetchone()[0])
+        source_rows = int(conn.execute(FTS_INDEXABLE_MESSAGE_COUNT_SQL).fetchone()[0])
         indexed_rows = int(conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0])
     with ArchiveStore.open_existing(archive_root, read_only=True) as archive:
         public_reads = _public_reads(archive, session_ids)

--- a/tests/unit/maintenance/test_reindex_campaign.py
+++ b/tests/unit/maintenance/test_reindex_campaign.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -26,18 +27,24 @@ from polylogue.sources.live.convergence_debt import convergence_debt_from_states
 from polylogue.sources.live.cursor import CursorStore
 from polylogue.storage.index_generation import IndexGenerationStore
 from polylogue.storage.raw_byte_duplicate_supersession import plan_byte_duplicate_supersession
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from tests.infra.convergence_harness import (
     debt_ledger_row,
     make_messages_fts_stale,
     set_debt_retry_at,
 )
-from tests.infra.reindex_campaign import ReindexCampaignCorpus, build_reindex_campaign_corpus
+from tests.infra.reindex_campaign import (
+    REINDEX_CAMPAIGN_REQUIRED_ORIGINS,
+    ReindexCampaignCorpus,
+    build_reindex_campaign_corpus,
+)
 from tests.infra.reindex_differential import (
     DerivedModelSnapshot,
     assert_derived_model_ready,
     assert_derived_models_equivalent,
     snapshot_derived_model,
 )
+from tests.infra.source_builders import SyntheticAntigravityLanguageServerClient
 
 
 def _digest(path: Path) -> str:
@@ -109,6 +116,9 @@ def test_reindex_campaign_manifest_has_positive_denominators(tmp_path: Path) -> 
 
     corpus = build_reindex_campaign_corpus(tmp_path / "campaign")
     corpus.manifest.assert_positive()
+    assert {
+        origin for origin, count in corpus.manifest.origin_session_counts if count > 0
+    } == REINDEX_CAMPAIGN_REQUIRED_ORIGINS
     assert corpus.manifest.lineage_session_ids
     assert corpus.manifest.attachment_session_ids
     assert corpus.manifest.parser_failure_raw_ids
@@ -128,11 +138,19 @@ def test_real_inactive_rebuild_and_canary_preserve_active_and_reject_parser_as_d
 
     corpus = build_reindex_campaign_corpus(tmp_path / "campaign")
     root = corpus.root
-    baseline = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+    with patch(
+        "polylogue.sources.parsers.antigravity.AntigravityLanguageServerClient",
+        SyntheticAntigravityLanguageServerClient,
+    ):
+        baseline = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
     assert baseline.status == "replayed"
     active_before = _digest(root / "index.db")
 
-    receipt = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=False))
+    with patch(
+        "polylogue.sources.parsers.antigravity.AntigravityLanguageServerClient",
+        SyntheticAntigravityLanguageServerClient,
+    ):
+        receipt = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=False))
     assert receipt.status == "replayed"
     assert receipt.generation["state"] == "inactive"
     assert receipt.generation["index_path"] != str((root / "index.db").resolve())
@@ -168,13 +186,38 @@ def test_real_inactive_rebuild_and_canary_preserve_active_and_reject_parser_as_d
         {candidate.raw_id for candidate in duplicate_plan.duplicates} & set(corpus.manifest.parser_failure_raw_ids)
     )
 
-    canary = run_reindex_canary(root, sessions_per_origin=100, no_promote=True)
+    with patch(
+        "polylogue.sources.parsers.antigravity.AntigravityLanguageServerClient",
+        SyntheticAntigravityLanguageServerClient,
+    ):
+        canary = run_reindex_canary(root, sessions_per_origin=100, no_promote=True)
     assert canary.comparison.unexpected_count > 0
     assert set(canary.comparison.counts_by_table) == {"raw_revision_applications", "raw_revision_heads"}
     canary_generation = canary.rebuild_receipt["generation"]
     assert isinstance(canary_generation, dict) and canary_generation["state"] == "inactive"
     assert _digest(root / "index.db") == active_before
     assert canary.selection.selected_session_ids
+
+
+def test_antigravity_raw_replay_refuses_missing_authoritative_trajectory(tmp_path: Path) -> None:
+    """A protobuf raw is replayed through its original language-server source.
+
+    Mutation killed: falling through to generic JSON parsing, which used to
+    erase the raw membership census and leave a false-clean candidate index.
+    """
+
+    corpus = build_reindex_campaign_corpus(tmp_path / "campaign")
+    with sqlite3.connect(corpus.root / "source.db") as source_conn:
+        raw_id, source_path = source_conn.execute(
+            "SELECT raw_id, source_path FROM raw_sessions WHERE origin = 'antigravity-session'"
+        ).fetchone()
+    Path(str(source_path)).unlink()
+
+    with ArchiveStore.open_existing(corpus.root, read_only=False) as archive:
+        with pytest.raises(RuntimeError, match="requires its original conversations"):
+            from polylogue.sources.revision_backfill import parse_retained_raw_sessions
+
+            parse_retained_raw_sessions(archive, str(raw_id))
 
 
 @pytest.mark.uses_real_clock("the restart differential deliberately controls source mtimes around the quiet window")

--- a/tests/unit/maintenance/test_reindex_campaign.py
+++ b/tests/unit/maintenance/test_reindex_campaign.py
@@ -176,7 +176,8 @@ def test_restart_debt_converges_to_uninterrupted_campaign_state(tmp_path: Path) 
     session_id = uninterrupted.manifest.restart_session_ids[0]
     restarted_session_id = restarted.manifest.restart_session_ids[0]
 
-    make_messages_fts_stale(uninterrupted.root / "index.db", session_id=session_id)
+    uninterrupted_removed_fts = make_messages_fts_stale(uninterrupted.root / "index.db", session_id=session_id)
+    assert uninterrupted_removed_fts > 0
     with sqlite3.connect(uninterrupted.root / "index.db") as conn:
         conn.execute("DELETE FROM session_profiles WHERE session_id = ?", (session_id,))
         conn.commit()
@@ -187,7 +188,14 @@ def test_restart_debt_converges_to_uninterrupted_campaign_state(tmp_path: Path) 
 
     source_path = _source_path_for_session(restarted, restarted_session_id)
     assert source_path.is_file()
-    make_messages_fts_stale(restarted.root / "index.db", session_id=restarted_session_id)
+    restarted_removed_fts = make_messages_fts_stale(restarted.root / "index.db", session_id=restarted_session_id)
+    assert restarted_removed_fts > 0
+    with sqlite3.connect(restarted.root / "index.db") as conn:
+        assert conn.execute(
+            "SELECT COUNT(*) FROM messages_fts_identity AS f "
+            "JOIN blocks AS b ON b.block_id = f.block_id WHERE b.session_id = ?",
+            (restarted_session_id,),
+        ).fetchone() == (0,)
     with sqlite3.connect(restarted.root / "index.db") as conn:
         conn.execute("DELETE FROM session_profiles WHERE session_id = ?", (restarted_session_id,))
         conn.commit()
@@ -272,6 +280,12 @@ def test_restart_debt_converges_to_uninterrupted_campaign_state(tmp_path: Path) 
         )
         is None
     )
+    with sqlite3.connect(restarted.root / "index.db") as conn:
+        assert conn.execute(
+            "SELECT COUNT(*) FROM messages_fts_identity AS f "
+            "JOIN blocks AS b ON b.block_id = f.block_id WHERE b.session_id = ?",
+            (restarted_session_id,),
+        ).fetchone() == (restarted_removed_fts,)
 
     uninterrupted_snapshot = _snapshot(uninterrupted)
     restarted_snapshot = _snapshot(restarted)

--- a/tests/unit/maintenance/test_reindex_campaign.py
+++ b/tests/unit/maintenance/test_reindex_campaign.py
@@ -1,0 +1,280 @@
+"""Executable reindex campaign corpus and convergence differential tests.
+
+These tests intentionally call the production ingest, daemon convergence,
+inactive rebuild, canary, and debt-retry routes.  No test-local parser,
+rebuild, promotion, or comparison implementation is used.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from polylogue.daemon.convergence import DaemonConverger
+from polylogue.daemon.convergence_stages import _HOT_INSIGHT_SOURCE_BYTES, make_fts_stage, make_insights_stage
+from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
+from polylogue.maintenance.reindex_canary import run_reindex_canary
+from polylogue.sources.live.convergence_debt import convergence_debt_from_states
+from polylogue.sources.live.cursor import CursorStore
+from polylogue.storage.index_generation import IndexGenerationStore
+from tests.infra.convergence_harness import (
+    debt_ledger_row,
+    make_messages_fts_stale,
+    set_debt_retry_at,
+)
+from tests.infra.reindex_campaign import ReindexCampaignCorpus, build_reindex_campaign_corpus
+from tests.infra.reindex_differential import (
+    DerivedModelSnapshot,
+    assert_derived_model_ready,
+    assert_derived_models_equivalent,
+    snapshot_derived_model,
+)
+
+
+def _digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _source_path_for_session(corpus: ReindexCampaignCorpus, session_id: str) -> Path:
+    with sqlite3.connect(corpus.root / "index.db") as index_conn:
+        raw_id = str(
+            index_conn.execute("SELECT raw_id FROM sessions WHERE session_id = ?", (session_id,)).fetchone()[0]
+        )
+    with sqlite3.connect(corpus.root / "source.db") as source_conn:
+        return Path(
+            str(source_conn.execute("SELECT source_path FROM raw_sessions WHERE raw_id = ?", (raw_id,)).fetchone()[0])
+        )
+
+
+def _retry_debt_in_fresh_process(index_db: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    env = os.environ.copy()
+    existing_pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = str(repo_root) if not existing_pythonpath else f"{repo_root}{os.pathsep}{existing_pythonpath}"
+    script = (
+        "from pathlib import Path\n"
+        "from polylogue.daemon.cli import _drain_convergence_debt_once\n"
+        f"result = _drain_convergence_debt_once(Path({str(index_db)!r}))\n"
+        "assert result >= 1, result\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    assert completed.returncode == 0, f"fresh convergence retry failed:\n{completed.stdout}\n{completed.stderr}"
+
+
+def _snapshot(corpus: ReindexCampaignCorpus) -> DerivedModelSnapshot:
+    return snapshot_derived_model(
+        corpus.root,
+        corpus.root / "index.db",
+        session_ids=corpus.manifest.session_ids,
+        search_queries=corpus.manifest.fts_queries,
+    )
+
+
+def _clone_campaign_corpus(source: ReindexCampaignCorpus, target_root: Path) -> ReindexCampaignCorpus:
+    """Clone one converged archive so differential rows retain source identity."""
+
+    shutil.copytree(source.root, target_root)
+    with sqlite3.connect(target_root / "source.db") as conn:
+        conn.execute(
+            """
+            UPDATE raw_sessions
+            SET source_path = replace(source_path, ?, ?)
+            WHERE source_path LIKE ?
+            """,
+            (str(source.root), str(target_root), f"{source.root}%"),
+        )
+        conn.commit()
+    return ReindexCampaignCorpus(root=target_root, manifest=source.manifest)
+
+
+def test_reindex_campaign_manifest_has_positive_denominators(tmp_path: Path) -> None:
+    """Every campaign edge class has a real production-ingested witness."""
+
+    corpus = build_reindex_campaign_corpus(tmp_path / "campaign")
+    corpus.manifest.assert_positive()
+    assert corpus.manifest.lineage_session_ids
+    assert corpus.manifest.attachment_session_ids
+    assert corpus.manifest.parser_failure_raw_ids
+    assert corpus.manifest.duplicate_raw_ids
+    assert corpus.manifest.restart_session_ids
+    assert set(corpus.manifest.parser_failure_raw_ids).isdisjoint(corpus.manifest.duplicate_raw_ids)
+
+
+def test_real_inactive_rebuild_and_canary_preserve_active_and_reject_parser_as_duplicate(tmp_path: Path) -> None:
+    """Full replay and the canary use inactive generations and never promote.
+
+    Mutations killed by this test include promoting a no-promote candidate,
+    omitting structured tool outcomes or attachments during replay, allowing
+    a parser-failed raw into duplicate-byte supersession, and comparing only
+    a fabricated summary instead of the candidate's real read model.
+    """
+
+    corpus = build_reindex_campaign_corpus(tmp_path / "campaign")
+    root = corpus.root
+    baseline = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+    assert baseline.status == "replayed"
+    active_before = _digest(root / "index.db")
+
+    receipt = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=False))
+    assert receipt.status == "replayed"
+    assert receipt.generation["state"] == "inactive"
+    assert receipt.generation["index_path"] != str((root / "index.db").resolve())
+    replayed_count = receipt.replay["replayed_logical_source_count"]
+    assert isinstance(replayed_count, int) and replayed_count >= 1
+
+    store = IndexGenerationStore.for_archive_root(root)
+    candidate = Path(str(receipt.generation["index_path"]))
+    assert store.active_pointer.resolve(strict=True) == (root / "index.db").resolve()
+    assert _digest(root / "index.db") == active_before
+    assert candidate.is_file()
+
+    with sqlite3.connect(root / "source.db") as source_conn:
+        for raw_id in corpus.manifest.parser_failure_raw_ids:
+            residual = source_conn.execute(
+                "SELECT parsed_at_ms, parse_error FROM raw_sessions WHERE raw_id = ?", (raw_id,)
+            ).fetchone()
+            assert residual is not None and residual[0] is None and residual[1]
+            assert (
+                source_conn.execute(
+                    "SELECT 1 FROM raw_byte_duplicate_supersession_receipts WHERE raw_id = ?", (raw_id,)
+                ).fetchone()
+                is None
+            )
+
+    canary = run_reindex_canary(root, sessions_per_origin=100, no_promote=True)
+    assert canary.comparison.unexpected_count > 0
+    assert set(canary.comparison.counts_by_table) == {"raw_revision_applications", "raw_revision_heads"}
+    canary_generation = canary.rebuild_receipt["generation"]
+    assert isinstance(canary_generation, dict) and canary_generation["state"] == "inactive"
+    assert _digest(root / "index.db") == active_before
+    assert canary.selection.selected_session_ids
+
+
+@pytest.mark.uses_real_clock("the restart differential deliberately controls source mtimes around the quiet window")
+def test_restart_debt_converges_to_uninterrupted_campaign_state(tmp_path: Path) -> None:
+    """A fresh-process debt retry reaches the same state as uninterrupted work."""
+
+    template = build_reindex_campaign_corpus(tmp_path / "template")
+    uninterrupted = _clone_campaign_corpus(template, tmp_path / "uninterrupted")
+    restarted = _clone_campaign_corpus(template, tmp_path / "restarted")
+    session_id = uninterrupted.manifest.restart_session_ids[0]
+    restarted_session_id = restarted.manifest.restart_session_ids[0]
+
+    make_messages_fts_stale(uninterrupted.root / "index.db", session_id=session_id)
+    with sqlite3.connect(uninterrupted.root / "index.db") as conn:
+        conn.execute("DELETE FROM session_profiles WHERE session_id = ?", (session_id,))
+        conn.commit()
+    uninterrupted_states, _ = DaemonConverger(
+        (make_fts_stage(uninterrupted.root / "index.db"), make_insights_stage(uninterrupted.root / "index.db"))
+    ).converge_sessions((session_id,))
+    assert uninterrupted_states[session_id].converged
+
+    source_path = _source_path_for_session(restarted, restarted_session_id)
+    assert source_path.is_file()
+    make_messages_fts_stale(restarted.root / "index.db", session_id=restarted_session_id)
+    with sqlite3.connect(restarted.root / "index.db") as conn:
+        conn.execute("DELETE FROM session_profiles WHERE session_id = ?", (restarted_session_id,))
+        conn.commit()
+    with source_path.open("ab") as restart_source:
+        restart_source.truncate(_HOT_INSIGHT_SOURCE_BYTES)
+    future = time.time() + 100_000
+    os.utime(source_path, (future, future))
+    stages = (make_fts_stage(restarted.root / "index.db"), make_insights_stage(restarted.root / "index.db"))
+    deferred_states, _ = DaemonConverger(stages).converge_batch((source_path,))
+    assert deferred_states[source_path].converged is False
+    assert deferred_states[source_path].last_error == "insights deferred until source quiet"
+    record = CursorStore(restarted.root / "index.db")
+    record_convergence = convergence_debt_from_states((source_path,), deferred_states)
+    assert record_convergence
+    from polylogue.sources.live.convergence_outcome import record_convergence_outcome
+
+    record_convergence_outcome(record, source_path, record_convergence, archive_root=restarted.root)
+    record.record_convergence_debt(
+        stage="fts",
+        subject_type="session_id",
+        subject_id=restarted_session_id,
+        error="deliberate restart FTS backlog",
+    )
+    debt = debt_ledger_row(
+        restarted.root / "ops.db",
+        stage="insights",
+        subject_type="session_id",
+        subject_id=restarted_session_id,
+    )
+    assert debt is not None and debt.status == "deferred"
+    set_debt_retry_at(
+        restarted.root / "ops.db",
+        stage="insights",
+        subject_type="session_id",
+        subject_id=restarted_session_id,
+        retry_at="1970-01-01T00:00:00+00:00",
+    )
+    set_debt_retry_at(
+        restarted.root / "ops.db",
+        stage="fts",
+        subject_type="session_id",
+        subject_id=restarted_session_id,
+        retry_at="9999-01-01T00:00:00+00:00",
+    )
+    old = time.time() - 100_000
+    os.utime(source_path, (old, old))
+
+    _retry_debt_in_fresh_process(restarted.root / "index.db")
+    assert (
+        debt_ledger_row(
+            restarted.root / "ops.db",
+            stage="insights",
+            subject_type="session_id",
+            subject_id=restarted_session_id,
+        )
+        is None
+    )
+    assert (
+        debt_ledger_row(
+            restarted.root / "ops.db",
+            stage="fts",
+            subject_type="session_id",
+            subject_id=restarted_session_id,
+        )
+        is not None
+    )
+
+    set_debt_retry_at(
+        restarted.root / "ops.db",
+        stage="fts",
+        subject_type="session_id",
+        subject_id=restarted_session_id,
+        retry_at="1970-01-01T00:00:00+00:00",
+    )
+    _retry_debt_in_fresh_process(restarted.root / "index.db")
+    assert (
+        debt_ledger_row(
+            restarted.root / "ops.db",
+            stage="fts",
+            subject_type="session_id",
+            subject_id=restarted_session_id,
+        )
+        is None
+    )
+
+    uninterrupted_snapshot = _snapshot(uninterrupted)
+    restarted_snapshot = _snapshot(restarted)
+    assert_derived_model_ready(uninterrupted_snapshot)
+    assert_derived_model_ready(restarted_snapshot)
+    assert_derived_models_equivalent(uninterrupted_snapshot, restarted_snapshot)

--- a/tests/unit/maintenance/test_reindex_campaign.py
+++ b/tests/unit/maintenance/test_reindex_campaign.py
@@ -25,6 +25,7 @@ from polylogue.maintenance.reindex_canary import run_reindex_canary
 from polylogue.sources.live.convergence_debt import convergence_debt_from_states
 from polylogue.sources.live.cursor import CursorStore
 from polylogue.storage.index_generation import IndexGenerationStore
+from polylogue.storage.raw_byte_duplicate_supersession import plan_byte_duplicate_supersession
 from tests.infra.convergence_harness import (
     debt_ledger_row,
     make_messages_fts_stale,
@@ -156,6 +157,16 @@ def test_real_inactive_rebuild_and_canary_preserve_active_and_reject_parser_as_d
                 ).fetchone()
                 is None
             )
+    source_conn = sqlite3.connect(f"file:{root / 'source.db'}?mode=ro", uri=True)
+    index_conn = sqlite3.connect(f"file:{root / 'index.db'}?mode=ro", uri=True)
+    try:
+        duplicate_plan = plan_byte_duplicate_supersession(source_conn, index_conn)
+    finally:
+        source_conn.close()
+        index_conn.close()
+    assert not (
+        {candidate.raw_id for candidate in duplicate_plan.duplicates} & set(corpus.manifest.parser_failure_raw_ids)
+    )
 
     canary = run_reindex_canary(root, sessions_per_origin=100, no_promote=True)
     assert canary.comparison.unexpected_count > 0

--- a/tests/unit/storage/test_raw_byte_duplicate_supersession.py
+++ b/tests/unit/storage/test_raw_byte_duplicate_supersession.py
@@ -87,6 +87,20 @@ def test_only_flags_quarantined_no_lsk_raws_byte_identical_to_an_indexed_twin(tm
             payload=duplicate_payload,
             source_path=str(tmp_path / "dup-twin.jsonl"),
         )
+        # A parser-failed raw can share bytes with a materialized twin, but
+        # parse failure is evidence to recover, not duplicate authority to
+        # supersede away.
+        _write_quarantined_no_lsk_raw(
+            archive,
+            raw_id="raw-parser-failed-dup",
+            payload=duplicate_payload,
+            source_path=str(tmp_path / "parser-failed-dup.jsonl"),
+        )
+        archive.mark_raw_parse_failed(
+            "raw-parser-failed-dup",
+            provider=Provider.CLAUDE_CODE,
+            error=ValueError("deliberate parser failure"),
+        )
         # Quarantined, no logical_source_key, but genuinely unique bytes --
         # no indexed twin exists anywhere. Must be left alone (novel; in
         # scope for lkrc/hjpx's reconciler, not this bead).
@@ -141,6 +155,7 @@ def test_only_flags_quarantined_no_lsk_raws_byte_identical_to_an_indexed_twin(tm
     # WHERE clause -- but it must not appear as a "duplicate OF itself").
     assert plan.scanned_count == 5
     assert {c.raw_id for c in plan.duplicates} == {"raw-dup"}
+    assert "raw-parser-failed-dup" not in {c.raw_id for c in plan.duplicates}
     duplicate = next(c for c in plan.duplicates if c.raw_id == "raw-dup")
     assert duplicate.duplicate_of_raw_id == "raw-dup-indexed-twin"
     assert duplicate.duplicate_of_session_id == "claude-code-session:native-dup-indexed-twin"


### PR DESCRIPTION
## Summary
Expand the executable reindex campaign to require a positive witness for every nine supported archive origins.

## Problem
The campaign previously exercised only Codex, Claude Code, and AI Studio. It could not detect source-specific reindex loss. A valid Grok export was also rejected by artifact taxonomy before dispatch, and Antigravity protobuf raw replay silently lost membership evidence.

## Solution
Add ChatGPT, Claude.ai, Gemini CLI, Hermes, Grok, and Antigravity production-ingest witnesses; enforce exact origin coverage in the manifest; admit Grok export documents; replay Antigravity trajectories through the original language-server source and reject missing source material.

## Verification
- `devtools test tests/unit/maintenance/test_reindex_campaign.py` -> `4 passed`
- `devtools verify --seed-testmon --skip-slow` reached static and generated-surface gates, then hit pre-existing xdist collection nondeterminism in unrelated `tests/unit/archive/query/test_discovery.py` parametrization.
- Pre-push `devtools verify --quick` -> success.