### PR TITLE
fix(storage): replay historical durable train slots

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/bootstrap.py
+++ b/polylogue/storage/sqlite/archive_tiers/bootstrap.py
@@ -229,7 +229,13 @@ def _ensure_ops_cursor_lag_sample_columns(conn: sqlite3.Connection) -> None:
     )
 
 
-def initialize_archive_database(path: Path, tier: ArchiveTier, *, allow_create: bool = True) -> None:
+def initialize_archive_database(
+    path: Path,
+    tier: ArchiveTier,
+    *,
+    allow_create: bool = True,
+    expected_version: int | None = None,
+) -> None:
     """Create or initialize one archive tier database file."""
     if allow_create:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -244,8 +250,8 @@ def initialize_archive_database(path: Path, tier: ArchiveTier, *, allow_create: 
         conn = sqlite3.connect(f"{path.resolve(strict=True).as_uri()}?mode=rw", uri=True)
     try:
         current_version = int(conn.execute("PRAGMA user_version").fetchone()[0])
-        expected_version = archive_tier_spec(tier).version
-        if current_version == expected_version:
+        required_version = archive_tier_spec(tier).version if expected_version is None else expected_version
+        if current_version == required_version:
             # ops.db is disposable and evolves through idempotent additive DDL
             # without version bumps. Re-apply it so existing same-version
             # archives receive newly introduced tables and indexes.
@@ -265,13 +271,13 @@ def initialize_archive_database(path: Path, tier: ArchiveTier, *, allow_create: 
                 conn.commit()
             return
         if current_version != 0:
-            if current_version < expected_version and tier in DURABLE_MIGRATION_TIERS:
+            if current_version < required_version and tier in DURABLE_MIGRATION_TIERS:
                 raise RuntimeError(
                     f"{path.name} schema version {current_version} is older than the current {tier.value} tier "
-                    f"version {expected_version}; run an explicit durable-tier migration with a verified backup "
+                    f"version {required_version}; run an explicit durable-tier migration with a verified backup "
                     "manifest"
                 )
-            if tier is ArchiveTier.INDEX and current_version < expected_version:
+            if tier is ArchiveTier.INDEX and current_version < required_version:
                 # index.db is rebuildable, but a bounded set of version gaps
                 # are DECLARED clone-safe (polylogue.storage.sqlite.lifecycle)
                 # -- no raw reparse, no consumer-visible semantic change. Apply
@@ -285,7 +291,7 @@ def initialize_archive_database(path: Path, tier: ArchiveTier, *, allow_create: 
                 )
                 from polylogue.storage.sqlite.lifecycle import index_fast_forward_plan
 
-                plan = index_fast_forward_plan(current_version, expected_version)
+                plan = index_fast_forward_plan(current_version, required_version)
                 if plan is not None:
                     apply_index_fast_forward(conn, plan)
                     return
@@ -296,7 +302,7 @@ def initialize_archive_database(path: Path, tier: ArchiveTier, *, allow_create: 
             )
             raise RuntimeError(
                 f"{path} schema version {current_version} is not the current {tier.value} tier version "
-                f"{expected_version}; move it aside and rebuild the archive root, e.g.: {rebuild_command}"
+                f"{required_version}; move it aside and rebuild the archive root, e.g.: {rebuild_command}"
             )
         initialize_archive_tier(conn, tier)
     finally:

--- a/polylogue/storage/sqlite/durable_change_train.py
+++ b/polylogue/storage/sqlite/durable_change_train.py
@@ -8,6 +8,7 @@ import json
 import os
 import re
 import sqlite3
+import tempfile
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from importlib import resources
@@ -382,6 +383,18 @@ def _runtime_consumer_results(
                             f"runtime consumer {consumer.consumer_id} is source-tier-only: {reference}"
                         )
                     detail = _probe_hook_match_stage(cast(Callable[..., object], value), train.target_version)
+                elif reference.endswith(":read_raw_failure_lifecycle"):
+                    if train.tier is not ArchiveTier.SOURCE:
+                        raise DurableChangeTrainError(
+                            f"runtime consumer {consumer.consumer_id} is source-tier-only: {reference}"
+                        )
+                    detail = _probe_raw_failure_lifecycle(cast(Callable[..., object], value), archive_root)
+                elif reference.endswith(":apply_raw_failure_dispositions"):
+                    if train.tier is not ArchiveTier.SOURCE:
+                        raise DurableChangeTrainError(
+                            f"runtime consumer {consumer.consumer_id} is source-tier-only: {reference}"
+                        )
+                    detail = _probe_raw_failure_disposition_apply(cast(Callable[..., object], value), archive_root)
                 elif not any(
                     parameter.default is inspect.Parameter.empty
                     and parameter.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
@@ -580,6 +593,79 @@ def _probe_hook_match_stage(match_stage: Callable[..., object], target_version: 
     return "staged one orphan with one unambiguous hook match"
 
 
+def _probe_raw_failure_lifecycle(reader: Callable[..., object], archive_root: Path) -> str:
+    """Exercise the source-tier failure lifecycle reader against live bytes."""
+    snapshot = reader(archive_root / "source.db", sample_limit=1)
+    if not getattr(snapshot, "available", False):
+        raise DurableChangeTrainError("raw failure lifecycle probe could not read source.db")
+    return f"read raw failure lifecycle state={getattr(snapshot, 'state', 'unknown')}"
+
+
+def _probe_raw_failure_disposition_apply(actuator: Callable[..., object], archive_root: Path) -> str:
+    """Exercise the disposition actuator's read-only validation route."""
+    del archive_root
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+
+    with tempfile.TemporaryDirectory(prefix="polylogue-durable-train-disposition-") as directory:
+        root = Path(directory)
+        source_path = root / "source.db"
+        with sqlite3.connect(source_path) as connection:
+            initialize_archive_tier(connection, ArchiveTier.SOURCE)
+            connection.execute(
+                """
+                INSERT INTO raw_sessions (
+                    raw_id, origin, source_path, source_index, blob_hash, blob_size,
+                    acquired_at_ms, parse_error
+                ) VALUES (?, ?, ?, 0, ?, 0, ?, ?)
+                """,
+                (
+                    "durable-change-train-disposition-raw",
+                    "claude-code-session",
+                    "/durable-change-train/disposition-probe.jsonl",
+                    b"\0" * 32,
+                    1_780_000_000_000,
+                    "durable change train probe failure",
+                ),
+            )
+            connection.execute(
+                """
+                INSERT INTO raw_artifacts (
+                    artifact_id, raw_id, origin, source_path, source_index,
+                    artifact_kind, support_status, classification_reason,
+                    first_observed_at_ms, last_observed_at_ms
+                ) VALUES (?, ?, ?, ?, 0, ?, ?, ?, ?, ?)
+                """,
+                (
+                    "durable-change-train-disposition-artifact",
+                    "durable-change-train-disposition-raw",
+                    "claude-code-session",
+                    "/durable-change-train/disposition-probe.jsonl",
+                    "coordinator_session_stream",
+                    "supported_parseable",
+                    "durable change train probe",
+                    1_780_000_000_000,
+                    1_780_000_000_000,
+                ),
+            )
+            connection.commit()
+        manifest_path = root / "dispositions.jsonl"
+        manifest_path.write_text(
+            json.dumps(
+                {
+                    "raw_id": "durable-change-train-disposition-raw",
+                    "disposition_kind": "terminal_corrupt_input",
+                    "detail": "durable change train read-only probe",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        report = actuator(root, manifest_path=manifest_path, dry_run=True)
+    if getattr(report, "applied", True) or getattr(report, "candidate_count", 0) != 1:
+        raise DurableChangeTrainError("raw failure disposition probe did not remain read-only")
+    return "validated one raw failure disposition without mutation"
+
+
 def _open_existing_tier(tier_path: Path) -> sqlite3.Connection:
     """Open an existing durable tier without allowing SQLite to create it."""
     try:
@@ -614,6 +700,26 @@ def _verify_persisted_live_tier_continuity(conn: sqlite3.Connection, train: Dura
         raise DurableChangeTrainError(
             f"{train.tier.value} durable tier continuity proof failed; refusing startup initialization/release"
         ) from exc
+
+
+def _verify_released_train_live_tier(conn: sqlite3.Connection, train: DurableChangeTrain) -> None:
+    """Verify a released train remains represented after later trains advance it."""
+    if train.apply_evidence is None:
+        raise DurableChangeTrainError(f"{train.state.value} train lacks post-apply continuity evidence")
+    actual = capture_durable_database_evidence(conn, train.tier)
+    if actual.user_version < train.target_version:
+        raise DurableChangeTrainError(
+            f"{train.tier.value} durable tier continuity proof failed: live version regressed below released train "
+            "target; refusing startup initialization"
+        )
+    if actual.user_version == train.target_version:
+        _verify_persisted_live_tier_continuity(conn, train)
+        return
+    integrity = conn.execute("PRAGMA integrity_check").fetchone()
+    if integrity != ("ok",):
+        raise DurableChangeTrainError(
+            f"{train.tier.value} durable tier integrity check failed after later train advancement"
+        )
 
 
 def _prove_and_release_persisted_train(
@@ -874,7 +980,7 @@ def _reconcile_durable_change_train_startup_locked(archive_root: Path) -> tuple[
             train = _persist_train_transition(manifest_path, recovered, expected_revision=train.revision)
         if train.state is DurableChangeTrainState.RELEASED:
             with _open_existing_tier(archive_root / f"{train.tier.value}.db") as live:
-                _verify_persisted_live_tier_continuity(live, train)
+                _verify_released_train_live_tier(live, train)
             reconciled.append(manifest_path)
             continue
         if train.state not in {

--- a/polylogue/storage/sqlite/durable_change_train.py
+++ b/polylogue/storage/sqlite/durable_change_train.py
@@ -297,10 +297,15 @@ def _fresh_ddl_parity_for_train(
     """Compare a live result, or two canonical creates, against bootstrap DDL."""
     from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
 
+    def prepare_target_schema(connection: sqlite3.Connection) -> None:
+        _migration_runner._prepare_fresh_connection_for_target(connection, train.tier, train.target_version)
+
     if migrated_connection is None:
         with sqlite3.connect(":memory:") as migrated, sqlite3.connect(":memory:") as fresh:
             initialize_archive_tier(migrated, train.tier)
             initialize_archive_tier(fresh, train.tier)
+            prepare_target_schema(migrated)
+            prepare_target_schema(fresh)
             return prove_durable_fresh_ddl_parity(
                 train.tier,
                 train.target_version,
@@ -310,6 +315,7 @@ def _fresh_ddl_parity_for_train(
             )
     with sqlite3.connect(":memory:") as fresh:
         initialize_archive_tier(fresh, train.tier)
+        prepare_target_schema(fresh)
         return prove_durable_fresh_ddl_parity(
             train.tier,
             train.target_version,
@@ -345,7 +351,16 @@ def _runtime_consumer_results(
             detail = f"resolved {reference}"
             try:
                 if reference.endswith(":initialize_archive_database"):
-                    value(archive_root / f"{train.tier.value}.db", train.tier, allow_create=False)
+                    tier_path = archive_root / f"{train.tier.value}.db"
+                    with _open_existing_tier(tier_path) as probe:
+                        live_version = int(probe.execute("PRAGMA user_version").fetchone()[0] or 0)
+                    runtime_target = cast(dict[ArchiveTier, int], vars(_migration_runner)["ARCHIVE_VERSION_BY_TIER"])[
+                        train.tier
+                    ]
+                    if live_version == runtime_target:
+                        value(tier_path, train.tier, allow_create=False)
+                    else:
+                        value(tier_path, train.tier, allow_create=False, expected_version=train.target_version)
                 elif reference.endswith(":initialize_archive_tier"):
                     with sqlite3.connect(":memory:") as probe:
                         value(probe, train.tier)
@@ -355,6 +370,18 @@ def _runtime_consumer_results(
                             f"runtime consumer {consumer.consumer_id} is source-tier-only: {reference}"
                         )
                     detail = _probe_source_hook_event_writer(cast(Callable[..., object], value))
+                elif reference.endswith(":_stage_locked_hook_snapshot"):
+                    if train.tier is not ArchiveTier.SOURCE:
+                        raise DurableChangeTrainError(
+                            f"runtime consumer {consumer.consumer_id} is source-tier-only: {reference}"
+                        )
+                    detail = _probe_locked_hook_snapshot(cast(Callable[..., object], value), train.target_version)
+                elif reference.endswith(":_create_match_stage"):
+                    if train.tier is not ArchiveTier.SOURCE:
+                        raise DurableChangeTrainError(
+                            f"runtime consumer {consumer.consumer_id} is source-tier-only: {reference}"
+                        )
+                    detail = _probe_hook_match_stage(cast(Callable[..., object], value), train.target_version)
                 elif not any(
                     parameter.default is inspect.Parameter.empty
                     and parameter.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
@@ -452,6 +479,105 @@ def _probe_source_hook_event_writer(writer: Callable[..., object]) -> str:
     if hook_row != expected_hook_row or blob_ref_row != expected_blob_ref_row or raw_session_count != (0,):
         raise DurableChangeTrainError("source hook writer probe did not persist the expected hook payload contract")
     return "wrote and read back a hook payload in a fresh source tier"
+
+
+def _runtime_probe_source_connection(target_version: int) -> sqlite3.Connection:
+    """Create a source-tier probe projected to the train's schema slot."""
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+
+    connection = sqlite3.connect(":memory:")
+    initialize_archive_tier(connection, ArchiveTier.SOURCE)
+    _migration_runner._prepare_fresh_connection_for_target(connection, ArchiveTier.SOURCE, target_version)
+    return connection
+
+
+def _seed_hook_reconciliation_probe(connection: sqlite3.Connection) -> tuple[str, bytes, str]:
+    """Install one deterministic orphaned raw payload and its hook evidence."""
+    from polylogue.core.enums import Origin
+    from polylogue.storage.sqlite.archive_tiers.source_write import (
+        deterministic_blob_hash,
+        deterministic_raw_session_id,
+    )
+
+    source_path = "/durable-change-train/hook-reconciliation-probe.jsonl"
+    payload = b'{"event":"PostToolUse","probe":"durable-change-train"}'
+    blob_hash = deterministic_blob_hash(payload)
+    native_id = "durable-change-train-hook-native"
+    ref_id = deterministic_raw_session_id(Origin.CODEX_SESSION, source_path, 0, blob_hash, native_id)
+    connection.execute(
+        """
+        INSERT INTO raw_hook_events (
+            hook_event_id, origin, native_id, session_native_id, source_path,
+            event_type, payload_json, observed_at_ms, blob_hash
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "durable-change-train-hook-event",
+            Origin.CODEX_SESSION.value,
+            native_id,
+            "durable-change-train-hook-session",
+            source_path,
+            "PostToolUse",
+            payload.decode("utf-8"),
+            1_780_000_000_000,
+            blob_hash,
+        ),
+    )
+    connection.execute(
+        """
+        INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+        VALUES (?, ?, 'raw_payload', ?, ?, ?)
+        """,
+        (blob_hash, ref_id, source_path, len(payload), 1_780_000_000_000),
+    )
+    connection.execute(
+        """
+        CREATE TEMP TABLE durable_change_train_probe_candidates (
+            blob_hash BLOB NOT NULL,
+            ref_type TEXT NOT NULL,
+            ref_id TEXT NOT NULL,
+            source_path TEXT,
+            size_bytes INTEGER NOT NULL,
+            acquired_at_ms INTEGER NOT NULL
+        ) STRICT
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO durable_change_train_probe_candidates
+        SELECT blob_hash, ref_type, ref_id, source_path, size_bytes, acquired_at_ms
+        FROM blob_refs
+        WHERE ref_type = 'raw_payload'
+        """
+    )
+    connection.commit()
+    return "durable_change_train_probe_candidates", payload, ref_id
+
+
+def _probe_locked_hook_snapshot(snapshot: Callable[..., object], target_version: int) -> str:
+    """Exercise liveness snapshotting against a real source-tier fixture."""
+    with _runtime_probe_source_connection(target_version) as connection:
+        candidate_table, _payload, _ref_id = _seed_hook_reconciliation_probe(connection)
+        returned_table = snapshot(connection, candidate_table)
+        locked_count = int(connection.execute("SELECT COUNT(*) FROM temp.blob_ref_liveness_locked_hooks").fetchone()[0])
+        identity_count = int(
+            connection.execute("SELECT COUNT(*) FROM temp.blob_ref_liveness_locked_identity_matches").fetchone()[0]
+        )
+    if returned_table != "blob_ref_liveness_locked_hooks" or locked_count != 1 or identity_count != 1:
+        raise DurableChangeTrainError(
+            "liveness hook snapshot probe did not preserve the expected candidate identity evidence"
+        )
+    return "staged one hook candidate with one identity match"
+
+
+def _probe_hook_match_stage(match_stage: Callable[..., object], target_version: int) -> str:
+    """Exercise hook match staging against a real orphan/reference fixture."""
+    with _runtime_probe_source_connection(target_version) as connection:
+        _candidate_table, payload, ref_id = _seed_hook_reconciliation_probe(connection)
+        result = match_stage(connection)
+    if result != (1, 1, len(payload), 0):
+        raise DurableChangeTrainError(f"hook match-stage probe produced unexpected counts for {ref_id}: {result!r}")
+    return "staged one orphan with one unambiguous hook match"
 
 
 def _open_existing_tier(tier_path: Path) -> sqlite3.Connection:
@@ -629,9 +755,12 @@ def execute_durable_change_train(
             fresh_ddl_parity=_fresh_ddl_parity_for_train(train),
             admission_evidence_ref=f"proof:maintenance-admission:{train.train_id}",
             migration_claims=(sidecar.train.migration,),
-            canonical_target_version=cast(dict[ArchiveTier, int], vars(_migration_runner)["ARCHIVE_VERSION_BY_TIER"])[
-                tier
-            ],
+            # A durable archive may be several numbered slots behind the
+            # shipped package.  Admit the exact next train before advancing
+            # to a later sidecar.  Comparing a historical slot with the
+            # package's final target rejects valid sequential recovery as
+            # "stale" before the migration can run.
+            canonical_target_version=sidecar.slot,
         )
         train = _persist_train_transition(manifest_path, train, expected_revision=previous_revision)
     if train.state is DurableChangeTrainState.ADMITTED:

--- a/polylogue/storage/sqlite/migration_runner.py
+++ b/polylogue/storage/sqlite/migration_runner.py
@@ -238,6 +238,47 @@ def _load_migrations(tier: ArchiveTier) -> tuple[MigrationStep, ...]:
     return tuple(steps)
 
 
+def _prepare_fresh_connection_for_target(
+    connection: sqlite3.Connection,
+    tier: ArchiveTier,
+    target_version: int,
+) -> None:
+    """Project current canonical DDL to an earlier additive migration slot.
+
+    The shipped bootstrap is necessarily at the newest version.  A durable
+    archive can be paused between numbered trains, so parity for one historical
+    step must exclude objects explicitly owned by later train riders.  Existing
+    object rewrites remain in the comparison and fail closed.
+    """
+    runtime_target = ARCHIVE_VERSION_BY_TIER[tier]
+    if target_version >= runtime_target:
+        return
+    steps = _load_migrations(tier)
+    from polylogue.storage.sqlite.durable_change_train import validate_durable_migration_sidecars
+
+    sidecars = validate_durable_migration_sidecars(tier, tuple((step.name, step.sql) for step in steps))
+    future_refs = {
+        schema_object
+        for sidecar in sidecars
+        if sidecar.slot > target_version
+        for rider in sidecar.train.riders
+        for schema_object in rider.schema_objects
+    }
+    drop_order = {"index": 0, "trigger": 0, "view": 0, "table": 1}
+    for schema_object in sorted(
+        future_refs,
+        key=lambda item: (drop_order.get(item.partition(":")[0], 2), item),
+    ):
+        object_type, separator, object_name = schema_object.partition(":")
+        if not separator or object_type not in drop_order:
+            continue
+        quoted_name = '"' + object_name.replace('"', '""') + '"'
+        connection.execute(f"DROP {object_type.upper()} IF EXISTS {quoted_name}")
+    if future_refs:
+        connection.execute(f"PRAGMA user_version = {target_version}")
+        connection.commit()
+
+
 def durable_migration_claims(tier: ArchiveTier) -> tuple[DurableMigrationClaim, ...]:
     """Return the exact claims consumed by the shipped migration runner."""
     return tuple(
@@ -1014,6 +1055,7 @@ def migrate_archive_tier(
                 fresh_connection.execute("PRAGMA foreign_keys = ON")
                 fresh_connection.executescript(ARCHIVE_DDL_BY_TIER[tier])
                 fresh_connection.execute(f"PRAGMA user_version = {target_version}")
+                _prepare_fresh_connection_for_target(fresh_connection, tier, target_version)
                 fresh_connection.commit()
                 fresh_parity = prove_durable_fresh_ddl_parity(
                     tier,

--- a/tests/unit/storage/test_durable_change_train.py
+++ b/tests/unit/storage/test_durable_change_train.py
@@ -634,6 +634,127 @@ def test_maintenance_route_persists_and_proves_a_future_train(tmp_path: Path, mo
         )
 
 
+def test_maintenance_route_replays_historical_sidecars_before_current_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A later shipped slot must not reject an earlier persisted train."""
+    package_root = tmp_path / "fixture_migrations_sequential"
+    source_package = package_root / "source"
+    source_package.mkdir(parents=True)
+    (package_root / "__init__.py").write_text("", encoding="utf-8")
+    (source_package / "__init__.py").write_text("", encoding="utf-8")
+
+    rider_template = DurableChangeRider(
+        rider_id="rider:maintenance",
+        owner_ref="owner:maintenance-rider",
+        schema_objects=(),
+        runtime_consumers=(
+            DurableRuntimeConsumer(
+                "bootstrap",
+                "polylogue/storage/sqlite/archive_tiers/bootstrap.py:initialize_archive_database",
+                "proof:bootstrap",
+                ("write",),
+            ),
+            DurableRuntimeConsumer(
+                "daemon-health",
+                "polylogue/storage/sqlite/archive_tiers/bootstrap.py:initialize_archive_tier",
+                "proof:daemon-health",
+                ("read",),
+            ),
+        ),
+        behavior_proof_refs=("proof:bootstrap", "proof:daemon-health"),
+    )
+    migrations = (
+        (2, "durable_items", "CREATE TABLE durable_items (id INTEGER PRIMARY KEY) STRICT;"),
+        (3, "later_items", "CREATE TABLE later_items (id INTEGER PRIMARY KEY) STRICT;"),
+    )
+    for slot, table_name, statement in migrations:
+        sql = f"-- migration-safety: additive-no-backup\n{statement}\n"
+        filename = f"{slot:03d}_{table_name}.sql"
+        (source_package / filename).write_text(sql, encoding="utf-8")
+        claim = durable_migration_claim_for_sql(
+            ArchiveTier.SOURCE,
+            filename,
+            sql,
+            owner_ref=f"owner:maintenance-source:{slot}",
+        )
+        rider = replace(
+            rider_template,
+            rider_id=f"rider:maintenance:{slot}",
+            schema_objects=(f"table:{table_name}",),
+        )
+        declared = declare_durable_change_train(
+            train_id=f"train:source:v{slot}",
+            tier=ArchiveTier.SOURCE,
+            current_version=slot - 1,
+            target_version=slot,
+            slot=slot,
+            owner_ref=f"owner:maintenance-source:{slot}",
+            migration=claim,
+            riders=(rider,),
+            declared_at_ms=slot,
+        )
+        (source_package / f"{slot:03d}.train.json").write_text(
+            json.dumps(migration_runner.durable_change_train_to_payload(declared)), encoding="utf-8"
+        )
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setattr(migration_runner, "_migration_package", lambda _tier: "fixture_migrations_sequential.source")
+    monkeypatch.setattr(
+        "polylogue.storage.sqlite.durable_change_train._migration_package",
+        lambda _tier: "fixture_migrations_sequential.source",
+    )
+    monkeypatch.setattr(
+        "polylogue.storage.sqlite.durable_change_train.DURABLE_MIGRATION_ADOPTION_FLOORS",
+        {ArchiveTier.SOURCE: 1, ArchiveTier.USER: 1},
+    )
+    versions = dict(ARCHIVE_VERSION_BY_TIER)
+    versions[ArchiveTier.SOURCE] = 3
+    monkeypatch.setattr(migration_runner, "ARCHIVE_VERSION_BY_TIER", versions)
+    from polylogue.storage.sqlite.archive_tiers import bootstrap
+
+    monkeypatch.setattr(bootstrap, "ARCHIVE_VERSION_BY_TIER", versions)
+    ddl = dict(ARCHIVE_DDL_BY_TIER)
+    ddl[ArchiveTier.SOURCE] = (
+        "CREATE TABLE base_items (item_id TEXT PRIMARY KEY, payload TEXT NOT NULL) STRICT;"
+        "CREATE TABLE durable_items (id INTEGER PRIMARY KEY) STRICT;"
+        "CREATE TABLE later_items (id INTEGER PRIMARY KEY) STRICT;"
+    )
+    monkeypatch.setattr(bootstrap, "ARCHIVE_DDL_BY_TIER", ddl)
+    monkeypatch.setattr(migration_runner, "ARCHIVE_DDL_BY_TIER", ddl)
+    db_path = tmp_path / "source.db"
+    _create_current_database(db_path)
+    released: list[bool] = []
+
+    first = execute_durable_change_train(
+        tmp_path,
+        ArchiveTier.SOURCE,
+        backup_manifest=None,
+        daemon_stopped_evidence_ref="proof:daemon-stopped",
+        single_writer_evidence_ref="proof:archive-ownership-lock",
+        release_archive_ownership=lambda: released.append(True),
+    )
+    assert first.migration_result is not None
+    assert first.migration_result.applied_versions == (2,)
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute("PRAGMA user_version").fetchone() == (2,)
+
+    second = execute_durable_change_train(
+        tmp_path,
+        ArchiveTier.SOURCE,
+        backup_manifest=None,
+        daemon_stopped_evidence_ref="proof:daemon-stopped",
+        single_writer_evidence_ref="proof:archive-ownership-lock",
+        release_archive_ownership=lambda: released.append(True),
+    )
+    assert second.migration_result is not None
+    assert second.migration_result.applied_versions == (3,)
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute("PRAGMA user_version").fetchone() == (3,)
+        assert conn.execute("SELECT name FROM sqlite_schema WHERE name='later_items'").fetchone() == ("later_items",)
+    assert released == [True, True]
+
+
 def test_future_train_sidecar_hash_and_slot_are_admission_bound(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/storage/test_durable_change_train.py
+++ b/tests/unit/storage/test_durable_change_train.py
@@ -305,6 +305,23 @@ def test_source_v27_sidecar_proves_the_real_hook_event_writer_against_fresh_sche
         assert conn.execute("SELECT COUNT(*) FROM blob_refs").fetchone() == (0,)
 
 
+def test_source_v29_sidecar_proves_failure_lifecycle_consumers_against_fresh_schema(tmp_path: Path) -> None:
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+
+    sidecar = durable_migration_sidecar_for_slot(ArchiveTier.SOURCE, 29)
+    assert sidecar is not None
+    initialize_archive_database(tmp_path / "source.db", ArchiveTier.SOURCE)
+
+    results = _runtime_consumer_results(sidecar.train, tmp_path)
+
+    assert [(result.consumer_id, result.passed) for result in results] == [
+        ("raw-failure-lifecycle", True),
+        ("historical-disposition-actuator", True),
+    ]
+    assert results[0].detail == "read raw failure lifecycle state=healthy"
+    assert results[1].detail == "validated one raw failure disposition without mutation"
+
+
 def test_applied_train_release_requires_the_source_hook_event_writer_probe(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
Repair durable-tier maintenance recovery when a shipped package contains later schema slots than a persisted earlier train.

## Problem
A source-v28 train applied under an interrupted rollout could not be released by the current package because admission compared the historical slot with the final runtime target. Fresh-DDL parity also included later train-owned objects, and the two source-v28 riders had no executable runtime probe adapters.

## Solution
Admit the exact next sidecar slot, project canonical fresh schemas to the requested historical target, and let bootstrap probes validate the train target during sequential recovery. Add production-shaped probes for the liveness snapshot and hook-match stages using a deterministic source-tier fixture with an orphan and an unambiguous hook match.

## Verification
- `direnv exec . devtools test tests/unit/storage/test_durable_change_train.py -k 'runtime_consumer or maintenance_route'`: 3 passed.
- Direct current source-v28 sidecar probe: both riders passed with one staged identity match and one unambiguous hook match.
- `direnv exec . devtools verify --quick`: exit 0, all 24 steps passed.
- The full durable-train file has one inherited failure in `test_canonical_inventory_preserves_trigger_literal_whitespace`; the changed focused selection is green.

Ref polylogue-60i5
