### PR TITLE
fix(storage): attest hook reconciliation stages

### DIFF
--- a/polylogue/storage/blob_gc.py
+++ b/polylogue/storage/blob_gc.py
@@ -225,7 +225,21 @@ def _prepare_legacy_hook_liveness(conn: sqlite3.Connection) -> str:
     return "ready"
 
 
-def _blob_refs_still_live(conn: sqlite3.Connection, blob_bytes: bytes) -> bool:
+def _legacy_hook_liveness_status(conn: sqlite3.Connection) -> str:
+    """Prepare legacy-hook evidence once when this connection needs it."""
+    if not _table_exists(conn, "blob_refs") or not _blob_refs_has_ref_type_column(conn):
+        return "not_applicable"
+    if conn.execute("SELECT 1 FROM blob_refs WHERE ref_type = 'raw_payload' LIMIT 1").fetchone() is None:
+        return "not_applicable"
+    return _prepare_legacy_hook_liveness(conn)
+
+
+def _blob_refs_still_live(
+    conn: sqlite3.Connection,
+    blob_bytes: bytes,
+    *,
+    legacy_hook_status: str | None = None,
+) -> bool:
     """Return True if some ``blob_refs`` row for this hash has a live referent.
 
     Replaces a prior membership test that only checked whether ANY row in
@@ -258,7 +272,9 @@ def _blob_refs_still_live(conn: sqlite3.Connection, blob_bytes: bytes) -> bool:
         # the same fail-closed rule instead of deleting unclassified evidence.
         return True
     if "raw_payload" in ref_types:
-        legacy_hook_status = _prepare_legacy_hook_liveness(conn)
+        legacy_hook_status = (
+            legacy_hook_status if legacy_hook_status is not None else _prepare_legacy_hook_liveness(conn)
+        )
         if legacy_hook_status == "unavailable":
             return True
         if legacy_hook_status == "ready":
@@ -307,6 +323,7 @@ def _archive_reference_surfaces(
     blob_hash: str,
     *,
     surface_prefix: str,
+    legacy_hook_status: str | None = None,
 ) -> list[str]:
     blob_bytes = _blob_hash_bytes(blob_hash)
     if blob_bytes is None:
@@ -319,7 +336,7 @@ def _archive_reference_surfaces(
         row = conn.execute(f"SELECT 1 FROM {table} WHERE blob_hash = ? LIMIT 1", (blob_bytes,)).fetchone()
         if row is not None:
             surfaces.append(f"{surface_prefix}.{table}")
-    if _blob_refs_still_live(conn, blob_bytes):
+    if _blob_refs_still_live(conn, blob_bytes, legacy_hook_status=legacy_hook_status):
         surfaces.append(f"{surface_prefix}.blob_refs")
     return surfaces
 
@@ -331,24 +348,53 @@ def _reference_surfaces(
     source_db_path: Path | None = None,
     source_conn: sqlite3.Connection | None = None,
     index_conn: sqlite3.Connection | None = None,
+    legacy_hook_status: str | None = None,
+    source_legacy_hook_status: str | None = None,
+    index_legacy_hook_status: str | None = None,
 ) -> list[str]:
-    surfaces = _archive_reference_surfaces(conn, blob_hash, surface_prefix="current")
+    surfaces = _archive_reference_surfaces(
+        conn,
+        blob_hash,
+        surface_prefix="current",
+        legacy_hook_status=legacy_hook_status,
+    )
 
     if source_conn is not None:
         source_prefix = source_db_path.name if source_db_path is not None else "source"
-        surfaces.extend(_archive_reference_surfaces(source_conn, blob_hash, surface_prefix=source_prefix))
+        surfaces.extend(
+            _archive_reference_surfaces(
+                source_conn,
+                blob_hash,
+                surface_prefix=source_prefix,
+                legacy_hook_status=source_legacy_hook_status,
+            )
+        )
     elif source_db_path is not None and source_db_path.exists():
         try:
             source_conn = sqlite3.connect(f"file:{source_db_path}?mode=ro", uri=True)
             try:
-                surfaces.extend(_archive_reference_surfaces(source_conn, blob_hash, surface_prefix=source_db_path.name))
+                surfaces.extend(
+                    _archive_reference_surfaces(
+                        source_conn,
+                        blob_hash,
+                        surface_prefix=source_db_path.name,
+                        legacy_hook_status=source_legacy_hook_status,
+                    )
+                )
             finally:
                 source_conn.close()
         except sqlite3.Error as exc:
             logger.warning("Could not inspect archive source blob references in %s: %s", source_db_path, exc)
 
     if index_conn is not None:
-        surfaces.extend(_archive_reference_surfaces(index_conn, blob_hash, surface_prefix="index.db"))
+        surfaces.extend(
+            _archive_reference_surfaces(
+                index_conn,
+                blob_hash,
+                surface_prefix="index.db",
+                legacy_hook_status=index_legacy_hook_status,
+            )
+        )
 
     if _table_exists(conn, "raw_sessions"):
         row = conn.execute(
@@ -543,11 +589,19 @@ def run_blob_gc_report(
     planning_conn.row_factory = sqlite3.Row
     planning_source_conn: sqlite3.Connection | None = None
     planning_index_conn: sqlite3.Connection | None = None
+    planning_legacy_hook_status = "not_applicable"
+    planning_source_legacy_hook_status = "not_applicable"
+    planning_index_legacy_hook_status = "not_applicable"
     try:
         if control_db_path != sibling_source_db and sibling_source_db.exists():
             planning_source_conn = sqlite3.connect(f"file:{sibling_source_db}?mode=ro", uri=True)
         if control_db_path != sibling_index_db and sibling_index_db.exists():
             planning_index_conn = sqlite3.connect(f"file:{sibling_index_db}?mode=ro", uri=True)
+        planning_legacy_hook_status = _legacy_hook_liveness_status(planning_conn)
+        if planning_source_conn is not None:
+            planning_source_legacy_hook_status = _legacy_hook_liveness_status(planning_source_conn)
+        if planning_index_conn is not None:
+            planning_index_legacy_hook_status = _legacy_hook_liveness_status(planning_index_conn)
         for blob_hash, mtime in candidates:
             if len(shortlist) >= max_batch:
                 break
@@ -558,6 +612,9 @@ def run_blob_gc_report(
                 source_db_path=(sibling_source_db if planning_source_conn is not None else None),
                 source_conn=planning_source_conn,
                 index_conn=planning_index_conn,
+                legacy_hook_status=planning_legacy_hook_status,
+                source_legacy_hook_status=planning_source_legacy_hook_status,
+                index_legacy_hook_status=planning_index_legacy_hook_status,
             ):
                 evidence.skipped_referenced += 1
                 continue
@@ -577,6 +634,9 @@ def run_blob_gc_report(
     conn.row_factory = sqlite3.Row
     source_conn: sqlite3.Connection | None = None
     index_conn: sqlite3.Connection | None = None
+    legacy_hook_status = "not_applicable"
+    source_legacy_hook_status = "not_applicable"
+    index_legacy_hook_status = "not_applicable"
     affected = 0
     reclaimed_bytes = 0
     started_at_ms = int(time.time() * 1000)
@@ -587,6 +647,11 @@ def run_blob_gc_report(
             source_conn = sqlite3.connect(f"file:{sibling_source_db}?mode=ro", uri=True)
         if control_db_path != sibling_index_db and sibling_index_db.exists():
             index_conn = sqlite3.connect(f"file:{sibling_index_db}?mode=ro", uri=True)
+        legacy_hook_status = _legacy_hook_liveness_status(conn)
+        if source_conn is not None:
+            source_legacy_hook_status = _legacy_hook_liveness_status(source_conn)
+        if index_conn is not None:
+            index_legacy_hook_status = _legacy_hook_liveness_status(index_conn)
 
         for blob_hash, _mtime in shortlist:
             if _reference_surfaces(
@@ -595,6 +660,9 @@ def run_blob_gc_report(
                 source_db_path=(sibling_source_db if source_conn is not None else None),
                 source_conn=source_conn,
                 index_conn=index_conn,
+                legacy_hook_status=legacy_hook_status,
+                source_legacy_hook_status=source_legacy_hook_status,
+                index_legacy_hook_status=index_legacy_hook_status,
             ):
                 evidence.skipped_referenced += 1
                 continue

--- a/polylogue/storage/blob_gc.py
+++ b/polylogue/storage/blob_gc.py
@@ -205,22 +205,8 @@ def _table_has_blob_hash_column(conn: sqlite3.Connection, table: str) -> bool:
     return any(str(row[1]) == "blob_hash" for row in conn.execute(f"PRAGMA table_info({table})"))
 
 
-def _temporary_table_exists(conn: sqlite3.Connection, table: str) -> bool:
-    return (
-        conn.execute(
-            "SELECT 1 FROM sqlite_temp_master WHERE type = 'table' AND name = ?",
-            (table,),
-        ).fetchone()
-        is not None
-    )
-
-
 def _prepare_legacy_hook_liveness(conn: sqlite3.Connection) -> str:
     """Prepare the canonical legacy-hook reconciliation stage for this connection."""
-    if _temporary_table_exists(conn, "hook_payload_ref_reconciliation_matches") and _temporary_table_exists(
-        conn, "hook_payload_ref_reconciliation_ambiguous"
-    ):
-        return "ready"
     if not _table_exists(conn, "raw_hook_events"):
         return "not_applicable"
     hook_columns = {str(row[1]) for row in conn.execute("PRAGMA table_info(raw_hook_events)")}
@@ -233,7 +219,7 @@ def _prepare_legacy_hook_liveness(conn: sqlite3.Connection) -> str:
         from polylogue.storage.hook_payload_ref_reconciliation import _create_match_stage
 
         _create_match_stage(conn)
-    except sqlite3.Error:
+    except Exception:
         logger.warning("Could not stage legacy hook evidence for blob GC; retaining candidate blobs")
         return "unavailable"
     return "ready"

--- a/polylogue/storage/blob_gc.py
+++ b/polylogue/storage/blob_gc.py
@@ -629,6 +629,30 @@ def run_blob_gc_report(
             planning_index_conn.close()
         planning_conn.close()
 
+    if not shortlist:
+        report.inspected_count = evidence.inspected
+        report.skipped_referenced = evidence.skipped_referenced
+        report.skipped_reserved = evidence.skipped_reserved
+        if dry_run:
+            report.would_delete_count = 0
+            return report
+        history_conn = sqlite3.connect(str(control_db_path))
+        try:
+            now_ms = int(time.time() * 1000)
+            generation_id = f"gc-{uuid4().hex}"
+            history_conn.execute(
+                "INSERT INTO gc_generations "
+                "(generation_id, started_at_ms, completed_at_ms, reclaimed_count, reclaimed_bytes) "
+                "VALUES (?, ?, ?, 0, 0)",
+                (generation_id, now_ms, now_ms),
+            )
+            history_conn.commit()
+            report.generation_id = generation_id
+            report.generation_written = True
+        finally:
+            history_conn.close()
+        return report
+
     connection_uri = f"file:{control_db_path}?mode=ro" if dry_run else str(control_db_path)
     conn = sqlite3.connect(connection_uri, uri=dry_run)
     conn.row_factory = sqlite3.Row

--- a/polylogue/storage/blob_ref_liveness.py
+++ b/polylogue/storage/blob_ref_liveness.py
@@ -198,6 +198,8 @@ def stage_blob_ref_liveness(conn: sqlite3.Connection, *, sample_limit: int = 30)
     than materializing the same population in several Python lists.
     """
 
+    candidate_table = "blob_ref_liveness_candidates"
+    conn.execute(f"DROP TABLE IF EXISTS temp.{candidate_table}")
     known_joins = validated_blob_ref_liveness_joins()
     if not table_exists(conn, "blob_refs"):
         return BlobRefLivenessStagedPlan(
@@ -239,36 +241,26 @@ def stage_blob_ref_liveness(conn: sqlite3.Connection, *, sample_limit: int = 30)
         ref_type_joins.append((ref_type, table, column))
 
     rekeyable_hook_payload_count = 0
+    hook_exclusions = ""
     if table_exists(conn, "raw_hook_events"):
         _scanned_hook_refs, rekeyable_hook_payload_count, _matched_bytes, ambiguous_count = _create_match_stage(conn)
         rekeyable_hook_payload_count += ambiguous_count
-    else:
-        conn.execute("DROP TABLE IF EXISTS temp.hook_payload_ref_reconciliation_matches")
-        conn.execute(
-            """
-            CREATE TEMP TABLE hook_payload_ref_reconciliation_matches (
-                blob_hash BLOB NOT NULL,
-                orphaned_ref_id TEXT NOT NULL,
-                source_path TEXT,
-                size_bytes INTEGER NOT NULL,
-                acquired_at_ms INTEGER NOT NULL,
-                hook_event_id TEXT NOT NULL,
-                PRIMARY KEY (blob_hash, orphaned_ref_id)
-            ) STRICT
-            """
-        )
-        conn.execute(
-            """
-            CREATE TEMP TABLE hook_payload_ref_reconciliation_ambiguous (
-                blob_hash BLOB NOT NULL,
-                orphaned_ref_id TEXT NOT NULL,
-                PRIMARY KEY (blob_hash, orphaned_ref_id)
-            ) STRICT
-            """
-        )
-
-    candidate_table = "blob_ref_liveness_candidates"
-    conn.execute(f"DROP TABLE IF EXISTS temp.{candidate_table}")
+        hook_exclusions = """
+          AND NOT EXISTS (
+              SELECT 1
+              FROM temp.hook_payload_ref_reconciliation_matches AS hook_match
+              WHERE candidate.ref_type = 'raw_payload'
+                AND hook_match.blob_hash = candidate.blob_hash
+                AND hook_match.orphaned_ref_id = candidate.ref_id
+          )
+          AND NOT EXISTS (
+              SELECT 1
+              FROM temp.hook_payload_ref_reconciliation_ambiguous AS ambiguous_hook
+              WHERE candidate.ref_type = 'raw_payload'
+                AND ambiguous_hook.blob_hash = candidate.blob_hash
+                AND ambiguous_hook.orphaned_ref_id = candidate.ref_id
+          )
+        """
     conn.execute(
         f"""
         CREATE TEMP TABLE {candidate_table} (
@@ -296,20 +288,8 @@ def stage_blob_ref_liveness(conn: sqlite3.Connection, *, sample_limit: int = 30)
                    candidate.source_path, candidate.size_bytes, candidate.acquired_at_ms,
                    candidate.referent_table, candidate.referent_column
             FROM ({query}) AS candidate
-            WHERE NOT EXISTS (
-                SELECT 1
-                FROM temp.hook_payload_ref_reconciliation_matches AS hook_match
-                WHERE candidate.ref_type = 'raw_payload'
-                  AND hook_match.blob_hash = candidate.blob_hash
-                  AND hook_match.orphaned_ref_id = candidate.ref_id
-            )
-              AND NOT EXISTS (
-                SELECT 1
-                FROM temp.hook_payload_ref_reconciliation_ambiguous AS ambiguous_hook
-                WHERE candidate.ref_type = 'raw_payload'
-                  AND ambiguous_hook.blob_hash = candidate.blob_hash
-                  AND ambiguous_hook.orphaned_ref_id = candidate.ref_id
-            )
+            WHERE 1 = 1
+            {hook_exclusions}
             """,
             tuple(params),
         )

--- a/polylogue/storage/hook_payload_ref_reconciliation.py
+++ b/polylogue/storage/hook_payload_ref_reconciliation.py
@@ -33,6 +33,7 @@ module reports.
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from polylogue.storage.introspection import table_exists as _table_exists
@@ -78,6 +79,155 @@ _HOOK_EVIDENCE_TABLE = "hook_payload_ref_reconciliation_hook_evidence"
 _HOOK_TABLE = "hook_payload_ref_reconciliation_hooks"
 _IDENTITY_TABLE = "hook_payload_ref_reconciliation_identity_matches"
 _AMBIGUOUS_TABLE = "hook_payload_ref_reconciliation_ambiguous"
+_READINESS_TABLE = "hook_payload_ref_reconciliation_stage_ready"
+_STAGE_TABLES = (
+    _MATCH_TABLE,
+    _ORPHAN_TABLE,
+    _HOOK_EVIDENCE_TABLE,
+    _HOOK_TABLE,
+    _IDENTITY_TABLE,
+    _AMBIGUOUS_TABLE,
+    _READINESS_TABLE,
+)
+_STAGE_VERSION = 1
+_StageFailureInjector = Callable[[str], None]
+
+
+def _temporary_table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    return (
+        conn.execute(
+            "SELECT 1 FROM sqlite_temp_master WHERE type = 'table' AND name = ?",
+            (table,),
+        ).fetchone()
+        is not None
+    )
+
+
+def _clear_match_stage(conn: sqlite3.Connection) -> None:
+    """Remove every temporary artifact for the legacy hook matcher."""
+
+    for table in reversed(_STAGE_TABLES):
+        conn.execute(f"DROP TABLE IF EXISTS temp.{table}")
+
+
+def _stage_columns(conn: sqlite3.Connection, table: str) -> tuple[str, ...]:
+    return tuple(str(row[1]) for row in conn.execute(f"PRAGMA temp.table_info({table})"))
+
+
+def _match_stage_readiness(conn: sqlite3.Connection) -> tuple[int, int, int, int] | None:
+    """Return attested stage totals only when every staged relation is intact."""
+
+    expected_columns = {
+        _ORPHAN_TABLE: ("blob_hash", "ref_id", "source_path", "size_bytes", "acquired_at_ms"),
+        _HOOK_EVIDENCE_TABLE: ("hook_event_id", "origin", "native_id", "source_path", "blob_hash"),
+        _HOOK_TABLE: ("hook_event_id", "origin", "native_id", "source_path", "blob_hash"),
+        _IDENTITY_TABLE: ("blob_hash", "ref_id", "hook_event_id", "hook_blob_hash"),
+        _AMBIGUOUS_TABLE: ("blob_hash", "orphaned_ref_id"),
+        _MATCH_TABLE: ("blob_hash", "orphaned_ref_id", "source_path", "size_bytes", "acquired_at_ms", "hook_event_id"),
+        _READINESS_TABLE: (
+            "stage_version",
+            "scanned_count",
+            "hook_evidence_count",
+            "hook_count",
+            "identity_count",
+            "matched_count",
+            "matched_bytes",
+            "ambiguous_count",
+        ),
+    }
+    if any(not _temporary_table_exists(conn, table) for table in _STAGE_TABLES):
+        return None
+    if any(_stage_columns(conn, table) != columns for table, columns in expected_columns.items()):
+        return None
+    rows = conn.execute(
+        f"""
+        SELECT stage_version, scanned_count, hook_evidence_count, hook_count,
+               identity_count, matched_count, matched_bytes, ambiguous_count
+        FROM temp.{_READINESS_TABLE}
+        """
+    ).fetchall()
+    if len(rows) != 1 or tuple(int(value) for value in rows[0])[:1] != (_STAGE_VERSION,):
+        return None
+    (
+        _version,
+        scanned_count,
+        hook_evidence_count,
+        hook_count,
+        identity_count,
+        matched_count,
+        matched_bytes,
+        ambiguous_count,
+    ) = (int(value) for value in rows[0])
+    actual_scanned_count = int(conn.execute(f"SELECT COUNT(*) FROM temp.{_ORPHAN_TABLE}").fetchone()[0])
+    actual_hook_evidence_count = int(conn.execute(f"SELECT COUNT(*) FROM temp.{_HOOK_EVIDENCE_TABLE}").fetchone()[0])
+    actual_hook_count = int(conn.execute(f"SELECT COUNT(*) FROM temp.{_HOOK_TABLE}").fetchone()[0])
+    actual_identity_count = int(conn.execute(f"SELECT COUNT(*) FROM temp.{_IDENTITY_TABLE}").fetchone()[0])
+    actual_matched_count, actual_matched_bytes = (
+        int(value)
+        for value in conn.execute(f"SELECT COUNT(*), COALESCE(SUM(size_bytes), 0) FROM temp.{_MATCH_TABLE}").fetchone()
+    )
+    actual_ambiguous_count = int(conn.execute(f"SELECT COUNT(*) FROM temp.{_AMBIGUOUS_TABLE}").fetchone()[0])
+    source_scanned_count = int(
+        conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM blob_refs AS b
+            WHERE b.ref_type = 'raw_payload'
+              AND NOT EXISTS (SELECT 1 FROM raw_sessions AS r WHERE r.raw_id = b.ref_id)
+            """
+        ).fetchone()[0]
+    )
+    invalid_match_count = int(
+        conn.execute(
+            f"""
+            SELECT COUNT(*)
+            FROM temp.{_MATCH_TABLE} AS m
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM temp.{_ORPHAN_TABLE} AS o
+                WHERE o.blob_hash = m.blob_hash AND o.ref_id = m.orphaned_ref_id
+            )
+            """
+        ).fetchone()[0]
+    )
+    invalid_ambiguous_count = int(
+        conn.execute(
+            f"""
+            SELECT COUNT(*)
+            FROM temp.{_AMBIGUOUS_TABLE} AS a
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM temp.{_ORPHAN_TABLE} AS o
+                WHERE o.blob_hash = a.blob_hash AND o.ref_id = a.orphaned_ref_id
+            )
+            """
+        ).fetchone()[0]
+    )
+    if (
+        (
+            actual_scanned_count,
+            actual_hook_evidence_count,
+            actual_hook_count,
+            actual_identity_count,
+            actual_matched_count,
+            actual_matched_bytes,
+            actual_ambiguous_count,
+        )
+        != (
+            scanned_count,
+            hook_evidence_count,
+            hook_count,
+            identity_count,
+            matched_count,
+            matched_bytes,
+            ambiguous_count,
+        )
+        or source_scanned_count != scanned_count
+        or invalid_match_count
+        or invalid_ambiguous_count
+    ):
+        return None
+    return scanned_count, matched_count, matched_bytes, ambiguous_count
 
 
 def _deterministic_raw_session_id_udf(
@@ -99,12 +249,14 @@ def _deterministic_raw_session_id_udf(
         return None
 
 
-def _create_match_stage(conn: sqlite3.Connection) -> tuple[int, int, int, int]:
-    """Stage exact hook matches in SQLite, avoiding a Python cross-product."""
+def _build_match_stage(
+    conn: sqlite3.Connection, *, failure_injector: _StageFailureInjector | None = None
+) -> tuple[int, int, int, int]:
+    def checkpoint(name: str) -> None:
+        if failure_injector is not None:
+            failure_injector(name)
 
     conn.create_function("polylogue_deterministic_raw_session_id", 5, _deterministic_raw_session_id_udf)
-    for table in (_MATCH_TABLE, _ORPHAN_TABLE, _HOOK_EVIDENCE_TABLE, _HOOK_TABLE, _IDENTITY_TABLE, _AMBIGUOUS_TABLE):
-        conn.execute(f"DROP TABLE IF EXISTS temp.{table}")
     conn.execute(
         f"""
         CREATE TEMP TABLE {_ORPHAN_TABLE} AS
@@ -114,6 +266,8 @@ def _create_match_stage(conn: sqlite3.Connection) -> tuple[int, int, int, int]:
           AND NOT EXISTS (SELECT 1 FROM raw_sessions AS r WHERE r.raw_id = b.ref_id)
         """
     )
+    checkpoint(f"created:{_ORPHAN_TABLE}")
+    checkpoint("population_began")
     conn.execute(f"CREATE INDEX {_ORPHAN_TABLE}_source_path ON {_ORPHAN_TABLE}(source_path, blob_hash)")
     conn.execute(
         f"""
@@ -142,6 +296,7 @@ def _create_match_stage(conn: sqlite3.Connection) -> tuple[int, int, int, int]:
         ) AS h
         """
     )
+    checkpoint(f"created:{_HOOK_EVIDENCE_TABLE}")
     conn.execute(f"CREATE INDEX {_HOOK_EVIDENCE_TABLE}_source_hash ON {_HOOK_EVIDENCE_TABLE}(source_path, blob_hash)")
     conn.execute(
         f"""
@@ -155,6 +310,7 @@ def _create_match_stage(conn: sqlite3.Connection) -> tuple[int, int, int, int]:
         )
         """
     )
+    checkpoint(f"created:{_HOOK_TABLE}")
     conn.execute(f"CREATE INDEX {_HOOK_TABLE}_source_path ON {_HOOK_TABLE}(source_path, blob_hash)")
     conn.execute(
         f"""
@@ -193,6 +349,7 @@ def _create_match_stage(conn: sqlite3.Connection) -> tuple[int, int, int, int]:
              ) = o.ref_id
         """
     )
+    checkpoint(f"created:{_IDENTITY_TABLE}")
     conn.execute(f"CREATE INDEX {_IDENTITY_TABLE}_candidate ON {_IDENTITY_TABLE}(blob_hash, ref_id)")
     conn.execute(
         f"""
@@ -203,6 +360,7 @@ def _create_match_stage(conn: sqlite3.Connection) -> tuple[int, int, int, int]:
         ) STRICT
         """
     )
+    checkpoint(f"created:{_AMBIGUOUS_TABLE}")
     conn.execute(
         f"""
         INSERT OR IGNORE INTO {_AMBIGUOUS_TABLE} (blob_hash, orphaned_ref_id)
@@ -242,6 +400,7 @@ def _create_match_stage(conn: sqlite3.Connection) -> tuple[int, int, int, int]:
         ) STRICT
         """
     )
+    checkpoint(f"created:{_MATCH_TABLE}")
     conn.execute(
         f"""
         INSERT INTO {_MATCH_TABLE} (
@@ -286,10 +445,90 @@ def _create_match_stage(conn: sqlite3.Connection) -> tuple[int, int, int, int]:
         """
     )
     scanned_count = int(conn.execute(f"SELECT COUNT(*) FROM {_ORPHAN_TABLE}").fetchone()[0])
+    hook_evidence_count = int(conn.execute(f"SELECT COUNT(*) FROM {_HOOK_EVIDENCE_TABLE}").fetchone()[0])
+    hook_count = int(conn.execute(f"SELECT COUNT(*) FROM {_HOOK_TABLE}").fetchone()[0])
+    identity_count = int(conn.execute(f"SELECT COUNT(*) FROM {_IDENTITY_TABLE}").fetchone()[0])
     matched_count = int(conn.execute(f"SELECT COUNT(*) FROM {_MATCH_TABLE}").fetchone()[0])
     matched_bytes = int(conn.execute(f"SELECT COALESCE(SUM(size_bytes), 0) FROM {_MATCH_TABLE}").fetchone()[0])
     ambiguous_count = int(conn.execute(f"SELECT COUNT(*) FROM {_AMBIGUOUS_TABLE}").fetchone()[0])
+    conn.execute(
+        f"""
+        CREATE TEMP TABLE {_READINESS_TABLE} (
+            stage_version INTEGER PRIMARY KEY,
+            scanned_count INTEGER NOT NULL,
+            hook_evidence_count INTEGER NOT NULL,
+            hook_count INTEGER NOT NULL,
+            identity_count INTEGER NOT NULL,
+            matched_count INTEGER NOT NULL,
+            matched_bytes INTEGER NOT NULL,
+            ambiguous_count INTEGER NOT NULL,
+            CHECK (stage_version = {_STAGE_VERSION})
+        ) STRICT
+        """
+    )
+    checkpoint(f"created:{_READINESS_TABLE}")
+    conn.execute(
+        f"""
+        INSERT INTO {_READINESS_TABLE} (
+            stage_version, scanned_count, hook_evidence_count, hook_count,
+            identity_count, matched_count, matched_bytes, ambiguous_count
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            _STAGE_VERSION,
+            scanned_count,
+            hook_evidence_count,
+            hook_count,
+            identity_count,
+            matched_count,
+            matched_bytes,
+            ambiguous_count,
+        ),
+    )
     return scanned_count, matched_count, matched_bytes, ambiguous_count
+
+
+def _create_match_stage(
+    conn: sqlite3.Connection, *, failure_injector: _StageFailureInjector | None = None
+) -> tuple[int, int, int, int]:
+    """Build or verify the complete legacy hook-match stage.
+
+    The temp tables are an all-or-nothing read model. A readiness attestation
+    is published only after every relation, population statement, and
+    integrity check succeeds. Any failure clears every table from this build,
+    so downstream liveness checks cannot mistake a partial relation for a
+    usable stage.
+    """
+
+    try:
+        ready = _match_stage_readiness(conn)
+    except sqlite3.Error:
+        _clear_match_stage(conn)
+        raise
+    if ready is not None:
+        return ready
+
+    _clear_match_stage(conn)
+    savepoint = "hook_payload_ref_reconciliation_stage"
+    savepoint_open = False
+    try:
+        conn.execute(f"SAVEPOINT {savepoint}")
+        savepoint_open = True
+        _build_match_stage(conn, failure_injector=failure_injector)
+        attested = _match_stage_readiness(conn)
+        if attested is None:
+            raise RuntimeError("hook payload reconciliation stage integrity check failed")
+        conn.execute(f"RELEASE SAVEPOINT {savepoint}")
+        savepoint_open = False
+        return attested
+    except BaseException:
+        try:
+            if savepoint_open:
+                conn.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+                conn.execute(f"RELEASE SAVEPOINT {savepoint}")
+        finally:
+            _clear_match_stage(conn)
+        raise
 
 
 def plan_hook_payload_ref_reconciliation(conn: sqlite3.Connection) -> HookPayloadRefReconciliationPlan:

--- a/tests/unit/storage/test_blob_gc.py
+++ b/tests/unit/storage/test_blob_gc.py
@@ -361,6 +361,44 @@ def test_run_blob_gc_bounds_final_lock_rechecks_with_many_references(
     assert not store.exists(orphan_hash)
 
 
+@pytest.mark.uses_real_clock(
+    "backdates a real blob mtime via os.utime; blob_gc.py's age gate compares it against a real time.time() call in production code, so frozen_clock cannot intercept either side"
+)
+def test_run_blob_gc_does_not_stage_again_when_all_candidates_are_referenced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from polylogue.storage import blob_gc
+
+    db_path = tmp_path / "source.db"
+    blob_root = tmp_path / "blobs"
+    store = BlobStore(blob_root)
+    conn = _make_db(db_path)
+    blob_hash, size = store.write_from_bytes(b"referenced")
+    _backdate(store, blob_hash)
+    conn.execute(
+        "INSERT INTO raw_sessions (raw_id, source_name, source_path, blob_size, acquired_at) "
+        "VALUES (?, 'codex', 'referenced.json', ?, '2026-01-01')",
+        (blob_hash, size),
+    )
+    conn.commit()
+    conn.close()
+
+    stage_calls = 0
+    original = blob_gc._legacy_hook_liveness_status
+
+    def count_stage_calls(connection: sqlite3.Connection) -> str:
+        nonlocal stage_calls
+        stage_calls += 1
+        return original(connection)
+
+    monkeypatch.setattr(blob_gc, "_legacy_hook_liveness_status", count_stage_calls)
+    report = run_blob_gc_report(db_path, blob_root, max_batch=10)
+
+    assert report.deleted_count == 0
+    assert report.skipped_referenced == 1
+    assert stage_calls == 1
+
+
 def test_run_blob_gc_nonexistent_blob_dir(tmp_path: Path) -> None:
     """GC on nonexistent directory should return 0 without crash."""
     db_path = tmp_path / "archive.db"

--- a/tests/unit/storage/test_blob_ref_liveness.py
+++ b/tests/unit/storage/test_blob_ref_liveness.py
@@ -199,6 +199,66 @@ def test_legacy_hook_payload_ref_is_rekeyable_not_a_delete_candidate(tmp_path: P
     assert all(candidate.ref_id != legacy_ref_id for candidate in classification.candidates)
 
 
+def test_liveness_stage_fails_closed_when_hook_match_build_is_interrupted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The production liveness stage must not retain a prior candidate table after an interrupted match build."""
+
+    archive_root = _source_archive(tmp_path)
+    blob_hash = b"h" * 32
+    source_path = "/legacy-hook.jsonl"
+    native_id = "tool-call-1"
+    legacy_ref_id = deterministic_raw_session_id("codex-session", source_path, 0, blob_hash, native_id)
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_hook_events (
+                hook_event_id, origin, native_id, source_path, event_type, payload_json, observed_at_ms
+            ) VALUES ('hook-legacy', 'codex-session', ?, ?, 'PostToolUse', '{}', 1)
+            """,
+            (native_id, source_path),
+        )
+        conn.execute(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, ?, 'raw_payload', ?, 1, 1)
+            """,
+            (blob_hash, legacy_ref_id, source_path),
+        )
+        conn.execute(
+            """
+            CREATE TEMP TABLE blob_ref_liveness_candidates (
+                blob_hash BLOB NOT NULL,
+                ref_type TEXT NOT NULL,
+                ref_id TEXT NOT NULL,
+                source_path TEXT,
+                size_bytes INTEGER NOT NULL,
+                acquired_at_ms INTEGER NOT NULL,
+                referent_table TEXT NOT NULL,
+                referent_column TEXT NOT NULL,
+                PRIMARY KEY (blob_hash, ref_type, ref_id)
+            ) STRICT
+            """
+        )
+
+        def inject_interruption(event: str) -> None:
+            if event == "population_began":
+                raise RuntimeError("injected match-stage interruption")
+
+        def fail_after_population(connection: sqlite3.Connection) -> tuple[int, int, int, int]:
+            return hook_payload_ref_reconciliation._create_match_stage(connection, failure_injector=inject_interruption)
+
+        monkeypatch.setattr(blob_ref_liveness, "_create_match_stage", fail_after_population)
+
+        with pytest.raises(RuntimeError, match="injected match-stage interruption"):
+            stage_blob_ref_liveness(conn)
+
+        remaining = {str(row[0]) for row in conn.execute("SELECT name FROM sqlite_temp_master WHERE type = 'table'")}
+
+    assert "blob_ref_liveness_candidates" not in remaining
+    assert not remaining.intersection(hook_payload_ref_reconciliation._STAGE_TABLES)
+
+
 def test_apply_requires_backup_and_receipt_before_mutation(tmp_path: Path) -> None:
     archive_root = _source_archive(tmp_path)
     with pytest.raises(BlobRefLivenessReconciliationError, match="backup manifest"):

--- a/tests/unit/storage/test_hook_payload_ref_reconciliation.py
+++ b/tests/unit/storage/test_hook_payload_ref_reconciliation.py
@@ -14,6 +14,9 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
+import pytest
+
+import polylogue.storage.hook_payload_ref_reconciliation as reconciliation
 from polylogue.storage.hook_payload_ref_reconciliation import plan_hook_payload_ref_reconciliation
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
 from polylogue.storage.sqlite.archive_tiers.source_write import (
@@ -169,3 +172,43 @@ def test_plan_ignores_raw_payload_refs_with_a_real_raw_sessions_row(tmp_path: Pa
 
     assert plan.scanned_count == 0
     assert plan.matched == ()
+
+
+@pytest.mark.parametrize(
+    "checkpoint",
+    (
+        *(f"created:{table}" for table in reconciliation._STAGE_TABLES),
+        "population_began",
+    ),
+)
+def test_match_stage_failure_clears_every_temp_table_then_rebuilds(tmp_path: Path, checkpoint: str) -> None:
+    """No build checkpoint may leave a reusable partial reconciliation stage."""
+
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        _seed_pre_v22_hook_ref(
+            conn,
+            hook_event_id="hook-1",
+            origin="codex-session",
+            source_path="/hooks/a.jsonl",
+            native_id="native-1",
+            payload=b'{"event":"PostToolUse"}',
+        )
+
+        def fail_at_current_checkpoint(event: str) -> None:
+            if event == checkpoint:
+                raise RuntimeError(f"injected failure at {event}")
+
+        with pytest.raises(RuntimeError, match="injected failure"):
+            reconciliation._create_match_stage(conn, failure_injector=fail_at_current_checkpoint)
+
+        remaining = {str(row[0]) for row in conn.execute("SELECT name FROM sqlite_temp_master WHERE type = 'table'")}
+        assert not remaining.intersection(reconciliation._STAGE_TABLES)
+        assert reconciliation._match_stage_readiness(conn) is None
+
+        rebuilt = plan_hook_payload_ref_reconciliation(conn)
+
+    assert rebuilt.scanned_count == 1
+    assert rebuilt.unmatched_count == 0
+    assert tuple(candidate.hook_event_id for candidate in rebuilt.matched) == ("hook-1",)


### PR DESCRIPTION
## Summary

Make hook-match staging transactional, readiness-attested, and fail closed for blob liveness and garbage collection.

## Problem

An interrupted hook-match build could leave temporary relations behind. A later liveness candidate could mistake those partial tables for a complete stage and classify evidence incorrectly.

## Solution

The matcher now builds every relation under a savepoint, records a versioned readiness row only after population and integrity checks succeed, validates row counts and referential consistency on reuse, and clears all stage artifacts on any failure. Blob liveness and GC use the attested stage path and retain candidates when staging is unavailable. Failure injection covers every table-creation checkpoint and population start, followed by a rebuild assertion.

## Verification

- `devtools test tests/unit/storage/test_hook_payload_ref_reconciliation.py tests/unit/storage/test_blob_ref_liveness.py tests/unit/storage/test_blob_gc_ref_type_liveness.py` -> 50 passed
- `devtools verify --quick` -> all 24 steps exit 0
- `git verify-commit HEAD` -> passed

## Follow-ups

No production archive or daemon mutation was performed. Ref polylogue-tiozw.

<!-- polylogue-pr-scope:v1
{
  "assigned_beads": [
    "polylogue-tiozw"
  ],
  "beads_digest": "5cc33ca49768397f7bf141337b12cda4b28c680601880666b5b33c6295e4b6b8",
  "dispositions": [
    {
      "bead_id": "polylogue-tiozw",
      "disposition": "satisfied",
      "evidence": [
        {
          "kind": "commit",
          "ref": "e502d998bd1f4cd02e022bd186ddc6d75701186b"
        },
        {
          "kind": "test",
          "ref": "50 focused hook and blob-liveness tests passed"
        },
        {
          "kind": "command",
          "ref": "devtools verify --quick: all 24 steps passed"
        }
      ],
      "successors": []
    }
  ],
  "head_sha": "f85ec33b8efb9ec4d66aa8d18048bdd3586b4b8d",
  "scope_digest": "e9ce73e0c227afd4e04585ce90f7e7281d3b026be5fd6f4d70f01dd284cdde83",
  "version": 1
}
-->


