### PR TITLE
fix(live): tolerate legacy catch-up metrics

### DIFF
--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -516,10 +516,13 @@ class LiveWatcher:
                     )
                     if metrics is not None:
                         _log_ingest_metrics(f"live.watcher: catch-up chunk {chunk_index}/{len(chunks)}", metrics)
-                        attempted += metrics.needed_file_count
-                        ingested += metrics.succeeded_file_count
-                        failed += metrics.failed_file_count
-                        for stage, elapsed_s in metrics.stage_timings_s.items():
+                        # Keep the catch-up coordinator compatible with older
+                        # metrics objects and focused test doubles.  The chunk
+                        # itself is the authoritative fallback denominator.
+                        attempted += int(getattr(metrics, "needed_file_count", len(chunk_paths)) or len(chunk_paths))
+                        ingested += int(getattr(metrics, "succeeded_file_count", 0) or 0)
+                        failed += int(getattr(metrics, "failed_file_count", 0) or 0)
+                        for stage, elapsed_s in getattr(metrics, "stage_timings_s", {}).items():
                             stage_timings_s[stage] = stage_timings_s.get(stage, 0.0) + elapsed_s
                         if (
                             getattr(metrics, "succeeded_file_count", 0) == 0


### PR DESCRIPTION
## Summary
Make live catch-up progress reporting compatible with older or minimal metrics objects.

## Problem
The full affected-area verification exposed watcher code that accessed newer catch-up metrics fields directly. Older persisted metrics and test doubles do not provide those fields, so a successful catch-up path could fail while publishing progress.

## Solution
Use the existing chunk-size value when `needed_file_count` is absent and default optional success, failure, and timing metrics through the established metrics object. The production watcher retains the richer metrics when available.

Ref polylogue-catchup-metrics-fix.

## Verification
- `devtools test tests/unit/sources/test_live_catchup_planning.py`: 20 passed in 1.43s
- `nix develop --command git push`: quick verification passed all 24 steps, including Ruff, mypy, rendering, layering, schema policies, and promotion audit.
