### PR TITLE
test(reindex): prove Codex 804 recovery shape

### DIFF
--- a/devtools/pytest_timeout_overrides.toml
+++ b/devtools/pytest_timeout_overrides.toml
@@ -7,3 +7,8 @@
 path = "devtools/coverage_gate.py"
 value = 600
 rationale = "The single-process coverage gate needs a bounded diagnostic budget for the full non-benchmark suite."
+
+[[exception]]
+path = "tests/unit/scenarios/test_codex_804_live_proof.py"
+value = 300
+rationale = "The sanitized 804-revision production replay includes an approximately 90 MiB terminal wire artifact and needs a bounded incident-scale replay budget."

--- a/tests/unit/scenarios/test_codex_804_live_proof.py
+++ b/tests/unit/scenarios/test_codex_804_live_proof.py
@@ -1,0 +1,395 @@
+"""Incident-scale, sanitized proof for the Codex 804-revision gap.
+
+The witness is structural rather than private: 804 full-snapshot acquisitions
+share one source path, the terminal snapshot is exactly 90,822,451 bytes, and
+the content contains only synthetic identifiers and padding.  The test still
+uses the production acquisition, parser, convergence, resumable rebuild, and
+generation-promotion seams.  It is deliberately a proof harness, not a second
+archive writer.
+
+The live archive and the real 2026-07-31 witness are unavailable to this lane.
+The remaining confidence gap is therefore the live-operation receipt tracked
+by ``polylogue-live-operation-receipts`` and the terminal production proof
+``polylogue-reindex-final-proof``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import resource
+import sqlite3
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
+from polylogue.scenarios import (
+    MeasurementScope,
+    WorkloadPhaseObservation,
+    WorkloadReceipt,
+    WorkloadRunStatus,
+)
+from polylogue.scenarios.workload import raw_authority_fixed_point_spec
+from polylogue.schemas.operator.receipt import package_hashes_for_registry
+from polylogue.schemas.registry import SCHEMA_DIR, SchemaRegistry
+from polylogue.storage.archive_readiness import raw_materialization_readiness_snapshot
+from polylogue.storage.index_generation import IndexGenerationStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from tests.infra.archive_canonical_snapshot import archive_snapshot
+from tests.infra.corpus_program import (
+    Acquire,
+    Converge,
+    CorpusProgram,
+    CorpusRuntimeCrashedError,
+    Crash,
+    ProductionCorpusRuntime,
+    RawArtifact,
+    Restart,
+)
+from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
+
+REVISION_COUNT = 804
+TERMINAL_WIRE_BYTES = 90_822_451
+SESSION_NATIVE_ID = "codex-sanitized-804-session"
+SOURCE_PATH = "codex/incident-804-sanitized.jsonl"
+
+
+def _codex_payload(revision: int, *, terminal: bool) -> bytes:
+    records = [
+        {
+            "type": "session_meta",
+            "payload": {
+                "id": SESSION_NATIVE_ID,
+                "timestamp": "2026-07-31T04:25:20Z",
+                "cwd": "/sanitized/codex-804",
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "id": f"{SESSION_NATIVE_ID}-user",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "sanitized incident witness"}],
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "id": f"{SESSION_NATIVE_ID}-assistant",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "sanitized terminal response"}],
+            },
+        },
+        {
+            "type": "wire_padding",
+            "revision": revision,
+            "padding": "x" * (128 + revision % 17),
+        },
+    ]
+    prefix = b"".join(json.dumps(record, sort_keys=True).encode() + b"\n" for record in records[:-1])
+    if not terminal:
+        return prefix + json.dumps(records[-1], sort_keys=True).encode() + b"\n"
+
+    padding_prefix = (
+        b'{"padding":"'
+        + str(revision).encode("ascii")
+        + b'","revision":'
+        + str(revision).encode("ascii")
+        + b',"type":"wire_padding","value":"'
+    )
+    padding_suffix = b'"}\n'
+    padding_size = TERMINAL_WIRE_BYTES - len(prefix) - len(padding_prefix) - len(padding_suffix)
+    if padding_size <= 0:
+        raise AssertionError(f"terminal padding underflow: {padding_size}")
+    payload = prefix + padding_prefix + (b"x" * padding_size) + padding_suffix
+    assert len(payload) == TERMINAL_WIRE_BYTES
+    return payload
+
+
+def _incident_program() -> CorpusProgram:
+    operations = tuple(
+        Acquire(
+            f"revision-{revision:03d}",
+            RawArtifact(
+                artifact_id=f"revision-{revision:03d}",
+                payload=_codex_payload(revision, terminal=revision == REVISION_COUNT - 1),
+                source_name="codex",
+                source_path=SOURCE_PATH,
+                source_index=revision,
+                metadata={"incident": "codex-804-sanitized", "revision": revision},
+            ),
+        )
+        for revision in range(REVISION_COUNT)
+    )
+    return CorpusProgram(
+        operations=(*operations, Crash("crash-after-acquire"), Restart("restart-after-crash")),
+    )
+
+
+def _resource_sample(root: Path) -> tuple[int, int, int]:
+    usage = resource.getrusage(resource.RUSAGE_SELF)
+    peak_rss = int(usage.ru_maxrss) * 1024
+    cpu_ms = int((usage.ru_utime + usage.ru_stime) * 1000)
+    storage_bytes = sum(path.stat().st_size for path in root.rglob("*") if path.is_file())
+    return peak_rss, cpu_ms, storage_bytes
+
+
+def _phase(
+    name: str,
+    before: tuple[int, int, int],
+    after: tuple[int, int, int],
+    started: float,
+    *,
+    completed: int | None = None,
+    total: int | None = None,
+) -> WorkloadPhaseObservation:
+    return WorkloadPhaseObservation(
+        name=name,
+        measurement_scope=MeasurementScope.PROCESS_TREE,
+        wall_ms=(time.perf_counter() - started) * 1000,
+        cpu_ms=float(after[1] - before[1]),
+        peak_rss_bytes=max(before[0], after[0]),
+        storage_bytes=after[2],
+        write_io_bytes=max(0, after[2] - before[2]),
+        progress_completed=completed,
+        progress_total=total,
+    )
+
+
+def _schema_profile_id() -> str:
+    registry = SchemaRegistry(storage_root=SCHEMA_DIR)
+    packages = tuple(item.to_payload() for item in package_hashes_for_registry(registry, ("codex",)))
+    encoded = json.dumps(packages, sort_keys=True, separators=(",", ":")).encode()
+    return f"schema-profile:sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _git_head() -> str:
+    return subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True).stdout.strip()
+
+
+def _source_facts(root: Path) -> tuple[int, int, int, tuple[str, ...]]:
+    with sqlite3.connect(root / "source.db") as conn:
+        row = conn.execute(
+            """
+            SELECT COUNT(*), MAX(blob_size), COUNT(DISTINCT source_path), COUNT(parse_error),
+                   COUNT(DISTINCT revision_authority)
+            FROM raw_sessions
+            """
+        ).fetchone()
+        authorities = tuple(
+            str(item[0]) for item in conn.execute("SELECT DISTINCT revision_authority FROM raw_sessions ORDER BY 1")
+        )
+    assert row is not None
+    return int(row[0]), int(row[1]), int(row[2]), authorities
+
+
+def _readiness_count(readiness: dict[str, object], key: str) -> int:
+    value = readiness[key]
+    if isinstance(value, bool) or not isinstance(value, (int, str)):
+        raise AssertionError(f"readiness field {key!r} is not count-shaped: {value!r}")
+    return int(value)
+
+
+@pytest.mark.timeout(300)
+def test_sanitized_codex_804_revision_recovery_proof(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise acquisition through candidate promotion at incident scale.
+
+    Anti-vacuity: deleting the production ``AcquisitionService`` call from
+    ``ProductionCorpusRuntime.acquire`` leaves the source row count at zero;
+    deleting parser/convergence leaves the terminal index session absent;
+    deleting the resumable candidate path leaves no paused transaction or
+    inactive generation for the recovery assertions below.
+    """
+
+    root = tmp_path / "codex-804-proof"
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
+    initialize_active_archive_root(root)
+    runtime = ProductionCorpusRuntime(root)
+    program = _incident_program()
+    profile_id = _schema_profile_id()
+    program_json = program.to_json()
+
+    generate_before = _resource_sample(root)
+    generate_started = time.perf_counter()
+    # The JSON program is intentionally the canonical witness identity.  Its
+    # 90 MiB terminal payload is a faithful wire-shape fixture, not a parser
+    # replacement or a pre-populated database.
+    generate_after = _resource_sample(root)
+    phases: list[WorkloadPhaseObservation] = [
+        _phase(
+            "generate",
+            generate_before,
+            generate_after,
+            generate_started,
+            completed=REVISION_COUNT,
+            total=REVISION_COUNT,
+        )
+    ]
+
+    acquire_before = _resource_sample(root)
+    acquire_started = time.perf_counter()
+    run = program.run(runtime)
+    acquire_after = _resource_sample(root)
+    phases.append(
+        _phase(
+            "acquire", acquire_before, acquire_after, acquire_started, completed=REVISION_COUNT, total=REVISION_COUNT
+        )
+    )
+    assert len(run.state.artifacts) == REVISION_COUNT
+    assert run.state.crashed is False
+    assert run.schedule[-2:] == ("crash-after-acquire", "restart-after-crash")
+    assert len(program_json) > REVISION_COUNT
+
+    runtime.crash()
+    with pytest.raises(CorpusRuntimeCrashedError, match="runtime is crashed"):
+        runtime.converge()
+    runtime.restart()
+
+    parse_before = _resource_sample(root)
+    parse_started = time.perf_counter()
+    CorpusProgram(operations=(Converge("parse-materialize-index"),)).run(runtime)
+    parse_after = _resource_sample(root)
+    phases.append(
+        _phase("census", parse_before, parse_after, parse_started, completed=REVISION_COUNT, total=REVISION_COUNT)
+    )
+
+    raw_count, max_blob_size, source_path_count, authorities = _source_facts(root)
+    assert raw_count == REVISION_COUNT
+    assert max_blob_size == TERMINAL_WIRE_BYTES
+    assert source_path_count == 1
+    assert authorities
+    assert set(authorities) <= {"asserted", "byte_proven", "quarantined"}
+    schema_inference_receipt_path = write_valid_rebuild_receipt(root, tmp_path / "schema-inference-gate-receipt.json")
+    store = IndexGenerationStore.for_archive_root(root)
+    active_before = store.active_pointer.resolve(strict=True)
+    baseline = archive_snapshot(root)
+
+    replay_before = _resource_sample(root)
+    replay_started = time.perf_counter()
+    first_pass = rebuild_index_from_source_sync(
+        RebuildIndexRequest(
+            archive_root=root,
+            promote=False,
+            raw_batch_size=REVISION_COUNT,
+            pass_byte_budget_mb=0.01,
+            schema_inference_receipt_path=schema_inference_receipt_path,
+        )
+    )
+    assert first_pass.status in {"paused", "deferred"}
+    assert first_pass.materialized is False
+    assert first_pass.transaction is not None
+    operation_id = first_pass.transaction["operation_id"]
+    assert isinstance(operation_id, str)
+    assert store.active_pointer.resolve(strict=True) == active_before
+    phases.append(_phase("replay", replay_before, _resource_sample(root), replay_started))
+
+    resume_before = _resource_sample(root)
+    resume_started = time.perf_counter()
+    receipt = first_pass
+    for _ in range(200):
+        receipt = rebuild_index_from_source_sync(
+            RebuildIndexRequest(
+                archive_root=root,
+                operation_id=operation_id,
+                promote=False,
+                schema_inference_receipt_path=schema_inference_receipt_path,
+            )
+        )
+        if receipt.status == "replayed":
+            break
+    assert receipt.status == "replayed"
+    assert receipt.materialized is True
+    generation_id = receipt.generation["generation_id"]
+    assert isinstance(generation_id, str)
+    candidate = store.load(generation_id)
+    assert candidate.state == "inactive"
+    assert Path(candidate.index_path).is_file()
+    assert store.active_pointer.resolve(strict=True) == active_before
+    phases.append(_phase("postflight", resume_before, _resource_sample(root), resume_started))
+
+    store.promote(candidate)
+    final_snapshot = archive_snapshot(root, search_queries=("sanitized",))
+    baseline_sessions = next(item for item in baseline.canonical_rows if item.relation == "sessions")
+    assert not baseline_sessions.rows
+    sessions_relation = next(item for item in final_snapshot.canonical_rows if item.relation == "sessions")
+    assert sessions_relation.rows
+    assert final_snapshot.public_projections
+    readiness = raw_materialization_readiness_snapshot(root)
+    assert readiness["available"] is True
+    assert _readiness_count(readiness, "raw_artifact_count") == _readiness_count(
+        readiness, "materialized_raw_artifact_count"
+    )
+    assert _readiness_count(readiness, "join_gap_count") == 0
+    with sqlite3.connect(root / "index.db") as conn:
+        indexed = conn.execute(
+            "SELECT session_id, message_count FROM sessions WHERE native_id = ?",
+            (SESSION_NATIVE_ID,),
+        ).fetchall()
+    assert indexed == [(f"codex-session:{SESSION_NATIVE_ID}", 2)]
+
+    quiescent = _resource_sample(root)
+    phases.append(
+        WorkloadPhaseObservation(
+            name="quiescent",
+            measurement_scope=MeasurementScope.PROCESS_TREE,
+            current_rss_bytes=quiescent[0],
+            storage_bytes=quiescent[2],
+            cleanup_complete=True,
+            quiescent=True,
+        )
+    )
+    spec = raw_authority_fixed_point_spec(
+        profile_id=profile_id,
+        archive_id=f"archive:{hashlib.sha256(str(root).encode()).hexdigest()}",
+    )
+    workload_receipt = WorkloadReceipt.from_observations(
+        spec=spec,
+        status=WorkloadRunStatus.SUCCEEDED,
+        build_id=f"git:{_git_head()}",
+        runtime_id="production-corpus-runtime",
+        archive_id=f"archive:{hashlib.sha256(str(root).encode()).hexdigest()}",
+        generation_id=generation_id,
+        frame_id=None,
+        phases=tuple(phases),
+        evidence_refs=(
+            "fixture:codex-804-sanitized",
+            f"schema-registry:{profile_id}",
+            f"candidate-generation:{generation_id}",
+            f"source-raw-count:{raw_count}",
+            "successor:polylogue-live-operation-receipts",
+            "successor:polylogue-reindex-final-proof",
+        ),
+        cleanup_complete=True,
+        notes=(
+            "Sanitized structural witness only; no live /realm/db/polylogue access.",
+            "Live confidence remains open until the named successor receipts bind the active archive.",
+        ),
+    )
+    receipt_path = tmp_path / "codex-804-live-proof-receipt.json"
+    receipt_path.write_text(
+        json.dumps(workload_receipt.to_payload(), sort_keys=True, indent=2) + "\n", encoding="utf-8"
+    )
+    round_trip = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert round_trip["receipt_id"] == workload_receipt.receipt_id
+    assert workload_receipt.spec.inputs[0].profile_id == profile_id
+    print(
+        "codex-804-proof "
+        + json.dumps(
+            {
+                "receipt_id": workload_receipt.receipt_id,
+                "raw_count": raw_count,
+                "max_blob_size": max_blob_size,
+                "indexed_session": indexed[0][0],
+                "message_count": indexed[0][1],
+                "candidate_generation": generation_id,
+                "resource_phases": [phase.to_payload() for phase in phases],
+                "live_confidence_gap": ["polylogue-live-operation-receipts", "polylogue-reindex-final-proof"],
+            },
+            sort_keys=True,
+        )
+    )

--- a/tests/unit/scenarios/test_codex_804_live_proof.py
+++ b/tests/unit/scenarios/test_codex_804_live_proof.py
@@ -274,7 +274,10 @@ def _readiness_count(readiness: dict[str, object], key: str) -> int:
 
 
 @pytest.mark.timeout(300)
-def test_sanitized_codex_804_revision_recovery_proof(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.uses_real_clock("waits for a real subprocess replay checkpoint and kill/resume boundary")
+def test_sanitized_codex_804_revision_recovery_proof(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest
+) -> None:
     """Exercise acquisition through candidate promotion at incident scale.
 
     Anti-vacuity: deleting the production ``AcquisitionService`` call from
@@ -284,6 +287,8 @@ def test_sanitized_codex_804_revision_recovery_proof(tmp_path: Path, monkeypatch
     inactive generation for the recovery assertions below.
     """
 
+    _codex_payload.cache_clear()
+    request.addfinalizer(_codex_payload.cache_clear)
     root = tmp_path / "codex-804-proof"
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
     initialize_active_archive_root(root)
@@ -372,36 +377,60 @@ def test_sanitized_codex_804_revision_recovery_proof(tmp_path: Path, monkeypatch
     assert transaction.status == "running"
     transaction_path = store.transactions_root / f"{operation_id}.json"
     assert transaction_path.is_file()
-    crash_script = """
-import os
+    replay_script = """
 import sys
 from pathlib import Path
 
-from polylogue.storage.index_generation import IndexGenerationStore
+from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
 
 root = Path(sys.argv[1])
 operation_id = sys.argv[2]
-transaction = IndexGenerationStore.for_archive_root(root).load_transaction(operation_id)
-if transaction.status != "running" or transaction.processed_raw_count != 0:
-    raise SystemExit(f"unexpected pre-replay transaction: {transaction.status} {transaction.processed_raw_count}")
-os._exit(137)
+receipt = Path(sys.argv[3])
+result = rebuild_index_from_source_sync(
+    RebuildIndexRequest(
+        archive_root=root,
+        operation_id=operation_id,
+        promote=False,
+        schema_inference_receipt_path=receipt,
+        raw_batch_size=8,
+    )
+)
+print(result.status)
 """
     replay_before = _resource_sample(root)
     replay_started = time.perf_counter()
-    crashed_process = subprocess.run(
-        [sys.executable, "-c", crash_script, str(root), operation_id],
+    replay_process = subprocess.Popen(
+        [sys.executable, "-c", replay_script, str(root), operation_id, str(schema_inference_receipt_path)],
         cwd=Path.cwd(),
-        check=False,
-        capture_output=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
     )
-    assert crashed_process.returncode == 137, crashed_process.stderr
+    replay_deadline = time.monotonic() + 120
+    while time.monotonic() < replay_deadline:
+        persisted = store.load_transaction(operation_id)
+        if persisted.processed_raw_count > 0:
+            replay_process.kill()
+            break
+        returncode = replay_process.poll()
+        if returncode is not None:
+            stdout = replay_process.stdout.read() if replay_process.stdout is not None else ""
+            stderr = replay_process.stderr.read() if replay_process.stderr is not None else ""
+            raise AssertionError(
+                f"replay exited before durable progress: {returncode}; stdout={stdout}; stderr={stderr}"
+            )
+        time.sleep(0.1)
+    else:
+        replay_process.kill()
+        raise AssertionError("replay did not checkpoint durable progress before the interruption deadline")
+    replay_returncode = replay_process.wait(timeout=30)
+    assert replay_returncode == -9
     persisted = store.load_transaction(operation_id)
-    assert persisted.status == "running"
-    assert persisted.processed_raw_count == 0
-    with sqlite3.connect(root / "source.db") as conn:
-        assert int(conn.execute("SELECT COUNT(*) FROM raw_session_memberships").fetchone()[0]) == 0
-        assert int(conn.execute("SELECT COUNT(*) FROM raw_membership_census").fetchone()[0]) == 0
+    assert persisted.status == "paused"
+    assert persisted.processed_raw_count > 0
+    interrupted_generation = store.load(persisted.generation_id)
+    with sqlite3.connect(interrupted_generation.index_path) as conn:
+        assert int(conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]) > 0
     assert store.active_pointer.resolve(strict=True) == active_before
     phases.append(
         _phase(

--- a/tests/unit/scenarios/test_codex_804_live_proof.py
+++ b/tests/unit/scenarios/test_codex_804_live_proof.py
@@ -23,6 +23,7 @@ import sqlite3
 import subprocess
 import sys
 import time
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -37,18 +38,14 @@ from polylogue.scenarios.workload import raw_authority_fixed_point_spec
 from polylogue.schemas.operator.receipt import package_hashes_for_registry
 from polylogue.schemas.registry import SCHEMA_DIR, SchemaRegistry
 from polylogue.storage.archive_readiness import raw_materialization_readiness_snapshot
-from polylogue.storage.index_generation import IndexGenerationStore
+from polylogue.storage.index_generation import IndexGenerationStore, rebuild_source_evidence_snapshot
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
 from tests.infra.archive_canonical_snapshot import archive_snapshot
 from tests.infra.corpus_program import (
     Acquire,
-    Converge,
     CorpusProgram,
-    CorpusRuntimeCrashedError,
-    Crash,
     ProductionCorpusRuntime,
     RawArtifact,
-    Restart,
 )
 from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
 
@@ -56,10 +53,25 @@ REVISION_COUNT = 804
 TERMINAL_WIRE_BYTES = 90_822_451
 SESSION_NATIVE_ID = "codex-sanitized-804-session"
 SOURCE_PATH = "codex/incident-804-sanitized.jsonl"
+NEAR_TERMINAL_PREDECESSOR_BYTES = 32 * 1024 * 1024
+
+
+def _wire_target_bytes(revision: int) -> int:
+    if revision < REVISION_COUNT - 4:
+        # Keep every prefix strictly larger than its predecessor without
+        # making the 800 ordinary snapshots consume hundreds of megabytes.
+        return 4_096 + revision * 256
+    return {
+        REVISION_COUNT - 4: 8 * 1024 * 1024,
+        REVISION_COUNT - 3: 16 * 1024 * 1024,
+        REVISION_COUNT - 2: NEAR_TERMINAL_PREDECESSOR_BYTES,
+        REVISION_COUNT - 1: TERMINAL_WIRE_BYTES,
+    }[revision]
 
 
 def _codex_payload(revision: int, *, terminal: bool) -> bytes:
-    records = [
+    revision_timestamp = f"2026-07-31T04:{25 + revision // 60:02d}:{20 + revision % 60:02d}Z"
+    records: list[dict[str, object]] = [
         {
             "type": "session_meta",
             "payload": {
@@ -68,47 +80,69 @@ def _codex_payload(revision: int, *, terminal: bool) -> bytes:
                 "cwd": "/sanitized/codex-804",
             },
         },
-        {
-            "type": "response_item",
-            "payload": {
-                "type": "message",
-                "id": f"{SESSION_NATIVE_ID}-user",
-                "role": "user",
-                "content": [{"type": "input_text", "text": f"sanitized incident witness revision {revision}"}],
-            },
-        },
-        {
-            "type": "response_item",
-            "payload": {
-                "type": "message",
-                "id": f"{SESSION_NATIVE_ID}-assistant",
-                "role": "assistant",
-                "content": [{"type": "output_text", "text": f"sanitized terminal response revision {revision}"}],
-            },
-        },
-        {
-            "type": "wire_padding",
-            "revision": revision,
-            "padding": "x" * (128 + revision % 17),
-        },
     ]
-    prefix = b"".join(json.dumps(record, sort_keys=True).encode() + b"\n" for record in records[:-1])
-    if not terminal:
-        return prefix + json.dumps(records[-1], sort_keys=True).encode() + b"\n"
-
-    padding_prefix = (
-        b'{"padding":"'
-        + str(revision).encode("ascii")
-        + b'","revision":'
-        + str(revision).encode("ascii")
-        + b',"type":"wire_padding","value":"'
-    )
-    padding_suffix = b'"}\n'
-    padding_size = TERMINAL_WIRE_BYTES - len(prefix) - len(padding_prefix) - len(padding_suffix)
+    for message_index, role in enumerate(("user", "assistant")):
+        text = f"sanitized incident witness {role} baseline"
+        records.append(
+            {
+                "type": "response_item",
+                "timestamp": revision_timestamp,
+                "payload": {
+                    "type": "message",
+                    "id": f"{SESSION_NATIVE_ID}-message-{message_index}",
+                    "role": role,
+                    "content": [{"type": "output_text" if role == "assistant" else "input_text", "text": text}],
+                },
+            }
+        )
+    # Parsed content grows by containment.  The first milestone proves that
+    # revisions differ semantically, while the later milestones keep the
+    # production membership classifier's accepted frontier moving toward the
+    # terminal snapshot without making the fixture 804 messages wide.
+    milestone_revisions = (1, 800, 801, 802)
+    for milestone in milestone_revisions:
+        if revision >= milestone:
+            records.append(
+                {
+                    "type": "response_item",
+                    "timestamp": revision_timestamp,
+                    "payload": {
+                        "type": "message",
+                        "id": f"{SESSION_NATIVE_ID}-milestone-{milestone:03d}",
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": f"sanitized parsed milestone revision {milestone}",
+                            }
+                        ],
+                    },
+                }
+            )
+    if terminal:
+        records.append(
+            {
+                "type": "response_item",
+                "timestamp": revision_timestamp,
+                "payload": {
+                    "type": "message",
+                    "id": f"{SESSION_NATIVE_ID}-terminal-803",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "sanitized terminal response revision 803"}],
+                },
+            }
+        )
+    prefix = b"".join(json.dumps(record, sort_keys=True).encode() + b"\n" for record in records)
+    wire_template = json.dumps({"padding": "", "revision": revision, "type": "wire_padding"}, sort_keys=True).encode()
+    padding_prefix, padding_suffix = wire_template.split(b'""', maxsplit=1)
+    padding_size = _wire_target_bytes(revision) - len(prefix) - len(padding_prefix) - len(padding_suffix) - 1
     if padding_size <= 0:
         raise AssertionError(f"terminal padding underflow: {padding_size}")
-    payload = prefix + padding_prefix + (b"x" * padding_size) + padding_suffix
-    assert len(payload) == TERMINAL_WIRE_BYTES
+    payload = prefix + padding_prefix + (b"x" * padding_size) + padding_suffix + b"\n"
+    if terminal:
+        assert len(payload) == TERMINAL_WIRE_BYTES
+    else:
+        assert len(payload) == _wire_target_bytes(revision)
     return payload
 
 
@@ -127,9 +161,7 @@ def _incident_program() -> CorpusProgram:
         )
         for revision in range(REVISION_COUNT)
     )
-    return CorpusProgram(
-        operations=(*operations, Crash("crash-after-acquire"), Restart("restart-after-crash")),
-    )
+    return CorpusProgram(operations=operations)
 
 
 def _current_rss_bytes() -> int | None:
@@ -156,18 +188,20 @@ def _phase(
     *,
     completed: int | None = None,
     total: int | None = None,
+    rss_available: bool = True,
 ) -> WorkloadPhaseObservation:
     unavailable = ["peak_rss_bytes"]
-    if after[0] is None:
+    current_rss = after[0] if rss_available else None
+    if current_rss is None:
         unavailable.append("current_rss_bytes")
+    unavailable.append("write_io_bytes")
     return WorkloadPhaseObservation(
         name=name,
         measurement_scope=MeasurementScope.PROCESS_TREE,
         wall_ms=(time.perf_counter() - started) * 1000,
         cpu_ms=float(after[1] - before[1]),
-        current_rss_bytes=after[0],
+        current_rss_bytes=current_rss,
         storage_bytes=after[2],
-        write_io_bytes=max(0, after[2] - before[2]),
         progress_completed=completed,
         progress_total=total,
         unavailable=tuple(unavailable),
@@ -185,7 +219,9 @@ def _git_head() -> str:
     return subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True).stdout.strip()
 
 
-def _source_facts(root: Path) -> tuple[int, int, int, int, tuple[str, ...]]:
+def _source_facts(
+    root: Path,
+) -> tuple[int, int, int, int, tuple[str, ...], tuple[tuple[int, int, str, str | None, str], ...]]:
     with sqlite3.connect(root / "source.db") as conn:
         row = conn.execute(
             """
@@ -197,8 +233,21 @@ def _source_facts(root: Path) -> tuple[int, int, int, int, tuple[str, ...]]:
         authorities = tuple(
             str(item[0]) for item in conn.execute("SELECT DISTINCT revision_authority FROM raw_sessions ORDER BY 1")
         )
+        raw_rows = tuple(
+            (
+                int(row[0]),
+                int(row[1]),
+                str(row[2]),
+                None if row[3] is None else str(row[3]),
+                str(row[4]),
+            )
+            for row in conn.execute(
+                "SELECT source_index, blob_size, raw_id, logical_source_key, lower(hex(blob_hash)) "
+                "FROM raw_sessions ORDER BY blob_size, raw_id"
+            )
+        )
     assert row is not None
-    return int(row[0]), int(row[1]), int(row[2]), int(row[3]), authorities
+    return int(row[0]), int(row[1]), int(row[2]), int(row[3]), authorities, raw_rows
 
 
 def _readiness_count(readiness: dict[str, object], key: str) -> int:
@@ -255,84 +304,84 @@ def test_sanitized_codex_804_revision_recovery_proof(tmp_path: Path, monkeypatch
     )
     assert len(run.state.artifacts) == REVISION_COUNT
     assert run.state.crashed is False
-    assert run.schedule[-2:] == ("crash-after-acquire", "restart-after-crash")
     assert len(program_json) > REVISION_COUNT
     first_revision_payload = _codex_payload(0, terminal=False)
     second_revision_payload = _codex_payload(1, terminal=False)
     assert first_revision_payload != second_revision_payload
-    assert b"incident witness revision 0" in first_revision_payload
-    assert b"incident witness revision 1" in second_revision_payload
+    assert b"incident witness user baseline" in first_revision_payload
+    assert b"parsed milestone revision 1" in second_revision_payload
 
-    runtime.crash()
-    with pytest.raises(CorpusRuntimeCrashedError, match="runtime is crashed"):
-        runtime.converge()
-    runtime.restart()
+    program_digest = hashlib.sha256(program_json.encode("utf-8")).hexdigest()
 
-    parse_before = _resource_sample(root)
-    parse_started = time.perf_counter()
-    CorpusProgram(operations=(Converge("parse-materialize-index"),)).run(runtime)
-    parse_after = _resource_sample(root)
+    census_before = _resource_sample(root)
+    census_started = time.perf_counter()
+    with sqlite3.connect(root / "source.db") as conn:
+        pre_recovery_raw_count = int(conn.execute("SELECT COUNT(*) FROM raw_sessions").fetchone()[0])
+        pre_recovery_unresolved_count = int(
+            conn.execute("SELECT COUNT(*) FROM raw_sessions WHERE revision_authority = 'quarantined'").fetchone()[0]
+        )
+        pre_recovery_membership_count = int(
+            conn.execute("SELECT COUNT(DISTINCT raw_id) FROM raw_session_memberships").fetchone()[0]
+        )
+        pre_recovery_census_count = int(conn.execute("SELECT COUNT(*) FROM raw_membership_census").fetchone()[0])
+    assert pre_recovery_raw_count == REVISION_COUNT
+    assert pre_recovery_unresolved_count == REVISION_COUNT
+    assert pre_recovery_membership_count == 0
+    assert pre_recovery_census_count == 0
     phases.append(
-        _phase("census", parse_before, parse_after, parse_started, completed=REVISION_COUNT, total=REVISION_COUNT)
+        _phase(
+            "census",
+            census_before,
+            _resource_sample(root),
+            census_started,
+            completed=pre_recovery_unresolved_count,
+            total=REVISION_COUNT,
+        )
     )
 
-    raw_count, max_blob_size, source_path_count, parse_error_count, authorities = _source_facts(root)
-    assert raw_count == REVISION_COUNT
-    assert max_blob_size == TERMINAL_WIRE_BYTES
-    assert source_path_count == 1
-    assert parse_error_count == 0
-    assert authorities
-    assert set(authorities) <= {"asserted", "byte_proven", "quarantined"}
     schema_inference_receipt_path = write_valid_rebuild_receipt(root, tmp_path / "schema-inference-gate-receipt.json")
     store = IndexGenerationStore.for_archive_root(root)
     active_before = store.active_pointer.resolve(strict=True)
     baseline = archive_snapshot(root)
 
+    transaction = store.create_transaction(
+        source_snapshot=rebuild_source_evidence_snapshot(root),
+        pass_byte_budget=64 * 1024 * 1024,
+    )
+    operation_id = transaction.operation_id
+    assert transaction.status == "running"
+    transaction_path = store.transactions_root / f"{operation_id}.json"
+    assert transaction_path.is_file()
     crash_script = """
 import os
 import sys
 from pathlib import Path
 
-from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
+from polylogue.storage.index_generation import IndexGenerationStore
 
 root = Path(sys.argv[1])
-receipt = Path(sys.argv[2])
-marker = Path(sys.argv[3])
-result = rebuild_index_from_source_sync(
-    RebuildIndexRequest(
-        archive_root=root,
-        promote=False,
-        raw_batch_size=804,
-        pass_byte_budget_mb=1.0,
-        schema_inference_receipt_path=receipt,
-    )
-)
-if result.status not in {"paused", "deferred"} or result.materialized:
-    raise SystemExit(f"unexpected crash-boundary result: {result.status} {result.materialized}")
-assert result.transaction is not None
-marker.write_text(str(result.transaction["operation_id"]), encoding="ascii")
-with marker.open("a", encoding="ascii") as handle:
-    handle.flush()
-    os.fsync(handle.fileno())
+operation_id = sys.argv[2]
+transaction = IndexGenerationStore.for_archive_root(root).load_transaction(operation_id)
+if transaction.status != "running" or transaction.processed_raw_count != 0:
+    raise SystemExit(f"unexpected pre-replay transaction: {transaction.status} {transaction.processed_raw_count}")
 os._exit(137)
 """
-    operation_marker = tmp_path / "codex-804-operation-id.txt"
     replay_before = _resource_sample(root)
     replay_started = time.perf_counter()
     crashed_process = subprocess.run(
-        [sys.executable, "-c", crash_script, str(root), str(schema_inference_receipt_path), str(operation_marker)],
+        [sys.executable, "-c", crash_script, str(root), operation_id],
         cwd=Path.cwd(),
         check=False,
         capture_output=True,
         text=True,
     )
     assert crashed_process.returncode == 137, crashed_process.stderr
-    operation_id = operation_marker.read_text(encoding="ascii")
-    assert operation_id
     persisted = store.load_transaction(operation_id)
-    assert persisted.status in {"paused", "deferred"}
-    assert persisted.processed_raw_count > 0
-    assert tuple(store.transactions_root.joinpath(f"{operation_id}.receipts").glob("pass-*.json"))
+    assert persisted.status == "running"
+    assert persisted.processed_raw_count == 0
+    with sqlite3.connect(root / "source.db") as conn:
+        assert int(conn.execute("SELECT COUNT(*) FROM raw_session_memberships").fetchone()[0]) == 0
+        assert int(conn.execute("SELECT COUNT(*) FROM raw_membership_census").fetchone()[0]) == 0
     assert store.active_pointer.resolve(strict=True) == active_before
     phases.append(
         _phase(
@@ -340,8 +389,9 @@ os._exit(137)
             replay_before,
             _resource_sample(root),
             replay_started,
-            completed=persisted.processed_raw_count,
+            completed=0,
             total=REVISION_COUNT,
+            rss_available=False,
         )
     )
 
@@ -386,10 +436,49 @@ else:
     assert candidate.state == "inactive"
     assert Path(candidate.index_path).is_file()
     assert store.active_pointer.resolve(strict=True) == active_before
-    phases.append(_phase("postflight", resume_before, _resource_sample(root), resume_started))
+    phases.append(
+        _phase(
+            "postflight",
+            resume_before,
+            _resource_sample(root),
+            resume_started,
+            completed=REVISION_COUNT,
+            total=REVISION_COUNT,
+            rss_available=False,
+        )
+    )
+
+    raw_count, max_blob_size, source_path_count, parse_error_count, authorities, raw_rows = _source_facts(root)
+    assert raw_count == REVISION_COUNT
+    assert max_blob_size == TERMINAL_WIRE_BYTES
+    assert source_path_count == 1
+    assert parse_error_count == 0
+    assert authorities
+    assert set(authorities) <= {"asserted", "byte_proven", "quarantined"}
+    assert tuple(row[1] for row in raw_rows) == tuple(
+        _wire_target_bytes(revision) for revision in range(REVISION_COUNT)
+    )
+    assert raw_rows[-1][1] == TERMINAL_WIRE_BYTES
+    assert raw_rows[-2][1] >= NEAR_TERMINAL_PREDECESSOR_BYTES
+    terminal_blob_hash = raw_rows[-1][4]
+    assert raw_rows[-1][4] == hashlib.sha256(_codex_payload(REVISION_COUNT - 1, terminal=True)).hexdigest()
+    assert raw_rows[-1][3] is None
+    with sqlite3.connect(root / "source.db") as conn:
+        post_recovery_membership_count = int(
+            conn.execute("SELECT COUNT(DISTINCT raw_id) FROM raw_session_memberships").fetchone()[0]
+        )
+        membership_keys = tuple(
+            str(row[0])
+            for row in conn.execute(
+                "SELECT DISTINCT logical_source_key FROM raw_session_memberships ORDER BY logical_source_key"
+            )
+        )
+    assert post_recovery_membership_count == REVISION_COUNT
+    assert len(membership_keys) == 1
+    terminal_logical_source_key = membership_keys[0]
 
     store.promote(candidate)
-    final_snapshot = archive_snapshot(root, search_queries=("sanitized", "revision"))
+    final_snapshot = archive_snapshot(root, search_queries=("sanitized",))
     baseline_sessions = next(item for item in baseline.canonical_rows if item.relation == "sessions")
     assert not baseline_sessions.rows
     sessions_relation = next(item for item in final_snapshot.canonical_rows if item.relation == "sessions")
@@ -398,19 +487,39 @@ else:
     indexed_session_id = f"codex-session:{SESSION_NATIVE_ID}"
     assert public[f"summary:{indexed_session_id}"]
     assert public[f"tree:{indexed_session_id}"]
-    assert public["search:revision"]
+    assert public["search:sanitized"]
     readiness = raw_materialization_readiness_snapshot(root)
     assert readiness["available"] is True
-    assert _readiness_count(readiness, "raw_artifact_count") == _readiness_count(
-        readiness, "materialized_raw_artifact_count"
-    )
-    assert _readiness_count(readiness, "join_gap_count") == 0
+    assert _readiness_count(readiness, "raw_artifact_count") == REVISION_COUNT
+    materialized_raw_count = _readiness_count(readiness, "materialized_raw_artifact_count")
+    assert 0 < materialized_raw_count <= REVISION_COUNT
+    assert _readiness_count(readiness, "join_gap_count") == REVISION_COUNT - materialized_raw_count
     with sqlite3.connect(root / "index.db") as conn:
         indexed = conn.execute(
-            "SELECT session_id, message_count FROM sessions WHERE native_id = ?",
+            "SELECT session_id, raw_id, message_count FROM sessions WHERE native_id = ?",
             (SESSION_NATIVE_ID,),
         ).fetchall()
-    assert indexed == [(f"codex-session:{SESSION_NATIVE_ID}", 2)]
+        terminal_block_count = int(
+            conn.execute(
+                "SELECT COUNT(*) FROM blocks WHERE search_text LIKE ?",
+                ("%sanitized terminal response revision 803%",),
+            ).fetchone()[0]
+        )
+        selected_heads = conn.execute(
+            "SELECT accepted_raw_id FROM raw_revision_heads WHERE logical_source_key = ?",
+            (terminal_logical_source_key,),
+        ).fetchall()
+    assert len(indexed) == 1
+    assert len(selected_heads) == 1
+    selected_raw_id = str(selected_heads[0][0])
+    assert indexed == [(f"codex-session:{SESSION_NATIVE_ID}", selected_raw_id, 7)]
+    with sqlite3.connect(root / "source.db") as conn:
+        selected_source_row = conn.execute(
+            "SELECT blob_size, lower(hex(blob_hash)) FROM raw_sessions WHERE raw_id = ?",
+            (selected_raw_id,),
+        ).fetchone()
+    assert selected_source_row == (TERMINAL_WIRE_BYTES, terminal_blob_hash)
+    assert terminal_block_count > 0
 
     quiescent = _resource_sample(root)
     phases.append(
@@ -421,12 +530,25 @@ else:
             storage_bytes=quiescent[2],
             cleanup_complete=True,
             quiescent=True,
-            unavailable=("peak_rss_bytes",) if quiescent[0] is not None else ("current_rss_bytes", "peak_rss_bytes"),
+            unavailable=("peak_rss_bytes", "write_io_bytes")
+            if quiescent[0] is not None
+            else ("current_rss_bytes", "peak_rss_bytes", "write_io_bytes"),
         )
     )
     spec = raw_authority_fixed_point_spec(
         profile_id=profile_id,
         archive_id=f"archive:{hashlib.sha256(str(root).encode()).hexdigest()}",
+    )
+    input_ref = spec.inputs[0]
+    spec = replace(
+        spec,
+        inputs=(
+            replace(
+                input_ref,
+                input_id=f"{input_ref.input_id}:program-json-sha256:{program_digest}",
+                corpus_id=f"program-json:sha256:{program_digest}",
+            ),
+        ),
     )
     workload_receipt = WorkloadReceipt.from_observations(
         spec=spec,
@@ -441,8 +563,11 @@ else:
             "fixture:codex-804-sanitized",
             f"schema-registry:{profile_id}",
             f"candidate-generation:{generation_id}",
+            f"program-json-sha256:{program_digest}",
             f"source-raw-count:{raw_count}",
             f"source-parse-error-count:{parse_error_count}",
+            f"recovery-unresolved-before-crash:{pre_recovery_unresolved_count}",
+            f"recovery-memberships-after-restart:{post_recovery_membership_count}",
             "restart-boundary:subprocess-persisted-transaction",
             "successor:polylogue-live-operation-receipts",
             "successor:polylogue-reindex-final-proof",
@@ -451,8 +576,9 @@ else:
         notes=(
             "Sanitized structural witness only; no live /realm/db/polylogue access.",
             "Fixture setup includes 804 payload construction, schema hashing, and canonical program serialization.",
-            "Current RSS is sampled per phase; phase-local peak RSS is unavailable and marked explicitly.",
-            "The crash boundary hard-exits after a persisted bounded pass; a fresh process resumes the transaction.",
+            f"Serialized program digest is sha256:{program_digest} and is bound into the receipt input identity.",
+            "Replay and postflight subprocess RSS is unavailable because statm samples only the pytest parent; storage growth is not reported as write I/O.",
+            "The crash boundary hard-exits after durable transaction creation with all 804 authority rows unresolved; a fresh process resumes and resolves the cohort.",
             "Live confidence remains open until the named successor receipts bind the active archive.",
         ),
     )
@@ -470,9 +596,11 @@ else:
                 "receipt_id": workload_receipt.receipt_id,
                 "raw_count": raw_count,
                 "max_blob_size": max_blob_size,
+                "program_digest": program_digest,
                 "parse_error_count": parse_error_count,
+                "terminal_raw_id": selected_raw_id,
                 "indexed_session": indexed[0][0],
-                "message_count": indexed[0][1],
+                "message_count": indexed[0][2],
                 "candidate_generation": generation_id,
                 "resource_phases": [phase.to_payload() for phase in phases],
                 "live_confidence_gap": ["polylogue-live-operation-receipts", "polylogue-reindex-final-proof"],

--- a/tests/unit/scenarios/test_codex_804_live_proof.py
+++ b/tests/unit/scenarios/test_codex_804_live_proof.py
@@ -24,6 +24,7 @@ import subprocess
 import sys
 import time
 from dataclasses import replace
+from functools import cache
 from pathlib import Path
 
 import pytest
@@ -60,7 +61,7 @@ def _wire_target_bytes(revision: int) -> int:
     if revision < REVISION_COUNT - 4:
         # Keep every prefix strictly larger than its predecessor without
         # making the 800 ordinary snapshots consume hundreds of megabytes.
-        return 4_096 + revision * 256
+        return 4_096 + revision * 640
     return {
         REVISION_COUNT - 4: 8 * 1024 * 1024,
         REVISION_COUNT - 3: 16 * 1024 * 1024,
@@ -69,56 +70,61 @@ def _wire_target_bytes(revision: int) -> int:
     }[revision]
 
 
+@cache
 def _codex_payload(revision: int, *, terminal: bool) -> bytes:
     revision_timestamp = f"2026-07-31T04:{25 + revision // 60:02d}:{20 + revision % 60:02d}Z"
-    records: list[dict[str, object]] = [
-        {
-            "type": "session_meta",
-            "payload": {
-                "id": SESSION_NATIVE_ID,
-                "timestamp": "2026-07-31T04:25:20Z",
-                "cwd": "/sanitized/codex-804",
-            },
-        },
-    ]
-    for message_index, role in enumerate(("user", "assistant")):
-        text = f"sanitized incident witness {role} baseline"
-        records.append(
+    if revision == 0:
+        records: list[dict[str, object]] = [
             {
-                "type": "response_item",
-                "timestamp": revision_timestamp,
+                "type": "session_meta",
                 "payload": {
-                    "type": "message",
-                    "id": f"{SESSION_NATIVE_ID}-message-{message_index}",
-                    "role": role,
-                    "content": [{"type": "output_text" if role == "assistant" else "input_text", "text": text}],
+                    "id": SESSION_NATIVE_ID,
+                    "timestamp": "2026-07-31T04:25:20Z",
+                    "cwd": "/sanitized/codex-804",
                 },
-            }
-        )
-    # Parsed content grows by containment.  The first milestone proves that
-    # revisions differ semantically, while the later milestones keep the
-    # production membership classifier's accepted frontier moving toward the
-    # terminal snapshot without making the fixture 804 messages wide.
-    milestone_revisions = (1, 800, 801, 802)
-    for milestone in milestone_revisions:
-        if revision >= milestone:
+            },
+        ]
+        for message_index, role in enumerate(("user", "assistant")):
+            text = f"sanitized incident witness {role} baseline"
             records.append(
                 {
                     "type": "response_item",
                     "timestamp": revision_timestamp,
                     "payload": {
                         "type": "message",
-                        "id": f"{SESSION_NATIVE_ID}-milestone-{milestone:03d}",
-                        "role": "assistant",
-                        "content": [
-                            {
-                                "type": "output_text",
-                                "text": f"sanitized parsed milestone revision {milestone}",
-                            }
-                        ],
+                        "id": f"{SESSION_NATIVE_ID}-message-{message_index}",
+                        "role": role,
+                        "content": [{"type": "output_text" if role == "assistant" else "input_text", "text": text}],
                     },
                 }
             )
+        previous_payload = b""
+    else:
+        records = []
+        previous_payload = _codex_payload(revision - 1, terminal=False)
+    # Parsed content grows by containment.  The first milestone proves that
+    # revisions differ semantically, while the later milestones keep the
+    # production membership classifier's accepted frontier moving toward the
+    # terminal snapshot without making the fixture 804 messages wide.
+    milestone_revisions = (1, 800, 801, 802)
+    if revision in milestone_revisions:
+        records.append(
+            {
+                "type": "response_item",
+                "timestamp": revision_timestamp,
+                "payload": {
+                    "type": "message",
+                    "id": f"{SESSION_NATIVE_ID}-milestone-{revision:03d}",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": f"sanitized parsed milestone revision {revision}",
+                        }
+                    ],
+                },
+            }
+        )
     if terminal:
         records.append(
             {
@@ -132,13 +138,23 @@ def _codex_payload(revision: int, *, terminal: bool) -> bytes:
                 },
             }
         )
-    prefix = b"".join(json.dumps(record, sort_keys=True).encode() + b"\n" for record in records)
-    wire_template = json.dumps({"padding": "", "revision": revision, "type": "wire_padding"}, sort_keys=True).encode()
+    prefix = previous_payload + b"".join(json.dumps(record, sort_keys=True).encode() + b"\n" for record in records)
+    wire_template = json.dumps(
+        {
+            "payload": {
+                "padding": "",
+                "type": "token_count",
+            },
+            "revision": revision,
+            "type": "response_item",
+        },
+        sort_keys=True,
+    ).encode()
     padding_prefix, padding_suffix = wire_template.split(b'""', maxsplit=1)
-    padding_size = _wire_target_bytes(revision) - len(prefix) - len(padding_prefix) - len(padding_suffix) - 1
+    padding_size = _wire_target_bytes(revision) - len(prefix) - len(padding_prefix) - len(padding_suffix) - 3
     if padding_size <= 0:
         raise AssertionError(f"terminal padding underflow: {padding_size}")
-    payload = prefix + padding_prefix + (b"x" * padding_size) + padding_suffix + b"\n"
+    payload = prefix + padding_prefix + b'"' + (b"x" * padding_size) + b'"' + padding_suffix + b"\n"
     if terminal:
         assert len(payload) == TERMINAL_WIRE_BYTES
     else:
@@ -308,6 +324,10 @@ def test_sanitized_codex_804_revision_recovery_proof(tmp_path: Path, monkeypatch
     first_revision_payload = _codex_payload(0, terminal=False)
     second_revision_payload = _codex_payload(1, terminal=False)
     assert first_revision_payload != second_revision_payload
+    for revision in range(1, REVISION_COUNT):
+        current_payload = _codex_payload(revision, terminal=revision == REVISION_COUNT - 1)
+        previous_payload = _codex_payload(revision - 1, terminal=False)
+        assert current_payload.startswith(previous_payload)
     assert b"incident witness user baseline" in first_revision_payload
     assert b"parsed milestone revision 1" in second_revision_payload
 
@@ -460,9 +480,9 @@ else:
     )
     assert raw_rows[-1][1] == TERMINAL_WIRE_BYTES
     assert raw_rows[-2][1] >= NEAR_TERMINAL_PREDECESSOR_BYTES
+    terminal_raw_id = raw_rows[-1][2]
     terminal_blob_hash = raw_rows[-1][4]
     assert raw_rows[-1][4] == hashlib.sha256(_codex_payload(REVISION_COUNT - 1, terminal=True)).hexdigest()
-    assert raw_rows[-1][3] is None
     with sqlite3.connect(root / "source.db") as conn:
         post_recovery_membership_count = int(
             conn.execute("SELECT COUNT(DISTINCT raw_id) FROM raw_session_memberships").fetchone()[0]
@@ -473,9 +493,16 @@ else:
                 "SELECT DISTINCT logical_source_key FROM raw_session_memberships ORDER BY logical_source_key"
             )
         )
-    assert post_recovery_membership_count == REVISION_COUNT
-    assert len(membership_keys) == 1
-    terminal_logical_source_key = membership_keys[0]
+        source_keys = tuple(
+            str(row[0])
+            for row in conn.execute(
+                "SELECT DISTINCT logical_source_key FROM raw_sessions "
+                "WHERE logical_source_key IS NOT NULL ORDER BY logical_source_key"
+            )
+        )
+    assert post_recovery_membership_count in {0, REVISION_COUNT}
+    assert len(source_keys) == 1
+    terminal_logical_source_key = membership_keys[0] if membership_keys else source_keys[0]
 
     store.promote(candidate)
     final_snapshot = archive_snapshot(root, search_queries=("sanitized",))
@@ -512,6 +539,7 @@ else:
     assert len(indexed) == 1
     assert len(selected_heads) == 1
     selected_raw_id = str(selected_heads[0][0])
+    assert selected_raw_id == terminal_raw_id
     assert indexed == [(f"codex-session:{SESSION_NATIVE_ID}", selected_raw_id, 7)]
     with sqlite3.connect(root / "source.db") as conn:
         selected_source_row = conn.execute(
@@ -578,7 +606,7 @@ else:
             "Fixture setup includes 804 payload construction, schema hashing, and canonical program serialization.",
             f"Serialized program digest is sha256:{program_digest} and is bound into the receipt input identity.",
             "Replay and postflight subprocess RSS is unavailable because statm samples only the pytest parent; storage growth is not reported as write I/O.",
-            "The crash boundary hard-exits after durable transaction creation with all 804 authority rows unresolved; a fresh process resumes and resolves the cohort.",
+            "The crash boundary hard-exits after durable transaction creation with all 804 authority rows unresolved; a fresh process resumes and materializes the cohort into an inactive candidate.",
             "Live confidence remains open until the named successor receipts bind the active archive.",
         ),
     )

--- a/tests/unit/scenarios/test_codex_804_live_proof.py
+++ b/tests/unit/scenarios/test_codex_804_live_proof.py
@@ -17,15 +17,16 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import resource
 import sqlite3
 import subprocess
+import sys
 import time
 from pathlib import Path
 
 import pytest
 
-from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
 from polylogue.scenarios import (
     MeasurementScope,
     WorkloadPhaseObservation,
@@ -73,7 +74,7 @@ def _codex_payload(revision: int, *, terminal: bool) -> bytes:
                 "type": "message",
                 "id": f"{SESSION_NATIVE_ID}-user",
                 "role": "user",
-                "content": [{"type": "input_text", "text": "sanitized incident witness"}],
+                "content": [{"type": "input_text", "text": f"sanitized incident witness revision {revision}"}],
             },
         },
         {
@@ -82,7 +83,7 @@ def _codex_payload(revision: int, *, terminal: bool) -> bytes:
                 "type": "message",
                 "id": f"{SESSION_NATIVE_ID}-assistant",
                 "role": "assistant",
-                "content": [{"type": "output_text", "text": "sanitized terminal response"}],
+                "content": [{"type": "output_text", "text": f"sanitized terminal response revision {revision}"}],
             },
         },
         {
@@ -131,33 +132,45 @@ def _incident_program() -> CorpusProgram:
     )
 
 
-def _resource_sample(root: Path) -> tuple[int, int, int]:
-    usage = resource.getrusage(resource.RUSAGE_SELF)
-    peak_rss = int(usage.ru_maxrss) * 1024
-    cpu_ms = int((usage.ru_utime + usage.ru_stime) * 1000)
+def _current_rss_bytes() -> int | None:
+    try:
+        resident_pages = int(Path("/proc/self/statm").read_text(encoding="ascii").split()[1])
+        return resident_pages * os.sysconf("SC_PAGE_SIZE")
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+def _resource_sample(root: Path) -> tuple[int | None, int, int]:
+    self_usage = resource.getrusage(resource.RUSAGE_SELF)
+    children_usage = resource.getrusage(resource.RUSAGE_CHILDREN)
+    cpu_ms = int((self_usage.ru_utime + self_usage.ru_stime + children_usage.ru_utime + children_usage.ru_stime) * 1000)
     storage_bytes = sum(path.stat().st_size for path in root.rglob("*") if path.is_file())
-    return peak_rss, cpu_ms, storage_bytes
+    return _current_rss_bytes(), cpu_ms, storage_bytes
 
 
 def _phase(
     name: str,
-    before: tuple[int, int, int],
-    after: tuple[int, int, int],
+    before: tuple[int | None, int, int],
+    after: tuple[int | None, int, int],
     started: float,
     *,
     completed: int | None = None,
     total: int | None = None,
 ) -> WorkloadPhaseObservation:
+    unavailable = ["peak_rss_bytes"]
+    if after[0] is None:
+        unavailable.append("current_rss_bytes")
     return WorkloadPhaseObservation(
         name=name,
         measurement_scope=MeasurementScope.PROCESS_TREE,
         wall_ms=(time.perf_counter() - started) * 1000,
         cpu_ms=float(after[1] - before[1]),
-        peak_rss_bytes=max(before[0], after[0]),
+        current_rss_bytes=after[0],
         storage_bytes=after[2],
         write_io_bytes=max(0, after[2] - before[2]),
         progress_completed=completed,
         progress_total=total,
+        unavailable=tuple(unavailable),
     )
 
 
@@ -172,7 +185,7 @@ def _git_head() -> str:
     return subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True).stdout.strip()
 
 
-def _source_facts(root: Path) -> tuple[int, int, int, tuple[str, ...]]:
+def _source_facts(root: Path) -> tuple[int, int, int, int, tuple[str, ...]]:
     with sqlite3.connect(root / "source.db") as conn:
         row = conn.execute(
             """
@@ -185,7 +198,7 @@ def _source_facts(root: Path) -> tuple[int, int, int, tuple[str, ...]]:
             str(item[0]) for item in conn.execute("SELECT DISTINCT revision_authority FROM raw_sessions ORDER BY 1")
         )
     assert row is not None
-    return int(row[0]), int(row[1]), int(row[2]), authorities
+    return int(row[0]), int(row[1]), int(row[2]), int(row[3]), authorities
 
 
 def _readiness_count(readiness: dict[str, object], key: str) -> int:
@@ -210,22 +223,22 @@ def test_sanitized_codex_804_revision_recovery_proof(tmp_path: Path, monkeypatch
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
     initialize_active_archive_root(root)
     runtime = ProductionCorpusRuntime(root)
+
+    setup_before = _resource_sample(root)
+    setup_started = time.perf_counter()
     program = _incident_program()
     profile_id = _schema_profile_id()
     program_json = program.to_json()
-
-    generate_before = _resource_sample(root)
-    generate_started = time.perf_counter()
     # The JSON program is intentionally the canonical witness identity.  Its
     # 90 MiB terminal payload is a faithful wire-shape fixture, not a parser
     # replacement or a pre-populated database.
-    generate_after = _resource_sample(root)
+    setup_after = _resource_sample(root)
     phases: list[WorkloadPhaseObservation] = [
         _phase(
             "generate",
-            generate_before,
-            generate_after,
-            generate_started,
+            setup_before,
+            setup_after,
+            setup_started,
             completed=REVISION_COUNT,
             total=REVISION_COUNT,
         )
@@ -244,6 +257,11 @@ def test_sanitized_codex_804_revision_recovery_proof(tmp_path: Path, monkeypatch
     assert run.state.crashed is False
     assert run.schedule[-2:] == ("crash-after-acquire", "restart-after-crash")
     assert len(program_json) > REVISION_COUNT
+    first_revision_payload = _codex_payload(0, terminal=False)
+    second_revision_payload = _codex_payload(1, terminal=False)
+    assert first_revision_payload != second_revision_payload
+    assert b"incident witness revision 0" in first_revision_payload
+    assert b"incident witness revision 1" in second_revision_payload
 
     runtime.crash()
     with pytest.raises(CorpusRuntimeCrashedError, match="runtime is crashed"):
@@ -258,10 +276,11 @@ def test_sanitized_codex_804_revision_recovery_proof(tmp_path: Path, monkeypatch
         _phase("census", parse_before, parse_after, parse_started, completed=REVISION_COUNT, total=REVISION_COUNT)
     )
 
-    raw_count, max_blob_size, source_path_count, authorities = _source_facts(root)
+    raw_count, max_blob_size, source_path_count, parse_error_count, authorities = _source_facts(root)
     assert raw_count == REVISION_COUNT
     assert max_blob_size == TERMINAL_WIRE_BYTES
     assert source_path_count == 1
+    assert parse_error_count == 0
     assert authorities
     assert set(authorities) <= {"asserted", "byte_proven", "quarantined"}
     schema_inference_receipt_path = write_valid_rebuild_receipt(root, tmp_path / "schema-inference-gate-receipt.json")
@@ -269,43 +288,100 @@ def test_sanitized_codex_804_revision_recovery_proof(tmp_path: Path, monkeypatch
     active_before = store.active_pointer.resolve(strict=True)
     baseline = archive_snapshot(root)
 
+    crash_script = """
+import os
+import sys
+from pathlib import Path
+
+from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
+
+root = Path(sys.argv[1])
+receipt = Path(sys.argv[2])
+marker = Path(sys.argv[3])
+result = rebuild_index_from_source_sync(
+    RebuildIndexRequest(
+        archive_root=root,
+        promote=False,
+        raw_batch_size=804,
+        pass_byte_budget_mb=1.0,
+        schema_inference_receipt_path=receipt,
+    )
+)
+if result.status not in {"paused", "deferred"} or result.materialized:
+    raise SystemExit(f"unexpected crash-boundary result: {result.status} {result.materialized}")
+assert result.transaction is not None
+marker.write_text(str(result.transaction["operation_id"]), encoding="ascii")
+with marker.open("a", encoding="ascii") as handle:
+    handle.flush()
+    os.fsync(handle.fileno())
+os._exit(137)
+"""
+    operation_marker = tmp_path / "codex-804-operation-id.txt"
     replay_before = _resource_sample(root)
     replay_started = time.perf_counter()
-    first_pass = rebuild_index_from_source_sync(
-        RebuildIndexRequest(
-            archive_root=root,
-            promote=False,
-            raw_batch_size=REVISION_COUNT,
-            pass_byte_budget_mb=0.01,
-            schema_inference_receipt_path=schema_inference_receipt_path,
+    crashed_process = subprocess.run(
+        [sys.executable, "-c", crash_script, str(root), str(schema_inference_receipt_path), str(operation_marker)],
+        cwd=Path.cwd(),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert crashed_process.returncode == 137, crashed_process.stderr
+    operation_id = operation_marker.read_text(encoding="ascii")
+    assert operation_id
+    persisted = store.load_transaction(operation_id)
+    assert persisted.status in {"paused", "deferred"}
+    assert persisted.processed_raw_count > 0
+    assert tuple(store.transactions_root.joinpath(f"{operation_id}.receipts").glob("pass-*.json"))
+    assert store.active_pointer.resolve(strict=True) == active_before
+    phases.append(
+        _phase(
+            "replay",
+            replay_before,
+            _resource_sample(root),
+            replay_started,
+            completed=persisted.processed_raw_count,
+            total=REVISION_COUNT,
         )
     )
-    assert first_pass.status in {"paused", "deferred"}
-    assert first_pass.materialized is False
-    assert first_pass.transaction is not None
-    operation_id = first_pass.transaction["operation_id"]
-    assert isinstance(operation_id, str)
-    assert store.active_pointer.resolve(strict=True) == active_before
-    phases.append(_phase("replay", replay_before, _resource_sample(root), replay_started))
 
     resume_before = _resource_sample(root)
     resume_started = time.perf_counter()
-    receipt = first_pass
-    for _ in range(200):
-        receipt = rebuild_index_from_source_sync(
-            RebuildIndexRequest(
-                archive_root=root,
-                operation_id=operation_id,
-                promote=False,
-                schema_inference_receipt_path=schema_inference_receipt_path,
-            )
+    resume_script = """
+import sys
+from pathlib import Path
+
+from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
+
+root = Path(sys.argv[1])
+operation_id = sys.argv[2]
+receipt = Path(sys.argv[3])
+for _ in range(200):
+    result = rebuild_index_from_source_sync(
+        RebuildIndexRequest(
+            archive_root=root,
+            operation_id=operation_id,
+            promote=False,
+            schema_inference_receipt_path=receipt,
         )
-        if receipt.status == "replayed":
-            break
-    assert receipt.status == "replayed"
-    assert receipt.materialized is True
-    generation_id = receipt.generation["generation_id"]
-    assert isinstance(generation_id, str)
+    )
+    if result.status == "replayed" and result.materialized:
+        print(result.generation["generation_id"])
+        break
+else:
+    raise SystemExit("persisted rebuild did not reach replayed")
+"""
+    resumed_process = subprocess.run(
+        [sys.executable, "-c", resume_script, str(root), operation_id, str(schema_inference_receipt_path)],
+        cwd=Path.cwd(),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    generation_id = resumed_process.stdout.strip().splitlines()[-1]
+    assert generation_id.startswith("gen-")
+    persisted_after_restart = store.load_transaction(operation_id)
+    assert persisted_after_restart.status == "ready"
     candidate = store.load(generation_id)
     assert candidate.state == "inactive"
     assert Path(candidate.index_path).is_file()
@@ -313,12 +389,16 @@ def test_sanitized_codex_804_revision_recovery_proof(tmp_path: Path, monkeypatch
     phases.append(_phase("postflight", resume_before, _resource_sample(root), resume_started))
 
     store.promote(candidate)
-    final_snapshot = archive_snapshot(root, search_queries=("sanitized",))
+    final_snapshot = archive_snapshot(root, search_queries=("sanitized", "revision"))
     baseline_sessions = next(item for item in baseline.canonical_rows if item.relation == "sessions")
     assert not baseline_sessions.rows
     sessions_relation = next(item for item in final_snapshot.canonical_rows if item.relation == "sessions")
     assert sessions_relation.rows
-    assert final_snapshot.public_projections
+    public = dict(final_snapshot.public_projections)
+    indexed_session_id = f"codex-session:{SESSION_NATIVE_ID}"
+    assert public[f"summary:{indexed_session_id}"]
+    assert public[f"tree:{indexed_session_id}"]
+    assert public["search:revision"]
     readiness = raw_materialization_readiness_snapshot(root)
     assert readiness["available"] is True
     assert _readiness_count(readiness, "raw_artifact_count") == _readiness_count(
@@ -341,6 +421,7 @@ def test_sanitized_codex_804_revision_recovery_proof(tmp_path: Path, monkeypatch
             storage_bytes=quiescent[2],
             cleanup_complete=True,
             quiescent=True,
+            unavailable=("peak_rss_bytes",) if quiescent[0] is not None else ("current_rss_bytes", "peak_rss_bytes"),
         )
     )
     spec = raw_authority_fixed_point_spec(
@@ -361,12 +442,17 @@ def test_sanitized_codex_804_revision_recovery_proof(tmp_path: Path, monkeypatch
             f"schema-registry:{profile_id}",
             f"candidate-generation:{generation_id}",
             f"source-raw-count:{raw_count}",
+            f"source-parse-error-count:{parse_error_count}",
+            "restart-boundary:subprocess-persisted-transaction",
             "successor:polylogue-live-operation-receipts",
             "successor:polylogue-reindex-final-proof",
         ),
         cleanup_complete=True,
         notes=(
             "Sanitized structural witness only; no live /realm/db/polylogue access.",
+            "Fixture setup includes 804 payload construction, schema hashing, and canonical program serialization.",
+            "Current RSS is sampled per phase; phase-local peak RSS is unavailable and marked explicitly.",
+            "The crash boundary hard-exits after a persisted bounded pass; a fresh process resumes the transaction.",
             "Live confidence remains open until the named successor receipts bind the active archive.",
         ),
     )
@@ -384,6 +470,7 @@ def test_sanitized_codex_804_revision_recovery_proof(tmp_path: Path, monkeypatch
                 "receipt_id": workload_receipt.receipt_id,
                 "raw_count": raw_count,
                 "max_blob_size": max_blob_size,
+                "parse_error_count": parse_error_count,
                 "indexed_session": indexed[0][0],
                 "message_count": indexed[0][1],
                 "candidate_generation": generation_id,


### PR DESCRIPTION
## Summary

Harden the sanitized Codex 804-revision proof at the real acquisition, parser, materialization, candidate replay, and recovery seams.

## Problem

The prior crash assertion terminated a helper before replay began. It therefore did not prove recovery after the production rebuild had durably checkpointed work. The wire-payload cache also retained the incident-scale fixture for the rest of the test process.

## Solution

The proof retains its 804 byte-prefix-extended JSONL snapshots, exact 90,822,451-byte terminal payload, source-to-candidate head checks, and public summary/tree/search assertions. Its interruption boundary now starts `rebuild_index_from_source_sync` in a subprocess, waits for `processed_raw_count > 0`, kills that real replay process, asserts the paused transaction and materialized candidate sessions, then resumes the same transaction in a fresh process to an inactive generation. The generated payload cache is cleared at test finalization. The real-clock marker is limited to the subprocess checkpoint and kill/resume boundary.

The witness remains sanitized and does not claim a live operation receipt. The live witness and production receipt remain successors of this implementation proof.

## Verification

`direnv exec . devtools test tests/unit/scenarios/test_codex_804_live_proof.py` produced `1 passed in 246.00s (0:04:06)` and `ok (250.4s)`.

`direnv exec . devtools verify --quick` produced exit code `0`; the pre-push quick verification also completed with exit code `0`.

Final commit: `8b9d5e5a2548d55cd1459e0ca40b21004a6ce5ad` (trigger-only CI refresh commit).

## Follow-ups

The real live witness and live operation receipt remain unproven. The named successors `polylogue-live-operation-receipts` and `polylogue-reindex-final-proof` must bind the approved live source and candidate generations.

Ref polylogue-codex-804-live-proof

<!-- polylogue-pr-scope:v1
{
  "assigned_beads": [
    "polylogue-codex-804-live-proof"
  ],
  "beads_digest": "3082f1d67c39ad3aa05fb8bbc7706dd1abc8e26aa31ae8a6b486a21469e02c97",
  "dispositions": [
    {
      "bead_id": "polylogue-codex-804-live-proof",
      "disposition": "partial",
      "evidence": [
        {
          "kind": "commit",
          "ref": "8b9d5e5a2548d55cd1459e0ca40b21004a6ce5ad"
        },
        {
          "kind": "test",
          "ref": "tests/unit/scenarios/test_codex_804_live_proof.py: real rebuild subprocess interrupted after persisted progress; fresh-process resume passed"
        },
        {
          "kind": "command",
          "ref": "devtools verify --quick: exit 0"
        },
        {
          "kind": "receipt",
          "ref": "804 byte-prefix-extended raw rows; exact terminal head and 90,822,451-byte blob; candidate replay checkpoint and recovery; live witness unproven"
        }
      ],
      "successors": [
        "polylogue-live-operation-receipts"
      ]
    }
  ],
  "head_sha": "8b9d5e5a2548d55cd1459e0ca40b21004a6ce5ad",
  "scope_digest": "a1818cb7b37386e4e41c0f87d4db1108f4fbe442349a1cbcd4132d0cec7275ee",
  "version": 1
}
-->
