### PR TITLE
fix(devtools): guard reindex proof edges

### DIFF
--- a/devtools/verify_bead_graph.py
+++ b/devtools/verify_bead_graph.py
@@ -29,6 +29,41 @@ class Finding:
     detail: str
 
 
+@dataclass(frozen=True, slots=True)
+class RequiredBlockingEdge:
+    """One non-negotiable ``blocks`` relation in the reindex proof graph."""
+
+    dependent_id: str
+    blocker_id: str
+
+
+# These are the twelve standalone live-proof records corrected by
+# polylogue-reindex-proof-edge-correction.  Keep this as structured policy,
+# rather than deriving ordering from issue text or close reasons.
+REINDEX_REQUIRED_LIVE_PROOF_BLOCKING_EDGES: tuple[RequiredBlockingEdge, ...] = (
+    RequiredBlockingEdge("polylogue-active-leaf-live-proof", "polylogue-2hwl"),
+    RequiredBlockingEdge("polylogue-hook-authority-conflict-proof", "polylogue-foee"),
+    RequiredBlockingEdge("polylogue-chatgpt-content-live-proof", "polylogue-xofj"),
+    RequiredBlockingEdge("polylogue-excluded-cursor-live-proof", "polylogue-ix5r"),
+    RequiredBlockingEdge("polylogue-byte-supersession-live-proof", "polylogue-6753s"),
+    RequiredBlockingEdge("polylogue-hook-reconciliation-apply-proof", "polylogue-nhbvf"),
+    RequiredBlockingEdge("polylogue-raw-dedupe-apply-proof", "polylogue-zm4w8"),
+    RequiredBlockingEdge("polylogue-claude-streaming-live-proof", "polylogue-4987i"),
+    RequiredBlockingEdge("polylogue-claude-vintage-live-proof", "polylogue-0qfy"),
+    RequiredBlockingEdge("polylogue-codex-804-live-proof", "polylogue-5iz4"),
+    RequiredBlockingEdge("polylogue-topology-live-proof", "polylogue-4ts.10"),
+    RequiredBlockingEdge("polylogue-stalled-cursor-live-proof", "polylogue-2qrx"),
+)
+
+# The guard itself is a prerequisite of both phase-graph consumers.  This
+# keeps the static edge policy on the real preflight and terminal-proof paths
+# without treating it as a live-production receipt.
+REINDEX_PROOF_EDGE_GUARD_PHASE_BINDINGS: tuple[RequiredBlockingEdge, ...] = (
+    RequiredBlockingEdge("polylogue-reindex-preflight-authorization", "polylogue-eqq02"),
+    RequiredBlockingEdge("polylogue-reindex-final-proof", "polylogue-eqq02"),
+)
+
+
 def _wave(issue: dict[str, Any]) -> tuple[int | None, Finding | None]:
     """Parse the issue's ``wave:`` label."""
     for label in issue.get("labels") or []:
@@ -164,9 +199,62 @@ def _parent_findings(issues: list[dict[str, Any]]) -> list[Finding]:
     return findings
 
 
+def _blocks_targets(issue: dict[str, Any]) -> set[str]:
+    """Return the structured blockers declared by one Bead record."""
+    dependencies = issue.get("dependencies")
+    if not isinstance(dependencies, list):
+        return set()
+    return {
+        target
+        for dependency in dependencies
+        if isinstance(dependency, dict)
+        and dependency.get("type") == "blocks"
+        and isinstance((target := dependency.get("depends_on_id")), str)
+        and target
+    }
+
+
+def _required_blocking_edge_findings(
+    issues: list[dict[str, Any]],
+    *,
+    required_edges: tuple[RequiredBlockingEdge, ...],
+    kind: str,
+) -> list[Finding]:
+    by_id = {str(issue["id"]): issue for issue in issues if isinstance(issue.get("id"), str)}
+    findings: list[Finding] = []
+    for edge in required_edges:
+        dependent = by_id.get(edge.dependent_id)
+        detail = f"required blocks dependency: {edge.dependent_id} -> {edge.blocker_id}"
+        if dependent is None:
+            findings.append(Finding(kind, edge.dependent_id, f"missing dependent; {detail}"))
+        elif edge.blocker_id not in _blocks_targets(dependent):
+            findings.append(Finding(kind, edge.dependent_id, f"missing {detail}"))
+    return findings
+
+
+def reindex_proof_edge_findings(issues: list[dict[str, Any]]) -> list[Finding]:
+    """Validate reindex live-proof ownership and its phase-graph bindings."""
+    issue_ids = {str(issue["id"]) for issue in issues if isinstance(issue.get("id"), str)}
+    phase_consumer_ids = {edge.dependent_id for edge in REINDEX_PROOF_EDGE_GUARD_PHASE_BINDINGS}
+    if not issue_ids.intersection(phase_consumer_ids):
+        return []
+    return [
+        *_required_blocking_edge_findings(
+            issues,
+            required_edges=REINDEX_REQUIRED_LIVE_PROOF_BLOCKING_EDGES,
+            kind="missing-required-reindex-proof-edge",
+        ),
+        *_required_blocking_edge_findings(
+            issues,
+            required_edges=REINDEX_PROOF_EDGE_GUARD_PHASE_BINDINGS,
+            kind="missing-reindex-proof-edge-guard-binding",
+        ),
+    ]
+
+
 def collect_findings(issues: list[dict[str, Any]]) -> list[Finding]:
     by_id = {str(issue["id"]): issue for issue in issues if isinstance(issue.get("id"), str)}
-    findings: list[Finding] = _parent_findings(issues)
+    findings: list[Finding] = [*_parent_findings(issues), *reindex_proof_edge_findings(issues)]
 
     waves: dict[str, int | None] = {}
     for issue_id, issue in sorted(by_id.items()):

--- a/tests/unit/devtools/test_verify_bead_graph.py
+++ b/tests/unit/devtools/test_verify_bead_graph.py
@@ -2,10 +2,29 @@ from __future__ import annotations
 
 import json
 import subprocess
+from copy import deepcopy
+from pathlib import Path
 
 import pytest
 
 from devtools import verify_bead_graph
+
+EXPECTED_REINDEX_LIVE_PROOF_BLOCKING_EDGES = frozenset(
+    {
+        ("polylogue-active-leaf-live-proof", "polylogue-2hwl"),
+        ("polylogue-hook-authority-conflict-proof", "polylogue-foee"),
+        ("polylogue-chatgpt-content-live-proof", "polylogue-xofj"),
+        ("polylogue-excluded-cursor-live-proof", "polylogue-ix5r"),
+        ("polylogue-byte-supersession-live-proof", "polylogue-6753s"),
+        ("polylogue-hook-reconciliation-apply-proof", "polylogue-nhbvf"),
+        ("polylogue-raw-dedupe-apply-proof", "polylogue-zm4w8"),
+        ("polylogue-claude-streaming-live-proof", "polylogue-4987i"),
+        ("polylogue-claude-vintage-live-proof", "polylogue-0qfy"),
+        ("polylogue-codex-804-live-proof", "polylogue-5iz4"),
+        ("polylogue-topology-live-proof", "polylogue-4ts.10"),
+        ("polylogue-stalled-cursor-live-proof", "polylogue-2qrx"),
+    }
+)
 
 
 def _issue(
@@ -28,6 +47,11 @@ def _issue(
         "priority": priority,
         "metadata": metadata if metadata is not None else {},
     }
+
+
+def _exported_issues() -> list[dict[str, object]]:
+    export_path = Path(__file__).parents[3] / ".beads" / "issues.jsonl"
+    return [json.loads(line) for line in export_path.read_text().splitlines() if line]
 
 
 def test_clean_graph_has_no_findings() -> None:
@@ -343,3 +367,51 @@ def test_json_report_lists_every_missing_ac_with_deterministic_partitions(
     assert census["by_priority"]["1"] == {"count": 1, "ids": ["polylogue-a"]}
     assert census["by_program_or_parent"]["polylogue-parent"]["ids"] == ["polylogue-a"]
     assert census["by_campaign_relevance"]["declared"]["ids"] == ["polylogue-a"]
+
+
+def test_current_export_satisfies_reindex_live_proof_edge_policy() -> None:
+    """The committed Beads export carries every edge required by the policy."""
+    assert {
+        (edge.dependent_id, edge.blocker_id) for edge in verify_bead_graph.REINDEX_REQUIRED_LIVE_PROOF_BLOCKING_EDGES
+    } == EXPECTED_REINDEX_LIVE_PROOF_BLOCKING_EDGES
+    assert verify_bead_graph.reindex_proof_edge_findings(_exported_issues()) == []
+
+
+@pytest.mark.parametrize(
+    "edge",
+    verify_bead_graph.REINDEX_REQUIRED_LIVE_PROOF_BLOCKING_EDGES,
+    ids=lambda edge: f"{edge.dependent_id}->{edge.blocker_id}",
+)
+def test_each_required_reindex_live_proof_edge_fails_closed_when_removed(
+    edge: verify_bead_graph.RequiredBlockingEdge,
+) -> None:
+    """Anti-vacuity: this mutates dependencies consumed by preflight and terminal readiness."""
+    issues = deepcopy(_exported_issues())
+    dependent = next(issue for issue in issues if issue["id"] == edge.dependent_id)
+    dependencies = dependent["dependencies"]
+    assert isinstance(dependencies, list)
+    dependent["dependencies"] = [
+        dependency
+        for dependency in dependencies
+        if not (
+            isinstance(dependency, dict)
+            and dependency.get("type") == "blocks"
+            and dependency.get("depends_on_id") == edge.blocker_id
+        )
+    ]
+
+    findings = verify_bead_graph.reindex_proof_edge_findings(issues)
+    report = verify_bead_graph.build_report(issues, cycles_ok=True, cycles_output="")
+
+    assert any(
+        finding.kind == "missing-required-reindex-proof-edge"
+        and finding.bead_id == edge.dependent_id
+        and edge.blocker_id in finding.detail
+        for finding in findings
+    )
+    assert any(
+        finding["kind"] == "missing-required-reindex-proof-edge"
+        and finding["id"] == edge.dependent_id
+        and edge.blocker_id in finding["detail"]
+        for finding in report["findings"]
+    )


### PR DESCRIPTION
## Summary

Add an executable policy guard for the twelve required reindex live-proof blocking edges and bind that guard to preflight and terminal proof readiness.

## Problem

The corrected Beads graph contained the required edges, but no executable policy failed when a required edge was removed. A future graph export could therefore lose proof ordering while static checks remained green.

## Solution

The graph verifier now owns a structured twelve-edge matrix plus phase-consumer bindings. It reports machine-readable missing-edge findings from the exported dependency structure, and parameterized tests remove each edge to prove the guard fails closed. The guard remains separate from live production receipts and does not inspect prose or close reasons.

## Verification

- Worker focused graph-policy tests -> passed
- Worker `direnv exec . devtools verify --quick` -> all 24 checks exit 0
- Commit check -> `git show --check` clean

## Follow-ups

The predecessor Bead remains open until this ready PR is merged and the graph is rechecked. Ref polylogue-eqq02.

<!-- polylogue-pr-scope:v1
{
  "assigned_beads": [
    "polylogue-eqq02"
  ],
  "beads_digest": "17af630a3c32fc38b888ff1ae2f047ccd0f4b2dc0c4f1b62f8fb9ea17c1edb23",
  "dispositions": [
    {
      "bead_id": "polylogue-eqq02",
      "disposition": "satisfied",
      "evidence": [
        {
          "kind": "commit",
          "ref": "bf218e0d9d16c6bcbc1fa551812468373db005d0"
        },
        {
          "kind": "test",
          "ref": "focused graph-policy tests passed"
        },
        {
          "kind": "command",
          "ref": "devtools verify --quick: all 24 steps passed"
        }
      ],
      "successors": []
    }
  ],
  "head_sha": "bf218e0d9d16c6bcbc1fa551812468373db005d0",
  "scope_digest": "74983e35c870960e42456a722676e4634995b813007fa4ba0ddf0b6096c246e4",
  "version": 1
}
-->
