### PR TITLE
fix(devtools): guard current reindex proof edges

### DIFF
--- a/devtools/verify_bead_graph.py
+++ b/devtools/verify_bead_graph.py
@@ -35,6 +35,40 @@ class Finding:
     detail: str
 
 
+@dataclass(frozen=True, slots=True)
+class RequiredBlockingEdge:
+    """One non-negotiable ``blocks`` relation in the reindex proof graph."""
+
+    dependent_id: str
+    blocker_id: str
+
+
+# These are the twelve live-proof records whose implementation/acceptance
+# blockers must remain explicit in the current graph. Keep this as structured
+# policy rather than deriving ordering from issue text or close reasons.
+REINDEX_REQUIRED_LIVE_PROOF_BLOCKING_EDGES: tuple[RequiredBlockingEdge, ...] = (
+    RequiredBlockingEdge("polylogue-active-leaf-live-proof", "polylogue-2hwl"),
+    RequiredBlockingEdge("polylogue-hook-authority-conflict-proof", "polylogue-foee"),
+    RequiredBlockingEdge("polylogue-chatgpt-content-live-proof", "polylogue-xofj"),
+    RequiredBlockingEdge("polylogue-excluded-cursor-live-proof", "polylogue-ix5r"),
+    RequiredBlockingEdge("polylogue-byte-supersession-live-proof", "polylogue-6753s"),
+    RequiredBlockingEdge("polylogue-hook-reconciliation-apply-proof", "polylogue-nhbvf"),
+    RequiredBlockingEdge("polylogue-raw-dedupe-apply-proof", "polylogue-zm4w8"),
+    RequiredBlockingEdge("polylogue-claude-streaming-live-proof", "polylogue-4987i"),
+    RequiredBlockingEdge("polylogue-claude-vintage-live-proof", "polylogue-0qfy"),
+    RequiredBlockingEdge("polylogue-codex-804-live-proof", "polylogue-27522"),
+    RequiredBlockingEdge("polylogue-topology-live-proof", "polylogue-4ts.10"),
+    RequiredBlockingEdge("polylogue-stalled-cursor-live-proof", "polylogue-2qrx"),
+)
+
+# The edge guard is consumed by both phase boundaries. This binds the static
+# policy to the actual readiness graph without turning it into a live receipt.
+REINDEX_PROOF_EDGE_GUARD_PHASE_BINDINGS: tuple[RequiredBlockingEdge, ...] = (
+    RequiredBlockingEdge("polylogue-reindex-preflight-authorization", "polylogue-eqq02"),
+    RequiredBlockingEdge("polylogue-reindex-final-proof", "polylogue-eqq02"),
+)
+
+
 def _wave(issue: dict[str, Any]) -> tuple[int | None, Finding | None]:
     """Parse the issue's ``wave:`` label."""
     for label in issue.get("labels") or []:
@@ -178,11 +212,65 @@ def _parent_findings(issues: list[dict[str, Any]]) -> list[Finding]:
     return findings
 
 
+def _blocks_targets(issue: dict[str, Any]) -> set[str]:
+    """Return the structured blockers declared by one Bead record."""
+    dependencies = issue.get("dependencies")
+    if not isinstance(dependencies, list):
+        return set()
+    return {
+        target
+        for dependency in dependencies
+        if isinstance(dependency, dict)
+        and dependency.get("type") == "blocks"
+        and isinstance((target := dependency.get("depends_on_id")), str)
+        and target
+    }
+
+
+def _required_blocking_edge_findings(
+    issues: list[dict[str, Any]],
+    *,
+    required_edges: tuple[RequiredBlockingEdge, ...],
+    kind: str,
+) -> list[Finding]:
+    """Report missing structured edges without accepting another edge kind."""
+    by_id = {str(issue["id"]): issue for issue in issues if isinstance(issue.get("id"), str)}
+    findings: list[Finding] = []
+    for edge in required_edges:
+        dependent = by_id.get(edge.dependent_id)
+        detail = f"required blocks dependency: {edge.dependent_id} -> {edge.blocker_id}"
+        if dependent is None:
+            findings.append(Finding(kind, edge.dependent_id, f"missing dependent; {detail}"))
+        elif edge.blocker_id not in _blocks_targets(dependent):
+            findings.append(Finding(kind, edge.dependent_id, f"missing {detail}"))
+    return findings
+
+
+def reindex_proof_edge_findings(issues: list[dict[str, Any]]) -> list[Finding]:
+    """Validate required reindex live-proof ownership and phase bindings."""
+    issue_ids = {str(issue["id"]) for issue in issues if isinstance(issue.get("id"), str)}
+    phase_consumer_ids = {edge.dependent_id for edge in REINDEX_PROOF_EDGE_GUARD_PHASE_BINDINGS}
+    if not issue_ids.intersection(phase_consumer_ids):
+        return []
+    return [
+        *_required_blocking_edge_findings(
+            issues,
+            required_edges=REINDEX_REQUIRED_LIVE_PROOF_BLOCKING_EDGES,
+            kind="missing-required-reindex-proof-edge",
+        ),
+        *_required_blocking_edge_findings(
+            issues,
+            required_edges=REINDEX_PROOF_EDGE_GUARD_PHASE_BINDINGS,
+            kind="missing-reindex-proof-edge-guard-binding",
+        ),
+    ]
+
+
 def collect_findings(
     issues: list[dict[str, Any]], *, required_contract_ids: frozenset[str] | None = None
 ) -> list[Finding]:
     by_id = {str(issue["id"]): issue for issue in issues if isinstance(issue.get("id"), str)}
-    findings: list[Finding] = _parent_findings(issues)
+    findings: list[Finding] = [*_parent_findings(issues), *reindex_proof_edge_findings(issues)]
 
     for issue_id in sorted(required_contract_ids or ()):
         issue = by_id.get(issue_id)

--- a/devtools/verify_bead_graph.py
+++ b/devtools/verify_bead_graph.py
@@ -238,9 +238,14 @@ def _required_blocking_edge_findings(
     findings: list[Finding] = []
     for edge in required_edges:
         dependent = by_id.get(edge.dependent_id)
+        blocker = by_id.get(edge.blocker_id)
         detail = f"required blocks dependency: {edge.dependent_id} -> {edge.blocker_id}"
-        if dependent is None:
+        if dependent is None and blocker is None:
+            findings.append(Finding(kind, edge.dependent_id, f"missing dependent and blocker; {detail}"))
+        elif dependent is None:
             findings.append(Finding(kind, edge.dependent_id, f"missing dependent; {detail}"))
+        elif blocker is None:
+            findings.append(Finding(kind, edge.blocker_id, f"missing blocker; {detail}"))
         elif edge.blocker_id not in _blocks_targets(dependent):
             findings.append(Finding(kind, edge.dependent_id, f"missing {detail}"))
     return findings
@@ -248,10 +253,6 @@ def _required_blocking_edge_findings(
 
 def reindex_proof_edge_findings(issues: list[dict[str, Any]]) -> list[Finding]:
     """Validate required reindex live-proof ownership and phase bindings."""
-    issue_ids = {str(issue["id"]) for issue in issues if isinstance(issue.get("id"), str)}
-    phase_consumer_ids = {edge.dependent_id for edge in REINDEX_PROOF_EDGE_GUARD_PHASE_BINDINGS}
-    if not issue_ids.intersection(phase_consumer_ids):
-        return []
     return [
         *_required_blocking_edge_findings(
             issues,
@@ -267,10 +268,15 @@ def reindex_proof_edge_findings(issues: list[dict[str, Any]]) -> list[Finding]:
 
 
 def collect_findings(
-    issues: list[dict[str, Any]], *, required_contract_ids: frozenset[str] | None = None
+    issues: list[dict[str, Any]],
+    *,
+    required_contract_ids: frozenset[str] | None = None,
+    enforce_reindex: bool = False,
 ) -> list[Finding]:
     by_id = {str(issue["id"]): issue for issue in issues if isinstance(issue.get("id"), str)}
-    findings: list[Finding] = [*_parent_findings(issues), *reindex_proof_edge_findings(issues)]
+    findings: list[Finding] = [*_parent_findings(issues)]
+    if enforce_reindex:
+        findings.extend(reindex_proof_edge_findings(issues))
 
     for issue_id in sorted(required_contract_ids or ()):
         issue = by_id.get(issue_id)
@@ -396,8 +402,13 @@ def build_report(
     cycles_ok: bool,
     cycles_output: str,
     required_contract_ids: frozenset[str] | None = None,
+    enforce_reindex: bool = False,
 ) -> dict[str, Any]:
-    findings = collect_findings(issues, required_contract_ids=required_contract_ids)
+    findings = collect_findings(
+        issues,
+        required_contract_ids=required_contract_ids,
+        enforce_reindex=enforce_reindex,
+    )
     by_kind: dict[str, int] = defaultdict(int)
     for finding in findings:
         by_kind[finding.kind] += 1
@@ -467,6 +478,7 @@ def main(argv: list[str] | None = None) -> int:
         cycles_ok=cycles_ok,
         cycles_output=cycles_output,
         required_contract_ids=REQUIRED_CONTRACT_IDS,
+        enforce_reindex=True,
     )
     if args.json:
         print(json.dumps(report, indent=2, sort_keys=True))

--- a/tests/unit/devtools/test_verify_bead_graph.py
+++ b/tests/unit/devtools/test_verify_bead_graph.py
@@ -25,6 +25,12 @@ EXPECTED_REINDEX_LIVE_PROOF_BLOCKING_EDGES = frozenset(
         ("polylogue-stalled-cursor-live-proof", "polylogue-2qrx"),
     }
 )
+EXPECTED_REINDEX_PHASE_BINDINGS = frozenset(
+    {
+        ("polylogue-reindex-preflight-authorization", "polylogue-eqq02"),
+        ("polylogue-reindex-final-proof", "polylogue-eqq02"),
+    }
+)
 
 
 def _issue(
@@ -268,6 +274,9 @@ def test_current_export_satisfies_reindex_live_proof_edge_policy() -> None:
     assert {
         (edge.dependent_id, edge.blocker_id) for edge in verify_bead_graph.REINDEX_REQUIRED_LIVE_PROOF_BLOCKING_EDGES
     } == EXPECTED_REINDEX_LIVE_PROOF_BLOCKING_EDGES
+    assert {
+        (edge.dependent_id, edge.blocker_id) for edge in verify_bead_graph.REINDEX_PROOF_EDGE_GUARD_PHASE_BINDINGS
+    } == EXPECTED_REINDEX_PHASE_BINDINGS
     assert verify_bead_graph.reindex_proof_edge_findings(_exported_issues()) == []
 
 
@@ -297,6 +306,64 @@ def test_required_reindex_edge_rejects_missing_blocker_endpoint() -> None:
         and finding.bead_id == blocker
         and "missing blocker" in finding.detail
         for finding in findings
+    )
+
+
+@pytest.mark.parametrize(
+    "edge_pair",
+    sorted(EXPECTED_REINDEX_PHASE_BINDINGS),
+    ids=lambda edge_pair: f"{edge_pair[0]}->{edge_pair[1]}",
+)
+def test_each_required_phase_binding_fails_closed_when_removed(edge_pair: tuple[str, str]) -> None:
+    issues = deepcopy(_exported_issues())
+    dependent, blocker = edge_pair
+    dependent_issue = next(issue for issue in issues if issue["id"] == dependent)
+    dependencies = dependent_issue["dependencies"]
+    assert isinstance(dependencies, list)
+    dependent_issue["dependencies"] = [
+        dependency
+        for dependency in dependencies
+        if not (
+            isinstance(dependency, dict)
+            and dependency.get("type") == "blocks"
+            and dependency.get("depends_on_id") == blocker
+        )
+    ]
+
+    findings = verify_bead_graph.reindex_proof_edge_findings(issues)
+
+    assert any(
+        finding.kind == "missing-reindex-proof-edge-guard-binding"
+        and finding.bead_id == dependent
+        and blocker in finding.detail
+        for finding in findings
+    )
+
+
+def test_main_enforces_reindex_edge_policy(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    issues = deepcopy(_exported_issues())
+    dependent, blocker = next(iter(EXPECTED_REINDEX_LIVE_PROOF_BLOCKING_EDGES))
+    dependent_issue = next(issue for issue in issues if issue["id"] == dependent)
+    dependencies = dependent_issue["dependencies"]
+    assert isinstance(dependencies, list)
+    dependent_issue["dependencies"] = [
+        dependency
+        for dependency in dependencies
+        if not (
+            isinstance(dependency, dict)
+            and dependency.get("type") == "blocks"
+            and dependency.get("depends_on_id") == blocker
+        )
+    ]
+    monkeypatch.setattr(verify_bead_graph, "_run_bd_dep_cycles", lambda: (True, "cycles clean"))
+    monkeypatch.setattr(verify_bead_graph, "_run_bd_list_all", lambda: issues)
+    monkeypatch.setattr(verify_bead_graph, "REQUIRED_CONTRACT_IDS", frozenset())
+
+    assert verify_bead_graph.main(["--json"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert any(
+        finding["kind"] == "missing-required-reindex-proof-edge" and finding["id"] == dependent
+        for finding in payload["findings"]
     )
 
 

--- a/tests/unit/devtools/test_verify_bead_graph.py
+++ b/tests/unit/devtools/test_verify_bead_graph.py
@@ -2,10 +2,16 @@ from __future__ import annotations
 
 import json
 import subprocess
+from copy import deepcopy
+from pathlib import Path
 
 import pytest
 
 from devtools import verify_bead_graph
+
+EXPECTED_REINDEX_LIVE_PROOF_BLOCKING_EDGES = frozenset(
+    {(edge.dependent_id, edge.blocker_id) for edge in verify_bead_graph.REINDEX_REQUIRED_LIVE_PROOF_BLOCKING_EDGES}
+)
 
 
 def _issue(
@@ -28,6 +34,11 @@ def _issue(
         "priority": priority,
         "metadata": metadata if metadata is not None else {},
     }
+
+
+def _exported_issues() -> list[dict[str, object]]:
+    export_path = Path(__file__).parents[3] / ".beads" / "issues.jsonl"
+    return [json.loads(line) for line in export_path.read_text(encoding="utf-8").splitlines() if line]
 
 
 def test_clean_graph_has_no_findings() -> None:
@@ -235,6 +246,46 @@ def test_parent_child_validation_rejects_duplicate_edge_records() -> None:
 
     assert verify_bead_graph.canonical_parent_map(issues)["polylogue-child"] is None
     assert ("multiple-parents", "polylogue-child") in {(finding.kind, finding.bead_id) for finding in findings}
+
+
+def test_current_export_satisfies_reindex_live_proof_edge_policy() -> None:
+    """The current Beads export carries every edge required by the policy."""
+    assert {
+        (edge.dependent_id, edge.blocker_id) for edge in verify_bead_graph.REINDEX_REQUIRED_LIVE_PROOF_BLOCKING_EDGES
+    } == EXPECTED_REINDEX_LIVE_PROOF_BLOCKING_EDGES
+    assert verify_bead_graph.reindex_proof_edge_findings(_exported_issues()) == []
+
+
+@pytest.mark.parametrize(
+    "edge",
+    verify_bead_graph.REINDEX_REQUIRED_LIVE_PROOF_BLOCKING_EDGES,
+    ids=lambda edge: f"{edge.dependent_id}->{edge.blocker_id}",
+)
+def test_each_required_reindex_live_proof_edge_fails_closed_when_removed(
+    edge: verify_bead_graph.RequiredBlockingEdge,
+) -> None:
+    """Removing one required edge must fail the graph policy."""
+    issues = deepcopy(_exported_issues())
+    dependent = next(issue for issue in issues if issue["id"] == edge.dependent_id)
+    dependencies = dependent["dependencies"]
+    assert isinstance(dependencies, list)
+    dependent["dependencies"] = [
+        dependency
+        for dependency in dependencies
+        if not (
+            isinstance(dependency, dict)
+            and dependency.get("type") == "blocks"
+            and dependency.get("depends_on_id") == edge.blocker_id
+        )
+    ]
+
+    findings = verify_bead_graph.reindex_proof_edge_findings(issues)
+    assert any(
+        finding.kind == "missing-required-reindex-proof-edge"
+        and finding.bead_id == edge.dependent_id
+        and edge.blocker_id in finding.detail
+        for finding in findings
+    )
 
 
 def test_parent_child_validation_rejects_malformed_targets() -> None:

--- a/tests/unit/devtools/test_verify_bead_graph.py
+++ b/tests/unit/devtools/test_verify_bead_graph.py
@@ -10,7 +10,20 @@ import pytest
 from devtools import verify_bead_graph
 
 EXPECTED_REINDEX_LIVE_PROOF_BLOCKING_EDGES = frozenset(
-    {(edge.dependent_id, edge.blocker_id) for edge in verify_bead_graph.REINDEX_REQUIRED_LIVE_PROOF_BLOCKING_EDGES}
+    {
+        ("polylogue-active-leaf-live-proof", "polylogue-2hwl"),
+        ("polylogue-hook-authority-conflict-proof", "polylogue-foee"),
+        ("polylogue-chatgpt-content-live-proof", "polylogue-xofj"),
+        ("polylogue-excluded-cursor-live-proof", "polylogue-ix5r"),
+        ("polylogue-byte-supersession-live-proof", "polylogue-6753s"),
+        ("polylogue-hook-reconciliation-apply-proof", "polylogue-nhbvf"),
+        ("polylogue-raw-dedupe-apply-proof", "polylogue-zm4w8"),
+        ("polylogue-claude-streaming-live-proof", "polylogue-4987i"),
+        ("polylogue-claude-vintage-live-proof", "polylogue-0qfy"),
+        ("polylogue-codex-804-live-proof", "polylogue-27522"),
+        ("polylogue-topology-live-proof", "polylogue-4ts.10"),
+        ("polylogue-stalled-cursor-live-proof", "polylogue-2qrx"),
+    }
 )
 
 
@@ -168,6 +181,8 @@ def test_main_exits_zero_when_all_waves_are_well_formed(
     monkeypatch.setattr(verify_bead_graph, "_run_bd_dep_cycles", lambda: (True, ""))
     monkeypatch.setattr(verify_bead_graph, "_run_bd_list_all", lambda: [_issue("polylogue-a", labels=["wave:1"])])
     monkeypatch.setattr(verify_bead_graph, "REQUIRED_CONTRACT_IDS", frozenset())
+    monkeypatch.setattr(verify_bead_graph, "REINDEX_REQUIRED_LIVE_PROOF_BLOCKING_EDGES", ())
+    monkeypatch.setattr(verify_bead_graph, "REINDEX_PROOF_EDGE_GUARD_PHASE_BINDINGS", ())
 
     rc = verify_bead_graph.main([])
 
@@ -256,16 +271,46 @@ def test_current_export_satisfies_reindex_live_proof_edge_policy() -> None:
     assert verify_bead_graph.reindex_proof_edge_findings(_exported_issues()) == []
 
 
+def test_reindex_edge_policy_remains_active_without_phase_consumers() -> None:
+    findings = verify_bead_graph.reindex_proof_edge_findings([])
+
+    assert len(findings) == 14
+    assert {finding.kind for finding in findings} == {
+        "missing-required-reindex-proof-edge",
+        "missing-reindex-proof-edge-guard-binding",
+    }
+
+
+def test_required_reindex_edge_rejects_missing_blocker_endpoint() -> None:
+    dependent, blocker = next(iter(EXPECTED_REINDEX_LIVE_PROOF_BLOCKING_EDGES))
+    issues = [
+        _issue(
+            dependent,
+            dependencies=[{"type": "blocks", "depends_on_id": blocker}],
+        )
+    ]
+
+    findings = verify_bead_graph.reindex_proof_edge_findings(issues)
+
+    assert any(
+        finding.kind == "missing-required-reindex-proof-edge"
+        and finding.bead_id == blocker
+        and "missing blocker" in finding.detail
+        for finding in findings
+    )
+
+
 @pytest.mark.parametrize(
-    "edge",
-    verify_bead_graph.REINDEX_REQUIRED_LIVE_PROOF_BLOCKING_EDGES,
-    ids=lambda edge: f"{edge.dependent_id}->{edge.blocker_id}",
+    "edge_pair",
+    sorted(EXPECTED_REINDEX_LIVE_PROOF_BLOCKING_EDGES),
+    ids=lambda edge_pair: f"{edge_pair[0]}->{edge_pair[1]}",
 )
 def test_each_required_reindex_live_proof_edge_fails_closed_when_removed(
-    edge: verify_bead_graph.RequiredBlockingEdge,
+    edge_pair: tuple[str, str],
 ) -> None:
     """Removing one required edge must fail the graph policy."""
     issues = deepcopy(_exported_issues())
+    edge = verify_bead_graph.RequiredBlockingEdge(*edge_pair)
     dependent = next(issue for issue in issues if issue["id"] == edge.dependent_id)
     dependencies = dependent["dependencies"]
     assert isinstance(dependencies, list)


### PR DESCRIPTION
## Summary

Add an executable guard for the twelve required reindex live-proof blocking edges and bind that guard to the current preflight and terminal-proof phase consumers.

## Problem

The current Beads graph carries the required proof ordering, but a future export could remove one of those `blocks` relations while the ordinary graph checks remained green. The earlier implementation branch was based on a stale graph and used the wrong Codex proof blocker.

## Solution

`devtools/verify_bead_graph.py` now owns a typed twelve-edge policy matrix, including the current `polylogue-27522` Codex recovery blocker, plus explicit bindings from the guard Bead to preflight authorization and final proof. The checker reads structured dependency records only and reports missing edges fail-closed. Parameterized tests remove each required edge from the current export and assert a finding.

## Verification

- `devtools test tests/unit/devtools/test_verify_bead_graph.py`: 43 passed
- `devtools verify --quick`: all 24 steps passed
- `ruff format`, `ruff check`, and strict `mypy`: passed

## Bead disposition

Ref `polylogue-eqq02`. The incident-ledger equality work remains a separate open Bead and is not claimed by this PR.

<!-- polylogue-pr-scope:v1
{
  "assigned_beads": [
    "polylogue-eqq02"
  ],
  "beads_digest": "17af630a3c32fc38b888ff1ae2f047ccd0f4b2dc0c4f1b62f8fb9ea17c1edb23",
  "dispositions": [
    {
      "bead_id": "polylogue-eqq02",
      "disposition": "satisfied",
      "evidence": [
        {
          "kind": "commit",
          "ref": "3ba49d1a722313821b21f436662c2572b72f23b6"
        },
        {
          "kind": "test",
          "ref": "tests/unit/devtools/test_verify_bead_graph.py: 43 passed"
        },
        {
          "kind": "command",
          "ref": "devtools verify --quick: all 24 steps passed"
        }
      ],
      "successors": []
    }
  ],
  "head_sha": "28cc9f91e51fbbce52b88671564bdd59c8bd0389",
  "scope_digest": "27d6eedeae12402364c73103bc1843416f5d831f31ffab163eef7b98df308702",
  "version": 1
}
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for required live-proof blocking relationships in graph reports.
  * Reports now identify missing dependents, blockers, or blocking relationships.
  * Added checks for required phase bindings.

* **Bug Fixes**
  * Graph verification now fails safely when required reindex relationships are incomplete.

* **Tests**
  * Expanded coverage for valid and invalid blocking-edge configurations, missing endpoints, and phase bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
