### PR TITLE
fix(daemon): recover typed CAS frontier failures

### DIFF
--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -22,6 +22,10 @@ from typing import TYPE_CHECKING
 
 from polylogue.config import load_polylogue_config
 from polylogue.core.enums import Provider
+from polylogue.core.raw_failure_evidence import (
+    RAW_FAILURE_DEFERRED_SUPPORT_STATUS,
+    RAW_FAILURE_REPLAY_AUTHORITY_EVIDENCE_KINDS,
+)
 from polylogue.daemon.convergence import ConvergenceStage, StageExecuteReturn, StageExecutionResult
 from polylogue.daemon.convergence_standing_queries import make_standing_query_stage
 from polylogue.logging import get_logger
@@ -884,6 +888,7 @@ def _raw_parse_recovery_pending_count(db_path: Path, path: Path, *, archive_root
         return 0
     index_db = ArchiveLocation.resolve(durable_root).active_index_path
     normalized_root = str(path).rstrip("/")
+    replay_authority_placeholders = ", ".join("?" for _ in RAW_FAILURE_REPLAY_AUTHORITY_EVIDENCE_KINDS)
     try:
         conn = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True, timeout=5.0)
     except sqlite3.Error:
@@ -924,10 +929,25 @@ def _raw_parse_recovery_pending_count(db_path: Path, path: Path, *, archive_root
                 OR r.parse_error = 'OperationalError: database is locked'
                 OR r.parse_error LIKE 'decode:%No such file or directory:%'
                 OR r.parse_error LIKE 'membership_replay_conflict:%'
+                OR EXISTS (
+                    SELECT 1
+                    FROM raw_artifacts AS failure_evidence
+                    WHERE failure_evidence.raw_id IS r.raw_id
+                      AND failure_evidence.origin IS r.origin
+                      AND failure_evidence.source_path IS r.source_path
+                      AND failure_evidence.source_index IS r.source_index
+                      AND failure_evidence.artifact_kind IN ({replay_authority_placeholders})
+                      AND failure_evidence.support_status = ?
+                )
               )
               {materialized_where}
             """,
-            (normalized_root, f"{normalized_root}/%"),
+            (
+                normalized_root,
+                f"{normalized_root}/%",
+                *sorted(RAW_FAILURE_REPLAY_AUTHORITY_EVIDENCE_KINDS),
+                RAW_FAILURE_DEFERRED_SUPPORT_STATUS,
+            ),
         ).fetchone()
         return int(row[0] or 0) if row is not None else 0
     except sqlite3.Error:

--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -923,12 +923,17 @@ def _raw_parse_recovery_pending_count(db_path: Path, path: Path, *, archive_root
             FROM raw_sessions AS r
             {materialized_join}
             WHERE (r.source_path = ? OR r.source_path LIKE ?)
-              AND r.parsed_at_ms IS NULL
+              AND COALESCE(r.validation_status, '') != 'failed'
               AND (
-                r.parse_error IS NULL
-                OR r.parse_error = 'OperationalError: database is locked'
-                OR r.parse_error LIKE 'decode:%No such file or directory:%'
-                OR r.parse_error LIKE 'membership_replay_conflict:%'
+                (
+                  r.parsed_at_ms IS NULL
+                  AND (
+                    r.parse_error IS NULL
+                    OR r.parse_error = 'OperationalError: database is locked'
+                    OR r.parse_error LIKE 'decode:%No such file or directory:%'
+                    OR r.parse_error LIKE 'membership_replay_conflict:%'
+                  )
+                )
                 OR EXISTS (
                     SELECT 1
                     FROM raw_artifacts AS failure_evidence

--- a/tests/unit/daemon/test_raw_parse_recovery.py
+++ b/tests/unit/daemon/test_raw_parse_recovery.py
@@ -299,6 +299,47 @@ def test_raw_parse_recovery_stage_drains_typed_cas_frontier_failure(
     assert _sessions_for_raw(tmp_path, raw_id) == [("conv-stuck", raw_id)]
 
 
+def test_raw_parse_recovery_skips_validation_failed_cas_frontier_failure(tmp_path: Path) -> None:
+    """A failed validation cannot keep CAS recovery debt pending forever."""
+    initialize_active_archive_root(tmp_path)
+    path = tmp_path / "validation-failed-cas-frontier.json"
+    raw_id = _write_stuck_raw(tmp_path, source_path=str(path))
+
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        archive.mark_raw_parse_failed(
+            raw_id,
+            provider=Provider.CHATGPT,
+            error=RawCASFrontierError("frontier changed after validation failed"),
+        )
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        conn.execute("UPDATE raw_sessions SET validation_status = 'failed' WHERE raw_id = ?", (raw_id,))
+        conn.commit()
+
+    assert make_raw_parse_recovery_stage(tmp_path / "index.db").check(path) is False
+
+
+def test_raw_parse_recovery_drains_previously_parsed_cas_frontier_failure(tmp_path: Path) -> None:
+    """CAS authority replays an unmaterialized raw even when parsing had completed."""
+    initialize_active_archive_root(tmp_path)
+    path = tmp_path / "previously-parsed-cas-frontier.json"
+    raw_id = _write_stuck_raw(tmp_path, source_path=str(path))
+
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        archive.mark_raw_parse_succeeded(raw_id, provider=Provider.CHATGPT)
+        archive.mark_raw_parse_failed(
+            raw_id,
+            provider=Provider.CHATGPT,
+            error=RawCASFrontierError("frontier changed after parsing completed"),
+        )
+
+    stage = make_raw_parse_recovery_stage(tmp_path / "index.db")
+
+    assert stage.check(path) is True
+    assert stage.execute(path) is True
+    assert stage.check(path) is False
+    assert _sessions_for_raw(tmp_path, raw_id) == [("conv-stuck", raw_id)]
+
+
 def test_raw_parse_recovery_source_open_failure_is_failed_and_retryable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/daemon/test_raw_parse_recovery.py
+++ b/tests/unit/daemon/test_raw_parse_recovery.py
@@ -29,6 +29,8 @@ from pathlib import Path
 import pytest
 
 from polylogue.core.enums import Provider
+from polylogue.core.errors import RawCASFrontierError
+from polylogue.core.raw_failure_evidence import RawFailureEvidenceKind
 from polylogue.daemon.convergence import DaemonConverger, StageState
 from polylogue.daemon.convergence_stages import make_raw_parse_recovery_stage
 from polylogue.sources.live.cursor import CursorStore
@@ -249,6 +251,52 @@ def test_raw_parse_recovery_retries_authorized_parse_failure(tmp_path: Path) -> 
     stage = make_raw_parse_recovery_stage(tmp_path / "index.db")
 
     assert stage.check(path) is True
+
+
+@pytest.mark.parametrize(
+    "evidence_kind",
+    [
+        RawFailureEvidenceKind.DEFERRED_CAS_FRONTIER,
+        RawFailureEvidenceKind.DEFERRED_CODEX_CAS_FRONTIER,
+    ],
+)
+def test_raw_parse_recovery_stage_drains_typed_cas_frontier_failure(
+    tmp_path: Path, evidence_kind: RawFailureEvidenceKind
+) -> None:
+    """A stopped daemon requeues canonical and historical CAS retry authority."""
+    initialize_active_archive_root(tmp_path)
+    path = tmp_path / "cas-frontier.json"
+    raw_id = _write_stuck_raw(tmp_path, source_path=str(path))
+
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        if evidence_kind is RawFailureEvidenceKind.DEFERRED_CAS_FRONTIER:
+            archive.mark_raw_parse_failed(
+                raw_id,
+                provider=Provider.CHATGPT,
+                error=RawCASFrontierError("frontier changed while daemon stopped"),
+            )
+        else:
+            archive.record_raw_failure_evidence(
+                raw_id,
+                provider=Provider.CHATGPT,
+                source_path=str(path),
+                source_index=0,
+                acquired_at_ms=1,
+                kind=evidence_kind,
+            )
+            archive.mark_raw_parse_failed(
+                raw_id,
+                provider=Provider.CHATGPT,
+                error=ValueError("historical CAS frontier failure"),
+                preserve_existing_failure_evidence=True,
+            )
+
+    stage = make_raw_parse_recovery_stage(tmp_path / "index.db")
+
+    assert stage.check(path) is True
+    assert stage.execute(path) is True
+    assert stage.check(path) is False
+    assert _sessions_for_raw(tmp_path, raw_id) == [("conv-stuck", raw_id)]
 
 
 def test_raw_parse_recovery_source_open_failure_is_failed_and_retryable(


### PR DESCRIPTION
## Summary

Route typed CAS-frontier failures into stopped-daemon raw recovery only when the existing repair selector authorizes replay. The probe recognizes canonical and historical CAS carriers by exact raw-artifact coordinate, admits previously parsed but unmaterialized raws, and delegates materialization to the existing repair engine.

## Problem

`raw_materialization` already selected `deferred_cas_frontier` and `deferred_codex_cas_frontier` as retry authority. The daemon's path-scoped `raw_parse_recovery` probe initially recognized only untyped error strings. Its first typed-carrier version then diverged from the executor in two ways: validation-failed raws stayed pending forever, while previously parsed but unmaterialized CAS raws were skipped.

## Solution

`polylogue/daemon/convergence_stages.py` imports the established core replay-authority vocabulary and requires the same raw ID, origin, source path, source index, partial-decode support status, failed-validation exclusion, and materialization guard before returning pending work. It keeps legacy raw retries unparsed-only while allowing typed CAS authority for previously parsed raws. `tests/unit/daemon/test_raw_parse_recovery.py` creates real file-backed temporary archive tiers, writes authority and parse transitions through `ArchiveStore`, and exercises `raw_parse_recovery` through the production repair engine until the session materializes.

| Bead | Whole-Bead disposition | Evidence | Remaining scope |
| --- | --- | --- | --- |
| `polylogue-dyica` | Partial | `08c363b0d`; stopped-daemon route regressions; quick gate | Current live census, deployment, backup-gated dry-run/apply, immutable receipt, and reprocessing remain under `polylogue-reindex-source-remediation`. |
| `polylogue-dyica.1` | Satisfied implementation slice | Canonical, historical, validation-failed, and previously-parsed carrier route tests; pre-fix reproductions; quick gate | Its required live successor exists through parent `polylogue-dyica` and remains open as `polylogue-reindex-source-remediation`; no live apply is claimed here. |

## Verification

`devtools test tests/unit/daemon/test_raw_parse_recovery.py -k 'validation_failed_cas_frontier_failure or previously_parsed_cas_frontier_failure'` failed before this correction with two inverse `stage.check(path)` assertions. `devtools test tests/unit/daemon/test_raw_parse_recovery.py` then reported `19 passed`. `devtools verify --quick` completed all 24 checks with exit 0. The suite uses real temporary `source.db` and `index.db` files, not an in-memory substitute. Reverting either eligibility condition restores its corresponding production-route failure, so the regressions constrain the probe rather than a test-local replica.

## Adversarial review notes

The late Codex review found two actionable probe/executor eligibility mismatches. This update adds red file-backed regressions for both: validation-failed rows are not pending, and previously parsed, unmaterialized CAS rows drain through the repair engine.

## What this PR does not do

No production archive, daemon, migration, deployment, reprocess, dry-run apply, or receipt was mutated. The 2026-08-04 preflight observed 112 raw failures, including 111 parse failures and one maintenance failure. This PR does not remeasure that live population. Its current size and any reduction remain unknown until the open successor runs a fresh backup-gated census and reviewed apply.

<!-- polylogue-pr-scope:v1
{
  "assigned_beads": [
    "polylogue-dyica",
    "polylogue-dyica.1"
  ],
  "beads_digest": "1edd0df67db7f58a3f38d07eb5041832a796f6cca49c4f8325b39247a7a79101",
  "dispositions": [
    {
      "bead_id": "polylogue-dyica",
      "disposition": "partial",
      "evidence": [
        {
          "kind": "commit",
          "ref": "08c363b0de3160234732f060e1791ad0e84dff6b"
        },
        {
          "kind": "test",
          "ref": "tests/unit/daemon/test_raw_parse_recovery.py::test_raw_parse_recovery_skips_validation_failed_cas_frontier_failure"
        },
        {
          "kind": "command",
          "ref": "devtools test tests/unit/daemon/test_raw_parse_recovery.py: 19 passed"
        },
        {
          "kind": "command",
          "ref": "devtools verify --quick: 24 steps passed, exit 0"
        }
      ],
      "successors": [
        "polylogue-reindex-source-remediation"
      ]
    },
    {
      "bead_id": "polylogue-dyica.1",
      "disposition": "satisfied",
      "evidence": [
        {
          "kind": "commit",
          "ref": "08c363b0de3160234732f060e1791ad0e84dff6b"
        },
        {
          "kind": "diff",
          "ref": "polylogue/daemon/convergence_stages.py"
        },
        {
          "kind": "test",
          "ref": "tests/unit/daemon/test_raw_parse_recovery.py::test_raw_parse_recovery_drains_previously_parsed_cas_frontier_failure"
        },
        {
          "kind": "command",
          "ref": "late-review production-route regressions: 2 failed at stage.check"
        },
        {
          "kind": "command",
          "ref": "devtools verify --quick: 24 steps passed, exit 0"
        }
      ],
      "successors": []
    }
  ],
  "head_sha": "08c363b0de3160234732f060e1791ad0e84dff6b",
  "scope_digest": "d3ac498ee0af0a87257bcfeab3b08dea0e770e3b3c99a5f3e4067cbda805b1e3",
  "version": 1
}
-->
