### PR TITLE
fix(reindex): enforce strict candidate acceptance gates

### DIFF
--- a/devtools/index_fast_forward.py
+++ b/devtools/index_fast_forward.py
@@ -35,7 +35,12 @@ from polylogue.maintenance.offline_guard import running_daemon_pid
 from polylogue.pipeline.ids import session_content_hash
 from polylogue.sources.origin_specs import lowering_fingerprint, parser_fingerprint_for_origin
 from polylogue.storage.blob_publication import ArchiveBlobPublisher
-from polylogue.storage.index_generation import IndexGenerationStore, RebuildLease, source_revision_snapshot
+from polylogue.storage.index_generation import (
+    IndexGeneration,
+    IndexGenerationStore,
+    RebuildLease,
+    source_revision_snapshot,
+)
 from polylogue.storage.runtime.store_constants import SESSION_INSIGHT_MATERIALIZER_VERSION
 from polylogue.storage.sqlite.archive_tiers import ARCHIVE_DDL_BY_TIER
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -499,6 +504,35 @@ def _require_candidate_strict_acceptance(archive_root: Path, candidate_index: Pa
         raise IndexFastForwardError(f"candidate strict acceptance gate failed: {failing}")
 
 
+def _require_recovery_evidence(
+    archive_root: Path,
+    receipt: dict[str, object],
+    generation: IndexGeneration,
+    generation_index: Path,
+) -> None:
+    """Reprove a pointer-swapped candidate before completing crash recovery."""
+    if generation.source_snapshot != receipt.get("source_snapshot"):
+        raise IndexFastForwardError("promoting generation source snapshot changed since preparation")
+    if source_revision_snapshot(archive_root) != receipt["source_snapshot"]:
+        raise IndexFastForwardError("source evidence changed since fast-forward preparation")
+    expected_identity = receipt.get("clone_identity")
+    if _proven_clone_identity(generation_index) != expected_identity:
+        raise IndexFastForwardError("prepared clone bytes changed before recovery")
+    canonical_sha = _canonical_schema_sha256(_canonical_schema_objects())
+    if canonical_sha != receipt.get("canonical_schema_sha256"):
+        raise IndexFastForwardError("canonical index schema changed since preparation")
+    _require_complete_proof(cast(dict[str, object], receipt.get("proof", {})))
+    manifest = cast(list[dict[str, object]], receipt.get("sample_manifest", []))
+    origins = tuple(sorted({str(origin) for entry in manifest for origin in cast(list[str], entry["origins"])}))
+    if _fingerprints(origins) != receipt.get("fingerprints"):
+        raise IndexFastForwardError("parser/materializer fingerprints changed since preparation")
+    _require_candidate_strict_acceptance(archive_root, generation_index)
+    if source_revision_snapshot(archive_root) != receipt["source_snapshot"]:
+        raise IndexFastForwardError("source evidence changed during promotion recovery")
+    if _proven_clone_identity(generation_index) != expected_identity:
+        raise IndexFastForwardError("prepared clone bytes changed during promotion recovery")
+
+
 def prepare_forward(
     *, archive_root: Path, receipt_path: Path, sample_size: int = DEFAULT_SAMPLE_SIZE
 ) -> dict[str, object]:
@@ -573,11 +607,24 @@ def activate_forward(*, receipt_path: Path) -> dict[str, object]:
     generation = store.load(str(generation_payload["generation_id"]))
     with RebuildLease(archive_root):
         _require_daemon_stopped(archive_root)
-        if status == "activating":
-            generation = store.recover_promotion(generation.generation_id)
         if generation.owner_id != generation_payload["owner_id"]:
             raise IndexFastForwardError("prepared generation ownership changed")
         clone = Path(generation.index_path)
+        if status == "activating":
+            pointer_target = (
+                store.active_pointer.resolve(strict=True)
+                if store.active_pointer.exists() or store.active_pointer.is_symlink()
+                else None
+            )
+            clone_target = clone.resolve(strict=True)
+            if pointer_target == clone_target:
+                if generation.state == "promoting":
+                    _require_recovery_evidence(archive_root, receipt, generation, clone)
+                    generation = store.complete_promotion_recovery(generation.generation_id)
+                elif generation.state == "active":
+                    _require_recovery_evidence(archive_root, receipt, generation, clone)
+            else:
+                generation = store.recover_promotion(generation.generation_id)
         if generation.state == "active":
             if store.active_pointer.resolve(strict=True) != clone.resolve(strict=True):
                 raise IndexFastForwardError("active generation does not own the active index pointer")

--- a/devtools/index_fast_forward.py
+++ b/devtools/index_fast_forward.py
@@ -504,6 +504,34 @@ def _require_candidate_strict_acceptance(archive_root: Path, candidate_index: Pa
         raise IndexFastForwardError(f"candidate strict acceptance gate failed: {failing}")
 
 
+def _require_generation_binding(
+    archive_root: Path,
+    receipt: dict[str, object],
+    generation_payload: dict[str, object],
+    generation: IndexGeneration,
+) -> None:
+    """Bind the loaded generation metadata to this receipt's archive and source."""
+    expected_archive_root = archive_root.resolve(strict=True)
+    receipt_archive_root = generation_payload.get("archive_root")
+    if (
+        not isinstance(receipt_archive_root, str)
+        or Path(receipt_archive_root).resolve(strict=False) != expected_archive_root
+    ):
+        raise IndexFastForwardError("prepared generation archive root changed or is foreign")
+    if Path(generation.archive_root).resolve(strict=False) != expected_archive_root:
+        raise IndexFastForwardError("prepared generation archive root changed or is foreign")
+    if generation.archive_root != receipt_archive_root:
+        raise IndexFastForwardError("prepared generation archive root metadata changed")
+
+    expected_source_snapshot = receipt.get("source_snapshot")
+    if not isinstance(expected_source_snapshot, str):
+        raise IndexFastForwardError("prepared generation source snapshot is missing")
+    if generation_payload.get("source_snapshot") != expected_source_snapshot:
+        raise IndexFastForwardError("prepared generation source snapshot changed since preparation")
+    if generation.source_snapshot != expected_source_snapshot:
+        raise IndexFastForwardError("prepared generation source snapshot changed since preparation")
+
+
 def _require_recovery_evidence(
     archive_root: Path,
     receipt: dict[str, object],
@@ -607,6 +635,7 @@ def activate_forward(*, receipt_path: Path) -> dict[str, object]:
     generation = store.load(str(generation_payload["generation_id"]))
     with RebuildLease(archive_root):
         _require_daemon_stopped(archive_root)
+        _require_generation_binding(archive_root, receipt, generation_payload, generation)
         if generation.owner_id != generation_payload["owner_id"]:
             raise IndexFastForwardError("prepared generation ownership changed")
         clone = Path(generation.index_path)

--- a/devtools/index_fast_forward.py
+++ b/devtools/index_fast_forward.py
@@ -26,8 +26,8 @@ from typing import cast
 from devtools.clone_support import reflink_clone
 from polylogue.config import Config
 from polylogue.maintenance.archive_verification import (
+    REINDEX_ACCEPTANCE_CHECKS,
     REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS,
-    passes_strict_acceptance,
     strict_acceptance_failures,
     verify_archive,
 )
@@ -481,13 +481,21 @@ def _require_complete_proof(proof: dict[str, object]) -> None:
 
 
 def _require_candidate_strict_acceptance(archive_root: Path, candidate_index: Path) -> None:
-    report = verify_archive(
+    index_only_report = verify_archive(
+        candidate_index.parent,
+        checks=REINDEX_ACCEPTANCE_CHECKS,
+    )
+    cross_tier_report = verify_archive(
         archive_root,
         checks=REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS,
         index_path_override=candidate_index,
     )
-    if not passes_strict_acceptance(report, required_checks=REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS):
-        failing = "; ".join(strict_acceptance_failures(report, required_checks=REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS))
+    failures = (
+        *strict_acceptance_failures(index_only_report, required_checks=REINDEX_ACCEPTANCE_CHECKS),
+        *strict_acceptance_failures(cross_tier_report, required_checks=REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS),
+    )
+    if failures:
+        failing = "; ".join(failures)
         raise IndexFastForwardError(f"candidate strict acceptance gate failed: {failing}")
 
 

--- a/devtools/index_fast_forward.py
+++ b/devtools/index_fast_forward.py
@@ -25,7 +25,12 @@ from typing import cast
 
 from devtools.clone_support import reflink_clone
 from polylogue.config import Config
-from polylogue.maintenance.archive_verification import CORPUS_FIDELITY_CHECKS, verify_archive
+from polylogue.maintenance.archive_verification import (
+    REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS,
+    passes_strict_acceptance,
+    strict_acceptance_failures,
+    verify_archive,
+)
 from polylogue.maintenance.offline_guard import running_daemon_pid
 from polylogue.pipeline.ids import session_content_hash
 from polylogue.sources.origin_specs import lowering_fingerprint, parser_fingerprint_for_origin
@@ -475,13 +480,15 @@ def _require_complete_proof(proof: dict[str, object]) -> None:
         raise IndexFastForwardError("source replay proof hashes disagree between clone and canonical replay")
 
 
-def _require_candidate_corpus_fidelity(archive_root: Path, candidate_index: Path) -> None:
-    report = verify_archive(archive_root, checks=CORPUS_FIDELITY_CHECKS, index_path_override=candidate_index)
-    if report.blocking:
-        failing = "; ".join(
-            f"{check.name}: {check.summary}" for check in report.checks if check.status.value == "error"
-        )
-        raise IndexFastForwardError(f"candidate corpus fidelity gate failed: {failing}")
+def _require_candidate_strict_acceptance(archive_root: Path, candidate_index: Path) -> None:
+    report = verify_archive(
+        archive_root,
+        checks=REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS,
+        index_path_override=candidate_index,
+    )
+    if not passes_strict_acceptance(report, required_checks=REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS):
+        failing = "; ".join(strict_acceptance_failures(report, required_checks=REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS))
+        raise IndexFastForwardError(f"candidate strict acceptance gate failed: {failing}")
 
 
 def prepare_forward(
@@ -592,7 +599,7 @@ def activate_forward(*, receipt_path: Path) -> dict[str, object]:
         origins = tuple(sorted({str(origin) for entry in manifest for origin in cast(list[str], entry["origins"])}))
         if _fingerprints(origins) != receipt.get("fingerprints"):
             raise IndexFastForwardError("parser/materializer fingerprints changed since preparation")
-        _require_candidate_corpus_fidelity(archive_root, clone)
+        _require_candidate_strict_acceptance(archive_root, clone)
         if source_revision_snapshot(archive_root) != receipt["source_snapshot"]:
             raise IndexFastForwardError("source evidence changed immediately before promotion")
         if _proven_clone_identity(clone) != receipt.get("clone_identity"):

--- a/devtools/index_fast_forward.py
+++ b/devtools/index_fast_forward.py
@@ -530,6 +530,38 @@ def _require_generation_binding(
         raise IndexFastForwardError("prepared generation source snapshot changed since preparation")
     if generation.source_snapshot != expected_source_snapshot:
         raise IndexFastForwardError("prepared generation source snapshot changed since preparation")
+    current_metadata = asdict(generation)
+    expected_metadata = dict(generation_payload)
+    current_metadata.pop("state", None)
+    expected_metadata.pop("state", None)
+    if current_metadata != expected_metadata:
+        raise IndexFastForwardError("prepared generation metadata changed since preparation")
+
+
+def _require_active_receipt_binding(
+    store: IndexGenerationStore,
+    receipt: dict[str, object],
+    generation_payload: dict[str, object],
+    generation: IndexGeneration,
+    generation_index: Path,
+) -> None:
+    """Prove an activated receipt still describes the live generation."""
+    if generation.state != "active":
+        raise IndexFastForwardError(f"activated receipt generation is not active: {generation.state}")
+    if asdict(generation) != generation_payload:
+        raise IndexFastForwardError("activated receipt generation metadata changed")
+    try:
+        pointer_target = store.active_pointer.resolve(strict=True)
+        generation_target = generation_index.resolve(strict=True)
+    except OSError as exc:
+        raise IndexFastForwardError("activated receipt active index pointer is not resolvable") from exc
+    if pointer_target != generation_target:
+        raise IndexFastForwardError("activated receipt generation no longer owns the active index pointer")
+    expected_identity = receipt.get("active_identity_after")
+    if not isinstance(expected_identity, dict):
+        raise IndexFastForwardError("activated receipt active pointer identity is missing")
+    if _file_identity(store.active_pointer) != expected_identity:
+        raise IndexFastForwardError("activated receipt active pointer identity changed")
 
 
 def _require_recovery_evidence(
@@ -626,8 +658,6 @@ def activate_forward(*, receipt_path: Path) -> dict[str, object]:
     status = receipt.get("status")
     if status not in {"prepared", "activating", "activated"}:
         raise IndexFastForwardError(f"receipt is not prepared: {status}")
-    if status == "activated":
-        return receipt
     archive_root = Path(str(receipt["archive_root"])).resolve(strict=True)
     _require_daemon_stopped(archive_root)
     store = IndexGenerationStore.for_archive_root(archive_root)
@@ -655,6 +685,10 @@ def activate_forward(*, receipt_path: Path) -> dict[str, object]:
             else:
                 generation = store.recover_promotion(generation.generation_id)
         if generation.state == "active":
+            if status == "activated":
+                _require_active_receipt_binding(store, receipt, generation_payload, generation, clone)
+                _require_recovery_evidence(archive_root, receipt, generation, clone)
+                return receipt
             if store.active_pointer.resolve(strict=True) != clone.resolve(strict=True):
                 raise IndexFastForwardError("active generation does not own the active index pointer")
             receipt.update(
@@ -662,6 +696,7 @@ def activate_forward(*, receipt_path: Path) -> dict[str, object]:
                     "status": "activated",
                     "activated_at_ms": receipt.get("activated_at_ms", _now_ms()),
                     "generation": asdict(generation),
+                    "active_identity_after": _file_identity(store.active_pointer),
                 }
             )
             _write_receipt(receipt_path, receipt)

--- a/polylogue/cli/commands/maintenance/_verify_archive.py
+++ b/polylogue/cli/commands/maintenance/_verify_archive.py
@@ -65,10 +65,15 @@ def verify_archive_command(
     temporarily busy under a concurrent rebuild -- never aborts the others;
     each independently reports ok/warning/error/skip plus evidence numbers.
 
-    Exit code is non-zero when any check reports an error (or, with
-    ``--strict``, a warning).
+    Exit code is non-zero when any check reports an unwaived error. With
+    ``--strict``, every selected check must be ``ok``: warnings, skips, and
+    waived errors fail the command.
     """
-    from polylogue.maintenance.archive_verification import verify_archive
+    from polylogue.maintenance.archive_verification import (
+        ARCHIVE_VERIFICATION_CHECK_NAMES,
+        passes_strict_acceptance,
+        verify_archive,
+    )
 
     try:
         report = verify_archive(
@@ -87,7 +92,13 @@ def verify_archive_command(
     else:
         _render_plain(report)
 
-    if report.blocking or (strict and report.warning_count > 0):
+    if report.blocking or (
+        strict
+        and not passes_strict_acceptance(
+            report,
+            required_checks=selected_checks or ARCHIVE_VERIFICATION_CHECK_NAMES,
+        )
+    ):
         raise SystemExit(1)
 
 

--- a/polylogue/maintenance/archive_verification.py
+++ b/polylogue/maintenance/archive_verification.py
@@ -2549,6 +2549,7 @@ REINDEX_ACCEPTANCE_CHECKS: tuple[str, ...] = (
 #: candidate runner so ``index_path_override`` cannot silently inspect the
 #: active generation.
 REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS: tuple[str, ...] = (
+    "raw-failure-lifecycle",
     "source-index-coverage",
     "blob-refs-liveness",
     "embeddings-refs-liveness",

--- a/polylogue/maintenance/archive_verification.py
+++ b/polylogue/maintenance/archive_verification.py
@@ -245,6 +245,48 @@ class ArchiveVerificationReport(OutcomeReport):
         )
 
 
+def strict_acceptance_failures(
+    report: ArchiveVerificationReport,
+    *,
+    required_checks: Sequence[str] | None = None,
+) -> tuple[str, ...]:
+    """Return every result that prevents a strict acceptance decision.
+
+    Strict acceptance is deliberately separate from :attr:`blocking`, which
+    is the ordinary monitoring gate and therefore honors reviewed waivers.
+    Acceptance proves a candidate is complete enough to activate: every
+    required check must be present and ``ok``. Warnings, skips, and errors all
+    fail this predicate, including errors carrying a waiver.
+    """
+    required = (
+        tuple(dict.fromkeys(required_checks))
+        if required_checks is not None
+        else tuple(check.name for check in report.checks)
+    )
+    by_name = {check.name: check for check in report.checks}
+    failures: list[str] = []
+    for name in required:
+        check = by_name.get(name)
+        if check is None:
+            failures.append(f"{name}: required check result is missing")
+            continue
+        if check.status is OutcomeStatus.OK:
+            continue
+        waiver = getattr(check, "waived_bead_id", None)
+        waiver_detail = f", waived by {waiver}" if waiver is not None else ""
+        failures.append(f"{check.name} [{check.status.value}{waiver_detail}]: {check.summary}")
+    return tuple(failures)
+
+
+def passes_strict_acceptance(
+    report: ArchiveVerificationReport,
+    *,
+    required_checks: Sequence[str] | None = None,
+) -> bool:
+    """Return whether a report is complete and wholly ``ok`` for activation."""
+    return not strict_acceptance_failures(report, required_checks=required_checks)
+
+
 ArchiveVerificationCheckFn = Callable[[Path, int], ArchiveVerificationCheck]
 ArchiveVerificationCandidateCheckFn = Callable[[Path, Path, int], ArchiveVerificationCheck]
 
@@ -393,6 +435,12 @@ def _check_pointer_coherence(archive_root: Path, _sample_limit: int) -> ArchiveV
 
 
 def _check_source_index_coverage(archive_root: Path, sample_limit: int) -> ArchiveVerificationCheck:
+    return _check_source_index_coverage_at_index_path(archive_root, _resolve_index_path(archive_root), sample_limit)
+
+
+def _check_source_index_coverage_at_index_path(
+    archive_root: Path, index_path: Path, sample_limit: int
+) -> ArchiveVerificationCheck:
     """Every logical source's head is indexed OR carries a typed refusal.
 
     Universe (polylogue-in24n, invariant I1): ``raw_sessions`` logical heads --
@@ -411,7 +459,6 @@ def _check_source_index_coverage(archive_root: Path, sample_limit: int) -> Archi
     (index sessions whose raw_id doesn't exist in source.db at all).
     """
     source_path = _tier_path(archive_root, ArchiveTier.SOURCE)
-    index_path = _resolve_index_path(archive_root)
     if not source_path.exists() or not index_path.exists():
         return _skip_check("source-index-coverage", "source.db or index.db not present")
 
@@ -609,6 +656,12 @@ def _check_source_index_coverage(archive_root: Path, sample_limit: int) -> Archi
             "orphan_sample": orphan_sample,
         },
     )
+
+
+def _check_source_index_coverage_at_candidate(
+    archive_root: Path, index_path: Path, sample_limit: int
+) -> ArchiveVerificationCheck:
+    return _check_source_index_coverage_at_index_path(archive_root, index_path, sample_limit)
 
 
 # ---------------------------------------------------------------------------
@@ -1055,6 +1108,20 @@ def _check_raw_failure_lifecycle(archive_root: Path, sample_limit: int) -> Archi
     )
 
 
+def _check_raw_failure_lifecycle_at_candidate(
+    archive_root: Path, _index_path: Path, sample_limit: int
+) -> ArchiveVerificationCheck:
+    """Run the source-only lifecycle gate for an inactive index candidate."""
+    return _check_raw_failure_lifecycle(archive_root, sample_limit)
+
+
+def _check_blob_refs_liveness_at_candidate(
+    archive_root: Path, _index_path: Path, sample_limit: int
+) -> ArchiveVerificationCheck:
+    """Run the source-only blob check while a candidate index is selected."""
+    return _check_blob_refs_liveness(archive_root, sample_limit)
+
+
 def _check_pathology_zoo_invariants(archive_root: Path, _sample_limit: int) -> ArchiveVerificationCheck:
     """Run each production-owned pathology-zoo invariant when its corpus is present."""
     from polylogue.maintenance.pathology_zoo import (
@@ -1149,6 +1216,12 @@ def _check_pathology_zoo_invariants_at_index_path(
 
 
 def _check_embeddings_refs_liveness(archive_root: Path, sample_limit: int) -> ArchiveVerificationCheck:
+    return _check_embeddings_refs_liveness_at_index_path(archive_root, _resolve_index_path(archive_root), sample_limit)
+
+
+def _check_embeddings_refs_liveness_at_index_path(
+    archive_root: Path, index_path: Path, sample_limit: int
+) -> ArchiveVerificationCheck:
     """Every ``message_embedding_refs`` row resolves to a live index message.
 
     embeddings.db is a rebuildable derived tier keyed off index.db's message
@@ -1159,7 +1232,6 @@ def _check_embeddings_refs_liveness(archive_root: Path, sample_limit: int) -> Ar
     longer exists in the index.
     """
     embeddings_path = _tier_path(archive_root, ArchiveTier.EMBEDDINGS)
-    index_path = _resolve_index_path(archive_root)
     if not embeddings_path.exists():
         return _skip_check("embeddings-refs-liveness", "embeddings.db not present")
     if not index_path.exists():
@@ -1220,6 +1292,12 @@ def _check_embeddings_refs_liveness(archive_root: Path, sample_limit: int) -> Ar
         details=[f"orphan:{message_id}" for message_id in orphan_sample],
         evidence={"ref_count": int(total or 0), "orphan_count": orphans, "orphan_sample": orphan_sample},
     )
+
+
+def _check_embeddings_refs_liveness_at_candidate(
+    archive_root: Path, index_path: Path, sample_limit: int
+) -> ArchiveVerificationCheck:
+    return _check_embeddings_refs_liveness_at_index_path(archive_root, index_path, sample_limit)
 
 
 # ---------------------------------------------------------------------------
@@ -2178,6 +2256,12 @@ def _check_convergence_freshness(archive_root: Path, _sample_limit: int) -> Arch
 
 
 def _check_user_tier_refs(archive_root: Path, sample_limit: int) -> ArchiveVerificationCheck:
+    return _check_user_tier_refs_at_index_path(archive_root, _resolve_index_path(archive_root), sample_limit)
+
+
+def _check_user_tier_refs_at_index_path(
+    archive_root: Path, index_path: Path, sample_limit: int
+) -> ArchiveVerificationCheck:
     """``assertions.target_ref`` of kind ``session``/``message`` must resolve
     to a live row in ``index.db`` (I10, polylogue-t0m73).
 
@@ -2190,7 +2274,6 @@ def _check_user_tier_refs(archive_root: Path, sample_limit: int) -> ArchiveVerif
     normal target-scoped query.
     """
     user_path = _tier_path(archive_root, ArchiveTier.USER)
-    index_path = _resolve_index_path(archive_root)
     if not user_path.exists() or not index_path.exists():
         return _skip_check("user-tier-refs", "user.db or index.db not present")
 
@@ -2264,6 +2347,12 @@ def _check_user_tier_refs(archive_root: Path, sample_limit: int) -> ArchiveVerif
     )
 
 
+def _check_user_tier_refs_at_candidate(
+    archive_root: Path, index_path: Path, sample_limit: int
+) -> ArchiveVerificationCheck:
+    return _check_user_tier_refs_at_index_path(archive_root, index_path, sample_limit)
+
+
 # ---------------------------------------------------------------------------
 # Registry + entrypoint
 # ---------------------------------------------------------------------------
@@ -2287,6 +2376,7 @@ ARCHIVE_VERIFICATION_CHECKS: tuple[ArchiveVerificationCheckSpec, ...] = (
         "untyped gaps and index-orphans (raw_id ground truth, not the census ledger, polylogue-in24n) block.",
         _check_source_index_coverage,
         ArchiveVerificationCheckClass.STATE_INVARIANT,
+        _check_source_index_coverage_at_candidate,
     ),
     ArchiveVerificationCheckSpec(
         "fts-parity",
@@ -2312,12 +2402,14 @@ ARCHIVE_VERIFICATION_CHECKS: tuple[ArchiveVerificationCheckSpec, ...] = (
         "not membership in blob_refs itself (polylogue-t0m73 I3).",
         _check_blob_refs_liveness,
         ArchiveVerificationCheckClass.LIVENESS,
+        _check_blob_refs_liveness_at_candidate,
     ),
     ArchiveVerificationCheckSpec(
         "raw-failure-lifecycle",
         "Every retained raw parse or validation failure has typed deferred or terminal lifecycle evidence.",
         _check_raw_failure_lifecycle,
         ArchiveVerificationCheckClass.STATE_INVARIANT,
+        _check_raw_failure_lifecycle_at_candidate,
     ),
     ArchiveVerificationCheckSpec(
         "pathology-zoo-invariants",
@@ -2332,6 +2424,7 @@ ARCHIVE_VERIFICATION_CHECKS: tuple[ArchiveVerificationCheckSpec, ...] = (
         "polylogue-t0m73 I4).",
         _check_embeddings_refs_liveness,
         ArchiveVerificationCheckClass.LIVENESS,
+        _check_embeddings_refs_liveness_at_candidate,
     ),
     ArchiveVerificationCheckSpec(
         "session-lineage-acyclic",
@@ -2375,12 +2468,16 @@ ARCHIVE_VERIFICATION_CHECKS: tuple[ArchiveVerificationCheckSpec, ...] = (
         "assertions.target_ref of kind session/message resolves to a live index.db row (polylogue-t0m73 I10).",
         _check_user_tier_refs,
         ArchiveVerificationCheckClass.LIVENESS,
+        _check_user_tier_refs_at_candidate,
     ),
     ArchiveVerificationCheckSpec(
         "excluded-cursor-vocabulary-honesty",
         "No excluded ingest_cursor row carries a live next_retry_at (would misreport as retry-due, polylogue-ix5r).",
         _check_excluded_cursor_vocabulary_honesty,
         ArchiveVerificationCheckClass.LIVENESS,
+        lambda archive_root, _index_path, sample_limit: _check_excluded_cursor_vocabulary_honesty(
+            archive_root, sample_limit
+        ),
     ),
     ArchiveVerificationCheckSpec(
         "stalled-append-cursor-freshness",
@@ -2388,6 +2485,9 @@ ARCHIVE_VERIFICATION_CHECKS: tuple[ArchiveVerificationCheckSpec, ...] = (
         "the stall-escalation threshold (polylogue-2qrx).",
         _check_stalled_append_cursor_freshness,
         ArchiveVerificationCheckClass.LIVENESS,
+        lambda archive_root, _index_path, sample_limit: _check_stalled_append_cursor_freshness(
+            archive_root, sample_limit
+        ),
     ),
     ArchiveVerificationCheckSpec(
         "raw-quarantine-group-dedup",
@@ -2430,20 +2530,9 @@ CORPUS_FIDELITY_CHECKS: tuple[str, ...] = (
     "corpus-revision-fidelity",
 )
 
-#: The subset of ground-truth checks a blue-green reindex candidate generation
-#: is expected to satisfy before promotion (polylogue-t0m73's "reindex
-#: acceptance gate"). Restricted to checks whose universe is satisfiable from
-#: ``index.db`` alone -- a candidate generation directory holds only the new
-#: ``index.db``, not the durable ``source.db``/``user.db``/``embeddings.db``
-#: tiers (those live once at the archive root, not per-generation), so
-#: cross-tier checks (``source-index-coverage``, ``blob-refs-liveness``,
-#: ``embeddings-refs-liveness``, ``tier-schema``) would either report a false
-#: ERROR (missing tiers they're not skip-tolerant of, e.g. tier-schema) or
-#: only ever SKIP (uninformative). Intended use: ``verify_archive(generation_
-#: root, checks=REINDEX_ACCEPTANCE_CHECKS)`` right before promotion, exactly
-#: how :mod:`polylogue.maintenance.rebuild_index` already ran the ``fts-
-#: parity`` singleton -- this constant widens that gate to the rest of the
-#: ground-truth-eligible registry.
+#: Index-only checks run against the inactive generation before promotion.
+#: Cross-tier checks live in :data:`REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS`
+#: because a generation directory contains only ``index.db``.
 REINDEX_ACCEPTANCE_CHECKS: tuple[str, ...] = (
     "fts-parity",
     "lineage-sanity",
@@ -2451,13 +2540,21 @@ REINDEX_ACCEPTANCE_CHECKS: tuple[str, ...] = (
     "session-lineage-acyclic",
     "message-count-projection",
     "session-fingerprint-stamps",
-    "planner-stats",
 )
 
-#: Candidate checks that need the durable archive tiers as well as the
-#: inactive generation's index. These are run with ``index_path_override`` so
-#: they cannot silently fall back to the active/default index.
+#: Full rebuild candidate checks that need durable archive tiers as well as
+#: the inactive generation's index. This is the strict promotion profile:
+#: source/index coverage, blob refs, embeddings refs, user refs, both cursor
+#: checks, and the existing corpus/pathology checks. Every entry has a
+#: candidate runner so ``index_path_override`` cannot silently inspect the
+#: active generation.
 REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS: tuple[str, ...] = (
+    "source-index-coverage",
+    "blob-refs-liveness",
+    "embeddings-refs-liveness",
+    "user-tier-refs",
+    "excluded-cursor-vocabulary-honesty",
+    "stalled-append-cursor-freshness",
     "corpus-absences",
     "corpus-attachment-fidelity",
     "corpus-revision-fidelity",
@@ -2558,5 +2655,7 @@ __all__ = [
     "ArchiveVerificationWaiver",
     "DEFAULT_SAMPLE_LIMIT",
     "read_raw_failure_lifecycle",
+    "passes_strict_acceptance",
+    "strict_acceptance_failures",
     "verify_archive",
 ]

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -663,6 +663,8 @@ def validate_rebuild_index_request(request: RebuildIndexRequest) -> None:
         raise ValueError("--raw-id cannot be combined with --only-missing")
     if (request.raw_ids or request.only_missing) and request.promote:
         raise ValueError("partial rebuild selections require --no-promote and can never replace the active index")
+    if request.promote and request.candidate_acceptance_checks is not None:
+        raise ValueError("caller-supplied candidate acceptance profiles require --no-promote")
     if request.max_blob_mb is not None and request.max_blob_mb <= 0:
         raise ValueError("max blob size must be positive")
     if request.max_blob_mb is not None and not request.raw_ids and not request.only_missing:

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -853,6 +853,8 @@ async def _rebuild_index_from_source_owned(
     from polylogue.maintenance.archive_verification import (
         REINDEX_ACCEPTANCE_CHECKS,
         REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS,
+        passes_strict_acceptance,
+        strict_acceptance_failures,
         verify_archive,
     )
     from polylogue.maintenance.replay import rebuild_index_from_source as replay_source
@@ -1328,13 +1330,20 @@ async def _rebuild_index_from_source_owned(
                 stage="reindex_acceptance",
                 elapsed_s=round(terminal_timings_s["terminal.reindex_acceptance"], 3),
             )
-            if any(report.blocking for report in acceptance_reports):
-                failing = "; ".join(
-                    f"{check.name}: {check.summary}"
-                    for report in acceptance_reports
-                    for check in report.checks
-                    if check.status.value == "error" and getattr(check, "waived_bead_id", None) is None
-                )
+            acceptance_requirements = (
+                REINDEX_ACCEPTANCE_CHECKS,
+                request.candidate_acceptance_checks
+                if request.candidate_acceptance_checks is not None
+                else REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS,
+            )
+            acceptance_failures = tuple(
+                failure
+                for report, required_checks in zip(acceptance_reports, acceptance_requirements, strict=True)
+                if not passes_strict_acceptance(report, required_checks=required_checks)
+                for failure in strict_acceptance_failures(report, required_checks=required_checks)
+            )
+            if acceptance_failures:
+                failing = "; ".join(acceptance_failures)
                 raise RuntimeError(
                     f"reindex acceptance gate failed for generation {generation.generation_id}: {failing}"
                 )

--- a/polylogue/storage/index_generation.py
+++ b/polylogue/storage/index_generation.py
@@ -824,19 +824,38 @@ class IndexGenerationStore:
         return removed
 
     def recover_promotion(self, generation_id: str) -> IndexGeneration:
-        """Reconcile a crash after the pointer swap but before active metadata."""
+        """Reconcile an incomplete promotion without trusting the pointer alone.
+
+        A pointer swap is only one durable step in promotion.  When the
+        pointer already targets the promoting generation, leave the metadata
+        in ``promoting`` until the activation caller has revalidated the
+        candidate against the current archive and explicitly completes
+        recovery.  A pointer mismatch means the swap never became visible, so
+        the candidate can safely return to ``inactive``.
+        """
         generation = self.load(generation_id)
         if generation.state != "promoting":
             return generation
         pointer = self.active_pointer
-        state = "inactive"
-        if pointer.exists() or pointer.is_symlink():
-            state = (
-                "active"
-                if pointer.resolve(strict=True) == Path(generation.index_path).resolve(strict=True)
-                else "inactive"
-            )
-        recovered = IndexGeneration(**{**asdict(generation), "state": state})
+        if (pointer.exists() or pointer.is_symlink()) and pointer.resolve(strict=True) == Path(
+            generation.index_path
+        ).resolve(strict=True):
+            return generation
+        recovered = IndexGeneration(**{**asdict(generation), "state": "inactive"})
+        self._write(recovered)
+        return recovered
+
+    def complete_promotion_recovery(self, generation_id: str) -> IndexGeneration:
+        """Record a pointer-swapped promotion as active after external validation."""
+        generation = self.load(generation_id)
+        if generation.state != "promoting":
+            return generation
+        pointer = self.active_pointer
+        if not (pointer.exists() or pointer.is_symlink()):
+            raise RuntimeError("cannot complete promotion recovery without an active index pointer")
+        if pointer.resolve(strict=True) != Path(generation.index_path).resolve(strict=True):
+            raise RuntimeError("cannot complete promotion recovery for a non-active generation")
+        recovered = IndexGeneration(**{**asdict(generation), "state": "active"})
         self._write(recovered)
         return recovered
 

--- a/tests/unit/cli/test_maintenance_verify_archive_cli.py
+++ b/tests/unit/cli/test_maintenance_verify_archive_cli.py
@@ -128,3 +128,40 @@ def test_verify_archive_cli_strict_fails_on_warning(
         ["--plain", "ops", "maintenance", "verify-archive", "--check", "planner-stats", "--strict"],
     )
     assert strict_result.exit_code == 1
+
+
+def test_verify_archive_cli_strict_fails_on_required_skip(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    (cli_workspace["archive_root"] / "embeddings.db").unlink()
+
+    ordinary = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "verify-archive",
+            "--check",
+            "embeddings-refs-liveness",
+            "--output-format",
+            "json",
+        ],
+    )
+    assert ordinary.exit_code == 0, ordinary.output
+    assert json.loads(ordinary.stdout)["checks"][0]["status"] == "skip"
+
+    strict = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "verify-archive",
+            "--check",
+            "embeddings-refs-liveness",
+            "--strict",
+        ],
+    )
+    assert strict.exit_code == 1, strict.output

--- a/tests/unit/devtools/test_index_fast_forward.py
+++ b/tests/unit/devtools/test_index_fast_forward.py
@@ -15,7 +15,7 @@ from polylogue.maintenance.archive_verification import (
     ArchiveVerificationReport,
 )
 from polylogue.sources.dispatch import parse_payload
-from polylogue.storage.index_generation import IndexGenerationStore
+from polylogue.storage.index_generation import IndexGeneration, IndexGenerationStore
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
@@ -104,6 +104,29 @@ def _no_corpus_failure(monkeypatch: pytest.MonkeyPatch) -> None:
             ]
         ),
     )
+
+
+def _simulate_pointer_swap_crash(root: Path, receipt_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    store = IndexGenerationStore.for_archive_root(root)
+    receipt = cast(dict[str, object], json.loads(receipt_path.read_text(encoding="utf-8")))
+    generation_payload = cast(dict[str, object], receipt["generation"])
+    generation_id = str(generation_payload["generation_id"])
+    original_write = IndexGenerationStore._write
+
+    def crash_after_pointer_swap(self: IndexGenerationStore, generation: IndexGeneration) -> None:
+        if generation.generation_id == generation_id and generation.state == "active":
+            raise RuntimeError("simulated crash after index pointer swap")
+        original_write(self, generation)
+
+    monkeypatch.setattr(IndexGenerationStore, "_write", crash_after_pointer_swap)
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        forward.activate_forward(receipt_path=receipt_path)
+    monkeypatch.setattr(IndexGenerationStore, "_write", original_write)
+
+    assert json.loads(receipt_path.read_text(encoding="utf-8"))["status"] == "activating"
+    assert store.active_pointer.resolve(strict=True) == Path(str(generation_payload["index_path"])).resolve(strict=True)
+    assert store.load(generation_id).state == "promoting"
+    return receipt
 
 
 def _write_raw_backed_session(root: Path, native_id: str) -> None:
@@ -199,6 +222,96 @@ def test_activation_refuses_source_metadata_mutation_after_candidate_gate(
         forward.activate_forward(receipt_path=receipt_path)
 
     assert IndexGenerationStore.for_archive_root(root).active_pointer.resolve().parent.name == "v36"
+
+
+def test_recovery_refuses_durable_source_mutation_after_pointer_swap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _patch_v37: None
+) -> None:
+    root = _archive(tmp_path)
+    monkeypatch.setattr(forward, "running_daemon_pid", lambda _config: None)
+    receipt_path = tmp_path / "transition.json"
+    forward.prepare_forward(archive_root=root, receipt_path=receipt_path)
+    _simulate_pointer_swap_crash(root, receipt_path, monkeypatch)
+
+    with sqlite3.connect(root / "source.db") as conn:
+        conn.execute("UPDATE raw_sessions SET source_path = 'mutated-after-pointer-swap'")
+        conn.commit()
+
+    with pytest.raises(forward.IndexFastForwardError, match="source evidence changed"):
+        forward.activate_forward(receipt_path=receipt_path)
+
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    store = IndexGenerationStore.for_archive_root(root)
+    assert receipt["status"] == "activating"
+    assert store.load(str(receipt["generation"]["generation_id"])).state == "promoting"
+
+
+def test_recovery_refuses_candidate_mutation_after_pointer_swap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _patch_v37: None
+) -> None:
+    root = _archive(tmp_path)
+    monkeypatch.setattr(forward, "running_daemon_pid", lambda _config: None)
+    receipt_path = tmp_path / "transition.json"
+    forward.prepare_forward(archive_root=root, receipt_path=receipt_path)
+    receipt = _simulate_pointer_swap_crash(root, receipt_path, monkeypatch)
+    generation_payload = cast(dict[str, object], receipt["generation"])
+    generation_path = Path(str(generation_payload["index_path"]))
+
+    with generation_path.open("ab") as handle:
+        handle.write(b"candidate mutation")
+
+    with pytest.raises(forward.IndexFastForwardError, match="clone bytes changed"):
+        forward.activate_forward(receipt_path=receipt_path)
+
+    store = IndexGenerationStore.for_archive_root(root)
+    assert json.loads(receipt_path.read_text(encoding="utf-8"))["status"] == "activating"
+    assert store.load(str(generation_payload["generation_id"])).state == "promoting"
+
+
+def test_recovery_completes_only_after_current_strict_acceptance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _patch_v37: None
+) -> None:
+    root = _archive(tmp_path)
+    monkeypatch.setattr(forward, "running_daemon_pid", lambda _config: None)
+    receipt_path = tmp_path / "transition.json"
+    forward.prepare_forward(archive_root=root, receipt_path=receipt_path)
+    _simulate_pointer_swap_crash(root, receipt_path, monkeypatch)
+
+    with sqlite3.connect(root / "embeddings.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO message_embedding_refs(message_id, session_id, origin, embedding_input_hash)
+            VALUES ('codex-session:source-backed-session:no-such-message', 'codex-session:source-backed-session', 'codex-session', ?)
+            """,
+            (b"r" * 32,),
+        )
+        conn.commit()
+
+    with pytest.raises(forward.IndexFastForwardError, match="embeddings-refs-liveness"):
+        forward.activate_forward(receipt_path=receipt_path)
+
+    store = IndexGenerationStore.for_archive_root(root)
+    receipt = cast(dict[str, object], json.loads(receipt_path.read_text(encoding="utf-8")))
+    generation_payload = cast(dict[str, object], receipt["generation"])
+    assert receipt["status"] == "activating"
+    assert store.load(str(generation_payload["generation_id"])).state == "promoting"
+
+
+def test_recovery_accepts_unchanged_pointer_swap_after_revalidation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _patch_v37: None
+) -> None:
+    root = _archive(tmp_path)
+    monkeypatch.setattr(forward, "running_daemon_pid", lambda _config: None)
+    receipt_path = tmp_path / "transition.json"
+    forward.prepare_forward(archive_root=root, receipt_path=receipt_path)
+    receipt = _simulate_pointer_swap_crash(root, receipt_path, monkeypatch)
+
+    recovered = forward.activate_forward(receipt_path=receipt_path)
+
+    assert recovered["status"] == "activated"
+    store = IndexGenerationStore.for_archive_root(root)
+    generation_payload = cast(dict[str, object], receipt["generation"])
+    assert store.load(str(generation_payload["generation_id"])).state == "active"
 
 
 def test_activation_refuses_waived_embedding_orphan_at_strict_candidate_gate(

--- a/tests/unit/devtools/test_index_fast_forward.py
+++ b/tests/unit/devtools/test_index_fast_forward.py
@@ -189,6 +189,71 @@ def test_prepare_receipt_proves_source_replay_equivalence(
         assert conn.execute("SELECT 1 FROM attachment_native_ids WHERE ref_id = 'orphan-ref'").fetchone() is None
 
 
+def test_activation_replays_unchanged_active_receipt_idempotently(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _patch_v37: None
+) -> None:
+    root = _archive(tmp_path)
+    monkeypatch.setattr(forward, "running_daemon_pid", lambda _config: None)
+    receipt_path = tmp_path / "transition.json"
+    forward.prepare_forward(archive_root=root, receipt_path=receipt_path)
+    _no_corpus_failure(monkeypatch)
+
+    first = forward.activate_forward(receipt_path=receipt_path)
+    second = forward.activate_forward(receipt_path=receipt_path)
+
+    assert first["status"] == "activated"
+    assert second == first
+    assert IndexGenerationStore.for_archive_root(root).active_pointer.resolve().parent.name.startswith("gen-")
+
+
+def test_activated_receipt_refuses_swapped_active_pointer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _patch_v37: None
+) -> None:
+    root = _archive(tmp_path)
+    monkeypatch.setattr(forward, "running_daemon_pid", lambda _config: None)
+    receipt_path = tmp_path / "transition.json"
+    forward.prepare_forward(archive_root=root, receipt_path=receipt_path)
+    _no_corpus_failure(monkeypatch)
+    forward.activate_forward(receipt_path=receipt_path)
+
+    store = IndexGenerationStore.for_archive_root(root)
+    receipt = cast(dict[str, object], json.loads(receipt_path.read_text(encoding="utf-8")))
+    active_identity = cast(dict[str, object], receipt["active_identity"])
+    stale_target = Path(str(active_identity["resolved_path"]))
+    temporary = store.active_pointer.with_name(f".{store.active_pointer.name}.stale")
+    temporary.symlink_to(stale_target)
+    temporary.replace(store.active_pointer)
+
+    with pytest.raises(forward.IndexFastForwardError, match="no longer owns the active index pointer"):
+        forward.activate_forward(receipt_path=receipt_path)
+
+    assert store.active_pointer.resolve(strict=True) == stale_target.resolve(strict=True)
+    assert json.loads(receipt_path.read_text(encoding="utf-8"))["status"] == "activated"
+
+
+def test_activated_receipt_refuses_recomputed_receipt_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _patch_v37: None
+) -> None:
+    root = _archive(tmp_path)
+    monkeypatch.setattr(forward, "running_daemon_pid", lambda _config: None)
+    receipt_path = tmp_path / "transition.json"
+    forward.prepare_forward(archive_root=root, receipt_path=receipt_path)
+    _no_corpus_failure(monkeypatch)
+    forward.activate_forward(receipt_path=receipt_path)
+
+    receipt = cast(dict[str, object], json.loads(receipt_path.read_text(encoding="utf-8")))
+    generation = cast(dict[str, object], receipt["generation"])
+    generation["state"] = "inactive"
+    forward._write_receipt(receipt_path, receipt)
+
+    with pytest.raises(forward.IndexFastForwardError, match="generation metadata changed"):
+        forward.activate_forward(receipt_path=receipt_path)
+
+    store = IndexGenerationStore.for_archive_root(root)
+    assert store.active_pointer.resolve(strict=True) == Path(str(generation["index_path"])).resolve(strict=True)
+    assert json.loads(receipt_path.read_text(encoding="utf-8"))["status"] == "activated"
+
+
 def test_activation_refuses_parser_or_materializer_fingerprint_drift(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _patch_v37: None
 ) -> None:

--- a/tests/unit/devtools/test_index_fast_forward.py
+++ b/tests/unit/devtools/test_index_fast_forward.py
@@ -268,6 +268,41 @@ def test_recovery_refuses_candidate_mutation_after_pointer_swap(
     assert store.load(str(generation_payload["generation_id"])).state == "promoting"
 
 
+@pytest.mark.parametrize(
+    ("field", "value", "error"),
+    (
+        ("archive_root", "foreign-archive", "generation archive root"),
+        ("source_snapshot", "foreign-source-snapshot", "generation source snapshot"),
+    ),
+)
+def test_prepared_activation_refuses_generation_metadata_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _patch_v37: None,
+    field: str,
+    value: str,
+    error: str,
+) -> None:
+    root = _archive(tmp_path)
+    monkeypatch.setattr(forward, "running_daemon_pid", lambda _config: None)
+    receipt_path = tmp_path / "transition.json"
+    forward.prepare_forward(archive_root=root, receipt_path=receipt_path)
+    receipt = cast(dict[str, object], json.loads(receipt_path.read_text(encoding="utf-8")))
+    generation_payload = cast(dict[str, object], receipt["generation"])
+    generation_path = Path(str(generation_payload["index_path"])).with_name("generation.json")
+    metadata = cast(dict[str, object], json.loads(generation_path.read_text(encoding="utf-8")))
+    metadata[field] = value
+    generation_path.write_text(json.dumps(metadata), encoding="utf-8")
+
+    with pytest.raises(forward.IndexFastForwardError, match=error):
+        forward.activate_forward(receipt_path=receipt_path)
+
+    store = IndexGenerationStore.for_archive_root(root)
+    assert store.active_pointer.resolve().parent.name == "v36"
+    assert json.loads(receipt_path.read_text(encoding="utf-8"))["status"] == "prepared"
+    assert store.load(str(generation_payload["generation_id"])).state == "inactive"
+
+
 def test_recovery_completes_only_after_current_strict_acceptance(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _patch_v37: None
 ) -> None:
@@ -294,6 +329,41 @@ def test_recovery_completes_only_after_current_strict_acceptance(
     receipt = cast(dict[str, object], json.loads(receipt_path.read_text(encoding="utf-8")))
     generation_payload = cast(dict[str, object], receipt["generation"])
     assert receipt["status"] == "activating"
+    assert store.load(str(generation_payload["generation_id"])).state == "promoting"
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "error"),
+    (
+        ("archive_root", "foreign-archive", "generation archive root"),
+        ("source_snapshot", "foreign-source-snapshot", "generation source snapshot"),
+    ),
+)
+def test_recovery_refuses_generation_metadata_mutation_after_pointer_swap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _patch_v37: None,
+    field: str,
+    value: str,
+    error: str,
+) -> None:
+    root = _archive(tmp_path)
+    monkeypatch.setattr(forward, "running_daemon_pid", lambda _config: None)
+    receipt_path = tmp_path / "transition.json"
+    forward.prepare_forward(archive_root=root, receipt_path=receipt_path)
+    receipt = _simulate_pointer_swap_crash(root, receipt_path, monkeypatch)
+    generation_payload = cast(dict[str, object], receipt["generation"])
+    generation_path = Path(str(generation_payload["index_path"])).with_name("generation.json")
+    metadata = cast(dict[str, object], json.loads(generation_path.read_text(encoding="utf-8")))
+    metadata[field] = value
+    generation_path.write_text(json.dumps(metadata), encoding="utf-8")
+
+    with pytest.raises(forward.IndexFastForwardError, match=error):
+        forward.activate_forward(receipt_path=receipt_path)
+
+    store = IndexGenerationStore.for_archive_root(root)
+    assert store.active_pointer.resolve(strict=True) == Path(str(generation_payload["index_path"])).resolve(strict=True)
+    assert json.loads(receipt_path.read_text(encoding="utf-8"))["status"] == "activating"
     assert store.load(str(generation_payload["generation_id"])).state == "promoting"
 
 

--- a/tests/unit/devtools/test_index_fast_forward.py
+++ b/tests/unit/devtools/test_index_fast_forward.py
@@ -11,7 +11,6 @@ import devtools.index_fast_forward as forward
 from polylogue.core.enums import Provider
 from polylogue.core.outcomes import OutcomeStatus
 from polylogue.maintenance.archive_verification import (
-    REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS,
     ArchiveVerificationCheck,
     ArchiveVerificationReport,
 )
@@ -101,8 +100,7 @@ def _no_corpus_failure(monkeypatch: pytest.MonkeyPatch) -> None:
         "verify_archive",
         lambda *args, **kwargs: ArchiveVerificationReport(
             checks=[
-                ArchiveVerificationCheck(name=name, status=OutcomeStatus.OK)
-                for name in REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS
+                ArchiveVerificationCheck(name=name, status=OutcomeStatus.OK) for name in tuple(kwargs.get("checks", ()))
             ]
         ),
     )
@@ -222,6 +220,47 @@ def test_activation_refuses_waived_embedding_orphan_at_strict_candidate_gate(
         conn.commit()
 
     with pytest.raises(forward.IndexFastForwardError, match=r"embeddings-refs-liveness.*waived by polylogue-feu0"):
+        forward.activate_forward(receipt_path=receipt_path)
+
+    assert IndexGenerationStore.for_archive_root(root).active_pointer.resolve().parent.name == "v36"
+
+
+@pytest.mark.parametrize(
+    ("status", "check_name"),
+    (
+        (OutcomeStatus.WARNING, "fts-parity"),
+        (OutcomeStatus.SKIP, "session-lineage-acyclic"),
+        (None, "message-count-projection"),
+    ),
+)
+def test_activation_rejects_non_ok_or_missing_index_acceptance_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _patch_v37: None,
+    status: OutcomeStatus | None,
+    check_name: str,
+) -> None:
+    """Activation must consume the complete strict profile on its real route."""
+    root = _archive(tmp_path)
+    monkeypatch.setattr(forward, "running_daemon_pid", lambda _config: None)
+    receipt_path = tmp_path / "transition.json"
+    forward.prepare_forward(archive_root=root, receipt_path=receipt_path)
+
+    def mutated_verifier(*args: object, **kwargs: object) -> ArchiveVerificationReport:
+        checks = cast(tuple[str, ...], kwargs["checks"])
+        return ArchiveVerificationReport(
+            checks=[
+                ArchiveVerificationCheck(
+                    name=name,
+                    status=(status if name == check_name and status is not None else OutcomeStatus.OK),
+                )
+                for name in checks
+                if name != check_name or status is not None
+            ]
+        )
+
+    monkeypatch.setattr(forward, "verify_archive", mutated_verifier)
+    with pytest.raises(forward.IndexFastForwardError, match=check_name):
         forward.activate_forward(receipt_path=receipt_path)
 
     assert IndexGenerationStore.for_archive_root(root).active_pointer.resolve().parent.name == "v36"

--- a/tests/unit/devtools/test_index_fast_forward.py
+++ b/tests/unit/devtools/test_index_fast_forward.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
 
@@ -10,17 +9,17 @@ import pytest
 
 import devtools.index_fast_forward as forward
 from polylogue.core.enums import Provider
+from polylogue.core.outcomes import OutcomeStatus
+from polylogue.maintenance.archive_verification import (
+    REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS,
+    ArchiveVerificationCheck,
+    ArchiveVerificationReport,
+)
 from polylogue.sources.dispatch import parse_payload
 from polylogue.storage.index_generation import IndexGenerationStore
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
-
-
-@dataclass(frozen=True)
-class _Report:
-    blocking: bool = False
-    checks: tuple[object, ...] = ()
 
 
 def _archive(tmp_path: Path, *, extra_native_ids: tuple[str, ...] = ()) -> Path:
@@ -97,7 +96,16 @@ def _patch_v37(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def _no_corpus_failure(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(forward, "verify_archive", lambda *args, **kwargs: _Report())
+    monkeypatch.setattr(
+        forward,
+        "verify_archive",
+        lambda *args, **kwargs: ArchiveVerificationReport(
+            checks=[
+                ArchiveVerificationCheck(name=name, status=OutcomeStatus.OK)
+                for name in REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS
+            ]
+        ),
+    )
 
 
 def _write_raw_backed_session(root: Path, native_id: str) -> None:
@@ -188,8 +196,32 @@ def test_activation_refuses_source_metadata_mutation_after_candidate_gate(
         with sqlite3.connect(root / "source.db") as conn:
             conn.execute("UPDATE raw_sessions SET source_path = 'mutated-after-proof'")
 
-    monkeypatch.setattr(forward, "_require_candidate_corpus_fidelity", mutate_source)
+    monkeypatch.setattr(forward, "_require_candidate_strict_acceptance", mutate_source)
     with pytest.raises(forward.IndexFastForwardError, match="immediately before promotion"):
+        forward.activate_forward(receipt_path=receipt_path)
+
+    assert IndexGenerationStore.for_archive_root(root).active_pointer.resolve().parent.name == "v36"
+
+
+def test_activation_refuses_waived_embedding_orphan_at_strict_candidate_gate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _patch_v37: None
+) -> None:
+    root = _archive(tmp_path)
+    monkeypatch.setattr(forward, "running_daemon_pid", lambda _config: None)
+    receipt_path = tmp_path / "transition.json"
+    forward.prepare_forward(archive_root=root, receipt_path=receipt_path)
+
+    with sqlite3.connect(root / "embeddings.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO message_embedding_refs(message_id, session_id, origin, embedding_input_hash)
+            VALUES ('codex-session:source-backed-session:no-such-message', 'codex-session:source-backed-session', 'codex-session', ?)
+            """,
+            (b"o" * 32,),
+        )
+        conn.commit()
+
+    with pytest.raises(forward.IndexFastForwardError, match=r"embeddings-refs-liveness.*waived by polylogue-feu0"):
         forward.activate_forward(receipt_path=receipt_path)
 
     assert IndexGenerationStore.for_archive_root(root).active_pointer.resolve().parent.name == "v36"

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -185,6 +185,24 @@ def test_raw_failure_lifecycle_mutation_red_twin_for_validation_failures(tmp_pat
     assert check.evidence["unexplained"] == 1
 
 
+def test_cross_tier_reindex_profile_includes_raw_failure_lifecycle(tmp_path: Path) -> None:
+    """Candidate acceptance cannot bypass the source failure lifecycle gate."""
+    _seed_coherent_archive(tmp_path)
+    candidate = tmp_path / "candidate-index.db"
+    shutil.copy2(tmp_path / "index.db", candidate)
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        conn.execute("UPDATE raw_sessions SET parse_error = 'parser failed' WHERE raw_id = 'raw-1'")
+        conn.commit()
+
+    report = verify_archive(
+        tmp_path,
+        checks=REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS,
+        index_path_override=candidate,
+    )
+
+    assert _check(report, "raw-failure-lifecycle").status is OutcomeStatus.ERROR
+
+
 def test_missing_tier_trips_tier_schema_check(tmp_path: Path) -> None:
     _seed_coherent_archive(tmp_path)
     (tmp_path / "embeddings.db").unlink()

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -21,11 +21,13 @@ from polylogue.maintenance.archive_verification import (
     ARCHIVE_VERIFICATION_CHECKS,
     ARCHIVE_VERIFICATION_WAIVERS,
     REINDEX_ACCEPTANCE_CHECKS,
+    REINDEX_CANARY_ACCEPTANCE_CHECKS,
     REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS,
     ArchiveVerificationCheck,
     ArchiveVerificationCheckClass,
     ArchiveVerificationReport,
     ArchiveVerificationWaiver,
+    passes_strict_acceptance,
     verify_archive,
 )
 from polylogue.sources.origin_specs import lowering_fingerprint, parser_fingerprint_for_origin
@@ -1408,12 +1410,58 @@ def test_real_waiver_table_also_waives_embeddings_refs_liveness(tmp_path: Path) 
     assert not report.blocking  # waived by the real table too -- consistent with the mechanism test above
 
 
+def test_strict_acceptance_rejects_warning_skip_and_waived_error() -> None:
+    report = ArchiveVerificationReport(
+        checks=[
+            ArchiveVerificationCheck(name="warning", status=OutcomeStatus.WARNING),
+            ArchiveVerificationCheck(name="skip", status=OutcomeStatus.SKIP),
+            ArchiveVerificationCheck(
+                name="waived-error",
+                status=OutcomeStatus.ERROR,
+                waived_bead_id="polylogue-feu0",
+            ),
+        ]
+    )
+
+    assert not report.blocking
+    assert not passes_strict_acceptance(report)
+
+
+def test_strict_acceptance_requires_every_named_check() -> None:
+    report = ArchiveVerificationReport(checks=[ArchiveVerificationCheck(name="present", status=OutcomeStatus.OK)])
+
+    assert not passes_strict_acceptance(report, required_checks=("present", "missing"))
+
+
 def test_reindex_acceptance_checks_are_all_registered_and_ground_truth_eligible() -> None:
     """Every name in :data:`REINDEX_ACCEPTANCE_CHECKS` must be a real
     registry check, and running it against an index-only root (mirroring a
     real generation directory, which has no source.db/user.db/embeddings.db)
     must never report ``error`` from a missing-tier false positive."""
     assert set(REINDEX_ACCEPTANCE_CHECKS) <= set(ARCHIVE_VERIFICATION_CHECK_NAMES)
+
+
+def test_full_rebuild_candidate_profile_covers_cross_tier_acceptance_and_canary_stays_partial() -> None:
+    expected = {
+        "source-index-coverage",
+        "fts-parity",
+        "lineage-sanity",
+        "session-lineage-acyclic",
+        "blob-refs-liveness",
+        "embeddings-refs-liveness",
+        "user-tier-refs",
+        "session-fingerprint-stamps",
+        "message-count-projection",
+        "excluded-cursor-vocabulary-honesty",
+        "stalled-append-cursor-freshness",
+        "corpus-absences",
+        "corpus-attachment-fidelity",
+        "corpus-revision-fidelity",
+        "pathology-zoo-invariants",
+    }
+
+    assert expected <= set(REINDEX_ACCEPTANCE_CHECKS) | set(REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS)
+    assert REINDEX_CANARY_ACCEPTANCE_CHECKS == ("pathology-zoo-invariants",)
 
 
 def test_reindex_acceptance_subset_is_satisfiable_from_index_only_root(tmp_path: Path) -> None:

--- a/tests/unit/maintenance/test_rebuild_index_candidate_promotion.py
+++ b/tests/unit/maintenance/test_rebuild_index_candidate_promotion.py
@@ -87,3 +87,60 @@ def test_stamp_corruption_blocks_real_candidate_promotion_without_touching_activ
     assert corruption_calls > 0
     assert store.active_pointer.resolve(strict=True) == active_before
     assert _active_snapshot(root) == snapshot_before
+
+
+def test_waived_embedding_orphan_blocks_full_rebuild_candidate_promotion(
+    tmp_path: Path,
+) -> None:
+    """The full rebuild route must not treat the feu0 waiver as acceptance."""
+    root = tmp_path / "archive"
+    initialize_active_archive_root(root)
+    _seed_raw(root, "active-session", "active generation remains exact")
+
+    initial = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+    assert initial.status == "replayed"
+
+    store = IndexGenerationStore.for_archive_root(root)
+    active_before = store.active_pointer.resolve(strict=True)
+    with sqlite3.connect(root / "embeddings.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO message_embedding_refs(message_id, session_id, origin, embedding_input_hash)
+            VALUES ('codex-session:active-session:no-such-message', 'codex-session:active-session', 'codex-session', ?)
+            """,
+            (b"o" * 32,),
+        )
+        conn.commit()
+    _seed_raw(root, "candidate-session", "candidate must never become active")
+
+    with pytest.raises(RuntimeError, match=r"embeddings-refs-liveness.*waived by polylogue-feu0"):
+        rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+
+    assert store.active_pointer.resolve(strict=True) == active_before
+
+
+def test_cross_tier_user_reference_blocks_full_rebuild_candidate_promotion(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "archive"
+    initialize_active_archive_root(root)
+    _seed_raw(root, "active-session", "active generation remains exact")
+    initial = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+    assert initial.status == "replayed"
+
+    store = IndexGenerationStore.for_archive_root(root)
+    active_before = store.active_pointer.resolve(strict=True)
+    with sqlite3.connect(root / "user.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO assertions(assertion_id, target_ref, kind, body_text, created_at_ms, updated_at_ms)
+            VALUES ('dangling-candidate-assertion', 'session:codex-session:no-such-session', 'note', 'orphaned', 1, 1)
+            """
+        )
+        conn.commit()
+    _seed_raw(root, "candidate-session", "candidate must never become active")
+
+    with pytest.raises(RuntimeError, match=r"user-tier-refs \[error\]"):
+        rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+
+    assert store.active_pointer.resolve(strict=True) == active_before

--- a/tests/unit/maintenance/test_rebuild_index_candidate_promotion.py
+++ b/tests/unit/maintenance/test_rebuild_index_candidate_promotion.py
@@ -10,8 +10,10 @@ from typing import cast
 
 import pytest
 
+import polylogue.maintenance.archive_verification as archive_verification
 import polylogue.storage.sqlite.archive_tiers.revision_governance as revision_governance
 from polylogue.core.enums import Provider
+from polylogue.core.outcomes import OutcomeStatus
 from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
 from polylogue.storage.index_generation import IndexGenerationStore
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -141,6 +143,51 @@ def test_cross_tier_user_reference_blocks_full_rebuild_candidate_promotion(
     _seed_raw(root, "candidate-session", "candidate must never become active")
 
     with pytest.raises(RuntimeError, match=r"user-tier-refs \[error\]"):
+        rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+
+    assert store.active_pointer.resolve(strict=True) == active_before
+
+
+@pytest.mark.parametrize(
+    ("status", "check_name"),
+    (
+        (OutcomeStatus.WARNING, "fts-parity"),
+        (OutcomeStatus.SKIP, "lineage-sanity"),
+        (None, "session-fingerprint-stamps"),
+    ),
+)
+def test_full_rebuild_promotion_rejects_non_ok_or_missing_required_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    status: OutcomeStatus | None,
+    check_name: str,
+) -> None:
+    """The production promotion route requires every strict result to be OK."""
+    root = tmp_path / "archive"
+    initialize_active_archive_root(root)
+    _seed_raw(root, "active-session", "active generation remains exact")
+    initial = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+    assert initial.status == "replayed"
+
+    store = IndexGenerationStore.for_archive_root(root)
+    active_before = store.active_pointer.resolve(strict=True)
+    _seed_raw(root, "candidate-session", "candidate must never become active")
+
+    def mutated_verifier(*args: object, **kwargs: object) -> archive_verification.ArchiveVerificationReport:
+        checks = cast(tuple[str, ...], kwargs["checks"])
+        return archive_verification.ArchiveVerificationReport(
+            checks=[
+                archive_verification.ArchiveVerificationCheck(
+                    name=name,
+                    status=(status if name == check_name and status is not None else OutcomeStatus.OK),
+                )
+                for name in checks
+                if name != check_name or status is not None
+            ]
+        )
+
+    monkeypatch.setattr(archive_verification, "verify_archive", mutated_verifier)
+    with pytest.raises(RuntimeError, match=f"reindex acceptance gate failed.*{check_name}"):
         rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
 
     assert store.active_pointer.resolve(strict=True) == active_before

--- a/tests/unit/maintenance/test_rebuild_index_selection.py
+++ b/tests/unit/maintenance/test_rebuild_index_selection.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import pytest
 
+from polylogue.maintenance.archive_verification import REINDEX_CANARY_ACCEPTANCE_CHECKS
 from polylogue.maintenance.rebuild_index import (
     RebuildIndexRequest,
     all_index_rebuild_raw_ids,
@@ -102,3 +103,20 @@ class TestValidateRebuildIndexRequestSharedService:
         request = RebuildIndexRequest(archive_root=tmp_path, raw_ids=("raw-1",), promote=True)
         with pytest.raises(ValueError, match="require --no-promote"):
             validate_rebuild_index_request(request)
+
+    def test_rejects_caller_supplied_acceptance_profile_for_promotion(self, tmp_path: Path) -> None:
+        request = RebuildIndexRequest(
+            archive_root=tmp_path,
+            promote=True,
+            candidate_acceptance_checks=REINDEX_CANARY_ACCEPTANCE_CHECKS,
+        )
+        with pytest.raises(ValueError, match="require --no-promote"):
+            validate_rebuild_index_request(request)
+
+    def test_allows_caller_supplied_canary_profile_without_promotion(self, tmp_path: Path) -> None:
+        request = RebuildIndexRequest(
+            archive_root=tmp_path,
+            promote=False,
+            candidate_acceptance_checks=REINDEX_CANARY_ACCEPTANCE_CHECKS,
+        )
+        validate_rebuild_index_request(request)

--- a/tests/unit/storage/test_index_generation.py
+++ b/tests/unit/storage/test_index_generation.py
@@ -232,7 +232,7 @@ def test_recover_promotion_without_active_pointer_marks_inactive(tmp_path: Path)
     assert recovered.state == "inactive"
 
 
-def test_recover_promotion_after_pointer_swap_marks_active(tmp_path: Path) -> None:
+def test_recover_promotion_after_pointer_swap_does_not_mark_active(tmp_path: Path) -> None:
     _archive(tmp_path)
     store = IndexGenerationStore.for_archive_root(tmp_path)
     generation = store.create(owner_id="operator", source_snapshot="snapshot-a")
@@ -242,7 +242,12 @@ def test_recover_promotion_after_pointer_swap_marks_active(tmp_path: Path) -> No
 
     recovered = store.recover_promotion(generation.generation_id)
 
-    assert recovered.state == "active"
+    assert recovered.state == "promoting"
+    assert store.load(generation.generation_id).state == "promoting"
+
+    completed = store.complete_promotion_recovery(generation.generation_id)
+
+    assert completed.state == "active"
 
 
 def test_archive_store_init_failure_releases_writer_lease(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Require every declared reindex acceptance check to be present and green before a candidate index can activate.

## Problem

Candidate promotion previously honored ordinary monitoring waivers and did not make the raw-failure lifecycle gate part of the fast-forward candidate profile. An archive could activate with incomplete, warning, skipped, or waived evidence.

## Solution

Separate strict acceptance from ordinary monitoring, apply it to full rebuild and fast-forward promotion, and validate receipt/generation binding during recovery. The cross-tier candidate profile now includes raw failure lifecycle evidence, so every promotion route rejects unexplained retained raw failures.

## Verification

- `devtools test tests/unit/maintenance/test_archive_verification.py -k "raw_failure_lifecycle or strict_acceptance"` passed: 5 selected.
- Earlier carried commits passed focused rebuild-promotion, fast-forward, and CLI tests plus `devtools verify --quick`; the final merge boundary will record a fresh broad gate.

Ref polylogue-60gzo

Ref polylogue-93xe

Ref polylogue-feu0