### PR TITLE
fix(nix): disable stale bootstrap-chain checks inside the 3.14t fixpoint

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -234,6 +234,46 @@
       # checks off from the moment nixpkgs' own internal `callPackage`
       # invokes it, keeping sibling dependency resolution self-consistent.
       freeThreadedNoCheckOverlay = _final: prev: {
+        # python-discovery 1.4.2 fails two stale assertions under Python
+        # 3.14t (test_predicate_with_fallback_specs,
+        # test_satisfies_path_not_abs_basename_match). The `.pkgs`
+        # replacement below cannot reach it: nixpkgs' own
+        # pyproject-version-patch-hook builds its helper env
+        # (tomlkit -> poetry-core -> checkInputs virtualenv ->
+        # python-discovery) inside the interpreter's INTERNAL package-set
+        # fixpoint, which ignores both the replaced `.pkgs` attr and
+        # `.override { packageOverrides }` (see the long comment above).
+        # `pythonPackagesExtensions` is the one mechanism nixpkgs applies
+        # inside every such fixpoint. Scoped to free-threaded interpreters
+        # (executable "python3.14t" -- there is no isFreeThreading passthru
+        # attr) so the standard 3.12/3.14 sets keep their cache hits.
+        # recheck: drop when nixpkgs bumps python-discovery past 1.4.2.
+        pythonPackagesExtensions = (prev.pythonPackagesExtensions or [ ]) ++ [
+          (
+            _pyFinal: pyPrev:
+            prev.lib.optionalAttrs (prev.lib.hasSuffix "t" (pyPrev.python.executable or "")) {
+              python-discovery = pyPrev.python-discovery.overrideAttrs (_old: {
+                doCheck = false;
+                doInstallCheck = false;
+              });
+              # Next link in the same chain: virtualenv's own test suite
+              # fails interpreter discovery under 3.14t once it builds at
+              # all (RuntimeError: failed to find interpreter for Builtin
+              # discover). Same stale-upstream class, same treatment.
+              virtualenv = pyPrev.virtualenv.overrideAttrs (_old: {
+                doCheck = false;
+                doInstallCheck = false;
+              });
+              # And its consumer: poetry-core's masonry wheel-tag tests
+              # assert ABI tags that do not exist under the free-threaded
+              # interpreter (test_tag/test_wheel_c_extension: assert None).
+              poetry-core = pyPrev.poetry-core.overrideAttrs (_old: {
+                doCheck = false;
+                doInstallCheck = false;
+              });
+            }
+          )
+        ];
         python314FreeThreading = prev.python314FreeThreading // {
           pkgs = prev.python314FreeThreading.pkgs.overrideScope (
             pyFinal: pySuper: {


### PR DESCRIPTION
## Summary

Make the Polylogue Nix closure buildable on consumer nixpkgs when `python314FreeThreading` is uncached by suppressing only stale bootstrap checks inside the free-threaded package fixpoint.

## Problem

The uncached free-threaded closure failed successively in `python-discovery` 1.4.2, `virtualenv`, and `poetry-core` during the `pyproject-version-patch-hook` helper environment. The existing overlay could not reach that internal fixpoint.

## Solution

Use `pythonPackagesExtensions`, which nixpkgs applies inside the internal fixpoint, to disable checks for those three stale bootstrap leaves only when the interpreter executable has the `3.14t` suffix. Standard Python package sets retain their checks. The change includes recheck markers and the Bead/provenance binding for this WIP.

## Verification

The end-to-end `sinnix switch` route with `SINNIX_POLYLOGUE_OVERRIDE` built and activated successfully after the fix; the prior failure and each intermediate bootstrap leaf were reproduced during diagnosis. The Polylogue quick structural gate is also required at this exact head.

<!-- polylogue-pr-scope:v1
{
  "assigned_beads": [
    "polylogue-2tk5h"
  ],
  "beads_digest": "47e26f28bb7a6c646be70872ead311950151e924376968108f8d0f1d1af4297c",
  "dispositions": [
    {
      "bead_id": "polylogue-2tk5h",
      "disposition": "satisfied",
      "evidence": [
        {
          "kind": "commit",
          "ref": "2da26d5d4"
        },
        {
          "kind": "test",
          "ref": "flake.nix"
        },
        {
          "kind": "command",
          "ref": "sinnix switch with SINNIX_POLYLOGUE_OVERRIDE"
        }
      ],
      "successors": []
    }
  ],
  "head_sha": "2aa9710dd7ed3e8d31dc5e2e610a3c6fc77f6ff7",
  "scope_digest": "3aafd42d78c35e8496b9b78e756c8246ff3d4160349762f4c7d31a706b5674f3",
  "version": 1
}
-->
