### PR TITLE
test(rebuild): cover offline attestation recovery

### DIFF
--- a/tests/unit/maintenance/test_rebuild_index_provenance_gate.py
+++ b/tests/unit/maintenance/test_rebuild_index_provenance_gate.py
@@ -1161,6 +1161,57 @@ def test_daemon_reconciles_active_generation_after_both_attestation_checkpoints_
     }
 
 
+def test_offline_retry_reconciles_active_generation_after_both_attestation_checkpoints_fail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An operator retry cannot resume a generation that was already promoted.
+
+    Anti-vacuity: the setup drives the real offline synchronous rebuild through
+    the pointer flip while both post-promotion transaction writes fail. The
+    retry uses that same public offline entry point, not the daemon resolver.
+    Removing its transaction reconciliation leaves the persisted transaction
+    ``ready`` alongside the active generation.
+    """
+    root = tmp_path / "archive"
+    _seed(root, count=1)
+    receipt_path = write_valid_rebuild_receipt(root, tmp_path / "receipt.json")
+    operation_id = "operator-created-post-promotion-failure"
+    store = IndexGenerationStore.for_archive_root(root)
+    store.create_transaction(
+        source_snapshot=rebuild_source_evidence_snapshot(root),
+        operation_id=operation_id,
+    )
+    original_checkpoint = IndexGenerationStore.checkpoint_transaction
+
+    def fail_attestation_checkpoint(self: IndexGenerationStore, transaction: object, **kwargs: object) -> object:
+        if kwargs.get("status") in {"promoted", "promoted-attestation-failed"}:
+            raise OSError("simulated double offline attestation checkpoint failure")
+        return original_checkpoint(self, transaction, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(IndexGenerationStore, "checkpoint_transaction", fail_attestation_checkpoint)
+    request = RebuildIndexRequest(
+        archive_root=root,
+        schema_inference_receipt_path=receipt_path,
+        operation_id=operation_id,
+        promote=True,
+    )
+    with pytest.raises(OSError, match="simulated double offline attestation checkpoint failure"):
+        rebuild_index_from_source_sync(request)
+
+    stranded = store.load_transaction(operation_id)
+    assert stranded.status == "ready"
+    assert store.load(stranded.generation_id).state == "active"
+
+    monkeypatch.undo()
+    with pytest.raises(RuntimeError, match=f"rebuild operation {operation_id} is promoted-attestation-failed"):
+        rebuild_index_from_source_sync(request)
+
+    reconciled = store.load_transaction(operation_id)
+    assert reconciled.status == "promoted-attestation-failed"
+    assert reconciled.generation_id == stranded.generation_id
+    assert store.load(reconciled.generation_id).state == "active"
+
+
 def test_provenance_failure_reconciles_active_generation_before_stale_retirement(tmp_path: Path) -> None:
     """Receipt rejection preserves an already-promoted owned generation's lifecycle fact."""
     root = tmp_path / "archive"


### PR DESCRIPTION
## Summary

This closes the remaining proof gap for `polylogue-q4qpl`: an operator-created offline rebuild retry now has a production-route regression covering the state where both post-promotion attestation checkpoints fail.

## Problem

The Bead audit correctly identified that a ready rebuild transaction paired with an active generation is unsafe. Current master already contains the two production fixes in `53396ae03`: `RebuildProvenanceContext.validate()` retains a refreshed external inventory token, and the offline operation-ID route reconciles an already-active owned generation. The remaining test coverage exercised the double-checkpoint recovery only through the daemon resolver, leaving the operator retry route unproven.

## Solution

`tests/unit/maintenance/test_rebuild_index_provenance_gate.py` now drives a real temporary SQLite archive through `rebuild_index_from_source_sync`: it creates an operator-named transaction, injects failures into both post-promotion checkpoints, observes the stranded ready transaction and active generation, then retries via the same public offline sync entry point. The retry must reconcile the operation to `promoted-attestation-failed` before it can replay. Removing `_reconcile_active_generation_transaction` from the offline operation-ID route makes this test fail against the pre-fix baseline.

| Bead AC | Disposition | Evidence |
| --- | --- | --- |
| 1. Parser-affecting metadata invalidates receipt and transaction | Satisfied | Existing source snapshot production-route coverage in `test_rebuild_index_provenance_gate.py` |
| 2. Identity-bound inventory token is reused without losing change detection | Satisfied | Nonresumable and resumable token regressions, 5 selected tests passed |
| 3. Referenced blob bytes are verified before readiness | Satisfied | Existing `test_blob_bytes_changed_after_replay_are_rejected_before_candidate_readiness` |
| 4. Post-promotion failure cannot leave a ready transaction with a different active generation | Satisfied | Existing pointer-attestation test plus this offline retry regression |
| 5. Relative daemon receipt paths resolve at the CLI boundary | Satisfied | `test_rebuild_index_daemon_resolves_relative_schema_receipt_before_post` |
| 6. Red tests are load-bearing | Satisfied | New test failed at `53396ae03~1` with `lost its inactive candidate` |
| 7. Focused checks and quick verification pass | Satisfied | Commands below |
| 8. No production migration or candidate promotion | Satisfied | Test-only diff using pytest temporary SQLite archives |
| 9. Refreshed token reaches every later provenance context validation | Satisfied | `RebuildProvenanceContext.validate()` and existing nonresumable/resumable token regressions |
| 10. Offline operator retry reconciles after both checkpoint failures | Satisfied | New `test_offline_retry_reconciles_active_generation_after_both_attestation_checkpoints_fail` |

## Verification

- `devtools test tests/unit/maintenance/test_rebuild_index_provenance_gate.py -k 'nonresumable_rebuild_persists_refreshed_inventory_evidence_after_detector_change or resumable_checkpoint_and_pass_receipt_reuse_refreshed_inventory_token or offline_retry_reconciles_active_generation_after_both_attestation_checkpoints_fail'`: `5 passed, 47 deselected`.
- `devtools test tests/unit/cli/test_archive_maintenance_cli.py::test_rebuild_index_daemon_resolves_relative_schema_receipt_before_post`: `1 passed`.
- The new node run against `53396ae03~1`: failed as expected because the offline retry left the transaction ready and raised `lost its inactive candidate`.
- `devtools verify --quick`: all 24 steps succeeded.

## Adversarial review notes

- Local independent review attempted through Codex session `019fec32-20b2-72d2-a09c-d813263a5409`; its runtime produced no final artifact and was terminated without touching the checkout.
- The schema-bound Claude judge receipt `47632ebb-6a71-4fb8-ae36-1b4499ced491` reports a transport failure before a verdict. Repository automated review is requested after PR publication.

## Scope carrier

<!-- polylogue-pr-scope:v1
{
  "assigned_beads": [
    "polylogue-q4qpl"
  ],
  "beads_digest": "2c764f87e8f99e222e12a61a1025a47ebd60af5ff3121b86b219af910ed9377c",
  "dispositions": [
    {
      "bead_id": "polylogue-q4qpl",
      "disposition": "satisfied",
      "evidence": [
        {
          "kind": "commit",
          "ref": "a13666b80ccec43ed1ef55319a630555fb6dd2c7"
        },
        {
          "kind": "test",
          "ref": "tests/unit/maintenance/test_rebuild_index_provenance_gate.py"
        },
        {
          "kind": "command",
          "ref": "devtools test tests/unit/maintenance/test_rebuild_index_provenance_gate.py -k token-and-offline-retry: 5 passed"
        },
        {
          "kind": "command",
          "ref": "devtools verify --quick @ a13666b80: 24 steps passed"
        }
      ],
      "successors": []
    }
  ],
  "head_sha": "a13666b80ccec43ed1ef55319a630555fb6dd2c7",
  "scope_digest": "b30d55d7966371abe125718fd1c51b557f27d712109e73afe18eac939e2e529f",
  "version": 1
}
-->
