### PR TITLE
test(infra): add production corpus operation programs

### DIFF
--- a/tests/infra/corpus_program.py
+++ b/tests/infra/corpus_program.py
@@ -18,7 +18,7 @@ from enum import StrEnum
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
-from polylogue.core.json import JSONDocument, JSONValue, is_json_document, require_json_document
+from polylogue.core.json import JSONDocument, JSONValue, is_json_document
 
 if TYPE_CHECKING:
     from polylogue.maintenance.rebuild_index import RebuildIndexReceipt
@@ -708,6 +708,18 @@ def operation_strategy(*, artifact_ids: Sequence[str] = ("a", "b")) -> Any:
                 payload=st.binary(max_size=32),
             ),
         ),
+        st.builds(
+            EmitHook,
+            operation_id=st.text("op", min_size=2, max_size=8),
+            hook=st.builds(
+                HookArtifact,
+                hook_event_id=st.text("hook", min_size=4, max_size=10),
+                provider=st.just("codex"),
+                event_type=st.just("session.created"),
+                session_native_id=st.text("session", min_size=4, max_size=12),
+                payload=st.binary(max_size=64),
+            ),
+        ),
         st.builds(Crash, operation_id=st.text("op", min_size=2, max_size=8)),
         st.builds(Restart, operation_id=st.text("op", min_size=2, max_size=8)),
         st.builds(Converge, operation_id=st.text("op", min_size=2, max_size=8)),
@@ -773,13 +785,10 @@ class ProductionCorpusRuntime:
 
     def emit_hook(self, hook: HookArtifact) -> object:
         self._ensure_running()
-        from polylogue.archive.artifact_taxonomy import classify_artifact_path
-        from polylogue.config import Source
         from polylogue.core.enums import Provider
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
         from polylogue.storage.sqlite.archive_tiers.source_write import ArchiveHookEvent
 
-        del classify_artifact_path, Source
         provider = Provider.from_string(hook.provider)
         payload = hook.payload
         with ArchiveStore.open_existing(self.archive_root, read_only=False) as archive:
@@ -874,11 +883,6 @@ class ProductionCorpusRuntime:
         return result
 
 
-def _unused_json_document(value: object) -> JSONDocument:
-    """Keep the public JSON contract available to callers without Any leakage."""
-    return require_json_document(value)
-
-
 __all__ = [
     "Acquire",
     "Append",
@@ -889,6 +893,7 @@ __all__ = [
     "CorpusProgramError",
     "CorpusRun",
     "CorpusRuntimeCrashed",
+    "CorpusRuntimeCrashedError",
     "CorpusState",
     "Crash",
     "Converge",

--- a/tests/infra/corpus_program.py
+++ b/tests/infra/corpus_program.py
@@ -1,0 +1,897 @@
+"""Typed, composable corpus programs for production-route property tests.
+
+The program layer owns only synthetic evidence and scheduling.  It does not
+know how to write an archive.  :class:`ProductionCorpusRuntime` delegates
+those effects to the existing acquisition, parsing, convergence, hook, and
+rebuild seams, which keeps this harness from becoming a second archive
+engine.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field, replace
+from enum import StrEnum
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING, Any, Protocol, cast
+
+from polylogue.core.json import JSONDocument, JSONValue, is_json_document, require_json_document
+
+if TYPE_CHECKING:
+    from polylogue.maintenance.rebuild_index import RebuildIndexReceipt
+    from polylogue.pipeline.services.parsing_models import ParseResult
+
+
+class CorpusProgramError(ValueError):
+    """Invalid corpus program or artifact reference."""
+
+
+class CorpusRuntimeCrashedError(RuntimeError):
+    """An operation attempted to use a crashed runtime before Restart."""
+
+
+CorpusRuntimeCrashed = CorpusRuntimeCrashedError
+
+
+def _validate_identifier(value: str, *, field_name: str) -> str:
+    if not value or value.strip() != value or any(char.isspace() for char in value):
+        raise CorpusProgramError(f"{field_name} must be a non-empty token")
+    return value
+
+
+def _validate_relative_path(value: str) -> str:
+    path = PurePosixPath(value)
+    if not value or path.is_absolute() or ".." in path.parts:
+        raise CorpusProgramError("source_path must be a non-empty relative path without '..'")
+    return path.as_posix()
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _b64(value: bytes) -> str:
+    return base64.b64encode(value).decode("ascii")
+
+
+def _unb64(value: object, *, field_name: str) -> bytes:
+    if not isinstance(value, str):
+        raise CorpusProgramError(f"{field_name} must be base64 text")
+    try:
+        return base64.b64decode(value.encode("ascii"), validate=True)
+    except (ValueError, UnicodeEncodeError) as exc:
+        raise CorpusProgramError(f"{field_name} is not valid base64") from exc
+
+
+@dataclass(frozen=True, slots=True)
+class AttachmentArtifact:
+    """Synthetic attachment bytes carried by a corpus artifact."""
+
+    attachment_id: str
+    name: str
+    mime_type: str = "application/octet-stream"
+    payload: bytes = b""
+
+    def __post_init__(self) -> None:
+        _validate_identifier(self.attachment_id, field_name="attachment_id")
+        if not self.name:
+            raise CorpusProgramError("attachment name must be non-empty")
+
+    def to_dict(self) -> JSONDocument:
+        return {
+            "attachment_id": self.attachment_id,
+            "name": self.name,
+            "mime_type": self.mime_type,
+            "payload_b64": _b64(self.payload),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> AttachmentArtifact:
+        return cls(
+            attachment_id=_required_string(payload, "attachment_id"),
+            name=_required_string(payload, "name"),
+            mime_type=_optional_string(payload, "mime_type") or "application/octet-stream",
+            payload=_unb64(payload.get("payload_b64"), field_name="payload_b64"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RawArtifact:
+    """One deterministic source artifact before it reaches production ingest."""
+
+    artifact_id: str
+    payload: bytes
+    source_name: str = "codex"
+    source_path: str = "sources/artifact.jsonl"
+    source_index: int = 0
+    parent_artifact_id: str | None = None
+    attachments: tuple[AttachmentArtifact, ...] = ()
+    metadata: Mapping[str, JSONValue] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        _validate_identifier(self.artifact_id, field_name="artifact_id")
+        _validate_relative_path(self.source_path)
+        if self.source_index < 0:
+            raise CorpusProgramError("source_index must be non-negative")
+        if not is_json_document(dict(self.metadata)):
+            raise CorpusProgramError("metadata must be JSON-compatible")
+
+    def with_payload(self, payload: bytes) -> RawArtifact:
+        return replace(self, payload=payload)
+
+    def with_attachment(self, attachment: AttachmentArtifact) -> RawArtifact:
+        if any(item.attachment_id == attachment.attachment_id for item in self.attachments):
+            raise CorpusProgramError(f"attachment already exists: {attachment.attachment_id}")
+        return replace(self, attachments=(*self.attachments, attachment))
+
+    def to_dict(self) -> JSONDocument:
+        return {
+            "artifact_id": self.artifact_id,
+            "payload_b64": _b64(self.payload),
+            "source_name": self.source_name,
+            "source_path": self.source_path,
+            "source_index": self.source_index,
+            "parent_artifact_id": self.parent_artifact_id,
+            "attachments": [attachment.to_dict() for attachment in self.attachments],
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> RawArtifact:
+        attachments_value = payload.get("attachments", [])
+        if not isinstance(attachments_value, list):
+            raise CorpusProgramError("attachments must be a list")
+        metadata = payload.get("metadata", {})
+        if not isinstance(metadata, Mapping):
+            raise CorpusProgramError("metadata must be an object")
+        return cls(
+            artifact_id=_required_string(payload, "artifact_id"),
+            payload=_unb64(payload.get("payload_b64"), field_name="payload_b64"),
+            source_name=_optional_string(payload, "source_name") or "codex",
+            source_path=_optional_string(payload, "source_path") or "sources/artifact.jsonl",
+            source_index=_required_int(payload, "source_index", default=0),
+            parent_artifact_id=_optional_string(payload, "parent_artifact_id"),
+            attachments=tuple(
+                AttachmentArtifact.from_dict(cast(Mapping[str, object], item))
+                for item in attachments_value
+                if isinstance(item, Mapping)
+            ),
+            metadata=cast(Mapping[str, JSONValue], dict(metadata)),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HookArtifact:
+    """A hook payload routed through the source-tier hook writer."""
+
+    hook_event_id: str
+    provider: str
+    event_type: str
+    session_native_id: str
+    payload: bytes
+    source_path: str = "hooks/events.jsonl"
+    observed_at_ms: int = 1_735_689_600_000
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("hook_event_id", self.hook_event_id),
+            ("provider", self.provider),
+            ("event_type", self.event_type),
+            ("session_native_id", self.session_native_id),
+        ):
+            _validate_identifier(value, field_name=name)
+        _validate_relative_path(self.source_path)
+
+    def to_dict(self) -> JSONDocument:
+        return {
+            "hook_event_id": self.hook_event_id,
+            "provider": self.provider,
+            "event_type": self.event_type,
+            "session_native_id": self.session_native_id,
+            "payload_b64": _b64(self.payload),
+            "source_path": self.source_path,
+            "observed_at_ms": self.observed_at_ms,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> HookArtifact:
+        return cls(
+            hook_event_id=_required_string(payload, "hook_event_id"),
+            provider=_required_string(payload, "provider"),
+            event_type=_required_string(payload, "event_type"),
+            session_native_id=_required_string(payload, "session_native_id"),
+            payload=_unb64(payload.get("payload_b64"), field_name="payload_b64"),
+            source_path=_optional_string(payload, "source_path") or "hooks/events.jsonl",
+            observed_at_ms=_required_int(payload, "observed_at_ms", default=1_735_689_600_000),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CorpusState:
+    """Immutable state returned after each operation, making shrinking local."""
+
+    artifacts: tuple[RawArtifact, ...] = ()
+    hooks: tuple[HookArtifact, ...] = ()
+    crashed: bool = False
+    applied_operation_ids: tuple[str, ...] = ()
+
+    def artifact(self, artifact_id: str) -> RawArtifact:
+        for artifact in self.artifacts:
+            if artifact.artifact_id == artifact_id:
+                return artifact
+        raise CorpusProgramError(f"unknown artifact: {artifact_id}")
+
+    def add_artifact(self, artifact: RawArtifact) -> CorpusState:
+        if any(item.artifact_id == artifact.artifact_id for item in self.artifacts):
+            raise CorpusProgramError(f"artifact already exists: {artifact.artifact_id}")
+        return replace(self, artifacts=(*self.artifacts, artifact))
+
+    def replace_artifact(self, artifact: RawArtifact) -> CorpusState:
+        if not any(item.artifact_id == artifact.artifact_id for item in self.artifacts):
+            raise CorpusProgramError(f"unknown artifact: {artifact.artifact_id}")
+        return replace(
+            self,
+            artifacts=tuple(artifact if item.artifact_id == artifact.artifact_id else item for item in self.artifacts),
+        )
+
+    def mark(self, operation_id: str, **changes: object) -> CorpusState:
+        return replace(self, applied_operation_ids=(*self.applied_operation_ids, operation_id), **changes)
+
+
+class OperationKind(StrEnum):
+    ACQUIRE = "Acquire"
+    APPEND = "Append"
+    REPLACE = "Replace"
+    DUPLICATE = "Duplicate"
+    FORK = "Fork"
+    ATTACH = "Attach"
+    EMIT_HOOK = "EmitHook"
+    CRASH = "Crash"
+    RESTART = "Restart"
+    CONVERGE = "Converge"
+    REBUILD = "Rebuild"
+    PROMOTE = "Promote"
+
+
+class CorpusRunner(Protocol):
+    """Effects that a program may delegate to a production route."""
+
+    def acquire(self, artifact: RawArtifact) -> object: ...
+
+    def emit_hook(self, hook: HookArtifact) -> object: ...
+
+    def crash(self) -> object: ...
+
+    def restart(self) -> object: ...
+
+    def converge(self) -> object: ...
+
+    def rebuild(self) -> object: ...
+
+    def promote(self) -> object: ...
+
+
+@dataclass(frozen=True, slots=True)
+class _Operation:
+    operation_id: str
+    kind: OperationKind = field(init=False)
+
+    def __post_init__(self) -> None:
+        _validate_identifier(self.operation_id, field_name="operation_id")
+
+    def to_dict(self) -> JSONDocument:
+        return {"operation_id": self.operation_id, "kind": self.kind.value}
+
+    def apply(self, state: CorpusState, runner: CorpusRunner | None) -> CorpusState:
+        raise NotImplementedError
+
+
+@dataclass(frozen=True, slots=True)
+class Acquire(_Operation):
+    artifact: RawArtifact
+    kind: OperationKind = field(default=OperationKind.ACQUIRE, init=False)
+
+    def apply(self, state: CorpusState, runner: CorpusRunner | None) -> CorpusState:
+        next_state = (
+            state.replace_artifact(self.artifact)
+            if any(item.artifact_id == self.artifact.artifact_id for item in state.artifacts)
+            else state.add_artifact(self.artifact)
+        )
+        if runner is not None:
+            runner.acquire(self.artifact)
+        return next_state.mark(self.operation_id)
+
+    def to_dict(self) -> JSONDocument:
+        return {**super().to_dict(), "artifact": self.artifact.to_dict()}
+
+
+@dataclass(frozen=True, slots=True)
+class Append(_Operation):
+    artifact_id: str
+    payload_delta: bytes
+    kind: OperationKind = field(default=OperationKind.APPEND, init=False)
+
+    def apply(self, state: CorpusState, runner: CorpusRunner | None) -> CorpusState:
+        artifact = state.artifact(self.artifact_id).with_payload(
+            state.artifact(self.artifact_id).payload + self.payload_delta
+        )
+        return state.replace_artifact(artifact).mark(self.operation_id)
+
+    def to_dict(self) -> JSONDocument:
+        return {**super().to_dict(), "artifact_id": self.artifact_id, "payload_delta_b64": _b64(self.payload_delta)}
+
+
+@dataclass(frozen=True, slots=True)
+class Replace(_Operation):
+    artifact_id: str
+    payload: bytes
+    kind: OperationKind = field(default=OperationKind.REPLACE, init=False)
+
+    def apply(self, state: CorpusState, runner: CorpusRunner | None) -> CorpusState:
+        return state.replace_artifact(state.artifact(self.artifact_id).with_payload(self.payload)).mark(
+            self.operation_id
+        )
+
+    def to_dict(self) -> JSONDocument:
+        return {**super().to_dict(), "artifact_id": self.artifact_id, "payload_b64": _b64(self.payload)}
+
+
+@dataclass(frozen=True, slots=True)
+class Duplicate(_Operation):
+    source_artifact_id: str
+    new_artifact_id: str
+    new_source_path: str | None = None
+    kind: OperationKind = field(default=OperationKind.DUPLICATE, init=False)
+
+    def apply(self, state: CorpusState, runner: CorpusRunner | None) -> CorpusState:
+        source = state.artifact(self.source_artifact_id)
+        copy = replace(
+            source,
+            artifact_id=self.new_artifact_id,
+            source_path=self.new_source_path or f"duplicates/{self.new_artifact_id}.jsonl",
+        )
+        return state.add_artifact(copy).mark(self.operation_id)
+
+    def to_dict(self) -> JSONDocument:
+        return {
+            **super().to_dict(),
+            "source_artifact_id": self.source_artifact_id,
+            "new_artifact_id": self.new_artifact_id,
+            "new_source_path": self.new_source_path,
+        }
+
+
+def _fork_payload(payload: bytes, new_session_id: str, parent_session_id: str) -> bytes:
+    """Update common session identity envelopes without parsing provider code."""
+    lines = payload.splitlines(keepends=True)
+    output: list[bytes] = []
+    changed = False
+    for line in lines:
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError:
+            output.append(line)
+            continue
+        if isinstance(value, dict):
+            for container in (value, value.get("payload")):
+                if not isinstance(container, dict):
+                    continue
+                for key in ("id", "sessionId", "session_id", "thread_id"):
+                    if container.get(key) == parent_session_id:
+                        container[key] = new_session_id
+                        changed = True
+                if container.get("type") == "session_meta":
+                    container["parent_id"] = parent_session_id
+            encoded = _canonical_json(value).encode("utf-8")
+            output.append(encoded + (b"\n" if line.endswith(b"\n") else b""))
+        else:
+            output.append(line)
+    return b"".join(output) if changed else payload
+
+
+@dataclass(frozen=True, slots=True)
+class Fork(_Operation):
+    source_artifact_id: str
+    new_artifact_id: str
+    new_session_id: str
+    kind: OperationKind = field(default=OperationKind.FORK, init=False)
+
+    def apply(self, state: CorpusState, runner: CorpusRunner | None) -> CorpusState:
+        source = state.artifact(self.source_artifact_id)
+        parent_id = str(source.metadata.get("session_id", source.artifact_id))
+        child = replace(
+            source,
+            artifact_id=self.new_artifact_id,
+            source_path=f"forks/{self.new_artifact_id}.jsonl",
+            parent_artifact_id=source.artifact_id,
+            payload=_fork_payload(source.payload, self.new_session_id, parent_id),
+            metadata={**source.metadata, "session_id": self.new_session_id, "parent_session_id": parent_id},
+        )
+        return state.add_artifact(child).mark(self.operation_id)
+
+    def to_dict(self) -> JSONDocument:
+        return {
+            **super().to_dict(),
+            "source_artifact_id": self.source_artifact_id,
+            "new_artifact_id": self.new_artifact_id,
+            "new_session_id": self.new_session_id,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class Attach(_Operation):
+    artifact_id: str
+    attachment: AttachmentArtifact
+    kind: OperationKind = field(default=OperationKind.ATTACH, init=False)
+
+    def apply(self, state: CorpusState, runner: CorpusRunner | None) -> CorpusState:
+        return state.replace_artifact(state.artifact(self.artifact_id).with_attachment(self.attachment)).mark(
+            self.operation_id
+        )
+
+    def to_dict(self) -> JSONDocument:
+        return {**super().to_dict(), "artifact_id": self.artifact_id, "attachment": self.attachment.to_dict()}
+
+
+@dataclass(frozen=True, slots=True)
+class EmitHook(_Operation):
+    hook: HookArtifact
+    kind: OperationKind = field(default=OperationKind.EMIT_HOOK, init=False)
+
+    def apply(self, state: CorpusState, runner: CorpusRunner | None) -> CorpusState:
+        if any(item.hook_event_id == self.hook.hook_event_id for item in state.hooks):
+            raise CorpusProgramError(f"hook already exists: {self.hook.hook_event_id}")
+        if runner is not None:
+            runner.emit_hook(self.hook)
+        return state.mark(self.operation_id, hooks=(*state.hooks, self.hook))
+
+    def to_dict(self) -> JSONDocument:
+        return {**super().to_dict(), "hook": self.hook.to_dict()}
+
+
+@dataclass(frozen=True, slots=True)
+class Crash(_Operation):
+    kind: OperationKind = field(default=OperationKind.CRASH, init=False)
+
+    def apply(self, state: CorpusState, runner: CorpusRunner | None) -> CorpusState:
+        if runner is not None:
+            runner.crash()
+        return state.mark(self.operation_id, crashed=True)
+
+
+@dataclass(frozen=True, slots=True)
+class Restart(_Operation):
+    kind: OperationKind = field(default=OperationKind.RESTART, init=False)
+
+    def apply(self, state: CorpusState, runner: CorpusRunner | None) -> CorpusState:
+        if runner is not None:
+            runner.restart()
+        return state.mark(self.operation_id, crashed=False)
+
+
+@dataclass(frozen=True, slots=True)
+class Converge(_Operation):
+    kind: OperationKind = field(default=OperationKind.CONVERGE, init=False)
+
+    def apply(self, state: CorpusState, runner: CorpusRunner | None) -> CorpusState:
+        if runner is not None:
+            runner.converge()
+        return state.mark(self.operation_id)
+
+
+@dataclass(frozen=True, slots=True)
+class Rebuild(_Operation):
+    kind: OperationKind = field(default=OperationKind.REBUILD, init=False)
+
+    def apply(self, state: CorpusState, runner: CorpusRunner | None) -> CorpusState:
+        if runner is not None:
+            runner.rebuild()
+        return state.mark(self.operation_id)
+
+
+@dataclass(frozen=True, slots=True)
+class Promote(_Operation):
+    kind: OperationKind = field(default=OperationKind.PROMOTE, init=False)
+
+    def apply(self, state: CorpusState, runner: CorpusRunner | None) -> CorpusState:
+        if runner is not None:
+            runner.promote()
+        return state.mark(self.operation_id)
+
+
+CorpusOperation = (
+    Acquire | Append | Replace | Duplicate | Fork | Attach | EmitHook | Crash | Restart | Converge | Rebuild | Promote
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CorpusRun:
+    state: CorpusState
+    schedule: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class CorpusProgram:
+    """A serializable operation graph with an explicit execution schedule."""
+
+    operations: tuple[CorpusOperation, ...]
+    schedule: tuple[str, ...] | None = None
+
+    def __post_init__(self) -> None:
+        operation_ids = tuple(operation.operation_id for operation in self.operations)
+        if len(set(operation_ids)) != len(operation_ids):
+            raise CorpusProgramError("operation ids must be unique")
+        schedule = tuple(operation_ids) if self.schedule is None else tuple(self.schedule)
+        if schedule != tuple(dict.fromkeys(schedule)) or set(schedule) != set(operation_ids):
+            raise CorpusProgramError("schedule must be a complete permutation of operation ids")
+        object.__setattr__(self, "schedule", schedule)
+
+    def ordered_operations(self) -> tuple[CorpusOperation, ...]:
+        by_id = {operation.operation_id: operation for operation in self.operations}
+        assert self.schedule is not None
+        return tuple(by_id[operation_id] for operation_id in self.schedule)
+
+    def run(self, runner: CorpusRunner | None = None) -> CorpusRun:
+        state = CorpusState()
+        for operation in self.ordered_operations():
+            state = operation.apply(state, runner)
+        assert self.schedule is not None
+        return CorpusRun(state=state, schedule=self.schedule)
+
+    def to_dict(self) -> JSONDocument:
+        return {
+            "operations": [operation.to_dict() for operation in self.operations],
+            "schedule": list(self.schedule or ()),
+        }
+
+    def to_json(self) -> str:
+        return _canonical_json(self.to_dict())
+
+    @classmethod
+    def from_json(cls, serialized: str | bytes) -> CorpusProgram:
+        value = json.loads(serialized)
+        if not isinstance(value, Mapping):
+            raise CorpusProgramError("corpus program JSON must be an object")
+        return cls.from_dict(cast(Mapping[str, object], value))
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> CorpusProgram:
+        raw_operations = payload.get("operations")
+        raw_schedule = payload.get("schedule")
+        if not isinstance(raw_operations, list) or not isinstance(raw_schedule, list):
+            raise CorpusProgramError("program requires operations and schedule lists")
+        operations = tuple(_operation_from_dict(cast(Mapping[str, object], item)) for item in raw_operations)
+        if not all(isinstance(item, str) for item in raw_schedule):
+            raise CorpusProgramError("schedule entries must be strings")
+        return cls(operations=operations, schedule=tuple(cast(list[str], raw_schedule)))
+
+
+def _operation_from_dict(payload: Mapping[str, object]) -> CorpusOperation:
+    kind = OperationKind(_required_string(payload, "kind"))
+    operation_id = _required_string(payload, "operation_id")
+    if kind is OperationKind.ACQUIRE:
+        artifact = payload.get("artifact")
+        if not isinstance(artifact, Mapping):
+            raise CorpusProgramError("Acquire requires artifact")
+        return Acquire(operation_id, RawArtifact.from_dict(cast(Mapping[str, object], artifact)))
+    if kind is OperationKind.APPEND:
+        return Append(
+            operation_id,
+            _required_string(payload, "artifact_id"),
+            _unb64(payload.get("payload_delta_b64"), field_name="payload_delta_b64"),
+        )
+    if kind is OperationKind.REPLACE:
+        return Replace(
+            operation_id,
+            _required_string(payload, "artifact_id"),
+            _unb64(payload.get("payload_b64"), field_name="payload_b64"),
+        )
+    if kind is OperationKind.DUPLICATE:
+        return Duplicate(
+            operation_id,
+            _required_string(payload, "source_artifact_id"),
+            _required_string(payload, "new_artifact_id"),
+            _optional_string(payload, "new_source_path"),
+        )
+    if kind is OperationKind.FORK:
+        return Fork(
+            operation_id,
+            _required_string(payload, "source_artifact_id"),
+            _required_string(payload, "new_artifact_id"),
+            _required_string(payload, "new_session_id"),
+        )
+    if kind is OperationKind.ATTACH:
+        attachment = payload.get("attachment")
+        if not isinstance(attachment, Mapping):
+            raise CorpusProgramError("Attach requires attachment")
+        return Attach(
+            operation_id,
+            _required_string(payload, "artifact_id"),
+            AttachmentArtifact.from_dict(cast(Mapping[str, object], attachment)),
+        )
+    if kind is OperationKind.EMIT_HOOK:
+        hook = payload.get("hook")
+        if not isinstance(hook, Mapping):
+            raise CorpusProgramError("EmitHook requires hook")
+        return EmitHook(operation_id, HookArtifact.from_dict(cast(Mapping[str, object], hook)))
+    constructors: dict[OperationKind, type[_Operation]] = {
+        OperationKind.CRASH: Crash,
+        OperationKind.RESTART: Restart,
+        OperationKind.CONVERGE: Converge,
+        OperationKind.REBUILD: Rebuild,
+        OperationKind.PROMOTE: Promote,
+    }
+    return constructors[kind](operation_id)
+
+
+def _required_string(payload: Mapping[str, object], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str):
+        raise CorpusProgramError(f"{key} must be a string")
+    return value
+
+
+def _optional_string(payload: Mapping[str, object], key: str) -> str | None:
+    value = payload.get(key)
+    if value is not None and not isinstance(value, str):
+        raise CorpusProgramError(f"{key} must be a string or null")
+    return value
+
+
+def _required_int(payload: Mapping[str, object], key: str, *, default: int | None = None) -> int:
+    value = payload.get(key, default)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise CorpusProgramError(f"{key} must be an integer")
+    return value
+
+
+def operation_strategy(*, artifact_ids: Sequence[str] = ("a", "b")) -> Any:
+    """Return a bounded Hypothesis strategy whose values shrink structurally."""
+    from hypothesis import strategies as st
+
+    ids = tuple(artifact_ids)
+    artifact = st.builds(
+        RawArtifact,
+        artifact_id=st.sampled_from(ids),
+        payload=st.binary(max_size=96),
+        source_path=st.sampled_from(tuple(f"sources/{artifact_id}.jsonl" for artifact_id in ids)),
+    )
+    return st.one_of(
+        st.builds(Acquire, operation_id=st.text("op", min_size=2, max_size=8), artifact=artifact),
+        st.builds(
+            Append,
+            operation_id=st.text("op", min_size=2, max_size=8),
+            artifact_id=st.sampled_from(ids),
+            payload_delta=st.binary(max_size=32),
+        ),
+        st.builds(
+            Replace,
+            operation_id=st.text("op", min_size=2, max_size=8),
+            artifact_id=st.sampled_from(ids),
+            payload=st.binary(max_size=96),
+        ),
+        st.builds(
+            Duplicate,
+            operation_id=st.text("op", min_size=2, max_size=8),
+            source_artifact_id=st.sampled_from(ids),
+            new_artifact_id=st.sampled_from(ids),
+        ),
+        st.builds(
+            Fork,
+            operation_id=st.text("op", min_size=2, max_size=8),
+            source_artifact_id=st.sampled_from(ids),
+            new_artifact_id=st.sampled_from(ids),
+            new_session_id=st.text("s", min_size=2, max_size=8),
+        ),
+        st.builds(
+            Attach,
+            operation_id=st.text("op", min_size=2, max_size=8),
+            artifact_id=st.sampled_from(ids),
+            attachment=st.builds(
+                AttachmentArtifact,
+                attachment_id=st.text("a", min_size=2, max_size=8),
+                name=st.just("fixture.bin"),
+                payload=st.binary(max_size=32),
+            ),
+        ),
+        st.builds(Crash, operation_id=st.text("op", min_size=2, max_size=8)),
+        st.builds(Restart, operation_id=st.text("op", min_size=2, max_size=8)),
+        st.builds(Converge, operation_id=st.text("op", min_size=2, max_size=8)),
+        st.builds(Rebuild, operation_id=st.text("op", min_size=2, max_size=8)),
+        st.builds(Promote, operation_id=st.text("op", min_size=2, max_size=8)),
+    )
+
+
+def corpus_program_strategy(*, max_operations: int = 8) -> Any:
+    """Generate programs with unique operation ids and a shrinkable schedule."""
+    from hypothesis import strategies as st
+
+    return st.lists(operation_strategy(), min_size=1, max_size=max_operations).map(
+        lambda operations: CorpusProgram(
+            operations=tuple(
+                replace(operation, operation_id=f"op-{index}") for index, operation in enumerate(operations)
+            ),
+        )
+    )
+
+
+class ProductionCorpusRuntime:
+    """Adapter from corpus operations to the live archive production seams."""
+
+    def __init__(self, archive_root: Path) -> None:
+        self.archive_root = archive_root.resolve()
+        self.source_root = self.archive_root / "corpus-program-sources"
+        self._raw_ids: dict[str, tuple[str, ...]] = {}
+        self._source_paths: dict[str, Path] = {}
+        self._rebuild_receipt: RebuildIndexReceipt | None = None
+        self._crashed = False
+        self.last_results: list[object] = []
+
+    def _ensure_running(self) -> None:
+        if self._crashed:
+            raise CorpusRuntimeCrashedError("runtime is crashed; apply Restart before the next effect")
+
+    def acquire(self, artifact: RawArtifact) -> object:
+        self._ensure_running()
+        from polylogue.config import Source
+        from polylogue.pipeline.services.acquisition import AcquisitionService
+        from polylogue.storage.sqlite import SQLiteBackend
+
+        path = self.source_root / _validate_relative_path(artifact.source_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(artifact.payload)
+
+        async def run() -> object:
+            backend = SQLiteBackend(db_path=self.archive_root / "index.db")
+            try:
+                result = await AcquisitionService(backend).acquire_sources(
+                    [Source(name=artifact.source_name, path=path)]
+                )
+                self._raw_ids[artifact.artifact_id] = tuple(result.raw_ids)
+                self._source_paths[artifact.artifact_id] = path
+                return result
+            finally:
+                await backend.close()
+
+        result = asyncio.run(run())
+        self.last_results.append(result)
+        return result
+
+    def emit_hook(self, hook: HookArtifact) -> object:
+        self._ensure_running()
+        from polylogue.archive.artifact_taxonomy import classify_artifact_path
+        from polylogue.config import Source
+        from polylogue.core.enums import Provider
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from polylogue.storage.sqlite.archive_tiers.source_write import ArchiveHookEvent
+
+        del classify_artifact_path, Source
+        provider = Provider.from_string(hook.provider)
+        payload = hook.payload
+        with ArchiveStore.open_existing(self.archive_root, read_only=False) as archive:
+            result = archive.write_hook_event(
+                provider=provider,
+                payload=payload,
+                source_path=hook.source_path,
+                acquired_at_ms=hook.observed_at_ms,
+                hook_event=ArchiveHookEvent(
+                    hook_event_id=hook.hook_event_id,
+                    origin=provider.value,
+                    source_path=hook.source_path,
+                    event_type=hook.event_type,
+                    payload={"session_id": hook.session_native_id},
+                    observed_at_ms=hook.observed_at_ms,
+                    native_id=hook.hook_event_id,
+                    session_native_id=hook.session_native_id,
+                ),
+            )
+        self.last_results.append(result)
+        return result
+
+    def crash(self) -> object:
+        self._crashed = True
+        return None
+
+    def restart(self) -> object:
+        self._crashed = False
+        return None
+
+    def converge(self) -> object:
+        self._ensure_running()
+        from polylogue.config import Config
+        from polylogue.daemon.convergence import DaemonConverger
+        from polylogue.daemon.convergence_stages import make_default_convergence_stages
+        from polylogue.pipeline.services.parsing import ParsingService
+        from polylogue.storage.repository import SessionRepository
+        from polylogue.storage.sqlite import SQLiteBackend
+
+        raw_ids = tuple(dict.fromkeys(raw_id for ids in self._raw_ids.values() for raw_id in ids))
+        paths = tuple(dict.fromkeys(self._source_paths.values()))
+
+        async def parse() -> ParseResult:
+            backend = SQLiteBackend(db_path=self.archive_root / "index.db")
+            try:
+                config = Config(
+                    archive_root=self.archive_root,
+                    render_root=self.archive_root / "render",
+                    sources=[],
+                    db_path=self.archive_root / "index.db",
+                )
+                service = ParsingService(
+                    repository=SessionRepository(backend=backend),
+                    archive_root=self.archive_root,
+                    config=config,
+                    ingest_workers=1,
+                )
+                return await service.parse_from_raw(raw_ids=list(raw_ids), force_write=True)
+            finally:
+                await backend.close()
+
+        parse_result = asyncio.run(parse())
+        states = DaemonConverger(make_default_convergence_stages(self.archive_root / "index.db")).converge_all(paths)
+        result = {"parse": parse_result, "convergence": states}
+        self.last_results.append(result)
+        return result
+
+    def rebuild(self) -> object:
+        self._ensure_running()
+        from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source
+
+        async def run() -> RebuildIndexReceipt:
+            return await rebuild_index_from_source(RebuildIndexRequest(archive_root=self.archive_root, promote=False))
+
+        result = asyncio.run(run())
+        self._rebuild_receipt = result
+        self.last_results.append(result)
+        return result
+
+    def promote(self) -> object:
+        self._ensure_running()
+        if self._rebuild_receipt is None:
+            raise CorpusProgramError("Promote requires a preceding Rebuild")
+        from polylogue.storage.index_generation import IndexGenerationStore
+
+        generation_id = self._rebuild_receipt.generation.get("generation_id")
+        if not isinstance(generation_id, str):
+            raise CorpusProgramError("Rebuild did not return an inactive generation")
+        store = IndexGenerationStore.for_archive_root(self.archive_root)
+        result = store.promote(store.load(generation_id))
+        self.last_results.append(result)
+        return result
+
+
+def _unused_json_document(value: object) -> JSONDocument:
+    """Keep the public JSON contract available to callers without Any leakage."""
+    return require_json_document(value)
+
+
+__all__ = [
+    "Acquire",
+    "Append",
+    "Attach",
+    "AttachmentArtifact",
+    "CorpusOperation",
+    "CorpusProgram",
+    "CorpusProgramError",
+    "CorpusRun",
+    "CorpusRuntimeCrashed",
+    "CorpusState",
+    "Crash",
+    "Converge",
+    "Duplicate",
+    "EmitHook",
+    "Fork",
+    "HookArtifact",
+    "OperationKind",
+    "ProductionCorpusRuntime",
+    "Promote",
+    "RawArtifact",
+    "Rebuild",
+    "Replace",
+    "Restart",
+    "corpus_program_strategy",
+    "operation_strategy",
+]

--- a/tests/infra/corpus_program.py
+++ b/tests/infra/corpus_program.py
@@ -237,8 +237,19 @@ class CorpusState:
             artifacts=tuple(artifact if item.artifact_id == artifact.artifact_id else item for item in self.artifacts),
         )
 
-    def mark(self, operation_id: str, **changes: object) -> CorpusState:
-        return replace(self, applied_operation_ids=(*self.applied_operation_ids, operation_id), **changes)
+    def mark(
+        self,
+        operation_id: str,
+        *,
+        crashed: bool | None = None,
+        hooks: tuple[HookArtifact, ...] | None = None,
+    ) -> CorpusState:
+        return replace(
+            self,
+            crashed=self.crashed if crashed is None else crashed,
+            hooks=self.hooks if hooks is None else hooks,
+            applied_operation_ids=(*self.applied_operation_ids, operation_id),
+        )
 
 
 class OperationKind(StrEnum):
@@ -624,7 +635,7 @@ def _operation_from_dict(payload: Mapping[str, object]) -> CorpusOperation:
         OperationKind.REBUILD: Rebuild,
         OperationKind.PROMOTE: Promote,
     }
-    return constructors[kind](operation_id)
+    return cast(CorpusOperation, constructors[kind](operation_id))
 
 
 def _required_string(payload: Mapping[str, object], key: str) -> str:

--- a/tests/infra/pathology_composer.py
+++ b/tests/infra/pathology_composer.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any
 
 from polylogue.archive.models import Session
@@ -55,6 +55,71 @@ class ComposedPathology:
     sessions: tuple[Session, ...] = ()
     raw_payloads: tuple[object, ...] = ()
     metadata: Mapping[str, object] = field(default_factory=dict)
+    components: tuple[ComposedPathology, ...] = ()
+    raw_ingestion_order: tuple[int, ...] | None = None
+
+    def __post_init__(self) -> None:
+        """Normalize and validate the raw sequence a harness will ingest."""
+        order = self.raw_ingestion_order
+        if order is None:
+            order = tuple(range(len(self.raw_payloads)))
+            object.__setattr__(self, "raw_ingestion_order", order)
+
+        expected = tuple(range(len(self.raw_payloads)))
+        if len(order) != len(expected) or not all(type(index) is int for index in order) or set(order) != set(expected):
+            raise ValueError("raw_ingestion_order must be a permutation of raw_payloads indexes")
+
+    @property
+    def raw_payloads_in_ingestion_order(self) -> tuple[object, ...]:
+        """Return raw payloads in the deterministic order a harness should ingest."""
+        assert self.raw_ingestion_order is not None
+        return tuple(self.raw_payloads[index] for index in self.raw_ingestion_order)
+
+    def with_raw_ingestion_order(self, raw_ingestion_order: Sequence[int]) -> ComposedPathology:
+        """Return this arrangement with a different deterministic raw ingest order."""
+        return replace(self, raw_ingestion_order=tuple(raw_ingestion_order))
+
+    def compose(
+        self,
+        *pathologies: ComposedPathology,
+        name: str | None = None,
+        raw_ingestion_order: Sequence[int] | None = None,
+    ) -> ComposedPathology:
+        """Nest this arrangement with others without introducing a corpus DSL."""
+        return compose_pathologies(
+            self,
+            *pathologies,
+            name=name,
+            raw_ingestion_order=raw_ingestion_order,
+        )
+
+
+def compose_pathologies(
+    *pathologies: ComposedPathology,
+    name: str | None = None,
+    raw_ingestion_order: Sequence[int] | None = None,
+) -> ComposedPathology:
+    """Combine existing arrangements and optionally permute their raw ingestion.
+
+    The result retains each direct component for inspection while exposing its
+    sessions and raw payloads as one flat corpus. ``raw_ingestion_order`` is a
+    permutation over that flat raw-payload sequence, so a metamorphic test can
+    feed the same artifacts through the real ingestion path under many orders.
+    """
+    if not pathologies:
+        raise ValueError("compose_pathologies requires at least one pathology")
+
+    component_names = tuple(pathology.name for pathology in pathologies)
+    return ComposedPathology(
+        name=name if name is not None else "+".join(component_names),
+        pathology="+".join(pathology.pathology for pathology in pathologies),
+        motivated_by="; ".join(pathology.motivated_by for pathology in pathologies),
+        description=f"Composition of archive pathologies: {', '.join(component_names)}.",
+        sessions=tuple(session for pathology in pathologies for session in pathology.sessions),
+        raw_payloads=tuple(payload for pathology in pathologies for payload in pathology.raw_payloads),
+        components=pathologies,
+        raw_ingestion_order=None if raw_ingestion_order is None else tuple(raw_ingestion_order),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -454,6 +519,7 @@ def extract_new_shape_turns(payload: JSONRecord) -> list[tuple[str, str]]:
 
 __all__ = [
     "ComposedPathology",
+    "compose_pathologies",
     "compose_append_revision_chain",
     "compose_fork_prefix_tail_lineage",
     "compose_multi_session_bundle",

--- a/tests/infra/test_corpus_program.py
+++ b/tests/infra/test_corpus_program.py
@@ -1,0 +1,166 @@
+"""Focused contracts for the composable corpus-program harness."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hypothesis import given
+
+from tests.infra.corpus_program import (
+    Acquire,
+    Append,
+    Attach,
+    AttachmentArtifact,
+    Converge,
+    CorpusProgram,
+    Crash,
+    Duplicate,
+    EmitHook,
+    Fork,
+    HookArtifact,
+    ProductionCorpusRuntime,
+    Promote,
+    RawArtifact,
+    Rebuild,
+    Replace,
+    Restart,
+    corpus_program_strategy,
+)
+
+
+class RecordingRunner:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def acquire(self, artifact: RawArtifact) -> None:
+        self.calls.append(f"acquire:{artifact.artifact_id}")
+
+    def emit_hook(self, hook: HookArtifact) -> None:
+        self.calls.append(f"hook:{hook.hook_event_id}")
+
+    def crash(self) -> None:
+        self.calls.append("crash")
+
+    def restart(self) -> None:
+        self.calls.append("restart")
+
+    def converge(self) -> None:
+        self.calls.append("converge")
+
+    def rebuild(self) -> None:
+        self.calls.append("rebuild")
+
+    def promote(self) -> None:
+        self.calls.append("promote")
+
+
+def _artifact(artifact_id: str, payload: bytes = b"payload") -> RawArtifact:
+    return RawArtifact(
+        artifact_id=artifact_id,
+        payload=payload,
+        source_path=f"sources/{artifact_id}.jsonl",
+        metadata={"session_id": artifact_id},
+    )
+
+
+def _hook() -> HookArtifact:
+    return HookArtifact(
+        hook_event_id="hook-1",
+        provider="claude-code",
+        event_type="SessionStart",
+        session_native_id="session-1",
+        payload=b'{"session_id":"session-1"}',
+    )
+
+
+def test_program_serialization_is_canonical_and_round_trips_all_operation_shapes() -> None:
+    attachment = AttachmentArtifact("att-1", "fixture.txt", "text/plain", b"hello")
+    operations = (
+        Acquire("acquire", _artifact("a")),
+        Append("append", "a", b"tail"),
+        Replace("replace", "a", b"replacement"),
+        Duplicate("duplicate", "a", "b"),
+        Fork("fork", "a", "c", "session-c"),
+        Attach("attach", "a", attachment),
+        EmitHook("hook", _hook()),
+        Crash("crash"),
+        Restart("restart"),
+        Converge("converge"),
+        Rebuild("rebuild"),
+        Promote("promote"),
+    )
+    program = CorpusProgram(operations, schedule=tuple(operation.operation_id for operation in operations))
+
+    serialized = program.to_json()
+    assert serialized == program.to_json()
+    assert " \n" not in serialized
+    assert CorpusProgram.from_json(serialized) == program
+
+
+def test_composition_applies_transformations_in_declared_schedule() -> None:
+    original = _artifact("a", b"one")
+    updated = _artifact("a", b"onetwo")
+    program = CorpusProgram(
+        operations=(
+            Acquire("first", original),
+            Append("append", "a", b"two"),
+            Acquire("second", updated),
+            Attach("attach", "a", AttachmentArtifact("att", "x.txt", payload=b"x")),
+            Duplicate("duplicate", "a", "b"),
+            Fork("fork", "a", "c", "session-c"),
+        )
+    )
+
+    run = program.run()
+    assert [artifact.artifact_id for artifact in run.state.artifacts] == ["a", "b", "c"]
+    assert run.state.artifact("a").payload == b"onetwo"
+    assert run.state.artifact("a").attachments[0].attachment_id == "att"
+    assert run.state.artifact("c").parent_artifact_id == "a"
+
+
+def test_adversarial_schedule_is_observable_and_cannot_be_ignored() -> None:
+    program = CorpusProgram(
+        operations=(Acquire("a-op", _artifact("a")), Acquire("b-op", _artifact("b"))),
+        schedule=("b-op", "a-op"),
+    )
+    runner = RecordingRunner()
+
+    program.run(runner)
+
+    assert runner.calls == ["acquire:b", "acquire:a"]
+
+
+@given(corpus_program_strategy(max_operations=5))
+def test_generated_programs_have_shrinkable_canonical_round_trips(program: CorpusProgram) -> None:
+    assert CorpusProgram.from_json(program.to_json()) == program
+
+
+def test_production_route_composes_acquire_append_and_converge(
+    workspace_env: dict[str, Path],
+) -> None:
+    fixture_path = Path(__file__).parents[1] / "data" / "codex_event_stream" / "text_only_stream.jsonl"
+    initial = fixture_path.read_bytes()
+    delta = b'{"type":"response_item","payload":{"type":"message","id":"msg-appended","role":"user","timestamp":"2025-01-15T10:01:00Z","content":[{"type":"input_text","text":"Append this turn."}]}}\n'
+    program = CorpusProgram(
+        operations=(
+            Acquire("acquire-v1", _artifact("session", initial)),
+            Append("append", "session", delta),
+            Acquire("acquire-v2", _artifact("session", initial + delta)),
+            Converge("converge"),
+        )
+    )
+    runtime = ProductionCorpusRuntime(workspace_env["archive_root"])
+
+    run = program.run(runtime)
+
+    assert run.state.artifact("session").payload.endswith(delta)
+    assert runtime.last_results
+    with runtime.archive_root.joinpath("index.db").open("rb"):
+        pass
+    import sqlite3
+
+    with sqlite3.connect(runtime.archive_root / "index.db") as conn:
+        session_count = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+        message_count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+    assert session_count == 1
+    assert message_count >= 3

--- a/tests/infra/test_pathology_composer.py
+++ b/tests/infra/test_pathology_composer.py
@@ -1,9 +1,8 @@
 """Tests proving each pathology composer's claimed structural property.
 
-These are pure structural assertions on the returned ``ComposedPathology``
-(no archive/database writes) -- see the module docstring in
-``pathology_composer.py`` for why a live write is not required to prove the
-claimed shape.
+These are structural assertions on returned ``ComposedPathology`` values. The
+composer is the test-infrastructure route that supplies ordered raw payloads
+to future production-ingestion metamorphic tests.
 """
 
 from __future__ import annotations
@@ -17,6 +16,7 @@ from tests.infra.pathology_composer import (
     compose_append_revision_chain,
     compose_fork_prefix_tail_lineage,
     compose_multi_session_bundle,
+    compose_pathologies,
     compose_quarantined_head_arrangement,
     compose_vintage_variant_pair,
     compose_whale_scale_component,
@@ -220,6 +220,38 @@ def test_vintage_variant_pair_extracted_content_is_equal_despite_shape_differenc
     new_turns = extract_new_shape_turns(new_shape)
 
     assert old_turns == new_turns == list(turns)
+
+
+# ---------------------------------------------------------------------------
+# Composition and ingestion order
+# ---------------------------------------------------------------------------
+
+
+def test_composition_nests_existing_pathologies_and_orders_flat_raw_payloads() -> None:
+    bundle = compose_multi_session_bundle([{"record": 1}, {"record": 2}], session_count=2)
+    variants = compose_vintage_variant_pair()
+    nested = compose_pathologies(bundle, variants, name="raw-shapes")
+    composed = compose_append_revision_chain(session_id="nested-append", revision_count=2).compose(
+        nested,
+        raw_ingestion_order=(2, 0, 1),
+    )
+
+    assert composed.components == (compose_append_revision_chain(session_id="nested-append", revision_count=2), nested)
+    assert nested.components == (bundle, variants)
+    assert composed.raw_ingestion_order == (2, 0, 1)
+    assert composed.raw_payloads_in_ingestion_order == (
+        variants.raw_payloads[1],
+        bundle.raw_payloads[0],
+        variants.raw_payloads[0],
+    )
+
+
+@pytest.mark.parametrize("order", [(0, 0), (0,), (0, 2), ("0", 1)])
+def test_raw_ingestion_order_must_be_a_complete_index_permutation(order: tuple[object, ...]) -> None:
+    pathology = compose_vintage_variant_pair()
+
+    with pytest.raises(ValueError, match="permutation"):
+        pathology.with_raw_ingestion_order(order)  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add a typed, deterministic corpus-program layer for composing raw artifacts, controlling ingestion order, and exercising the live acquisition, parsing, convergence, rebuild, promotion, and hook seams. Ref polylogue-un60n.

## Problem

The existing pathology helpers could compose only fixed fixture outputs and exposed no executable operation algebra. The convergence-property design requires shrinkable programs whose transformations can be serialized, reordered, and replayed through production routes.

## Solution

- `tests/infra/pathology_composer.py` and `tests/infra/test_pathology_composer.py` retain immutable pathology composition, provenance, and validated raw-ingestion permutations.
- `tests/infra/corpus_program.py` adds typed `RawArtifact`, `AttachmentArtifact`, `HookArtifact`, immutable `CorpusState`, deterministic JSON serialization, explicit schedules, and shrinkable Hypothesis strategies.
- The operation set covers `Acquire`, `Append`, `Replace`, `Duplicate`, `Fork`, `Attach`, `EmitHook`, `Crash`, `Restart`, `Converge`, `Rebuild`, and `Promote`.
- `ProductionCorpusRuntime` delegates effects to existing acquisition, archive hook, parsing, daemon convergence, index rebuild, and generation promotion seams. It does not implement a second archive writer or convergence engine.
- `tests/infra/test_corpus_program.py` covers canonical round trips, composable transformations, an adversarial schedule whose runner call order follows the explicit permutation, shrinkable generated programs, and a real Codex JSONL acquire/append/converge composition.

## Verification

- `env -u VIRTUAL_ENV uv run devtools test tests/infra/test_pathology_composer.py tests/infra/test_corpus_program.py` -> `36 passed in 9.28s`
- `env -u VIRTUAL_ENV uv run devtools verify --quick` -> exit `0`; ruff, mypy, rendering, layering, closure matrix, schema, manifest, documentation, policy, and promotion checks passed.
- `env -u VIRTUAL_ENV uv run ruff check tests/infra/corpus_program.py tests/infra/test_corpus_program.py` -> `All checks passed!`
- `git diff --check e805f2b1e..HEAD` -> no output, exit `0`.

The repository testmon seed command was attempted twice with `env -u VIRTUAL_ENV uv run devtools verify --seed-testmon --skip-slow`. Both attempts were blocked before pytest because `verify.py` removes the linked-worktree `seed.json` marker immediately before `tests/conftest.py` checks it, producing `checkout environment is untrustworthy` for `.cache/testmon`. This is recorded as residual harness uncertainty; the focused production-route tests and all quick gates pass.

## Acceptance criteria

| Criterion | Status |
| --- | --- |
| Typed artifacts and all twelve requested operations | Satisfied |
| Deterministic serialization and explicit ingestion schedule | Satisfied |
| Composable, shrinkable transformations | Satisfied |
| Existing production seams used for effects | Satisfied |
| Production-route composition test | Satisfied |
| Adversarial order-control test | Satisfied |
| Forbidden archive snapshot and provider parser files untouched | Satisfied |
| Full affected testmon run | Deferred by the linked-worktree testmon marker defect described above |

## Residual work

This lane made no Beads writes. The coordinator should connect this program layer to the existing polylogue-rrxe4 convergence-property harness and reconcile any remaining graph state.
