### PR TITLE
fix(raw): add historical failure disposition receipts

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -1150,6 +1150,23 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
+        "workspace raw-failure-disposition-apply",
+        "workspace",
+        "Apply reviewed terminal dispositions to historical raw parse failures.",
+        "devtools.raw_failure_disposition_apply",
+        use_when=(
+            "polylogue-dyica: terminal historical parse failures predate typed lifecycle evidence. "
+            "Default is dry-run; --apply requires an exact JSONL disposition manifest and a verified "
+            "source-tier backup. It retains raw bytes and parser errors while replacing only the stale "
+            "artifact classification and writing immutable per-row receipts."
+        ),
+        examples=(
+            "devtools workspace raw-failure-disposition-apply --manifest-path /realm/staging/raw-failure-disposition.jsonl",
+            "devtools workspace raw-failure-disposition-apply --apply --manifest-path /realm/staging/raw-failure-disposition.jsonl "
+            "--backup-manifest /realm/staging/polylogue-backup/manifest.json",
+        ),
+    ),
+    CommandSpec(
         "workspace raw-append-chain-backfill-apply",
         "workspace",
         "Promote membershipless append raws proven correct by live-source verification.",

--- a/devtools/raw_failure_disposition_apply.py
+++ b/devtools/raw_failure_disposition_apply.py
@@ -1,0 +1,59 @@
+"""Apply reviewed terminal dispositions to historical raw parse failures.
+
+The supplied JSONL manifest is dry-run checked by default. ``--apply`` also
+requires a verified source-tier backup manifest and writes immutable receipts;
+it retains raw payload bytes and the original parser diagnostics.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import TextIO
+
+from polylogue.maintenance.raw_failure_disposition_apply import (
+    RawFailureDispositionApplyError,
+    apply_raw_failure_dispositions,
+)
+from polylogue.paths import archive_root as default_archive_root
+
+
+def main(argv: list[str] | None = None, *, stdout: TextIO | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--archive-root", type=Path, default=None)
+    parser.add_argument("--manifest-path", type=Path, required=True)
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--backup-manifest", type=Path, default=None)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    root = args.archive_root if args.archive_root is not None else default_archive_root()
+    try:
+        report = apply_raw_failure_dispositions(
+            root,
+            manifest_path=args.manifest_path,
+            backup_manifest=args.backup_manifest,
+            dry_run=not args.apply,
+        )
+    except (RawFailureDispositionApplyError, FileNotFoundError) as exc:
+        print(f"refused: {exc}", file=stdout)
+        return 1
+    payload = {
+        "applied": report.applied,
+        "manifest_sha256": report.manifest_sha256,
+        "candidate_count": report.candidate_count,
+        "disposed_raw_ids": list(report.disposed_raw_ids),
+        "backup_manifest": str(report.backup_manifest) if report.backup_manifest is not None else None,
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True), file=stdout)
+    else:
+        mode = "APPLIED" if report.applied else "dry-run (no mutation performed)"
+        print(f"mode: {mode}", file=stdout)
+        print(f"terminal dispositions: {report.candidate_count}", file=stdout)
+        print(f"manifest sha256: {report.manifest_sha256}", file=stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -288,6 +288,7 @@ Catalog bypass audit sites are machine-checked across workflow runs, CI-owned np
 | `devtools workspace raw-authority-restart-proof` | Prove raw-authority crash recovery and conserved fixed-point convergence. |
 | `devtools workspace raw-authority-scale-proof` | Run bounded raw-authority replay to a two-census fixed point. |
 | `devtools workspace raw-byte-duplicate-supersession-apply` | Promote quarantined, logical-key-less raws proven byte-identical to an already-indexed raw. |
+| `devtools workspace raw-failure-disposition-apply` | Apply reviewed terminal dispositions to historical raw parse failures. |
 | `devtools workspace raw-live-source-reconciliation` | Classify quarantined raw evidence against its live source file's current bytes. |
 | `devtools workspace raw-live-source-reconciliation-apply` | Promote quarantined raw evidence proven correct by live-source verification. |
 | `devtools workspace raw-membership-writeback-apply` | Propagate already-decided membership verdicts onto raw_sessions.revision_authority. |

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -21,7 +21,7 @@ over the `CREATE TABLE` statement.
 
 | Tier file | Tier | Version constant |
 |-----------|------|------------------|
-| `source.py` | `source.db` | `SOURCE_SCHEMA_VERSION = 28` |
+| `source.py` | `source.db` | `SOURCE_SCHEMA_VERSION = 29` |
 | `index.py` | `index.db` | `INDEX_SCHEMA_VERSION = 53` |
 | `embeddings.py` | `embeddings.db` | `EMBEDDINGS_SCHEMA_VERSION = 4` |
 | `user.py` | `user.db` | `USER_SCHEMA_VERSION = 10` |

--- a/polylogue/maintenance/raw_failure_disposition_apply.py
+++ b/polylogue/maintenance/raw_failure_disposition_apply.py
@@ -114,7 +114,8 @@ def _validate_candidate(conn: sqlite3.Connection, candidate: RawFailureDispositi
     row = conn.execute(
         """
         SELECT r.raw_id, r.origin, r.source_path, r.source_index, r.blob_hash, r.blob_size,
-               r.parse_error, r.validation_status, a.artifact_id
+               r.parse_error, r.validation_status, a.artifact_id, a.artifact_kind,
+               a.support_status, a.classification_reason
         FROM raw_sessions AS r
         JOIN raw_artifacts AS a
           ON a.raw_id = r.raw_id
@@ -176,9 +177,10 @@ def _apply_candidate(
         """
         INSERT INTO raw_failure_disposition_receipts (
             raw_id, artifact_id, origin, source_path, source_index, blob_hash, blob_size,
-            previous_parse_error, previous_validation_status, disposition_kind, manifest_sha256,
-            disposed_at_ms, tool_version, backup_manifest_path, detail
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            previous_parse_error, previous_validation_status, previous_artifact_kind,
+            previous_support_status, previous_classification_reason, disposition_kind,
+            manifest_sha256, disposed_at_ms, tool_version, backup_manifest_path, detail
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             row["raw_id"],
@@ -190,6 +192,9 @@ def _apply_candidate(
             row["blob_size"],
             row["parse_error"],
             row["validation_status"],
+            row["artifact_kind"],
+            row["support_status"],
+            row["classification_reason"],
             candidate.disposition_kind.value,
             manifest_sha256,
             disposed_at_ms,

--- a/polylogue/maintenance/raw_failure_disposition_apply.py
+++ b/polylogue/maintenance/raw_failure_disposition_apply.py
@@ -1,0 +1,274 @@
+"""Apply a reviewed terminal disposition to retained historical raw failures.
+
+The live writer records a typed ``raw_artifacts`` outcome as soon as it knows
+a malformed or non-conversation payload is terminal. Historical rows created
+before that route retain the bytes and parser diagnostic but lack the outcome.
+This actuator closes only an explicit JSONL manifest, after a verified source
+backup, and writes one immutable receipt per changed raw. It never clears the
+original parser error, deletes bytes, runs GC, or retries a payload.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+from polylogue.config import Config
+from polylogue.core.raw_failure_evidence import RawFailureEvidenceKind
+from polylogue.maintenance.offline_guard import offline_maintenance_block_reason
+from polylogue.paths import render_root
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.migration_runner import validate_migration_backup_manifest
+
+TOOL_VERSION = "raw-failure-disposition-apply-v1"
+_TERMINAL_KINDS = frozenset(
+    {
+        RawFailureEvidenceKind.TERMINAL_CORRUPT_INPUT,
+        RawFailureEvidenceKind.TERMINAL_UNSUPPORTED_SHAPE,
+    }
+)
+
+
+class RawFailureDispositionApplyError(RuntimeError):
+    """Raised when a historical disposition would weaken raw evidence."""
+
+
+@dataclass(frozen=True, slots=True)
+class RawFailureDisposition:
+    raw_id: str
+    disposition_kind: RawFailureEvidenceKind
+    detail: str
+
+
+@dataclass(frozen=True, slots=True)
+class RawFailureDispositionPlan:
+    manifest_sha256: str
+    candidates: tuple[RawFailureDisposition, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class RawFailureDispositionApplyReport:
+    manifest_sha256: str
+    candidate_count: int
+    disposed_raw_ids: tuple[str, ...]
+    applied: bool
+    backup_manifest: Path | None = None
+
+
+def _offline_config(archive_root: Path) -> Config:
+    return Config(archive_root=archive_root, render_root=render_root(), sources=[])
+
+
+def _manifest_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def load_raw_failure_disposition_manifest(path: Path) -> RawFailureDispositionPlan:
+    """Load an exact, immutable JSONL disposition manifest.
+
+    Entries must name one raw id, a closed terminal kind, and a sanitized
+    reason. Duplicate raw ids and unknown keys are rejected so the operator's
+    reviewed manifest cannot silently collapse or broaden its scope.
+    """
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise RawFailureDispositionApplyError(f"could not read disposition manifest: {path}") from exc
+    if not lines:
+        raise RawFailureDispositionApplyError("disposition manifest is empty")
+    candidates: list[RawFailureDisposition] = []
+    seen: set[str] = set()
+    for line_no, line in enumerate(lines, start=1):
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise RawFailureDispositionApplyError(f"manifest line {line_no} is not JSON") from exc
+        if not isinstance(payload, dict) or set(payload) != {"raw_id", "disposition_kind", "detail"}:
+            raise RawFailureDispositionApplyError(
+                f"manifest line {line_no} must contain exactly raw_id, disposition_kind, detail"
+            )
+        raw_id = payload["raw_id"]
+        detail = payload["detail"]
+        if not isinstance(raw_id, str) or not raw_id or not isinstance(detail, str) or not detail.strip():
+            raise RawFailureDispositionApplyError(f"manifest line {line_no} has invalid raw_id or detail")
+        try:
+            kind = RawFailureEvidenceKind(str(payload["disposition_kind"]))
+        except ValueError as exc:
+            raise RawFailureDispositionApplyError(f"manifest line {line_no} has unknown disposition kind") from exc
+        if kind not in _TERMINAL_KINDS:
+            raise RawFailureDispositionApplyError(f"manifest line {line_no} is not a terminal disposition")
+        if raw_id in seen:
+            raise RawFailureDispositionApplyError(f"manifest repeats raw_id: {raw_id}")
+        seen.add(raw_id)
+        candidates.append(RawFailureDisposition(raw_id=raw_id, disposition_kind=kind, detail=detail.strip()))
+    return RawFailureDispositionPlan(manifest_sha256=_manifest_sha256(path), candidates=tuple(candidates))
+
+
+def _validate_candidate(conn: sqlite3.Connection, candidate: RawFailureDisposition) -> sqlite3.Row:
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        """
+        SELECT r.raw_id, r.origin, r.source_path, r.source_index, r.blob_hash, r.blob_size,
+               r.parse_error, r.validation_status, a.artifact_id
+        FROM raw_sessions AS r
+        JOIN raw_artifacts AS a
+          ON a.raw_id = r.raw_id
+         AND a.origin = r.origin
+         AND a.source_path = r.source_path
+         AND a.source_index = r.source_index
+        WHERE r.raw_id = ?
+          AND r.parse_error IS NOT NULL
+          AND TRIM(r.parse_error) != ''
+          AND NOT EXISTS (
+              SELECT 1 FROM raw_failure_disposition_receipts AS receipt WHERE receipt.raw_id = r.raw_id
+          )
+        """,
+        (candidate.raw_id,),
+    ).fetchone()
+    if row is None:
+        raise RawFailureDispositionApplyError(
+            f"raw {candidate.raw_id} is missing, has no matching artifact, is not failed, or was already disposed"
+        )
+    return cast(sqlite3.Row, row)
+
+
+def _checkpoint_live_tier(conn: sqlite3.Connection) -> None:
+    try:
+        row = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+    except sqlite3.Error as exc:
+        raise RawFailureDispositionApplyError("could not checkpoint source.db before backup validation") from exc
+    if row is None:
+        raise RawFailureDispositionApplyError("could not checkpoint source.db before backup validation")
+
+
+def _apply_candidate(
+    conn: sqlite3.Connection,
+    candidate: RawFailureDisposition,
+    *,
+    manifest_sha256: str,
+    backup_manifest: Path,
+    disposed_at_ms: int,
+) -> str:
+    row = _validate_candidate(conn, candidate)
+    updated = conn.execute(
+        """
+        UPDATE raw_artifacts
+        SET artifact_kind = ?, support_status = ?, classification_reason = ?,
+            parse_as_session = 0, schema_eligible = 0, last_observed_at_ms = ?
+        WHERE artifact_id = ?
+        """,
+        (
+            candidate.disposition_kind.value,
+            candidate.disposition_kind.support_status.value,
+            candidate.disposition_kind.value,
+            disposed_at_ms,
+            row["artifact_id"],
+        ),
+    )
+    if updated.rowcount != 1:
+        raise RawFailureDispositionApplyError(f"artifact changed during disposition: {candidate.raw_id}")
+    conn.execute(
+        """
+        INSERT INTO raw_failure_disposition_receipts (
+            raw_id, artifact_id, origin, source_path, source_index, blob_hash, blob_size,
+            previous_parse_error, previous_validation_status, disposition_kind, manifest_sha256,
+            disposed_at_ms, tool_version, backup_manifest_path, detail
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            row["raw_id"],
+            row["artifact_id"],
+            row["origin"],
+            row["source_path"],
+            row["source_index"],
+            row["blob_hash"],
+            row["blob_size"],
+            row["parse_error"],
+            row["validation_status"],
+            candidate.disposition_kind.value,
+            manifest_sha256,
+            disposed_at_ms,
+            TOOL_VERSION,
+            str(backup_manifest),
+            candidate.detail,
+        ),
+    )
+    return str(row["raw_id"])
+
+
+def apply_raw_failure_dispositions(
+    archive_root: Path,
+    *,
+    manifest_path: Path,
+    backup_manifest: Path | None = None,
+    dry_run: bool = True,
+) -> RawFailureDispositionApplyReport:
+    """Validate and, with backup authorization, apply terminal dispositions."""
+    source_db = archive_root / "source.db"
+    if not source_db.exists():
+        raise FileNotFoundError(f"no source.db at {source_db}")
+    plan = load_raw_failure_disposition_manifest(manifest_path)
+    if dry_run:
+        conn = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
+        try:
+            for candidate in plan.candidates:
+                _validate_candidate(conn, candidate)
+        finally:
+            conn.close()
+        return RawFailureDispositionApplyReport(plan.manifest_sha256, len(plan.candidates), (), False)
+    if backup_manifest is None:
+        raise RawFailureDispositionApplyError(
+            "applying raw-failure dispositions requires a verified backup manifest (--backup-manifest)"
+        )
+    if reason := offline_maintenance_block_reason(_offline_config(archive_root), active=True, dry_run=False):
+        raise RawFailureDispositionApplyError(reason)
+    conn = sqlite3.connect(source_db)
+    disposed: list[str] = []
+    try:
+        _checkpoint_live_tier(conn)
+        validate_migration_backup_manifest(backup_manifest, ArchiveTier.SOURCE, connection=conn)
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            validate_migration_backup_manifest(backup_manifest, ArchiveTier.SOURCE, connection=conn)
+            disposed_at_ms = int(time.time() * 1000)
+            for candidate in plan.candidates:
+                disposed.append(
+                    _apply_candidate(
+                        conn,
+                        candidate,
+                        manifest_sha256=plan.manifest_sha256,
+                        backup_manifest=backup_manifest,
+                        disposed_at_ms=disposed_at_ms,
+                    )
+                )
+            quick_check = conn.execute("PRAGMA quick_check").fetchone()
+            if quick_check is None or str(quick_check[0]).lower() != "ok":
+                raise RawFailureDispositionApplyError(
+                    f"source.db quick_check failed after disposition: {quick_check!r}"
+                )
+        except Exception:
+            if conn.in_transaction:
+                conn.rollback()
+            raise
+        else:
+            conn.commit()
+    finally:
+        conn.close()
+    return RawFailureDispositionApplyReport(
+        plan.manifest_sha256, len(plan.candidates), tuple(disposed), True, backup_manifest
+    )
+
+
+__all__ = [
+    "RawFailureDisposition",
+    "RawFailureDispositionApplyError",
+    "RawFailureDispositionApplyReport",
+    "RawFailureDispositionPlan",
+    "apply_raw_failure_dispositions",
+    "load_raw_failure_disposition_manifest",
+]

--- a/polylogue/storage/sqlite/archive_tiers/source.py
+++ b/polylogue/storage/sqlite/archive_tiers/source.py
@@ -21,7 +21,7 @@ from polylogue.core.enums import (
 from polylogue.storage.sqlite.archive_tiers.common import check, literal_check, nullable_check
 from polylogue.storage.sqlite.archive_tiers.types import ProvenRevisionAuthority
 
-SOURCE_SCHEMA_VERSION = 28
+SOURCE_SCHEMA_VERSION = 29
 
 SOURCE_DDL = f"""
 CREATE TABLE IF NOT EXISTS raw_sessions (
@@ -264,6 +264,36 @@ ON raw_byte_duplicate_supersession_receipts(promoted_at_ms);
 
 CREATE INDEX IF NOT EXISTS idx_raw_byte_duplicate_supersession_receipts_duplicate_of
 ON raw_byte_duplicate_supersession_receipts(duplicate_of_raw_id);
+
+-- v29 (polylogue-dyica): a stopped daemon can leave historical parse failures
+-- whose retained bytes are known terminal inputs, but which predate the live
+-- writer's typed raw_artifacts outcome.  This immutable receipt records the
+-- reviewed manifest and source-tier backup that authorized replacing the
+-- stale artifact classification with a terminal lifecycle classification.
+-- The raw bytes and original parse diagnostic remain untouched.
+CREATE TABLE IF NOT EXISTS raw_failure_disposition_receipts (
+    raw_id                     TEXT PRIMARY KEY REFERENCES raw_sessions(raw_id) ON DELETE CASCADE,
+    artifact_id                TEXT NOT NULL UNIQUE REFERENCES raw_artifacts(artifact_id),
+    origin                     TEXT NOT NULL CHECK ({check("origin", Origin)}),
+    source_path                TEXT NOT NULL,
+    source_index               INTEGER NOT NULL,
+    blob_hash                  BLOB NOT NULL CHECK(length(blob_hash) = 32),
+    blob_size                  INTEGER NOT NULL CHECK(blob_size >= 0),
+    previous_parse_error       TEXT NOT NULL,
+    previous_validation_status TEXT,
+    disposition_kind           TEXT NOT NULL CHECK(disposition_kind IN (
+        'terminal_corrupt_input',
+        'terminal_unsupported_shape'
+    )),
+    manifest_sha256            TEXT NOT NULL CHECK(length(manifest_sha256) = 64),
+    disposed_at_ms             INTEGER NOT NULL CHECK(disposed_at_ms >= 0),
+    tool_version               TEXT NOT NULL,
+    backup_manifest_path       TEXT NOT NULL,
+    detail                     TEXT NOT NULL DEFAULT ''
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_raw_failure_disposition_receipts_disposed_at
+ON raw_failure_disposition_receipts(disposed_at_ms);
 
 -- v27 (polylogue-r9xsj): a non-session classification alone is not a
 -- duplicate disposition. This immutable receipt binds an excluded raw blob to

--- a/polylogue/storage/sqlite/archive_tiers/source.py
+++ b/polylogue/storage/sqlite/archive_tiers/source.py
@@ -281,6 +281,9 @@ CREATE TABLE IF NOT EXISTS raw_failure_disposition_receipts (
     blob_size                  INTEGER NOT NULL CHECK(blob_size >= 0),
     previous_parse_error       TEXT NOT NULL,
     previous_validation_status TEXT,
+    previous_artifact_kind     TEXT NOT NULL,
+    previous_support_status    TEXT NOT NULL,
+    previous_classification_reason TEXT NOT NULL,
     disposition_kind           TEXT NOT NULL CHECK(disposition_kind IN (
         'terminal_corrupt_input',
         'terminal_unsupported_shape'

--- a/polylogue/storage/sqlite/migrations/source/029.train.json
+++ b/polylogue/storage/sqlite/migrations/source/029.train.json
@@ -12,7 +12,7 @@
     "slot": 29,
     "path": "029_raw_failure_disposition_receipts.sql",
     "owner_ref": "polylogue/storage/sqlite/migrations/source/029_raw_failure_disposition_receipts.sql",
-    "sql_sha256": "56c02cf667e89f32ce97593428b219c05db74daf1d5aef94a7ad7d44aca7b133",
+    "sql_sha256": "9b68e792faf1ce53db93c1e7be9e9087d6abbb5d4340ed4bed15be102f94ed0d",
     "requires_backup": true
   },
   "riders": [
@@ -64,5 +64,5 @@
   "released_at_ms": null,
   "release_evidence_ref": null,
   "proof_refs": [],
-  "manifest_sha256": "691ef7bd5982568263a0a4fa5f51545f01afafdec0f80da65430b3d3c5433c40"
+  "manifest_sha256": "984492f16315f887312d93e9b80ad1281caecbfaabfaf09240c9e7584d68f0d3"
 }

--- a/polylogue/storage/sqlite/migrations/source/029.train.json
+++ b/polylogue/storage/sqlite/migrations/source/029.train.json
@@ -1,0 +1,68 @@
+{
+  "manifest_format": "polylogue.durable-change-train.v1",
+  "train_id": "train:source:v29",
+  "tier": "source",
+  "current_version": 28,
+  "target_version": 29,
+  "slot": 29,
+  "owner_ref": "polylogue-dyica",
+  "migration": {
+    "tier": "source",
+    "target_version": 29,
+    "slot": 29,
+    "path": "029_raw_failure_disposition_receipts.sql",
+    "owner_ref": "polylogue/storage/sqlite/migrations/source/029_raw_failure_disposition_receipts.sql",
+    "sql_sha256": "56c02cf667e89f32ce97593428b219c05db74daf1d5aef94a7ad7d44aca7b133",
+    "requires_backup": true
+  },
+  "riders": [
+    {
+      "rider_id": "rider:raw-failure-disposition-receipts",
+      "owner_ref": "polylogue-dyica",
+      "schema_objects": [
+        "table:raw_failure_disposition_receipts",
+        "index:idx_raw_failure_disposition_receipts_disposed_at"
+      ],
+      "runtime_consumers": [
+        {
+          "consumer_id": "raw-failure-lifecycle",
+          "production_ref": "polylogue.storage.raw_failure_lifecycle:read_raw_failure_lifecycle",
+          "behavior_proof_ref": "proof:source-v29:historical-disposition-lifecycle",
+          "roles": ["read"]
+        },
+        {
+          "consumer_id": "historical-disposition-actuator",
+          "production_ref": "polylogue.maintenance.raw_failure_disposition_apply:apply_raw_failure_dispositions",
+          "behavior_proof_ref": "proof:source-v29:historical-disposition-apply",
+          "roles": ["read", "write"]
+        }
+      ],
+      "behavior_proof_refs": [
+        "proof:source-v29:historical-disposition-lifecycle",
+        "proof:source-v29:historical-disposition-apply"
+      ],
+      "after_rider_ids": [],
+      "trust_floor_exception_ref": null
+    }
+  ],
+  "ordering_constraints": [],
+  "drop_constraints": [],
+  "row_change_allowances": [],
+  "backup_plan_ref": "backup-profile:source-tier",
+  "state": "declared",
+  "revision": 0,
+  "declared_at_ms": 1785954424000,
+  "admitted_at_ms": null,
+  "admission_evidence_ref": null,
+  "fresh_ddl_parity": null,
+  "reservation": null,
+  "backup_authorization": null,
+  "pre_apply_evidence": null,
+  "apply_evidence": null,
+  "proof": null,
+  "failure": null,
+  "released_at_ms": null,
+  "release_evidence_ref": null,
+  "proof_refs": [],
+  "manifest_sha256": "691ef7bd5982568263a0a4fa5f51545f01afafdec0f80da65430b3d3c5433c40"
+}

--- a/polylogue/storage/sqlite/migrations/source/029_raw_failure_disposition_receipts.sql
+++ b/polylogue/storage/sqlite/migrations/source/029_raw_failure_disposition_receipts.sql
@@ -13,6 +13,9 @@ CREATE TABLE IF NOT EXISTS raw_failure_disposition_receipts (
     blob_size                  INTEGER NOT NULL CHECK(blob_size >= 0),
     previous_parse_error       TEXT NOT NULL,
     previous_validation_status TEXT,
+    previous_artifact_kind     TEXT NOT NULL,
+    previous_support_status    TEXT NOT NULL,
+    previous_classification_reason TEXT NOT NULL,
     disposition_kind           TEXT NOT NULL CHECK(disposition_kind IN (
         'terminal_corrupt_input',
         'terminal_unsupported_shape'

--- a/polylogue/storage/sqlite/migrations/source/029_raw_failure_disposition_receipts.sql
+++ b/polylogue/storage/sqlite/migrations/source/029_raw_failure_disposition_receipts.sql
@@ -1,0 +1,28 @@
+CREATE TABLE IF NOT EXISTS raw_failure_disposition_receipts (
+    raw_id                     TEXT PRIMARY KEY REFERENCES raw_sessions(raw_id) ON DELETE CASCADE,
+    artifact_id                TEXT NOT NULL UNIQUE REFERENCES raw_artifacts(artifact_id),
+    origin                     TEXT NOT NULL CHECK(origin IN (
+        'claude-code-session', 'codex-session', 'gemini-cli-session',
+        'hermes-session', 'antigravity-session', 'beads-issue', 'grok-export',
+        'chatgpt-export', 'claude-ai-export', 'claude-design-session',
+        'aistudio-drive', 'unknown-export'
+    )),
+    source_path                TEXT NOT NULL,
+    source_index               INTEGER NOT NULL,
+    blob_hash                  BLOB NOT NULL CHECK(length(blob_hash) = 32),
+    blob_size                  INTEGER NOT NULL CHECK(blob_size >= 0),
+    previous_parse_error       TEXT NOT NULL,
+    previous_validation_status TEXT,
+    disposition_kind           TEXT NOT NULL CHECK(disposition_kind IN (
+        'terminal_corrupt_input',
+        'terminal_unsupported_shape'
+    )),
+    manifest_sha256            TEXT NOT NULL CHECK(length(manifest_sha256) = 64),
+    disposed_at_ms             INTEGER NOT NULL CHECK(disposed_at_ms >= 0),
+    tool_version               TEXT NOT NULL,
+    backup_manifest_path       TEXT NOT NULL,
+    detail                     TEXT NOT NULL DEFAULT ''
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_raw_failure_disposition_receipts_disposed_at
+ON raw_failure_disposition_receipts(disposed_at_ms);

--- a/tests/unit/maintenance/test_raw_failure_disposition_apply.py
+++ b/tests/unit/maintenance/test_raw_failure_disposition_apply.py
@@ -116,9 +116,19 @@ def test_apply_reclassifies_only_manifested_failed_raw_and_writes_receipt(
     assert lifecycle.unexplained == 0
     with sqlite3.connect(root / "source.db") as conn:
         receipt = conn.execute(
-            "SELECT raw_id, disposition_kind, tool_version, detail FROM raw_failure_disposition_receipts"
+            "SELECT raw_id, previous_artifact_kind, previous_support_status, "
+            "previous_classification_reason, disposition_kind, tool_version, detail "
+            "FROM raw_failure_disposition_receipts"
         ).fetchone()
-    assert receipt == (raw_id, "terminal_corrupt_input", TOOL_VERSION, "empty retained byte stream")
+    assert receipt == (
+        raw_id,
+        "coordinator_session_stream",
+        "supported_parseable",
+        "legacy-path-classification",
+        "terminal_corrupt_input",
+        TOOL_VERSION,
+        "empty retained byte stream",
+    )
 
 
 def test_apply_refuses_duplicate_or_nonterminal_manifest_entries(tmp_path: Path) -> None:

--- a/tests/unit/maintenance/test_raw_failure_disposition_apply.py
+++ b/tests/unit/maintenance/test_raw_failure_disposition_apply.py
@@ -1,0 +1,138 @@
+"""Historical terminal raw-failure disposition stays receipt-bound and lossless."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.core.enums import ArtifactSupportStatus, Origin, Provider
+from polylogue.maintenance.raw_failure_disposition_apply import (
+    TOOL_VERSION,
+    RawFailureDispositionApplyError,
+    apply_raw_failure_dispositions,
+)
+from polylogue.storage.raw_failure_lifecycle import read_raw_failure_lifecycle
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from polylogue.storage.sqlite.archive_tiers.source_write import ArchiveSourceArtifact, upsert_raw_artifact
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+
+def _manifest(path: Path, *entries: dict[str, str]) -> Path:
+    path.write_text("".join(json.dumps(entry, sort_keys=True) + "\n" for entry in entries), encoding="utf-8")
+    return path
+
+
+def _archive(tmp_path: Path) -> tuple[Path, str]:
+    root = tmp_path / "archive"
+    initialize_active_archive_root(root)
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        raw_id = archive.write_raw_payload(
+            provider=Provider.CLAUDE_CODE,
+            payload=b"",
+            source_path="/captures/empty.jsonl",
+            acquired_at_ms=100,
+        )
+    with sqlite3.connect(root / "source.db") as conn:
+        conn.execute(
+            "UPDATE raw_sessions SET parse_error = 'captured JSONL payload ends before a complete record boundary'"
+        )
+        upsert_raw_artifact(
+            conn,
+            raw_id,
+            ArchiveSourceArtifact(
+                artifact_id="historical-empty",
+                origin=Origin.CLAUDE_CODE_SESSION,
+                source_path="/captures/empty.jsonl",
+                source_index=0,
+                artifact_kind="coordinator_session_stream",
+                classification_reason="legacy-path-classification",
+                support_status=ArtifactSupportStatus.SUPPORTED_PARSEABLE,
+                first_observed_at_ms=100,
+                last_observed_at_ms=100,
+            ),
+        )
+        conn.commit()
+    return root, raw_id
+
+
+def _state(root: Path) -> tuple[str, str, int]:
+    with sqlite3.connect(root / "source.db") as conn:
+        artifact_kind, parse_error = conn.execute(
+            "SELECT a.artifact_kind, r.parse_error FROM raw_sessions r JOIN raw_artifacts a ON a.raw_id = r.raw_id"
+        ).fetchone()
+        receipts = conn.execute("SELECT COUNT(*) FROM raw_failure_disposition_receipts").fetchone()[0]
+    return str(artifact_kind), str(parse_error), int(receipts)
+
+
+def test_dry_run_preserves_historical_raw_and_artifact(tmp_path: Path) -> None:
+    root, raw_id = _archive(tmp_path)
+    manifest = _manifest(
+        tmp_path / "manifest.jsonl",
+        {"raw_id": raw_id, "disposition_kind": "terminal_corrupt_input", "detail": "empty retained byte stream"},
+    )
+    before = _state(root)
+
+    report = apply_raw_failure_dispositions(root, manifest_path=manifest)
+
+    assert report.applied is False
+    assert report.candidate_count == 1
+    assert report.disposed_raw_ids == ()
+    assert _state(root) == before
+
+
+def test_apply_reclassifies_only_manifested_failed_raw_and_writes_receipt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, raw_id = _archive(tmp_path)
+    manifest = _manifest(
+        tmp_path / "manifest.jsonl",
+        {"raw_id": raw_id, "disposition_kind": "terminal_corrupt_input", "detail": "empty retained byte stream"},
+    )
+    backup = tmp_path / "backup" / "manifest.json"
+    checked: list[tuple[Path, object]] = []
+
+    def _validate(path: Path, tier: object, *, connection: sqlite3.Connection) -> Path:
+        checked.append((path, tier))
+        return path
+
+    monkeypatch.setattr(
+        "polylogue.maintenance.raw_failure_disposition_apply.validate_migration_backup_manifest", _validate
+    )
+    report = apply_raw_failure_dispositions(root, manifest_path=manifest, backup_manifest=backup, dry_run=False)
+
+    assert report.applied is True
+    assert report.disposed_raw_ids == (raw_id,)
+    assert checked == [(backup, ArchiveTier.SOURCE), (backup, ArchiveTier.SOURCE)]
+    artifact_kind, parse_error, receipt_count = _state(root)
+    assert artifact_kind == "terminal_corrupt_input"
+    assert "complete record boundary" in parse_error
+    assert receipt_count == 1
+    lifecycle = read_raw_failure_lifecycle(root / "source.db")
+    assert lifecycle.terminal == 1
+    assert lifecycle.unexplained == 0
+    with sqlite3.connect(root / "source.db") as conn:
+        receipt = conn.execute(
+            "SELECT raw_id, disposition_kind, tool_version, detail FROM raw_failure_disposition_receipts"
+        ).fetchone()
+    assert receipt == (raw_id, "terminal_corrupt_input", TOOL_VERSION, "empty retained byte stream")
+
+
+def test_apply_refuses_duplicate_or_nonterminal_manifest_entries(tmp_path: Path) -> None:
+    root, raw_id = _archive(tmp_path)
+    duplicate = _manifest(
+        tmp_path / "duplicate.jsonl",
+        {"raw_id": raw_id, "disposition_kind": "terminal_corrupt_input", "detail": "one"},
+        {"raw_id": raw_id, "disposition_kind": "terminal_corrupt_input", "detail": "two"},
+    )
+    with pytest.raises(RawFailureDispositionApplyError, match="repeats raw_id"):
+        apply_raw_failure_dispositions(root, manifest_path=duplicate)
+    deferred = _manifest(
+        tmp_path / "deferred.jsonl",
+        {"raw_id": raw_id, "disposition_kind": "deferred_hot_jsonl_capture", "detail": "not terminal"},
+    )
+    with pytest.raises(RawFailureDispositionApplyError, match="not a terminal"):
+        apply_raw_failure_dispositions(root, manifest_path=deferred)


### PR DESCRIPTION
## Summary

Add a backup-gated, manifest-bound path to close terminal historical raw failures without deleting bytes or hiding their parser diagnostics.

## Problem

The stopped-daemon audit identified 92 retained raw failures whose bytes are conclusively terminal input, but their historical artifact classifications predate typed lifecycle evidence. They correctly block reindex today, yet had no safe way to become terminally classified with an immutable audit trail.

## Solution

Source schema v29 adds immutable per-raw disposition receipts. The new actuator validates an exact JSONL manifest in dry-run mode, then with a verified source backup and stopped-daemon authority updates only the matching artifact classification and writes its receipt in one transaction. It leaves raw payloads and parse errors unchanged.

## Verification

- `devtools test tests/unit/maintenance/test_raw_failure_disposition_apply.py` passed: 3 tests.
- `devtools test tests/unit/storage/test_durable_migrations.py -k "source_tier_v1_migrates_to_current_without_native_uniqueness or fresh_source"` passed: 1 selected.
- `devtools lab policy schema-versioning` passed.
- `devtools render all --check` passed.
- `devtools verify --quick` passed: all 24 steps exited 0.

Ref polylogue-dyica