### PR TITLE
fix(schema): attest authoritative inference receipts

### DIFF
--- a/devtools/schema_commit.py
+++ b/devtools/schema_commit.py
@@ -18,7 +18,10 @@ from pathlib import Path
 
 from polylogue.cli.shared.schema_command_support import build_schema_privacy_config
 from polylogue.config import get_config
-from polylogue.maintenance.schema_inference_gate import authorize_schema_generation
+from polylogue.maintenance.schema_inference_gate import (
+    authorize_schema_generation,
+    resolve_schema_inference_archive_root,
+)
 from polylogue.schemas.operator.commit import commit_provider_schema
 from polylogue.schemas.operator.models import SchemaCommitRequest
 
@@ -103,7 +106,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.dry_run:
         result = commit_provider_schema(request)
     else:
-        archive_root = getattr(config, "archive_root", None) or config.db_path.parent
+        archive_root = resolve_schema_inference_archive_root(config, fallback_db_path=config.db_path)
         with authorize_schema_generation(archive_root, args.schema_inference_receipt):
             result = commit_provider_schema(request)
 

--- a/devtools/schema_commit.py
+++ b/devtools/schema_commit.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 from polylogue.cli.shared.schema_command_support import build_schema_privacy_config
 from polylogue.config import get_config
+from polylogue.maintenance.schema_inference_gate import authorize_schema_generation
 from polylogue.schemas.operator.commit import commit_provider_schema
 from polylogue.schemas.operator.models import SchemaCommitRequest
 
@@ -64,6 +65,11 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Preview what a commit would change without writing to --output-dir.",
     )
     parser.add_argument("--json", action="store_true", help="Output as JSON.")
+    parser.add_argument(
+        "--schema-inference-receipt",
+        type=Path,
+        help="Fresh authoritative PASS receipt from devtools verify schema-inference-gate.",
+    )
     return parser
 
 
@@ -81,17 +87,25 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     output_dir = args.output_dir if args.output_dir is not None else DEFAULT_OUTPUT_DIR
 
-    result = commit_provider_schema(
-        SchemaCommitRequest(
-            provider=str(args.provider),
-            output_dir=output_dir,
-            db_path=get_config().db_path,
-            max_samples=args.max_samples,
-            privacy_config=privacy_config,
-            full_corpus=bool(args.full_corpus),
-            dry_run=bool(args.dry_run),
-        )
+    config = get_config()
+    if not args.dry_run and args.schema_inference_receipt is None:
+        print("schema-commit: --schema-inference-receipt is required when persisting schema packages", file=sys.stderr)
+        return 1
+    request = SchemaCommitRequest(
+        provider=str(args.provider),
+        output_dir=output_dir,
+        db_path=config.db_path,
+        max_samples=args.max_samples,
+        privacy_config=privacy_config,
+        full_corpus=bool(args.full_corpus),
+        dry_run=bool(args.dry_run),
     )
+    if args.dry_run:
+        result = commit_provider_schema(request)
+    else:
+        archive_root = getattr(config, "archive_root", None) or config.db_path.parent
+        with authorize_schema_generation(archive_root, args.schema_inference_receipt):
+            result = commit_provider_schema(request)
 
     if not result.success:
         error = result.generation.error or "Schema generation failed"

--- a/devtools/schema_generate.py
+++ b/devtools/schema_generate.py
@@ -19,6 +19,7 @@ from polylogue.cli.shared.schema_command_support import build_schema_privacy_con
 from polylogue.cli.shared.schema_rendering import render_schema_generate_result
 from polylogue.config import get_config
 from polylogue.core.json import JSONDocument
+from polylogue.maintenance.schema_inference_gate import authorize_schema_generation
 from polylogue.schemas.operator.models import SchemaInferRequest
 from polylogue.schemas.operator.workflow import infer_schema
 from polylogue.storage.sqlite.connection_profile import open_readonly_connection
@@ -89,6 +90,12 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--receipt", type=Path, default=None, help="Write an aggregate-only generation receipt as JSON."
     )
+    parser.add_argument(
+        "--schema-inference-receipt",
+        type=Path,
+        required=True,
+        help="Fresh authoritative PASS receipt from devtools verify schema-inference-gate.",
+    )
     return parser
 
 
@@ -104,21 +111,24 @@ def main(argv: list[str] | None = None) -> int:
             print(f"schema-generate: {json.dumps(event, sort_keys=True)}", file=sys.stderr, flush=True)
 
     try:
+        config = get_config()
         privacy_config = build_schema_privacy_config(
             privacy=args.privacy,
             privacy_config_path=args.privacy_config,
         )
-        result = infer_schema(
-            SchemaInferRequest(
-                provider=str(args.provider),
-                db_path=get_config().db_path,
-                max_samples=args.max_samples,
-                privacy_config=privacy_config,
-                cluster=bool(args.cluster),
-                full_corpus=bool(args.full_corpus),
-                progress_callback=on_progress if args.progress or args.receipt is not None else None,
+        archive_root = getattr(config, "archive_root", None) or config.db_path.parent
+        with authorize_schema_generation(archive_root, args.schema_inference_receipt):
+            result = infer_schema(
+                SchemaInferRequest(
+                    provider=str(args.provider),
+                    db_path=config.db_path,
+                    max_samples=args.max_samples,
+                    privacy_config=privacy_config,
+                    cluster=bool(args.cluster),
+                    full_corpus=bool(args.full_corpus),
+                    progress_callback=on_progress if args.progress or args.receipt is not None else None,
+                )
             )
-        )
     except ValueError as exc:
         print(f"schema-generate: {exc}", file=sys.stderr)
         return 1

--- a/devtools/schema_generate.py
+++ b/devtools/schema_generate.py
@@ -19,7 +19,10 @@ from polylogue.cli.shared.schema_command_support import build_schema_privacy_con
 from polylogue.cli.shared.schema_rendering import render_schema_generate_result
 from polylogue.config import get_config
 from polylogue.core.json import JSONDocument
-from polylogue.maintenance.schema_inference_gate import authorize_schema_generation
+from polylogue.maintenance.schema_inference_gate import (
+    authorize_schema_generation,
+    resolve_schema_inference_archive_root,
+)
 from polylogue.schemas.operator.models import SchemaInferRequest
 from polylogue.schemas.operator.workflow import infer_schema
 from polylogue.storage.sqlite.connection_profile import open_readonly_connection
@@ -116,7 +119,7 @@ def main(argv: list[str] | None = None) -> int:
             privacy=args.privacy,
             privacy_config_path=args.privacy_config,
         )
-        archive_root = getattr(config, "archive_root", None) or config.db_path.parent
+        archive_root = resolve_schema_inference_archive_root(config, fallback_db_path=config.db_path)
         with authorize_schema_generation(archive_root, args.schema_inference_receipt):
             result = infer_schema(
                 SchemaInferRequest(

--- a/polylogue/maintenance/schema_inference_gate.py
+++ b/polylogue/maintenance/schema_inference_gate.py
@@ -11,29 +11,36 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import platform
 import sqlite3
 import sys
 from collections import Counter
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Iterable, Iterator, Mapping, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Literal, NotRequired, TypeAlias, TypedDict, cast
+from uuid import uuid4
 
 from polylogue.maintenance.archive_verification import CORPUS_FIDELITY_CHECKS, verify_archive
+from polylogue.maintenance.offline_guard import running_daemon_pid
 from polylogue.storage.archive_identity import ArchiveIdentity, ArchiveLocation
 from polylogue.storage.blob_store import BlobStore
+from polylogue.storage.index_generation import RebuildLease, RebuildLeaseUnavailableError
 from polylogue.storage.introspection import table_exists
 from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 from polylogue.version import POLYLOGUE_VERSION
 
-RECEIPT_SCHEMA = "polylogue.schema-inference-gate.v1"
-GATE_VERSION = "2"
+RECEIPT_SCHEMA = "polylogue.schema-inference-gate.v2"
+GATE_VERSION = "3"
 DEFAULT_SAMPLE_LIMIT = 10
 RECEIPT_FILENAME = "schema-inference-gate-receipt.json"
+RECEIPT_TTL = timedelta(hours=24)
+RECEIPT_CLOCK_SKEW = timedelta(minutes=5)
 
 _ALLOWED_RESIDUAL_EXPLANATIONS = frozenset(
     {"materialized", "superseded-duplicate", "legitimately-excluded-non-conversation"}
@@ -474,26 +481,98 @@ def _failed_source_gates(reason: str) -> dict[str, object]:
     }
 
 
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(8 * 1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _sqlite_schema_digest(conn: sqlite3.Connection) -> str:
+    rows = conn.execute(
+        "SELECT type, name, tbl_name, sql FROM sqlite_master "
+        "WHERE sql IS NOT NULL AND name != 'sqlite_stat1' ORDER BY type, name, tbl_name"
+    ).fetchall()
+    encoded = json.dumps(
+        [[str(value) if value is not None else None for value in row] for row in rows],
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _canonical_schema_digest(tier: ArchiveTier) -> str | None:
+    """Return the schema identity of a fresh canonical tier, when loadable."""
+
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+    from polylogue.storage.sqlite.sqlite_vec_extension import try_load_sqlite_vec
+
+    conn = sqlite3.connect(":memory:")
+    try:
+        if tier is ArchiveTier.EMBEDDINGS:
+            loaded, _error = try_load_sqlite_vec(conn)
+            if not loaded:
+                return None
+        initialize_archive_tier(conn, tier)
+        return _sqlite_schema_digest(conn)
+    except sqlite3.Error:
+        return None
+    finally:
+        conn.close()
+
+
 def _tier_schema_identity(archive_root: Path, location: ArchiveLocation) -> dict[str, object]:
     tiers: dict[str, object] = {}
     for tier, spec in ARCHIVE_TIER_SPECS.items():
-        path = location.active_index_path if tier is ArchiveTier.INDEX else archive_root / spec.filename
+        identity = (
+            location.active_index if tier is ArchiveTier.INDEX else location.configured_tier(cast(Any, tier.value))
+        )
+        path = identity.resolved_path
+        expected_schema_sha256 = _canonical_schema_digest(tier)
         entry: dict[str, object] = {
             "path": str(path),
+            "stable_id": identity.stable_id,
             "expected_user_version": spec.version,
             "durability": spec.durability,
             "exists": path.exists(),
             "actual_user_version": None,
+            "content_sha256": None,
+            "schema_sha256": None,
+            "expected_schema_sha256": expected_schema_sha256,
         }
         if path.exists():
             try:
                 with open_readonly_connection(path) as conn:
                     entry["actual_user_version"] = int(conn.execute("PRAGMA user_version").fetchone()[0])
+                    entry["schema_sha256"] = _sqlite_schema_digest(conn)
             except sqlite3.Error as exc:
                 entry["error"] = str(exc)
+            try:
+                entry["content_sha256"] = _file_sha256(path)
+            except OSError as exc:
+                entry["error"] = str(exc)
         entry["matches_expected"] = entry["actual_user_version"] == spec.version
+        if expected_schema_sha256 is not None:
+            entry["matches_expected"] = bool(entry["matches_expected"]) and (
+                entry["schema_sha256"] == expected_schema_sha256
+            )
         tiers[tier.value] = entry
-    return {"archive": ArchiveIdentity.resolve_location(location).as_dict(), "tiers": tiers}
+    archive_identity = ArchiveIdentity.resolve_location(location)
+    runtime_archive_payload = archive_identity.as_dict()
+    archive_payload = {
+        key: runtime_archive_payload[key]
+        for key in (
+            "configured_root",
+            "durable_id",
+            "active_generation",
+            "generation_owner",
+            "generation_state",
+            "tiers",
+        )
+    }
+    archive_payload["authority_identity_digest"] = archive_identity.authority_identity_digest
+    return {"archive": archive_payload, "tiers": tiers}
 
 
 def _resolve_receipt_path(receipt_path: Path, *, archive_root: Path) -> Path:
@@ -1018,26 +1097,148 @@ def _int_or_zero(value: object) -> int:
     return value if isinstance(value, int) and not isinstance(value, bool) else 0
 
 
+def schema_inference_gate_receipt_digest(payload: Mapping[str, object]) -> str:
+    """Digest every receipt field except the self-authenticating digest."""
+
+    body = {key: value for key, value in payload.items() if key != "receipt_sha256"}
+    encoded = json.dumps(body, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
 def _write_json(path: Path, payload: dict[str, object]) -> None:
+    payload["receipt_sha256"] = schema_inference_gate_receipt_digest(payload)
     path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_name(f".{path.name}.tmp")
-    temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    temporary.replace(path)
+    encoded = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    try:
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError as exc:
+        raise SchemaInferenceGateError(f"immutable schema-inference gate receipt already exists: {path}") from exc
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            descriptor = -1
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+    finally:
+        if descriptor != -1:
+            os.close(descriptor)
+    directory = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        os.fsync(directory)
+    finally:
+        os.close(directory)
 
 
-def run_schema_inference_gate(
+def _archive_config(root: Path) -> Any:
+    from polylogue.config import Config
+
+    return Config(archive_root=root, render_root=root / "render", sources=[])
+
+
+@contextmanager
+def schema_inference_quiescence(archive_root: Path) -> Iterator[None]:
+    """Hold the archive-wide offline lease for the complete evidence window."""
+
+    root = Path(archive_root).absolute()
+    daemon_pid = running_daemon_pid(_archive_config(root))
+    if daemon_pid is not None:
+        raise SchemaInferenceGateError(
+            f"schema-inference gate requires a quiesced archive; polylogued PID {daemon_pid} is running"
+        )
+    try:
+        with RebuildLease(root):
+            yield
+    except RebuildLeaseUnavailableError as exc:
+        raise SchemaInferenceGateError(
+            f"schema-inference gate requires exclusive offline archive ownership: {exc}"
+        ) from exc
+
+
+def _parse_receipt_time(value: object) -> datetime:
+    if not isinstance(value, str):
+        raise SchemaInferenceGateError("schema-inference gate receipt generated_at is missing")
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise SchemaInferenceGateError("schema-inference gate receipt generated_at is invalid") from exc
+    if parsed.tzinfo is None:
+        raise SchemaInferenceGateError("schema-inference gate receipt generated_at must include a timezone")
+    return parsed.astimezone(UTC)
+
+
+def validate_schema_inference_gate_receipt(
+    receipt_path: Path,
+    *,
+    archive_root: Path,
+    now: datetime | None = None,
+) -> dict[str, object]:
+    """Validate a fresh, immutable PASS receipt against the live archive."""
+
+    root = Path(archive_root).absolute()
+    safe_path = _resolve_receipt_path(Path(receipt_path), archive_root=root)
+    try:
+        raw = safe_path.read_bytes()
+        loaded = json.loads(raw.decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SchemaInferenceGateError(f"unable to read schema-inference gate receipt: {exc}") from exc
+    if not isinstance(loaded, dict):
+        raise SchemaInferenceGateError("schema-inference gate receipt must be a JSON object")
+    payload = cast(dict[str, object], loaded)
+    if payload.get("schema") != RECEIPT_SCHEMA or payload.get("gate_version") != GATE_VERSION:
+        raise SchemaInferenceGateError("schema-inference gate receipt schema version is unsupported")
+    if payload.get("verdict") != "PASS":
+        raise SchemaInferenceGateError("schema-inference gate receipt is not a PASS")
+    if payload.get("receipt_sha256") != schema_inference_gate_receipt_digest(payload):
+        raise SchemaInferenceGateError("schema-inference gate receipt content digest mismatch")
+    generated_at = _parse_receipt_time(payload.get("generated_at"))
+    current_time = (now or datetime.now(UTC)).astimezone(UTC)
+    age = current_time - generated_at
+    if age < -RECEIPT_CLOCK_SKEW or age > RECEIPT_TTL:
+        raise SchemaInferenceGateError("schema-inference gate receipt is stale or from the future")
+    location = ArchiveLocation.resolve(root)
+    if payload.get("archive_root") != str(root):
+        raise SchemaInferenceGateError("schema-inference gate receipt targets a different archive")
+    live_identity = _tier_schema_identity(root, location)
+    if payload.get("schema_identity") != live_identity:
+        raise SchemaInferenceGateError("schema-inference gate receipt archive or tier identity is stale")
+    archive_payload = _as_dict(live_identity.get("archive"))
+    if payload.get("archive_identity_digest") != archive_payload.get("authority_identity_digest"):
+        raise SchemaInferenceGateError("schema-inference gate receipt archive identity is stale")
+    if payload.get("source_schema_identity") != _as_dict(_as_dict(live_identity.get("tiers")).get("source")):
+        raise SchemaInferenceGateError("schema-inference gate receipt source schema identity is stale")
+    if not all(bool(_as_dict(value).get("matches_expected")) for value in _as_dict(live_identity["tiers"]).values()):
+        raise SchemaInferenceGateError("live archive has a stale durable or derived tier schema identity")
+    input_paths = _as_dict(payload.get("input_paths"))
+    if input_paths.get("receipt") != str(safe_path):
+        raise SchemaInferenceGateError("schema-inference gate receipt is bound to a different receipt path")
+    reasons = payload.get("pass_fail_reasons")
+    if not isinstance(reasons, list) or reasons:
+        raise SchemaInferenceGateError("schema-inference gate receipt contains failure reasons")
+    return payload
+
+
+@contextmanager
+def authorize_schema_generation(archive_root: Path, receipt_path: Path) -> Iterator[dict[str, object]]:
+    """Hold quiescence while authorizing one schema-generation scan."""
+
+    with schema_inference_quiescence(archive_root):
+        yield validate_schema_inference_gate_receipt(receipt_path, archive_root=archive_root)
+
+
+def _run_schema_inference_gate_locked(
     archive_root: Path,
     *,
     receipt_path: Path,
     ground_truth_roots: Mapping[str, Sequence[Path]] | None = None,
     sample_limit: int = DEFAULT_SAMPLE_LIMIT,
 ) -> SchemaInferenceGateResult:
-    """Run and persist the schema-inference prerequisite receipt."""
+    """Run and persist the schema-inference prerequisite while already locked."""
 
     if sample_limit <= 0:
         raise SchemaInferenceGateError("sample_limit must be positive")
     root = Path(archive_root).absolute()
     safe_receipt_path = _resolve_receipt_path(Path(receipt_path), archive_root=root)
+    location: ArchiveLocation | None = None
     try:
         location = ArchiveLocation.resolve(root)
         index_path = location.active_index_path
@@ -1104,14 +1305,26 @@ def run_schema_inference_gate(
         if isinstance(ground_truth_reasons, list):
             reasons.extend(str(reason) for reason in ground_truth_reasons)
 
+    final_schema_identity = _tier_schema_identity(root, location) if location is not None else schema_identity
+    tier_entries = _as_dict(final_schema_identity.get("tiers"))
+    schema_identity_ok = len(tier_entries) == len(ARCHIVE_TIER_SPECS) and all(
+        bool(_as_dict(value).get("matches_expected")) for value in tier_entries.values()
+    )
+    if not schema_identity_ok:
+        for tier_name, entry in tier_entries.items():
+            if not bool(_as_dict(entry).get("matches_expected")):
+                reasons.append(f"{tier_name}.db schema identity is stale or does not match the packaged schema")
+    archive_payload = _as_dict(final_schema_identity.get("archive"))
     payload: dict[str, object] = {
         "schema": RECEIPT_SCHEMA,
         "gate_version": GATE_VERSION,
         "generated_at": datetime.now(UTC).isoformat(),
-        "verdict": "PASS" if not reasons and passed_hard_gates else "FAIL",
+        "receipt_nonce": uuid4().hex,
+        "verdict": "PASS" if not reasons and passed_hard_gates and schema_identity_ok else "FAIL",
         "archive_root": str(root),
-        "schema_identity": schema_identity,
-        "source_schema_identity": source_entry,
+        "archive_identity_digest": archive_payload.get("authority_identity_digest"),
+        "schema_identity": final_schema_identity,
+        "source_schema_identity": _as_dict(tier_entries.get("source")),
         "query_results": gate_results,
         "source_denominators": source_gates.get("source_counts", {}),
         "blob_denominators": blob_denominators,
@@ -1126,6 +1339,7 @@ def run_schema_inference_gate(
             "active_index_db": str(index_path),
             "receipt": str(safe_receipt_path),
         },
+        "quiescence": {"lease": "index-rebuild-exclusive", "daemon_pid": None},
         "tool_versions": {
             "polylogue": POLYLOGUE_VERSION,
             "gate": GATE_VERSION,
@@ -1139,6 +1353,24 @@ def run_schema_inference_gate(
     return SchemaInferenceGateResult(payload)
 
 
+def run_schema_inference_gate(
+    archive_root: Path,
+    *,
+    receipt_path: Path,
+    ground_truth_roots: Mapping[str, Sequence[Path]] | None = None,
+    sample_limit: int = DEFAULT_SAMPLE_LIMIT,
+) -> SchemaInferenceGateResult:
+    """Run the prerequisite under exclusive offline ownership."""
+
+    with schema_inference_quiescence(Path(archive_root).absolute()):
+        return _run_schema_inference_gate_locked(
+            archive_root,
+            receipt_path=receipt_path,
+            ground_truth_roots=ground_truth_roots,
+            sample_limit=sample_limit,
+        )
+
+
 __all__ = [
     "DEFAULT_SAMPLE_LIMIT",
     "GROUND_TRUTH_INPUTS",
@@ -1146,5 +1378,9 @@ __all__ = [
     "RECEIPT_SCHEMA",
     "SchemaInferenceGateError",
     "SchemaInferenceGateResult",
+    "authorize_schema_generation",
+    "schema_inference_gate_receipt_digest",
+    "schema_inference_quiescence",
+    "validate_schema_inference_gate_receipt",
     "run_schema_inference_gate",
 ]

--- a/polylogue/maintenance/schema_inference_gate.py
+++ b/polylogue/maintenance/schema_inference_gate.py
@@ -27,6 +27,11 @@ from uuid import uuid4
 from polylogue.maintenance.archive_verification import CORPUS_FIDELITY_CHECKS, verify_archive
 from polylogue.maintenance.offline_guard import running_daemon_pid
 from polylogue.storage.archive_identity import ArchiveIdentity, ArchiveLocation
+from polylogue.storage.backup_attestation import (
+    BackupAttestationError,
+    sign_verification_receipt,
+    verify_verification_receipt,
+)
 from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.index_generation import RebuildLease, RebuildLeaseUnavailableError
 from polylogue.storage.introspection import table_exists
@@ -700,6 +705,22 @@ def _external_inventory(roots: Sequence[Path]) -> list[_ExternalGroundTruthFile]
     return inventory
 
 
+def _validate_external_ground_truth_roots(archive_root: Path, roots: Sequence[Path]) -> None:
+    """Reject archive-owned bytes from posing as independent source evidence."""
+
+    protected = (archive_root.resolve(), (archive_root / "blob").resolve())
+    for root in roots:
+        candidate = root.resolve()
+        for owned in protected:
+            try:
+                candidate.relative_to(owned)
+            except ValueError:
+                continue
+            raise SchemaInferenceGateError(
+                f"ground-truth root must be external to the archive and blob namespace: {candidate}"
+            )
+
+
 def _external_receipt(
     item: _ExternalGroundTruthFile,
     disposition: ExternalDisposition,
@@ -822,6 +843,16 @@ def _ground_truth_evidence(
                 evidence[origin] = {"exempt": True, "reason": declared.get("reason")}
                 continue
             declared_roots = tuple(Path(path).expanduser().resolve() for path in root_map.get(origin, ()))
+            try:
+                _validate_external_ground_truth_roots(archive_root, declared_roots)
+            except SchemaInferenceGateError as exc:
+                errors.append(f"ground truth for {origin} is invalid: {exc}")
+                evidence[origin] = {
+                    "exempt": False,
+                    "declared_roots": [str(path) for path in declared_roots],
+                    "passed": False,
+                }
+                continue
             unavailable = [str(path) for path in declared_roots if not path.exists()]
             if not declared_roots or unavailable:
                 errors.append(f"ground truth for {origin} is unavailable or undeclared")
@@ -1100,13 +1131,14 @@ def _int_or_zero(value: object) -> int:
 def schema_inference_gate_receipt_digest(payload: Mapping[str, object]) -> str:
     """Digest every receipt field except the self-authenticating digest."""
 
-    body = {key: value for key, value in payload.items() if key != "receipt_sha256"}
+    body = {key: value for key, value in payload.items() if key not in {"receipt_sha256", "attestations"}}
     encoded = json.dumps(body, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
 
-def _write_json(path: Path, payload: dict[str, object]) -> None:
+def _write_json(path: Path, payload: dict[str, object], *, authority_paths: Mapping[str, Path]) -> None:
     payload["receipt_sha256"] = schema_inference_gate_receipt_digest(payload)
+    payload = sign_verification_receipt(payload, authority_paths=authority_paths)
     path.parent.mkdir(parents=True, exist_ok=True)
     encoded = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
     try:
@@ -1190,6 +1222,11 @@ def validate_schema_inference_gate_receipt(
         raise SchemaInferenceGateError("schema-inference gate receipt is not a PASS")
     if payload.get("receipt_sha256") != schema_inference_gate_receipt_digest(payload):
         raise SchemaInferenceGateError("schema-inference gate receipt content digest mismatch")
+    try:
+        verify_verification_receipt(payload, tier="source", live_tier_path=root / "source.db")
+        verify_verification_receipt(payload, tier="user", live_tier_path=root / "user.db")
+    except BackupAttestationError as exc:
+        raise SchemaInferenceGateError(f"schema-inference gate receipt attestation is invalid: {exc}") from exc
     generated_at = _parse_receipt_time(payload.get("generated_at"))
     current_time = (now or datetime.now(UTC)).astimezone(UTC)
     age = current_time - generated_at
@@ -1292,6 +1329,8 @@ def _run_schema_inference_gate_locked(
     reasons = [
         str(_as_dict(result).get("reason")) for result in gate_results.values() if _as_dict(result).get("reason")
     ]
+    if not source_gates.get("source_counts"):
+        reasons.append("schema inference requires at least one reconciled source raw")
     if not source_schema_ok:
         reasons.append("source.db schema identity is missing or does not match the packaged schema")
     if not bool(fidelity.get("passed")):
@@ -1349,7 +1388,11 @@ def _run_schema_inference_gate_locked(
         },
         "pass_fail_reasons": reasons,
     }
-    _write_json(safe_receipt_path, payload)
+    _write_json(
+        safe_receipt_path,
+        payload,
+        authority_paths={"source": root / "source.db", "user": root / "user.db"},
+    )
     return SchemaInferenceGateResult(payload)
 
 

--- a/polylogue/maintenance/schema_inference_gate.py
+++ b/polylogue/maintenance/schema_inference_gate.py
@@ -1167,6 +1167,13 @@ def _archive_config(root: Path) -> Any:
     return Config(archive_root=root, render_root=root / "render", sources=[])
 
 
+def resolve_schema_inference_archive_root(config: object, *, fallback_db_path: Path) -> Path:
+    """Resolve the archive root consistently across privileged schema routes."""
+
+    configured_root = getattr(config, "archive_root", None)
+    return Path(configured_root) if configured_root is not None else fallback_db_path.parent
+
+
 @contextmanager
 def schema_inference_quiescence(archive_root: Path) -> Iterator[None]:
     """Hold the archive-wide offline lease for the complete evidence window."""
@@ -1256,7 +1263,7 @@ def validate_schema_inference_gate_receipt(
 
 @contextmanager
 def authorize_schema_generation(archive_root: Path, receipt_path: Path) -> Iterator[dict[str, object]]:
-    """Hold quiescence while authorizing one schema-generation scan."""
+    """Hold quiescence for one fresh schema operation or compatible short sequence."""
 
     with schema_inference_quiescence(archive_root):
         yield validate_schema_inference_gate_receipt(receipt_path, archive_root=archive_root)

--- a/polylogue/schemas/operator/schema_inference.py
+++ b/polylogue/schemas/operator/schema_inference.py
@@ -22,6 +22,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from polylogue.config import get_config
+from polylogue.maintenance.schema_inference_gate import authorize_schema_generation
+
 # Re-export the full public API so callers don't need to know the split.
 from polylogue.schemas.field_stats.stats import (
     UUID_PATTERN,
@@ -121,17 +124,30 @@ def cli_main(args: list[str] | None = None) -> int:
         action="store_true",
         help="Also write an aggregate archive composition profile beside staged provider packages",
     )
+    parser.add_argument(
+        "--schema-inference-receipt",
+        type=Path,
+        help="Fresh authoritative PASS receipt required before writing schema packages.",
+    )
 
     parsed = parser.parse_args(args)
 
+    if parsed.schema_inference_receipt is None:
+        print("schema-inference: --schema-inference-receipt is required before writing schema packages")
+        return 1
+
     providers = None if parsed.provider == "all" else [parsed.provider]
-    results = generate_all_schemas(
-        output_dir=parsed.output_dir,
-        db_path=parsed.db_path,
-        providers=providers,
-        max_samples=parsed.max_samples,
-        include_archive_workload_profile=parsed.archive_workload_profile,
-    )
+    config = get_config()
+    db_path = parsed.db_path or config.db_path
+    archive_root = getattr(config, "archive_root", None) or db_path.parent
+    with authorize_schema_generation(archive_root, parsed.schema_inference_receipt):
+        results = generate_all_schemas(
+            output_dir=parsed.output_dir,
+            db_path=db_path,
+            providers=providers,
+            max_samples=parsed.max_samples,
+            include_archive_workload_profile=parsed.archive_workload_profile,
+        )
 
     success = []
     failed = []

--- a/polylogue/schemas/operator/schema_inference.py
+++ b/polylogue/schemas/operator/schema_inference.py
@@ -23,7 +23,10 @@ from __future__ import annotations
 from pathlib import Path
 
 from polylogue.config import get_config
-from polylogue.maintenance.schema_inference_gate import authorize_schema_generation
+from polylogue.maintenance.schema_inference_gate import (
+    authorize_schema_generation,
+    resolve_schema_inference_archive_root,
+)
 
 # Re-export the full public API so callers don't need to know the split.
 from polylogue.schemas.field_stats.stats import (
@@ -127,19 +130,16 @@ def cli_main(args: list[str] | None = None) -> int:
     parser.add_argument(
         "--schema-inference-receipt",
         type=Path,
+        required=True,
         help="Fresh authoritative PASS receipt required before writing schema packages.",
     )
 
     parsed = parser.parse_args(args)
 
-    if parsed.schema_inference_receipt is None:
-        print("schema-inference: --schema-inference-receipt is required before writing schema packages")
-        return 1
-
     providers = None if parsed.provider == "all" else [parsed.provider]
     config = get_config()
     db_path = parsed.db_path or config.db_path
-    archive_root = getattr(config, "archive_root", None) or db_path.parent
+    archive_root = resolve_schema_inference_archive_root(config, fallback_db_path=db_path)
     with authorize_schema_generation(archive_root, parsed.schema_inference_receipt):
         results = generate_all_schemas(
             output_dir=parsed.output_dir,

--- a/tests/infra/schema_inference.py
+++ b/tests/infra/schema_inference.py
@@ -1,0 +1,66 @@
+"""Shared archive fixtures for schema-inference gate routes."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from polylogue.storage.blob_store import BlobStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+
+def seed_schema_inference_archive(root: Path) -> Path:
+    """Create one source raw whose actual external file and blob agree."""
+
+    initialize_active_archive_root(root)
+    ground_truth = root.parent / f"{root.name}-codex-ground-truth"
+    ground_truth.mkdir()
+    payload = b"actual external codex raw"
+    source_file = ground_truth / "session.jsonl"
+    source_file.write_bytes(payload)
+    blob_hash, blob_size = BlobStore(root / "blob").write_from_bytes(payload)
+    with sqlite3.connect(root / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_sessions(
+                raw_id, origin, native_id, source_path, blob_hash, blob_size,
+                acquired_at_ms, logical_source_key, revision_authority
+            ) VALUES ('raw-1', 'codex-session', 'session', ?, ?, ?, 100,
+                      'codex:session', 'byte_proven')
+            """,
+            (str(source_file), bytes.fromhex(blob_hash), blob_size),
+        )
+        conn.execute(
+            """
+            INSERT INTO raw_session_memberships(
+                raw_id, logical_source_key, provider_session_id, source_revision,
+                normalized_content_hash, message_count, decision, decided_at_ms
+            ) VALUES ('raw-1', 'codex:session', 'session', 'rev-1', ?, 1, 'applied', 100)
+            """,
+            (b"m" * 32,),
+        )
+    with sqlite3.connect(root / "index.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO sessions(native_id, origin, raw_id, content_hash, message_count)
+            VALUES ('session', 'codex-session', 'raw-1', ?, 1)
+            """,
+            (b"s" * 32,),
+        )
+        conn.execute(
+            """
+            INSERT INTO messages(session_id, position, role, material_origin, content_hash)
+            VALUES ('codex-session:session', 0, 'user', 'human_authored', ?)
+            """,
+            (b"n" * 32,),
+        )
+        conn.execute(
+            """
+            INSERT INTO blocks(message_id, session_id, position, block_type, text)
+            VALUES ('codex-session:session:0.0', 'codex-session:session', 0, 'text', 'hello')
+            """
+        )
+        conn.execute("ANALYZE blocks")
+        conn.execute("ANALYZE messages")
+        conn.execute("ANALYZE action_pairs")
+    return ground_truth

--- a/tests/unit/core/test_schema_generation.py
+++ b/tests/unit/core/test_schema_generation.py
@@ -751,14 +751,14 @@ class TestCliMain:
     """CLI entry point behavior."""
 
     def test_cli_with_no_db(self, tmp_path: Path) -> None:
-        exit_code = cli_main(
-            [
-                "--provider",
-                "chatgpt",
-                "--output-dir",
-                str(tmp_path / "out"),
-                "--db-path",
-                str(tmp_path / "missing.db"),
-            ]
-        )
-        assert isinstance(exit_code, int)
+        with pytest.raises(SystemExit, match="2"):
+            cli_main(
+                [
+                    "--provider",
+                    "chatgpt",
+                    "--output-dir",
+                    str(tmp_path / "out"),
+                    "--db-path",
+                    str(tmp_path / "missing.db"),
+                ]
+            )

--- a/tests/unit/devtools/test_schema_commit_command.py
+++ b/tests/unit/devtools/test_schema_commit_command.py
@@ -8,6 +8,8 @@ covered end-to-end in ``tests/unit/schemas/test_operator_commit.py``.
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -21,6 +23,11 @@ from polylogue.schemas.operator.models import SchemaCommitRequest, SchemaCommitR
 @dataclass(frozen=True)
 class _ConfigStub:
     db_path: Path
+
+
+@contextmanager
+def _allow_schema_generation(*_args: object, **_kwargs: object) -> Iterator[dict[str, object]]:
+    yield {}
 
 
 def test_schema_commit_forwards_request_and_defaults_output_dir(
@@ -42,8 +49,11 @@ def test_schema_commit_forwards_request_and_defaults_output_dir(
 
     monkeypatch.setattr(schema_commit, "get_config", fake_get_config)
     monkeypatch.setattr(schema_commit, "commit_provider_schema", fake_commit)
+    monkeypatch.setattr(schema_commit, "authorize_schema_generation", _allow_schema_generation)
 
-    assert schema_commit.main(["--provider", "chatgpt"]) == 0
+    assert (
+        schema_commit.main(["--provider", "chatgpt", "--schema-inference-receipt", str(tmp_path / "receipt.json")]) == 0
+    )
 
     assert len(captured) == 1
     request = captured[0]
@@ -52,6 +62,16 @@ def test_schema_commit_forwards_request_and_defaults_output_dir(
     assert request.db_path == tmp_path / "archive.db"
     assert request.full_corpus is True
     assert request.dry_run is False
+
+
+def test_schema_commit_refuses_persistence_without_authoritative_receipt(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(schema_commit, "get_config", lambda: _ConfigStub(db_path=tmp_path / "archive.db"))
+    monkeypatch.setattr(schema_commit, "commit_provider_schema", pytest.fail)
+
+    assert schema_commit.main(["--provider", "chatgpt"]) == 1
+    assert "schema-inference-receipt is required" in capsys.readouterr().err
 
 
 def test_schema_commit_honors_output_dir_and_dry_run_overrides(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -87,6 +107,7 @@ def test_schema_commit_json_output_reports_success(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setattr(schema_commit, "get_config", lambda: _ConfigStub(db_path=tmp_path / "archive.db"))
+    monkeypatch.setattr(schema_commit, "authorize_schema_generation", _allow_schema_generation)
     monkeypatch.setattr(
         schema_commit,
         "commit_provider_schema",
@@ -102,7 +123,12 @@ def test_schema_commit_json_output_reports_success(
         ),
     )
 
-    assert schema_commit.main(["--provider", "chatgpt", "--json"]) == 0
+    assert (
+        schema_commit.main(
+            ["--provider", "chatgpt", "--json", "--schema-inference-receipt", str(tmp_path / "receipt.json")]
+        )
+        == 0
+    )
 
     payload = json.loads(capsys.readouterr().out)
     assert payload["provider"] == "chatgpt"
@@ -117,6 +143,7 @@ def test_schema_commit_exits_nonzero_on_generation_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setattr(schema_commit, "get_config", lambda: _ConfigStub(db_path=tmp_path / "archive.db"))
+    monkeypatch.setattr(schema_commit, "authorize_schema_generation", _allow_schema_generation)
     monkeypatch.setattr(
         schema_commit,
         "commit_provider_schema",
@@ -128,7 +155,12 @@ def test_schema_commit_exits_nonzero_on_generation_failure(
         ),
     )
 
-    assert schema_commit.main(["--provider", "broken-provider", "--json"]) == 1
+    assert (
+        schema_commit.main(
+            ["--provider", "broken-provider", "--json", "--schema-inference-receipt", str(tmp_path / "receipt.json")]
+        )
+        == 1
+    )
     payload = json.loads(capsys.readouterr().out)
     assert payload["success"] is False
     assert payload["error"] == "No samples"
@@ -139,6 +171,7 @@ def test_schema_commit_exits_nonzero_when_narrowed(monkeypatch: pytest.MonkeyPat
     not report a clean exit code -- the whole point of the report is that a
     bad promotion can't land unnoticed."""
     monkeypatch.setattr(schema_commit, "get_config", lambda: _ConfigStub(db_path=tmp_path / "archive.db"))
+    monkeypatch.setattr(schema_commit, "authorize_schema_generation", _allow_schema_generation)
     monkeypatch.setattr(
         schema_commit,
         "commit_provider_schema",
@@ -154,4 +187,6 @@ def test_schema_commit_exits_nonzero_when_narrowed(monkeypatch: pytest.MonkeyPat
         ),
     )
 
-    assert schema_commit.main(["--provider", "chatgpt"]) == 1
+    assert (
+        schema_commit.main(["--provider", "chatgpt", "--schema-inference-receipt", str(tmp_path / "receipt.json")]) == 1
+    )

--- a/tests/unit/devtools/test_schema_commit_command.py
+++ b/tests/unit/devtools/test_schema_commit_command.py
@@ -49,7 +49,14 @@ def test_schema_commit_forwards_request_and_defaults_output_dir(
 
     monkeypatch.setattr(schema_commit, "get_config", fake_get_config)
     monkeypatch.setattr(schema_commit, "commit_provider_schema", fake_commit)
-    monkeypatch.setattr(schema_commit, "authorize_schema_generation", _allow_schema_generation)
+    authorization_calls: list[tuple[object, ...]] = []
+
+    @contextmanager
+    def allow_schema_generation(*args: object, **_kwargs: object) -> Iterator[dict[str, object]]:
+        authorization_calls.append(args)
+        yield {}
+
+    monkeypatch.setattr(schema_commit, "authorize_schema_generation", allow_schema_generation)
 
     assert (
         schema_commit.main(["--provider", "chatgpt", "--schema-inference-receipt", str(tmp_path / "receipt.json")]) == 0
@@ -62,6 +69,7 @@ def test_schema_commit_forwards_request_and_defaults_output_dir(
     assert request.db_path == tmp_path / "archive.db"
     assert request.full_corpus is True
     assert request.dry_run is False
+    assert authorization_calls == [(tmp_path, tmp_path / "receipt.json")]
 
 
 def test_schema_commit_refuses_persistence_without_authoritative_receipt(

--- a/tests/unit/devtools/test_schema_inference_gate.py
+++ b/tests/unit/devtools/test_schema_inference_gate.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from devtools import schema_inference_gate
 from polylogue.maintenance.schema_inference_gate import RECEIPT_FILENAME
-from tests.unit.maintenance.test_schema_inference_gate import _seed_archive
+from tests.infra.schema_inference import seed_schema_inference_archive as _seed_archive
 
 
 def test_devtools_command_requires_caller_root_and_persists_receipt(tmp_path: Path) -> None:

--- a/tests/unit/devtools/test_schema_lab_commands.py
+++ b/tests/unit/devtools/test_schema_lab_commands.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
 import json
+import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
 
 from devtools import schema_audit, schema_generate, schema_inspect, schema_promote
 from polylogue.core.outcomes import OutcomeCheck, OutcomeStatus
+from polylogue.maintenance.schema_inference_gate import (
+    run_schema_inference_gate,
+    schema_inference_gate_receipt_digest,
+)
 from polylogue.schemas.audit.models import AuditReport
 from polylogue.schemas.generation.models import GenerationResult
 from polylogue.schemas.operator.models import (
@@ -20,11 +28,19 @@ from polylogue.schemas.operator.models import (
     SchemaPromoteRequest,
     SchemaPromoteResult,
 )
+from polylogue.storage.index_generation import RebuildLease
+from tests.unit.maintenance.test_schema_inference_gate import _seed_archive
 
 
 @dataclass(frozen=True)
 class _ConfigStub:
     db_path: Path
+    archive_root: Path | None = None
+
+
+@contextmanager
+def _allow_schema_generation(*_args: object, **_kwargs: object) -> Iterator[dict[str, object]]:
+    yield {}
 
 
 def test_schema_audit_returns_success_for_passing_report(
@@ -181,8 +197,21 @@ def test_schema_generate_forwards_generation_request(
 
     monkeypatch.setattr(schema_generate, "get_config", fake_get_config)
     monkeypatch.setattr(schema_generate, "infer_schema", fake_infer)
+    monkeypatch.setattr(schema_generate, "authorize_schema_generation", _allow_schema_generation)
 
-    assert schema_generate.main(["--provider", "chatgpt", "--max-samples", "2"]) == 0
+    assert (
+        schema_generate.main(
+            [
+                "--provider",
+                "chatgpt",
+                "--max-samples",
+                "2",
+                "--schema-inference-receipt",
+                str(tmp_path / "receipt.json"),
+            ]
+        )
+        == 0
+    )
 
     assert captured == [
         SchemaInferRequest(
@@ -228,8 +257,22 @@ def test_schema_generate_writes_aggregate_progress_receipt(
     receipt_path = tmp_path / "receipt.json"
     monkeypatch.setattr(schema_generate, "get_config", fake_get_config)
     monkeypatch.setattr(schema_generate, "infer_schema", fake_infer)
+    monkeypatch.setattr(schema_generate, "authorize_schema_generation", _allow_schema_generation)
 
-    assert schema_generate.main(["--provider", "chatgpt", "--progress", "--receipt", str(receipt_path)]) == 0
+    assert (
+        schema_generate.main(
+            [
+                "--provider",
+                "chatgpt",
+                "--progress",
+                "--receipt",
+                str(receipt_path),
+                "--schema-inference-receipt",
+                str(tmp_path / "schema-inference-gate-receipt.json"),
+            ]
+        )
+        == 0
+    )
 
     receipt = json.loads(receipt_path.read_text())
     assert receipt["generation"]["status"] == "succeeded"
@@ -270,9 +313,122 @@ def test_schema_generate_cluster_without_manifest_fails(
 
     monkeypatch.setattr(schema_generate, "get_config", fake_get_config)
     monkeypatch.setattr(schema_generate, "infer_schema", fake_infer)
+    monkeypatch.setattr(schema_generate, "authorize_schema_generation", _allow_schema_generation)
 
-    assert schema_generate.main(["--provider", "chatgpt", "--cluster"]) == 1
+    assert (
+        schema_generate.main(
+            ["--provider", "chatgpt", "--cluster", "--schema-inference-receipt", str(tmp_path / "receipt.json")]
+        )
+        == 1
+    )
     assert "No samples found for clustering" in capsys.readouterr().err
+
+
+def _authoritative_schema_gate(tmp_path: Path, name: str) -> tuple[Path, Path]:
+    root = tmp_path / name
+    ground_truth = _seed_archive(root)
+    receipt = tmp_path / f"{name}-receipt" / "schema-inference-gate-receipt.json"
+    result = run_schema_inference_gate(
+        root,
+        receipt_path=receipt,
+        ground_truth_roots={"codex-session": (ground_truth,)},
+    )
+    assert result.passed, result.payload["pass_fail_reasons"]
+    return root, receipt
+
+
+def _successful_inference(request: SchemaInferRequest) -> SchemaInferResult:
+    return SchemaInferResult(
+        generation=GenerationResult(
+            provider=request.provider,
+            schema={"type": "object"},
+            sample_count=1,
+        )
+    )
+
+
+def test_schema_generate_direct_command_bypass_refuses_without_authoritative_receipt() -> None:
+    with pytest.raises(SystemExit):
+        schema_generate.main(["--provider", "chatgpt"])
+
+
+def test_schema_generate_valid_route_consumes_fresh_gate_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root, receipt = _authoritative_schema_gate(tmp_path, "valid")
+    monkeypatch.setattr(schema_generate, "get_config", lambda: _ConfigStub(root / "index.db", root))
+    monkeypatch.setattr(schema_generate, "infer_schema", _successful_inference)
+
+    assert schema_generate.main(["--provider", "chatgpt", "--schema-inference-receipt", str(receipt)]) == 0
+    assert "Generated schema package set for chatgpt" in capsys.readouterr().out
+
+
+def test_schema_generate_rejects_receipt_for_a_different_archive(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _archive_a, receipt_a = _authoritative_schema_gate(tmp_path, "archive-a")
+    archive_b, _receipt_b = _authoritative_schema_gate(tmp_path, "archive-b")
+    monkeypatch.setattr(schema_generate, "get_config", lambda: _ConfigStub(archive_b / "index.db", archive_b))
+    monkeypatch.setattr(schema_generate, "infer_schema", pytest.fail)
+
+    assert schema_generate.main(["--provider", "chatgpt", "--schema-inference-receipt", str(receipt_a)]) == 1
+    assert "different archive" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("mutation", ["replaced", "stale"])
+def test_schema_generate_rejects_replaced_or_stale_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mutation: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root, receipt = _authoritative_schema_gate(tmp_path, mutation)
+    payload = json.loads(receipt.read_text(encoding="utf-8"))
+    if mutation == "replaced":
+        payload["receipt_nonce"] = "attacker-replacement"
+    else:
+        payload["generated_at"] = datetime(2020, 1, 1, tzinfo=UTC).isoformat()
+        payload["receipt_sha256"] = schema_inference_gate_receipt_digest(payload)
+    receipt.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    monkeypatch.setattr(schema_generate, "get_config", lambda: _ConfigStub(root / "index.db", root))
+    monkeypatch.setattr(schema_generate, "infer_schema", pytest.fail)
+
+    assert schema_generate.main(["--provider", "chatgpt", "--schema-inference-receipt", str(receipt)]) == 1
+    error = capsys.readouterr().err
+    assert "digest mismatch" in error or "stale" in error
+
+
+def test_schema_generate_rejects_stale_non_source_tier(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root, receipt = _authoritative_schema_gate(tmp_path, "stale-user-tier")
+    with sqlite3.connect(root / "user.db") as connection:
+        connection.execute("PRAGMA user_version = 0")
+    monkeypatch.setattr(schema_generate, "get_config", lambda: _ConfigStub(root / "index.db", root))
+    monkeypatch.setattr(schema_generate, "infer_schema", pytest.fail)
+
+    assert schema_generate.main(["--provider", "chatgpt", "--schema-inference-receipt", str(receipt)]) == 1
+    assert "tier identity is stale" in capsys.readouterr().err
+
+
+def test_schema_generate_refuses_concurrent_writer(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root, receipt = _authoritative_schema_gate(tmp_path, "concurrent-writer")
+    monkeypatch.setattr(schema_generate, "get_config", lambda: _ConfigStub(root / "index.db", root))
+    monkeypatch.setattr(schema_generate, "infer_schema", pytest.fail)
+
+    with RebuildLease(root):
+        assert schema_generate.main(["--provider", "chatgpt", "--schema-inference-receipt", str(receipt)]) == 1
+    assert "exclusive offline archive ownership" in capsys.readouterr().err
 
 
 def test_schema_promote_forwards_cluster_request(

--- a/tests/unit/devtools/test_schema_lab_commands.py
+++ b/tests/unit/devtools/test_schema_lab_commands.py
@@ -376,7 +376,8 @@ def test_schema_generate_rejects_receipt_for_a_different_archive(
     monkeypatch.setattr(schema_generate, "infer_schema", pytest.fail)
 
     assert schema_generate.main(["--provider", "chatgpt", "--schema-inference-receipt", str(receipt_a)]) == 1
-    assert "different archive" in capsys.readouterr().err
+    error = capsys.readouterr().err
+    assert "different archive" in error or "attestation" in error
 
 
 @pytest.mark.parametrize("mutation", ["replaced", "stale"])
@@ -399,7 +400,7 @@ def test_schema_generate_rejects_replaced_or_stale_receipt(
 
     assert schema_generate.main(["--provider", "chatgpt", "--schema-inference-receipt", str(receipt)]) == 1
     error = capsys.readouterr().err
-    assert "digest mismatch" in error or "stale" in error
+    assert "digest mismatch" in error or "stale" in error or "attestation" in error
 
 
 def test_schema_generate_rejects_stale_non_source_tier(

--- a/tests/unit/devtools/test_schema_lab_commands.py
+++ b/tests/unit/devtools/test_schema_lab_commands.py
@@ -29,7 +29,7 @@ from polylogue.schemas.operator.models import (
     SchemaPromoteResult,
 )
 from polylogue.storage.index_generation import RebuildLease
-from tests.unit.maintenance.test_schema_inference_gate import _seed_archive
+from tests.infra.schema_inference import seed_schema_inference_archive as _seed_archive
 
 
 @dataclass(frozen=True)

--- a/tests/unit/maintenance/test_schema_inference_gate.py
+++ b/tests/unit/maintenance/test_schema_inference_gate.py
@@ -183,6 +183,16 @@ def test_clean_archive_runs_actual_blobstore_verifier_and_external_reconciliatio
     } == before
 
 
+def test_empty_archive_cannot_authorize_schema_inference(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    initialize_active_archive_root(root)
+
+    payload = _run(root, tmp_path, ground_truth_roots={})
+
+    assert payload["verdict"] == "FAIL"
+    assert "schema inference requires at least one reconciled source raw" in payload["pass_fail_reasons"]
+
+
 def test_gate_rejects_stale_non_source_tier_schema_identity(tmp_path: Path) -> None:
     root = tmp_path / "archive"
     ground_truth = _seed_archive(root)
@@ -275,6 +285,19 @@ def test_extra_external_file_is_rejected_by_bidirectional_reconciliation(tmp_pat
     assert origin["count_discrepancy"] is True
     assert origin["byte_discrepancy"] is True
     assert any("external file(s) have no source raw match" in reason for reason in payload["pass_fail_reasons"])
+
+
+def test_archive_owned_blob_cannot_pose_as_external_ground_truth(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _seed_archive(root)
+    blob_path = next(path for path in (root / "blob").rglob("*") if path.is_file())
+
+    payload = _run(root, tmp_path, ground_truth=blob_path)
+
+    assert payload["verdict"] == "FAIL"
+    assert any(
+        "must be external to the archive and blob namespace" in reason for reason in payload["pass_fail_reasons"]
+    )
 
 
 def test_cross_origin_external_source_is_rejected_and_recorded(tmp_path: Path) -> None:

--- a/tests/unit/maintenance/test_schema_inference_gate.py
+++ b/tests/unit/maintenance/test_schema_inference_gate.py
@@ -16,6 +16,7 @@ from polylogue.maintenance.schema_inference_gate import (
     run_schema_inference_gate,
 )
 from polylogue.storage.blob_store import BlobStore
+from polylogue.storage.index_generation import RebuildLease
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
 
 
@@ -137,9 +138,10 @@ def _run(
     ground_truth_roots: dict[str, tuple[Path, ...]] | None = None,
 ) -> _GateReceipt:
     external_root = ground_truth or root.parent / f"{root.name}-codex-ground-truth"
+    receipt_count = sum(1 for child in tmp_path.iterdir() if child.name.startswith("schema-gate-receipt-"))
     result = run_schema_inference_gate(
         root,
-        receipt_path=tmp_path / RECEIPT_FILENAME,
+        receipt_path=tmp_path / f"schema-gate-receipt-{receipt_count}" / RECEIPT_FILENAME,
         ground_truth_roots=ground_truth_roots or {"codex-session": (external_root,)},
     )
     return cast(_GateReceipt, result.payload)
@@ -179,6 +181,40 @@ def test_clean_archive_runs_actual_blobstore_verifier_and_external_reconciliatio
     assert {
         name: hashlib.sha256((root / name).read_bytes()).hexdigest() for name in ("source.db", "index.db")
     } == before
+
+
+def test_gate_rejects_stale_non_source_tier_schema_identity(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    ground_truth = _seed_archive(root)
+    with sqlite3.connect(root / "user.db") as conn:
+        conn.execute("PRAGMA user_version = 0")
+
+    payload = _run(root, tmp_path, ground_truth=ground_truth)
+
+    assert payload["verdict"] == "FAIL"
+    assert any("user.db schema identity is stale" in reason for reason in payload["pass_fail_reasons"])
+
+
+def test_gate_receipt_path_is_immutable(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    ground_truth = _seed_archive(root)
+    receipt = tmp_path / RECEIPT_FILENAME
+    run_schema_inference_gate(root, receipt_path=receipt, ground_truth_roots={"codex-session": (ground_truth,)})
+
+    with pytest.raises(SchemaInferenceGateError, match="immutable"):
+        run_schema_inference_gate(root, receipt_path=receipt, ground_truth_roots={"codex-session": (ground_truth,)})
+
+
+def test_gate_refuses_concurrent_writer_lease(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    ground_truth = _seed_archive(root)
+    with RebuildLease(root):
+        with pytest.raises(SchemaInferenceGateError, match="exclusive offline archive ownership"):
+            run_schema_inference_gate(
+                root,
+                receipt_path=tmp_path / RECEIPT_FILENAME,
+                ground_truth_roots={"codex-session": (ground_truth,)},
+            )
 
 
 def test_receipt_target_can_never_replace_a_live_tier(tmp_path: Path) -> None:

--- a/tests/unit/maintenance/test_schema_inference_gate.py
+++ b/tests/unit/maintenance/test_schema_inference_gate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import sqlite3
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TypedDict, cast
 
@@ -14,10 +15,12 @@ from polylogue.maintenance.schema_inference_gate import (
     RECEIPT_FILENAME,
     SchemaInferenceGateError,
     run_schema_inference_gate,
+    validate_schema_inference_gate_receipt,
 )
 from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.index_generation import RebuildLease
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from tests.infra.schema_inference import seed_schema_inference_archive
 
 
 class _RawGroundTruthProvenance(TypedDict):
@@ -73,61 +76,7 @@ class _GateReceipt(TypedDict):
     pass_fail_reasons: list[str]
 
 
-def _seed_archive(root: Path) -> Path:
-    """Create one source raw whose actual external file and blob agree."""
-
-    initialize_active_archive_root(root)
-    ground_truth = root.parent / f"{root.name}-codex-ground-truth"
-    ground_truth.mkdir()
-    payload = b"actual external codex raw"
-    source_file = ground_truth / "session.jsonl"
-    source_file.write_bytes(payload)
-    blob_hash, blob_size = BlobStore(root / "blob").write_from_bytes(payload)
-    with sqlite3.connect(root / "source.db") as conn:
-        conn.execute(
-            """
-            INSERT INTO raw_sessions(
-                raw_id, origin, native_id, source_path, blob_hash, blob_size,
-                acquired_at_ms, logical_source_key, revision_authority
-            ) VALUES ('raw-1', 'codex-session', 'session', ?, ?, ?, 100,
-                      'codex:session', 'byte_proven')
-            """,
-            (str(source_file), bytes.fromhex(blob_hash), blob_size),
-        )
-        conn.execute(
-            """
-            INSERT INTO raw_session_memberships(
-                raw_id, logical_source_key, provider_session_id, source_revision,
-                normalized_content_hash, message_count, decision, decided_at_ms
-            ) VALUES ('raw-1', 'codex:session', 'session', 'rev-1', ?, 1, 'applied', 100)
-            """,
-            (b"m" * 32,),
-        )
-    with sqlite3.connect(root / "index.db") as conn:
-        conn.execute(
-            """
-            INSERT INTO sessions(native_id, origin, raw_id, content_hash, message_count)
-            VALUES ('session', 'codex-session', 'raw-1', ?, 1)
-            """,
-            (b"s" * 32,),
-        )
-        conn.execute(
-            """
-            INSERT INTO messages(session_id, position, role, material_origin, content_hash)
-            VALUES ('codex-session:session', 0, 'user', 'human_authored', ?)
-            """,
-            (b"n" * 32,),
-        )
-        conn.execute(
-            """
-            INSERT INTO blocks(message_id, session_id, position, block_type, text)
-            VALUES ('codex-session:session:0.0', 'codex-session:session', 0, 'text', 'hello')
-            """
-        )
-        conn.execute("ANALYZE blocks")
-        conn.execute("ANALYZE messages")
-        conn.execute("ANALYZE action_pairs")
-    return ground_truth
+_seed_archive = seed_schema_inference_archive
 
 
 def _run(
@@ -142,7 +91,7 @@ def _run(
     result = run_schema_inference_gate(
         root,
         receipt_path=tmp_path / f"schema-gate-receipt-{receipt_count}" / RECEIPT_FILENAME,
-        ground_truth_roots=ground_truth_roots or {"codex-session": (external_root,)},
+        ground_truth_roots=({"codex-session": (external_root,)} if ground_truth_roots is None else ground_truth_roots),
     )
     return cast(_GateReceipt, result.payload)
 
@@ -213,6 +162,25 @@ def test_gate_receipt_path_is_immutable(tmp_path: Path) -> None:
 
     with pytest.raises(SchemaInferenceGateError, match="immutable"):
         run_schema_inference_gate(root, receipt_path=receipt, ground_truth_roots={"codex-session": (ground_truth,)})
+
+
+def test_authoritative_receipt_expires_from_its_signed_generation_time(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    ground_truth = _seed_archive(root)
+    receipt = tmp_path / RECEIPT_FILENAME
+    payload = run_schema_inference_gate(
+        root,
+        receipt_path=receipt,
+        ground_truth_roots={"codex-session": (ground_truth,)},
+    ).payload
+    generated_at = datetime.fromisoformat(str(payload["generated_at"])).astimezone(UTC)
+
+    with pytest.raises(SchemaInferenceGateError, match="stale or from the future"):
+        validate_schema_inference_gate_receipt(
+            receipt,
+            archive_root=root,
+            now=generated_at + timedelta(hours=24, seconds=1),
+        )
 
 
 def test_gate_refuses_concurrent_writer_lease(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Bind schema inference and commit authority to a signed receipt from an external, non-archive ground-truth source.

## Problem

The prior gate could accept archive/blob data as its own external ground truth, accept empty evidence, and permit schema commit or the legacy operator CLI to bypass receipt authorization. A receipt hash could also be recomputed after evidence replacement.

## Solution

Reject archive-local evidence roots, require nonempty verified evidence, sign the canonical receipt with durable authority material, and require authorized receipts for generation and commit entrypoints. Add mutation-sensitive tests for every bypass path.

## Verification

- `devtools test tests/unit/maintenance/test_schema_inference_gate.py` passed: 74 tests.
- `devtools verify --quick` passed before this branch was published; pre-push records its current quick baseline.

Ref polylogue-tnqqt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authorization receipts for schema generation and schema commits.
  * Added validation for receipt freshness, integrity, archive identity, schema compatibility, and successful status.
  * Added protections against concurrent changes during schema generation.

* **Bug Fixes**
  * Prevented schema generation using stale, replaced, mismatched, or invalid authorization receipts.
  * Rejected unauthorized external data locations within managed archive areas.

* **Tests**
  * Expanded coverage for authorization failures, stale data, immutable receipts, empty archives, and concurrent writers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->