### PR TITLE
test(storage): cover liveness stage failure cleanup

### DIFF
--- a/tests/unit/storage/test_blob_ref_liveness.py
+++ b/tests/unit/storage/test_blob_ref_liveness.py
@@ -173,26 +173,8 @@ def test_default_dry_run_does_not_acquire_the_archive_writer_lease(
 
 def test_legacy_hook_payload_ref_is_rekeyable_not_a_delete_candidate(tmp_path: Path) -> None:
     archive_root = _source_archive(tmp_path)
-    blob_hash = b"h" * 32
-    source_path = "/legacy-hook.jsonl"
-    native_id = "tool-call-1"
-    legacy_ref_id = deterministic_raw_session_id("codex-session", source_path, 0, blob_hash, native_id)
     with sqlite3.connect(archive_root / "source.db") as conn:
-        conn.execute(
-            """
-            INSERT INTO raw_hook_events (
-                hook_event_id, origin, native_id, source_path, event_type, payload_json, observed_at_ms
-            ) VALUES ('hook-legacy', 'codex-session', ?, ?, 'PostToolUse', '{}', 1)
-            """,
-            (native_id, source_path),
-        )
-        conn.execute(
-            """
-            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
-            VALUES (?, ?, 'raw_payload', ?, 1, 1)
-            """,
-            (blob_hash, legacy_ref_id, source_path),
-        )
+        legacy_ref_id = _seed_legacy_hook_ref(conn)
         classification = classify_blob_ref_liveness(conn)
 
     assert classification.rekeyable_hook_payload_count == 1
@@ -200,51 +182,67 @@ def test_legacy_hook_payload_ref_is_rekeyable_not_a_delete_candidate(tmp_path: P
     assert all(candidate.ref_id != legacy_ref_id for candidate in classification.candidates)
 
 
-def test_liveness_stage_fails_closed_when_hook_match_build_is_interrupted(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The production liveness stage must not retain a prior candidate table after an interrupted match build."""
-
-    archive_root = _source_archive(tmp_path)
+def _seed_legacy_hook_ref(conn: sqlite3.Connection) -> str:
     blob_hash = b"h" * 32
     source_path = "/legacy-hook.jsonl"
     native_id = "tool-call-1"
     legacy_ref_id = deterministic_raw_session_id("codex-session", source_path, 0, blob_hash, native_id)
+    conn.execute(
+        """
+        INSERT INTO raw_hook_events (
+            hook_event_id, origin, native_id, source_path, event_type, payload_json, observed_at_ms
+        ) VALUES ('hook-legacy', 'codex-session', ?, ?, 'PostToolUse', '{}', 1)
+        """,
+        (native_id, source_path),
+    )
+    conn.execute(
+        """
+        INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+        VALUES (?, ?, 'raw_payload', ?, 1, 1)
+        """,
+        (blob_hash, legacy_ref_id, source_path),
+    )
+    return legacy_ref_id
+
+
+def _seed_liveness_candidate_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TEMP TABLE blob_ref_liveness_candidates (
+            blob_hash BLOB NOT NULL,
+            ref_type TEXT NOT NULL,
+            ref_id TEXT NOT NULL,
+            source_path TEXT,
+            size_bytes INTEGER NOT NULL,
+            acquired_at_ms INTEGER NOT NULL,
+            referent_table TEXT NOT NULL,
+            referent_column TEXT NOT NULL,
+            PRIMARY KEY (blob_hash, ref_type, ref_id)
+        ) STRICT
+        """
+    )
+
+
+@pytest.mark.parametrize(
+    "checkpoint",
+    (
+        *(f"created:{table}" for table in hook_payload_ref_reconciliation._STAGE_TABLES),
+        "population_began",
+    ),
+)
+def test_liveness_route_discards_failed_match_stage_then_rebuilds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, checkpoint: str
+) -> None:
+    """The real liveness route cannot retain or reuse a failed match stage."""
+
+    archive_root = _source_archive(tmp_path)
     with sqlite3.connect(archive_root / "source.db") as conn:
-        conn.execute(
-            """
-            INSERT INTO raw_hook_events (
-                hook_event_id, origin, native_id, source_path, event_type, payload_json, observed_at_ms
-            ) VALUES ('hook-legacy', 'codex-session', ?, ?, 'PostToolUse', '{}', 1)
-            """,
-            (native_id, source_path),
-        )
-        conn.execute(
-            """
-            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
-            VALUES (?, ?, 'raw_payload', ?, 1, 1)
-            """,
-            (blob_hash, legacy_ref_id, source_path),
-        )
-        conn.execute(
-            """
-            CREATE TEMP TABLE blob_ref_liveness_candidates (
-                blob_hash BLOB NOT NULL,
-                ref_type TEXT NOT NULL,
-                ref_id TEXT NOT NULL,
-                source_path TEXT,
-                size_bytes INTEGER NOT NULL,
-                acquired_at_ms INTEGER NOT NULL,
-                referent_table TEXT NOT NULL,
-                referent_column TEXT NOT NULL,
-                PRIMARY KEY (blob_hash, ref_type, ref_id)
-            ) STRICT
-            """
-        )
+        legacy_ref_id = _seed_legacy_hook_ref(conn)
+        _seed_liveness_candidate_table(conn)
 
         def inject_interruption(event: str) -> None:
-            if event == "population_began":
-                raise RuntimeError("injected match-stage interruption")
+            if event == checkpoint:
+                raise RuntimeError(f"injected match-stage interruption at {event}")
 
         def fail_after_population(connection: sqlite3.Connection) -> tuple[int, int, int, int]:
             return hook_payload_ref_reconciliation._create_match_stage(connection, failure_injector=inject_interruption)
@@ -255,9 +253,16 @@ def test_liveness_stage_fails_closed_when_hook_match_build_is_interrupted(
             stage_blob_ref_liveness(conn)
 
         remaining = {str(row[0]) for row in conn.execute("SELECT name FROM sqlite_temp_master WHERE type = 'table'")}
+        assert not remaining.intersection(hook_payload_ref_reconciliation._STAGE_TABLES)
+        assert "blob_ref_liveness_candidates" not in remaining
 
-    assert "blob_ref_liveness_candidates" not in remaining
-    assert not remaining.intersection(hook_payload_ref_reconciliation._STAGE_TABLES)
+        monkeypatch.setattr(
+            blob_ref_liveness, "_create_match_stage", hook_payload_ref_reconciliation._create_match_stage
+        )
+        rebuilt = stage_blob_ref_liveness(conn, sample_limit=0)
+
+        assert rebuilt.classification.rekeyable_hook_payload_count == 1
+        assert all(candidate.ref_id != legacy_ref_id for candidate in rebuilt.candidates(conn))
 
 
 def test_apply_requires_backup_and_receipt_before_mutation(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Add load-bearing failure-path coverage for hook match-stage construction and blob-liveness evaluation.

## Problem

Interrupted or failed match-stage construction can leave partial temporary state that a later liveness check may reuse as if it were complete. The existing implementation needs coverage at every stage-table and population failure boundary.

## Solution

Add real-route exception-injection coverage for each stage-table checkpoint, population failure, cleanup, fail-closed behavior, and same-connection rebuild. The tests prove that disabling cleanup produces failures, rather than merely asserting helper calls.

## Verification

- 48 focused hook/blob-liveness tests passed.
- Cleanup-disabled mutation matrix produced 8 failures.
- `devtools verify --quick`: 24/24 steps passed.
- No Beads or production archive mutation.

<!-- polylogue-pr-scope:v1
{
  "assigned_beads": [
    "polylogue-tiozw"
  ],
  "beads_digest": "0c61453859d024add76d7cc0b40bf7b800e65a37b8fd2f561f2549ba460955f0",
  "dispositions": [
    {
      "bead_id": "polylogue-tiozw",
      "disposition": "satisfied",
      "evidence": [
        {
          "kind": "commit",
          "ref": "b2d25ad5335d5864173b93717078e23f69cc82b3"
        },
        {
          "kind": "test",
          "ref": "48 focused hook/blob-liveness tests passed"
        },
        {
          "kind": "test",
          "ref": "cleanup-disabled mutation matrix produced 8 failures"
        },
        {
          "kind": "command",
          "ref": "devtools verify --quick: 24/24 passed"
        }
      ],
      "successors": []
    }
  ],
  "head_sha": "b2d25ad5335d5864173b93717078e23f69cc82b3",
  "scope_digest": "ce48a631ab4c24d221a0546f13d92074e7ddc2121b2f33351dd41400fdb19f2a",
  "version": 1
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery after interrupted liveness checks.
  * Ensured temporary staging data is cleaned up after failures.
  * Subsequent staging attempts now rebuild successfully without incorrectly marking legacy references for deletion.

* **Tests**
  * Added coverage for interrupted staging and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->