### PR TITLE
fix(daemon): persist judgment scheduler health receipts

### DIFF
--- a/docs/plans/layering-surface-baseline.json
+++ b/docs/plans/layering-surface-baseline.json
@@ -1485,6 +1485,21 @@
     "import": "polylogue.storage.sqlite.connection_profile"
   },
   {
+    "target": "polylogue/api",
+    "file": "polylogue/api/archive.py",
+    "import": "polylogue.storage.sqlite.archive_tiers.ops_write"
+  },
+  {
+    "target": "polylogue/daemon",
+    "file": "polylogue/daemon/events.py",
+    "import": "polylogue.storage.sqlite.archive_tiers.ops_write"
+  },
+  {
+    "target": "polylogue/daemon",
+    "file": "polylogue/daemon/judgment_automation.py",
+    "import": "polylogue.storage.sqlite.archive_tiers.ops_write"
+  },
+  {
     "target": "polylogue/daemon",
     "file": "polylogue/daemon/status_snapshot.py",
     "import": "polylogue.storage.archive_identity"

--- a/docs/plans/layering.yaml
+++ b/docs/plans/layering.yaml
@@ -131,7 +131,8 @@ writer_modules:
         [add_convergence_debt, record_cursor_lag_sample, record_daemon_stage_event, record_fts_drift_sample,
         record_ingest_attempt, record_schema_drift_sample,
         record_daemon_lifecycle_heartbeat, record_daemon_lifecycle_signal, record_daemon_lifecycle_start,
-        record_daemon_lifecycle_stop, record_mcp_call, record_route_observation, upsert_embedding_catchup_run,
+        record_daemon_lifecycle_stop, record_judgment_scheduler_receipt,
+        record_mcp_call, record_route_observation, upsert_embedding_catchup_run,
         upsert_ingest_cursor]
     - path: polylogue/storage/sqlite/archive_tiers/ingest_precedence.py
       surfaces:

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -1570,6 +1570,7 @@ def _archive_assertion_candidate_queue_health(
         judgment_automation_receipt_freshness_window_ms,
     )
     from polylogue.daemon.lifecycle import DAEMON_HEARTBEAT_STALE_AFTER_SECONDS
+    from polylogue.storage.sqlite.archive_tiers.ops_write import _read_latest_judgment_scheduler_receipt
     from polylogue.storage.sqlite.archive_tiers.user_write import (
         ASSERTION_CANDIDATE_JUDGMENT_KINDS,
         ASSERTION_CANDIDATE_REVIEW_STATUSES,
@@ -1733,9 +1734,19 @@ def _archive_assertion_candidate_queue_health(
                             scheduler_state = "fresh"
                         else:
                             scheduler_state = "stale"
-                if ops_conn.execute(
+                typed_receipt = _read_latest_judgment_scheduler_receipt(ops_conn)
+                if typed_receipt is not None:
+                    judgment_scheduler_receipt_status = cast(
+                        Literal["completed", "parked", "failed"], typed_receipt.status
+                    )
+                    judgment_scheduler_receipt_at_ms = typed_receipt.observed_at_ms
+                    judgment_scheduler_receipt_reason = typed_receipt.reason
+                elif ops_conn.execute(
                     "SELECT 1 FROM sqlite_master WHERE type='table' AND name='daemon_events'"
                 ).fetchone():
+                    # Compatibility for ops.db files created before the typed
+                    # receipt table. Once a typed row exists it is authoritative,
+                    # even if a newer legacy event is malformed or stale.
                     receipt_row = ops_conn.execute(
                         """
                         SELECT ts_ms, payload_json

--- a/polylogue/daemon/events.py
+++ b/polylogue/daemon/events.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import uuid
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
@@ -12,6 +14,10 @@ from typing import TYPE_CHECKING, cast
 
 from polylogue.paths import archive_root
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+from polylogue.storage.sqlite.archive_tiers.ops_write import (
+    ArchiveJudgmentSchedulerReceipt,
+    record_judgment_scheduler_receipt,
+)
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.connection_profile import open_daemon_connection, open_readonly_connection
 
@@ -121,6 +127,34 @@ def emit_daemon_event(
     """Emit a daemon event to the event ledger."""
     conn = _ensure_events_db() if archive_root_path is None else _ensure_events_db(archive_root_path / "ops.db")
     try:
+        if kind == "judgment-automation":
+            receipt_payload = payload or {}
+            typed_operation_id = operation_id or f"judgment-automation:{uuid.uuid4().hex}"
+            counters = {
+                name: receipt_payload.get(name, 0)
+                for name in ("considered", "accepted", "rejected", "escalated", "idempotent", "failed")
+            }
+            with suppress(ValueError):
+                record_judgment_scheduler_receipt(
+                    conn,
+                    ArchiveJudgmentSchedulerReceipt(
+                        operation_id=typed_operation_id,
+                        observed_at_ms=current_epoch_ms() if observed_at_ms is None else observed_at_ms,
+                        status=str(receipt_payload.get("status", "")),
+                        reason=str(receipt_payload.get("reason", "")),
+                        retryable=receipt_payload.get("retryable", False),  # type: ignore[arg-type]
+                        retry_route=str(receipt_payload.get("retry_route", "")),
+                        batch_limit=receipt_payload.get("batch_limit", 0),  # type: ignore[arg-type]
+                        considered=counters["considered"],  # type: ignore[arg-type]
+                        accepted=counters["accepted"],  # type: ignore[arg-type]
+                        rejected=counters["rejected"],  # type: ignore[arg-type]
+                        escalated=counters["escalated"],  # type: ignore[arg-type]
+                        idempotent=counters["idempotent"],  # type: ignore[arg-type]
+                        failed=counters["failed"],  # type: ignore[arg-type]
+                        receipt_persistence_degraded=receipt_payload.get("receipt_persistence_degraded", False),  # type: ignore[arg-type]
+                        receipt_persistence_recovered=receipt_payload.get("receipt_persistence_recovered", False),  # type: ignore[arg-type]
+                    ),
+                )
         conn.execute(
             "INSERT INTO daemon_events (ts_ms, kind, operation_id, payload_json) VALUES (?, ?, ?, ?)",
             (

--- a/polylogue/daemon/judgment_automation.py
+++ b/polylogue/daemon/judgment_automation.py
@@ -346,14 +346,22 @@ def recover_pending_judgment_automation_receipts(root: Path, *, now_ms: int | No
     if not user_db.exists():
         return 0
     from polylogue.daemon.events import get_latest_daemon_event
+    from polylogue.storage.sqlite.archive_tiers.ops_write import _read_latest_judgment_scheduler_receipt
     from polylogue.storage.sqlite.archive_tiers.user_write import (
         ack_judgment_automation_receipt_outbox,
         list_judgment_automation_receipt_outbox,
     )
-    from polylogue.storage.sqlite.connection_profile import open_connection
+    from polylogue.storage.sqlite.connection_profile import open_connection, open_readonly_connection
 
     conn = open_connection(user_db)
     conn.row_factory = sqlite3.Row
+    ops_conn: sqlite3.Connection | None = None
+    ops_db = root / "ops.db"
+    if ops_db.exists():
+        try:
+            ops_conn = open_readonly_connection(ops_db)
+        except sqlite3.Error:
+            logger.warning("judgment_automation: typed receipt recovery probe could not open ops.db", exc_info=True)
     acknowledged = 0
     try:
         for marker in list_judgment_automation_receipt_outbox(
@@ -366,6 +374,20 @@ def recover_pending_judgment_automation_receipts(root: Path, *, now_ms: int | No
             if not isinstance(operation_id, str) or not operation_id or not isinstance(receipt, dict):
                 logger.error("judgment_automation: malformed receipt outbox marker %s", marker.assertion_id)
                 continue
+            if ops_conn is not None:
+                try:
+                    typed_receipt = _read_latest_judgment_scheduler_receipt(ops_conn, operation_id=operation_id)
+                except (sqlite3.Error, ValueError) as exc:
+                    logger.warning(
+                        "judgment_automation: typed receipt recovery probe failed for marker %s: %s",
+                        marker.assertion_id,
+                        exc,
+                        exc_info=True,
+                    )
+                    typed_receipt = None
+                if typed_receipt is not None:
+                    acknowledged += int(ack_judgment_automation_receipt_outbox(conn, marker, now_ms=now_ms))
+                    continue
             latest = get_latest_daemon_event(
                 JUDGMENT_AUTOMATION_STAGE,
                 operation_id=operation_id,
@@ -415,6 +437,8 @@ def recover_pending_judgment_automation_receipts(root: Path, *, now_ms: int | No
             conn.commit()
     finally:
         conn.close()
+        if ops_conn is not None:
+            ops_conn.close()
     return acknowledged
 
 

--- a/polylogue/storage/sqlite/archive_tiers/ops.py
+++ b/polylogue/storage/sqlite/archive_tiers/ops.py
@@ -215,6 +215,30 @@ CREATE INDEX IF NOT EXISTS idx_daemon_events_ts ON daemon_events(ts_ms);
 CREATE INDEX IF NOT EXISTS idx_daemon_events_kind_id ON daemon_events(kind, id DESC);
 CREATE INDEX IF NOT EXISTS idx_daemon_events_lifecycle ON daemon_events(kind, operation_id, id DESC);
 
+-- Judgment automation receipts are the typed authority for scheduler health.
+-- Keep the legacy daemon_events row as a compatibility/event-stream record,
+-- but do not require queue-health readers to decode its JSON payload.
+CREATE TABLE IF NOT EXISTS judgment_scheduler_receipts (
+    operation_id                    TEXT PRIMARY KEY,
+    observed_at_ms                  INTEGER NOT NULL,
+    status                          TEXT NOT NULL CHECK(status IN ('completed', 'parked', 'failed')),
+    reason                          TEXT NOT NULL,
+    retryable                       INTEGER NOT NULL CHECK(retryable IN (0, 1)),
+    retry_route                     TEXT NOT NULL,
+    batch_limit                     INTEGER NOT NULL CHECK(batch_limit > 0),
+    considered                      INTEGER NOT NULL DEFAULT 0 CHECK(considered >= 0),
+    accepted                        INTEGER NOT NULL DEFAULT 0 CHECK(accepted >= 0),
+    rejected                        INTEGER NOT NULL DEFAULT 0 CHECK(rejected >= 0),
+    escalated                       INTEGER NOT NULL DEFAULT 0 CHECK(escalated >= 0),
+    idempotent                      INTEGER NOT NULL DEFAULT 0 CHECK(idempotent >= 0),
+    failed                          INTEGER NOT NULL DEFAULT 0 CHECK(failed >= 0),
+    receipt_persistence_degraded    INTEGER NOT NULL DEFAULT 0 CHECK(receipt_persistence_degraded IN (0, 1)),
+    receipt_persistence_recovered   INTEGER NOT NULL DEFAULT 0 CHECK(receipt_persistence_recovered IN (0, 1))
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_judgment_scheduler_receipts_observed
+ON judgment_scheduler_receipts(observed_at_ms DESC, operation_id);
+
 CREATE TABLE IF NOT EXISTS daemon_lifecycle (
     run_id               TEXT PRIMARY KEY,
     started_at_ms        INTEGER NOT NULL,

--- a/polylogue/storage/sqlite/archive_tiers/ops_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/ops_write.py
@@ -112,6 +112,163 @@ class ArchiveDaemonLifecycle:
 
 
 @dataclass(frozen=True, slots=True)
+class ArchiveJudgmentSchedulerReceipt:
+    """Typed scheduler receipt persisted in the disposable ops tier."""
+
+    operation_id: str
+    observed_at_ms: int
+    status: str
+    reason: str
+    retryable: bool
+    retry_route: str
+    batch_limit: int
+    considered: int = 0
+    accepted: int = 0
+    rejected: int = 0
+    escalated: int = 0
+    idempotent: int = 0
+    failed: int = 0
+    receipt_persistence_degraded: bool = False
+    receipt_persistence_recovered: bool = False
+
+
+_JUDGMENT_SCHEDULER_RECEIPT_STATUSES = frozenset(("completed", "parked", "failed"))
+_JUDGMENT_SCHEDULER_RECEIPT_COUNTERS = (
+    "considered",
+    "accepted",
+    "rejected",
+    "escalated",
+    "idempotent",
+    "failed",
+)
+
+
+def _is_exact_bool(value: object) -> bool:
+    return type(value) is bool
+
+
+def _validate_judgment_scheduler_receipt(receipt: ArchiveJudgmentSchedulerReceipt) -> None:
+    if not receipt.operation_id:
+        raise ValueError("judgment scheduler receipt operation_id must not be empty")
+    if receipt.status not in _JUDGMENT_SCHEDULER_RECEIPT_STATUSES:
+        raise ValueError(f"unknown judgment scheduler receipt status: {receipt.status}")
+    if not receipt.reason:
+        raise ValueError("judgment scheduler receipt reason must not be empty")
+    if not _is_exact_bool(receipt.retryable) or not _is_exact_bool(receipt.receipt_persistence_degraded):
+        raise ValueError("judgment scheduler receipt boolean fields must be bool")
+    if not _is_exact_bool(receipt.receipt_persistence_recovered):
+        raise ValueError("judgment scheduler receipt boolean fields must be bool")
+    if not receipt.retry_route:
+        raise ValueError("judgment scheduler receipt retry_route must not be empty")
+    if type(receipt.observed_at_ms) is not int:
+        raise ValueError("judgment scheduler receipt observed_at_ms must be an integer")
+    if type(receipt.batch_limit) is not int or receipt.batch_limit <= 0:
+        raise ValueError("judgment scheduler receipt batch_limit must be positive")
+    counters = tuple(getattr(receipt, name) for name in _JUDGMENT_SCHEDULER_RECEIPT_COUNTERS)
+    if any(isinstance(value, bool) or not isinstance(value, int) or value < 0 for value in counters):
+        raise ValueError("judgment scheduler receipt counters must be non-negative integers")
+    if receipt.considered != sum(counters[1:]):
+        raise ValueError("judgment scheduler receipt counters do not sum to considered")
+
+
+def record_judgment_scheduler_receipt(
+    conn: sqlite3.Connection,
+    receipt: ArchiveJudgmentSchedulerReceipt,
+) -> None:
+    """Upsert one operation-owned scheduler receipt without JSON decoding."""
+
+    _validate_judgment_scheduler_receipt(receipt)
+    conn.execute(
+        """
+        INSERT INTO judgment_scheduler_receipts (
+            operation_id, observed_at_ms, status, reason, retryable, retry_route,
+            batch_limit, considered, accepted, rejected, escalated, idempotent,
+            failed, receipt_persistence_degraded, receipt_persistence_recovered
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(operation_id) DO UPDATE SET
+            observed_at_ms = excluded.observed_at_ms,
+            status = excluded.status,
+            reason = excluded.reason,
+            retryable = excluded.retryable,
+            retry_route = excluded.retry_route,
+            batch_limit = excluded.batch_limit,
+            considered = excluded.considered,
+            accepted = excluded.accepted,
+            rejected = excluded.rejected,
+            escalated = excluded.escalated,
+            idempotent = excluded.idempotent,
+            failed = excluded.failed,
+            receipt_persistence_degraded = excluded.receipt_persistence_degraded,
+            receipt_persistence_recovered = excluded.receipt_persistence_recovered
+        """,
+        (
+            receipt.operation_id,
+            receipt.observed_at_ms,
+            receipt.status,
+            receipt.reason,
+            int(receipt.retryable),
+            receipt.retry_route,
+            receipt.batch_limit,
+            receipt.considered,
+            receipt.accepted,
+            receipt.rejected,
+            receipt.escalated,
+            receipt.idempotent,
+            receipt.failed,
+            int(receipt.receipt_persistence_degraded),
+            int(receipt.receipt_persistence_recovered),
+        ),
+    )
+
+
+def _read_latest_judgment_scheduler_receipt(
+    conn: sqlite3.Connection,
+    *,
+    operation_id: str | None = None,
+) -> ArchiveJudgmentSchedulerReceipt | None:
+    """Read the newest typed scheduler receipt, optionally for one operation."""
+
+    table = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'judgment_scheduler_receipts'"
+    ).fetchone()
+    if table is None:
+        return None
+    query = """
+        SELECT operation_id, observed_at_ms, status, reason, retryable, retry_route,
+               batch_limit, considered, accepted, rejected, escalated, idempotent,
+               failed, receipt_persistence_degraded, receipt_persistence_recovered
+        FROM judgment_scheduler_receipts
+    """
+    params: tuple[object, ...] = ()
+    if operation_id is not None:
+        query += " WHERE operation_id = ?"
+        params = (operation_id,)
+    query += " ORDER BY rowid DESC LIMIT 1"
+    row = conn.execute(query, params).fetchone()
+    if row is None:
+        return None
+    receipt = ArchiveJudgmentSchedulerReceipt(
+        operation_id=str(row[0]),
+        observed_at_ms=int(row[1]),
+        status=str(row[2]),
+        reason=str(row[3]),
+        retryable=bool(row[4]),
+        retry_route=str(row[5]),
+        batch_limit=int(row[6]),
+        considered=int(row[7]),
+        accepted=int(row[8]),
+        rejected=int(row[9]),
+        escalated=int(row[10]),
+        idempotent=int(row[11]),
+        failed=int(row[12]),
+        receipt_persistence_degraded=bool(row[13]),
+        receipt_persistence_recovered=bool(row[14]),
+    )
+    _validate_judgment_scheduler_receipt(receipt)
+    return receipt
+
+
+@dataclass(frozen=True, slots=True)
 class ArchiveMcpCallLogEntry:
     """Compact read-back row for one durable MCP tool call-log entry."""
 
@@ -1591,6 +1748,7 @@ def _json_loads(raw_json: str | None) -> dict[str, object]:
 __all__ = [
     "ArchiveCursorLagSample",
     "ArchiveDaemonLifecycle",
+    "ArchiveJudgmentSchedulerReceipt",
     "ArchiveDaemonStageEvent",
     "ArchiveEmbeddingCatchupRun",
     "ArchiveFtsDriftSample",
@@ -1622,6 +1780,7 @@ __all__ = [
     "record_daemon_lifecycle_start",
     "record_daemon_lifecycle_stop",
     "record_daemon_stage_event",
+    "record_judgment_scheduler_receipt",
     "record_fts_drift_sample",
     "record_ingest_attempt",
     "record_route_observation",

--- a/tests/unit/api/test_assertion_candidate_queue_health.py
+++ b/tests/unit/api/test_assertion_candidate_queue_health.py
@@ -216,6 +216,48 @@ def test_pending_queue_with_fresh_scheduler_receipt_is_active_pending(tmp_path: 
     assert health.judgment_scheduler_receipt_age_ms == 60_000
 
 
+def test_typed_scheduler_receipt_is_authoritative_over_newer_legacy_event(tmp_path: Path) -> None:
+    config = _initialize(tmp_path)
+    now_ms = 1_800_000_000_000
+    with sqlite3.connect(tmp_path / "user.db") as conn:
+        upsert_assertion(
+            conn,
+            assertion_id="candidate-typed-authority",
+            target_ref="session:queue-health",
+            kind=AssertionKind.LESSON,
+            body_text="A pending judgment candidate",
+            author_ref="agent:standing-queries",
+            author_kind="agent",
+            now_ms=now_ms - 25 * _DAY_MS,
+        )
+    emit_daemon_event(
+        "judgment-automation",
+        archive_root_path=tmp_path,
+        operation_id="judgment-automation:typed-authority",
+        observed_at_ms=now_ms - 60_000,
+        payload={
+            "status": "completed",
+            "reason": "sweep_completed",
+            "retryable": False,
+            "retry_route": "next enabled judgment-automation tick",
+            "batch_limit": 200,
+            "receipt_persistence_degraded": False,
+            "receipt_persistence_recovered": False,
+        },
+    )
+    with sqlite3.connect(tmp_path / "ops.db") as conn:
+        conn.execute(
+            "INSERT INTO daemon_events (ts_ms, kind, operation_id, payload_json) VALUES (?, ?, ?, ?)",
+            (now_ms, "judgment-automation", "legacy-newer", '{"status":"failed","reason":"stale-legacy"}'),
+        )
+
+    health = _archive_assertion_candidate_queue_health(config, now_ms=now_ms)
+
+    assert health.state == "pending"
+    assert health.judgment_scheduler_receipt_status == "completed"
+    assert health.judgment_scheduler_receipt_reason == "sweep_completed"
+
+
 def test_latest_scheduler_receipt_uses_ledger_order_when_clock_regresses(tmp_path: Path) -> None:
     config = _initialize(tmp_path)
     now_ms = 1_800_000_000_000

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -37,6 +37,7 @@ from polylogue.cli.commands.status import (
 from polylogue.cli.shared.types import AppEnv
 from polylogue.core.enums import ArtifactSupportStatus
 from polylogue.daemon.convergence_debt_status import ConvergenceDebtSummary
+from polylogue.daemon.events import emit_daemon_event
 from polylogue.maintenance.failure_routing import route_failure_sample
 from polylogue.maintenance.planner import FailureSample
 from polylogue.storage.sqlite.archive_tiers import ARCHIVE_VERSION_BY_TIER
@@ -1947,6 +1948,54 @@ class TestNoArchiveStatus:
         assert payload["source"] == "direct"
         assert payload["assertion_candidate_queue"]["pending_count"] == 1
         assert payload["assertion_candidate_queue"]["state"] == "parked-pending"
+
+    def test_status_command_direct_json_fallback_projects_typed_scheduler_failure(self, tmp_path: Path) -> None:
+        env = _make_app_env()
+        for tier in (ArchiveTier.INDEX, ArchiveTier.USER, ArchiveTier.OPS):
+            initialize_archive_database(tmp_path / f"{tier.value}.db", tier)
+        with sqlite3.connect(tmp_path / "user.db") as conn:
+            upsert_assertion(
+                conn,
+                assertion_id="direct-status-stalled",
+                target_ref="session:direct-status",
+                kind=AssertionKind.LESSON,
+                body_text="pending direct status candidate",
+                author_ref="agent:test",
+                author_kind="agent",
+            )
+            conn.commit()
+        emit_daemon_event(
+            "judgment-automation",
+            archive_root_path=tmp_path,
+            operation_id="judgment-automation:direct-status-stalled",
+            observed_at_ms=1_800_000_000_000,
+            payload={
+                "status": "failed",
+                "reason": "transient_sqlite_lock",
+                "retryable": True,
+                "retry_route": "next enabled judgment-automation tick",
+                "batch_limit": 200,
+                "receipt_persistence_degraded": False,
+                "receipt_persistence_recovered": False,
+            },
+        )
+
+        with (
+            patch("polylogue.paths.db_path", return_value=tmp_path / "index.db"),
+            patch("polylogue.paths.archive_root", return_value=tmp_path),
+            patch("polylogue.cli.commands.status._daemon_live", return_value=False),
+            patch("polylogue.cli.commands.status.urlopen", side_effect=TimeoutError),
+        ):
+            result = CliRunner().invoke(
+                status_command,
+                ["--daemon-url", "http://127.0.0.1:8766", "--json"],
+                obj=env,
+            )
+
+        assert result.exit_code == 1
+        payload = json.loads(_combined_calls(env))
+        assert payload["assertion_candidate_queue"]["state"] == "scheduler-stalled"
+        assert payload["assertion_candidate_queue"]["judgment_scheduler_receipt_reason"] == "transient_sqlite_lock"
 
     def test_status_command_direct_json_fallback_uses_configured_scheduler_interval(self, tmp_path: Path) -> None:
         env = _make_app_env()

--- a/tests/unit/daemon/test_judgment_automation.py
+++ b/tests/unit/daemon/test_judgment_automation.py
@@ -313,6 +313,29 @@ def test_sweep_receipt_and_bounded_retry_drain(tmp_path: Path) -> None:
     assert receipt["status"] == "completed"
     assert row[0] == 2_000
     assert receipt["accepted"] == 1
+    typed = conn.execute(
+        """
+        SELECT operation_id, observed_at_ms, status, reason, retryable, batch_limit,
+               considered, accepted, rejected, escalated, idempotent, failed
+        FROM judgment_scheduler_receipts
+        ORDER BY observed_at_ms DESC, rowid DESC
+        LIMIT 1
+        """
+    ).fetchone()
+    assert typed is not None
+    assert typed[1:] == (
+        2_000,
+        "completed",
+        "sweep_completed",
+        0,
+        2,
+        1,
+        1,
+        0,
+        0,
+        0,
+        0,
+    )
 
 
 def test_missing_ops_receipt_failure_preserves_committed_result_metadata(tmp_path: Path) -> None:
@@ -388,6 +411,18 @@ def test_committed_judgment_receipt_outbox_recovers_after_ops_crash(tmp_path: Pa
     assert row is not None
     assert row[0] == operation_id
     assert row[1] == 10_000
+    typed = conn.execute(
+        """
+        SELECT operation_id, observed_at_ms, status, reason, retryable,
+               considered, accepted, rejected, escalated, idempotent, failed,
+               receipt_persistence_recovered
+        FROM judgment_scheduler_receipts
+        """
+    ).fetchone()
+    assert typed is not None
+    assert typed[0] == operation_id
+    assert typed[1:11] == (10_000, "completed", "sweep_completed", 0, 1, 1, 0, 0, 0, 0)
+    assert typed[11] == 1
     recovered_receipt = json.loads(row[2])
     assert recovered_receipt["status"] == "completed"
     assert recovered_receipt["accepted"] == 1
@@ -505,6 +540,52 @@ def test_recovery_retains_marker_when_latest_durable_event_is_malformed(tmp_path
 
     with sqlite3.connect(tmp_path / "user.db") as conn:
         assert len(list_judgment_automation_receipt_outbox(conn)) == 1
+
+
+def test_recovery_acknowledges_typed_receipt_before_newer_malformed_legacy_event(tmp_path: Path) -> None:
+    _init_user_db(tmp_path / "user.db")
+    _init_ops_db(tmp_path / "ops.db")
+    operation_id = "judgment-automation:typed-recovery"
+    with sqlite3.connect(tmp_path / "user.db") as conn:
+        upsert_judgment_automation_receipt_outbox(
+            conn,
+            operation_id=operation_id,
+            receipt_payload={
+                "status": "completed",
+                "reason": "sweep_completed",
+                "retryable": False,
+                "retry_route": "next enabled judgment-automation tick",
+                "batch_limit": 200,
+                "receipt_persistence_degraded": False,
+                "receipt_persistence_recovered": False,
+            },
+            now_ms=10_000,
+        )
+        conn.commit()
+    emit_daemon_event(
+        "judgment-automation",
+        operation_id=operation_id,
+        archive_root_path=tmp_path,
+        observed_at_ms=10_000,
+        payload={
+            "status": "completed",
+            "reason": "sweep_completed",
+            "retryable": False,
+            "retry_route": "next enabled judgment-automation tick",
+            "batch_limit": 200,
+            "receipt_persistence_degraded": False,
+            "receipt_persistence_recovered": False,
+        },
+    )
+    with sqlite3.connect(tmp_path / "ops.db") as conn:
+        conn.execute(
+            "INSERT INTO daemon_events (ts_ms, kind, operation_id, payload_json) VALUES (?, ?, ?, ?)",
+            (11_000, "judgment-automation", operation_id, '{"status":"completed"}'),
+        )
+
+    assert recover_pending_judgment_automation_receipts(tmp_path, now_ms=12_000) == 1
+    with sqlite3.connect(tmp_path / "user.db") as conn:
+        assert list_judgment_automation_receipt_outbox(conn) == []
 
 
 def test_coalesced_receipt_keeps_outbox_marker_for_operation_recovery(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Persist typed judgment-scheduler receipts and expose queue health through the daemon, API, and CLI status surfaces.

## Problem

Judgment scheduling had lifecycle events but no durable, typed authority for completed, parked, failed, retryable, or bounded-result state. A restart could therefore lose queue-health meaning or leave surfaces unable to distinguish parked pending from scheduler-stalled work.

## Solution

Add ops.db receipt storage with status, reason, retryability, batch bound, and result counters; make receipt writes failure-contained and restart-retryable; emit scheduler lifecycle health through the daemon; and project the typed state through the API and status/CLI surfaces. Generated layering inventories and focused real-route tests cover the new path.

## Verification

- 66 focused daemon/API/status/CLI tests passed.
- `devtools verify --quick`: all 25 steps passed.
- `git diff --check`: passed.
- No production archive, deployment, or Beads mutation.
- Live deployment remains outside this implementation lane.

<!-- polylogue-pr-scope:v1
{
  "assigned_beads": [
    "polylogue-6qjc.1"
  ],
  "beads_digest": "b2ea752a02b8d6a1ab9cb79514c64a09025d540f75772759b6daaf0e7a6b6445",
  "dispositions": [
    {
      "bead_id": "polylogue-6qjc.1",
      "disposition": "satisfied",
      "evidence": [
        {
          "kind": "commit",
          "ref": "6d04b010d812f9bfacb49e22575a88cdec3fc32d"
        },
        {
          "kind": "test",
          "ref": "66 focused daemon/API/status/CLI tests passed"
        },
        {
          "kind": "command",
          "ref": "devtools verify --quick: all 25 steps passed"
        },
        {
          "kind": "diff",
          "ref": "origin/master...6d04b010d: no reindex/remediation paths"
        }
      ],
      "successors": []
    }
  ],
  "head_sha": "6d04b010d812f9bfacb49e22575a88cdec3fc32d",
  "scope_digest": "2e08ada367090b18920b203a054b5023497d191006f412fafcb7b931fd4a0a1c",
  "version": 1
}
-->
