### PR TITLE
chore(devtools): adopt audit toolchain

### DIFF
--- a/.github/workflows/dep-audit.yml
+++ b/.github/workflows/dep-audit.yml
@@ -35,13 +35,13 @@ jobs:
         with:
           python-version: "3.14"
       - name: Install dependencies (frozen lockfile)
-        run: uv sync --extra dev --frozen
+        run: uv sync --extra dev --group audit --frozen
       - name: Export hash-pinned requirements (excludes editable polylogue)
         # `uv export` emits a deterministic, hash-pinned requirements.txt
         # derived from `uv.lock`. We deliberately exclude the project itself
         # (--no-emit-project) so pip-audit only sees external dependencies;
         # the editable install of polylogue would otherwise fail the audit.
-        run: uv export --format requirements-txt --no-emit-project --frozen --extra dev > requirements-audit.txt
+        run: uv export --format requirements-txt --no-emit-project --frozen --extra dev --group audit > requirements-audit.txt
       - name: Run pip-audit against locked dependencies
         # --vulnerability-service osv: query the OSV database (covers PyPA
         #   advisory DB, GHSA, and others) — broader than PyPI advisories alone.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,16 @@ devtools status
 devtools render all
 ```
 
+### Audit tooling
+
+The `audit` dependency group supplies `ast-grep` for local structural candidate generation:
+
+```bash
+uv sync --group audit
+```
+
+The project devshell also provides `scc` for code-size and complexity summaries and `codeql` for periodic security-focused analysis. These tools are advisory until a separately scoped audit policy adopts a specific rule or query.
+
 Before choosing a module, read [Code Navigation](docs/code-navigation.md). It
 maps common changes to the package that owns their meaning, the production
 route that must be exercised, and the minimum verification expected. The

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,8 @@ devtools render all
 The `audit` dependency group supplies `ast-grep` for local structural candidate generation:
 
 ```bash
-uv sync --group audit
+uv sync --extra dev --group audit --frozen
+uv run --group audit ast-grep --version
 ```
 
 The project devshell also provides `scc` for code-size and complexity summaries and `codeql` for periodic security-focused analysis. These tools are advisory until a separately scoped audit policy adopts a specific rule or query.

--- a/experiments/audit-tooling/REPORT.md
+++ b/experiments/audit-tooling/REPORT.md
@@ -1,0 +1,14 @@
+# Audit tooling adoption report
+
+This document records the production-toolchain disposition of the preserved audit lab at `e0f9e1d1d4818688173cd72cce4d5ef7ec63da93`. The lab's probes and experimental rules remain on that preserved branch; they are not part of this production landing.
+
+## Adopted toolchain
+
+- The `[dependency-groups].audit` stanza in [`pyproject.toml`](../../pyproject.toml) provides `ast-grep-cli`. Run `uv sync --group audit` from a fresh checkout before using `ast-grep`; `sg` is a different system command in the devshell.
+- The default devshell's `buildInputs` stanza in [`flake.nix`](../../flake.nix) provides `ast-grep`, `scc`, and `codeql`. CodeQL's Nix unfree exception is limited to its package name in the same file.
+
+The lab established distinct production-useful roles for these tools: ast-grep generates structural candidates, scc reports cheap code-size and complexity trends, and CodeQL supports periodic security-focused dataflow analysis. They do not independently enforce any audit policy.
+
+## Deliberately not adopted
+
+This Bead does not carry forward the lab's probe scripts, query packs, rule files, generated outputs, or exploratory Python dependencies. A future policy change can adopt a specific rule, query, or additional dependency with its own verification contract.

--- a/experiments/audit-tooling/REPORT.md
+++ b/experiments/audit-tooling/REPORT.md
@@ -4,7 +4,7 @@ This document records the production-toolchain disposition of the preserved audi
 
 ## Adopted toolchain
 
-- The `[dependency-groups].audit` stanza in [`pyproject.toml`](../../pyproject.toml) provides `ast-grep-cli`. Run `uv sync --group audit` from a fresh checkout before using `ast-grep`; `sg` is a different system command in the devshell.
+- The `[dependency-groups].audit` stanza in [`pyproject.toml`](../../pyproject.toml) provides `ast-grep-cli`. Run `uv sync --extra dev --group audit --frozen` from a fresh checkout, then use `uv run --group audit ast-grep`; `sg` is a different system command in the devshell.
 - The default devshell's `buildInputs` stanza in [`flake.nix`](../../flake.nix) provides `ast-grep`, `scc`, and `codeql`. CodeQL's Nix unfree exception is limited to its package name in the same file.
 
 The lab established distinct production-useful roles for these tools: ast-grep generates structural candidates, scc reports cheap code-size and complexity trends, and CodeQL supports periodic security-focused dataflow analysis. They do not independently enforce any audit policy.

--- a/experiments/audit-tooling/REPORT.md
+++ b/experiments/audit-tooling/REPORT.md
@@ -9,6 +9,8 @@ This document records the production-toolchain disposition of the preserved audi
 
 The lab established distinct production-useful roles for these tools: ast-grep generates structural candidates, scc reports cheap code-size and complexity trends, and CodeQL supports periodic security-focused dataflow analysis. They do not independently enforce any audit policy.
 
+The landing PR also carries a versioned Beads-scope receipt; validate the published boundary with `devtools workspace pr-scope check --pr 3917` before merging.
+
 ## Deliberately not adopted
 
 This Bead does not carry forward the lab's probe scripts, query packs, rule files, generated outputs, or exploratory Python dependencies. A future policy change can adopt a specific rule, query, or additional dependency with its own verification contract.

--- a/flake.nix
+++ b/flake.nix
@@ -11,9 +11,13 @@
       nixpkgs,
     }:
     let
+      lib = nixpkgs.lib;
       system = "x86_64-linux";
       pkgs = import nixpkgs {
         inherit system;
+        # CodeQL is unfree in nixpkgs. Keep the exception scoped to the one
+        # devshell tool instead of enabling all unfree packages.
+        config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [ "codeql" ];
         # See the long comment above `mkNoCheckOverride`/`freeThreadedNoCheckOverlay`
         # below (polylogue-xikl): this MUST be a top-level `pkgs` overlay, not a
         # locally-scoped `.pkgs.overrideScope` on a `let`-bound variable --
@@ -354,6 +358,9 @@
           devtoolsCli
           pkgs.git
           pkgs.ruff
+          pkgs.ast-grep
+          pkgs.scc
+          pkgs.codeql
         ];
 
         shellHook = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,14 @@ tree-sitter = [
   "tree-sitter-yaml>=0.6.0",
 ]
 
+[dependency-groups]
+# Structural candidate generation for repository audits.  This is a tooling
+# group, not a shipped product dependency; the devshell supplies the
+# complementary native tools (scc and CodeQL).
+audit = [
+  "ast-grep-cli>=0.45.0",
+]
+
 [project.urls]
 Homepage = "https://sinity.github.io/polylogue/"
 Repository = "https://github.com/sinity/polylogue"

--- a/uv.lock
+++ b/uv.lock
@@ -37,6 +37,21 @@ wheels = [
 ]
 
 [[package]]
+name = "ast-grep-cli"
+version = "0.45.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/31/e202db9b63bb2851f48d29c01aa27b74c5b7b36bc6c158f80f6443a7dbfa/ast_grep_cli-0.45.1.tar.gz", hash = "sha256:3b214f39554cb6fd51d0fd441eab9427c7dd8bfb12dbff5ef7618369c6a22628", size = 279952, upload-time = "2026-08-07T15:25:10.762Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/2f/5db21c7c3c61f758f0cde8ebbc60e5876d026857ca5a1ca41acb9607b18b/ast_grep_cli-0.45.1-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:3536a040aed9d95b29af27d2eea0c831a48ee151afa8de2c6a842b9fc75e8c87", size = 16028194, upload-time = "2026-08-07T15:24:51.186Z" },
+    { url = "https://files.pythonhosted.org/packages/86/52/4cd380e4fc56f8fc5e9d6526b6c353c7802d96b78624ecb49dca6cfe6a86/ast_grep_cli-0.45.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:befa0add772663a012d42e22bb28483ecb8558d66634fa364efe09a1c7187542", size = 8007620, upload-time = "2026-08-07T15:24:54.375Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f8/2bb3e74a50e75b41a34d8f6f8e6d42867b088147a15fb7e73f5cb94d7f7f/ast_grep_cli-0.45.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:80caab89daefa0ddaf69f59f7838e6ff4480fd35daf6ea273fa3055506e992df", size = 7864976, upload-time = "2026-08-07T15:24:56.366Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/3e/193f347a7add7ba413a0f4169cc8185bd58ba0477e6947a683f4887c4872/ast_grep_cli-0.45.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:497810f387e9ab0624f72dd300557fb25a2a49b0429c71472e5d08180f16bdbc", size = 8166938, upload-time = "2026-08-07T15:24:58.593Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f1/0d04cd5e0a5bdd1c1f1c8f78ec1efab30ad1d585bda207657d125e0613ef/ast_grep_cli-0.45.1-py3-none-win32.whl", hash = "sha256:bfd8aceeb6d6e8623a18a0804d22f9cdc67ad84d7dd1f03c3e8b6a33990189e3", size = 15198061, upload-time = "2026-08-07T15:25:02.014Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/96/5544e348c00381c7526462332dcb56ed1129de3402b0610a100fc683db84/ast_grep_cli-0.45.1-py3-none-win_amd64.whl", hash = "sha256:b3bbcdeb49db5a7942c4687c117c478be8e5eeb4bcfa79851d4154965f6c7402", size = 16177239, upload-time = "2026-08-07T15:25:05.528Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/52/d2644a91e78e876af197a05ff7bd499d2e0c615935f31756ab432cd157df/ast_grep_cli-0.45.1-py3-none-win_arm64.whl", hash = "sha256:0a945ef6495c2ce2e09001e25b81ad14ccbe7afe446467c4d912ac06271c6c13", size = 15566175, upload-time = "2026-08-07T15:25:08.702Z" },
+]
+
+[[package]]
 name = "ast-serialize"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1288,6 +1303,11 @@ tree-sitter = [
     { name = "tree-sitter-yaml" },
 ]
 
+[package.dev-dependencies]
+audit = [
+    { name = "ast-grep-cli" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.19.0" },
@@ -1360,6 +1380,9 @@ requires-dist = [
     { name = "watchfiles", specifier = ">=1.2.0" },
 ]
 provides-extras = ["speed", "dev-common", "dev", "fuzz", "sqlite-compat", "tree-sitter"]
+
+[package.metadata.requires-dev]
+audit = [{ name = "ast-grep-cli", specifier = ">=0.45.0" }]
 
 [[package]]
 name = "pre-commit"


### PR DESCRIPTION
## Summary

Adopt the proven audit-toolchain dependencies and devshell tools.

## Problem

The audit-tooling lab proved a useful, bounded roster, but the repository did not provide the tools or record the adoption boundary.

## Solution

Add the `audit` dependency group for `ast-grep-cli`, add `ast-grep`, `scc`, and `codeql` to the devshell with a scoped unfree allowance, and publish the adoption report. Experimental probes and policy rules remain excluded.

## Verification

- `git diff --check`
- `uv lock --check`
- Exact acceptance scope: `polylogue-29hwx`
- `nix develop --command devtools verify --quick` was attempted but correctly deferred while the shared heavy-work lease was held.

## Bead disposition matrix

| Assigned Bead | Whole-Bead disposition | Evidence refs | Named successor for residual work |
| --- | --- | --- | --- |
| `polylogue-29hwx` | satisfied | `diff:pyproject.toml, flake.nix, uv.lock, experiments/audit-tooling/REPORT.md`; `command:git diff --check`; `command:uv lock --check` | n/a |

<!-- polylogue-pr-scope:v1
{
  "assigned_beads": [
    "polylogue-29hwx"
  ],
  "beads_digest": "e17e4bda41da20d140002db39fbba3ad9404ebfb6f6036d26b0a14fbeffbead3",
  "dispositions": [
    {
      "bead_id": "polylogue-29hwx",
      "disposition": "satisfied",
      "evidence": [
        {
          "kind": "diff",
          "ref": "pyproject.toml, flake.nix, uv.lock, experiments/audit-tooling/REPORT.md"
        },
        {
          "kind": "command",
          "ref": "git diff --check"
        },
        {
          "kind": "command",
          "ref": "uv lock --check"
        }
      ],
      "successors": []
    }
  ],
  "head_sha": "6951d449b2af6110d88ae5edde8844fdeb172f6a",
  "scope_digest": "e5487b91b28b9afebf9f9ed5ac39ae0fc4965bddae45e00aa8d3cd0d4782eddc",
  "version": 1
}
-->

## Risks and Follow-ups

The tools are advisory until a separately scoped audit policy adopts a specific rule or query.
