### PR TITLE
test: add canonical archive snapshot comparator

### DIFF
--- a/tests/infra/archive_canonical_snapshot.py
+++ b/tests/infra/archive_canonical_snapshot.py
@@ -1,0 +1,449 @@
+"""Canonical semantic snapshots for real archive-route comparisons.
+
+The comparator is deliberately a read-only adapter around the production
+SQLite archive and ``ArchiveStore`` read surfaces.  It compares semantic rows
+and public projections, rather than database bytes or generation-local files.
+Only fields named in :data:`RUN_LOCAL_NORMALIZATION_ALLOWLIST` are omitted;
+provider identity, semantic timestamps, provenance, authority, and result
+states remain part of the comparison.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import sqlite3
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date, datetime
+from enum import Enum
+from pathlib import Path
+
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+SqlValue = str | int | float | None
+FactRow = tuple[SqlValue, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class RelationSnapshot:
+    """A deterministic projection of one table or view."""
+
+    database: str
+    relation: str
+    exists: bool
+    columns: tuple[str, ...]
+    rows: tuple[FactRow, ...]
+
+    @property
+    def relation_key(self) -> tuple[str, str]:
+        return self.database, self.relation
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalArchiveSnapshot:
+    """The semantic archive state used by every route-equivalence proof."""
+
+    canonical_rows: tuple[RelationSnapshot, ...]
+    provenance: tuple[RelationSnapshot, ...]
+    authority: tuple[RelationSnapshot, ...]
+    links: tuple[RelationSnapshot, ...]
+    attachments: tuple[RelationSnapshot, ...]
+    derived_views: tuple[RelationSnapshot, ...]
+    public_projections: tuple[tuple[str, object], ...]
+
+
+# This is intentionally a field-level allowlist, not a rule such as "ignore
+# all timestamps".  Acquisition, authored-content, authority, and evidence
+# timestamps are semantic facts and must survive route comparison.
+RUN_LOCAL_NORMALIZATION_ALLOWLIST: Mapping[str, frozenset[str]] = {
+    "index.insight_materialization": frozenset({"materialized_at_ms"}),
+    "index.session_links": frozenset({"observed_at_ms", "resolved_at_ms"}),
+    "index.session_profiles": frozenset({"materialized_at", "priced_at_ms"}),
+    "index.session_latency_profiles": frozenset({"materialized_at"}),
+    "index.session_tag_rollups": frozenset({"materialized_at"}),
+    "index.threads": frozenset({"materialized_at"}),
+    "index.fts_freshness_state": frozenset({"checked_at"}),
+    "source.raw_authority_verdicts": frozenset({"computed_at_ms"}),
+    "ops.convergence_debt": frozenset({"debt_id", "created_at_ms", "updated_at_ms", "next_retry_at"}),
+}
+
+# Absolute paths are run-local when they point inside a temporary archive.
+# They are retained as archive-relative paths so a route comparison still
+# catches a wrong source file while ignoring each run's temporary root.
+RUN_LOCAL_PATH_ALLOWLIST: Mapping[str, frozenset[str]] = {
+    "source.raw_sessions": frozenset({"source_path"}),
+    "source.raw_artifacts": frozenset({"source_path"}),
+    "source.raw_live_source_reconciliation_receipts": frozenset({"source_path", "backup_manifest_path"}),
+    "source.raw_append_chain_backfill_receipts": frozenset({"source_path", "backup_manifest_path"}),
+    "source.raw_membership_writeback_receipts": frozenset({"backup_manifest_path"}),
+    "source.raw_byte_duplicate_supersession_receipts": frozenset({"backup_manifest_path"}),
+    "source.raw_quarantine_group_dedup_receipts": frozenset({"source_path", "backup_manifest_path"}),
+    "source.raw_failure_disposition_receipts": frozenset({"source_path", "backup_manifest_path"}),
+    "source.blob_refs": frozenset({"source_path"}),
+}
+
+PUBLIC_RUN_LOCAL_FIELDS = frozenset({"materialized_at", "priced_at"})
+
+# The categories are intentionally explicit.  A newly relevant relation must
+# be named here and reviewed, rather than silently disappearing from a proof.
+_RELATION_GROUPS: Mapping[str, tuple[tuple[str, str], ...]] = {
+    "canonical_rows": (
+        ("index", "sessions"),
+        ("index", "messages"),
+        ("index", "blocks"),
+    ),
+    "provenance": (
+        ("index", "session_events"),
+        ("index", "session_agent_policies"),
+        ("index", "session_working_dirs"),
+        ("index", "session_refs"),
+        ("index", "session_repos"),
+        ("index", "session_commits"),
+        ("index", "session_provider_usage_events"),
+        ("index", "session_model_usage"),
+        ("index", "file_edits"),
+        ("index", "paste_spans"),
+        ("source", "raw_artifacts"),
+        ("source", "raw_hook_events"),
+    ),
+    "authority": (
+        ("source", "raw_sessions"),
+        ("source", "raw_capture_observations"),
+        ("source", "raw_session_memberships"),
+        ("source", "raw_membership_census"),
+        ("source", "raw_authority_parser_census"),
+        ("source", "raw_authority_censuses"),
+        ("source", "raw_authority_plans"),
+        ("source", "raw_authority_census_plans"),
+        ("source", "raw_authority_census_post_plans"),
+        ("source", "raw_authority_blockers"),
+        ("source", "raw_authority_verdicts"),
+        ("source", "raw_revision_heads"),
+        ("source", "raw_live_source_reconciliation_receipts"),
+        ("source", "raw_membership_writeback_receipts"),
+        ("source", "raw_append_chain_backfill_receipts"),
+        ("source", "raw_byte_duplicate_supersession_receipts"),
+        ("source", "raw_non_session_duplicate_exclusion_receipts"),
+        ("source", "raw_quarantine_group_dedup_receipts"),
+        ("source", "raw_unknown_export_reclassification_receipts"),
+        ("source", "raw_failure_disposition_receipts"),
+        ("source", "blob_refs"),
+        ("source", "verified_blob_receipts"),
+    ),
+    "links": (
+        ("index", "session_links"),
+        ("index", "action_pairs"),
+        ("index", "delegation_facts"),
+        ("index", "work_evidence_edges"),
+        ("index", "work_evidence_nodes"),
+        ("index", "work_evidence_graphs"),
+    ),
+    "attachments": (
+        ("index", "attachments"),
+        ("index", "attachment_refs"),
+        ("index", "attachment_native_ids"),
+    ),
+    "derived_views": (
+        ("index", "session_profiles"),
+        ("index", "session_latency_profiles"),
+        ("index", "session_work_events"),
+        ("index", "session_phases"),
+        ("index", "threads"),
+        ("index", "thread_sessions"),
+        ("index", "session_tags"),
+        ("index", "session_tag_rollups"),
+        ("index", "repos"),
+        ("index", "repo_checkouts"),
+        ("index", "insight_materialization"),
+        ("index", "actions"),
+        ("index", "delegations"),
+        ("index", "fts_freshness_state"),
+        ("ops", "convergence_debt"),
+    ),
+}
+
+# These are physical maintenance relations, not semantic archive state.  The
+# exclusion is explicit so adding one here is visible in code review.
+NON_COMPARABLE_RELATIONS: Mapping[str, str] = {
+    "index.messages_fts": "compared through public search projections",
+    "index.messages_fts_identity": "compared through indexed block identity projections",
+    "index.blocks_command_trigram": "compared through action/public projections",
+    "index.session_work_events_fts": "compared through public work-event projections",
+    "index.query_unit_frame_state": "cursor invalidation is route history, not archive state",
+    "source.raw_revision_applications": "attempt receipt ids and timestamps are run-local",
+}
+
+
+def capture_canonical_snapshot(
+    archive_root: Path,
+    *,
+    session_ids: Sequence[str] | None = None,
+    search_queries: Sequence[str] = (),
+) -> CanonicalArchiveSnapshot:
+    """Capture semantic rows and representative public reads without writes."""
+
+    root = archive_root.expanduser().resolve()
+    connections = _open_connections(root)
+    try:
+        sections = {
+            name: tuple(
+                _capture_relation(connections[database], database, relation, root) for database, relation in relations
+            )
+            for name, relations in _RELATION_GROUPS.items()
+        }
+        ids = tuple(session_ids) if session_ids is not None else _session_ids(connections["index"])
+        public = _capture_public_projections(root, ids, tuple(search_queries))
+        return CanonicalArchiveSnapshot(
+            canonical_rows=sections["canonical_rows"],
+            provenance=sections["provenance"],
+            authority=sections["authority"],
+            links=sections["links"],
+            attachments=sections["attachments"],
+            derived_views=sections["derived_views"],
+            public_projections=public,
+        )
+    finally:
+        for connection in connections.values():
+            connection.close()
+
+
+def archive_snapshot(
+    archive_root: Path,
+    *,
+    session_ids: Sequence[str] | None = None,
+    search_queries: Sequence[str] = (),
+) -> CanonicalArchiveSnapshot:
+    """Compatibility name for the shared canonical snapshot capture."""
+
+    return capture_canonical_snapshot(archive_root, session_ids=session_ids, search_queries=search_queries)
+
+
+def diff_canonical_snapshots(expected: CanonicalArchiveSnapshot, actual: CanonicalArchiveSnapshot) -> tuple[str, ...]:
+    """Return named semantic differences, preserving the first useful detail."""
+
+    differences: list[str] = []
+    for section in (
+        "canonical_rows",
+        "provenance",
+        "authority",
+        "links",
+        "attachments",
+        "derived_views",
+        "public_projections",
+    ):
+        expected_value = getattr(expected, section)
+        actual_value = getattr(actual, section)
+        if expected_value == actual_value:
+            continue
+        if section == "public_projections":
+            differences.append(f"public_projections: {_value_difference(expected_value, actual_value)}")
+            continue
+        expected_relations = {relation.relation_key: relation for relation in expected_value}
+        actual_relations = {relation.relation_key: relation for relation in actual_value}
+        for key in sorted(set(expected_relations) | set(actual_relations)):
+            left = expected_relations.get(key)
+            right = actual_relations.get(key)
+            if left != right:
+                differences.append(f"{section}/{key}: {_relation_difference(left, right)}")
+    return tuple(differences)
+
+
+def assert_canonical_snapshots_equal(expected: CanonicalArchiveSnapshot, actual: CanonicalArchiveSnapshot) -> None:
+    """Assert equality with a category/relation diagnostic for red mutations."""
+
+    differences = diff_canonical_snapshots(expected, actual)
+    if differences:
+        detail = "\n".join(f"  {difference}" for difference in differences[:8])
+        raise AssertionError(f"canonical archive snapshots differ:\n{detail}")
+
+
+def assert_canonical_archives_equal(
+    expected_root: Path,
+    actual_root: Path,
+    *,
+    session_ids: Sequence[str] | None = None,
+    search_queries: Sequence[str] = (),
+) -> None:
+    """Capture and compare two archive roots through production read seams."""
+
+    expected = capture_canonical_snapshot(expected_root, session_ids=session_ids, search_queries=search_queries)
+    actual = capture_canonical_snapshot(actual_root, session_ids=session_ids, search_queries=search_queries)
+    assert_canonical_snapshots_equal(expected, actual)
+
+
+def assert_archives_equivalent(expected: object, actual: object) -> None:
+    """Accept either archive roots or harness objects exposing ``.root``."""
+
+    expected_root = _archive_root(expected)
+    actual_root = _archive_root(actual)
+    assert_canonical_archives_equal(expected_root, actual_root)
+
+
+def _open_connections(root: Path) -> dict[str, sqlite3.Connection]:
+    paths = {name: root / f"{name}.db" for name in ("index", "source", "ops")}
+    connections: dict[str, sqlite3.Connection] = {}
+    try:
+        for name, path in paths.items():
+            if path.exists():
+                connection = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+                connection.row_factory = sqlite3.Row
+                connections[name] = connection
+        if "index" not in connections:
+            raise FileNotFoundError(f"archive index database not found: {root / 'index.db'}")
+        return connections
+    except Exception:
+        for connection in connections.values():
+            connection.close()
+        raise
+
+
+def _capture_relation(
+    connection: sqlite3.Connection | None,
+    database: str,
+    relation: str,
+    root: Path,
+) -> RelationSnapshot:
+    key = f"{database}.{relation}"
+    if connection is None:
+        return RelationSnapshot(database, relation, False, (), ())
+    kind_row = connection.execute(
+        "SELECT type FROM sqlite_master WHERE name = ? COLLATE BINARY", (relation,)
+    ).fetchone()
+    if kind_row is None:
+        return RelationSnapshot(database, relation, False, (), ())
+    columns = tuple(str(row[1]) for row in connection.execute(f'PRAGMA table_info("{relation}")'))
+    omitted = RUN_LOCAL_NORMALIZATION_ALLOWLIST.get(key, frozenset())
+    unknown = omitted - set(columns)
+    if unknown:
+        raise AssertionError(f"run-local normalization names missing columns in {key}: {sorted(unknown)}")
+    selected = tuple(column for column in columns if column not in omitted)
+    if not selected:
+        raise AssertionError(f"canonical relation {key} has no stable columns")
+    quoted = ", ".join(f'"{column}"' for column in selected)
+    rows = [
+        tuple(
+            _normalize_value(database, relation, column, value, root)
+            for column, value in zip(selected, row, strict=True)
+        )
+        for row in connection.execute(f'SELECT {quoted} FROM "{relation}"')
+    ]
+    return RelationSnapshot(database, relation, True, selected, tuple(sorted(rows, key=repr)))
+
+
+def _capture_public_projections(
+    root: Path, session_ids: Sequence[str], search_queries: Sequence[str]
+) -> tuple[tuple[str, object], ...]:
+    values: list[tuple[str, object]] = []
+    with ArchiveStore.open_existing(root, read_only=True) as archive:
+        ids = tuple(dict.fromkeys(str(session_id) for session_id in session_ids))
+        for session_id in ids:
+            values.extend(
+                (
+                    (f"summary:{session_id}", _freeze_public(archive.read_summary(session_id))),
+                    (f"tree:{session_id}", _freeze_public(archive.get_session_tree(session_id))),
+                    (f"profile:{session_id}", _freeze_public(archive.get_session_profile_insight(session_id))),
+                    (f"latency:{session_id}", _freeze_public(archive.get_session_latency_profile_insight(session_id))),
+                    (f"work-events:{session_id}", _freeze_public(archive.get_session_work_event_insights(session_id))),
+                    (f"phases:{session_id}", _freeze_public(archive.get_session_phase_insights(session_id))),
+                )
+            )
+        values.extend(
+            (
+                ("actions", _freeze_public(archive.query_session_actions(ids, limit=100_000))),
+                ("threads", _freeze_public(archive.list_thread_insights(limit=None))),
+                ("index-status", _freeze_public(archive.index_status())),
+            )
+        )
+        values.extend((f"search:{query}", tuple(archive.search_blocks(query))) for query in search_queries)
+    return tuple(values)
+
+
+def _session_ids(connection: sqlite3.Connection) -> tuple[str, ...]:
+    return tuple(str(row[0]) for row in connection.execute("SELECT session_id FROM sessions ORDER BY session_id"))
+
+
+def _normalize_value(database: str, relation: str, column: str, value: object, root: Path) -> SqlValue:
+    if isinstance(value, bytes):
+        return value.hex()
+    if value is None or isinstance(value, (str, int, float)):
+        if isinstance(value, str) and column in RUN_LOCAL_PATH_ALLOWLIST.get(f"{database}.{relation}", frozenset()):
+            return _archive_relative_path(value, root)
+        return value
+    raise TypeError(f"unsupported SQLite value in {database}.{relation}.{column}: {type(value)!r}")
+
+
+def _archive_relative_path(value: str, root: Path) -> str:
+    candidate = Path(value)
+    if candidate.is_absolute():
+        try:
+            return candidate.resolve().relative_to(root).as_posix()
+        except ValueError:
+            return value
+    return candidate.as_posix()
+
+
+def _freeze_public(value: object) -> object:
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return _freeze_public(dataclasses.asdict(value))
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        return _freeze_public(model_dump(mode="json"))
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, Mapping):
+        return tuple(
+            (str(key), _freeze_public(item))
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+            if str(key) not in PUBLIC_RUN_LOCAL_FIELDS
+        )
+    if isinstance(value, (tuple, list, set, frozenset)):
+        return tuple(_freeze_public(item) for item in value)
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if isinstance(value, Path):
+        return value.as_posix()
+    return value
+
+
+def _archive_root(value: object) -> Path:
+    if isinstance(value, (str, Path)):
+        return Path(value)
+    root = getattr(value, "root", None)
+    if isinstance(root, Path):
+        return root
+    raise TypeError(f"expected archive root or object with Path root, got {type(value)!r}")
+
+
+def _relation_difference(expected: RelationSnapshot | None, actual: RelationSnapshot | None) -> str:
+    if expected is None or actual is None:
+        return f"missing expected={expected is not None}, actual={actual is not None}"
+    if not expected.exists or not actual.exists:
+        return f"exists expected={expected.exists}, actual={actual.exists}"
+    if expected.columns != actual.columns:
+        return f"columns expected={expected.columns}, actual={actual.columns}"
+    expected_rows = set(expected.rows)
+    actual_rows = set(actual.rows)
+    return (
+        f"only_expected={sorted(expected_rows - actual_rows, key=repr)[:2]!r}, "
+        f"only_actual={sorted(actual_rows - expected_rows, key=repr)[:2]!r}"
+    )
+
+
+def _value_difference(expected: object, actual: object) -> str:
+    return f"expected={expected!r}, actual={actual!r}"
+
+
+__all__ = [
+    "CanonicalArchiveSnapshot",
+    "FactRow",
+    "NON_COMPARABLE_RELATIONS",
+    "RUN_LOCAL_NORMALIZATION_ALLOWLIST",
+    "RUN_LOCAL_PATH_ALLOWLIST",
+    "RelationSnapshot",
+    "archive_snapshot",
+    "assert_archives_equivalent",
+    "assert_canonical_archives_equal",
+    "assert_canonical_snapshots_equal",
+    "capture_canonical_snapshot",
+    "diff_canonical_snapshots",
+]

--- a/tests/infra/convergence_harness.py
+++ b/tests/infra/convergence_harness.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import re
 import sqlite3
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -49,6 +48,15 @@ from polylogue.storage.sqlite.archive_tiers.source_write import write_source_raw
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
 from polylogue.storage.sqlite.connection import open_connection
+from tests.infra.archive_canonical_snapshot import (
+    CanonicalArchiveSnapshot as ArchiveSnapshot,
+)
+from tests.infra.archive_canonical_snapshot import (
+    archive_snapshot,
+)
+from tests.infra.archive_canonical_snapshot import (
+    assert_archives_equivalent as _assert_canonical_archives_equivalent,
+)
 from tests.infra.pathology_composer import (
     ComposedPathology,
     compose_append_revision_chain,
@@ -103,24 +111,6 @@ class SessionMaterializationFacts:
     threads: tuple[FactRow, ...]
     thread_sessions: tuple[FactRow, ...]
     table_counts: tuple[tuple[str, int], ...]
-
-
-@dataclass(frozen=True, slots=True)
-class ArchiveSnapshot:
-    """Semantic archive state, deliberately excluding run-local stamps and ids."""
-
-    sessions: tuple[FactRow, ...]
-    messages: tuple[FactRow, ...]
-    blocks: tuple[FactRow, ...]
-    session_links: tuple[FactRow, ...]
-    profiles: tuple[FactRow, ...]
-    work_events: tuple[FactRow, ...]
-    phases: tuple[FactRow, ...]
-    threads: tuple[FactRow, ...]
-    thread_sessions: tuple[FactRow, ...]
-    semantic_tables: tuple[tuple[str, tuple[FactRow, ...]], ...]
-    fts_matches: tuple[tuple[str, object], ...]
-    raw_authority: tuple[FactRow, ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -289,75 +279,10 @@ def assert_archive_verification_green(root: Path) -> ArchiveVerificationReport:
     return report
 
 
-def archive_snapshot(root: Path) -> ArchiveSnapshot:
-    """Return the one canonical archive comparator shared by all properties."""
-    with sqlite3.connect(root / "index.db") as conn:
-        sessions = conn.execute(
-            """
-            SELECT session_id, origin, native_id, title, parent_session_id,
-                   root_session_id, branch_type, active_leaf_message_id, message_count
-            FROM sessions ORDER BY session_id
-            """
-        ).fetchall()
-        messages = conn.execute(
-            """
-            SELECT session_id, native_id, position, variant_index, role,
-                   material_origin, message_type, parent_message_id, model_name,
-                   model_effort, input_tokens, output_tokens, cache_read_tokens,
-                   cache_write_tokens, duration_ms, stop_reason, content_hash
-            FROM messages ORDER BY session_id, position, variant_index
-            """
-        ).fetchall()
-        blocks = conn.execute(
-            """
-            SELECT session_id, message_id, position, block_type, text, tool_id,
-                   tool_name, tool_input, semantic_type, media_type,
-                   tool_result_is_error, tool_result_exit_code, content_hash
-            FROM blocks ORDER BY session_id, message_id, position
-            """
-        ).fetchall()
-        session_links = conn.execute(
-            """
-            SELECT src_session_id, dst_origin, dst_native_id, link_type,
-                   resolved_dst_session_id, branch_point_message_id, inheritance,
-                   status, parent_tool_use_block_id, method, confidence,
-                   evidence_json
-            FROM session_links
-            ORDER BY src_session_id, dst_origin, dst_native_id, link_type
-            """
-        ).fetchall()
-        profiles = _table_rows(conn, "session_profiles", order_by="session_id")
-        work_events = _table_rows(conn, "session_work_events", order_by="session_id, position")
-        phases = _table_rows(conn, "session_phases", order_by="session_id, position")
-        threads = _table_rows(conn, "threads", order_by="thread_id")
-        thread_sessions = _table_rows(conn, "thread_sessions", order_by="thread_id, session_id, position")
-        semantic_tables = tuple(
-            (table, _table_rows(conn, table, order_by=order_by)) for table, order_by in _SEMANTIC_TABLES
-        )
-        fts_matches = _fts_match_snapshot(conn)
-    raw_authority = raw_authority_facts(root / "source.db", archive_root=root)
-    return ArchiveSnapshot(
-        sessions=_fact_rows(sessions),
-        messages=_fact_rows(messages),
-        blocks=_fact_rows(blocks),
-        session_links=_fact_rows(session_links),
-        profiles=profiles,
-        work_events=work_events,
-        phases=phases,
-        threads=threads,
-        thread_sessions=thread_sessions,
-        semantic_tables=semantic_tables,
-        fts_matches=fts_matches,
-        raw_authority=raw_authority,
-    )
-
-
 def assert_archives_equivalent(left: ConvergenceArchive, right: ConvergenceArchive) -> None:
-    """Compare archives through ``archive_snapshot`` rather than database bytes."""
-    left_snapshot = archive_snapshot(left.root)
-    right_snapshot = archive_snapshot(right.root)
-    if left_snapshot != right_snapshot:
-        raise AssertionError(f"canonical archive snapshots differ:\nleft={left_snapshot!r}\nright={right_snapshot!r}")
+    """Compare property archives through the shared canonical comparator."""
+
+    _assert_canonical_archives_equivalent(left, right)
 
 
 def derived_readiness_snapshot(root: Path) -> DerivedReadinessSnapshot:
@@ -576,112 +501,6 @@ def _parsed_session(session: object, *, corpus_index: int) -> ParsedSession:
             )
         ],
     )
-
-
-_SEMANTIC_TABLES: tuple[tuple[str, str], ...] = (
-    ("session_events", "session_id, position"),
-    ("session_agent_policies", "session_id, position"),
-    ("session_working_dirs", "session_id, position, path"),
-    ("session_refs", "session_id, position"),
-    ("attachments", "attachment_id"),
-    ("attachment_refs", "session_id, message_id, position"),
-    ("attachment_native_ids", "ref_id, id_kind, native_id"),
-    ("repos", "repo_id"),
-    ("repo_checkouts", "repo_id, root_path"),
-    ("session_repos", "session_id, repo_id"),
-    ("session_commits", "session_id, commit_sha"),
-    ("session_provider_usage_events", "session_id, position"),
-    ("session_model_usage", "session_id, model_name"),
-    ("session_tags", "session_id, tag, tag_source"),
-    ("action_pairs", "session_id, message_id, use_rank"),
-    ("delegation_facts", "delegation_id"),
-    ("insight_materialization", "session_id, insight_type"),
-)
-
-
-_SNAPSHOT_VOLATILE_COLUMNS: dict[str, frozenset[str]] = {
-    "insight_materialization": frozenset({"materialized_at_ms"}),
-    "session_links": frozenset({"observed_at_ms", "resolved_at_ms"}),
-    "session_profiles": frozenset({"materialized_at", "priced_at_ms"}),
-    # Thread source_updated_at is derived from provider-backed member
-    # timestamps, unlike materialized_at.
-    "threads": frozenset({"materialized_at"}),
-}
-
-
-def _table_rows(conn: sqlite3.Connection, table: str, *, order_by: str) -> tuple[FactRow, ...]:
-    columns = tuple(row[1] for row in conn.execute(f"PRAGMA table_info({table})"))
-    selected_columns = tuple(
-        column for column in columns if column not in _SNAPSHOT_VOLATILE_COLUMNS.get(table, frozenset())
-    )
-    if not selected_columns:
-        raise AssertionError(f"snapshot has no stable columns for {table}")
-    quoted_columns = ", ".join(f'"{column}"' for column in selected_columns)
-    rows = conn.execute(f"SELECT {quoted_columns} FROM {table} ORDER BY {order_by}").fetchall()
-    return _fact_rows(rows)
-
-
-def _fts_match_snapshot(conn: sqlite3.Connection) -> tuple[tuple[str, object], ...]:
-    """Capture semantic FTS postings for fixture tokens, never physical rowids."""
-    text_rows = conn.execute("SELECT text FROM blocks WHERE text IS NOT NULL ORDER BY block_id").fetchall()
-    tokens = sorted({token.lower() for row in text_rows for token in re.findall(r"[A-Za-z0-9_]{3,}", str(row[0]))})
-    matches: list[tuple[str, object]] = []
-    for token in tokens:
-        block_ids = conn.execute(
-            """
-            SELECT i.block_id
-            FROM messages_fts AS f
-            JOIN messages_fts_identity AS i ON i.rowid = f.rowid
-            WHERE messages_fts MATCH ?
-            ORDER BY i.block_id
-            """,
-            (f'"{token}"',),
-        ).fetchall()
-        matches.append((f"messages_fts:{token}", tuple(str(row[0]) for row in block_ids)))
-    fts_identity_table = "messages_fts_" + "identity"
-    identity_rows = conn.execute(
-        f"SELECT block_id, hex(source_hash), recipe_id FROM {fts_identity_table} ORDER BY block_id"
-    ).fetchall()
-    matches.append(("messages_fts:identity", _fact_rows(identity_rows)))
-
-    command_rows = conn.execute(
-        "SELECT tool_detail_text FROM blocks WHERE tool_detail_text IS NOT NULL ORDER BY block_id"
-    ).fetchall()
-    command_tokens = sorted(
-        {token.lower() for row in command_rows for token in re.findall(r"[A-Za-z0-9_]{3,}", str(row[0]))}
-    )
-    for token in command_tokens:
-        block_ids = conn.execute(
-            """
-            SELECT b.block_id
-            FROM blocks_command_trigram AS f
-            JOIN blocks AS b ON b.rowid = f.rowid
-            WHERE blocks_command_trigram MATCH ?
-            ORDER BY b.block_id
-            """,
-            (f'"{token}"',),
-        ).fetchall()
-        matches.append((f"blocks_command_trigram:{token}", tuple(str(row[0]) for row in block_ids)))
-
-    event_rows = conn.execute(
-        "SELECT search_text FROM session_work_events WHERE search_text IS NOT NULL ORDER BY event_id"
-    ).fetchall()
-    event_tokens = sorted(
-        {token.lower() for row in event_rows for token in re.findall(r"[A-Za-z0-9_]{3,}", str(row[0]))}
-    )
-    for token in event_tokens:
-        event_ids = conn.execute(
-            """
-            SELECT e.event_id
-            FROM session_work_events_fts AS f
-            JOIN session_work_events AS e ON e.event_id = f.event_id
-            WHERE session_work_events_fts MATCH ?
-            ORDER BY e.event_id
-            """,
-            (f'"{token}"',),
-        ).fetchall()
-        matches.append((f"session_work_events_fts:{token}", tuple(str(row[0]) for row in event_ids)))
-    return tuple(matches)
 
 
 def _raw_payload(session: ParsedSession) -> bytes:

--- a/tests/unit/infra/test_archive_canonical_snapshot.py
+++ b/tests/unit/infra/test_archive_canonical_snapshot.py
@@ -1,0 +1,197 @@
+"""Focused contract tests for the shared real-archive snapshot comparator."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType, Provider
+from polylogue.pipeline.ids import session_content_hash
+from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
+from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
+from polylogue.storage.sqlite.connection import open_connection
+from tests.infra.archive_canonical_snapshot import (
+    RUN_LOCAL_NORMALIZATION_ALLOWLIST,
+    RelationSnapshot,
+    assert_canonical_snapshots_equal,
+    capture_canonical_snapshot,
+)
+from tests.infra.convergence_harness import (
+    ConvergenceArchive,
+    converge_convergence_archive,
+    ingest_convergence_pathology,
+    initialize_active_archive,
+    rich_convergence_pathology,
+)
+from tests.infra.pathology_composer import ComposedPathology
+
+
+def _relation_keys(section: tuple[RelationSnapshot, ...]) -> set[tuple[str, str]]:
+    return {(relation.database, relation.relation) for relation in section}
+
+
+def _add_real_action_result(archive_root: Path) -> None:
+    """Add one action/result pair through the production parsed-session writer."""
+    tool_id = "canonical-snapshot-tool"
+    session = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="canonical-snapshot-action",
+        title="Canonical snapshot action result",
+        created_at="2026-01-01T00:00:00+00:00",
+        updated_at="2026-01-01T00:00:00+00:00",
+        messages=[
+            ParsedMessage(
+                provider_message_id="action-message",
+                role=Role.ASSISTANT,
+                position=0,
+                text="run the action",
+                blocks=[
+                    ParsedContentBlock(
+                        type=BlockType.TOOL_USE,
+                        tool_name="Task",
+                        tool_id=tool_id,
+                        tool_input={"prompt": "run the action"},
+                    ),
+                    ParsedContentBlock(
+                        type=BlockType.TOOL_RESULT,
+                        tool_id=tool_id,
+                        text="command failed",
+                        is_error=True,
+                        exit_code=1,
+                    ),
+                ],
+            )
+        ],
+    )
+    with open_connection(archive_root / "index.db") as conn:
+        write_parsed_session_to_archive(conn, session, content_hash=session_content_hash(session))
+
+
+def _build_archive(root: Path, pathology: ComposedPathology | None = None) -> ConvergenceArchive:
+    """Use production ingest and convergence without the unrelated blob audit."""
+    selected_pathology = rich_convergence_pathology() if pathology is None else pathology
+    initialize_active_archive(root)
+    archive = ingest_convergence_pathology(
+        root,
+        selected_pathology,
+        session_indexes=tuple(range(len(selected_pathology.sessions))),
+        converge_after_each=False,
+    )
+    converge_convergence_archive(archive)
+    return archive
+
+
+def test_snapshot_covers_semantic_archive_and_public_read_surfaces(tmp_path: Path) -> None:
+    archive = _build_archive(tmp_path / "archive", rich_convergence_pathology())
+    snapshot = capture_canonical_snapshot(archive.root, search_queries=("fixture",))
+
+    assert ("index", "sessions") in _relation_keys(snapshot.canonical_rows)
+    assert ("index", "messages") in _relation_keys(snapshot.canonical_rows)
+    assert ("index", "blocks") in _relation_keys(snapshot.canonical_rows)
+    assert ("index", "session_events") in _relation_keys(snapshot.provenance)
+    assert ("source", "raw_sessions") in _relation_keys(snapshot.authority)
+    assert ("source", "raw_authority_verdicts") in _relation_keys(snapshot.authority)
+    assert ("index", "session_links") in _relation_keys(snapshot.links)
+    assert ("index", "action_pairs") in _relation_keys(snapshot.links)
+    assert ("index", "attachments") in _relation_keys(snapshot.attachments)
+    assert ("index", "session_profiles") in _relation_keys(snapshot.derived_views)
+    assert ("index", "actions") in _relation_keys(snapshot.derived_views)
+
+    public_names = {name for name, _value in snapshot.public_projections}
+    assert any(name.startswith("summary:") for name in public_names)
+    assert any(name.startswith("profile:") for name in public_names)
+    assert "actions" in public_names
+    assert "threads" in public_names
+    assert "search:fixture" in public_names
+
+
+def test_only_allowlisted_materialization_stamps_are_ignored(tmp_path: Path) -> None:
+    archive = _build_archive(tmp_path / "archive", rich_convergence_pathology())
+    before = capture_canonical_snapshot(archive.root)
+
+    with sqlite3.connect(archive.root / "index.db") as conn:
+        profile = conn.execute("SELECT session_id FROM session_profiles LIMIT 1").fetchone()
+        materialization = conn.execute("SELECT session_id FROM insight_materialization LIMIT 1").fetchone()
+        assert profile is not None
+        assert materialization is not None
+        conn.execute(
+            "UPDATE session_profiles SET materialized_at = '2099-01-01T00:00:00+00:00', priced_at_ms = 2099 "
+            "WHERE session_id = ?",
+            (profile[0],),
+        )
+        conn.execute(
+            "UPDATE insight_materialization SET materialized_at_ms = 2099 WHERE session_id = ?",
+            (materialization[0],),
+        )
+        conn.commit()
+
+    after = capture_canonical_snapshot(archive.root)
+    assert_canonical_snapshots_equal(before, after)
+    assert RUN_LOCAL_NORMALIZATION_ALLOWLIST["index.session_profiles"] == frozenset({"materialized_at", "priced_at_ms"})
+
+
+@pytest.mark.parametrize(
+    ("name", "mutate"),
+    (
+        (
+            "material_origin",
+            lambda conn: conn.execute(
+                "UPDATE messages SET material_origin = 'runtime_protocol' "
+                "WHERE message_id = (SELECT message_id FROM messages LIMIT 1)"
+            ),
+        ),
+        (
+            "link status",
+            lambda conn: conn.execute(
+                "UPDATE session_links SET status = CASE WHEN status = 'quarantined' THEN 'repaired' "
+                "ELSE 'quarantined' END WHERE rowid = (SELECT rowid FROM session_links LIMIT 1)"
+            ),
+        ),
+        (
+            "provenance",
+            lambda conn: conn.execute(
+                "UPDATE session_profiles SET evidence_payload_json = '{\"red_mutation\":true}' "
+                "WHERE session_id = (SELECT session_id FROM session_profiles LIMIT 1)"
+            ),
+        ),
+        (
+            "action result state",
+            lambda conn: conn.execute(
+                "UPDATE blocks SET tool_result_is_error = CASE WHEN tool_result_is_error = 1 THEN 0 ELSE 1 END "
+                "WHERE block_id = (SELECT block_id FROM blocks WHERE block_type = 'tool_result' LIMIT 1)"
+            ),
+        ),
+    ),
+)
+def test_semantic_mutations_are_red(
+    tmp_path: Path, name: str, mutate: Callable[[sqlite3.Connection], sqlite3.Cursor]
+) -> None:
+    """The comparator must fail on semantic fields, not normalize them away."""
+    pathology = rich_convergence_pathology()
+    canonical = _build_archive(tmp_path / "canonical", pathology)
+    mutated = _build_archive(tmp_path / "mutated", pathology)
+    if name == "action result state":
+        _add_real_action_result(canonical.root)
+        _add_real_action_result(mutated.root)
+        converge_convergence_archive(canonical)
+        converge_convergence_archive(mutated)
+    with sqlite3.connect(mutated.root / "index.db") as conn:
+        result = mutate(conn)
+        if result.rowcount != 1:
+            raise AssertionError(f"{name} mutation did not update exactly one row")
+        conn.commit()
+
+    expected = capture_canonical_snapshot(canonical.root)
+    actual = capture_canonical_snapshot(mutated.root)
+    expected_marker = {
+        "material_origin": "messages",
+        "link status": "session_links",
+        "provenance": "session_profiles",
+        "action result state": "actions",
+    }[name]
+    with pytest.raises(AssertionError, match=expected_marker):
+        assert_canonical_snapshots_equal(expected, actual)


### PR DESCRIPTION
Summary

Add one production-seam canonical archive comparator and route-equivalence tests for the polylogue-canonical-snapshot lane.

Problem

The convergence harness compared a narrow hand-picked table subset and reimplemented FTS token matching. That left provenance, authority, attachments, action results, and representative public reads outside the shared equivalence proof, while a broad volatile-column rule could normalize semantic facts away.

Solution

Add tests/infra/archive_canonical_snapshot.py with explicit relation categories, read-only SQLite capture, public ArchiveStore projections, named run-local field and path allowlists, and relation-level diagnostics. Delegate the existing convergence_harness.assert_archives_equivalent seam to this comparator and remove the duplicate snapshot and FTS replica. Add real-route tests covering canonical rows, provenance, authority, links, attachments, derived views, public projections, allowlisted stamps, and red mutations of material_origin, link status, provenance, and action-result state.

Verification

- devtools test tests/unit/infra/test_archive_canonical_snapshot.py: 6 passed in 13.58s
- devtools test tests/property/test_convergence_property_mutations.py::test_convergence_property_fts_repair_mutation_red_twin tests/property/test_convergence_property_mutations.py::test_convergence_property_insight_repair_mutation_red_twin: 2 passed in 8.79s
- devtools verify --quick: exit_code 0; ruff, mypy, render, layering, policy, and schema promotion checks passed
- git diff --check: passed
- The affected incremental property reproduces an existing pre-comparison failure at make_messages_fts_stale for shift=1, and the raw replay and materialized-content properties stop on the existing blob-integrity report (missing_referenced_blobs=5; orphan_blobs=1). These failures do not reach the new comparator and were not changed in this lane.

Acceptance matrix

| Acceptance criterion | Status | Evidence |
| --- | --- | --- |
| One comparator is reusable by convergence, incident, crash-recovery, and promotion harnesses | Satisfied | Public root/object APIs plus unchanged convergence_harness compatibility seam |
| Compare canonical rows, provenance, authority, links, attachments, derived views, and public projections | Satisfied | Explicit CanonicalArchiveSnapshot sections and focused coverage test |
| Normalize only explicitly allowlisted run-local fields | Satisfied | RUN_LOCAL_NORMALIZATION_ALLOWLIST and path allowlists; semantic timestamps and provider identity remain captured |
| Mutations to material_origin, link status, provenance, or action-result state are red | Satisfied | Four parameterized real SQLite mutation tests fail with relation-level diagnostics |
| Exercise production archive and convergence seams | Satisfied | Tests use initialize_active_archive, production ingest writer, DaemonConverger, ArchiveStore, and public read methods |

Anti-vacuity

The red mutation test mutates production-written SQLite rows after real ingestion and convergence. It changes messages.material_origin, session_links.status, session_profiles evidence_payload_json, and blocks.tool_result_is_error, then requires the shared comparator to reject the twin.

Bead trail

No Beads writes were made from the lane, per assignment. The coordinator should record the implementation and verification trail for polylogue-canonical-snapshot.