### PR TITLE
test(reindex): harden Claude vintage drift proofs (#3895)

### DIFF
--- a/polylogue/maintenance/pathology_zoo.py
+++ b/polylogue/maintenance/pathology_zoo.py
@@ -81,6 +81,8 @@ _CLAUDE_CODE = "claude-code-session"
 _CHATGPT = "chatgpt-export"
 _DESIGN = "claude-design-session"
 _GEMINI = "aistudio-drive"
+_CLAUDE_VINTAGE_NATIVE_ID = "9ed2056f-b415-4f51-b18e-5265f21a67bf"
+_CLAUDE_VINTAGE_LOGICAL_SOURCE_KEY = f"claude-ai:{_CLAUDE_VINTAGE_NATIVE_ID}"
 
 
 PATHOLOGY_ZOO_MANIFEST: tuple[PathologyZooMember, ...] = (
@@ -270,9 +272,10 @@ PATHOLOGY_ZOO_MANIFEST: tuple[PathologyZooMember, ...] = (
                 THEN 1 ELSE 0 END
             FROM raw_sessions AS r
             JOIN raw_session_memberships AS m ON m.raw_id = r.raw_id
-            WHERE r.native_id = ?
+            WHERE r.origin = ?
+              AND m.logical_source_key = ?
             """,
-            ("9ed2056f-b415-4f51-b18e-5265f21a67bf",),
+            (_CLAUDE_AI, _CLAUDE_VINTAGE_LOGICAL_SOURCE_KEY),
             (1,),
         ),
         evidence_note=(

--- a/tests/infra/claude_vintage_live_proof.py
+++ b/tests/infra/claude_vintage_live_proof.py
@@ -27,6 +27,8 @@ from polylogue.sources.parsers.claude.ai_parser import parse_ai
 from polylogue.sources.revision_backfill import backfill_historical_revision_evidence
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
 from tests.infra.pathology_zoo import (
+    CLAUDE_VINTAGE_LIVE_PROOF_LOGICAL_SOURCE_KEY,
+    CLAUDE_VINTAGE_LIVE_PROOF_ORIGIN,
     CLAUDE_VINTAGE_LIVE_PROOF_SESSION_ID,
     write_claude_vintage_live_proof_pair,
 )
@@ -185,10 +187,14 @@ def _read_membership_rows(archive_root: Path) -> tuple[dict[str, object], ...]:
             SELECT r.source_path, m.normalized_content_hash, m.decision
             FROM raw_sessions AS r
             JOIN raw_session_memberships AS m ON m.raw_id = r.raw_id
-            WHERE m.logical_source_key = ?
+            WHERE r.origin = ?
+              AND m.logical_source_key = ?
             ORDER BY r.source_path
             """,
-            (f"claude-ai:{CLAUDE_VINTAGE_LIVE_PROOF_SESSION_ID}",),
+            (
+                CLAUDE_VINTAGE_LIVE_PROOF_ORIGIN,
+                CLAUDE_VINTAGE_LIVE_PROOF_LOGICAL_SOURCE_KEY,
+            ),
         ).fetchall()
     return tuple(
         {

--- a/tests/infra/pathology_zoo.py
+++ b/tests/infra/pathology_zoo.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from polylogue.config import Source
+from polylogue.core.enums import Origin
 from polylogue.maintenance.pathology_zoo import (
     PATHOLOGY_ZOO_MANIFEST as PRODUCTION_PATHOLOGY_ZOO_MANIFEST,
 )
@@ -31,6 +32,10 @@ from polylogue.scenarios import CorpusSpec
 from polylogue.schemas.synthetic import SyntheticCorpus
 from polylogue.sources.hooks import drain_hook_event_spool, enqueue_hook_event
 from tests.infra.source_builders import SyntheticAntigravityLanguageServerClient
+
+CLAUDE_VINTAGE_LIVE_PROOF_SESSION_ID = "9ed2056f-b415-4f51-b18e-5265f21a67bf"
+CLAUDE_VINTAGE_LIVE_PROOF_ORIGIN = Origin.CLAUDE_AI_EXPORT.value
+CLAUDE_VINTAGE_LIVE_PROOF_LOGICAL_SOURCE_KEY = f"claude-ai:{CLAUDE_VINTAGE_LIVE_PROOF_SESSION_ID}"
 
 
 @dataclass(frozen=True, slots=True)
@@ -116,16 +121,23 @@ _PATHOLOGY_ZOO_MUTATIONS: dict[str, PathologyZooMutation] = {
     "claude-vintage-live-proof": PathologyZooMutation(
         "source",
         """
-        UPDATE raw_session_memberships
-        SET decision = 'superseded_prefix'
-        WHERE raw_id IN (
-            SELECT m.raw_id
+        DELETE FROM raw_sessions
+        WHERE raw_id = (
+            SELECT r.raw_id
             FROM raw_sessions AS r
             JOIN raw_session_memberships AS m ON m.raw_id = r.raw_id
-            WHERE r.native_id = ? AND m.decision = 'applied'
+            WHERE r.origin = ?
+              AND m.logical_source_key = ?
+              AND r.source_path LIKE ?
+            ORDER BY r.source_path DESC
+            LIMIT 1
         )
         """,
-        ("9ed2056f-b415-4f51-b18e-5265f21a67bf",),
+        (
+            Origin.CLAUDE_AI_EXPORT.value,
+            f"claude-ai:{CLAUDE_VINTAGE_LIVE_PROOF_SESSION_ID}",
+            "%claude-live-proof-new.json",
+        ),
     ),
     "lifecycle-anchor-drift": PathologyZooMutation(
         "index",
@@ -235,7 +247,6 @@ def _chatgpt_node(
     return node
 
 
-CLAUDE_VINTAGE_LIVE_PROOF_SESSION_ID = "9ed2056f-b415-4f51-b18e-5265f21a67bf"
 CLAUDE_VINTAGE_LIVE_PROOF_MESSAGE_IDS = (
     "64878c9e-2642-437b-a384-0961184f84ea",
     "4c341ad3-dbd9-4224-9ab4-dcb4f833b3f9",

--- a/tests/infra/pathology_zoo.py
+++ b/tests/infra/pathology_zoo.py
@@ -118,14 +118,14 @@ _PATHOLOGY_ZOO_MUTATIONS: dict[str, PathologyZooMutation] = {
         """
         UPDATE raw_session_memberships
         SET decision = 'superseded_prefix'
-        WHERE raw_id = (
-            SELECT r.raw_id
+        WHERE raw_id IN (
+            SELECT m.raw_id
             FROM raw_sessions AS r
             JOIN raw_session_memberships AS m ON m.raw_id = r.raw_id
-            WHERE r.native_id = ? AND r.source_path LIKE ? AND m.decision = 'applied'
+            WHERE r.native_id = ? AND m.decision = 'applied'
         )
         """,
-        ("9ed2056f-b415-4f51-b18e-5265f21a67bf", "%claude-live-proof-new.json"),
+        ("9ed2056f-b415-4f51-b18e-5265f21a67bf",),
     ),
     "lifecycle-anchor-drift": PathologyZooMutation(
         "index",

--- a/tests/infra/pathology_zoo.py
+++ b/tests/infra/pathology_zoo.py
@@ -115,7 +115,16 @@ _PATHOLOGY_ZOO_MUTATIONS: dict[str, PathologyZooMutation] = {
     ),
     "claude-vintage-live-proof": PathologyZooMutation(
         "source",
-        "DELETE FROM raw_sessions WHERE native_id = ? AND source_path LIKE ?",
+        """
+        UPDATE raw_session_memberships
+        SET decision = 'superseded_prefix'
+        WHERE raw_id = (
+            SELECT r.raw_id
+            FROM raw_sessions AS r
+            JOIN raw_session_memberships AS m ON m.raw_id = r.raw_id
+            WHERE r.native_id = ? AND r.source_path LIKE ? AND m.decision = 'applied'
+        )
+        """,
         ("9ed2056f-b415-4f51-b18e-5265f21a67bf", "%claude-live-proof-new.json"),
     ),
     "lifecycle-anchor-drift": PathologyZooMutation(

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -40,7 +40,11 @@ from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS, initialize_active_archive_root
 from polylogue.storage.sqlite.archive_tiers.source_write import ArchiveSourceArtifact, upsert_raw_artifact
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
-from tests.infra.pathology_zoo import build_pathology_zoo, make_pathology_zoo_member_red
+from tests.infra.pathology_zoo import (
+    CLAUDE_VINTAGE_LIVE_PROOF_SESSION_ID,
+    build_pathology_zoo,
+    make_pathology_zoo_member_red,
+)
 from tests.infra.workload_artifacts import SeededArchiveArtifact
 
 
@@ -1536,9 +1540,11 @@ def test_registry_execution_phase_projections_do_not_keep_handwritten_membership
 
 def test_pathology_zoo_contract_is_production_owned_and_registered() -> None:
     """The archive verifier, rather than tests, owns the zoo's enforcement boundary."""
-    from polylogue.maintenance.pathology_zoo import PATHOLOGY_ZOO_MANIFEST
+    from polylogue.maintenance.pathology_zoo import PATHOLOGY_ZOO_MANIFEST, pathology_zoo_manifest
 
-    assert len(PATHOLOGY_ZOO_MANIFEST) == 17
+    registered_manifest = pathology_zoo_manifest()
+    assert registered_manifest is PATHOLOGY_ZOO_MANIFEST
+    assert len({member.member_id for member in registered_manifest}) == len(registered_manifest)
     assert "pathology-zoo-invariants" in ARCHIVE_VERIFICATION_CHECK_NAMES
 
 
@@ -1797,6 +1803,51 @@ def test_pathology_zoo_invariants_red_twin(tmp_path: Path) -> None:
         check = _check(red, "pathology-zoo-invariants")
         assert check.status is OutcomeStatus.ERROR, member.invariant.condition
         assert member.member_id in check.evidence["failed_member_ids"]
+
+
+def test_pathology_zoo_claude_vintage_registered_invariant_rejects_each_semantic_drift(tmp_path: Path) -> None:
+    """The Claude registry check fails for hash and either membership verdict drift."""
+    zoo = build_pathology_zoo(tmp_path / "zoo")
+
+    for drift in ("hash", "applied", "superseded_equivalent"):
+        mutated_root = tmp_path / f"claude-vintage-{drift}"
+        copytree(zoo.archive_root, mutated_root)
+        with sqlite3.connect(mutated_root / "source.db") as conn:
+            rows = conn.execute(
+                """
+                SELECT r.raw_id, m.normalized_content_hash, m.decision
+                FROM raw_sessions AS r
+                JOIN raw_session_memberships AS m ON m.raw_id = r.raw_id
+                WHERE r.native_id = ?
+                ORDER BY r.source_path
+                """,
+                (CLAUDE_VINTAGE_LIVE_PROOF_SESSION_ID,),
+            ).fetchall()
+            assert len(rows) == 2
+
+            if drift == "hash":
+                raw_id, content_hash, _decision = rows[0]
+                original_hash = bytes(content_hash)
+                drifted_hash = bytearray(original_hash)
+                drifted_hash[0] ^= 0xFF
+                if bytes(drifted_hash) == bytes(rows[1][1]):
+                    drifted_hash[1] ^= 0xFF
+                conn.execute(
+                    "UPDATE raw_session_memberships SET normalized_content_hash = ? WHERE raw_id = ?",
+                    (bytes(drifted_hash), raw_id),
+                )
+            else:
+                raw_id = next(row[0] for row in rows if row[2] == drift)
+                conn.execute(
+                    "UPDATE raw_session_memberships SET decision = 'superseded_prefix' WHERE raw_id = ?",
+                    (raw_id,),
+                )
+            conn.commit()
+
+        red = verify_archive(mutated_root, checks=("pathology-zoo-invariants",))
+        check = _check(red, "pathology-zoo-invariants")
+        assert check.status is OutcomeStatus.ERROR
+        assert "claude-vintage-live-proof" in check.evidence["failed_member_ids"]
 
 
 def test_pathology_zoo_candidate_check_uses_candidate_index_and_durable_source(tmp_path: Path) -> None:

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -35,12 +35,15 @@ from polylogue.maintenance.archive_verification import (
     validate_archive_verification_registry,
     verify_archive,
 )
+from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
 from polylogue.sources.origin_specs import lowering_fingerprint, parser_fingerprint_for_origin
 from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS, initialize_active_archive_root
 from polylogue.storage.sqlite.archive_tiers.source_write import ArchiveSourceArtifact, upsert_raw_artifact
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from tests.infra.pathology_zoo import (
+    CLAUDE_VINTAGE_LIVE_PROOF_LOGICAL_SOURCE_KEY,
+    CLAUDE_VINTAGE_LIVE_PROOF_ORIGIN,
     CLAUDE_VINTAGE_LIVE_PROOF_SESSION_ID,
     build_pathology_zoo,
     make_pathology_zoo_member_red,
@@ -50,6 +53,68 @@ from tests.infra.workload_artifacts import SeededArchiveArtifact
 
 def _connect(path: Path) -> sqlite3.Connection:
     return sqlite3.connect(path)
+
+
+def _insert_foreign_same_native_id_row(source_db: Path) -> str:
+    """Add a valid-looking foreign-origin row that shares Claude's native ID."""
+    foreign_raw_id = "foreign-origin-same-native-id"
+    foreign_origin = "chatgpt-export"
+    foreign_logical_source_key = f"chatgpt:{CLAUDE_VINTAGE_LIVE_PROOF_SESSION_ID}"
+    with _connect(source_db) as conn:
+        raw = conn.execute(
+            """
+            SELECT r.native_id, r.blob_hash, r.blob_size, r.acquired_at_ms,
+                   m.normalized_content_hash, m.message_count
+            FROM raw_sessions AS r
+            JOIN raw_session_memberships AS m ON m.raw_id = r.raw_id
+            WHERE r.origin = ? AND m.logical_source_key = ?
+            ORDER BY r.source_path
+            LIMIT 1
+            """,
+            (CLAUDE_VINTAGE_LIVE_PROOF_ORIGIN, CLAUDE_VINTAGE_LIVE_PROOF_LOGICAL_SOURCE_KEY),
+        ).fetchone()
+        assert raw is not None
+        native_id, blob_hash, blob_size, acquired_at_ms, content_hash, message_count = raw
+        conn.execute(
+            """
+            INSERT INTO raw_sessions(
+                raw_id, origin, native_id, source_path, blob_hash, blob_size,
+                acquired_at_ms, logical_source_key, revision_kind, source_revision,
+                revision_authority, capture_mode
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'full', ?, 'byte_proven', 'chatgpt')
+            """,
+            (
+                foreign_raw_id,
+                foreign_origin,
+                native_id,
+                "foreign-origin/same-native-id.json",
+                blob_hash,
+                blob_size,
+                acquired_at_ms,
+                foreign_logical_source_key,
+                "foreign-origin-revision",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO raw_session_memberships(
+                raw_id, logical_source_key, provider_session_id, source_revision,
+                normalized_content_hash, message_count, revision_authority,
+                decision, decided_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, 'byte_proven', 'applied', ?)
+            """,
+            (
+                foreign_raw_id,
+                foreign_logical_source_key,
+                native_id,
+                "foreign-origin-revision",
+                content_hash,
+                message_count,
+                acquired_at_ms,
+            ),
+        )
+        conn.commit()
+    return foreign_raw_id
 
 
 def _seed_coherent_archive(root: Path) -> None:
@@ -1825,7 +1890,7 @@ def test_pathology_zoo_invariants_red_twin(tmp_path: Path) -> None:
 
 
 def test_pathology_zoo_claude_vintage_registered_invariant_rejects_each_semantic_drift(tmp_path: Path) -> None:
-    """The Claude registry check fails for hash and either membership verdict drift."""
+    """The Claude registry check fails for every scoped revision drift."""
     zoo = build_pathology_zoo(tmp_path / "zoo")
     green = verify_archive(zoo.archive_root, checks=("pathology-zoo-invariants",))
     green_check = _check(green, "pathology-zoo-invariants")
@@ -1833,20 +1898,26 @@ def test_pathology_zoo_claude_vintage_registered_invariant_rejects_each_semantic
     assert green_check.evidence["active"] is True
     assert "claude-vintage-live-proof" in green_check.evidence["checked_member_ids"]
     assert "claude-vintage-live-proof" not in green_check.evidence["failed_member_ids"]
+    foreign_logical_source_key = f"chatgpt:{CLAUDE_VINTAGE_LIVE_PROOF_SESSION_ID}"
 
-    for drift in ("hash", "applied", "superseded_equivalent"):
+    for drift in ("hash", "applied", "superseded_equivalent", "missing"):
         mutated_root = tmp_path / f"claude-vintage-{drift}"
         copytree(zoo.archive_root, mutated_root)
+        foreign_raw_id = _insert_foreign_same_native_id_row(mutated_root / "source.db")
         with sqlite3.connect(mutated_root / "source.db") as conn:
             rows = conn.execute(
                 """
                 SELECT r.raw_id, m.normalized_content_hash, m.decision
                 FROM raw_sessions AS r
                 JOIN raw_session_memberships AS m ON m.raw_id = r.raw_id
-                WHERE r.native_id = ?
+                WHERE r.origin = ?
+                  AND m.logical_source_key = ?
                 ORDER BY r.source_path
                 """,
-                (CLAUDE_VINTAGE_LIVE_PROOF_SESSION_ID,),
+                (
+                    CLAUDE_VINTAGE_LIVE_PROOF_ORIGIN,
+                    CLAUDE_VINTAGE_LIVE_PROOF_LOGICAL_SOURCE_KEY,
+                ),
             ).fetchall()
             assert len(rows) == 2
 
@@ -1861,7 +1932,7 @@ def test_pathology_zoo_claude_vintage_registered_invariant_rejects_each_semantic
                     "UPDATE raw_session_memberships SET normalized_content_hash = ? WHERE raw_id = ?",
                     (bytes(drifted_hash), raw_id),
                 )
-            else:
+            elif drift in ("applied", "superseded_equivalent"):
                 raw_id = next(row[0] for row in rows if row[2] == drift)
                 conn.execute(
                     "UPDATE raw_session_memberships SET decision = 'superseded_prefix' WHERE raw_id = ?",
@@ -1869,10 +1940,45 @@ def test_pathology_zoo_claude_vintage_registered_invariant_rejects_each_semantic
                 )
             conn.commit()
 
+        foreign_scoped_green = verify_archive(mutated_root, checks=("pathology-zoo-invariants",))
+        foreign_scoped_check = _check(foreign_scoped_green, "pathology-zoo-invariants")
+        assert foreign_scoped_check.status is OutcomeStatus.OK
+        assert "claude-vintage-live-proof" not in foreign_scoped_check.evidence["failed_member_ids"]
+
+        if drift == "missing":
+            make_pathology_zoo_member_red(mutated_root, "claude-vintage-live-proof")
+
         red = verify_archive(mutated_root, checks=("pathology-zoo-invariants",))
         check = _check(red, "pathology-zoo-invariants")
         assert check.status is OutcomeStatus.ERROR
         assert "claude-vintage-live-proof" in check.evidence["failed_member_ids"]
+
+        with sqlite3.connect(mutated_root / "source.db") as conn:
+            foreign_after = conn.execute(
+                "SELECT origin, logical_source_key, decision FROM raw_sessions AS r "
+                "JOIN raw_session_memberships AS m ON m.raw_id = r.raw_id "
+                "WHERE r.raw_id = ? AND m.logical_source_key = ?",
+                (foreign_raw_id, foreign_logical_source_key),
+            ).fetchone()
+        assert foreign_after == ("chatgpt-export", foreign_logical_source_key, "applied")
+
+        candidate = mutated_root / "candidate-index.db"
+        shutil.copy2(mutated_root / "index.db", candidate)
+        candidate_report = verify_archive(
+            mutated_root,
+            checks=REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS,
+            index_path_override=candidate,
+        )
+        candidate_check = _check(candidate_report, "pathology-zoo-invariants")
+        assert candidate_check.status is OutcomeStatus.ERROR
+        assert "claude-vintage-live-proof" in candidate_check.evidence["failed_member_ids"]
+        assert not passes_strict_acceptance(candidate_report, required_checks=REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS)
+
+    reindex_root = tmp_path / "claude-vintage-reindex"
+    copytree(zoo.archive_root, reindex_root)
+    make_pathology_zoo_member_red(reindex_root, "claude-vintage-live-proof")
+    with pytest.raises(RuntimeError, match=r"reindex acceptance gate failed.*pathology-zoo-invariants"):
+        rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=reindex_root, promote=False))
 
 
 def test_pathology_zoo_candidate_check_uses_candidate_index_and_durable_source(tmp_path: Path) -> None:

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -55,11 +55,86 @@ def _connect(path: Path) -> sqlite3.Connection:
     return sqlite3.connect(path)
 
 
-def _insert_foreign_same_native_id_row(source_db: Path) -> str:
-    """Add a valid-looking foreign-origin row that shares Claude's native ID."""
-    foreign_raw_id = "foreign-origin-same-native-id"
-    foreign_origin = "chatgpt-export"
-    foreign_logical_source_key = f"chatgpt:{CLAUDE_VINTAGE_LIVE_PROOF_SESSION_ID}"
+def _insert_claude_identity_collision_rows(source_db: Path) -> tuple[str, ...]:
+    """Add decoys that independently collide on origin and logical source key."""
+    collision_rows = (
+        (
+            "same-origin-different-logical-key",
+            CLAUDE_VINTAGE_LIVE_PROOF_ORIGIN,
+            f"claude-ai:collision:{CLAUDE_VINTAGE_LIVE_PROOF_SESSION_ID}",
+            "foreign-origin/same-origin-different-key.json",
+            "claude-ai",
+        ),
+        (
+            "different-origin-same-logical-key",
+            "chatgpt-export",
+            CLAUDE_VINTAGE_LIVE_PROOF_LOGICAL_SOURCE_KEY,
+            "foreign-origin/different-origin-same-key.json",
+            "chatgpt",
+        ),
+    )
+    with _connect(source_db) as conn:
+        raw = conn.execute(
+            """
+            SELECT r.native_id, r.blob_hash, r.blob_size, r.acquired_at_ms,
+                   m.normalized_content_hash, m.message_count
+            FROM raw_sessions AS r
+            JOIN raw_session_memberships AS m ON m.raw_id = r.raw_id
+            WHERE r.origin = ? AND m.logical_source_key = ?
+            ORDER BY r.source_path
+            LIMIT 1
+            """,
+            (CLAUDE_VINTAGE_LIVE_PROOF_ORIGIN, CLAUDE_VINTAGE_LIVE_PROOF_LOGICAL_SOURCE_KEY),
+        ).fetchone()
+        assert raw is not None
+        native_id, blob_hash, blob_size, acquired_at_ms, content_hash, message_count = raw
+        for raw_id, origin, logical_source_key, source_path, capture_mode in collision_rows:
+            conn.execute(
+                """
+                INSERT INTO raw_sessions(
+                    raw_id, origin, native_id, source_path, blob_hash, blob_size,
+                    acquired_at_ms, logical_source_key, revision_kind, source_revision,
+                    revision_authority, capture_mode
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'full', ?, 'byte_proven', ?)
+                """,
+                (
+                    raw_id,
+                    origin,
+                    native_id,
+                    source_path,
+                    blob_hash,
+                    blob_size,
+                    acquired_at_ms,
+                    logical_source_key,
+                    f"{raw_id}-revision",
+                    capture_mode,
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO raw_session_memberships(
+                    raw_id, logical_source_key, provider_session_id, source_revision,
+                    normalized_content_hash, message_count, revision_authority,
+                    decision, decided_at_ms
+                ) VALUES (?, ?, ?, ?, ?, ?, 'byte_proven', 'applied', ?)
+                """,
+                (
+                    raw_id,
+                    logical_source_key,
+                    native_id,
+                    f"{raw_id}-revision",
+                    content_hash,
+                    message_count,
+                    acquired_at_ms,
+                ),
+            )
+        conn.commit()
+    return tuple(row[0] for row in collision_rows)
+
+
+def _insert_claude_vintage_extra_revision(source_db: Path) -> str:
+    """Add a third in-scope revision whose typed decision is otherwise ignored."""
+    extra_raw_id = "claude-vintage-extra-revision"
     with _connect(source_db) as conn:
         raw = conn.execute(
             """
@@ -81,18 +156,18 @@ def _insert_foreign_same_native_id_row(source_db: Path) -> str:
                 raw_id, origin, native_id, source_path, blob_hash, blob_size,
                 acquired_at_ms, logical_source_key, revision_kind, source_revision,
                 revision_authority, capture_mode
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'full', ?, 'byte_proven', 'chatgpt')
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'full', ?, 'byte_proven', 'claude-ai')
             """,
             (
-                foreign_raw_id,
-                foreign_origin,
+                extra_raw_id,
+                CLAUDE_VINTAGE_LIVE_PROOF_ORIGIN,
                 native_id,
-                "foreign-origin/same-native-id.json",
+                "manual/claude-live-proof-extra.json",
                 blob_hash,
                 blob_size,
                 acquired_at_ms,
-                foreign_logical_source_key,
-                "foreign-origin-revision",
+                CLAUDE_VINTAGE_LIVE_PROOF_LOGICAL_SOURCE_KEY,
+                "claude-vintage-extra-revision",
             ),
         )
         conn.execute(
@@ -101,20 +176,20 @@ def _insert_foreign_same_native_id_row(source_db: Path) -> str:
                 raw_id, logical_source_key, provider_session_id, source_revision,
                 normalized_content_hash, message_count, revision_authority,
                 decision, decided_at_ms
-            ) VALUES (?, ?, ?, ?, ?, ?, 'byte_proven', 'applied', ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, 'byte_proven', 'superseded_prefix', ?)
             """,
             (
-                foreign_raw_id,
-                foreign_logical_source_key,
+                extra_raw_id,
+                CLAUDE_VINTAGE_LIVE_PROOF_LOGICAL_SOURCE_KEY,
                 native_id,
-                "foreign-origin-revision",
+                "claude-vintage-extra-revision",
                 content_hash,
                 message_count,
                 acquired_at_ms,
             ),
         )
         conn.commit()
-    return foreign_raw_id
+    return extra_raw_id
 
 
 def _seed_coherent_archive(root: Path) -> None:
@@ -1898,12 +1973,20 @@ def test_pathology_zoo_claude_vintage_registered_invariant_rejects_each_semantic
     assert green_check.evidence["active"] is True
     assert "claude-vintage-live-proof" in green_check.evidence["checked_member_ids"]
     assert "claude-vintage-live-proof" not in green_check.evidence["failed_member_ids"]
-    foreign_logical_source_key = f"chatgpt:{CLAUDE_VINTAGE_LIVE_PROOF_SESSION_ID}"
+    collision_logical_keys = {
+        "same-origin-different-logical-key": f"claude-ai:collision:{CLAUDE_VINTAGE_LIVE_PROOF_SESSION_ID}",
+        "different-origin-same-logical-key": CLAUDE_VINTAGE_LIVE_PROOF_LOGICAL_SOURCE_KEY,
+    }
 
-    for drift in ("hash", "applied", "superseded_equivalent", "missing"):
+    for drift in ("hash", "applied", "superseded_equivalent", "missing", "overpopulation"):
         mutated_root = tmp_path / f"claude-vintage-{drift}"
         copytree(zoo.archive_root, mutated_root)
-        foreign_raw_id = _insert_foreign_same_native_id_row(mutated_root / "source.db")
+        collision_raw_ids = _insert_claude_identity_collision_rows(mutated_root / "source.db")
+        foreign_scoped_green = verify_archive(mutated_root, checks=("pathology-zoo-invariants",))
+        foreign_scoped_check = _check(foreign_scoped_green, "pathology-zoo-invariants")
+        assert foreign_scoped_check.status is OutcomeStatus.OK
+        assert "claude-vintage-live-proof" not in foreign_scoped_check.evidence["failed_member_ids"]
+
         with sqlite3.connect(mutated_root / "source.db") as conn:
             rows = conn.execute(
                 """
@@ -1940,13 +2023,25 @@ def test_pathology_zoo_claude_vintage_registered_invariant_rejects_each_semantic
                 )
             conn.commit()
 
-        foreign_scoped_green = verify_archive(mutated_root, checks=("pathology-zoo-invariants",))
-        foreign_scoped_check = _check(foreign_scoped_green, "pathology-zoo-invariants")
-        assert foreign_scoped_check.status is OutcomeStatus.OK
-        assert "claude-vintage-live-proof" not in foreign_scoped_check.evidence["failed_member_ids"]
-
         if drift == "missing":
             make_pathology_zoo_member_red(mutated_root, "claude-vintage-live-proof")
+        elif drift == "overpopulation":
+            extra_raw_id = _insert_claude_vintage_extra_revision(mutated_root / "source.db")
+            with sqlite3.connect(mutated_root / "source.db") as conn:
+                aggregate = conn.execute(
+                    """
+                    SELECT COUNT(*), COUNT(DISTINCT m.normalized_content_hash),
+                           SUM(m.decision = 'applied'),
+                           SUM(m.decision = 'superseded_equivalent'),
+                           SUM(m.decision = 'superseded_prefix')
+                    FROM raw_sessions AS r
+                    JOIN raw_session_memberships AS m ON m.raw_id = r.raw_id
+                    WHERE r.origin = ? AND m.logical_source_key = ?
+                    """,
+                    (CLAUDE_VINTAGE_LIVE_PROOF_ORIGIN, CLAUDE_VINTAGE_LIVE_PROOF_LOGICAL_SOURCE_KEY),
+                ).fetchone()
+            assert aggregate == (3, 1, 1, 1, 1)
+            assert extra_raw_id == "claude-vintage-extra-revision"
 
         red = verify_archive(mutated_root, checks=("pathology-zoo-invariants",))
         check = _check(red, "pathology-zoo-invariants")
@@ -1954,13 +2049,25 @@ def test_pathology_zoo_claude_vintage_registered_invariant_rejects_each_semantic
         assert "claude-vintage-live-proof" in check.evidence["failed_member_ids"]
 
         with sqlite3.connect(mutated_root / "source.db") as conn:
-            foreign_after = conn.execute(
-                "SELECT origin, logical_source_key, decision FROM raw_sessions AS r "
+            collision_after = conn.execute(
+                "SELECT raw_id, origin, logical_source_key, decision FROM raw_sessions AS r "
                 "JOIN raw_session_memberships AS m ON m.raw_id = r.raw_id "
-                "WHERE r.raw_id = ? AND m.logical_source_key = ?",
-                (foreign_raw_id, foreign_logical_source_key),
-            ).fetchone()
-        assert foreign_after == ("chatgpt-export", foreign_logical_source_key, "applied")
+                "WHERE r.raw_id IN (?, ?) ORDER BY r.raw_id",
+                collision_raw_ids,
+            ).fetchall()
+        assert collision_after == [
+            (
+                raw_id,
+                CLAUDE_VINTAGE_LIVE_PROOF_ORIGIN if raw_id == "same-origin-different-logical-key" else "chatgpt-export",
+                collision_logical_keys[
+                    "same-origin-different-logical-key"
+                    if raw_id == "same-origin-different-logical-key"
+                    else "different-origin-same-logical-key"
+                ],
+                "applied",
+            )
+            for raw_id in sorted(collision_raw_ids)
+        ]
 
         candidate = mutated_root / "candidate-index.db"
         shutil.copy2(mutated_root / "index.db", candidate)
@@ -2004,6 +2111,35 @@ def test_pathology_zoo_candidate_check_uses_candidate_index_and_durable_source(t
     check = _check(red, "pathology-zoo-invariants")
     assert check.status is OutcomeStatus.ERROR
     assert "whale-component" in check.evidence["failed_member_ids"]
+
+
+def test_pathology_zoo_claude_candidate_acceptance_uses_selected_index(tmp_path: Path) -> None:
+    """The Claude acceptance report must inspect its selected inactive index."""
+    zoo = build_pathology_zoo(tmp_path / "zoo")
+    candidate = tmp_path / "candidate-index.db"
+    shutil.copy2(zoo.archive_root / "index.db", candidate)
+
+    active = verify_archive(zoo.archive_root, checks=("pathology-zoo-invariants",))
+    assert _check(active, "pathology-zoo-invariants").status is OutcomeStatus.OK
+
+    with _connect(candidate) as conn:
+        conn.execute(
+            "UPDATE sessions SET origin = 'codex-session' WHERE session_id = ?",
+            ("claude-design-session:zoo-design-session",),
+        )
+
+    active_after_candidate_mutation = verify_archive(zoo.archive_root, checks=("pathology-zoo-invariants",))
+    assert _check(active_after_candidate_mutation, "pathology-zoo-invariants").status is OutcomeStatus.OK
+
+    candidate_report = verify_archive(
+        zoo.archive_root,
+        checks=REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS,
+        index_path_override=candidate,
+    )
+    candidate_check = _check(candidate_report, "pathology-zoo-invariants")
+    assert candidate_check.status is OutcomeStatus.ERROR
+    assert "claude-design" in candidate_check.evidence["failed_member_ids"]
+    assert not passes_strict_acceptance(candidate_report, required_checks=REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS)
 
 
 def test_every_non_complexity_check_has_a_red_twin_test() -> None:

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -1828,7 +1828,11 @@ def test_pathology_zoo_claude_vintage_registered_invariant_rejects_each_semantic
     """The Claude registry check fails for hash and either membership verdict drift."""
     zoo = build_pathology_zoo(tmp_path / "zoo")
     green = verify_archive(zoo.archive_root, checks=("pathology-zoo-invariants",))
-    assert _check(green, "pathology-zoo-invariants").status is OutcomeStatus.OK
+    green_check = _check(green, "pathology-zoo-invariants")
+    assert green_check.status is OutcomeStatus.OK
+    assert green_check.evidence["active"] is True
+    assert "claude-vintage-live-proof" in green_check.evidence["checked_member_ids"]
+    assert "claude-vintage-live-proof" not in green_check.evidence["failed_member_ids"]
 
     for drift in ("hash", "applied", "superseded_equivalent"):
         mutated_root = tmp_path / f"claude-vintage-{drift}"

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -1543,8 +1543,27 @@ def test_pathology_zoo_contract_is_production_owned_and_registered() -> None:
     from polylogue.maintenance.pathology_zoo import PATHOLOGY_ZOO_MANIFEST, pathology_zoo_manifest
 
     registered_manifest = pathology_zoo_manifest()
+    expected_member_ids = (
+        "whale-component",
+        "append-self-describing",
+        "append-opaque",
+        "fork-prefix-tail",
+        "lineage-cycle",
+        "grouped-jsonl",
+        "quarantined-head",
+        "empty-session",
+        "hook-event",
+        "claude-design",
+        "vintage-reorder",
+        "claude-vintage-live-proof",
+        "lifecycle-anchor-drift",
+        "non-stream-safe",
+        "attachment-with-bytes",
+        "attachment-without-bytes",
+        "events-sidecars",
+    )
     assert registered_manifest is PATHOLOGY_ZOO_MANIFEST
-    assert len({member.member_id for member in registered_manifest}) == len(registered_manifest)
+    assert tuple(member.member_id for member in registered_manifest) == expected_member_ids
     assert "pathology-zoo-invariants" in ARCHIVE_VERIFICATION_CHECK_NAMES
 
 
@@ -1808,6 +1827,8 @@ def test_pathology_zoo_invariants_red_twin(tmp_path: Path) -> None:
 def test_pathology_zoo_claude_vintage_registered_invariant_rejects_each_semantic_drift(tmp_path: Path) -> None:
     """The Claude registry check fails for hash and either membership verdict drift."""
     zoo = build_pathology_zoo(tmp_path / "zoo")
+    green = verify_archive(zoo.archive_root, checks=("pathology-zoo-invariants",))
+    assert _check(green, "pathology-zoo-invariants").status is OutcomeStatus.OK
 
     for drift in ("hash", "applied", "superseded_equivalent"):
         mutated_root = tmp_path / f"claude-vintage-{drift}"


### PR DESCRIPTION
## Summary

Complete the Claude vintage pathology-proof continuation at the exact published head by closing three anti-vacuity gaps in source identity, candidate selection, and revision cardinality. The production invariant remains unchanged and still requires exactly two equivalent Claude revisions with one applied and one superseded-equivalent decision.

## Problem

The cold exact-head review found that the collision fixture changed both identity predicates at once, the Claude candidate assertion copied an unchanged index, and the missing-revision twin covered only loss of a required row. Those shapes could leave one identity predicate, candidate-index binding, or the exact upper count bound unproven.

## Solution

- Add independent same-origin/different-logical-key and different-origin/same-logical-key rows. Baseline selection and every Claude source mutation remain scoped by canonical `claude-ai-export` origin plus the exact `claude-ai:<native-id>` logical source key, and both decoys are asserted unchanged.
- Add a Claude candidate red twin that mutates only the copied inactive index, keeps the active index green, and requires the real `verify_archive(..., index_path_override=..., checks=REINDEX_CROSS_TIER_ACCEPTANCE_CHECKS)` route to report the Claude candidate failure.
- Add a third in-scope revision with the typed `superseded_prefix` decision. Its aggregate retains one hash, one applied row, one superseded-equivalent row, and one extra typed state while `COUNT(*)` becomes three, independently protecting the exact upper bound. The registered missing-revision deletion and real rebuild acceptance invocation remain present.

## Acceptance and review matrix

| Finding or acceptance claim | Disposition | Evidence |
| --- | --- | --- |
| Codex finding `3742221322`: missing Claude revision red twin | Addressed | Signed commit `630e3857986692e70949ead19c22da1f9f10e5f6`; registered deletion remains in the semantic drift loop and the real rebuild acceptance invocation. |
| Current finding `3742409019`: baseline must be green before each mutation | Addressed | Signed commit `de70b68ddbc95e2c707f5dd542645f8c38beca55`; each copied archive is verified immediately after collision insertion and before its drift mutation. |
| Current finding `3742409022`: isolate origin and logical-source predicates | Addressed | Signed commit `de70b68ddbc95e2c707f5dd542645f8c38beca55`; orthogonal collision rows independently match one predicate and are asserted untouched. |
| Current finding `3742409023`: protect the exact upper revision bound | Addressed | Signed commit `de70b68ddbc95e2c707f5dd542645f8c38beca55`; the third canonical row preserves all other aggregate state and makes the production invariant red at count three. |
| Claude candidate acceptance must use the selected candidate index | Addressed in code, runtime blocked | The candidate-only Claude twin keeps the active index green and uses the real cross-tier candidate verifier. The full zoo route remains blocked before these assertions by the Antigravity residual below. |
| Antigravity synthetic route | Explicit blocked residual | `UnsupportedSyntheticWireRouteError` at `polylogue/schemas/synthetic/selection.py:100`: Antigravity requires the language-server `.pb` adapter and source-path semantics, which generic JSON generation does not exercise. Ref #3899 remains the enabling scope. |
| Live-export recovery | Partial and honestly bounded | The Claude pair remains sanitized measured-shape evidence with `live_export_recovered=false`; this PR makes no live-prevalence or live-current-corpus claim. |

## Bead disposition

| Bead | Disposition | Remaining scope |
| --- | --- | --- |
| `polylogue-kmt1c` | Partial | The broader `polylogue-yazae` pathology-zoo fixture and manifest dependency remains open. No broader live Claude proof or live current-corpus support is claimed. |

## Verification

`POLYLOGUE_PYTEST_WORKERS=1 env PATH="$PWD/.venv/bin:$PATH" devtools test tests/unit/infra/test_claude_vintage_live_proof.py`

Result: 3 passed in 14.96 seconds through the real Claude parse, ingest, historical revision backfill, convergence, and receipt route. The receipt retained `live_export_recovered=false`.

`POLYLOGUE_PYTEST_WORKERS=1 env PATH="$PWD/.venv/bin:$PATH" devtools test tests/unit/maintenance/test_archive_verification.py -k 'pathology_zoo_claude_vintage_registered_invariant_rejects_each_semantic_drift or pathology_zoo_claude_candidate_acceptance_uses_selected_index'`

Result: both selected tests reached the known Antigravity fixture boundary and were blocked before their assertions by `UnsupportedSyntheticWireRouteError` at `polylogue/schemas/synthetic/selection.py:100`. No Antigravity support was fabricated.

`direnv exec . devtools verify --quick`

Result: all 24 steps passed at `de70b68ddbc95e2c707f5dd542645f8c38beca55`, including format, lint, mypy, rendering, layering, policy, and schema promotion checks. Run id: `20260809T052439Z-quick-2665560-d64042d3`.

`git diff --check`

Result: clean.

`git verify-commit de70b68ddbc95e2c707f5dd542645f8c38beca55`

Result: good GitHub signer binding for `ezo.dev@gmail.com`.

## Review disposition

The three current exact-head findings are addressed in signed commit `de70b68ddbc95e2c707f5dd542645f8c38beca55`. The prior missing-revision finding remains addressed in signed commit `630e3857986692e70949ead19c22da1f9f10e5f6`. A fresh exact-head Codex review is requested after this publication.

<!-- polylogue-pr-scope:v1
{
  "assigned_beads": [
    "polylogue-kmt1c"
  ],
  "beads_digest": "9043243a2aaa4609a5e8e9a05813b84e4036e4248cbcb33daf47691f51bf8d73",
  "dispositions": [
    {
      "bead_id": "polylogue-kmt1c",
      "disposition": "partial",
      "evidence": [
        {
          "kind": "commit",
          "ref": "de70b68ddbc95e2c707f5dd542645f8c38beca55"
        },
        {
          "kind": "test",
          "ref": "tests/unit/maintenance/test_archive_verification.py"
        },
        {
          "kind": "command",
          "ref": "devtools verify --quick"
        }
      ],
      "successors": [
        "polylogue-yazae"
      ]
    }
  ],
  "head_sha": "de70b68ddbc95e2c707f5dd542645f8c38beca55",
  "scope_digest": "ae5ccf25f97295b5d8d6b509a19c0f7219053b95453d3b95c70cb0faf1139e3d",
  "version": 1
}
-->
