### PR TITLE
test(proof): add Claude vintage receipt

### DIFF
--- a/polylogue/maintenance/pathology_zoo.py
+++ b/polylogue/maintenance/pathology_zoo.py
@@ -250,28 +250,13 @@ PATHOLOGY_ZOO_MANIFEST: tuple[PathologyZooMember, ...] = (
         ),
     ),
     PathologyZooMember(
-        "content-blocks-vintage",
-        "content-blocks-vintage",
-        ("polylogue-yazae", "polylogue-0qfy"),
-        (f"{_CLAUDE_AI}:zoo-content-blocks-vintage",),
-        ("manual/content-blocks-old.json", "manual/content-blocks-new.json"),
-        PathologyZooCanaryEligibility.SESSION_BACKED,
-        _invariant(
-            "the content-block vintage keeps its parsed text block",
-            "index",
-            "SELECT COUNT(*) FROM blocks WHERE session_id = ?",
-            (f"{_CLAUDE_AI}:zoo-content-blocks-vintage",),
-            (1,),
-        ),
-    ),
-    PathologyZooMember(
         "claude-vintage-live-proof",
         "claude-vintage-live-proof",
         ("polylogue-claude-vintage-live-proof", "polylogue-0qfy"),
         (f"{_CLAUDE_AI}:9ed2056f-b415-4f51-b18e-5265f21a67bf",),
         (
-            "manual/claude-vintage-live-proof-old.json",
-            "manual/claude-vintage-live-proof-new.json",
+            "manual/claude-live-proof-old.json",
+            "manual/claude-live-proof-new.json",
         ),
         PathologyZooCanaryEligibility.SESSION_BACKED,
         _invariant(

--- a/polylogue/maintenance/pathology_zoo.py
+++ b/polylogue/maintenance/pathology_zoo.py
@@ -60,6 +60,7 @@ class PathologyZooMember:
     canary_eligibility: PathologyZooCanaryEligibility
     invariant: PathologyZooInvariant
     durable_paths: tuple[str, ...] = ()
+    evidence_note: str | None = None
 
     def __post_init__(self) -> None:
         if self.canary_eligibility is PathologyZooCanaryEligibility.SESSION_BACKED and not self.session_ids:
@@ -261,6 +262,30 @@ PATHOLOGY_ZOO_MANIFEST: tuple[PathologyZooMember, ...] = (
             "SELECT COUNT(*) FROM blocks WHERE session_id = ?",
             (f"{_CLAUDE_AI}:zoo-content-blocks-vintage",),
             (1,),
+        ),
+    ),
+    PathologyZooMember(
+        "claude-vintage-live-proof",
+        "claude-vintage-live-proof",
+        ("polylogue-claude-vintage-live-proof", "polylogue-0qfy"),
+        (f"{_CLAUDE_AI}:9ed2056f-b415-4f51-b18e-5265f21a67bf",),
+        (
+            "manual/claude-vintage-live-proof-old.json",
+            "manual/claude-vintage-live-proof-new.json",
+        ),
+        PathologyZooCanaryEligibility.SESSION_BACKED,
+        _invariant(
+            "the sanitized measured-shape cohort retains both raw revisions",
+            "source",
+            "SELECT COUNT(*) FROM raw_sessions WHERE native_id = ?",
+            ("9ed2056f-b415-4f51-b18e-5265f21a67bf",),
+            (2,),
+        ),
+        evidence_note=(
+            "Live export bytes were not recoverable outside the protected live archive. "
+            "This pair reconstructs the parent bead's measured old-flat/new-nested Claude "
+            "shape with synthetic identifiers and sanitized text. The real-route receipt "
+            "must retain live_evidence_recovered=false until captured wire bytes are supplied."
         ),
     ),
     PathologyZooMember(

--- a/polylogue/maintenance/pathology_zoo.py
+++ b/polylogue/maintenance/pathology_zoo.py
@@ -260,11 +260,20 @@ PATHOLOGY_ZOO_MANIFEST: tuple[PathologyZooMember, ...] = (
         ),
         PathologyZooCanaryEligibility.SESSION_BACKED,
         _invariant(
-            "the sanitized measured-shape cohort retains both raw revisions",
+            "the sanitized measured-shape cohort converges to one equivalent canonical revision",
             "source",
-            "SELECT COUNT(*) FROM raw_sessions WHERE native_id = ?",
+            """
+            SELECT CASE WHEN COUNT(*) = 2
+                AND COUNT(DISTINCT normalized_content_hash) = 1
+                AND SUM(decision = 'applied') = 1
+                AND SUM(decision = 'superseded_equivalent') = 1
+                THEN 1 ELSE 0 END
+            FROM raw_sessions AS r
+            JOIN raw_session_memberships AS m ON m.raw_id = r.raw_id
+            WHERE r.native_id = ?
+            """,
             ("9ed2056f-b415-4f51-b18e-5265f21a67bf",),
-            (2,),
+            (1,),
         ),
         evidence_note=(
             "Live export bytes were not recoverable outside the protected live archive. "

--- a/tests/infra/claude_vintage_live_proof.py
+++ b/tests/infra/claude_vintage_live_proof.py
@@ -1,0 +1,207 @@
+"""Measured-shape Claude vintage proof through the production archive route.
+
+The parent measurement established the wire-shape difference, but its live
+export bytes were not recoverable for this lane. This harness therefore keeps
+the pair private-data-free, records that confidence gap in every receipt, and
+still exercises the real parser, archive ingest, membership replay, and
+convergence seams.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from polylogue.archive.session_revision_membership import MembershipRevision, classify_membership_revisions
+from polylogue.config import Source
+from polylogue.core.enums import Origin
+from polylogue.daemon.convergence import DaemonConverger
+from polylogue.daemon.convergence_stages import make_fts_stage, make_insights_stage
+from polylogue.pipeline.ids import session_revision_projection
+from polylogue.pipeline.services.archive_ingest import parse_sources_archive
+from polylogue.sources.parsers.claude.ai_parser import parse_ai
+from polylogue.sources.revision_backfill import backfill_historical_revision_evidence
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from tests.infra.pathology_zoo import (
+    CLAUDE_VINTAGE_LIVE_PROOF_SESSION_ID,
+    write_claude_vintage_live_proof_pair,
+)
+
+ReceiptVerdict = Literal["equivalent", "conflict", "unresolved"]
+
+CONFIDENCE_GAP = (
+    "The cited live Claude export bytes and cohort member ids were not recoverable "
+    "outside the protected live archive. This receipt proves the measured old-flat "
+    "versus new-nested wire shape and the production route, but it does not establish "
+    "the parent cohort's live prevalence or exact member set."
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ClaudeVintageReclassificationReceipt:
+    """Sanitized, read-only evidence for one cohort reclassification."""
+
+    schema_version: int
+    fixture_member_id: str
+    live_export_recovered: bool
+    confidence_gap: str
+    production_route: tuple[str, ...]
+    parser_branch: tuple[tuple[str, object], ...]
+    classifier_probe: tuple[tuple[str, tuple[str, ...]], ...]
+    canonical_identity: str
+    canonical_content_hash: str
+    verdict: ReceiptVerdict
+    route_counts: tuple[tuple[str, int], ...]
+    convergence_session_count: int
+
+    def as_dict(self) -> dict[str, object]:
+        """Return a JSON-safe receipt without raw paths or raw identifiers."""
+        return {
+            "schema_version": self.schema_version,
+            "fixture_member_id": self.fixture_member_id,
+            "live_export_recovered": self.live_export_recovered,
+            "confidence_gap": self.confidence_gap,
+            "production_route": list(self.production_route),
+            "parser_branch": dict(self.parser_branch),
+            "classifier_probe": {key: list(value) for key, value in self.classifier_probe},
+            "canonical_identity": self.canonical_identity,
+            "canonical_content_hash": self.canonical_content_hash,
+            "verdict": self.verdict,
+            "route_counts": dict(self.route_counts),
+            "convergence_session_count": self.convergence_session_count,
+        }
+
+    def as_json(self) -> str:
+        """Render the receipt deterministically for evidence capture."""
+        return json.dumps(self.as_dict(), sort_keys=True, indent=2) + "\n"
+
+
+def run_claude_vintage_live_proof(archive_root: Path) -> ClaudeVintageReclassificationReceipt:
+    """Run the sanitized pair through production parse, ingest, replay, and convergence."""
+    wire_root = archive_root / "wire"
+    old_path, new_path = write_claude_vintage_live_proof_pair(wire_root)
+    initialize_active_archive_root(archive_root)
+
+    ingest = asyncio.run(
+        parse_sources_archive(
+            archive_root,
+            [Source(name="claude-ai", path=wire_root)],
+            parse_workers=1,
+        )
+    )
+    backfill = backfill_historical_revision_evidence(archive_root, ingest_workers=1)
+
+    with sqlite3.connect(archive_root / "index.db") as connection:
+        session_ids = tuple(
+            str(row[0]) for row in connection.execute("SELECT session_id FROM sessions ORDER BY session_id")
+        )
+    converger = DaemonConverger(
+        (
+            make_fts_stage(archive_root / "index.db"),
+            make_insights_stage(archive_root / "index.db"),
+        )
+    )
+    states, _timings = converger.converge_sessions(session_ids)
+    if any(not state.converged for state in states.values()):
+        pending = {session_id: state.last_error for session_id, state in states.items() if not state.converged}
+        raise AssertionError(f"Claude vintage proof did not converge: {pending}")
+
+    old_payload = json.loads(old_path.read_text(encoding="utf-8"))
+    new_payload = json.loads(new_path.read_text(encoding="utf-8"))
+    old_session = parse_ai(old_payload, "synthetic-fallback-old")
+    new_session = parse_ai(new_payload, "synthetic-fallback-new")
+    old_projection = session_revision_projection(old_session)
+    new_projection = session_revision_projection(new_session)
+    probe = classify_membership_revisions(
+        [
+            MembershipRevision("fixture-old", old_projection),
+            MembershipRevision("fixture-new", new_projection),
+        ]
+    )
+
+    rows = _read_membership_rows(archive_root)
+    if len(rows) != 2:
+        raise AssertionError(f"expected two sanitized cohort membership rows, got {len(rows)}")
+    hashes = {row["content_hash"] for row in rows}
+    if len(hashes) != 1:
+        raise AssertionError(f"production membership hashes diverged: {hashes}")
+    content_hash = next(iter(hashes))
+    if not isinstance(content_hash, str):
+        raise AssertionError(f"production membership hash is not text: {content_hash!r}")
+    decisions = {str(row["decision"]) for row in rows}
+    if decisions != {"applied", "superseded_equivalent"}:
+        raise AssertionError(f"unexpected production membership decisions: {decisions}")
+    if len(session_ids) != 1:
+        raise AssertionError(f"expected one canonical indexed identity, got {session_ids}")
+
+    route_counts = (
+        ("ingest_sessions", int(ingest.counts["sessions"])),
+        ("ingest_messages", int(ingest.counts["messages"])),
+        ("backfill_scanned", int(backfill.scanned)),
+        ("backfill_classified_full", int(backfill.classified_full)),
+        ("backfill_replayed_logical_sources", int(backfill.replayed_logical_sources)),
+        ("backfill_quarantined", int(backfill.quarantined)),
+    )
+    return ClaudeVintageReclassificationReceipt(
+        schema_version=1,
+        fixture_member_id="claude-vintage-live-proof",
+        live_export_recovered=False,
+        confidence_gap=CONFIDENCE_GAP,
+        production_route=(
+            "parse_sources_archive",
+            "backfill_historical_revision_evidence",
+            "DaemonConverger(make_fts_stage, make_insights_stage)",
+        ),
+        parser_branch=(
+            ("old_wire_shape", "top_level_text"),
+            ("new_wire_shape", "content_text_segment"),
+            ("old_parsed_block_count", len(old_session.messages[2].blocks)),
+            ("new_parsed_block_count", len(new_session.messages[2].blocks)),
+            ("projection_hash_equal", old_projection.session_hash == new_projection.session_hash),
+        ),
+        classifier_probe=(
+            ("accepted_raw_ids", tuple(probe.accepted_raw_ids)),
+            ("equivalent_raw_ids", tuple(probe.equivalent_raw_ids)),
+            ("ambiguous_raw_ids", tuple(probe.ambiguous_raw_ids)),
+        ),
+        canonical_identity=f"{Origin.CLAUDE_AI_EXPORT.value}:{CLAUDE_VINTAGE_LIVE_PROOF_SESSION_ID}",
+        canonical_content_hash=content_hash,
+        verdict="equivalent",
+        route_counts=route_counts,
+        convergence_session_count=len(states),
+    )
+
+
+def _read_membership_rows(archive_root: Path) -> tuple[dict[str, object], ...]:
+    """Read the production membership verdict through read-only SQLite handles."""
+    source_path = archive_root / "source.db"
+    with sqlite3.connect(f"file:{source_path}?mode=ro", uri=True) as connection:
+        rows = connection.execute(
+            """
+            SELECT r.source_path, m.normalized_content_hash, m.decision
+            FROM raw_sessions AS r
+            JOIN raw_session_memberships AS m ON m.raw_id = r.raw_id
+            WHERE m.logical_source_key = ?
+            ORDER BY r.source_path
+            """,
+            (f"claude-ai:{CLAUDE_VINTAGE_LIVE_PROOF_SESSION_ID}",),
+        ).fetchall()
+    return tuple(
+        {
+            "label": Path(str(source_path)).stem.rsplit("-", 1)[-1],
+            "content_hash": bytes(content_hash).hex(),
+            "decision": str(decision),
+        }
+        for source_path, content_hash, decision in rows
+    )
+
+
+__all__ = [
+    "CONFIDENCE_GAP",
+    "ClaudeVintageReclassificationReceipt",
+    "run_claude_vintage_live_proof",
+]

--- a/tests/infra/pathology_zoo.py
+++ b/tests/infra/pathology_zoo.py
@@ -113,8 +113,10 @@ _PATHOLOGY_ZOO_MUTATIONS: dict[str, PathologyZooMutation] = {
     "vintage-reorder": PathologyZooMutation(
         "source", "DELETE FROM raw_sessions WHERE source_path LIKE '%vintage-new.json'"
     ),
-    "content-blocks-vintage": PathologyZooMutation(
-        "index", "DELETE FROM blocks WHERE session_id = ?", ("claude-ai-export:zoo-content-blocks-vintage",)
+    "claude-vintage-live-proof": PathologyZooMutation(
+        "source",
+        "DELETE FROM raw_sessions WHERE native_id = ? AND source_path LIKE ?",
+        ("9ed2056f-b415-4f51-b18e-5265f21a67bf", "%claude-live-proof-new.json"),
     ),
     "lifecycle-anchor-drift": PathologyZooMutation(
         "index",
@@ -279,11 +281,11 @@ def write_claude_vintage_live_proof_pair(root: Path) -> tuple[Path, Path]:
     manual = root / "manual"
     return (
         _write_json(
-            manual / "claude-vintage-live-proof-old.json",
+            manual / "claude-live-proof-old.json",
             _claude_vintage_live_proof_payload(nested_target=False),
         ),
         _write_json(
-            manual / "claude-vintage-live-proof-new.json",
+            manual / "claude-live-proof-new.json",
             _claude_vintage_live_proof_payload(nested_target=True),
         ),
     )

--- a/tests/infra/pathology_zoo.py
+++ b/tests/infra/pathology_zoo.py
@@ -224,6 +224,71 @@ def _chatgpt_node(
     return node
 
 
+CLAUDE_VINTAGE_LIVE_PROOF_SESSION_ID = "9ed2056f-b415-4f51-b18e-5265f21a67bf"
+CLAUDE_VINTAGE_LIVE_PROOF_MESSAGE_IDS = (
+    "64878c9e-2642-437b-a384-0961184f84ea",
+    "4c341ad3-dbd9-4224-9ab4-dcb4f833b3f9",
+    "49cad03c-d06e-48a8-8f0a-81e40ef234cd",
+)
+
+
+def _claude_vintage_live_proof_payload(*, nested_target: bool) -> dict[str, object]:
+    """Return the sanitized old/new wire pair from the parent measurement.
+
+    The parent measurement identified a Claude.ai export-vintage difference:
+    one version carries a message's text at the top level, while another
+    carries the same text in one ``content`` text segment. The IDs and prose
+    here are synthetic because the cited live bytes were not recoverable.
+    """
+    target: dict[str, object] = {
+        "uuid": CLAUDE_VINTAGE_LIVE_PROOF_MESSAGE_IDS[2],
+        "sender": "human",
+    }
+    if nested_target:
+        target["content"] = [{"type": "text", "text": "sanitized measured target turn"}]
+    else:
+        target["text"] = "sanitized measured target turn"
+    return {
+        "uuid": CLAUDE_VINTAGE_LIVE_PROOF_SESSION_ID,
+        "title": "sanitized measured Claude vintage cohort",
+        "created_at": "2026-07-31T00:00:00Z",
+        "updated_at": "2026-07-31T00:03:00Z",
+        "chat_messages": [
+            {
+                "uuid": CLAUDE_VINTAGE_LIVE_PROOF_MESSAGE_IDS[0],
+                "sender": "human",
+                "text": "sanitized first turn",
+                "created_at": "2026-07-31T00:00:00Z",
+            },
+            {
+                "uuid": CLAUDE_VINTAGE_LIVE_PROOF_MESSAGE_IDS[1],
+                "sender": "assistant",
+                "text": "sanitized assistant turn",
+                "created_at": "2026-07-31T00:01:00Z",
+            },
+            {
+                **target,
+                "created_at": "2026-07-31T00:02:00Z",
+            },
+        ],
+    }
+
+
+def write_claude_vintage_live_proof_pair(root: Path) -> tuple[Path, Path]:
+    """Write the sanitized measured-shape pair into a pathology wire root."""
+    manual = root / "manual"
+    return (
+        _write_json(
+            manual / "claude-vintage-live-proof-old.json",
+            _claude_vintage_live_proof_payload(nested_target=False),
+        ),
+        _write_json(
+            manual / "claude-vintage-live-proof-new.json",
+            _claude_vintage_live_proof_payload(nested_target=True),
+        ),
+    )
+
+
 def _write_manual_members(root: Path) -> tuple[Path, ...]:
     manual = root / "manual"
     grouped_records = (
@@ -285,6 +350,7 @@ def _write_manual_members(root: Path) -> tuple[Path, ...]:
                 ],
             },
         ),
+        *write_claude_vintage_live_proof_pair(root),
         _write_json(
             manual / "attachment-metadata.json",
             {

--- a/tests/unit/infra/test_claude_vintage_live_proof.py
+++ b/tests/unit/infra/test_claude_vintage_live_proof.py
@@ -1,0 +1,101 @@
+"""Production-route proof for the sanitized Claude export-vintage cohort."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from polylogue.archive.session_revision_membership import MembershipRevision, classify_membership_revisions
+from polylogue.maintenance.pathology_zoo import PATHOLOGY_ZOO_MANIFEST
+from polylogue.pipeline import ids
+from polylogue.pipeline.ids import session_revision_projection
+from polylogue.sources.parsers.base import ParsedMessage
+from polylogue.sources.parsers.claude.ai_parser import parse_ai
+from tests.infra.archive_canonical_snapshot import capture_canonical_snapshot
+from tests.infra.claude_vintage_live_proof import (
+    CONFIDENCE_GAP,
+    run_claude_vintage_live_proof,
+)
+from tests.infra.pathology_zoo import (
+    CLAUDE_VINTAGE_LIVE_PROOF_SESSION_ID,
+    _claude_vintage_live_proof_payload,
+)
+
+
+def test_sanitized_pair_runs_the_real_route_and_emits_read_only_receipt(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    receipt = run_claude_vintage_live_proof(tmp_path / "archive")
+
+    assert receipt.live_export_recovered is False
+    assert receipt.confidence_gap == CONFIDENCE_GAP
+    assert receipt.verdict == "equivalent"
+    assert receipt.canonical_identity == f"claude-ai-export:{CLAUDE_VINTAGE_LIVE_PROOF_SESSION_ID}"
+    assert receipt.canonical_content_hash and len(receipt.canonical_content_hash) == 64
+    assert dict(receipt.parser_branch)["old_parsed_block_count"] == 0
+    assert dict(receipt.parser_branch)["new_parsed_block_count"] == 1
+    assert dict(receipt.parser_branch)["projection_hash_equal"] is True
+    assert dict(receipt.classifier_probe) == {
+        "accepted_raw_ids": ("fixture-new",),
+        "equivalent_raw_ids": ("fixture-old",),
+        "ambiguous_raw_ids": (),
+    }
+    assert dict(receipt.route_counts) == {
+        "ingest_sessions": 1,
+        "ingest_messages": 3,
+        "backfill_scanned": 2,
+        "backfill_classified_full": 2,
+        "backfill_replayed_logical_sources": 1,
+        "backfill_quarantined": 0,
+    }
+    assert receipt.convergence_session_count == 1
+
+    rendered = receipt.as_json()
+    assert json.loads(rendered)["live_export_recovered"] is False
+    assert "raw_sessions" not in rendered
+    print(rendered)
+    assert json.loads(capsys.readouterr().out)["verdict"] == "equivalent"
+
+    snapshot = capture_canonical_snapshot(
+        tmp_path / "archive",
+        session_ids=(receipt.canonical_identity,),
+    )
+    sessions = next(relation for relation in snapshot.canonical_rows if relation.relation == "sessions")
+    assert sessions.rows
+    assert any(key == f"summary:{receipt.canonical_identity}" for key, _value in snapshot.public_projections)
+
+
+def test_red_mutation_restores_the_vintage_conflict_verdict(monkeypatch: pytest.MonkeyPatch) -> None:
+    old_session = parse_ai(_claude_vintage_live_proof_payload(nested_target=False), "old-fallback")
+    new_session = parse_ai(_claude_vintage_live_proof_payload(nested_target=True), "new-fallback")
+    current_message_hash_payload = ids._message_hash_payload
+
+    def legacy_message_hash_payload(message: ParsedMessage, message_id: str) -> dict[str, object]:
+        payload: dict[str, object] = dict(current_message_hash_payload(message, message_id))
+        if message.blocks:
+            payload["content_blocks"] = [ids._content_block_payload(block) for block in message.blocks]
+        return payload
+
+    monkeypatch.setattr(ids, "_message_hash_payload", legacy_message_hash_payload)
+    old_projection = session_revision_projection(old_session)
+    new_projection = session_revision_projection(new_session)
+    assert old_projection.session_hash != new_projection.session_hash
+
+    result = classify_membership_revisions(
+        [
+            MembershipRevision("fixture-old", old_projection),
+            MembershipRevision("fixture-new", new_projection),
+        ]
+    )
+    assert result.accepted_raw_ids == ("fixture-old",)
+    assert result.equivalent_raw_ids == ()
+    assert result.ambiguous_raw_ids == ("fixture-new",)
+
+
+def test_registry_records_the_unrecovered_live_evidence_gap() -> None:
+    member = next(item for item in PATHOLOGY_ZOO_MANIFEST if item.member_id == "claude-vintage-live-proof")
+    assert member.session_ids == (f"claude-ai-export:{CLAUDE_VINTAGE_LIVE_PROOF_SESSION_ID}",)
+    assert member.evidence_note is not None
+    assert "not recoverable" in member.evidence_note

--- a/tests/unit/infra/test_pathology_zoo.py
+++ b/tests/unit/infra/test_pathology_zoo.py
@@ -34,6 +34,7 @@ def test_pathology_zoo_manifest_covers_every_v0_dimension(pathology_zoo: Patholo
         "claude-design-session-origin",
         "export-vintage-reorder",
         "content-blocks-vintage",
+        "claude-vintage-live-proof",
         "lifecycle-anchor-drift",
         "non-stream-safe-origin",
         "attachment-with-acquired-bytes",

--- a/tests/unit/infra/test_pathology_zoo.py
+++ b/tests/unit/infra/test_pathology_zoo.py
@@ -11,6 +11,7 @@ import pytest
 from polylogue.maintenance.pathology_zoo import PATHOLOGY_ZOO_MANIFEST, PathologyZooCanaryEligibility
 from polylogue.maintenance.reindex_canary import CanarySelectionError, select_canary_sessions
 from tests.infra.pathology_zoo import (
+    CLAUDE_VINTAGE_LIVE_PROOF_SESSION_ID,
     PathologyZoo,
     build_pathology_zoo,
 )
@@ -33,7 +34,6 @@ def test_pathology_zoo_manifest_covers_every_v0_dimension(pathology_zoo: Patholo
         "hook-event-raw",
         "claude-design-session-origin",
         "export-vintage-reorder",
-        "content-blocks-vintage",
         "claude-vintage-live-proof",
         "lifecycle-anchor-drift",
         "non-stream-safe-origin",
@@ -51,8 +51,8 @@ def test_pathology_zoo_members_are_queryable_after_real_ingest(pathology_zoo: Pa
     with sqlite3.connect(pathology_zoo.archive_root / "index.db") as conn:
         session_ids = {str(row[0]) for row in conn.execute("SELECT session_id FROM sessions")}
     assert {session_id for member in pathology_zoo.manifest for session_id in member.session_ids} <= session_ids
-    assert pathology_zoo.members_for("content-blocks-vintage")[0].motivating_beads == (
-        "polylogue-yazae",
+    assert pathology_zoo.members_for("claude-vintage-live-proof")[0].motivating_beads == (
+        "polylogue-claude-vintage-live-proof",
         "polylogue-0qfy",
     )
 
@@ -86,10 +86,11 @@ def test_pathology_zoo_canary_eligibility_is_explicit(pathology_zoo: PathologyZo
 
 
 def test_zoo_preserves_the_named_vintage_and_lifecycle_red_cases(pathology_zoo: PathologyZoo) -> None:
-    """The three K-class entries remain production-ingested, not parser-only samples."""
+    """The named K-class entries remain production-ingested, not parser-only samples."""
     with sqlite3.connect(pathology_zoo.archive_root / "index.db") as conn:
         content_blocks = conn.execute(
-            "SELECT COUNT(*) FROM blocks WHERE session_id = ?", ("claude-ai-export:zoo-content-blocks-vintage",)
+            "SELECT COUNT(*) FROM blocks WHERE session_id = ?",
+            (f"claude-ai-export:{CLAUDE_VINTAGE_LIVE_PROOF_SESSION_ID}",),
         ).fetchone()
         lifecycle = conn.execute(
             "SELECT source_message_provider_id FROM session_events WHERE session_id = ? AND event_type = 'generation_lifecycle'",
@@ -97,7 +98,8 @@ def test_zoo_preserves_the_named_vintage_and_lifecycle_red_cases(pathology_zoo: 
         ).fetchall()
     with sqlite3.connect(pathology_zoo.archive_root / "source.db") as conn:
         vintage_raws = conn.execute(
-            "SELECT COUNT(*) FROM raw_sessions WHERE source_path LIKE ?", ("%vintage-%.json",)
+            "SELECT COUNT(*) FROM raw_sessions WHERE origin = ? AND native_id = ?",
+            ("chatgpt-export", "zoo-vintage-reorder"),
         ).fetchone()
     assert content_blocks == (1,)
     assert lifecycle == [("lifecycle-b",)]


### PR DESCRIPTION
## Summary

Add a private-data-free Claude export-vintage proof that exercises the real parser, membership replay, canonical identity, and convergence route. The receipt explicitly records that the exact live cohort was unavailable.

## Problem

The prior vintage-normalization implementation had a measured shape but no durable production-route evidence. A generic fixture alone would overclaim live cohort coverage, so this slice records the confidence boundary in the receipt and keeps the acceptance bead partial.

## Solution

Add a sanitized old-flat/new-nested Claude pair to the pathology registry, run both revisions through archive ingest and historical membership replay, verify one canonical identity and equivalent content hash, and emit a deterministic receipt. Add a red mutation that restores the vintage conflict verdict when the normalized hash behavior is removed. The fixture is routed through production parser and convergence seams rather than inserting rows directly.

## Verification

`direnv exec /realm/worktrees/polylogue-claude-vintage-live-proof devtools test tests/unit/infra/test_claude_vintage_live_proof.py` passed: 3 passed. The focused repair selection passed before the registered invariant was tightened. The pre-push quick verification passed all 24 steps at `6339b90f49b52bf87fa1d54a0d7e2c8b82d63ca1`. The broader pathology-zoo selection remains blocked by the pre-existing unsupported Antigravity synthetic route; that failure is recorded rather than hidden.

## Follow-ups

The exact measured live export bytes and cohort member ids were unavailable outside the protected archive. The receipt therefore sets `live_export_recovered=false` and does not claim live prevalence or exact cohort membership. The remaining live-operation proof is carried by `polylogue-live-operation-receipts`.

Ref polylogue-claude-vintage-live-proof

<!-- polylogue-pr-scope:v1
{
  "assigned_beads": [
    "polylogue-claude-vintage-live-proof"
  ],
  "beads_digest": "673df962b122cf20aead62072929da3b3cacc31d14fab15e83c450e9e88f6b63",
  "dispositions": [
    {
      "bead_id": "polylogue-claude-vintage-live-proof",
      "disposition": "partial",
      "evidence": [
        {
          "kind": "commit",
          "ref": "080d8b4086b94d304c4cc76dc2460c2ba2f0dffe"
        },
        {
          "kind": "test",
          "ref": "tests/unit/infra/test_claude_vintage_live_proof.py::test_sanitized_pair_runs_the_real_route_and_emits_read_only_receipt"
        },
        {
          "kind": "receipt",
          "ref": "live_export_recovered=false; exact measured cohort unavailable"
        }
      ],
      "successors": [
        "polylogue-live-operation-receipts"
      ]
    }
  ],
  "head_sha": "080d8b4086b94d304c4cc76dc2460c2ba2f0dffe",
  "scope_digest": "251802f39100bbc45a7c85bc6d90b3fd871898460af272a6949884fa09f2d739",
  "version": 1
}
-->
