### PR TITLE
test(sources): verify origin parser claims

### DIFF
--- a/tests/data/origin_capability_matrix.json
+++ b/tests/data/origin_capability_matrix.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 1,
+  "entries": [
+    {"origin": "claude-code-session", "status": "supported", "provider": "claude-code", "fixture": "tests/fixtures/claude-code/claude-normalization-main.jsonl", "format": "jsonl", "fallback_id": "origin-matrix-claude-code", "parser_claims": [{"provider": "claude-code"}]},
+    {"origin": "codex-session", "status": "supported", "provider": "codex", "fixture": "tests/data/codex_event_stream/text_only_stream.jsonl", "format": "jsonl", "fallback_id": "origin-matrix-codex", "parser_claims": [{"provider": "codex"}]},
+    {"origin": "gemini-cli-session", "status": "supported", "provider": "gemini-cli", "fixture": "tests/fixtures/origin-capability/gemini-cli-session.json", "format": "json", "fallback_id": "origin-matrix-gemini-cli", "parser_claims": [{"provider": "gemini-cli"}]},
+    {"origin": "hermes-session", "status": "supported", "provider": "hermes", "fixture": "tests/fixtures/hermes/atif/nemo_relay_atif_v1.7_real_redacted.json", "format": "json", "fallback_id": "origin-matrix-hermes", "parser_claims": [{"provider": "hermes"}]},
+    {"origin": "antigravity-session", "status": "supported", "provider": "antigravity", "fixture": "tests/fixtures/origin-capability/antigravity-session.json", "format": "json", "fallback_id": "origin-matrix-antigravity", "parser_claims": [{"provider": "antigravity"}]},
+    {"origin": "beads-issue", "status": "supported", "provider": "beads", "fixture": "tests/fixtures/beads/issue-interactions.jsonl", "format": "jsonl", "fallback_id": "origin-matrix-beads", "parser_claims": [{"provider": "beads"}]},
+    {"origin": "grok-export", "status": "supported", "provider": "grok", "fixture": "tests/fixtures/origin-capability/grok-export.json", "format": "json", "fallback_id": "origin-matrix-grok", "parser_claims": [{"provider": "grok"}]},
+    {"origin": "chatgpt-export", "status": "supported", "provider": "chatgpt", "fixture": "tests/fixtures/chatgpt/native-conversation-v1.json", "format": "json", "fallback_id": "origin-matrix-chatgpt", "parser_claims": [{"provider": "chatgpt"}]},
+    {"origin": "claude-ai-export", "status": "supported", "provider": "claude-ai", "fixture": "tests/fixtures/origin-capability/claude-ai-export.json", "format": "json", "fallback_id": "origin-matrix-claude-ai", "parser_claims": [{"provider": "claude-ai"}]},
+    {"origin": "claude-design-session", "status": "supported", "provider": "claude-design", "fixture": "tests/fixtures/origin-capability/claude-design-session.json", "format": "json", "fallback_id": "origin-matrix-claude-design", "parser_claims": [{"provider": "claude-design"}]},
+    {"origin": "aistudio-drive", "status": "supported", "provider": "gemini", "fixture": "tests/data/gemini_chunked_prompt/text_only_session.json", "format": "json", "fallback_id": "origin-matrix-aistudio", "parser_claims": [{"provider": "gemini"}]},
+    {"origin": "unknown-export", "status": "unsupported", "parser_claims": [], "unsupported": {"status": "unsupported", "reason": "compatibility-only", "detail": "OriginSpec is a compatibility fallback with no parser binding; retain evidence until a concrete source adapter is admitted."}}
+  ],
+  "malformed": [
+    {"name": "claude-code-missing-envelope", "provider": "claude-code", "payload": [{"sessionId": "only-an-id"}]},
+    {"name": "codex-missing-record-shape", "provider": "codex", "payload": [{"type": "response_item", "payload": {"type": "message", "role": "user"}}]},
+    {"name": "chatgpt-missing-document-identity", "provider": "chatgpt", "payload": {"mapping": {"node": {}}}},
+    {"name": "claude-ai-missing-content", "provider": "claude-ai", "payload": {"chat_messages": [{"sender": "human"}]}},
+    {"name": "gemini-cli-invalid-kind", "provider": "gemini-cli", "payload": {"sessionId": "invalid", "kind": "unknown", "messages": []}},
+    {"name": "grok-malformed-conversation", "provider": "grok", "payload": {"conversations": [{"not": "a conversation"}]}}
+  ],
+  "collisions": [
+    {"name": "claude-code-before-codex", "expected_provider": "claude-code", "fallback_id": "origin-matrix-collision-claude", "payload": [{"sessionId": "collision-session", "parentUuid": "collision-parent", "role": "user", "content": [{"type": "text", "text": "collision witness"}]}]},
+    {"name": "chatgpt-before-claude-ai", "expected_provider": "chatgpt", "fallback_id": "origin-matrix-collision-chatgpt", "payload": {"id": "collision-conversation", "conversation_id": "collision-conversation", "create_time": 1700000000.0, "current_node": "node-1", "mapping": {"node-1": {"id": "node-1", "parent": null, "children": [], "message": {"id": "message-1", "author": {"role": "user"}, "content": {"content_type": "text", "parts": ["collision witness"]}}}}, "chat_messages": [{"sender": "human", "text": "collision witness"}]}}
+  ]
+}

--- a/tests/fixtures/origin-capability/antigravity-session.json
+++ b/tests/fixtures/origin-capability/antigravity-session.json
@@ -1,0 +1,9 @@
+{
+  "source": "antigravity_language_server",
+  "cascadeId": "origin-matrix-antigravity",
+  "title": "Origin capability matrix",
+  "workspaceName": "polylogue",
+  "snippet": "Prove the parser claim.",
+  "lastModifiedTime": "2026-08-01T10:00:02Z",
+  "markdown": "### User Input\n\nProve the parser claim.\n\n### Planner Response\n\nThe production route parsed this witness.\n"
+}

--- a/tests/fixtures/origin-capability/claude-ai-export.json
+++ b/tests/fixtures/origin-capability/claude-ai-export.json
@@ -1,0 +1,14 @@
+{
+  "uuid": "origin-matrix-claude-ai",
+  "title": "Origin capability matrix",
+  "created_at": "2026-08-01T10:00:00Z",
+  "updated_at": "2026-08-01T10:00:02Z",
+  "chat_messages": [
+    {
+      "uuid": "message-1",
+      "sender": "human",
+      "text": "Prove the parser claim.",
+      "created_at": "2026-08-01T10:00:01Z"
+    }
+  ]
+}

--- a/tests/fixtures/origin-capability/claude-design-session.json
+++ b/tests/fixtures/origin-capability/claude-design-session.json
@@ -1,0 +1,20 @@
+{
+  "uuid": "origin-matrix-claude-design",
+  "project": {
+    "uuid": "origin-matrix-project",
+    "name": "Polylogue"
+  },
+  "messages": [
+    {
+      "uuid": "message-1",
+      "role": "user",
+      "content": {
+        "role": "user",
+        "content": "Prove the parser claim.",
+        "authorAccountUuid": "origin-matrix-account",
+        "authorName": "Sinity",
+        "timestamp": "2026-08-01T10:00:01.000Z"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/origin-capability/gemini-cli-session.json
+++ b/tests/fixtures/origin-capability/gemini-cli-session.json
@@ -1,0 +1,23 @@
+{
+  "sessionId": "origin-matrix-gemini-cli",
+  "projectHash": "origin-matrix-project",
+  "startTime": "2026-08-01T10:00:00.000Z",
+  "lastUpdated": "2026-08-01T10:00:02.000Z",
+  "kind": "chat",
+  "summary": "Origin capability matrix",
+  "messages": [
+    {
+      "id": "user-1",
+      "timestamp": "2026-08-01T10:00:01.000Z",
+      "type": "user",
+      "content": ["Prove the parser claim."]
+    },
+    {
+      "id": "assistant-1",
+      "timestamp": "2026-08-01T10:00:02.000Z",
+      "type": "gemini",
+      "content": "The production route parsed this witness.",
+      "model": "gemini-matrix"
+    }
+  ]
+}

--- a/tests/fixtures/origin-capability/grok-export.json
+++ b/tests/fixtures/origin-capability/grok-export.json
@@ -1,0 +1,22 @@
+{
+  "conversations": [
+    {
+      "conversation": {
+        "title": "Origin capability matrix",
+        "create_time": "2026-08-01T10:00:00Z"
+      },
+      "responses": [
+        {
+          "sender": "human",
+          "message": "Prove the parser claim.",
+          "create_time": "2026-08-01T10:00:01Z"
+        },
+        {
+          "sender": "assistant",
+          "message": "The production route parsed this witness.",
+          "create_time": "2026-08-01T10:00:02Z"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/infra/origin_capability_matrix.py
+++ b/tests/infra/origin_capability_matrix.py
@@ -1,0 +1,249 @@
+"""Typed loader and production-path helpers for the origin capability matrix."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, TypeVar, cast
+
+from polylogue.core.enums import Origin, Provider
+from polylogue.sources.origin_specs import ORIGIN_SPECS, OriginSpec
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO_ROOT / "tests" / "data" / "origin_capability_matrix.json"
+
+UnsupportedReason = Literal["compatibility-only", "no-parser"]
+_LiteralValue = TypeVar("_LiteralValue", bound=str)
+
+
+@dataclass(frozen=True, slots=True)
+class ParserClaim:
+    provider: Provider
+
+
+@dataclass(frozen=True, slots=True)
+class UnsupportedReceipt:
+    status: Literal["unsupported"]
+    reason: UnsupportedReason
+    detail: str
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityEntry:
+    origin: Origin
+    parser_claims: tuple[ParserClaim, ...]
+    fixture_path: str | None
+    fixture_format: Literal["json", "jsonl"] | None
+    fallback_id: str | None
+    unsupported: UnsupportedReceipt | None
+
+
+@dataclass(frozen=True, slots=True)
+class NegativeCase:
+    name: str
+    provider: Provider
+    payload: object
+
+
+@dataclass(frozen=True, slots=True)
+class CollisionCase:
+    name: str
+    expected_provider: Provider
+    payload: object
+    fallback_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityManifest:
+    entries: tuple[CapabilityEntry, ...]
+    malformed: tuple[NegativeCase, ...]
+    collisions: tuple[CollisionCase, ...]
+
+
+def load_manifest() -> CapabilityManifest:
+    """Load the committed matrix and validate it against live OriginSpec declarations."""
+    return load_manifest_payload(json.loads(MANIFEST_PATH.read_text(encoding="utf-8")))
+
+
+def load_manifest_payload(payload: object) -> CapabilityManifest:
+    """Validate one manifest payload, including parser-claim cardinality."""
+    root = _mapping(payload, "manifest")
+    if root.get("schema_version") != 1:
+        raise ValueError("origin capability manifest schema_version must be 1")
+
+    raw_entries = _list(root.get("entries"), "manifest.entries")
+    entries = tuple(_entry(item) for item in raw_entries)
+    origins = tuple(entry.origin for entry in entries)
+    if len(set(origins)) != len(origins):
+        raise ValueError("origin capability manifest contains duplicate origins")
+
+    declared_origins = {spec.origin for spec in ORIGIN_SPECS}
+    if set(origins) != set(Origin) or declared_origins != set(Origin):
+        raise ValueError("origin capability manifest must cover every OriginSpec and public Origin")
+
+    malformed = tuple(_negative_case(item) for item in _list(root.get("malformed"), "manifest.malformed"))
+    collisions = tuple(_collision_case(item) for item in _list(root.get("collisions"), "manifest.collisions"))
+    if not malformed:
+        raise ValueError("origin capability manifest requires malformed negatives")
+    if not collisions:
+        raise ValueError("origin capability manifest requires collision negatives")
+    return CapabilityManifest(entries=entries, malformed=malformed, collisions=collisions)
+
+
+def load_fixture(entry: CapabilityEntry) -> object:
+    """Read one committed witness fixture without invoking a parser helper."""
+    if entry.fixture_path is None or entry.fixture_format is None:
+        raise ValueError(f"{entry.origin.value}: unsupported entry has no fixture")
+    path = _repo_path(entry.fixture_path)
+    if entry.fixture_format == "json":
+        return json.loads(path.read_text(encoding="utf-8"))
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def _entry(payload: object) -> CapabilityEntry:
+    raw = _mapping(payload, "manifest entry")
+    origin = _origin(raw.get("origin"))
+    status = raw.get("status")
+    raw_claims = _list(raw.get("parser_claims"), f"{origin.value}.parser_claims")
+    claims = tuple(
+        ParserClaim(provider=_provider(_mapping(item, "parser claim").get("provider"))) for item in raw_claims
+    )
+
+    if status == "supported":
+        if len(claims) != 1:
+            raise ValueError(f"{origin.value}: supported entry requires exactly one parser claim")
+        spec = _spec_for(origin)
+        if spec.lifecycle != "executable":
+            raise ValueError(f"{origin.value}: supported entry is not executable in OriginSpec")
+        declared_provider = _provider(raw["provider"]) if raw.get("provider") is not None else claims[0].provider
+        if declared_provider is not claims[0].provider:
+            raise ValueError(f"{origin.value}: provider field disagrees with its parser claim")
+        if claims[0].provider not in spec.provider_wires:
+            raise ValueError(f"{origin.value}: parser claim is not declared by OriginSpec")
+        fixture_path = _string(raw.get("fixture"), f"{origin.value}.fixture")
+        fixture_format = cast(
+            Literal["json", "jsonl"],
+            _literal(raw.get("format"), ("json", "jsonl"), f"{origin.value}.format"),
+        )
+        _repo_path(fixture_path)
+        fallback_id = _string(raw.get("fallback_id"), f"{origin.value}.fallback_id")
+        if raw.get("unsupported") is not None:
+            raise ValueError(f"{origin.value}: supported entry cannot carry an unsupported receipt")
+        return CapabilityEntry(origin, claims, fixture_path, fixture_format, fallback_id, None)
+
+    if status != "unsupported":
+        raise ValueError(f"{origin.value}: status must be supported or unsupported")
+    if claims:
+        raise ValueError(f"{origin.value}: unsupported entry cannot declare parser claims")
+    spec = _spec_for(origin)
+    if spec.lifecycle == "executable":
+        raise ValueError(f"{origin.value}: executable OriginSpec cannot be silently unsupported")
+    receipt = _unsupported_receipt(raw.get("unsupported"), origin)
+    if raw.get("fixture") is not None or raw.get("format") is not None or raw.get("fallback_id") is not None:
+        raise ValueError(f"{origin.value}: unsupported entry cannot carry a fixture")
+    return CapabilityEntry(origin, (), None, None, None, receipt)
+
+
+def _unsupported_receipt(payload: object, origin: Origin) -> UnsupportedReceipt:
+    raw = _mapping(payload, f"{origin.value}.unsupported")
+    reason = cast(
+        UnsupportedReason,
+        _literal(raw.get("reason"), ("compatibility-only", "no-parser"), f"{origin.value}.unsupported.reason"),
+    )
+    detail = _string(raw.get("detail"), f"{origin.value}.unsupported.detail")
+    return UnsupportedReceipt(status="unsupported", reason=reason, detail=detail)
+
+
+def _negative_case(payload: object) -> NegativeCase:
+    raw = _mapping(payload, "malformed case")
+    return NegativeCase(
+        name=_string(raw.get("name"), "malformed.name"),
+        provider=_provider(raw.get("provider")),
+        payload=raw.get("payload"),
+    )
+
+
+def _collision_case(payload: object) -> CollisionCase:
+    raw = _mapping(payload, "collision case")
+    return CollisionCase(
+        name=_string(raw.get("name"), "collision.name"),
+        expected_provider=_provider(raw.get("expected_provider")),
+        payload=raw.get("payload"),
+        fallback_id=_string(raw.get("fallback_id"), "collision.fallback_id"),
+    )
+
+
+def _spec_for(origin: Origin) -> OriginSpec:
+    for spec in ORIGIN_SPECS:
+        if spec.origin is origin:
+            return spec
+    raise ValueError(f"{origin.value}: missing OriginSpec")
+
+
+def _repo_path(value: str) -> Path:
+    path = (REPO_ROOT / value).resolve()
+    try:
+        path.relative_to(REPO_ROOT)
+    except ValueError as exc:
+        raise ValueError(f"fixture path escapes repository: {value!r}") from exc
+    if not path.is_file():
+        raise ValueError(f"fixture path does not exist: {value!r}")
+    return path
+
+
+def _mapping(value: object, label: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must be an object")
+    return cast(Mapping[str, object], value)
+
+
+def _list(value: object, label: str) -> list[object]:
+    if not isinstance(value, list):
+        raise ValueError(f"{label} must be a list")
+    return value
+
+
+def _string(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} must be a non-empty string")
+    return value
+
+
+def _origin(value: object) -> Origin:
+    if not isinstance(value, str):
+        raise ValueError("origin must be a string")
+    try:
+        return Origin(value)
+    except ValueError as exc:
+        raise ValueError(f"unknown origin: {value!r}") from exc
+
+
+def _provider(value: object) -> Provider:
+    if not isinstance(value, str):
+        raise ValueError("provider must be a string")
+    try:
+        return Provider(value)
+    except ValueError as exc:
+        raise ValueError(f"unknown provider: {value!r}") from exc
+
+
+def _literal(value: object, choices: tuple[_LiteralValue, ...], label: str) -> _LiteralValue:
+    if not isinstance(value, str) or value not in choices:
+        raise ValueError(f"{label} must be one of {choices!r}")
+    return value
+
+
+__all__ = [
+    "CapabilityEntry",
+    "CapabilityManifest",
+    "CollisionCase",
+    "MANIFEST_PATH",
+    "NegativeCase",
+    "ParserClaim",
+    "UnsupportedReceipt",
+    "load_fixture",
+    "load_manifest",
+    "load_manifest_payload",
+]

--- a/tests/unit/sources/test_origin_capability_matrix.py
+++ b/tests/unit/sources/test_origin_capability_matrix.py
@@ -1,0 +1,116 @@
+"""Production-route capability matrix for every public archive origin."""
+
+from __future__ import annotations
+
+import copy
+import json
+
+import pytest
+
+from polylogue.core.enums import Origin
+from polylogue.core.sources import origin_from_provider
+from polylogue.sources.dispatch import (
+    detect_provider,
+    detect_provider_evidence,
+    parse_payload,
+    require_positive_conversational_evidence,
+)
+from tests.infra.origin_capability_matrix import (
+    MANIFEST_PATH,
+    load_fixture,
+    load_manifest,
+    load_manifest_payload,
+)
+
+
+def test_manifest_covers_every_origin_with_typed_support_state() -> None:
+    manifest = load_manifest()
+    assert {entry.origin for entry in manifest.entries} == set(Origin)
+
+    supported = [entry for entry in manifest.entries if entry.unsupported is None]
+    unsupported = [entry for entry in manifest.entries if entry.unsupported is not None]
+    assert len(supported) == 11
+    assert len(unsupported) == 1
+    assert unsupported[0].origin is Origin.UNKNOWN_EXPORT
+    assert unsupported[0].unsupported is not None
+    assert unsupported[0].unsupported.status == "unsupported"
+    assert unsupported[0].unsupported.reason == "compatibility-only"
+    assert unsupported[0].unsupported.detail
+
+
+def test_each_supported_origin_has_one_claim_and_reaches_production_detector_and_parser() -> None:
+    manifest = load_manifest()
+
+    for entry in manifest.entries:
+        if entry.unsupported is not None:
+            assert entry.parser_claims == ()
+            continue
+
+        assert len(entry.parser_claims) == 1
+        claim = entry.parser_claims[0]
+        payload = load_fixture(entry)
+        detected, evidence = detect_provider_evidence(payload, entry.fixture_path)
+
+        assert detected is claim.provider, entry.origin.value
+        assert origin_from_provider(detected) is entry.origin
+        assert evidence.strip(), entry.origin.value
+
+        sessions = parse_payload(
+            claim.provider,
+            payload,
+            entry.fallback_id or "origin-capability",
+            source_path=entry.fixture_path,
+        )
+        accepted = require_positive_conversational_evidence(
+            sessions,
+            provider=claim.provider,
+            source_path=entry.fixture_path,
+        )
+        assert accepted, entry.origin.value
+
+
+def test_malformed_witnesses_are_rejected_by_detector_and_content_gate() -> None:
+    manifest = load_manifest()
+
+    for case in manifest.malformed:
+        detect_provider(case.payload)
+        sessions = parse_payload(case.provider, case.payload, f"malformed-{case.name}")
+        assert (
+            require_positive_conversational_evidence(
+                sessions,
+                provider=case.provider,
+                source_path=None,
+            )
+            == []
+        ), case.name
+
+
+def test_collision_witnesses_follow_real_detector_precedence_and_still_parse() -> None:
+    manifest = load_manifest()
+
+    for case in manifest.collisions:
+        detected, evidence = detect_provider_evidence(case.payload)
+        assert detected is case.expected_provider, case.name
+        assert evidence.strip(), case.name
+        sessions = parse_payload(case.expected_provider, case.payload, case.fallback_id)
+        assert sessions, case.name
+
+
+@pytest.mark.parametrize("claim_count", [0, 2])
+def test_zero_or_multiple_parser_claims_fail_manifest_validation(claim_count: int) -> None:
+    payload = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    supported = next(item for item in payload["entries"] if item["status"] == "supported")
+    claim = supported["parser_claims"][0]
+    supported["parser_claims"] = [] if claim_count == 0 else [claim, copy.deepcopy(claim)]
+
+    with pytest.raises(ValueError, match="exactly one parser claim"):
+        load_manifest_payload(payload)
+
+
+def test_unsupported_route_cannot_become_silent_green_support() -> None:
+    payload = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    unsupported = next(item for item in payload["entries"] if item["status"] == "unsupported")
+    unsupported["status"] = "supported"
+
+    with pytest.raises(ValueError, match="exactly one parser claim"):
+        load_manifest_payload(payload)


### PR DESCRIPTION
## Summary

Add a committed capability matrix for every public OriginSpec declaration. Supported origins have one raw-wire witness and one parser claim. The compatibility-only unknown route has a typed unsupported receipt. Ref polylogue-origin-capability-matrix

## Problem

OriginSpec and provider-specific parser tests existed separately, so there was no one artifact proving that every public origin reached the real detector and lowering path or that unsupported coverage remained visible. A manifest without production-route assertions could certify itself.

## Solution

Add `tests/data/origin_capability_matrix.json` and a typed loader that validates Origin and OriginSpec coverage, fixture paths, provider bindings, claim cardinality, collision cases, malformed cases, and unsupported receipts. Add five minimal raw-wire fixtures for origins without committed raw fixture files. Add focused tests that call `detect_provider_evidence`, `detect_provider`, `parse_payload`, and the positive-content gate. The canonical comparator, corpus program, and parser implementations are unchanged.

## Verification

- `direnv exec /realm/worktrees/polylogue-origin-capability-matrix devtools test tests/unit/sources/test_origin_capability_matrix.py`: 7 passed.
- `direnv exec /realm/worktrees/polylogue-origin-capability-matrix devtools verify --quick`: exit 0.
- `direnv exec /realm/worktrees/polylogue-origin-capability-matrix mypy --strict tests/infra/origin_capability_matrix.py tests/unit/sources/test_origin_capability_matrix.py`: no issues found.
- Direct loader receipt: `entries=12 supported=11 unsupported=1 malformed=6 collisions=2`.

## AC status

| Acceptance criterion | Status | Evidence |
| --- | --- | --- |
| Cover all committed origins and inferred constructs | Satisfied | 12 Origin entries, 11 supported witnesses, 6 malformed negatives, 2 collision precedence cases |
| Exercise production ingest detection and parsing | Satisfied | Real `detect_provider_evidence`, `detect_provider`, `parse_payload`, and positive-content gate |
| Fail on zero claims or multiple claims | Satisfied | Parametrized zero and duplicate claim mutations raise validation errors |
| Keep unsupported routes typed and visible | Satisfied | `unknown-export` carries an explicit unsupported receipt and silent promotion fails validation |

## Residual uncertainty

The matrix proves representative raw-wire routes, not every provider fixture variant. Existing provider-specific suites remain responsible for deeper fidelity and corpus breadth.