### PR TITLE
fix(verification): bind source coverage to raw-head registry

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -513,7 +513,7 @@ extensible registry):
 | --- | --- |
 | `tier-schema` | Every tier file (source/index/embeddings/user/ops) exists at its current `PRAGMA user_version`. |
 | `pointer-coherence` | The conventional `index.db` path and the active `.index-active-pointer` generation agree (an interrupted blue-green promotion leaves these diverged — polylogue-k8kj class). |
-| `source-index-coverage` | Every raw session with a complete census has a materialized index session (missing work), and every index session's `raw_id` still resolves to a real raw row (orphans) — reported as counts and id samples, not booleans. |
+| `source-index-coverage` | Every raw logical head is materialized, has an explicit terminal disposition, or is quarantined, and every index session's `raw_id` still resolves to a real raw row (orphans). The raw source population, not the derived census ledger, defines the coverage universe. |
 | `fts-parity` | `messages_fts`/`blocks_command_trigram` exactly cover their source `blocks` rows, archive-wide, with the worst-offending sessions surfaced by name. |
 | `lineage-sanity` | `session_links.resolved_dst_session_id` and `branch_point_message_id` resolve to real sessions/messages (the latter is deliberately not a foreign key — see the data-model docs). |
 | `planner-stats` | `sqlite_stat1` covers `blocks`/`messages`/`action_pairs` (warn-level: a fresh generation without `ANALYZE` picks pathological query plans — polylogue-l3tk class). |

--- a/polylogue/maintenance/archive_verification.py
+++ b/polylogue/maintenance/archive_verification.py
@@ -14,7 +14,7 @@ New checks slot into :data:`ARCHIVE_VERIFICATION_CHECKS` without touching
 :func:`verify_archive` or its callers -- the registry is the extension point
 for future checks (blob-reference debt, cost rollups, ...).
 
-**Registry contract rule (polylogue-in24n):** a check's universe must be a
+**Registry contract rule (polylogue-r4jiu):** a check's universe must be a
 ground-truth table, never a derived ledger of the mechanism under audit. The
 canonical violation this rule exists to prevent: an earlier version of
 ``source-index-coverage`` computed its universe from ``raw_membership_census``
@@ -487,7 +487,7 @@ def _check_source_index_coverage_at_index_path(
 ) -> ArchiveVerificationCheck:
     """Every logical source's head is indexed OR carries a typed refusal.
 
-    Universe (polylogue-in24n, invariant I1): ``raw_sessions`` logical heads --
+    Universe (polylogue-r4jiu, invariant I1): ``raw_sessions`` logical heads --
     the latest revision per ``(origin, COALESCE(native_id, source_path))`` --
     which is a ground-truth table every acquired raw lands in, not a ledger a
     downstream reconciliation stage can silently omit rows from. A logical
@@ -2669,13 +2669,15 @@ ARCHIVE_VERIFICATION_CHECKS: tuple[ArchiveVerificationCheckSpec, ...] = (
     _registry_spec(
         "source-index-coverage",
         "Every raw_sessions logical head is indexed or typed (parse_error/non_session/quarantined); "
-        "untyped gaps and index-orphans (raw_id ground truth, not the census ledger, polylogue-in24n) block.",
+        "untyped gaps and index-orphans (raw_id ground truth, not the census ledger, polylogue-r4jiu) block.",
         _check_source_index_coverage,
         ArchiveVerificationCheckClass.STATE_INVARIANT,
-        incident_bead="polylogue-in24n",
+        incident_bead="polylogue-r4jiu",
         universe_tables=("source.db.raw_sessions", "index.db.sessions"),
         red_twin=_red_twin(
-            "coherent-archive", "untyped raw head", "test_raw_with_no_typed_refusal_and_no_session_is_untyped_gap"
+            "coherent-archive",
+            "delete an unindexed raw head from the derived census",
+            "test_source_index_coverage_census_deletion_does_not_hide_raw_head",
         ),
         execution_phases=_phases(ArchiveVerificationExecutionPhase.REINDEX_CROSS_TIER_CANDIDATE),
         candidate_mode=_CROSS_TIER,

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -462,6 +462,61 @@ def test_raw_with_no_typed_refusal_and_no_session_is_untyped_gap(tmp_path: Path)
     assert check.evidence["orphan_count"] == 0
 
 
+def test_source_index_coverage_census_deletion_does_not_hide_raw_head(tmp_path: Path) -> None:
+    """RED TWIN (polylogue-r4jiu): census removal cannot shrink I1's universe.
+
+    The raw source of truth keeps an unindexed, byte-proven logical head while
+    the derived census ledger first records it and then loses it.  The actual
+    ``verify_archive`` registry route must remain red after that deletion;
+    the predecessor's census-derived query instead returned green because it
+    selected only rows the ledger still described.
+    """
+    _seed_coherent_archive(tmp_path)
+    source_path = tmp_path / "source.db"
+    source_conn = _connect(source_path)
+    try:
+        source_conn.execute(
+            """
+            INSERT INTO raw_sessions(
+                raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms, revision_authority
+            )
+            VALUES ('raw-census-deleted', 'codex-session', 'never-materialized', '/census-deleted', ?, 10, 100,
+                    'byte_proven')
+            """,
+            (b"d" * 32,),
+        )
+        source_conn.execute(
+            """
+            INSERT INTO raw_membership_census(raw_id, parser_fingerprint, status, member_count, censused_at_ms)
+            VALUES ('raw-census-deleted', 'fp', 'complete', 1, 100)
+            """
+        )
+        source_conn.commit()
+
+        assert _check(verify_archive(tmp_path, checks=("source-index-coverage",)), "source-index-coverage").status is (
+            OutcomeStatus.ERROR
+        )
+
+        source_conn.execute("DELETE FROM raw_membership_census WHERE raw_id = 'raw-census-deleted'")
+        source_conn.commit()
+        raw = source_conn.execute(
+            "SELECT raw_id, parse_error, revision_authority FROM raw_sessions WHERE raw_id = 'raw-census-deleted'"
+        ).fetchone()
+    finally:
+        source_conn.close()
+
+    assert raw == ("raw-census-deleted", None, "byte_proven")
+    check = _check(verify_archive(tmp_path, checks=("source-index-coverage",)), "source-index-coverage")
+    assert check.status is OutcomeStatus.ERROR
+    assert check.evidence["untyped_count"] == 1
+    assert check.evidence["untyped_sample"] == ["raw-census-deleted"]
+
+    spec = next(spec for spec in ARCHIVE_VERIFICATION_CHECKS if spec.name == "source-index-coverage")
+    assert spec.incident is not None and spec.incident.bead_id == "polylogue-r4jiu"
+    assert spec.red_twin is not None
+    assert spec.red_twin.test_name == "test_source_index_coverage_census_deletion_does_not_hide_raw_head"
+
+
 def test_quarantined_head_with_no_session_is_warning_not_error(tmp_path: Path) -> None:
     """The polylogue-in24n bug class in reverse: a quarantined raw (the
     default ``revision_authority``) that never materialized is a *typed*


### PR DESCRIPTION
## Summary

Bind `source-index-coverage` to `polylogue-r4jiu` and prove it derives its audited population from raw logical heads, not `raw_membership_census`.

## Problem

The historical production predicate selected only complete census rows. Deleting a derived census record while leaving its raw source row unchanged removed that raw head from the audit universe and returned a green result. The current raw-head predicate was already present, but the production registry still routed the check and red-twin metadata through `polylogue-in24n`, and no regression exercised the census-deletion mutation.

## Solution

- Route the existing production `source-index-coverage` registry entry and red-twin metadata to `polylogue-r4jiu`.
- Add a file-backed SQLite regression that creates an unindexed raw logical head, deletes only its census row, and invokes `verify_archive` through the production registry.
- State the raw-head universe explicitly in maintenance documentation.

## Acceptance criteria

| Bead | Criterion | Disposition | Evidence |
| --- | --- | --- | --- |
| `polylogue-r4jiu` | Coverage universe is raw logical heads from `source.db`, not the census ledger. | Satisfied | Production predicate and registry route; regression test. |
| `polylogue-r4jiu` | Each raw logical head is indexed or represented by a typed lifecycle state. | Satisfied | Existing source coverage and typed raw-failure lifecycle checks exercised together. |
| `polylogue-r4jiu` | Deleting a derived census row while source data is unchanged makes coverage fail. | Satisfied | Historical production reproduction at `2cb0b7f16` fails; new production-route regression stays `ERROR`. |
| `polylogue-r4jiu` | Focused verification and `devtools verify --quick` pass. | Satisfied | Commands below. |

## Whole-Bead disposition

| Bead | Disposition | Typed evidence | Open successor |
| --- | --- | --- | --- |
| `polylogue-r4jiu` | Satisfied | commit, diff, test, command, receipt, review | None |

## Verification

- `POLYLOGUE_PYTEST_WORKERS=1 devtools test tests/unit/maintenance/test_archive_verification.py -k 'source_index_coverage_census_deletion or raw_failure_lifecycle_accepts_only_typed_deferred_or_terminal_evidence or cross_tier_reindex_profile_includes_raw_failure_lifecycle or raw_with_no_typed_refusal_and_no_session or quarantined_head_with_no_session or parse_error_head_with_no_session or non_session_census_head_with_no_session'` -> `7 passed in 13.44s`.
- `devtools render all --check` -> exit 0, every rendered surface `sync OK`.
- `POLYLOGUE_PYTEST_WORKERS=1 devtools verify --quick` -> exit 0, 24 successful checks, run `20260810T132817Z-quick-1259651-acd40d1c`.
- `git diff --check` -> exit 0; `git verify-commit HEAD` -> good signature for `b42059fcf127e33bae89fcc6de171b6a69f941f8`.

## Adversarial review notes

The first cold review questioned whether a bare parse error could satisfy coverage. That concern is handled by the separately registered `raw-failure-lifecycle` production check, which requires typed raw-artifact evidence and is selected by the same cross-tier profile; its focused contract tests pass. The second review required historical proof. In a temporary hook-free worktree at `2cb0b7f16`, the equivalent production-route regression failed exactly as expected: after deleting only the census row, `source-index-coverage` returned `OK` rather than `ERROR`.

## Residual

None for `polylogue-r4jiu`. This change did not mutate a live archive or Beads state.

<!-- polylogue-pr-scope:v1
{
  "assigned_beads": [
    "polylogue-r4jiu"
  ],
  "beads_digest": "9dfafd79ca3763abff8cd823301b6ce0dbb73352692413dc1e510a0eac46efcd",
  "dispositions": [
    {
      "bead_id": "polylogue-r4jiu",
      "disposition": "satisfied",
      "evidence": [
        {
          "kind": "commit",
          "ref": "b42059fcf127e33bae89fcc6de171b6a69f941f8"
        },
        {
          "kind": "diff",
          "ref": "polylogue/maintenance/archive_verification.py; tests/unit/maintenance/test_archive_verification.py; docs/maintenance.md"
        },
        {
          "kind": "test",
          "ref": "tests/unit/maintenance/test_archive_verification.py::test_source_index_coverage_census_deletion_does_not_hide_raw_head"
        },
        {
          "kind": "command",
          "ref": "POLYLOGUE_PYTEST_WORKERS=1 devtools test tests/unit/maintenance/test_archive_verification.py -k source_index_coverage_census_deletion...: 7 passed in 13.44s"
        },
        {
          "kind": "receipt",
          "ref": ".cache/verify/20260810T132817Z-quick-1259651-acd40d1c: devtools verify --quick exit 0"
        },
        {
          "kind": "review",
          "ref": "two cold adversarial reviews; the historical production route at 2cb0b7f16 failed the census-deletion regression as expected"
        }
      ],
      "successors": []
    }
  ],
  "head_sha": "b42059fcf127e33bae89fcc6de171b6a69f941f8",
  "scope_digest": "6408a30aef53928fc59fa9df52ec7f68ea40ca43c40c6a52c21be667c4c32c4e",
  "version": 1
}
-->
