### PR TITLE
fix(storage): make blob reference liveness fail closed

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -213,10 +213,13 @@ not by index-tier `attachment_refs` or `raw_artifacts.artifact_id`.
 `hook_payload` refs join `raw_hook_events.hook_event_id`. Unknown or unavailable
 ref types are counted as explicit census dispositions and block an apply; blob
 GC also retains their bytes until a typed disposition is available. The
-command never deletes blob files.
+command never deletes blob files. Use `--census-only` for the privacy-safe
+production census. It returns counts and dispositions only, without reference
+identifiers, source paths, or hashes.
 
 ```bash
 polylogue ops maintenance blob-reference-liveness --output-format json
+polylogue ops maintenance blob-reference-liveness --census-only --output-format json
 polylogue ops maintenance blob-reference-liveness --apply \
   --backup-manifest /path/to/verified-source-backup-manifest.json \
   --receipt-file /path/to/new/blob-ref-liveness.jsonl \

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -209,8 +209,11 @@ conflicting state. It never attempts a repair move.
 Read-only by default. It classifies source-tier `blob_refs` rows with the
 actual referent join for each `ref_type`; source-tier `attachment` refs join
 `raw_sessions.raw_id` because they are keyed by the parent raw acquisition,
-not by index-tier `attachment_refs`. Unknown or unavailable ref types block an
-apply. The command never deletes blob files.
+not by index-tier `attachment_refs` or `raw_artifacts.artifact_id`.
+`hook_payload` refs join `raw_hook_events.hook_event_id`. Unknown or unavailable
+ref types are counted as explicit census dispositions and block an apply; blob
+GC also retains their bytes until a typed disposition is available. The
+command never deletes blob files.
 
 ```bash
 polylogue ops maintenance blob-reference-liveness --output-format json

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -215,7 +215,7 @@ ref types are counted as explicit census dispositions and block an apply; blob
 GC also retains their bytes until a typed disposition is available. The
 command never deletes blob files. Use `--census-only` for the privacy-safe
 production census. It returns counts and dispositions only, without reference
-identifiers, source paths, or hashes.
+identifiers, source paths, hashes, or unknown reference-type names.
 
 ```bash
 polylogue ops maintenance blob-reference-liveness --output-format json

--- a/polylogue/cli/commands/maintenance/_blob_integrity.py
+++ b/polylogue/cli/commands/maintenance/_blob_integrity.py
@@ -64,7 +64,7 @@ def blob_reference_liveness_command(
         from polylogue.maintenance.blob_ref_liveness_reconciliation import census_blob_ref_liveness
 
         census = census_blob_ref_liveness(archive_root())
-        payload = {"mode": "blob_reference_census", "mutates": False, **census.to_dict()}
+        payload = {"mode": "blob_reference_census", "mutates": False, **census.to_privacy_safe_dict()}
         if output_format == "json":
             click.echo(json.dumps(payload, indent=2, sort_keys=True))
         else:

--- a/polylogue/cli/commands/maintenance/_blob_integrity.py
+++ b/polylogue/cli/commands/maintenance/_blob_integrity.py
@@ -68,13 +68,14 @@ def blob_reference_liveness_command(
         if output_format == "json":
             click.echo(json.dumps(payload, indent=2, sort_keys=True))
         else:
+            safe_payload = census.to_privacy_safe_dict()
             click.echo("Blob reference liveness census")
             click.echo(f"Scanned:      {census.scanned_count:,} blob_refs row(s)")
             click.echo(f"Orphans:      {census.total:,} row(s)")
             click.echo(f"Schema held:  {census.schema_unavailable_count:,} row(s)")
             click.echo(f"By ref type:  {json.dumps(census.by_ref_type, sort_keys=True)}")
-            click.echo(f"Unknown:      {json.dumps(census.unknown_ref_types or {}, sort_keys=True)}")
-            click.echo(f"Unavailable:  {json.dumps(census.unavailable_ref_types or {}, sort_keys=True)}")
+            click.echo(f"Unknown:      {safe_payload['unknown_ref_type_count']:,} ref(s)")
+            click.echo(f"Unavailable:  {json.dumps(safe_payload['unavailable_ref_types'], sort_keys=True)}")
         return
 
     from polylogue.maintenance.blob_ref_liveness_reconciliation import reconcile_blob_ref_liveness

--- a/polylogue/cli/commands/maintenance/_blob_integrity.py
+++ b/polylogue/cli/commands/maintenance/_blob_integrity.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import sqlite3
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -62,11 +61,9 @@ def blob_reference_liveness_command(
             raise click.UsageError(
                 "--census-only cannot be combined with --apply, --backup-manifest, or --receipt-file"
             )
-        from polylogue.storage.blob_gc import census_orphaned_blob_refs
+        from polylogue.maintenance.blob_ref_liveness_reconciliation import census_blob_ref_liveness
 
-        source_db = archive_root() / "source.db"
-        with sqlite3.connect(f"file:{source_db}?mode=ro", uri=True) as conn:
-            census = census_orphaned_blob_refs(conn)
+        census = census_blob_ref_liveness(archive_root())
         payload = {"mode": "blob_reference_census", "mutates": False, **census.to_dict()}
         if output_format == "json":
             click.echo(json.dumps(payload, indent=2, sort_keys=True))

--- a/polylogue/cli/commands/maintenance/_blob_integrity.py
+++ b/polylogue/cli/commands/maintenance/_blob_integrity.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -36,6 +37,11 @@ if TYPE_CHECKING:
 )
 @click.option("--sample-limit", type=int, default=30, show_default=True)
 @click.option(
+    "--census-only",
+    is_flag=True,
+    help="Return counts-only liveness dispositions without identifiers, paths, or hashes.",
+)
+@click.option(
     "--output-format",
     "output_format",
     type=click.Choice(["plain", "json"]),
@@ -47,9 +53,33 @@ def blob_reference_liveness_command(
     backup_manifest: Path | None,
     receipt_file: Path | None,
     sample_limit: int,
+    census_only: bool,
     output_format: str,
 ) -> None:
     """Classify source-tier orphan refs; apply only with backup and receipt."""
+    if census_only:
+        if apply_changes or backup_manifest is not None or receipt_file is not None:
+            raise click.UsageError(
+                "--census-only cannot be combined with --apply, --backup-manifest, or --receipt-file"
+            )
+        from polylogue.storage.blob_gc import census_orphaned_blob_refs
+
+        source_db = archive_root() / "source.db"
+        with sqlite3.connect(f"file:{source_db}?mode=ro", uri=True) as conn:
+            census = census_orphaned_blob_refs(conn)
+        payload = {"mode": "blob_reference_census", "mutates": False, **census.to_dict()}
+        if output_format == "json":
+            click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            click.echo("Blob reference liveness census")
+            click.echo(f"Scanned:      {census.scanned_count:,} blob_refs row(s)")
+            click.echo(f"Orphans:      {census.total:,} row(s)")
+            click.echo(f"Schema held:  {census.schema_unavailable_count:,} row(s)")
+            click.echo(f"By ref type:  {json.dumps(census.by_ref_type, sort_keys=True)}")
+            click.echo(f"Unknown:      {json.dumps(census.unknown_ref_types or {}, sort_keys=True)}")
+            click.echo(f"Unavailable:  {json.dumps(census.unavailable_ref_types or {}, sort_keys=True)}")
+        return
+
     from polylogue.maintenance.blob_ref_liveness_reconciliation import reconcile_blob_ref_liveness
 
     report = reconcile_blob_ref_liveness(

--- a/polylogue/maintenance/blob_ref_liveness_reconciliation.py
+++ b/polylogue/maintenance/blob_ref_liveness_reconciliation.py
@@ -11,6 +11,10 @@ from collections.abc import Iterable, Iterator
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from polylogue.storage.blob_gc import OrphanedBlobRefCensus
 
 from polylogue.config import Config
 from polylogue.daemon.write_coordinator import daemon_write_lease_active
@@ -910,7 +914,7 @@ def reconcile_blob_ref_liveness(
     )
 
 
-def census_blob_ref_liveness(archive_root: Path):
+def census_blob_ref_liveness(archive_root: Path) -> OrphanedBlobRefCensus:
     """Return the privacy-safe source-tier blob-ref census without mutation."""
     from polylogue.storage.blob_gc import census_orphaned_blob_refs
 

--- a/polylogue/maintenance/blob_ref_liveness_reconciliation.py
+++ b/polylogue/maintenance/blob_ref_liveness_reconciliation.py
@@ -910,6 +910,15 @@ def reconcile_blob_ref_liveness(
     )
 
 
+def census_blob_ref_liveness(archive_root: Path):
+    """Return the privacy-safe source-tier blob-ref census without mutation."""
+    from polylogue.storage.blob_gc import census_orphaned_blob_refs
+
+    source_db = archive_root / "source.db"
+    with sqlite3.connect(f"file:{source_db}?mode=ro", uri=True) as conn:
+        return census_orphaned_blob_refs(conn)
+
+
 __all__ = [
     "BlobRefLivenessReconciliationError",
     "BlobRefLivenessReconciliationReport",

--- a/polylogue/storage/blob_gc.py
+++ b/polylogue/storage/blob_gc.py
@@ -215,22 +215,48 @@ def _blob_refs_still_live(conn: sqlite3.Connection, blob_bytes: bytes) -> bool:
     (see ``_BLOB_REF_LIVENESS_JOIN``) still has the row identified by
     ``ref_id``. A hook-event blob ref whose ``raw_hook_events`` row was
     deleted, or a stale ref left behind by a since-reverted write, no longer
-    joins to anything and is correctly treated as dead here.
+    joins to anything and is correctly treated as dead here. Unknown ref
+    types and known types whose referent table or key column is unavailable
+    are retained because GC cannot prove them dead.
     """
-    if not _table_exists(conn, "blob_refs") or not _blob_refs_has_ref_type_column(conn):
+    if not _table_exists(conn, "blob_refs"):
         return False
+    if not _blob_refs_has_ref_type_column(conn):
+        # A legacy or malformed reference table cannot prove that its rows are
+        # dead. Keep the blob until an offline integrity tool records a typed
+        # disposition; GC must never turn an unknown schema into evidence loss.
+        return True
+    ref_types = {
+        str(row[0])
+        for row in conn.execute("SELECT DISTINCT ref_type FROM blob_refs WHERE blob_hash = ?", (blob_bytes,))
+    }
+    if not ref_types:
+        return False
+    known_ref_types = {ref_type for ref_type, _table, _column in _BLOB_REF_LIVENESS_JOIN}
+    if ref_types - known_ref_types:
+        # Reconciliation reports unknown ref types as a blocker. GC follows
+        # the same fail-closed rule instead of deleting unclassified evidence.
+        return True
     clauses = [
         f"(ref_type = ? AND EXISTS (SELECT 1 FROM {referent_table} WHERE {referent_table}.{referent_column} = blob_refs.ref_id))"
         for ref_type, referent_table, referent_column in _BLOB_REF_LIVENESS_JOIN
-        if _table_exists(conn, referent_table)
+        if ref_type in ref_types
     ]
+    params: list[str] = []
+    for ref_type, referent_table, referent_column in _BLOB_REF_LIVENESS_JOIN:
+        if ref_type not in ref_types:
+            continue
+        if not _table_exists(conn, referent_table):
+            # The type is known, but this archive cannot evaluate its join.
+            # Keep the blob until the missing referent surface is restored or
+            # an integrity tool records a disposition.
+            return True
+        referent_columns = {row[1] for row in conn.execute(f"PRAGMA table_info({referent_table})")}
+        if referent_column not in referent_columns:
+            return True
+        params.append(ref_type)
     if not clauses:
         return False
-    params = [
-        ref_type
-        for ref_type, referent_table, _referent_column in _BLOB_REF_LIVENESS_JOIN
-        if _table_exists(conn, referent_table)
-    ]
     query = f"SELECT 1 FROM blob_refs WHERE blob_hash = ? AND ({' OR '.join(clauses)}) LIMIT 1"
     row = conn.execute(query, (blob_bytes, *params)).fetchone()
     return row is not None
@@ -657,25 +683,51 @@ class OrphanedBlobRefCensus:
 
     total: int
     by_ref_type: dict[str, int]
+    scanned_count: int = 0
+    ref_type_counts: dict[str, int] | None = None
+    unknown_ref_types: dict[str, int] | None = None
+    unavailable_ref_types: dict[str, int] | None = None
 
     def to_dict(self) -> dict[str, object]:
-        return {"total": self.total, "by_ref_type": dict(self.by_ref_type)}
+        return {
+            "scanned_count": self.scanned_count,
+            "ref_type_counts": dict(self.ref_type_counts or {}),
+            "total": self.total,
+            "by_ref_type": dict(self.by_ref_type),
+            "unknown_ref_types": dict(self.unknown_ref_types or {}),
+            "unavailable_ref_types": dict(self.unavailable_ref_types or {}),
+        }
 
 
 def census_orphaned_blob_refs(conn: sqlite3.Connection) -> OrphanedBlobRefCensus:
     """Count ``blob_refs`` rows whose ``ref_id`` has no live referent, per ref_type.
 
     Read-only; safe to call against a live connection or a read-only handle.
-    A ``ref_type`` whose referent table does not exist (an old archive
-    predating that table) is skipped rather than counted as fully orphaned --
-    its rows are simply not evaluable, the same conservative stance
-    ``_blob_refs_still_live`` takes.
+    A ``ref_type`` whose referent table or key column does not exist (an old
+    archive predating that table) is reported as unavailable rather than
+    counted as fully orphaned. Unknown ref types are reported separately.
+    Neither disposition is included in ``total`` because neither is proven
+    dead, matching the fail-closed stance ``_blob_refs_still_live`` takes.
     """
-    if not _table_exists(conn, "blob_refs"):
+    if not _table_exists(conn, "blob_refs") or not _blob_refs_has_ref_type_column(conn):
         return OrphanedBlobRefCensus(total=0, by_ref_type={})
+    ref_type_counts = {
+        str(row[0]): int(row[1])
+        for row in conn.execute("SELECT ref_type, COUNT(*) FROM blob_refs GROUP BY ref_type ORDER BY ref_type")
+    }
     by_ref_type: dict[str, int] = {}
+    unknown_ref_types: dict[str, int] = {}
+    unavailable_ref_types: dict[str, int] = {}
     for ref_type, referent_table, referent_column in _BLOB_REF_LIVENESS_JOIN:
+        count = ref_type_counts.get(ref_type, 0)
+        if not count:
+            continue
         if not _table_exists(conn, referent_table):
+            unavailable_ref_types[ref_type] = count
+            continue
+        referent_columns = {row[1] for row in conn.execute(f"PRAGMA table_info({referent_table})")}
+        if referent_column not in referent_columns:
+            unavailable_ref_types[ref_type] = count
             continue
         row = conn.execute(
             f"""
@@ -691,7 +743,18 @@ def census_orphaned_blob_refs(conn: sqlite3.Connection) -> OrphanedBlobRefCensus
         count = int(row[0]) if row is not None else 0
         if count:
             by_ref_type[ref_type] = count
-    return OrphanedBlobRefCensus(total=sum(by_ref_type.values()), by_ref_type=by_ref_type)
+    known_ref_types = {ref_type for ref_type, _table, _column in _BLOB_REF_LIVENESS_JOIN}
+    unknown_ref_types = {
+        ref_type: count for ref_type, count in ref_type_counts.items() if ref_type not in known_ref_types
+    }
+    return OrphanedBlobRefCensus(
+        total=sum(by_ref_type.values()),
+        by_ref_type=by_ref_type,
+        scanned_count=sum(ref_type_counts.values()),
+        ref_type_counts=ref_type_counts,
+        unknown_ref_types=unknown_ref_types,
+        unavailable_ref_types=unavailable_ref_types,
+    )
 
 
 __all__ = [

--- a/polylogue/storage/blob_gc.py
+++ b/polylogue/storage/blob_gc.py
@@ -205,6 +205,40 @@ def _table_has_blob_hash_column(conn: sqlite3.Connection, table: str) -> bool:
     return any(str(row[1]) == "blob_hash" for row in conn.execute(f"PRAGMA table_info({table})"))
 
 
+def _temporary_table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    return (
+        conn.execute(
+            "SELECT 1 FROM sqlite_temp_master WHERE type = 'table' AND name = ?",
+            (table,),
+        ).fetchone()
+        is not None
+    )
+
+
+def _prepare_legacy_hook_liveness(conn: sqlite3.Connection) -> str:
+    """Prepare the canonical legacy-hook reconciliation stage for this connection."""
+    if _temporary_table_exists(conn, "hook_payload_ref_reconciliation_matches") and _temporary_table_exists(
+        conn, "hook_payload_ref_reconciliation_ambiguous"
+    ):
+        return "ready"
+    if not _table_exists(conn, "raw_hook_events"):
+        return "not_applicable"
+    hook_columns = {str(row[1]) for row in conn.execute("PRAGMA table_info(raw_hook_events)")}
+    required = {"hook_event_id", "origin", "native_id", "source_path", "blob_hash"}
+    if required - hook_columns:
+        return "unavailable"
+    try:
+        # Reuse the same bounded, ambiguity-aware stage that the offline
+        # reconciliation classifier uses. GC only reads its match tables.
+        from polylogue.storage.hook_payload_ref_reconciliation import _create_match_stage
+
+        _create_match_stage(conn)
+    except sqlite3.Error:
+        logger.warning("Could not stage legacy hook evidence for blob GC; retaining candidate blobs")
+        return "unavailable"
+    return "ready"
+
+
 def _blob_refs_still_live(conn: sqlite3.Connection, blob_bytes: bytes) -> bool:
     """Return True if some ``blob_refs`` row for this hash has a live referent.
 
@@ -237,6 +271,26 @@ def _blob_refs_still_live(conn: sqlite3.Connection, blob_bytes: bytes) -> bool:
         # Reconciliation reports unknown ref types as a blocker. GC follows
         # the same fail-closed rule instead of deleting unclassified evidence.
         return True
+    if "raw_payload" in ref_types:
+        legacy_hook_status = _prepare_legacy_hook_liveness(conn)
+        if legacy_hook_status == "unavailable":
+            return True
+        if legacy_hook_status == "ready":
+            legacy_hook_row = conn.execute(
+                """
+                SELECT 1
+                FROM temp.hook_payload_ref_reconciliation_matches
+                WHERE blob_hash = ?
+                UNION ALL
+                SELECT 1
+                FROM temp.hook_payload_ref_reconciliation_ambiguous
+                WHERE blob_hash = ?
+                LIMIT 1
+                """,
+                (blob_bytes, blob_bytes),
+            ).fetchone()
+            if legacy_hook_row is not None:
+                return True
     clauses = [
         f"(ref_type = ? AND EXISTS (SELECT 1 FROM {referent_table} WHERE {referent_table}.{referent_column} = blob_refs.ref_id))"
         for ref_type, referent_table, referent_column in _BLOB_REF_LIVENESS_JOIN
@@ -673,12 +727,13 @@ class OrphanedBlobRefCensus:
     A "orphaned" row here is exactly the shape blob GC's liveness join
     (``_blob_refs_still_live``) treats as dead: its ``ref_type`` names a
     referent table, but no row in that table has the ``ref_id`` this row
-    claims. These rows are harmless (GC already reclaims their blob once it
-    ages out) but their *count* is operator-relevant evidence of how much
-    write-time drift (deleted rows, since-fixed bugs like the hook-payload one
-    this census was built for) has accumulated. Intended to be read by a
-    daemon health/expensive tier; wiring that in is left to the caller
-    (polylogue-tfzw0 explicitly defers "wire into health tiers" as optional).
+    claims. Their *count* is operator-relevant evidence of how much write-time
+    drift (deleted rows, since-fixed bugs like the hook-payload one this census
+    was built for) has accumulated. Unavailable schemas and unknown ref types
+    are counted as dispositions rather than treated as dead. Intended to be
+    read by a daemon health/expensive tier; wiring that in is left to the
+    caller (polylogue-tfzw0 explicitly defers "wire into health tiers" as
+    optional).
     """
 
     total: int
@@ -687,6 +742,7 @@ class OrphanedBlobRefCensus:
     ref_type_counts: dict[str, int] | None = None
     unknown_ref_types: dict[str, int] | None = None
     unavailable_ref_types: dict[str, int] | None = None
+    schema_unavailable_count: int = 0
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -696,6 +752,7 @@ class OrphanedBlobRefCensus:
             "by_ref_type": dict(self.by_ref_type),
             "unknown_ref_types": dict(self.unknown_ref_types or {}),
             "unavailable_ref_types": dict(self.unavailable_ref_types or {}),
+            "schema_unavailable_count": self.schema_unavailable_count,
         }
 
 
@@ -710,7 +767,10 @@ def census_orphaned_blob_refs(conn: sqlite3.Connection) -> OrphanedBlobRefCensus
     dead, matching the fail-closed stance ``_blob_refs_still_live`` takes.
     """
     if not _table_exists(conn, "blob_refs") or not _blob_refs_has_ref_type_column(conn):
-        return OrphanedBlobRefCensus(total=0, by_ref_type={})
+        count = (
+            int(conn.execute("SELECT COUNT(*) FROM blob_refs").fetchone()[0]) if _table_exists(conn, "blob_refs") else 0
+        )
+        return OrphanedBlobRefCensus(total=0, by_ref_type={}, schema_unavailable_count=count)
     ref_type_counts = {
         str(row[0]): int(row[1])
         for row in conn.execute("SELECT ref_type, COUNT(*) FROM blob_refs GROUP BY ref_type ORDER BY ref_type")

--- a/polylogue/storage/blob_gc.py
+++ b/polylogue/storage/blob_gc.py
@@ -743,6 +743,7 @@ class OrphanedBlobRefCensus:
     unknown_ref_types: dict[str, int] | None = None
     unavailable_ref_types: dict[str, int] | None = None
     schema_unavailable_count: int = 0
+    deferred_by_ref_type: dict[str, int] | None = None
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -753,7 +754,22 @@ class OrphanedBlobRefCensus:
             "unknown_ref_types": dict(self.unknown_ref_types or {}),
             "unavailable_ref_types": dict(self.unavailable_ref_types or {}),
             "schema_unavailable_count": self.schema_unavailable_count,
+            "deferred_by_ref_type": dict(self.deferred_by_ref_type or {}),
         }
+
+    def to_privacy_safe_dict(self) -> dict[str, object]:
+        """Serialize aggregate counts without exposing database-derived names."""
+        payload = self.to_dict()
+        known_ref_types = {ref_type for ref_type, _table, _column in BLOB_REF_LIVENESS_JOIN}
+        ref_type_counts = self.ref_type_counts or {}
+        payload["ref_type_counts"] = {
+            ref_type: count for ref_type, count in ref_type_counts.items() if ref_type in known_ref_types
+        }
+        payload.pop("unknown_ref_types", None)
+        payload["unknown_ref_type_count"] = sum(
+            count for ref_type, count in ref_type_counts.items() if ref_type not in known_ref_types
+        )
+        return payload
 
 
 def census_orphaned_blob_refs(conn: sqlite3.Connection) -> OrphanedBlobRefCensus:
@@ -778,6 +794,10 @@ def census_orphaned_blob_refs(conn: sqlite3.Connection) -> OrphanedBlobRefCensus
     by_ref_type: dict[str, int] = {}
     unknown_ref_types: dict[str, int] = {}
     unavailable_ref_types: dict[str, int] = {}
+    deferred_by_ref_type: dict[str, int] = {}
+    legacy_hook_status = "not_applicable"
+    if ref_type_counts.get("raw_payload"):
+        legacy_hook_status = _prepare_legacy_hook_liveness(conn)
     for ref_type, referent_table, referent_column in _BLOB_REF_LIVENESS_JOIN:
         count = ref_type_counts.get(ref_type, 0)
         if not count:
@@ -789,14 +809,65 @@ def census_orphaned_blob_refs(conn: sqlite3.Connection) -> OrphanedBlobRefCensus
         if referent_column not in referent_columns:
             unavailable_ref_types[ref_type] = count
             continue
+        legacy_exclusion = ""
+        if ref_type == "raw_payload" and legacy_hook_status in {"ready", "unavailable"}:
+            orphan_count = int(
+                conn.execute(
+                    f"""
+                    SELECT COUNT(*) FROM blob_refs AS b
+                    WHERE b.ref_type = ?
+                      AND NOT EXISTS (SELECT 1 FROM {referent_table} AS r WHERE r.{referent_column} = b.ref_id)
+                    """,
+                    (ref_type,),
+                ).fetchone()[0]
+            )
+            if legacy_hook_status == "unavailable":
+                if orphan_count:
+                    deferred_by_ref_type[ref_type] = orphan_count
+                continue
+            deferred_count = int(
+                conn.execute(
+                    f"""
+                    SELECT COUNT(*) FROM blob_refs AS b
+                    WHERE b.ref_type = ?
+                      AND NOT EXISTS (SELECT 1 FROM {referent_table} AS r WHERE r.{referent_column} = b.ref_id)
+                      AND (
+                          EXISTS (
+                              SELECT 1 FROM temp.hook_payload_ref_reconciliation_matches AS m
+                              WHERE m.blob_hash = b.blob_hash AND m.orphaned_ref_id = b.ref_id
+                          )
+                          OR EXISTS (
+                              SELECT 1 FROM temp.hook_payload_ref_reconciliation_ambiguous AS a
+                              WHERE a.blob_hash = b.blob_hash AND a.orphaned_ref_id = b.ref_id
+                          )
+                      )
+                    """,
+                    (ref_type,),
+                ).fetchone()[0]
+            )
+            if deferred_count:
+                deferred_by_ref_type[ref_type] = deferred_count
+            legacy_exclusion = """
+              AND NOT (
+                  EXISTS (
+                      SELECT 1 FROM temp.hook_payload_ref_reconciliation_matches AS m
+                      WHERE m.blob_hash = b.blob_hash AND m.orphaned_ref_id = b.ref_id
+                  )
+                  OR EXISTS (
+                      SELECT 1 FROM temp.hook_payload_ref_reconciliation_ambiguous AS a
+                      WHERE a.blob_hash = b.blob_hash AND a.orphaned_ref_id = b.ref_id
+                  )
+              )
+            """
         row = conn.execute(
             f"""
-            SELECT COUNT(*) FROM blob_refs
-            WHERE ref_type = ?
+            SELECT COUNT(*) FROM blob_refs AS b
+            WHERE b.ref_type = ?
               AND NOT EXISTS (
                   SELECT 1 FROM {referent_table}
-                  WHERE {referent_table}.{referent_column} = blob_refs.ref_id
+                  WHERE {referent_table}.{referent_column} = b.ref_id
               )
+              {legacy_exclusion}
             """,
             (ref_type,),
         ).fetchone()
@@ -814,6 +885,7 @@ def census_orphaned_blob_refs(conn: sqlite3.Connection) -> OrphanedBlobRefCensus
         ref_type_counts=ref_type_counts,
         unknown_ref_types=unknown_ref_types,
         unavailable_ref_types=unavailable_ref_types,
+        deferred_by_ref_type=deferred_by_ref_type,
     )
 
 

--- a/tests/unit/cli/test_blob_ref_liveness_cli.py
+++ b/tests/unit/cli/test_blob_ref_liveness_cli.py
@@ -4,9 +4,11 @@ import json
 import sqlite3
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 from polylogue.cli.click_app import cli
+from polylogue.storage.blob_gc import OrphanedBlobRefCensus
 
 
 def test_blob_reference_liveness_cli_defaults_to_read_only(
@@ -76,15 +78,45 @@ def test_blob_reference_liveness_cli_census_is_counts_only(
     payload = json.loads(result.stdout)
     assert payload == {
         "by_ref_type": {"raw_payload": 1},
+        "deferred_by_ref_type": {},
         "mode": "blob_reference_census",
         "mutates": False,
         "ref_type_counts": {"raw_payload": 1},
         "scanned_count": 1,
         "schema_unavailable_count": 0,
         "total": 1,
-        "unknown_ref_types": {},
         "unavailable_ref_types": {},
+        "unknown_ref_type_count": 0,
     }
     assert "/private/path" not in result.stdout
     assert "historical-raw" not in result.stdout
     assert "686868" not in result.stdout
+
+
+def test_blob_reference_liveness_cli_census_redacts_unknown_ref_type_names(
+    cli_workspace: dict[str, Path], cli_runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "polylogue.maintenance.blob_ref_liveness_reconciliation.census_blob_ref_liveness",
+        lambda _archive_root: OrphanedBlobRefCensus(
+            total=0,
+            by_ref_type={},
+            scanned_count=1,
+            ref_type_counts={"future:/private/secret/hash": 1},
+            unknown_ref_types={"future:/private/secret/hash": 1},
+        ),
+    )
+
+    result = cli_runner.invoke(
+        cli,
+        ["--plain", "ops", "maintenance", "blob-reference-liveness", "--census-only", "--output-format", "json"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["unknown_ref_type_count"] == 1
+    assert payload["ref_type_counts"] == {}
+    assert "future:/private/secret/hash" not in result.stdout
+    assert "secret-ref" not in result.stdout
+    assert "/private/path" not in result.stdout

--- a/tests/unit/cli/test_blob_ref_liveness_cli.py
+++ b/tests/unit/cli/test_blob_ref_liveness_cli.py
@@ -43,3 +43,48 @@ def test_blob_reference_liveness_cli_defaults_to_read_only(
     assert payload["orphaned_by_ref_type"] == {"raw_payload": 1}
     with sqlite3.connect(archive_root / "source.db") as conn:
         assert conn.execute("SELECT COUNT(*) FROM blob_refs").fetchone() == (1,)
+
+
+def test_blob_reference_liveness_cli_census_is_counts_only(
+    cli_workspace: dict[str, Path], cli_runner: CliRunner
+) -> None:
+    archive_root = cli_workspace["archive_root"]
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, 'historical-raw', 'raw_payload', '/private/path', 1, 1)
+            """,
+            (b"h" * 32,),
+        )
+
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "blob-reference-liveness",
+            "--census-only",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "by_ref_type": {"raw_payload": 1},
+        "mode": "blob_reference_census",
+        "mutates": False,
+        "ref_type_counts": {"raw_payload": 1},
+        "scanned_count": 1,
+        "schema_unavailable_count": 0,
+        "total": 1,
+        "unknown_ref_types": {},
+        "unavailable_ref_types": {},
+    }
+    assert "/private/path" not in result.stdout
+    assert "historical-raw" not in result.stdout
+    assert "686868" not in result.stdout

--- a/tests/unit/cli/test_blob_ref_liveness_cli.py
+++ b/tests/unit/cli/test_blob_ref_liveness_cli.py
@@ -120,3 +120,13 @@ def test_blob_reference_liveness_cli_census_redacts_unknown_ref_type_names(
     assert "future:/private/secret/hash" not in result.stdout
     assert "secret-ref" not in result.stdout
     assert "/private/path" not in result.stdout
+
+    plain_result = cli_runner.invoke(
+        cli,
+        ["--plain", "ops", "maintenance", "blob-reference-liveness", "--census-only"],
+        catch_exceptions=False,
+    )
+
+    assert plain_result.exit_code == 0
+    assert "Unknown:      1 ref(s)" in plain_result.stdout
+    assert "future:/private/secret/hash" not in plain_result.stdout

--- a/tests/unit/storage/test_blob_gc.py
+++ b/tests/unit/storage/test_blob_gc.py
@@ -139,7 +139,7 @@ def test_still_referenced_recognizes_archive_source_hash(tmp_path: Path) -> None
     source_conn.commit()
 
     assert _still_referenced(source_conn, blob_hash) is True
-    assert _reference_surfaces(source_conn, blob_hash) == ["current.raw_sessions"]
+    assert _reference_surfaces(source_conn, blob_hash) == ["current.raw_sessions", "current.blob_refs"]
     source_conn.close()
 
 

--- a/tests/unit/storage/test_blob_gc_ref_type_liveness.py
+++ b/tests/unit/storage/test_blob_gc_ref_type_liveness.py
@@ -40,8 +40,10 @@ from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
 from polylogue.storage.sqlite.archive_tiers.source_write import (
     ArchiveHookEvent,
+    ArchiveSourceBlobRef,
     deterministic_blob_hash,
     deterministic_raw_session_id,
+    write_source_raw_session,
 )
 
 pytestmark = pytest.mark.uses_real_clock(
@@ -163,39 +165,25 @@ def test_gc_retains_live_raw_attachment_and_hook_references_together(tmp_path: P
     )
 
     with sqlite3.connect(archive_root / "source.db") as conn:
-        conn.execute(
-            """
-            INSERT INTO raw_sessions (
-                raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms
-            ) VALUES ('raw-live', 'codex-session', 'raw-live', '/raw.jsonl', ?, 11, 1)
-            """,
-            (bytes.fromhex(raw_hash),),
+        raw_id = write_source_raw_session(
+            conn,
+            origin=Origin.CODEX_SESSION,
+            source_path="/raw.jsonl",
+            source_index=0,
+            native_id="raw-live",
+            payload=b"raw payload",
+            acquired_at_ms=1,
+            additional_blob_refs=(
+                ArchiveSourceBlobRef(
+                    blob_hash=bytes.fromhex(attachment_hash),
+                    ref_type="attachment",
+                    source_path="/raw.jsonl",
+                    size_bytes=18,
+                    acquired_at_ms=1,
+                ),
+            ),
         )
-        # Attachment refs use the parent raw session as their ref_id in the
-        # source tier. Its payload is deliberately a different, non-file hash
-        # so this assertion exercises the attachment ref join itself.
-        conn.execute(
-            """
-            INSERT INTO raw_sessions (
-                raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms
-            ) VALUES ('attachment-parent', 'codex-session', 'attachment-parent', '/parent.jsonl', ?, 1, 1)
-            """,
-            (b"p" * 32,),
-        )
-        conn.execute(
-            """
-            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
-            VALUES (?, 'raw-live', 'raw_payload', '/raw.jsonl', 11, 1)
-            """,
-            (bytes.fromhex(raw_hash),),
-        )
-        conn.execute(
-            """
-            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
-            VALUES (?, 'attachment-parent', 'attachment', '/parent.jsonl', 18, 1)
-            """,
-            (bytes.fromhex(attachment_hash),),
-        )
+        assert conn.execute("SELECT ref_id FROM blob_refs WHERE ref_type = 'attachment'").fetchone() == (raw_id,)
 
     with sqlite3.connect(archive_root / "source.db") as conn:
         hook_hash = conn.execute("SELECT blob_hash FROM raw_hook_events WHERE hook_event_id = 'hook-batch'").fetchone()[
@@ -209,12 +197,73 @@ def test_gc_retains_live_raw_attachment_and_hook_references_together(tmp_path: P
     assert all(blob_store.exists(blob_hash) for blob_hash in (raw_hash, attachment_hash, bytes(hook_hash).hex()))
 
     with sqlite3.connect(archive_root / "source.db") as conn:
-        conn.execute("DELETE FROM blob_refs WHERE ref_id IN ('raw-live', 'attachment-parent')")
-        conn.execute("DELETE FROM raw_sessions WHERE raw_id IN ('raw-live', 'attachment-parent')")
+        conn.execute("DELETE FROM blob_refs WHERE ref_id = ?", (raw_id,))
+        conn.execute("DELETE FROM raw_sessions WHERE raw_id = ?", (raw_id,))
     assert _delete_hook_event(archive_root, hook_event_id="hook-batch") is True
 
     assert run_blob_gc(archive_root / "source.db", archive_root / "blob", max_batch=10) == 3
     assert not any(blob_store.exists(blob_hash) for blob_hash in (raw_hash, attachment_hash, bytes(hook_hash).hex()))
+
+
+def test_gc_retains_unclassified_blob_refs_and_census_reports_disposition(tmp_path: Path) -> None:
+    """GC must not delete bytes when a legacy ref type has no proven join."""
+    source_db = tmp_path / "source.db"
+    blob_store = BlobStore(tmp_path / "blob")
+    blob_hash, _size = blob_store.write_from_bytes(b"unclassified reference")
+
+    with sqlite3.connect(source_db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE raw_sessions (raw_id TEXT PRIMARY KEY);
+            CREATE TABLE blob_refs (
+                blob_hash BLOB NOT NULL,
+                ref_id TEXT NOT NULL,
+                ref_type TEXT NOT NULL,
+                source_path TEXT,
+                size_bytes INTEGER NOT NULL,
+                acquired_at_ms INTEGER NOT NULL,
+                PRIMARY KEY (blob_hash, ref_type, ref_id)
+            ) STRICT;
+            CREATE TABLE gc_generations (
+                generation_id TEXT PRIMARY KEY,
+                started_at_ms INTEGER NOT NULL,
+                completed_at_ms INTEGER,
+                reclaimed_count INTEGER NOT NULL,
+                reclaimed_bytes INTEGER NOT NULL
+            ) STRICT;
+            """
+        )
+        conn.executemany(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, ?, ?, NULL, 23, 1)
+            """,
+            [
+                (bytes.fromhex(blob_hash), "future-ref", "future_type"),
+                (bytes.fromhex(blob_hash), "sidecar-ref", "sidecar"),
+            ],
+        )
+
+    _backdate(blob_store, blob_hash)
+    assert run_blob_gc(source_db, blob_store.root, max_batch=10) == 0
+    assert blob_store.exists(blob_hash)
+
+    with sqlite3.connect(source_db) as conn:
+        census = census_orphaned_blob_refs(conn)
+
+    assert census.total == 0
+    assert census.by_ref_type == {}
+    assert census.ref_type_counts == {"future_type": 1, "sidecar": 1}
+    assert census.unknown_ref_types == {"future_type": 1}
+    assert census.unavailable_ref_types == {"sidecar": 1}
+    assert census.to_dict() == {
+        "scanned_count": 2,
+        "ref_type_counts": {"future_type": 1, "sidecar": 1},
+        "total": 0,
+        "by_ref_type": {},
+        "unknown_ref_types": {"future_type": 1},
+        "unavailable_ref_types": {"sidecar": 1},
+    }
 
 
 def test_interrupted_hook_rekey_blocks_liveness_deletion_and_preserves_blob(
@@ -329,6 +378,10 @@ def test_census_orphaned_blob_refs_counts_by_ref_type(tmp_path: Path) -> None:
         census = census_orphaned_blob_refs(conn)
         assert census.total == 0
         assert census.by_ref_type == {}
+        assert census.scanned_count == 1
+        assert census.ref_type_counts == {"hook_payload": 1}
+        assert census.unknown_ref_types == {}
+        assert census.unavailable_ref_types == {}
 
         # Two orphaned refs: one raw_payload (no raw_sessions row), one
         # hook_payload (no raw_hook_events row).
@@ -351,4 +404,15 @@ def test_census_orphaned_blob_refs_counts_by_ref_type(tmp_path: Path) -> None:
         census = census_orphaned_blob_refs(conn)
         assert census.total == 2
         assert census.by_ref_type == {"raw_payload": 1, "hook_payload": 1}
-        assert census.to_dict() == {"total": 2, "by_ref_type": {"raw_payload": 1, "hook_payload": 1}}
+        assert census.scanned_count == 3
+        assert census.ref_type_counts == {"hook_payload": 2, "raw_payload": 1}
+        assert census.unknown_ref_types == {}
+        assert census.unavailable_ref_types == {}
+        assert census.to_dict() == {
+            "scanned_count": 3,
+            "ref_type_counts": {"hook_payload": 2, "raw_payload": 1},
+            "total": 2,
+            "by_ref_type": {"raw_payload": 1, "hook_payload": 1},
+            "unknown_ref_types": {},
+            "unavailable_ref_types": {},
+        }

--- a/tests/unit/storage/test_blob_gc_ref_type_liveness.py
+++ b/tests/unit/storage/test_blob_gc_ref_type_liveness.py
@@ -264,6 +264,7 @@ def test_gc_retains_unclassified_blob_refs_and_census_reports_disposition(tmp_pa
         "unknown_ref_types": {"future_type": 1},
         "unavailable_ref_types": {"sidecar": 1},
         "schema_unavailable_count": 0,
+        "deferred_by_ref_type": {},
     }
 
 
@@ -302,11 +303,15 @@ def test_interrupted_hook_rekey_blocks_liveness_deletion_and_preserves_blob(
             (blob_hash, legacy_ref_id, source_path, len(payload), 1_700_000_000_000),
         )
         classification = classify_blob_ref_liveness(conn)
+        census = census_orphaned_blob_refs(conn)
         conn.commit()
 
     assert classification.rekeyable_hook_payload_count == 1
     assert classification.safe_to_apply is False
     assert all(candidate.ref_id != legacy_ref_id for candidate in classification.candidates)
+    assert census.total == 0
+    assert census.by_ref_type == {}
+    assert census.deferred_by_ref_type == {"raw_payload": 1}
 
     monkeypatch.setattr(
         "polylogue.maintenance.blob_ref_liveness_reconciliation.validate_migration_backup_manifest",
@@ -379,6 +384,7 @@ def test_gc_census_reports_untyped_blob_ref_schema_without_deleting_bytes(tmp_pa
         "unknown_ref_types": {},
         "unavailable_ref_types": {},
         "schema_unavailable_count": 1,
+        "deferred_by_ref_type": {},
     }
 
 
@@ -461,4 +467,5 @@ def test_census_orphaned_blob_refs_counts_by_ref_type(tmp_path: Path) -> None:
             "unknown_ref_types": {},
             "unavailable_ref_types": {},
             "schema_unavailable_count": 0,
+            "deferred_by_ref_type": {},
         }

--- a/tests/unit/storage/test_blob_gc_ref_type_liveness.py
+++ b/tests/unit/storage/test_blob_gc_ref_type_liveness.py
@@ -263,6 +263,7 @@ def test_gc_retains_unclassified_blob_refs_and_census_reports_disposition(tmp_pa
         "by_ref_type": {},
         "unknown_ref_types": {"future_type": 1},
         "unavailable_ref_types": {"sidecar": 1},
+        "schema_unavailable_count": 0,
     }
 
 
@@ -290,6 +291,7 @@ def test_interrupted_hook_rekey_blocks_liveness_deletion_and_preserves_blob(
         blob_hash = conn.execute(
             "SELECT blob_hash FROM raw_hook_events WHERE hook_event_id = ?", (hook_event_id,)
         ).fetchone()[0]
+        conn.execute("UPDATE raw_hook_events SET blob_hash = NULL WHERE hook_event_id = ?", (hook_event_id,))
         legacy_ref_id = deterministic_raw_session_id("codex-session", source_path, 0, blob_hash, native_id)
         conn.execute("DELETE FROM blob_refs WHERE ref_type = 'hook_payload' AND ref_id = ?", (hook_event_id,))
         conn.execute(
@@ -335,6 +337,49 @@ def test_interrupted_hook_rekey_blocks_liveness_deletion_and_preserves_blob(
     deleted = run_blob_gc(archive_root / "source.db", archive_root / "blob", max_batch=10)
     assert deleted == 0
     assert blob_store.exists(blob_hash_hex)
+
+
+def test_gc_census_reports_untyped_blob_ref_schema_without_deleting_bytes(tmp_path: Path) -> None:
+    source_db = tmp_path / "source.db"
+    blob_store = BlobStore(tmp_path / "blob")
+    blob_hash, _size = blob_store.write_from_bytes(b"untyped reference")
+
+    with sqlite3.connect(source_db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE blob_refs (
+                blob_hash BLOB NOT NULL,
+                owner_id TEXT NOT NULL,
+                PRIMARY KEY (blob_hash, owner_id)
+            ) STRICT;
+            CREATE TABLE gc_generations (
+                generation_id TEXT PRIMARY KEY,
+                started_at_ms INTEGER NOT NULL,
+                completed_at_ms INTEGER,
+                reclaimed_count INTEGER NOT NULL,
+                reclaimed_bytes INTEGER NOT NULL
+            ) STRICT;
+            """
+        )
+        conn.execute(
+            "INSERT INTO blob_refs (blob_hash, owner_id) VALUES (?, 'legacy-owner')", (bytes.fromhex(blob_hash),)
+        )
+
+    _backdate(blob_store, blob_hash)
+    assert run_blob_gc(source_db, blob_store.root, max_batch=10) == 0
+    with sqlite3.connect(source_db) as conn:
+        census = census_orphaned_blob_refs(conn)
+
+    assert census.schema_unavailable_count == 1
+    assert census.to_dict() == {
+        "scanned_count": 0,
+        "ref_type_counts": {},
+        "total": 0,
+        "by_ref_type": {},
+        "unknown_ref_types": {},
+        "unavailable_ref_types": {},
+        "schema_unavailable_count": 1,
+    }
 
 
 def test_attachment_ref_type_joins_against_raw_sessions_not_raw_artifacts(tmp_path: Path) -> None:
@@ -415,4 +460,5 @@ def test_census_orphaned_blob_refs_counts_by_ref_type(tmp_path: Path) -> None:
             "by_ref_type": {"raw_payload": 1, "hook_payload": 1},
             "unknown_ref_types": {},
             "unavailable_ref_types": {},
+            "schema_unavailable_count": 0,
         }


### PR DESCRIPTION
## Summary

Ref polylogue-tfzw0 hardens blob reference liveness around the existing source-tier design: hook payloads use a first-class `hook_payload` reference joined to `raw_hook_events`, attachments use the parent `raw_sessions` reference, and every other reference type has an explicit liveness or fail-closed disposition. It adds a production maintenance census that reports counts without identifiers, paths, hashes, or arbitrary unknown type names.

## Problem

The previous GC liveness check treated membership in `blob_refs` as proof that a blob was live. That made the reference row prove its own liveness and obscured orphaned hook payload rows. The bead records 73,427 historical `raw_payload` rows and approximately 1.94 GiB of affected bytes, plus an attachment orphan class with 1,336 rows lacking a matching `raw_artifacts` row. The hook payload rows are inline in `raw_hook_events`, so their truthful referent is the hook event row and its `blob_hash`, not a raw session.

## Solution

The implementation uses one shared `BLOB_REF_LIVENESS_JOIN` map for GC and census classification. The map joins `raw_payload` to `raw_sessions`, `attachment` to its parent `raw_sessions`, `hook_payload` to `raw_hook_events`, and `sidecar` to `history_sidecars`. Unknown types, unavailable joins, malformed legacy schemas, and interrupted legacy hook re-key states fail closed and retain bytes. Legacy hook matching reuses the existing reconciliation match stage, so GC does not acquire a second repair or GC implementation. The CLI routes census reads through the maintenance layer and both JSON and plain output are counts-only. No archive data was changed and no Beads state was written from this worktree.

### Acceptance criteria

| Criterion | Status | Evidence |
| --- | --- | --- |
| Hook payload references are truthful and liveness-joined | Satisfied | Production `ArchiveStore.write_hook_event` route writes `hook_payload` keyed by `raw_hook_events.hook_event_id`; GC retains the live blob and reclaims it after the hook row and reference are removed. |
| Every `ref_type` has an explicit join or verified disposition | Satisfied | One shared join map covers the known types; unknown, unavailable, malformed, and interrupted legacy states are classified and retained fail-closed. |
| Attachment orphan class is handled | Satisfied | Production source writer coverage proves attachment refs use the parent raw session id; an attachment ref with no matching `raw_sessions` row is reclaimed. |
| Privacy-safe census exists | Satisfied | `ops maintenance blob-reference-liveness --census-only` reaches the maintenance implementation and emits aggregate counts only, including redaction of arbitrary unknown type names in JSON and plain output. |
| Production-route tests cover the repair surface | Satisfied | Tests exercise hook acquisition, source-session attachment acquisition, `run_blob_gc`, legacy reconciliation classification, and the CLI census route. |
| No second GC implementation or silent evidence deletion | Satisfied | GC and census share the liveness map; legacy hook protection reuses the existing reconciliation match stage; unknown and unavailable evidence is retained. |
| Forbidden active reindex foundation files remain untouched | Satisfied | The branch changes only the seven files listed in this PR and none of the excluded foundation, manifest, harness, or ledger files. |
| Residual scope | None | The bead is coherent at this boundary, so no follow-up Bead was created. |

## Verification

Red reproduction before the implementation:

```text
direnv exec /realm/worktrees/polylogue-tfzw0 devtools test tests/unit/storage/test_blob_gc_ref_type_liveness.py -k 'gc_retains_live_raw_attachment_and_hook_references_together or gc_retains_unclassified_blob_refs_and_census_reports_disposition'
1 failed, 1 passed, 6 deselected
```

Focused affected suite after the final commit:

```text
direnv exec /realm/worktrees/polylogue-tfzw0 devtools test tests/unit/storage/test_blob_gc_ref_type_liveness.py tests/unit/storage/test_blob_gc.py tests/unit/storage/test_blob_ref_liveness.py tests/unit/storage/test_archive_tiers_source_write.py tests/unit/cli/test_blob_ref_liveness_cli.py
65 passed in 12.65s
ok (16.8s)
```

Final quick verification at `a87da7da3`:

```text
direnv exec /realm/worktrees/polylogue-tfzw0 devtools verify --quick
24 steps, every step exit 0, including render all, layering, mypy, schema and policy checks
total_duration_s: 98.89
exit_code: 0
```

Additional checks passed: `git diff --check origin/master...HEAD` produced no output, and the branch diff contains exactly the seven files named in this PR. `devtools verify --all` was not run because this lane uses the focused affected suite and the quick gate. Live archive reconciliation or apply was not run because the tests use isolated temporary archives and the change does not authorize mutation of the live archive.

### Anti-vacuity evidence

The hook tests depend on `ArchiveStore.write_hook_event -> write_source_hook_event -> _insert_blob_ref` and `run_blob_gc`; reverting GC to a bare `blob_refs` membership check makes the final deletion assertion fail. The attachment test depends on `write_source_raw_session(additional_blob_refs=...)` and asserts the persisted ref id is the resolved parent raw session id before testing orphan reclamation. The CLI test invokes the registered maintenance command and verifies the counts-only output, including the plain-output unknown-type redaction.

### Adversarial review

Three independent review iterations were run. Iteration one found and led to fixes for legacy hook evidence retention, malformed-schema census disposition, and the missing production census route. Iteration two found and led to fixes for census alignment with GC holds and unknown type-name redaction in JSON. Iteration three found the remaining plain-output redaction gap, which is included in `a87da7da3` and covered by the final focused suite. The Claude review lane was unavailable due to its weekly quota, with no code finding returned.
