### PR TITLE
fix(devtools): type testmon seed resource timeouts

### DIFF
--- a/devtools/checkout_guard.py
+++ b/devtools/checkout_guard.py
@@ -132,7 +132,7 @@ class CheckoutEnvironmentFingerprint:
 _TESTMON_STATE_DIR = Path(".cache/testmon")
 _TESTMON_STATE_MARKER = _TESTMON_STATE_DIR / "seed.json"
 _TESTMON_SEED_ATTEMPT = _TESTMON_STATE_DIR / "seed-attempt.json"
-_TESTMON_SEED_PROTOCOL_VERSION = 5
+_TESTMON_SEED_PROTOCOL_VERSION = 6
 _VERIFY_STATE_DIR = Path(".cache/verify")
 _VERIFY_STATE_MARKER = _VERIFY_STATE_DIR / "current-run.json"
 

--- a/devtools/testmon_state.py
+++ b/devtools/testmon_state.py
@@ -43,6 +43,16 @@ class BaselineStatus(StrEnum):
     RED = "red"
 
 
+class SeedAttemptOutcome(StrEnum):
+    """Terminal result of a seed attempt, separate from graph reusability."""
+
+    GREEN_RELEASE_BASELINE = "green-release-baseline"
+    RED_BASELINE = "red-baseline"
+    SELECTION_ONLY = "selection-only"
+    INCOMPLETE = "incomplete"
+    RESOURCE_TIMEOUT = "resource-timeout"
+
+
 class BindingMode(StrEnum):
     EXACT = "exact"
     RELATIVE_FILE_FINGERPRINTS = "relative-file-fingerprints"
@@ -821,6 +831,21 @@ def stamp_from_attempt(
     """Parse a complete attempt, withholding release authority until publication."""
     if attempt.get("protocol_version") != protocol_version or attempt.get("status") not in {"reusable", "complete"}:
         return None
+    if protocol_version >= 6:
+        raw_outcome = attempt.get("outcome")
+        if not isinstance(raw_outcome, str):
+            return None
+        try:
+            outcome = SeedAttemptOutcome(raw_outcome)
+        except ValueError:
+            return None
+        if attempt.get("status") == "complete" and outcome is not SeedAttemptOutcome.GREEN_RELEASE_BASELINE:
+            return None
+        if attempt.get("status") == "reusable" and outcome not in {
+            SeedAttemptOutcome.RED_BASELINE,
+            SeedAttemptOutcome.SELECTION_ONLY,
+        }:
+            return None
     selection = attempt.get("selection")
     expected = attempt.get("expected_nodeids")
     identity = attempt.get("identity")
@@ -965,6 +990,7 @@ __all__ = [
     "CollectionStatus",
     "GraphInspection",
     "GraphStatus",
+    "SeedAttemptOutcome",
     "TestmonBinding",
     "TestmonIdentity",
     "TestmonSeedStamp",

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -61,6 +61,7 @@ from devtools.testmon_bootstrap import maybe_bootstrap_testmon_seed
 from devtools.testmon_state import (
     BindingMode,
     GraphStatus,
+    SeedAttemptOutcome,
     TerminalAuthorization,
     TestmonBinding,
     TestmonSeedStamp,
@@ -213,7 +214,7 @@ TESTMON_DATA = Path(".cache/testmon/testmondata")
 TESTMON_SEED_STAMP = Path(".cache/testmon/seed.json")
 TESTMON_SEED_ATTEMPT = Path(".cache/testmon/seed-attempt.json")
 TESTMON_AFFECTED_STAMP = Path(".cache/testmon/affected.json")
-TESTMON_SEED_PROTOCOL_VERSION = 5
+TESTMON_SEED_PROTOCOL_VERSION = 6
 PYTEST_REPORT_DIR = Path(".cache/verify")
 PYTEST_REPORT_PATH = PYTEST_REPORT_DIR / "last-pytest.json"
 PYTEST_JUNIT_REPORT_DIR = Path(".cache/test-reports")
@@ -2585,6 +2586,28 @@ def _seed_node_outcomes_from_events(
     return results
 
 
+def _seed_attempt_outcome(
+    *,
+    release_eligible: bool,
+    terminal_graph: bool,
+    exit_code: int,
+    pytest_step: Mapping[str, Any] | None,
+) -> SeedAttemptOutcome:
+    """Classify the terminal seed result without hiding a bounded resource stop."""
+    if release_eligible:
+        return SeedAttemptOutcome.GREEN_RELEASE_BASELINE
+    if terminal_graph:
+        return SeedAttemptOutcome.RED_BASELINE if exit_code != 0 else SeedAttemptOutcome.SELECTION_ONLY
+    diagnosis = str((pytest_step or {}).get("diagnosis") or "").casefold()
+    termination_reason = str((pytest_step or {}).get("termination_reason") or "").casefold()
+    if diagnosis in {"pytest_timeout", "pytest_stall_timeout", "pytest_resource_preflight_failed"} or any(
+        marker in termination_reason
+        for marker in ("runtime exceeded", "tmpfs budget exceeded", "resource budget", "resource limit")
+    ):
+        return SeedAttemptOutcome.RESOURCE_TIMEOUT
+    return SeedAttemptOutcome.INCOMPLETE
+
+
 def _finalize_testmon_seed_attempt(
     *,
     prepared: Mapping[str, Any],
@@ -2654,12 +2677,27 @@ def _finalize_testmon_seed_attempt(
     narrow_terminal = isinstance(identity, Mapping) and identity.get("skip_slow") is True
     terminal_authorized = _testmon_seed_terminal_authorized(prepared)
     release_eligible = green_complete and (not narrow_terminal or terminal_authorized)
+    terminal_graph = (
+        database["error"] is None
+        and database["graph_status"] == GraphStatus.COMPLETE.value
+        and not database["missing_nodeids"]
+        and database["orphan_execution_edges"] == 0
+        and database["orphan_fingerprint_edges"] == 0
+        and all(item.get("outcome") in {"passed", "failed", "error", "skipped"} for item in node_outcomes)
+    )
+    outcome = _seed_attempt_outcome(
+        release_eligible=release_eligible,
+        terminal_graph=terminal_graph,
+        exit_code=exit_code,
+        pytest_step=pytest_step,
+    )
     seed_scope = (
         VerificationScope.NARROW_TERMINAL.value if narrow_terminal else VerificationScope.RELEASE_BASELINE.value
     )
     attempt_candidate = {
         **dict(prepared),
-        "status": "complete" if release_eligible else "reusable",
+        "status": "complete" if release_eligible else "reusable" if terminal_graph else "incomplete",
+        "outcome": outcome.value,
         "exit_code": exit_code,
         "expected_nodeids": expected,
         "expected_count": len(expected),
@@ -2700,6 +2738,7 @@ def _finalize_testmon_seed_attempt(
     payload = {
         **dict(prepared),
         "status": attempt_status,
+        "outcome": outcome.value,
         "finished_at": datetime.now(timezone.utc).isoformat(),
         "exit_code": exit_code,
         "expected_nodeids": expected,
@@ -2788,6 +2827,11 @@ def _refresh_testmon_selection_attempt(
     payload = {
         **attempt,
         "status": "reusable" if graph_complete and terminal else "incomplete",
+        "outcome": (
+            SeedAttemptOutcome.RED_BASELINE.value
+            if graph_complete and terminal
+            else SeedAttemptOutcome.INCOMPLETE.value
+        ),
         "finished_at": datetime.now(timezone.utc).isoformat(),
         "exit_code": exit_code,
         "expected_nodeids": expected,
@@ -3065,6 +3109,7 @@ def main(argv: list[str] | None = None) -> int:
     if seed_receipt is not None:
         history_entry["testmon_seed"] = {
             "status": seed_receipt["status"],
+            "outcome": seed_receipt["outcome"],
             "resume": seed_receipt["resume"],
             "expected_count": seed_receipt["expected_count"],
             "attempt_path": str(TESTMON_SEED_ATTEMPT),

--- a/tests/integration/devtools/test_testmon_seed_recovery.py
+++ b/tests/integration/devtools/test_testmon_seed_recovery.py
@@ -47,6 +47,7 @@ def test_real_testmon_graph_copies_and_rebinds_in_a_temporary_lane(
     attempt = {
         "protocol_version": verify.TESTMON_SEED_PROTOCOL_VERSION,
         "status": "reusable",
+        "outcome": "red-baseline",
         "identity": {
             "git_head": "head",
             "worktree_fingerprint": "source-tree",

--- a/tests/unit/devtools/test_testmon_state.py
+++ b/tests/unit/devtools/test_testmon_state.py
@@ -120,6 +120,26 @@ def test_omitted_interrupted_and_uncovered_nodes_fail_closed(tmp_path: Path) -> 
     assert stamp_from_attempt(_attempt(data), data, checkout_root=tmp_path, protocol_version=PROTOCOL) is None
 
 
+def test_current_protocol_rejects_a_reusable_attempt_with_a_nonreusable_outcome(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    data = tmp_path / "testmondata"
+    _write_graph(data, failed=True)
+    attempt = _attempt(data)
+    attempt["protocol_version"] = 6
+    identity = attempt["identity"]
+    assert isinstance(identity, dict)
+    identity["dependency_environment"] = "dependencies"
+    identity["pytest_harness"] = "harness"
+    monkeypatch.setattr(testmon_state, "testmon_runtime_identity", lambda _root: ("dependencies", "harness"))
+
+    attempt["outcome"] = "resource-timeout"
+    assert stamp_from_attempt(attempt, data, checkout_root=tmp_path, protocol_version=6) is None
+
+    attempt["outcome"] = "red-baseline"
+    assert stamp_from_attempt(attempt, data, checkout_root=tmp_path, protocol_version=6) is not None
+
+
 def test_stamp_from_attempt_does_not_reopen_the_validated_database(tmp_path: Path) -> None:
     data = tmp_path / "testmondata"
     _write_graph(data)

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -955,6 +955,67 @@ def test_seed_node_outcomes_preserve_interrupted_active_node(tmp_path: Path) -> 
     assert outcomes[0]["outcome"] == "interrupted"
 
 
+def test_seed_resource_timeout_has_a_distinct_typed_terminal_outcome(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A supervisor resource stop must not collapse into generic incompleteness."""
+    monkeypatch.chdir(tmp_path)
+    expected = ["tests/test_seed.py::test_active"]
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+    (artifact_dir / "selection.json").write_text(
+        json.dumps(
+            {
+                "selected_count": len(expected),
+                "deselected_count": 0,
+                "selected_nodeids": expected,
+                "selected_nodeids_omitted": 0,
+            }
+        )
+    )
+    (artifact_dir / "events.jsonl").write_text(json.dumps({"event": "test_started", "nodeid": expected[0]}) + "\n")
+    TESTMON_DATA.parent.mkdir(parents=True)
+    with sqlite3.connect(TESTMON_DATA) as connection:
+        connection.execute("create table environment (id integer primary key, environment_name text)")
+        connection.execute("create table file_fp (id integer primary key, filename text, fsha text)")
+        connection.execute("create table test_execution (id integer primary key, test_name text, failed integer)")
+        connection.execute("create table test_execution_file_fp (test_execution_id integer, fingerprint_id integer)")
+    _write_run_receipt(tmp_path, "run-resource-timeout")
+
+    receipt = _finalize_testmon_seed_attempt(
+        prepared={
+            "protocol_version": TESTMON_SEED_PROTOCOL_VERSION,
+            "status": "running",
+            "identity": {
+                "git_head": "head",
+                "worktree_fingerprint": "tree",
+                "python": "python",
+                "skip_slow": False,
+                "lab": False,
+                **_testmon_runtime_identity_fields(Path.cwd()),
+            },
+            "resume": False,
+            "expected_nodeids": [],
+            "run_id": "run-resource-timeout",
+            "artifact_dir": ".cache/verify/runs/run-resource-timeout",
+        },
+        step_results=[
+            {
+                "name": "pytest seed-testmon",
+                "artifact_dir": str(artifact_dir),
+                "exit": 124,
+                "diagnosis": "pytest_terminated",
+                "termination_reason": "pytest tmpfs budget exceeded: 512.0 MiB > 500 MiB",
+            }
+        ],
+        exit_code=124,
+    )
+
+    assert receipt["status"] == "incomplete"
+    assert receipt["outcome"] == "resource-timeout"
+    assert receipt["release_baseline_allowed"] is False
+
+
 def test_seed_node_outcomes_accept_setup_skip_as_terminal_skip(tmp_path: Path) -> None:
     events = tmp_path / "events.jsonl"
     events.write_text(


### PR DESCRIPTION
## Summary

Record bounded testmon seed results as typed terminal outcomes and reject promotion attempts whose receipt state cannot grant a release baseline.

## Problem

A bounded seed that exhausted its runtime envelope was persisted only as generic `incomplete` state. The receipt retained pytest metadata, but the release ledger could not distinguish a resource timeout from other unfinished work or make a clear, fail-closed promotion decision.

## Solution

- Add protocol-v6 `SeedAttemptOutcome` values for green, red, selection-only, incomplete, and resource-timeout results.
- Derive `resource-timeout` from the production verification diagnosis and termination record, then persist it in the seed attempt and its history.
- Permit stamps only for completed green receipts and terminal red or selection-only receipts. Incomplete and resource-timeout receipts cannot promote a release baseline.
- Align the checkout guard with protocol v6 and cover the production seed-finalization route with a temporary SQLite-backed regression test.

## Verification

- `devtools test tests/unit/devtools/test_verify.py tests/unit/devtools/test_testmon_state.py tests/unit/devtools/test_checkout_guard.py tests/unit/devtools/test_testmon_bootstrap.py tests/integration/devtools/test_testmon_seed_recovery.py` → `162 passed in 26.50s`.
- `devtools verify --quick` → exit 0; all 24 checks passed.
- `POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S=600 devtools verify --seed-testmon` → exit 124 after 617.17s of pytest with 4 workers. The 600-second cap was exceeded; peak PSS was 6161.3 MiB and basetemp peak was 739.0 MiB.

## Fresh seed receipt

The fresh receipt for this exact head records `protocol_version: 6`, `status: incomplete`, and `outcome: resource-timeout`. It bound the declared 20,984-node universe and digest `7838782be561e3e285c71ca55c454636ee90ea24f2aef573fd37d5b524134772`, but grants no release baseline (`release_baseline_allowed: false`). The workload receipt is `workload-receipt:sha256:4ef0a68349eef7b5d9021b2a5497b3283f415d702c6030e623928601f2ce4254`.

This PR intentionally does not claim a green release baseline. The two assigned Beads require a typed, replayable terminal decision for a bounded fresh seed; this receipt provides the required resource-timeout decision. No existing open Bead names a longer-envelope follow-up, so no ID is invented here.

## Bead disposition matrix

| Assigned Bead | Whole-Bead disposition | Evidence | Residual |
| --- | --- | --- | --- |
| polylogue-817er | satisfied | Commit `e0ff6a56f`; focused harness suite; quick verification | Fresh seed is resource-timeout and cannot promote a release baseline. |
| polylogue-d96ta | satisfied | Protocol-v6 fresh seed receipt and workload receipt | Fresh seed is resource-timeout and cannot promote a release baseline. |

<!-- polylogue-pr-scope:v1
{
  "assigned_beads": [
    "polylogue-817er",
    "polylogue-d96ta"
  ],
  "beads_digest": "0b80596f652dd0b6861e4ad427c51c156738dac56f9bcea4bd205032941b16c3",
  "dispositions": [
    {
      "bead_id": "polylogue-817er",
      "disposition": "satisfied",
      "evidence": [
        {
          "kind": "commit",
          "ref": "e0ff6a56f fix(devtools): type testmon seed terminal outcomes"
        },
        {
          "kind": "test",
          "ref": "devtools test test_verify.py test_testmon_state.py test_checkout_guard.py test_testmon_bootstrap.py test_testmon_seed_recovery.py: 162 passed"
        },
        {
          "kind": "command",
          "ref": "devtools verify --quick: exit 0, all 24 checks passed"
        }
      ],
      "successors": []
    },
    {
      "bead_id": "polylogue-d96ta",
      "disposition": "satisfied",
      "evidence": [
        {
          "kind": "receipt",
          "ref": ".cache/testmon/seed-attempt.json: protocol 6, outcome resource-timeout, expected_count 20984, release_baseline_allowed false"
        },
        {
          "kind": "receipt",
          "ref": "workload-receipt:sha256:4ef0a68349eef7b5d9021b2a5497b3283f415d702c6030e623928601f2ce4254"
        },
        {
          "kind": "command",
          "ref": "POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S=600 devtools verify --seed-testmon: exit 124 after 617.17s, 4 workers, 600s cap exceeded"
        }
      ],
      "successors": []
    }
  ],
  "head_sha": "e0ff6a56f16a307fe0d74e65825f89f9cf0a3ec6",
  "scope_digest": "e64f3bb93f379bb6cf523a1b5f91e0827796dc96a6273ff92a34b46f5329126c",
  "version": 1
}
-->
