### PR TITLE
fix(read): project fresh session display labels

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -2077,7 +2077,7 @@ def _archive_message_to_domain(message: ArchiveMessageRow, *, origin: Origin) ->
     )
 
 
-def _archive_session_to_session(session: ArchiveSessionEnvelope) -> Session:
+def _archive_session_to_session(session: ArchiveSessionEnvelope, *, display_label: str | None = None) -> Session:
     origin = Origin.from_string(session.origin)
     messages = [_archive_message_to_domain(message, origin=origin) for message in session.messages]
     timestamps = [message.timestamp for message in messages if message.timestamp is not None]
@@ -2090,7 +2090,8 @@ def _archive_session_to_session(session: ArchiveSessionEnvelope) -> Session:
     return Session(
         id=SessionId(session.session_id),
         origin=origin,
-        title=session.title,
+        title=session.title if session.title_source in {"origin", "heuristic"} else None,
+        display_label=display_label,
         title_source=TitleSource(session.title_source) if session.title_source is not None else None,
         title_ref=session.title_ref,
         title_confidence=session.title_confidence,
@@ -2113,6 +2114,7 @@ def _archive_summary_to_domain(summary: ArchiveSessionSummary) -> SessionSummary
         id=SessionId(summary.session_id),
         origin=Origin.from_string(summary.origin),
         title=summary.title,
+        display_label=summary.display_label,
         title_source=TitleSource(summary.title_source) if summary.title_source is not None else None,
         title_ref=summary.title_ref,
         title_confidence=summary.title_confidence,
@@ -2282,7 +2284,10 @@ class _ArchiveNeighborRuntime:
     async def get(self, session_id: str) -> Session | None:
         try:
             resolved = self._archive.resolve_session_id(session_id)
-            return _archive_session_to_session(self._archive.read_session(resolved))
+            summary = self._archive.read_summary(resolved)
+            return _archive_session_to_session(
+                self._archive.read_session(resolved), display_label=summary.display_label
+            )
         except KeyError:
             return None
 
@@ -2526,7 +2531,10 @@ class PolylogueArchiveMixin:
                 resolved_id = archive.resolve_session_id(session_id)
             except KeyError:
                 return None
-            session = _archive_session_to_session(archive.read_session(resolved_id))
+            summary = archive.read_summary(resolved_id)
+            session = _archive_session_to_session(
+                archive.read_session(resolved_id), display_label=summary.display_label
+            )
             if content_projection is None or not content_projection.filters_content():
                 return session
             return session.with_content_projection(content_projection)
@@ -4077,7 +4085,8 @@ class PolylogueArchiveMixin:
             )
         session_id = str(row["session_id"])
         message_id = str(row["message_id"])
-        session = _archive_session_to_session(archive.read_session(session_id))
+        summary = archive.read_summary(session_id)
+        session = _archive_session_to_session(archive.read_session(session_id), display_label=summary.display_label)
         message = next((item for item in session.messages if str(item.id) == message_id), None)
         if message is None:
             return cast(
@@ -4604,7 +4613,10 @@ class PolylogueArchiveMixin:
             model_json_document,
         )
 
-        session = _archive_session_to_session(archive.read_session(str(summary.session_id)))
+        session = _archive_session_to_session(
+            archive.read_session(str(summary.session_id)),
+            display_label=summary.display_label,
+        )
         digest = compile_session_digest(session)
         if object_ref.kind == "run":
             for run in digest.run_projection.runs:
@@ -4614,7 +4626,7 @@ class PolylogueArchiveMixin:
                     run_ref=run.run_ref.format(),
                     session_id=str(summary.session_id),
                     origin=str(summary.origin),
-                    title=summary.title,
+                    title=summary.display_label or summary.title,
                     native_session_id=run.native_session_id,
                     native_parent_session_id=run.native_parent_session_id,
                     parent_run_ref=run.parent_run_ref.format() if run.parent_run_ref else None,
@@ -4638,7 +4650,7 @@ class PolylogueArchiveMixin:
                     resolved=True,
                     payload_kind="run",
                     payload=model_json_document(run_payload),
-                    title=summary.title,
+                    title=summary.display_label or summary.title,
                     summary=f"{run_payload.role} {run_payload.status}",
                     object_refs=(f"session:{summary.session_id}", normalized_ref),
                     evidence_refs=run_payload.evidence_refs,
@@ -4651,7 +4663,7 @@ class PolylogueArchiveMixin:
                     event_ref=event.event_ref.format(),
                     session_id=str(summary.session_id),
                     origin=str(summary.origin),
-                    title=summary.title,
+                    title=summary.display_label or summary.title,
                     kind=event.kind,
                     summary=event.summary,
                     delivery_state=event.delivery_state,
@@ -4666,7 +4678,7 @@ class PolylogueArchiveMixin:
                     resolved=True,
                     payload_kind="observed-event",
                     payload=model_json_document(event_payload),
-                    title=summary.title,
+                    title=summary.display_label or summary.title,
                     summary=event_payload.summary,
                     object_refs=(f"session:{summary.session_id}", normalized_ref, *event_payload.object_refs),
                     evidence_refs=event_payload.evidence_refs,
@@ -4679,7 +4691,7 @@ class PolylogueArchiveMixin:
                     snapshot_ref=snapshot.snapshot_ref.format(),
                     session_id=str(summary.session_id),
                     origin=str(summary.origin),
-                    title=summary.title,
+                    title=summary.display_label or summary.title,
                     run_ref=snapshot.run_ref.format(),
                     boundary=snapshot.boundary,
                     inheritance_mode=snapshot.inheritance_mode,
@@ -4694,7 +4706,7 @@ class PolylogueArchiveMixin:
                     resolved=True,
                     payload_kind="context-snapshot",
                     payload=model_json_document(snapshot_payload),
-                    title=summary.title,
+                    title=summary.display_label or summary.title,
                     summary=f"{snapshot_payload.boundary} ({snapshot_payload.inheritance_mode})",
                     object_refs=(
                         f"session:{summary.session_id}",
@@ -4761,7 +4773,13 @@ class PolylogueArchiveMixin:
                 origin=origin,
                 limit=50 if limit is None else limit,
             )
-            sessions = [_archive_session_to_session(archive.read_session(summary.session_id)) for summary in summaries]
+            sessions = [
+                _archive_session_to_session(
+                    archive.read_session(summary.session_id),
+                    display_label=summary.display_label,
+                )
+                for summary in summaries
+            ]
             if content_projection is None or not content_projection.filters_content():
                 return sessions
             return [session.with_content_projection(content_projection) for session in sessions]
@@ -5318,7 +5336,10 @@ class PolylogueArchiveMixin:
             stats = archive.stats()
             word_row = archive._conn.execute("SELECT COALESCE(SUM(word_count), 0) FROM sessions").fetchone()
             recent = [
-                _archive_session_to_session(archive.read_session(summary.session_id))
+                _archive_session_to_session(
+                    archive.read_session(summary.session_id),
+                    display_label=summary.display_label,
+                )
                 for summary in archive.list_summaries(limit=5)
             ]
             return PublicArchiveStats(
@@ -5992,7 +6013,7 @@ class PolylogueArchiveMixin:
         return [
             {
                 "id": summary.session_id,
-                "title": summary.title,
+                "title": summary.display_label or summary.title,
                 "origin": summary.origin,
                 "created_at": parse_archive_datetime(summary.created_at),
                 "updated_at": parse_archive_datetime(summary.updated_at),
@@ -6294,7 +6315,11 @@ class PolylogueArchiveMixin:
             operation="archive.session_tree",
             arguments={"session_id": session_id},
             work=lambda archive: [
-                _archive_session_to_session(session) for session in archive.get_session_tree(session_id)
+                _archive_session_to_session(
+                    session,
+                    display_label=archive.read_summary(session.session_id).display_label,
+                )
+                for session in archive.get_session_tree(session_id)
             ],
             projection="session-tree",
             stable_order="depth,session_id",

--- a/polylogue/archive/query/archive_execution.py
+++ b/polylogue/archive/query/archive_execution.py
@@ -186,6 +186,7 @@ def _summary_to_domain(summary: ArchiveSessionSummary) -> SessionSummary:
         id=SessionId(summary.session_id),
         origin=Origin.from_string(summary.origin),
         title=summary.title,
+        display_label=summary.display_label,
         title_source=_coerce_title_source(summary.title_source),
         title_ref=summary.title_ref,
         title_confidence=summary.title_confidence,
@@ -267,7 +268,7 @@ def _message_to_domain(message: ArchiveMessageRow, *, origin: Origin) -> Message
     )
 
 
-def _session_to_session(session: ArchiveSessionEnvelope) -> Session:
+def _session_to_session(session: ArchiveSessionEnvelope, *, display_label: str | None = None) -> Session:
     from polylogue.archive.session.branch_type import BranchType
 
     origin = Origin.from_string(session.origin)
@@ -276,7 +277,8 @@ def _session_to_session(session: ArchiveSessionEnvelope) -> Session:
     return Session(
         id=SessionId(session.session_id),
         origin=origin,
-        title=session.title,
+        title=session.title if session.title_source in {"origin", "heuristic"} else None,
+        display_label=display_label,
         title_source=_coerce_title_source(session.title_source),
         title_ref=session.title_ref,
         title_confidence=session.title_confidence,
@@ -501,7 +503,10 @@ async def list_archive(
             default_limit=default_limit,
         )
         sessions = _attach_units_to_domain(
-            [_session_to_session(archive.read_session(summary.session_id)) for summary in archive_rows],
+            [
+                _session_to_session(archive.read_session(summary.session_id), display_label=summary.display_label)
+                for summary in archive_rows
+            ],
             archive,
             with_units,
             with_unit_fields,

--- a/polylogue/archive/query/support.py
+++ b/polylogue/archive/query/support.py
@@ -28,6 +28,7 @@ def session_to_summary(session: Session) -> SessionSummary:
         id=session.id,
         origin=session.origin,
         title=session.title,
+        display_label=session.display_label,
         created_at=session.created_at,
         updated_at=session.updated_at,
         metadata=session.metadata,

--- a/polylogue/archive/session/display_mixin.py
+++ b/polylogue/archive/session/display_mixin.py
@@ -41,10 +41,12 @@ class DisplayTitleTagsMixin:
     - parent_id: SessionId | None
     - branch_type: BranchType | None
     - display_name: str | None
+    - display_label: str | None
     """
 
     id: SessionId
     title: str | None
+    display_label: str | None
     created_at: datetime | None
     updated_at: datetime | None
     metadata: dict[str, object]
@@ -64,10 +66,12 @@ class DisplayTitleTagsMixin:
 
     @property
     def display_title(self) -> str:
-        """Return the display title with precedence: user_title > title > display_name > id[:8]."""
+        """Return the read-time display label, preserving provider titles."""
         user_title = self.user_title
         if user_title:
             return user_title
+        if self.display_label:
+            return self.display_label
         if self.title:
             return self.title
         # polylogue-cgfy: provider-assigned display name (e.g. Claude Code's

--- a/polylogue/archive/session/domain_models.py
+++ b/polylogue/archive/session/domain_models.py
@@ -36,6 +36,8 @@ class SessionSummary(SessionSummaryRuntimeMixin, BaseModel):
     id: SessionId
     origin: Origin
     title: str | None = None
+    # Read-time projection over current structural evidence. Never persisted.
+    display_label: str | None = None
     title_source: TitleSource | None = None
     # Specific provenance beyond title_source's coarse strategy label: exact
     # evidence reference plus a 0..1 confidence signal (polylogue-ih67).
@@ -97,6 +99,8 @@ class Session(SessionRuntimeMixin, BaseModel):
     id: SessionId
     origin: Origin
     title: str | None = None
+    # Read-time projection over current structural evidence. Never persisted.
+    display_label: str | None = None
     title_source: TitleSource | None = None
     # Specific provenance beyond title_source's coarse strategy label: exact
     # evidence reference plus a 0..1 confidence signal (polylogue-ih67).

--- a/polylogue/cli/archive_query.py
+++ b/polylogue/cli/archive_query.py
@@ -2819,7 +2819,7 @@ def _summary_payload(
             SessionListRowPayload(
                 id=summary.session_id,
                 origin=summary.origin,
-                title=bound_display_text(summary.title or summary.session_id, max_chars=96),
+                title=bound_display_text(summary.display_label or summary.title or summary.session_id, max_chars=96),
                 target_ref=TargetRefPayload.session(summary.session_id),
                 anchor=reader_anchor("session", summary.session_id),
                 created_at=summary.created_at,
@@ -2861,7 +2861,9 @@ def _hit_payload(
                 session=SessionSummaryPayload(
                     id=summary.session_id,
                     origin=summary.origin,
-                    title=bound_display_text(summary.title or summary.session_id, max_chars=96),
+                    title=bound_display_text(
+                        summary.display_label or summary.title or summary.session_id, max_chars=96
+                    ),
                     message_count=summary.message_count,
                     target_ref=TargetRefPayload.session(summary.session_id),
                     anchor=reader_anchor("session", summary.session_id),

--- a/polylogue/cli/read_views/standard.py
+++ b/polylogue/cli/read_views/standard.py
@@ -258,7 +258,7 @@ def _dialogue_payload(session: Session, *, projection: ProjectionSpec | None = N
     return {
         "id": str(session.id),
         "origin": session.origin.value,
-        "title": session.title,
+        "title": session.display_title,
         "created_at": session.created_at.isoformat() if session.created_at else None,
         "updated_at": session.updated_at.isoformat() if session.updated_at else None,
         "message_count": len(all_messages),
@@ -288,6 +288,7 @@ def _archive_summary_to_domain(summary: Any) -> SessionSummary:
         id=SessionId(str(summary.session_id)),
         origin=Origin.from_string(summary.origin),
         title=summary.title,
+        display_label=summary.display_label,
         created_at=parse_archive_datetime(summary.created_at),
         updated_at=parse_archive_datetime(summary.updated_at),
         working_directories=tuple(summary.working_directories),

--- a/polylogue/core/enums.py
+++ b/polylogue/core/enums.py
@@ -346,11 +346,9 @@ class TitleSource(PolylogueStrEnum):
     ``UNKNOWN`` was a second, redundant spelling of "no title evidence" on an
     already-nullable column (every read site branching on ``title_source``
     treated ``NULL`` and ``'unknown'`` identically) -- deleted in favor of
-    ``NULL`` alone. ``PATH`` looks unused the same way at a glance (nothing
-    ever *stores* it in ``sessions.title_source``), but it has a genuine
-    read-time producer: ``archive_tiers/archive.py``'s ``_summary_from_row``
-    assigns it whenever a session has neither a real provider title nor a
-    display name, synthesizing a structural label instead -- kept.
+    ``NULL`` alone. ``PATH`` is retained for compatibility with legacy rows,
+    but current read-time display-label projection leaves ``title_source``
+    NULL when a session has no provider title.
     """
 
     ORIGIN = "origin"

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -3322,7 +3322,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         return {
             "id": session_id,
             "session_id": session_id,
-            "title": summary.title or session_id,
+            "title": summary.display_label or summary.title or session_id,
             "origin": summary.origin,
             "target_ref": _dump_target_ref(target_ref),
             "anchor": reader_anchor("session", session_id),

--- a/polylogue/insights/session_label.py
+++ b/polylogue/insights/session_label.py
@@ -1,19 +1,16 @@
-"""Session structural label projection (polylogue-cijx.4 decision 3).
+"""Session display-label projection (polylogue-6e7m).
 
 A readable session label is a **read-time projection**, never a stored
-column. It is computed from three inputs that must themselves be resolved
-correctly first (decisions 1 and 2 of the same bead):
+column. It is computed from structural inputs already present in the index:
 
 - the session's normalized repository name (or a directory fallback when no
   repository could be resolved -- see ``archive/session/repo_identity.py``
   and the write-path fix in ``storage/sqlite/archive_tiers/write.py``),
-- the session's dominant repo-relative file path (``repo_relative_path``),
-- the session's message count.
+- the number of distinct touched repo-relative file paths,
+- the session's message count,
+- the session date.
 
-When the provider supplied a real title, that title is used in place of the
-path clause -- the structural form only fires as a fallback for the large
-share of sessions that never get a provider title (auto-generated agent
-sessions, subagent dispatch, etc). The label is never written to
+The label is never written to
 ``sessions.title``: doing so would collide with genuine provider titles and
 freeze mid-session ("340 msgs" becomes wrong the moment message 341 lands).
 """
@@ -30,6 +27,7 @@ __all__ = [
     "SessionLabelInputs",
     "SessionRepoRootPath",
     "compute_session_structural_label",
+    "distinct_repo_relative_file_count_for_session",
     "dominant_repo_relative_path_for_session",
     "session_structural_label_for_session",
 ]
@@ -47,19 +45,20 @@ class SessionLabelInputs:
     """``True`` when ``repo_name`` names a bare directory rather than a
     resolved repository (no git remote, no discoverable git root)."""
     dominant_path: str | None
-    """The most-touched repo-relative file path, already stripped of the
-    checkout root (decision 2), or ``None`` when no file evidence exists."""
+    """Retained for compatibility with the earlier path-based projection."""
     additional_file_count: int
-    """Count of OTHER distinct files touched besides ``dominant_path``."""
+    """Retained for compatibility with the earlier path-based projection."""
     message_count: int
+    distinct_file_count: int | None = None
+    session_date: str | None = None
 
 
 def compute_session_structural_label(inputs: SessionLabelInputs) -> str:
     """Compose the structural label for one session.
 
     Provider title wins when present. Otherwise:
-    ``<repo-or-directory> · <dominant path>[ +N] · <messages> msgs``,
-    degrading gracefully as pieces of evidence are missing.
+    ``<repo> · <files> files · <messages> msgs · <date>``, degrading
+    gracefully as pieces of evidence are missing.
     """
     if inputs.provider_title and inputs.provider_title.strip():
         return inputs.provider_title.strip()
@@ -73,13 +72,16 @@ def compute_session_structural_label(inputs: SessionLabelInputs) -> str:
     if inputs.repo_name and not inputs.is_directory:
         parts.append(inputs.repo_name)
 
-    if inputs.dominant_path:
-        path_clause = inputs.dominant_path
-        if inputs.additional_file_count > 0:
-            path_clause = f"{path_clause} +{inputs.additional_file_count}"
-        parts.append(path_clause)
+    distinct_file_count = inputs.distinct_file_count
+    if distinct_file_count is None:
+        distinct_file_count = (1 + inputs.additional_file_count) if inputs.dominant_path else 0
+    if distinct_file_count:
+        noun = "file" if distinct_file_count == 1 else "files"
+        parts.append(f"{distinct_file_count} {noun}")
 
     parts.append(f"{inputs.message_count} msgs")
+    if inputs.session_date:
+        parts.append(inputs.session_date[:10])
     return " · ".join(parts)
 
 
@@ -170,12 +172,32 @@ def dominant_repo_relative_path_for_session(
     return dominant_path, additional_file_count
 
 
+def distinct_repo_relative_file_count_for_session(
+    conn: sqlite3.Connection,
+    session_id: str,
+) -> int:
+    """Return the number of distinct repo-relative files touched by a session."""
+    repo_root = _session_repo_root(conn, session_id)
+    root_path = repo_root.root_path if repo_root else ""
+    rows = conn.execute(
+        """
+        SELECT tool_path
+        FROM action_pairs
+        WHERE session_id = ? AND tool_path IS NOT NULL AND tool_path != ''
+        """,
+        (session_id,),
+    ).fetchall()
+    paths = {repo_relative_path(str(raw_path), root_path) if root_path else str(raw_path) for (raw_path,) in rows}
+    return len({path for path in paths if path})
+
+
 def session_structural_label_for_session(
     conn: sqlite3.Connection,
     session_id: str,
     *,
     message_count: int,
     provider_title: str | None,
+    session_date: str | None = None,
 ) -> str:
     """Compute the structural label for ``session_id`` against a live index.db.
 
@@ -183,14 +205,16 @@ def session_structural_label_for_session(
     ``action_pairs``), never writes.
     """
     repo_root = _session_repo_root(conn, session_id)
-    dominant_path, additional_file_count = dominant_repo_relative_path_for_session(conn, session_id)
+    distinct_file_count = distinct_repo_relative_file_count_for_session(conn, session_id)
 
     inputs = SessionLabelInputs(
         provider_title=provider_title,
         repo_name=repo_root.repo_name if repo_root else None,
         is_directory=repo_root.is_directory if repo_root else True,
-        dominant_path=dominant_path,
-        additional_file_count=additional_file_count,
+        dominant_path=None,
+        additional_file_count=0,
         message_count=message_count,
+        distinct_file_count=distinct_file_count,
+        session_date=session_date,
     )
     return compute_session_structural_label(inputs)

--- a/polylogue/mcp/archive_support.py
+++ b/polylogue/mcp/archive_support.py
@@ -175,7 +175,7 @@ def archive_summary_payload(summary: ArchiveSessionSummary) -> MCPSessionSummary
     return MCPSessionSummaryPayload(
         id=session_id,
         origin=summary.origin,
-        title=summary.title or "(untitled)",
+        title=summary.display_label or summary.title or "(untitled)",
         message_count=summary.message_count,
         target_ref=TargetRefPayload.session(session_id),
         anchor=reader_anchor("session", session_id),

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -387,7 +387,7 @@ class MCPArchiveSessionSummaryPayload(SurfacePayloadModel):
             native_id=summary.native_id,
             origin=summary.origin,
             source=summary.origin,
-            title=summary.title,
+            title=summary.display_label or summary.title,
             created_at=summary.created_at,
             updated_at=summary.updated_at,
             message_count=summary.message_count,

--- a/polylogue/mcp/server_prompts.py
+++ b/polylogue/mcp/server_prompts.py
@@ -149,7 +149,7 @@ def _archive_prompt_session_page(archive: ArchiveStore, session_id: str, *, limi
     return PromptSession(
         id=summary.session_id,
         origin=summary.origin,
-        display_title=summary.title or "(untitled)",
+        display_title=summary.display_label or summary.title or "(untitled)",
         messages=tuple(
             PromptMessage(
                 role=row.role,

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -413,6 +413,8 @@ class ArchiveSessionSummary:
     # (polylogue-cgfy): a provider-assigned name (e.g. Claude Code's slug)
     # distinct from the (possibly derived) title.
     display_name: str | None = None
+    # Read-time projection over current structural evidence. Never persisted.
+    display_label: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -8793,8 +8795,8 @@ def _summary_from_row(row: sqlite3.Row, conn: sqlite3.Connection) -> ArchiveSess
     message_count = int(row["message_count"] or 0)
     raw_title = str(row["title"]) if row["title"] is not None else None
     raw_title_source = str(row["title_source"]) if row["title_source"] is not None else None
-    # A non-blank ``sessions.title`` is only a genuine provider/derived title
-    # when ``title_source`` says so. ``title_source='unknown'`` rows still
+    # A non-blank ``sessions.title`` is only a genuine provider title when
+    # ``title_source`` says so. ``title_source='unknown'`` rows still
     # carry a NON-NULL title -- the writer's pre-cijx.4 fallback stores the
     # raw native id there (a bare UUID, or "<uuid>:agent-<hash>" for a
     # subagent), which is exactly the "worse than the UUID it replaces" case
@@ -8821,31 +8823,17 @@ def _summary_from_row(row: sqlite3.Row, conn: sqlite3.Connection) -> ArchiveSess
         display_name: str | None = None
     else:
         display_name = str(raw_display_name).strip() or None if raw_display_name is not None else None
-    if provider_title is not None:
-        title = provider_title
-        title_source = raw_title_source
-    elif display_name:
-        # polylogue-cgfy: a provider-assigned display name (Claude Code's
-        # slug, e.g. "greedy-squishing-hamming") is real origin evidence --
-        # prefer it over the derived structural label below. This is the fix
-        # for subagent rows rendering as "<uuid-prefix>:agent-<suffix>"
-        # instead of a human-readable name when no title sidecar evidence
-        # exists for that specific session.
-        title = display_name
-        title_source = "origin"
-    else:
-        # No provider-supplied title or display name (or a blank/synthetic
-        # one): fall back to the structural label (polylogue-cijx.4
-        # decision 3) rather than exposing a bare/blank title to CLI/MCP/API
-        # surfaces. This is a read-time projection only -- never written
-        # back to sessions.title.
-        title = session_structural_label_for_session(
-            conn,
-            session_id,
-            message_count=message_count,
-            provider_title=None,
-        )
-        title_source = "path"
+    session_date = _iso_from_ms(row["created_at_ms"]) or _iso_from_ms(row["updated_at_ms"])
+    structural_label = session_structural_label_for_session(
+        conn,
+        session_id,
+        message_count=message_count,
+        provider_title=None,
+        session_date=session_date,
+    )
+    display_label = provider_title or display_name or structural_label
+    title = provider_title
+    title_source = raw_title_source if provider_title is not None else None
     parent_id: str | None
     try:
         raw_parent_id = row["parent_session_id"]
@@ -8862,6 +8850,7 @@ def _summary_from_row(row: sqlite3.Row, conn: sqlite3.Connection) -> ArchiveSess
         native_id=str(row["native_id"]),
         origin=origin,
         title=title,
+        display_label=display_label,
         title_source=title_source,
         parent_id=parent_id,
         title_ref=str(row["title_ref"]) if row["title_ref"] is not None else None,

--- a/polylogue/storage/sqlite/archive_tiers/index.py
+++ b/polylogue/storage/sqlite/archive_tiers/index.py
@@ -243,10 +243,10 @@ from polylogue.storage.sqlite.delegation_facts import delegation_facts_insert_sq
 #    read site branching on title_source already treated NULL and 'unknown'
 #    identically), so parsers now leave title_source unset instead of
 #    stamping UNKNOWN. TitleSource.USER is deleted too (zero producers,
-#    write- or read-time). TitleSource.PATH is KEPT despite also having zero
-#    *write*-time producers: archive_tiers/archive.py's `_summary_from_row`
-#    assigns it live at read time whenever a session has neither a real
-#    title nor a display name.
+#    write- or read-time). TitleSource.PATH is KEPT for compatibility with
+#    legacy rows, but current read-time display-label projection leaves
+#    title_source NULL when a session has neither a real title nor a display
+#    name.
 #  - session_links.link_type drops LinkType.REPAIRED (zero producers, and a
 #    same-string collision with the unrelated TopologyEdgeStatus.REPAIRED on
 #    the `status` column of the same table). FORK and RESUME are kept

--- a/tests/unit/cli/test_archive_query.py
+++ b/tests/unit/cli/test_archive_query.py
@@ -39,12 +39,32 @@ from polylogue.cli.archive_query import (
     _sort,
     _stats_by_line,
     _summary_line,
+    _summary_payload,
     _tool_tokens,
     _tuple_tokens,
 )
 from polylogue.operations import OperationSpec, build_runtime_operation_catalog
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveSessionSummary
 from polylogue.storage.sqlite.archive_tiers.write import ArchiveBlockRow, ArchiveMessageRow, ArchiveSessionEnvelope
+
+
+def test_summary_payload_renders_read_time_display_label() -> None:
+    summary = ArchiveSessionSummary(
+        session_id="claude-code-session:display-label",
+        native_id="display-label",
+        origin="claude-code-session",
+        title=None,
+        created_at="2026-08-06T00:00:00+00:00",
+        updated_at="2026-08-06T00:00:00+00:00",
+        message_count=3,
+        word_count=10,
+        tags=(),
+        display_label="polylogue · 2 files · 3 msgs · 2026-08-06",
+    )
+
+    payload = _summary_payload(summary)
+
+    assert payload["title"] == "polylogue · 2 files · 3 msgs · 2026-08-06"
 
 
 def test_emit_no_results_includes_convergence_warning(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/unit/insights/test_session_label.py
+++ b/tests/unit/insights/test_session_label.py
@@ -79,8 +79,7 @@ def test_provider_title_wins_over_structural_form() -> None:
 
 
 def test_structural_label_matches_bead_evidence_shape() -> None:
-    """Reproduces the exact example from polylogue-cijx.4's evidence:
-    'polylogue · pipeline/services/ingest_batch/_core.py +26 · 499 msgs'."""
+    """Uses the measured repo/file-count/message-count/date shape."""
     inputs = SessionLabelInputs(
         provider_title=None,
         repo_name="polylogue",
@@ -89,12 +88,10 @@ def test_structural_label_matches_bead_evidence_shape() -> None:
         additional_file_count=26,
         message_count=499,
     )
-    assert (
-        compute_session_structural_label(inputs) == "polylogue · pipeline/services/ingest_batch/_core.py +26 · 499 msgs"
-    )
+    assert compute_session_structural_label(inputs) == "polylogue · 27 files · 499 msgs"
 
 
-def test_structural_label_omits_plus_n_when_only_one_file_touched() -> None:
+def test_structural_label_uses_singular_file_for_one_touched_file() -> None:
     inputs = SessionLabelInputs(
         provider_title=None,
         repo_name="sinex",
@@ -103,7 +100,7 @@ def test_structural_label_omits_plus_n_when_only_one_file_touched() -> None:
         additional_file_count=0,
         message_count=12,
     )
-    assert compute_session_structural_label(inputs) == "sinex · src/main.rs · 12 msgs"
+    assert compute_session_structural_label(inputs) == "sinex · 1 file · 12 msgs"
 
 
 def test_structural_label_degrades_to_message_count_only_with_no_evidence() -> None:
@@ -248,7 +245,7 @@ def test_session_structural_label_for_session_end_to_end(tmp_path: Path) -> None
         message_count=2,
         provider_title=None,
     )
-    assert label == "myrepo · core.py · 2 msgs"
+    assert label == "myrepo · 1 file · 2 msgs"
 
     # A real provider title always wins over the structural form.
     titled_label = session_structural_label_for_session(

--- a/tests/unit/storage/test_display_label_projection.py
+++ b/tests/unit/storage/test_display_label_projection.py
@@ -1,0 +1,167 @@
+"""Production-route coverage for the read-time session display label."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType, Provider, TitleSource
+from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
+
+
+def _edit_message(index: int, path: Path) -> ParsedMessage:
+    return ParsedMessage(
+        provider_message_id=f"assistant-{index}",
+        role=Role.ASSISTANT,
+        position=index,
+        blocks=[
+            ParsedContentBlock(
+                type=BlockType.TOOL_USE,
+                tool_name="Edit",
+                tool_id=f"tool-{index}",
+                tool_input={"file_path": str(path)},
+            ),
+            ParsedContentBlock(
+                type=BlockType.TOOL_RESULT,
+                tool_id=f"tool-{index}",
+                text="ok",
+                is_error=False,
+                exit_code=0,
+            ),
+        ],
+    )
+
+
+def _session(
+    native_id: str,
+    root: Path,
+    paths: tuple[str, ...],
+    *,
+    title: str | None = None,
+    title_source: TitleSource | None = None,
+    created_at: str = "2026-08-06T10:00:00+00:00",
+) -> ParsedSession:
+    messages = [
+        ParsedMessage(
+            provider_message_id="user-0",
+            role=Role.USER,
+            position=0,
+            text="work on the repository",
+            blocks=[ParsedContentBlock(type=BlockType.TEXT, text="work on the repository")],
+        )
+    ]
+    messages.extend(_edit_message(index + 1, root / path) for index, path in enumerate(paths))
+    return ParsedSession(
+        source_name=Provider.CLAUDE_CODE,
+        provider_session_id=native_id,
+        title=title,
+        title_source=title_source,
+        working_directories=[str(root)],
+        created_at=created_at,
+        updated_at=created_at,
+        messages=messages,
+    )
+
+
+def _write_sessions(db_path: Path, sessions: list[ParsedSession]) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        for session in sessions:
+            write_parsed_session_to_archive(conn, session)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_display_label_is_fresh_and_keeps_stored_title_absent(tmp_path: Path) -> None:
+    root = tmp_path / "polylogue"
+    (root / ".git").mkdir(parents=True)
+    db_path = tmp_path / "index.db"
+    with ArchiveStore(tmp_path, initialize=True, read_only=False):
+        pass
+
+    _write_sessions(db_path, [_session("fresh", root, ("archive.py",))])
+    with ArchiveStore(tmp_path, initialize=False, read_only=True) as archive:
+        session_id = archive.resolve_session_id("fresh")
+        first = archive.read_summary(session_id)
+        listed = archive.list_summaries(repo_names=("polylogue",), limit=10, offset=0)
+
+    assert first.title is None
+    assert first.title_source is None
+    assert first.display_label == "polylogue · 1 file · 2 msgs · 2026-08-06"
+    assert [item.display_label for item in listed if item.session_id == session_id] == [first.display_label]
+
+    _write_sessions(
+        db_path,
+        [_session("fresh", root, ("archive.py", "query.py"))],
+    )
+    with ArchiveStore(tmp_path, initialize=False, read_only=True) as archive:
+        refreshed = archive.read_summary(session_id)
+
+    assert refreshed.title is None
+    assert refreshed.title_source is None
+    assert refreshed.display_label == "polylogue · 2 files · 3 msgs · 2026-08-06"
+
+    raw = (
+        sqlite3.connect(db_path)
+        .execute(
+            "SELECT title, title_source FROM sessions WHERE session_id = ?",
+            (session_id,),
+        )
+        .fetchone()
+    )
+    assert raw == (None, None)
+
+
+def test_provider_title_and_provenance_survive_the_projection(tmp_path: Path) -> None:
+    root = tmp_path / "polylogue"
+    (root / ".git").mkdir(parents=True)
+    db_path = tmp_path / "index.db"
+    with ArchiveStore(tmp_path, initialize=True, read_only=False):
+        pass
+
+    _write_sessions(
+        db_path,
+        [
+            _session(
+                "provider-title", root, ("archive.py",), title="Repair the read path", title_source=TitleSource.ORIGIN
+            )
+        ],
+    )
+
+    with ArchiveStore(tmp_path, initialize=False, read_only=True) as archive:
+        summary = archive.read_summary(archive.resolve_session_id("provider-title"))
+
+    assert summary.title == "Repair the read path"
+    assert summary.display_label == "Repair the read path"
+    assert summary.title_source == TitleSource.ORIGIN.value
+
+
+def test_structural_label_collisions_are_small_and_explicit_on_list_route(tmp_path: Path) -> None:
+    root = tmp_path / "polylogue"
+    (root / ".git").mkdir(parents=True)
+    db_path = tmp_path / "index.db"
+    with ArchiveStore(tmp_path, initialize=True, read_only=False):
+        pass
+
+    _write_sessions(
+        db_path,
+        [
+            _session("collision-a", root, ("same.py",)),
+            _session("collision-b", root, ("other.py",)),
+            _session("distinct", root, ("one.py", "two.py")),
+        ],
+    )
+
+    with ArchiveStore(tmp_path, initialize=False, read_only=True) as archive:
+        summaries = archive.list_summaries(repo_names=("polylogue",), limit=10, offset=0)
+
+    labels = {summary.native_id: summary.display_label for summary in summaries}
+    assert labels["collision-a"] == labels["collision-b"] == "polylogue · 1 file · 2 msgs · 2026-08-06"
+    assert labels["distinct"] == "polylogue · 2 files · 3 msgs · 2026-08-06"
+    assert len(set(labels.values())) == 2
+    assert sum(1 for label in labels.values() if label and "polylogue" in label) == 3

--- a/tests/unit/storage/test_title_source_queryable.py
+++ b/tests/unit/storage/test_title_source_queryable.py
@@ -79,15 +79,12 @@ def test_archive_store_summary_reads_expose_title_source(tmp_path: Path) -> None
         assert [s.title_source for s in listed if s.session_id == session_id] == ["origin"]
 
 
-def test_titleless_session_falls_back_to_structural_label(tmp_path: Path) -> None:
-    """polylogue-cijx.4 decision 3: a session with no provider title reads a
-    computed structural label (never a bare/blank title), sourced ``"path"``.
+def test_titleless_session_exposes_structural_display_label(tmp_path: Path) -> None:
+    """A titleless session reads a computed label without title provenance.
 
-    This is a read-time-only projection: ``sessions.title`` itself stays
-    ``NULL`` in storage -- only the ``ArchiveSessionSummary`` read model is
-    backfilled, exercised here through the real ``ArchiveStore.read_summary``/
-    ``list_summaries`` production routes (not a direct call into
-    ``session_structural_label_for_session``).
+    This is exercised through the real ``ArchiveStore.read_summary``/
+    ``list_summaries`` production routes, not a direct call into the label
+    helper.
     """
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
@@ -100,14 +97,16 @@ def test_titleless_session_falls_back_to_structural_label(tmp_path: Path) -> Non
     with ArchiveStore(tmp_path, initialize=False, read_only=True) as archive:
         session_id = archive.resolve_session_id("codex-ts-notitle")
         summary = archive.read_summary(session_id)
-        assert summary.title == "1 msgs"
-        assert summary.title_source == "path"
+        assert summary.title is None
+        assert summary.display_label == "1 msgs"
+        assert summary.title_source is None
 
         listed = archive.list_summaries(origin="codex-session", limit=10, offset=0)
         matched = [s for s in listed if s.session_id == session_id]
         assert len(matched) == 1
-        assert matched[0].title == "1 msgs"
-        assert matched[0].title_source == "path"
+        assert matched[0].title is None
+        assert matched[0].display_label == "1 msgs"
+        assert matched[0].title_source is None
 
 
 def test_no_title_source_falls_back_to_structural_label(tmp_path: Path) -> None:
@@ -161,14 +160,16 @@ def test_no_title_source_falls_back_to_structural_label(tmp_path: Path) -> None:
     with ArchiveStore(tmp_path, initialize=False, read_only=True) as archive:
         session_id = archive.resolve_session_id("raw-uuid-1234")
         summary = archive.read_summary(session_id)
-        assert summary.title != "raw-uuid-1234"
-        assert summary.title_source == "path"
+        assert summary.title is None
+        assert summary.display_label == "1 msgs"
+        assert summary.title_source is None
 
         listed = archive.list_summaries(origin="claude-code-session", limit=10, offset=0)
         matched = [s for s in listed if s.session_id == session_id]
         assert len(matched) == 1
-        assert matched[0].title != "raw-uuid-1234"
-        assert matched[0].title_source == "path"
+        assert matched[0].title is None
+        assert matched[0].display_label == "1 msgs"
+        assert matched[0].title_source is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Add a read-time display-label projection for titleless sessions. Labels use current repository identity, distinct touched-file count, message count, and session date, then flow through archive summaries, query/domain projections, API and surface readers, and the CLI find route.

## Problem
The previous read fallback assigned structural labels to the title field and reported `title_source=path`. That obscured absent provider-title evidence and made the label contract look like stored title provenance. Native-id title fallbacks also remained poor display text. The Bead measured 78-way prompt-echo collisions and a 3.5% collision rate in the untitled Claude sample, so the target is collision tolerance with read-time freshness.

## Solution
`ArchiveStore._summary_from_row` now keeps provider titles in `title`, leaves absent title provenance as `NULL`, and computes `display_label` from current `action_pairs` and session metadata. The query executor, domain models, API readers, CLI find payload, daemon, and MCP archive readers carry the projection through their existing read algebra. Provider display names remain display labels without being misreported as `title_source=origin`. No parser, writer, migration, schema, or reindex foundation files changed.

## Verification
- `env -u VIRTUAL_ENV direnv exec . devtools test tests/unit/storage/test_display_label_projection.py tests/unit/storage/test_title_source_queryable.py tests/unit/storage/test_session_display_name_reaches_repository.py tests/unit/insights/test_session_label.py tests/unit/cli/test_archive_query.py tests/unit/mcp/test_archive_support_miss_predicates.py`: `127 passed in 14.67s`.
- `env -u VIRTUAL_ENV direnv exec . devtools verify --quick`: all 24 steps passed, including ruff, mypy, render, layering, policy, and schema promotion checks.
- The pre-push quick baseline at commit `04cb254e5aef50d12566f8d7858a8cb31e8478f7` also exited 0.
- Temporary-archive production check with `polylogue find repo:polylogue --limit 5 --format json`: before `polylogue · 1 file · 2 msgs · 2026-08-06`; after adding a touched file `polylogue · 2 files · 3 msgs · 2026-08-06`.
- Static review confirms no production assignment of `title_source = "path"` and the focused freshness test reads stored `(title, title_source) == (None, None)`.

## Acceptance matrix

| Criterion | Result | Evidence |
| --- | --- | --- |
| Stored `sessions.title` remains provider title or `NULL`; synthesized labels are never written | Satisfied | `tests/unit/storage/test_display_label_projection.py`, direct SQLite assertion `(None, None)` |
| Display label is computed at read time from current repository, work shape, size, and date evidence | Satisfied | `ArchiveStore._summary_from_row` projection over repository identity, distinct `action_pairs.tool_path`, message count, and session date; refresh test changes 1 file to 2 files and 2 messages to 3 |
| Provider title and `title_source` semantics are preserved | Satisfied | Provider-title route retains the exact title and `origin`; absent-title routes expose `title=None` and `title_source=None`; legacy `path` values remain compatibility-only |
| Acquisition and title-input threads remain outside this slice | Satisfied | No parser, write, migration, or reindex foundation files changed |
| `find repo:polylogue` path is verified | Satisfied | Temporary archive before/after command output recorded above; CLI payload test covers the same production adapter |
| Collision behavior is explicit and freshness is guaranteed | Satisfied | Three-session list-route test records one intentional pair collision and one distinct two-file label; measured Bead sample remains the live collision baseline |

## Boundary and residual uncertainty
This PR completes the read/projection/title slice described by the Bead. No successor is required. The full repository test suite and the existing MCP golden `test_registered_read_transactions_match_production_goldens` were not used as completion gates; that golden currently fails at an unrelated message content-block assertion on this branch and on an exact-node rerun, while the affected MCP archive adapter tests pass.

Ref polylogue-6e7m