### PR TITLE
fix(devtools): stabilize PR scope attestation

### DIFF
--- a/.claude/agents/lane.md
+++ b/.claude/agents/lane.md
@@ -117,7 +117,9 @@ Before publishing the PR as non-draft, render the versioned embedded carrier
 with `devtools workspace pr-scope render --input <scope.json>`, put that exact
 comment beside the human matrix, and validate the published PR with
 `devtools workspace pr-scope check --pr <N>`. Never infer a disposition from
-Bead acceptance prose or invent a successor ID.
+Bead acceptance prose or invent a successor ID. The v2 body is stable intent;
+use `devtools workspace pr-scope sync --pr <N>` to inspect the current
+head-bound attestation rather than rewriting the body after every commit.
 
 Reference any bead with neutral wording only (`Ref polylogue-xxxx` /
 `Ref #N`). **Never use GitHub resolver keywords** (closes/fixes/resolves)

--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -29,7 +29,7 @@ consider the change safe to merge. Do not edit the branch.
 
 For every non-draft PR, inspect the human per-Bead disposition matrix and run
 `devtools workspace pr-scope check --pr <N>`. Reject a missing carrier, a
-carrier not bound to the current head, stale Bead records, a partial outcome
+missing current head-bound attestation, stale Bead records, a partial outcome
 without an open named successor, or evidence that does not support the stated
 whole-Bead disposition. Do not treat Bead acceptance prose as machine input.
 """

--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -27,9 +27,11 @@ Lead with concrete findings, most severe first, each with a source anchor
 and a reproduction command where applicable. State explicitly whether you
 consider the change safe to merge. Do not edit the branch.
 
-For every non-draft PR, inspect the human per-Bead disposition matrix and run
-`devtools workspace pr-scope check --pr <N>`. Reject a missing carrier, a
-missing current head-bound attestation, stale Bead records, a partial outcome
-without an open named successor, or evidence that does not support the stated
-whole-Bead disposition. Do not treat Bead acceptance prose as machine input.
+For every non-draft PR, inspect the human per-Bead disposition matrix, run
+`devtools workspace pr-scope check --pr <N>`, and run
+`devtools workspace pr-scope sync --pr <N>`. Reject a missing carrier, a
+missing or invalid sync-produced current-head attestation, stale Bead records,
+a partial outcome without an open named successor, or evidence that does not
+support the stated whole-Bead disposition. Do not treat Bead acceptance prose
+as machine input.
 """

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,14 +24,18 @@ _Exact commands run and any manual validation performed._
 | --- | --- | --- | --- |
 | `polylogue-...` | satisfied / partial / deferred / superseded | `test:...`, `command:...` | `polylogue-...` or n/a |
 
-<!-- polylogue-pr-scope:v1
+<!-- polylogue-pr-scope:v2
 Replace this comment with the output of:
 devtools workspace pr-scope render --input .agent/pr-scope.json > /tmp/pr-scope.md
 
-The input declares assigned_beads and one disposition with typed evidence for
-each. Partial, deferred, and superseded dispositions require an existing open
-successor Bead. Copy the rendered comment here after the final push, then run:
-devtools workspace pr-scope check --pr <PR-number>
+The stable intent input declares scope_kind, assigned_beads, mutated_beads, and
+one disposition with typed evidence for each assigned Bead. Use
+scope_kind=self_contained with empty Bead lists for a self-contained PR.
+mutated_beads declares every Bead record changed by this PR. Partial, deferred,
+and superseded dispositions require an existing open successor Bead. The body
+does not contain a head SHA or Bead digest. After each push, inspect the live
+attestation with:
+devtools workspace pr-scope sync --pr <PR-number>
 -->
 
 ## Changelog

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -381,12 +381,14 @@ workflow, not optional conveniences — use them at the point named, every time:
 - **Before opening a non-draft PR for a Bead lane**: render the versioned
   carrier with `devtools workspace pr-scope render --input <scope.json>`, put
   it in the PR body beside the human whole-Bead disposition matrix, then run
-  `devtools workspace pr-scope check --pr <PR>`. The carrier binds the exact
-  head SHA, canonical Bead records, typed dispositions, evidence refs, and
-  open successors for residual work; it never parses acceptance prose. After
-  the final commit is created, regenerate the carrier for that exact SHA and
-  update the PR body before pushing; CircleCI does not rerun for a body-only
-  edit.
+  `devtools workspace pr-scope check --pr <PR>`. The v2 carrier is stable PR
+  intent: scope kind, assigned and mutated Beads, typed dispositions, evidence
+  refs, and open successors for residual work. It never parses acceptance
+  prose. `devtools workspace pr-scope sync --pr <PR>` reports the current
+  head-bound attestation, including canonical Bead state, without editing the
+  PR body after every commit. `mutated_beads` must name every Bead record this
+  PR changes. A self-contained PR uses the typed `self_contained` scope with
+  empty Bead lists.
   CircleCI uses `pr-scope check-ci`, resolves PR metadata through public GitHub
   REST when `CIRCLE_PULL_REQUEST` is absent, and executes the validator from
   the PR base revision so a PR cannot weaken its own scope gate.
@@ -404,7 +406,7 @@ workflow, not optional conveniences — use them at the point named, every time:
   then auto-records a receipt if none is fresh for the current head
   sha (running `--command`, default `devtools verify`), BLOCKs the merge on
   any `merge-gate check` failure (no fresh receipt, stale receipt, nonzero
-  exit, a changed carrier digest, or an unacked review comment newer than the head commit), strips a
+  exit, a changed head-bound scope attestation, or an unacked review comment newer than the head commit), strips a
   doubled `(#N) (#N)` squash-subject suffix, then runs the actual
   `gh pr merge --squash`. `--dry-run` runs every check without merging;
   `--with-verify` immediately runs and records the merge-train's terminal

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -774,19 +774,20 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
     CommandSpec(
         "workspace pr-scope",
         "workspace",
-        "Render and validate the versioned PR Bead-scope carrier.",
+        "Render stable PR scope intent and inspect its mutable merge attestation.",
         "devtools.pr_scope",
         use_when=(
-            "Before publishing a non-draft PR, render the machine-readable carrier from the assigned "
-            "Bead dispositions, then validate the exact body against its head SHA and committed Bead records. "
-            "CircleCI quick-gate and `workspace merge` run the same validator; the command never interprets "
-            "acceptance prose."
+            "Before publishing a non-draft PR, render the machine-readable v2 intent from assigned and mutated "
+            "Beads plus typed dispositions. The PR body stays stable across commits; `sync --pr` reports the "
+            "current head- and Bead-bound attestation consumed by merge-gate. CircleCI quick-gate and "
+            "`workspace merge` run the same validator; the command never interprets acceptance prose."
         ),
         examples=(
             "devtools workspace pr-scope render --input .agent/pr-scope.json > /tmp/pr-scope.md",
             "devtools workspace pr-scope check --pr 3517",
+            "devtools workspace pr-scope sync --pr 3517",
             "devtools workspace pr-scope check-ci --pr 3517 --repo Sinity/polylogue --expected-head-sha $(git rev-parse HEAD)",
-            "devtools workspace pr-scope check --body-file pr-body.md --head-sha $(git rev-parse HEAD)",
+            "devtools workspace pr-scope check --body-file pr-body.md --head-sha $(git rev-parse HEAD) --base-sha $(git rev-parse origin/master)",
         ),
     ),
     CommandSpec(
@@ -805,7 +806,7 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
             "3x20s, covering CodeRabbit's 30-60s late-arrival window) and BLOCKs unless a receipt exists "
             "for the CURRENT head sha within a freshness window with exit_code 0, and no review comment's "
             "created_at is newer than the head commit's timestamp unless explicitly `ack`'d for that exact "
-            "head sha. The receipt binds the carrier digest, so a changed scope requires re-recording. Motivated by two 2026-08-01 incidents: PR #3502 merged before CodeRabbit's findings "
+            "head sha. The receipt binds the carrier digest plus a fresh head- and Bead-bound scope attestation, so a changed scope or Bead state requires re-recording. Motivated by two 2026-08-01 incidents: PR #3502 merged before CodeRabbit's findings "
             "posted, and PR #3517 nearly merged with a 43-test regression no CI check or review comment "
             "ever flagged -- plus review findings on this tool itself (recording from an unrelated "
             "checkout, a --quick example that would have missed its own motivating regression, a single "

--- a/devtools/lane_brief.py
+++ b/devtools/lane_brief.py
@@ -95,10 +95,12 @@ _VERIFICATION_TIER = (
 )
 
 _PR_SCOPE_CARRIER = (
-    "Before opening a non-draft PR, render the structured carrier from assigned Bead IDs, "
+    "Before opening a non-draft PR, render stable v2 intent from assigned and mutated Bead IDs, "
     "whole-Bead dispositions, typed evidence refs, and open successors for residual work: "
     "`devtools workspace pr-scope render --input .agent/pr-scope.json`. Embed the rendered comment "
     "in the PR body and validate the published PR with `devtools workspace pr-scope check --pr <N>`. "
+    "Use `devtools workspace pr-scope sync --pr <N>` to inspect the current head-bound attestation without "
+    "rewriting the body after each commit. "
     "Do not infer acceptance from Bead prose or invent missing Bead IDs."
 )
 

--- a/devtools/merge_boundary.py
+++ b/devtools/merge_boundary.py
@@ -650,7 +650,9 @@ def cmd_merge(
         return 0
 
     try:
-        final_info = _gh_json(["pr", "view", str(pr), "--json", "headRefOid,baseRefOid,state"])
+        final_info = _gh_json(
+            ["pr", "view", str(pr), "--json", "headRefOid,baseRefOid,state,body,isDraft,author,files"]
+        )
     except (RuntimeError, json.JSONDecodeError, OSError, subprocess.SubprocessError) as exc:
         print(f"REFUSING to merge PR #{pr}: final authority check failed: {exc}", file=sys.stderr)
         return 1
@@ -663,6 +665,16 @@ def cmd_merge(
             f"REFUSING to merge PR #{pr}: head, base, or state changed after merge-gate validation",
             file=sys.stderr,
         )
+        return 1
+    final_scope = merge_gate._scope_verdict(pr, final_info, head_sha=head_sha)
+    initial_attestation = pr_scope.attestation_payload(
+        scope, head_sha=head_sha, base_sha=merge_gate._base_sha(info)
+    ).get("attestation_digest")
+    final_attestation = pr_scope.attestation_payload(
+        final_scope, head_sha=head_sha, base_sha=merge_gate._base_sha(final_info)
+    ).get("attestation_digest")
+    if not final_scope.ok or final_attestation != initial_attestation:
+        print(f"REFUSING to merge PR #{pr}: structured scope changed after merge-gate validation", file=sys.stderr)
         return 1
 
     try:

--- a/devtools/merge_boundary.py
+++ b/devtools/merge_boundary.py
@@ -610,7 +610,13 @@ def cmd_merge(
     head_sha = info["headRefOid"]
     scope = merge_gate._scope_verdict(pr, info, head_sha=head_sha)
 
-    if not scope.ok or not _receipt_is_fresh_for_scope(
+    if not scope.ok:
+        print(f"REFUSING to merge PR #{pr}: invalid structured pr-scope carrier:", file=sys.stderr)
+        for reason in scope.reasons:
+            print(f"  - {reason}", file=sys.stderr)
+        return 2
+
+    if not _receipt_is_fresh_for_scope(
         pr,
         head_sha=head_sha,
         scope=scope,
@@ -642,6 +648,22 @@ def cmd_merge(
     if dry_run:
         print(f"PR #{pr} @ {head_sha[:8]}: merge-gate OK -- dry-run, not merging (title would be {clean_title!r})")
         return 0
+
+    try:
+        final_info = _gh_json(["pr", "view", str(pr), "--json", "headRefOid,baseRefOid,state"])
+    except (RuntimeError, json.JSONDecodeError, OSError, subprocess.SubprocessError) as exc:
+        print(f"REFUSING to merge PR #{pr}: final authority check failed: {exc}", file=sys.stderr)
+        return 1
+    if (
+        final_info.get("state") != "OPEN"
+        or final_info.get("headRefOid") != head_sha
+        or merge_gate._base_sha(final_info) != merge_gate._base_sha(info)
+    ):
+        print(
+            f"REFUSING to merge PR #{pr}: head, base, or state changed after merge-gate validation",
+            file=sys.stderr,
+        )
+        return 1
 
     try:
         _record_merge_intent(pr, head_sha, clean_title)

--- a/devtools/merge_boundary.py
+++ b/devtools/merge_boundary.py
@@ -77,7 +77,7 @@ from collections.abc import Iterator, Mapping
 from pathlib import Path
 from typing import Any
 
-from devtools import merge_gate
+from devtools import merge_gate, pr_scope
 from devtools.testmon_state import TerminalAuthorization, VerificationScope
 
 _LEDGER_PATH = Path(".cache/verify/merge-gate/merge-train-ledger.json")
@@ -418,11 +418,23 @@ def _pending_prs_since_last_full_verify(ledger: dict[str, Any]) -> list[dict[str
     ]
 
 
-def _receipt_is_fresh_for_head(pr: int, head_sha: str, max_age_s: int) -> bool:
+def _receipt_is_fresh_for_scope(
+    pr: int,
+    *,
+    head_sha: str,
+    scope: pr_scope.ScopeVerdict,
+    base_sha: str | None,
+    max_age_s: int,
+) -> bool:
     receipt = merge_gate._read_json_object(merge_gate._receipt_path(pr))
     if receipt is None:
         return False
     if receipt.get("head_sha") != head_sha:
+        return False
+    expected_attestation = pr_scope.attestation_payload(scope, head_sha=head_sha, base_sha=base_sha)[
+        "attestation_digest"
+    ]
+    if receipt.get("pr_scope_attestation_digest") != expected_attestation:
         return False
     age_s = time.time() - float(receipt.get("recorded_at", 0))
     return bool(age_s <= max_age_s)
@@ -567,7 +579,15 @@ def cmd_merge(
     verify_command: str,
 ) -> int:
     try:
-        info = _gh_json(["pr", "view", str(pr), "--json", "headRefOid,title,state"])
+        info = _gh_json(
+            [
+                "pr",
+                "view",
+                str(pr),
+                "--json",
+                "headRefOid,baseRefOid,title,state,body,isDraft,author,files",
+            ]
+        )
     except (RuntimeError, json.JSONDecodeError, OSError, subprocess.SubprocessError) as exc:
         print(f"REFUSING to merge PR #{pr}: gh pr view failed: {exc}", file=sys.stderr)
         return 1
@@ -577,8 +597,15 @@ def cmd_merge(
         return 1
 
     head_sha = info["headRefOid"]
+    scope = merge_gate._scope_verdict(pr, info, head_sha=head_sha)
 
-    if not _receipt_is_fresh_for_head(pr, head_sha, max_age_s):
+    if not scope.ok or not _receipt_is_fresh_for_scope(
+        pr,
+        head_sha=head_sha,
+        scope=scope,
+        base_sha=merge_gate._base_sha(info),
+        max_age_s=max_age_s,
+    ):
         print(
             f"no fresh merge-gate receipt for PR #{pr} @ {head_sha[:8]} -- recording one now via {command!r}",
             file=sys.stderr,

--- a/devtools/merge_boundary.py
+++ b/devtools/merge_boundary.py
@@ -439,13 +439,13 @@ def _receipt_is_fresh_for_scope(
     if receipt.get("exit_code") != 0:
         return False
     verification_scope = receipt.get("verification_scope")
-    valid_scopes = {scope.value for scope in merge_gate.VerificationScope}
+    valid_scopes = {scope.value for scope in VerificationScope}
     if verification_scope not in valid_scopes:
         return False
     release_allowed = receipt.get("release_baseline_allowed")
     if not isinstance(release_allowed, bool):
         return False
-    if verification_scope == merge_gate.VerificationScope.RELEASE_BASELINE.value and not release_allowed:
+    if verification_scope == VerificationScope.RELEASE_BASELINE.value and not release_allowed:
         return False
     age_s = time.time() - float(receipt.get("recorded_at", 0))
     return bool(age_s <= max_age_s)

--- a/devtools/merge_boundary.py
+++ b/devtools/merge_boundary.py
@@ -436,6 +436,17 @@ def _receipt_is_fresh_for_scope(
     ]
     if receipt.get("pr_scope_attestation_digest") != expected_attestation:
         return False
+    if receipt.get("exit_code") != 0:
+        return False
+    verification_scope = receipt.get("verification_scope")
+    valid_scopes = {scope.value for scope in merge_gate.VerificationScope}
+    if verification_scope not in valid_scopes:
+        return False
+    release_allowed = receipt.get("release_baseline_allowed")
+    if not isinstance(release_allowed, bool):
+        return False
+    if verification_scope == merge_gate.VerificationScope.RELEASE_BASELINE.value and not release_allowed:
+        return False
     age_s = time.time() - float(receipt.get("recorded_at", 0))
     return bool(age_s <= max_age_s)
 

--- a/devtools/merge_gate.py
+++ b/devtools/merge_gate.py
@@ -255,6 +255,12 @@ def _terminal_authorization(stdout: str) -> str | None:
     return value if value in {authorization.value for authorization in TerminalAuthorization} else None
 
 
+def _base_sha(info: dict[str, Any]) -> str | None:
+    """Read the PR base commit SHA when GitHub reported one."""
+    value = info.get("baseRefOid")
+    return value if isinstance(value, str) else None
+
+
 def _scope_verdict(pr: int, info: dict[str, Any], *, head_sha: str) -> pr_scope.ScopeVerdict:
     """Use the same carrier or typed bot exception for record and check."""
     author = info.get("author")
@@ -278,7 +284,7 @@ def _scope_verdict(pr: int, info: dict[str, Any], *, head_sha: str) -> pr_scope.
         info.get("body") or "",
         head_sha=head_sha,
         is_draft=bool(info.get("isDraft")),
-        base_sha=info.get("baseRefOid") if isinstance(info.get("baseRefOid"), str) else None,
+        base_sha=_base_sha(info),
     )
 
 
@@ -333,7 +339,7 @@ def cmd_record(pr: int, command: str) -> int:
         "pr_scope_attestation_digest": pr_scope.attestation_payload(
             scope,
             head_sha=head_sha,
-            base_sha=info.get("baseRefOid") if isinstance(info.get("baseRefOid"), str) else None,
+            base_sha=_base_sha(info),
         )["attestation_digest"],
         "branch": info["headRefName"],
         "command": command,
@@ -479,6 +485,19 @@ def cmd_check(
     head_sha = info["headRefOid"]
     verdict.head_sha = head_sha
 
+    local_head = _git_head_sha()
+    if local_head != head_sha:
+        verdict.ok = False
+        verdict.reasons.append(
+            f"current checkout HEAD ({local_head[:8] if local_head else '?'}) does not match PR #{pr}'s "
+            f"head ({head_sha[:8]}); check out the exact PR commit before checking"
+        )
+    if not _git_is_clean():
+        verdict.ok = False
+        verdict.reasons.append(
+            "current checkout has uncommitted changes; merge-gate check requires committed PR content"
+        )
+
     scope = _scope_verdict(pr, info, head_sha=head_sha)
     verdict.pr_scope = asdict(scope)
     if not scope.ok:
@@ -544,7 +563,7 @@ def cmd_check(
             expected_attestation_digest = pr_scope.attestation_payload(
                 scope,
                 head_sha=head_sha,
-                base_sha=info.get("baseRefOid") if isinstance(info.get("baseRefOid"), str) else None,
+                base_sha=_base_sha(info),
             )["attestation_digest"]
             if receipt.get("pr_scope_attestation_digest") != expected_attestation_digest:
                 verdict.ok = False

--- a/devtools/merge_gate.py
+++ b/devtools/merge_gate.py
@@ -278,11 +278,12 @@ def _scope_verdict(pr: int, info: dict[str, Any], *, head_sha: str) -> pr_scope.
         info.get("body") or "",
         head_sha=head_sha,
         is_draft=bool(info.get("isDraft")),
+        base_sha=info.get("baseRefOid") if isinstance(info.get("baseRefOid"), str) else None,
     )
 
 
 def cmd_record(pr: int, command: str) -> int:
-    info = _gh_json(["pr", "view", str(pr), "--json", "headRefOid,headRefName,body,isDraft,author,files"])
+    info = _gh_json(["pr", "view", str(pr), "--json", "headRefOid,headRefName,baseRefOid,body,isDraft,author,files"])
     head_sha = info["headRefOid"]
 
     local_head = _git_head_sha()
@@ -328,6 +329,12 @@ def cmd_record(pr: int, command: str) -> int:
         "pr_scope_digest": scope.scope_digest,
         "pr_scope_beads_digest": scope.beads_digest,
         "pr_scope_assigned_beads": scope.assigned_beads,
+        "pr_scope_mutated_beads": scope.mutated_beads,
+        "pr_scope_attestation_digest": pr_scope.attestation_payload(
+            scope,
+            head_sha=head_sha,
+            base_sha=info.get("baseRefOid") if isinstance(info.get("baseRefOid"), str) else None,
+        )["attestation_digest"],
         "branch": info["headRefName"],
         "command": command,
         "skips_tests": _command_skips_tests(command),
@@ -459,7 +466,7 @@ def cmd_check(
                 "view",
                 str(pr),
                 "--json",
-                "headRefOid,mergeStateStatus,state,commits,body,isDraft,author,files",
+                "headRefOid,baseRefOid,mergeStateStatus,state,commits,body,isDraft,author,files",
             ]
         )
     except (RuntimeError, json.JSONDecodeError, OSError, subprocess.SubprocessError) as exc:
@@ -528,6 +535,21 @@ def cmd_check(
                 verdict.ok = False
                 verdict.reasons.append(
                     "receipt pr_scope_assigned_beads does not match the current carrier -- re-record"
+                )
+            if receipt.get("pr_scope_mutated_beads") != scope.mutated_beads:
+                verdict.ok = False
+                verdict.reasons.append(
+                    "receipt pr_scope_mutated_beads does not match the complete current Bead mutation scope -- re-record"
+                )
+            expected_attestation_digest = pr_scope.attestation_payload(
+                scope,
+                head_sha=head_sha,
+                base_sha=info.get("baseRefOid") if isinstance(info.get("baseRefOid"), str) else None,
+            )["attestation_digest"]
+            if receipt.get("pr_scope_attestation_digest") != expected_attestation_digest:
+                verdict.ok = False
+                verdict.reasons.append(
+                    "receipt pr_scope_attestation_digest does not match the current head-bound scope attestation -- re-record"
                 )
             age_s = time.time() - receipt.get("recorded_at", 0)
             if age_s > max_age_s:

--- a/devtools/pr_scope.py
+++ b/devtools/pr_scope.py
@@ -31,6 +31,7 @@ _VERSION = 2
 _BEADS_PATH = Path(".beads/issues.jsonl")
 _GITHUB_API_URL = "https://api.github.com"
 _REPOSITORY_PATTERN = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+_GIT_OBJECT_PATTERN = re.compile(r"[0-9a-fA-F]{7,64}")
 _V1_CARRIER_KEYS = frozenset({"version", "head_sha", "assigned_beads", "beads_digest", "dispositions", "scope_digest"})
 _V2_CARRIER_KEYS = frozenset(
     {"version", "scope_kind", "assigned_beads", "mutated_beads", "dispositions", "scope_digest"}
@@ -102,15 +103,12 @@ def _digest(value: object) -> str:
     return hashlib.sha256(_canonical_json(value).encode()).hexdigest()
 
 
-def load_bead_records(path: Path = _BEADS_PATH) -> dict[str, dict[str, Any]]:
-    """Load the repository's committed Bead records without invoking ``bd``.
-
-    The carrier needs the exact Bead snapshot that CI checked out. Reading the
-    JSONL avoids mutating shared Dolt state from a worktree and keeps this
-    validation independent of Beads' CLI synchronization hooks.
-    """
+def _parse_bead_records(lines: object, *, line_label: str) -> dict[str, dict[str, Any]]:
+    """Parse issue records from a Beads JSONL snapshot."""
+    if not isinstance(lines, list) or not all(isinstance(line, str) for line in lines):
+        raise ValueError("Bead JSONL snapshot must contain text lines")
     records: dict[str, dict[str, Any]] = {}
-    for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+    for line_no, line in enumerate(lines, start=1):
         if not line.strip():
             continue
         raw = json.loads(line)
@@ -118,9 +116,19 @@ def load_bead_records(path: Path = _BEADS_PATH) -> dict[str, dict[str, Any]]:
             continue
         bead_id = raw["id"]
         if bead_id in records:
-            raise ValueError(f"duplicate Bead id {bead_id!r} on line {line_no}")
+            raise ValueError(f"duplicate Bead id {bead_id!r} on {line_label} {line_no}")
         records[bead_id] = raw
     return records
+
+
+def load_bead_records(path: Path = _BEADS_PATH) -> dict[str, dict[str, Any]]:
+    """Load the repository's committed Bead records without invoking ``bd``.
+
+    The carrier needs the exact Bead snapshot that CI checked out. Reading the
+    JSONL avoids mutating shared Dolt state from a worktree and keeps this
+    validation independent of Beads' CLI synchronization hooks.
+    """
+    return _parse_bead_records(path.read_text(encoding="utf-8").splitlines(), line_label="line")
 
 
 def canonical_beads_digest(
@@ -206,26 +214,24 @@ def _bead_ids(value: object, *, label: str, allow_empty: bool, reasons: list[str
 
 
 def _bead_records_at(base_sha: str) -> dict[str, dict[str, Any]]:
+    if not _GIT_OBJECT_PATTERN.fullmatch(base_sha):
+        raise ValueError("base revision must be a hexadecimal Git object name")
     result = subprocess.run(
         ["git", "show", f"{base_sha}:.beads/issues.jsonl"], capture_output=True, text=True, check=False
     )
     if result.returncode != 0:
         raise ValueError(f"cannot read .beads/issues.jsonl at base revision {base_sha[:8]}")
-    records: dict[str, dict[str, Any]] = {}
-    for line_no, line in enumerate(result.stdout.splitlines(), start=1):
-        if not line.strip():
-            continue
-        raw = json.loads(line)
-        if isinstance(raw, dict) and raw.get("_type") == "issue" and isinstance(raw.get("id"), str):
-            if raw["id"] in records:
-                raise ValueError(f"duplicate Bead id {raw['id']!r} on base line {line_no}")
-            records[raw["id"]] = raw
-    return records
+    return _parse_bead_records(result.stdout.splitlines(), line_label="base line")
 
 
 def changed_bead_ids(*, base_sha: str, beads_path: Path = _BEADS_PATH) -> list[str]:
-    """Return the complete Bead-record mutation set between base and checkout."""
-    before = _bead_records_at(base_sha)
+    """Return the complete Bead-record mutation set from the PR merge base."""
+    if not _GIT_OBJECT_PATTERN.fullmatch(base_sha):
+        raise ValueError("base revision must be a hexadecimal Git object name")
+    merge_base = subprocess.run(["git", "merge-base", base_sha, "HEAD"], capture_output=True, text=True, check=False)
+    if merge_base.returncode != 0 or not _GIT_OBJECT_PATTERN.fullmatch(merge_base.stdout.strip()):
+        raise ValueError(f"cannot resolve PR merge base from base revision {base_sha[:8]}")
+    before = _bead_records_at(merge_base.stdout.strip())
     after = load_bead_records(beads_path)
     return sorted(bead_id for bead_id in set(before) | set(after) if before.get(bead_id) != after.get(bead_id))
 
@@ -343,10 +349,8 @@ def validate_carrier(
         mutated_ids = _bead_ids(carrier.get("mutated_beads"), label="mutated_beads", allow_empty=True, reasons=reasons)
         if scope_kind == ScopeKind.BEAD.value and not assigned_ids:
             reasons.append("bead scope requires at least one assigned Bead")
-        if scope_kind == ScopeKind.SELF_CONTAINED.value and (
-            assigned_ids or mutated_ids or carrier.get("dispositions") != []
-        ):
-            reasons.append("self_contained scope cannot declare Beads, dispositions, or Bead mutations")
+        if scope_kind == ScopeKind.SELF_CONTAINED.value and (assigned_ids or carrier.get("dispositions") != []):
+            reasons.append("self_contained scope cannot declare assigned Beads or dispositions")
     if is_draft:
         reasons.append("PR is draft; publish a non-draft PR before validation")
 
@@ -358,13 +362,17 @@ def validate_carrier(
     records: dict[str, dict[str, Any]] = {}
     try:
         records = load_bead_records(beads_path)
+        missing_assigned = [bead_id for bead_id in assigned_ids if bead_id not in records]
+        if missing_assigned:
+            reasons.append(f"assigned Bead record(s) missing: {', '.join(missing_assigned)}")
         bound_ids = list(assigned_ids)
         if not is_v1:
             bound_ids.extend(mutated_ids)
-            for entry in carrier.get("dispositions", []):
+            dispositions = carrier.get("dispositions")
+            for entry in dispositions if isinstance(dispositions, list) else []:
                 if isinstance(entry, dict) and isinstance(entry.get("successors"), list):
                     bound_ids.extend(item for item in entry["successors"] if isinstance(item, str))
-        bound_ids = sorted(set(bound_ids))
+        bound_ids = sorted({bead_id for bead_id in bound_ids if bead_id in records})
         expected_beads_digest = canonical_beads_digest(records, bound_ids, carrier_version=int(version))
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         expected_beads_digest = None
@@ -672,6 +680,11 @@ def _run_validator_source(
         body_path = root / "pr-body.md"
         validator_path.write_bytes(source)
         body_path.write_text(metadata.body, encoding="utf-8")
+        help_result = subprocess.run(
+            [sys.executable, str(validator_path), "check", "--help"], capture_output=True, text=True, check=False
+        )
+        if help_result.returncode != 0:
+            raise RuntimeError("base-revision pr-scope validator cannot report its check interface")
         argv = [
             sys.executable,
             str(validator_path),
@@ -683,7 +696,7 @@ def _run_validator_source(
             "--beads-path",
             str(beads_path.resolve()),
         ]
-        if b'add_argument("--base-sha"' in source:
+        if "--base-sha" in help_result.stdout:
             argv.extend(["--base-sha", metadata.base_sha])
         result = subprocess.run(
             argv,
@@ -822,6 +835,8 @@ def main(argv: list[str] | None = None) -> int:
         try:
             repository = resolve_repository(args.repo)
             metadata = fetch_pr_metadata(args.pr, repository=repository)
+            if _git_head_sha() != metadata.head_sha:
+                raise ValueError("current checkout HEAD does not match the fetched PR head")
             verdict = validate_pr_body(
                 metadata.body,
                 head_sha=metadata.head_sha,
@@ -849,6 +864,8 @@ def main(argv: list[str] | None = None) -> int:
             head_sha = metadata.head_sha
             is_draft = metadata.is_draft
             base_sha = metadata.base_sha
+            if _git_head_sha() != head_sha:
+                raise ValueError("current checkout HEAD does not match the fetched PR head")
         else:
             if not args.head_sha:
                 raise ValueError("--head-sha is required with --body-file")
@@ -863,7 +880,7 @@ def main(argv: list[str] | None = None) -> int:
             beads_path=args.beads_path,
             base_sha=base_sha,
         )
-    except (OSError, ValueError, json.JSONDecodeError, subprocess.SubprocessError) as exc:
+    except (OSError, ValueError, json.JSONDecodeError, RuntimeError, subprocess.SubprocessError) as exc:
         print(f"REFUSING to check pr-scope carrier: {exc}", file=sys.stderr)
         return 2
 

--- a/devtools/pr_scope.py
+++ b/devtools/pr_scope.py
@@ -1,10 +1,10 @@
 """Structured PR scope carrier used by CI and the merge boundary.
 
-The carrier is an embedded JSON comment, not a convention inferred from PR
-prose. It binds the declared Bead scope to a PR head, a canonical digest of the
-assigned Bead records, whole-Bead dispositions, and concrete evidence refs.
-Bead acceptance text is deliberately opaque here: it is hashed as part of the
-record snapshot, never interpreted by this module.
+The embedded v2 JSON comment is stable intent, not a mutable commit receipt.
+The merge boundary binds that intent to the current PR head and canonical Bead
+snapshot in its exact-head attestation. Bead acceptance text remains opaque:
+the checker consumes typed identifiers, dispositions, evidence refs, and graph
+links without interpreting prose.
 """
 
 from __future__ import annotations
@@ -23,14 +23,18 @@ from pathlib import Path
 from typing import Any
 from urllib import error, parse, request
 
-_CARRIER_PREFIX = "polylogue-pr-scope:v1"
-_CARRIER_START = f"<!-- {_CARRIER_PREFIX}"
+_CARRIER_PREFIX = "polylogue-pr-scope"
+_CARRIER_START_PATTERN = re.compile(r"<!--\s+polylogue-pr-scope:v(?P<version>[1-9][0-9]*)\b")
 _CARRIER_END = "-->"
-_VERSION = 1
+_V1 = 1
+_VERSION = 2
 _BEADS_PATH = Path(".beads/issues.jsonl")
 _GITHUB_API_URL = "https://api.github.com"
 _REPOSITORY_PATTERN = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
-_CARRIER_KEYS = frozenset({"version", "head_sha", "assigned_beads", "beads_digest", "dispositions", "scope_digest"})
+_V1_CARRIER_KEYS = frozenset({"version", "head_sha", "assigned_beads", "beads_digest", "dispositions", "scope_digest"})
+_V2_CARRIER_KEYS = frozenset(
+    {"version", "scope_kind", "assigned_beads", "mutated_beads", "dispositions", "scope_digest"}
+)
 _DISPOSITION_KEYS = frozenset({"bead_id", "disposition", "evidence", "successors"})
 _EVIDENCE_KEYS = frozenset({"kind", "ref"})
 
@@ -51,11 +55,17 @@ class EvidenceKind(StrEnum):
     TEST = "test"
 
 
+class ScopeKind(StrEnum):
+    BEAD = "bead"
+    SELF_CONTAINED = "self_contained"
+
+
 _DISPOSITIONS = frozenset(item.value for item in ScopeDisposition)
 _RESIDUAL_DISPOSITIONS = frozenset(
     {ScopeDisposition.PARTIAL.value, ScopeDisposition.DEFERRED.value, ScopeDisposition.SUPERSEDED.value}
 )
 _EVIDENCE_KINDS = frozenset(item.value for item in EvidenceKind)
+_SCOPE_KINDS = frozenset(item.value for item in ScopeKind)
 _SUCCESSOR_LINK_TYPES = frozenset({"blocks", "discovered-from", "relates-to", "supersedes"})
 
 
@@ -66,6 +76,7 @@ class ScopeVerdict:
     scope_digest: str | None = None
     beads_digest: str | None = None
     assigned_beads: list[str] = field(default_factory=list)
+    mutated_beads: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True, slots=True)
@@ -112,12 +123,14 @@ def load_bead_records(path: Path = _BEADS_PATH) -> dict[str, dict[str, Any]]:
     return records
 
 
-def canonical_beads_digest(records: dict[str, dict[str, Any]], bead_ids: list[str]) -> str:
+def canonical_beads_digest(
+    records: dict[str, dict[str, Any]], bead_ids: list[str], *, carrier_version: int = _V1
+) -> str:
     """Digest whole canonical records for the declared IDs, sorted by Bead ID."""
     missing = [bead_id for bead_id in bead_ids if bead_id not in records]
     if missing:
         raise ValueError(f"assigned Bead record(s) missing: {', '.join(missing)}")
-    return _digest({"version": _VERSION, "records": [records[bead_id] for bead_id in sorted(bead_ids)]})
+    return _digest({"version": carrier_version, "records": [records[bead_id] for bead_id in sorted(bead_ids)]})
 
 
 def _successor_is_linked(source_id: str, successor_id: str, records: dict[str, dict[str, Any]]) -> bool:
@@ -143,12 +156,13 @@ def carrier_digest(carrier: dict[str, Any]) -> str:
 
 
 def extract_carrier(body: str) -> tuple[dict[str, Any] | None, list[str]]:
-    starts = [index for index in range(len(body)) if body.startswith(_CARRIER_START, index)]
+    starts = list(_CARRIER_START_PATTERN.finditer(body))
     if not starts:
         return None, ["PR body is missing the structured pr-scope carrier"]
     if len(starts) != 1:
         return None, ["PR body contains more than one structured pr-scope carrier"]
-    start = starts[0] + len(_CARRIER_START)
+    marker = starts[0]
+    start = marker.end()
     end = body.find(_CARRIER_END, start)
     if end < 0:
         return None, ["structured pr-scope carrier is missing its closing comment"]
@@ -159,6 +173,8 @@ def extract_carrier(body: str) -> tuple[dict[str, Any] | None, list[str]]:
         return None, [f"structured pr-scope carrier is not valid JSON: {exc.msg}"]
     if not isinstance(carrier, dict):
         return None, ["structured pr-scope carrier must be a JSON object"]
+    if carrier.get("version") != int(marker.group("version")):
+        return None, ["structured pr-scope carrier version does not match its comment marker"]
     return carrier, []
 
 
@@ -178,34 +194,159 @@ def _validate_keys(
         reasons.append(f"{label} is missing required field(s): {', '.join(missing)}")
 
 
+def _bead_ids(value: object, *, label: str, allow_empty: bool, reasons: list[str]) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) and item for item in value):
+        reasons.append(f"{label} must be a list of Bead IDs")
+        return []
+    if not value and not allow_empty:
+        reasons.append(f"{label} must be a non-empty list of Bead IDs")
+    if len(set(value)) != len(value):
+        reasons.append(f"{label} contains duplicate Bead IDs")
+    return value
+
+
+def _bead_records_at(base_sha: str) -> dict[str, dict[str, Any]]:
+    result = subprocess.run(
+        ["git", "show", f"{base_sha}:.beads/issues.jsonl"], capture_output=True, text=True, check=False
+    )
+    if result.returncode != 0:
+        raise ValueError(f"cannot read .beads/issues.jsonl at base revision {base_sha[:8]}")
+    records: dict[str, dict[str, Any]] = {}
+    for line_no, line in enumerate(result.stdout.splitlines(), start=1):
+        if not line.strip():
+            continue
+        raw = json.loads(line)
+        if isinstance(raw, dict) and raw.get("_type") == "issue" and isinstance(raw.get("id"), str):
+            if raw["id"] in records:
+                raise ValueError(f"duplicate Bead id {raw['id']!r} on base line {line_no}")
+            records[raw["id"]] = raw
+    return records
+
+
+def changed_bead_ids(*, base_sha: str, beads_path: Path = _BEADS_PATH) -> list[str]:
+    """Return the complete Bead-record mutation set between base and checkout."""
+    before = _bead_records_at(base_sha)
+    after = load_bead_records(beads_path)
+    return sorted(bead_id for bead_id in set(before) | set(after) if before.get(bead_id) != after.get(bead_id))
+
+
+def _validate_dispositions(
+    dispositions: object,
+    *,
+    assigned_ids: list[str],
+    records: dict[str, dict[str, Any]],
+    reasons: list[str],
+) -> None:
+    by_bead: dict[str, dict[str, Any]] = {}
+    if not isinstance(dispositions, list):
+        reasons.append("dispositions must be a list with one entry per assigned Bead")
+        return
+    for entry in dispositions:
+        if not isinstance(entry, dict) or not isinstance(entry.get("bead_id"), str):
+            reasons.append("each disposition must be an object with a bead_id")
+            continue
+        _validate_keys(
+            entry,
+            label=f"disposition for {entry['bead_id']}",
+            allowed=_DISPOSITION_KEYS,
+            required=_DISPOSITION_KEYS,
+            reasons=reasons,
+        )
+        bead_id = entry["bead_id"]
+        if bead_id in by_bead:
+            reasons.append(f"duplicate disposition for assigned Bead {bead_id}")
+        by_bead[bead_id] = entry
+    missing = sorted(set(assigned_ids) - set(by_bead))
+    extra = sorted(set(by_bead) - set(assigned_ids))
+    if missing:
+        reasons.append(f"missing whole-Bead disposition(s): {', '.join(missing)}")
+    if extra:
+        reasons.append(f"disposition(s) reference unassigned Bead(s): {', '.join(extra)}")
+    for bead_id, entry in by_bead.items():
+        disposition = entry.get("disposition")
+        if disposition not in _DISPOSITIONS:
+            reasons.append(f"{bead_id}: unknown whole-Bead disposition {disposition!r}")
+        evidence = entry.get("evidence")
+        if not isinstance(evidence, list) or not evidence:
+            reasons.append(f"{bead_id}: disposition needs at least one typed evidence reference")
+        else:
+            for ref in evidence:
+                if isinstance(ref, dict):
+                    _validate_keys(
+                        ref,
+                        label=f"evidence for {bead_id}",
+                        allowed=_EVIDENCE_KEYS,
+                        required=_EVIDENCE_KEYS,
+                        reasons=reasons,
+                    )
+                if (
+                    not isinstance(ref, dict)
+                    or ref.get("kind") not in _EVIDENCE_KINDS
+                    or not isinstance(ref.get("ref"), str)
+                    or not ref["ref"].strip()
+                ):
+                    reasons.append(f"{bead_id}: evidence references need a known kind and non-empty ref")
+                    break
+        successors = entry.get("successors", [])
+        if not isinstance(successors, list) or not all(isinstance(item, str) and item for item in successors):
+            reasons.append(f"{bead_id}: successors must be a list of Bead IDs")
+            continue
+        if len(set(successors)) != len(successors):
+            reasons.append(f"{bead_id}: successors contains duplicate Bead IDs")
+        if disposition in _RESIDUAL_DISPOSITIONS and not successors:
+            reasons.append(f"{bead_id}: {disposition} disposition requires a named successor Bead")
+        if disposition == "satisfied" and successors:
+            reasons.append(f"{bead_id}: satisfied disposition cannot carry residual successors")
+        for successor in successors:
+            record = records.get(successor)
+            if record is None:
+                reasons.append(f"{bead_id}: successor {successor} is unknown")
+            elif record.get("status") == "closed":
+                reasons.append(f"{bead_id}: successor {successor} is closed")
+            elif not _successor_is_linked(bead_id, successor, records):
+                reasons.append(f"{bead_id}: successor {successor} has no durable Beads relationship")
+            if successor == bead_id:
+                reasons.append(f"{bead_id}: cannot name itself as a successor")
+
+
 def validate_carrier(
     carrier: dict[str, Any],
     *,
     head_sha: str,
     is_draft: bool,
     beads_path: Path = _BEADS_PATH,
+    base_sha: str | None = None,
 ) -> ScopeVerdict:
     reasons: list[str] = []
+    version = carrier.get("version")
+    if version not in {_V1, _VERSION}:
+        return ScopeVerdict(ok=False, reasons=[f"carrier version must be {_V1} or {_VERSION}"])
+    is_v1 = version == _V1
     _validate_keys(
         carrier,
         label="carrier",
-        allowed=_CARRIER_KEYS,
-        required=_CARRIER_KEYS,
+        allowed=_V1_CARRIER_KEYS if is_v1 else _V2_CARRIER_KEYS,
+        required=_V1_CARRIER_KEYS if is_v1 else _V2_CARRIER_KEYS,
         reasons=reasons,
     )
-    assigned = carrier.get("assigned_beads")
-    if not isinstance(assigned, list) or not assigned or not all(isinstance(item, str) and item for item in assigned):
-        reasons.append("assigned_beads must be a non-empty list of Bead IDs")
-        assigned_ids: list[str] = []
+    assigned_ids = _bead_ids(
+        carrier.get("assigned_beads"), label="assigned_beads", allow_empty=not is_v1, reasons=reasons
+    )
+    mutated_ids: list[str] = []
+    if is_v1:
+        if carrier.get("head_sha") != head_sha:
+            reasons.append("carrier head_sha does not match the PR head SHA")
     else:
-        assigned_ids = assigned
-        if len(set(assigned_ids)) != len(assigned_ids):
-            reasons.append("assigned_beads contains duplicate Bead IDs")
-
-    if carrier.get("version") != _VERSION:
-        reasons.append(f"carrier version must be {_VERSION}")
-    if carrier.get("head_sha") != head_sha:
-        reasons.append("carrier head_sha does not match the PR head SHA")
+        scope_kind = carrier.get("scope_kind")
+        if scope_kind not in _SCOPE_KINDS:
+            reasons.append(f"scope_kind must be one of: {', '.join(sorted(_SCOPE_KINDS))}")
+        mutated_ids = _bead_ids(carrier.get("mutated_beads"), label="mutated_beads", allow_empty=True, reasons=reasons)
+        if scope_kind == ScopeKind.BEAD.value and not assigned_ids:
+            reasons.append("bead scope requires at least one assigned Bead")
+        if scope_kind == ScopeKind.SELF_CONTAINED.value and (
+            assigned_ids or mutated_ids or carrier.get("dispositions") != []
+        ):
+            reasons.append("self_contained scope cannot declare Beads, dispositions, or Bead mutations")
     if is_draft:
         reasons.append("PR is draft; publish a non-draft PR before validation")
 
@@ -215,97 +356,38 @@ def validate_carrier(
         reasons.append("carrier scope_digest does not match its canonical content")
 
     records: dict[str, dict[str, Any]] = {}
-    if assigned_ids:
-        try:
-            records = load_bead_records(beads_path)
-            expected_beads_digest = canonical_beads_digest(records, assigned_ids)
-        except (OSError, ValueError, json.JSONDecodeError) as exc:
-            expected_beads_digest = None
-            reasons.append(f"cannot resolve assigned Bead records: {exc}")
-        if expected_beads_digest is not None and carrier.get("beads_digest") != expected_beads_digest:
-            reasons.append("carrier beads_digest is stale for the canonical assigned Bead records")
-    else:
+    try:
+        records = load_bead_records(beads_path)
+        bound_ids = list(assigned_ids)
+        if not is_v1:
+            bound_ids.extend(mutated_ids)
+            for entry in carrier.get("dispositions", []):
+                if isinstance(entry, dict) and isinstance(entry.get("successors"), list):
+                    bound_ids.extend(item for item in entry["successors"] if isinstance(item, str))
+        bound_ids = sorted(set(bound_ids))
+        expected_beads_digest = canonical_beads_digest(records, bound_ids, carrier_version=int(version))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
         expected_beads_digest = None
+        reasons.append(f"cannot resolve declared Bead records: {exc}")
+    if is_v1 and expected_beads_digest is not None and carrier.get("beads_digest") != expected_beads_digest:
+        reasons.append("carrier beads_digest is stale for the canonical assigned Bead records")
+    if not is_v1 and base_sha is not None:
+        try:
+            actual_mutations = changed_bead_ids(base_sha=base_sha, beads_path=beads_path)
+        except (OSError, ValueError, json.JSONDecodeError, subprocess.SubprocessError) as exc:
+            reasons.append(f"cannot resolve Bead mutation scope: {exc}")
+        else:
+            if actual_mutations != sorted(mutated_ids):
+                reasons.append("mutated_beads does not match the complete Bead mutation set")
 
-    dispositions = carrier.get("dispositions")
-    by_bead: dict[str, dict[str, Any]] = {}
-    if not isinstance(dispositions, list):
-        reasons.append("dispositions must be a list with one entry per assigned Bead")
-    else:
-        for entry in dispositions:
-            if not isinstance(entry, dict) or not isinstance(entry.get("bead_id"), str):
-                reasons.append("each disposition must be an object with a bead_id")
-                continue
-            _validate_keys(
-                entry,
-                label=f"disposition for {entry['bead_id']}",
-                allowed=_DISPOSITION_KEYS,
-                required=_DISPOSITION_KEYS,
-                reasons=reasons,
-            )
-            bead_id = entry["bead_id"]
-            if bead_id in by_bead:
-                reasons.append(f"duplicate disposition for assigned Bead {bead_id}")
-            by_bead[bead_id] = entry
-        missing = sorted(set(assigned_ids) - set(by_bead))
-        extra = sorted(set(by_bead) - set(assigned_ids))
-        if missing:
-            reasons.append(f"missing whole-Bead disposition(s): {', '.join(missing)}")
-        if extra:
-            reasons.append(f"disposition(s) reference unassigned Bead(s): {', '.join(extra)}")
-
-        for bead_id, entry in by_bead.items():
-            disposition = entry.get("disposition")
-            if disposition not in _DISPOSITIONS:
-                reasons.append(f"{bead_id}: unknown whole-Bead disposition {disposition!r}")
-            evidence = entry.get("evidence")
-            if not isinstance(evidence, list) or not evidence:
-                reasons.append(f"{bead_id}: disposition needs at least one typed evidence reference")
-            else:
-                for ref in evidence:
-                    if isinstance(ref, dict):
-                        _validate_keys(
-                            ref,
-                            label=f"evidence for {bead_id}",
-                            allowed=_EVIDENCE_KEYS,
-                            required=_EVIDENCE_KEYS,
-                            reasons=reasons,
-                        )
-                    if (
-                        not isinstance(ref, dict)
-                        or ref.get("kind") not in _EVIDENCE_KINDS
-                        or not isinstance(ref.get("ref"), str)
-                        or not ref["ref"].strip()
-                    ):
-                        reasons.append(f"{bead_id}: evidence references need a known kind and non-empty ref")
-                        break
-            successors = entry.get("successors", [])
-            if not isinstance(successors, list) or not all(isinstance(item, str) and item for item in successors):
-                reasons.append(f"{bead_id}: successors must be a list of Bead IDs")
-                continue
-            if len(set(successors)) != len(successors):
-                reasons.append(f"{bead_id}: successors contains duplicate Bead IDs")
-            if disposition in _RESIDUAL_DISPOSITIONS and not successors:
-                reasons.append(f"{bead_id}: {disposition} disposition requires a named successor Bead")
-            if disposition == "satisfied" and successors:
-                reasons.append(f"{bead_id}: satisfied disposition cannot carry residual successors")
-            for successor in successors:
-                record = records.get(successor)
-                if record is None:
-                    reasons.append(f"{bead_id}: successor {successor} is unknown")
-                elif record.get("status") == "closed":
-                    reasons.append(f"{bead_id}: successor {successor} is closed")
-                elif not _successor_is_linked(bead_id, successor, records):
-                    reasons.append(f"{bead_id}: successor {successor} has no durable Beads relationship")
-                if successor == bead_id:
-                    reasons.append(f"{bead_id}: cannot name itself as a successor")
-
+    _validate_dispositions(carrier.get("dispositions"), assigned_ids=assigned_ids, records=records, reasons=reasons)
     return ScopeVerdict(
         ok=not reasons,
         reasons=reasons,
         scope_digest=scope_digest if isinstance(scope_digest, str) else None,
-        beads_digest=carrier.get("beads_digest") if isinstance(carrier.get("beads_digest"), str) else None,
+        beads_digest=expected_beads_digest,
         assigned_beads=assigned_ids,
+        mutated_beads=mutated_ids,
     )
 
 
@@ -315,32 +397,56 @@ def validate_pr_body(
     head_sha: str,
     is_draft: bool,
     beads_path: Path = _BEADS_PATH,
+    base_sha: str | None = None,
 ) -> ScopeVerdict:
     carrier, reasons = extract_carrier(body)
     if carrier is None:
         return ScopeVerdict(ok=False, reasons=reasons)
-    return validate_carrier(carrier, head_sha=head_sha, is_draft=is_draft, beads_path=beads_path)
+    return validate_carrier(carrier, head_sha=head_sha, is_draft=is_draft, beads_path=beads_path, base_sha=base_sha)
 
 
 def render_carrier(carrier: dict[str, Any]) -> str:
-    return f"{_CARRIER_START}\n{json.dumps(carrier, indent=2, ensure_ascii=False, sort_keys=True)}\n{_CARRIER_END}"
+    version = carrier.get("version")
+    return f"<!-- {_CARRIER_PREFIX}:v{version}\n{json.dumps(carrier, indent=2, ensure_ascii=False, sort_keys=True)}\n{_CARRIER_END}"
 
 
 def build_carrier(input_payload: dict[str, Any], *, head_sha: str, beads_path: Path = _BEADS_PATH) -> dict[str, Any]:
     carrier = dict(input_payload)
-    carrier["version"] = _VERSION
-    carrier["head_sha"] = head_sha
-    carrier.pop("beads_digest", None)
+    version = carrier.get("version", _VERSION if "scope_kind" in carrier else _V1)
+    if version not in {_V1, _VERSION}:
+        raise ValueError(f"input version must be {_V1} or {_VERSION}")
+    carrier["version"] = version
     carrier.pop("scope_digest", None)
-    assigned = carrier.get("assigned_beads")
-    if not isinstance(assigned, list) or not all(isinstance(item, str) for item in assigned):
-        raise ValueError("input assigned_beads must be a list of Bead IDs")
-    carrier["beads_digest"] = canonical_beads_digest(load_bead_records(beads_path), assigned)
+    if version == _V1:
+        carrier["head_sha"] = head_sha
+        carrier.pop("beads_digest", None)
+        assigned = carrier.get("assigned_beads")
+        if not isinstance(assigned, list) or not all(isinstance(item, str) for item in assigned):
+            raise ValueError("input assigned_beads must be a list of Bead IDs")
+        carrier["beads_digest"] = canonical_beads_digest(load_bead_records(beads_path), assigned, carrier_version=_V1)
+    else:
+        carrier.pop("head_sha", None)
+        carrier.pop("beads_digest", None)
     carrier["scope_digest"] = carrier_digest(carrier)
     verdict = validate_carrier(carrier, head_sha=head_sha, is_draft=False, beads_path=beads_path)
     if not verdict.ok:
         raise ValueError("invalid scope input: " + "; ".join(verdict.reasons))
     return carrier
+
+
+def attestation_payload(scope: ScopeVerdict, *, head_sha: str, base_sha: str | None) -> dict[str, object]:
+    """Bind stable body intent to the mutable state observed at a merge boundary."""
+    payload: dict[str, object] = {
+        "version": _VERSION,
+        "head_sha": head_sha,
+        "base_sha": base_sha,
+        "scope_digest": scope.scope_digest,
+        "beads_digest": scope.beads_digest,
+        "assigned_beads": scope.assigned_beads,
+        "mutated_beads": scope.mutated_beads,
+    }
+    payload["attestation_digest"] = _digest(payload)
+    return payload
 
 
 def _git_head_sha() -> str:
@@ -566,18 +672,21 @@ def _run_validator_source(
         body_path = root / "pr-body.md"
         validator_path.write_bytes(source)
         body_path.write_text(metadata.body, encoding="utf-8")
+        argv = [
+            sys.executable,
+            str(validator_path),
+            "check",
+            "--body-file",
+            str(body_path),
+            "--head-sha",
+            metadata.head_sha,
+            "--beads-path",
+            str(beads_path.resolve()),
+        ]
+        if b'add_argument("--base-sha"' in source:
+            argv.extend(["--base-sha", metadata.base_sha])
         result = subprocess.run(
-            [
-                sys.executable,
-                str(validator_path),
-                "check",
-                "--body-file",
-                str(body_path),
-                "--head-sha",
-                metadata.head_sha,
-                "--beads-path",
-                str(beads_path.resolve()),
-            ],
+            argv,
             capture_output=True,
             text=True,
             check=False,
@@ -635,6 +744,7 @@ def check_ci_metadata(
         head_sha=metadata.head_sha,
         is_draft=metadata.is_draft,
         beads_path=beads_path,
+        base_sha=metadata.base_sha,
     )
     return _emit_verdict(verdict, head_sha=metadata.head_sha, as_json=False)
 
@@ -645,7 +755,7 @@ def main(argv: list[str] | None = None) -> int:
 
     render = sub.add_parser("render", help="render a carrier from a JSON scope input")
     render.add_argument("--input", required=True, type=Path, help="JSON with assigned_beads and dispositions")
-    render.add_argument("--head-sha", default=None, help="PR head SHA (default: current git HEAD)")
+    render.add_argument("--head-sha", default=None, help="v1 transition head SHA (default: current git HEAD)")
     render.add_argument("--beads-path", type=Path, default=_BEADS_PATH)
 
     check = sub.add_parser("check", help="validate a PR's embedded carrier")
@@ -654,6 +764,7 @@ def main(argv: list[str] | None = None) -> int:
     check_source.add_argument("--body-file", type=Path, help="PR body file for local validation")
     check.add_argument("--repo", help="GitHub OWNER/REPO (default: CI metadata or origin remote)")
     check.add_argument("--head-sha", help="required with --body-file")
+    check.add_argument("--base-sha", help="base SHA used to validate the complete Bead mutation scope")
     check.add_argument("--beads-path", type=Path, default=_BEADS_PATH)
     check.add_argument("--json", action="store_true", dest="as_json")
 
@@ -662,6 +773,11 @@ def main(argv: list[str] | None = None) -> int:
     check_ci.add_argument("--repo", required=True, help="GitHub OWNER/REPO from CI metadata")
     check_ci.add_argument("--expected-head-sha", default=os.environ.get("CIRCLE_SHA1"))
     check_ci.add_argument("--beads-path", type=Path, default=_BEADS_PATH)
+
+    sync = sub.add_parser("sync", help="report the current mutable attestation for a stable PR carrier")
+    sync.add_argument("--pr", type=int, required=True, help="GitHub PR number to inspect")
+    sync.add_argument("--repo", help="GitHub OWNER/REPO (default: CI metadata or origin remote)")
+    sync.add_argument("--beads-path", type=Path, default=_BEADS_PATH)
 
     args = parser.parse_args(argv)
     if args.action == "render":
@@ -702,6 +818,29 @@ def main(argv: list[str] | None = None) -> int:
             print(f"REFUSING CI pr-scope check: {exc}", file=sys.stderr)
             return 2
 
+    if args.action == "sync":
+        try:
+            repository = resolve_repository(args.repo)
+            metadata = fetch_pr_metadata(args.pr, repository=repository)
+            verdict = validate_pr_body(
+                metadata.body,
+                head_sha=metadata.head_sha,
+                is_draft=metadata.is_draft,
+                beads_path=args.beads_path,
+                base_sha=metadata.base_sha,
+            )
+            if not verdict.ok:
+                return _emit_verdict(verdict, head_sha=metadata.head_sha, as_json=False)
+            print(
+                json.dumps(
+                    attestation_payload(verdict, head_sha=metadata.head_sha, base_sha=metadata.base_sha), indent=2
+                )
+            )
+            return 0
+        except (OSError, ValueError, json.JSONDecodeError, RuntimeError, subprocess.SubprocessError) as exc:
+            print(f"REFUSING to sync pr-scope attestation: {exc}", file=sys.stderr)
+            return 2
+
     try:
         if args.pr is not None:
             repository = resolve_repository(args.repo)
@@ -709,13 +848,21 @@ def main(argv: list[str] | None = None) -> int:
             body = metadata.body
             head_sha = metadata.head_sha
             is_draft = metadata.is_draft
+            base_sha = metadata.base_sha
         else:
             if not args.head_sha:
                 raise ValueError("--head-sha is required with --body-file")
             body = args.body_file.read_text(encoding="utf-8")
             head_sha = args.head_sha
             is_draft = False
-        verdict = validate_pr_body(body, head_sha=head_sha, is_draft=is_draft, beads_path=args.beads_path)
+            base_sha = args.base_sha
+        verdict = validate_pr_body(
+            body,
+            head_sha=head_sha,
+            is_draft=is_draft,
+            beads_path=args.beads_path,
+            base_sha=base_sha,
+        )
     except (OSError, ValueError, json.JSONDecodeError, subprocess.SubprocessError) as exc:
         print(f"REFUSING to check pr-scope carrier: {exc}", file=sys.stderr)
         return 2

--- a/devtools/pr_scope.py
+++ b/devtools/pr_scope.py
@@ -854,6 +854,12 @@ def check_ci_metadata(
     if metadata.is_draft:
         print("REFUSING CI pr-scope check: PR is draft; publish it before validation", file=sys.stderr)
         return 2
+    if not _beads_snapshot_matches_head(beads_path):
+        print(
+            "REFUSING CI pr-scope check: Beads snapshot does not match the committed PR head",
+            file=sys.stderr,
+        )
+        return 2
 
     if _automated_dependency_scope_allowed(metadata):
         print(

--- a/devtools/pr_scope.py
+++ b/devtools/pr_scope.py
@@ -181,7 +181,8 @@ def extract_carrier(body: str) -> tuple[dict[str, Any] | None, list[str]]:
         return None, [f"structured pr-scope carrier is not valid JSON: {exc.msg}"]
     if not isinstance(carrier, dict):
         return None, ["structured pr-scope carrier must be a JSON object"]
-    if carrier.get("version") != int(marker.group("version")):
+    carrier_version = carrier.get("version")
+    if type(carrier_version) is not int or carrier_version != int(marker.group("version")):
         return None, ["structured pr-scope carrier version does not match its comment marker"]
     return carrier, []
 
@@ -360,7 +361,7 @@ def validate_carrier(
 ) -> ScopeVerdict:
     reasons: list[str] = []
     version = carrier.get("version")
-    if version not in {_V1, _VERSION}:
+    if type(version) is not int or version not in {_V1, _VERSION}:
         return ScopeVerdict(ok=False, reasons=[f"carrier version must be {_V1} or {_VERSION}"])
     is_v1 = version == _V1
     _validate_keys(
@@ -384,8 +385,10 @@ def validate_carrier(
         mutated_ids = _bead_ids(carrier.get("mutated_beads"), label="mutated_beads", allow_empty=True, reasons=reasons)
         if scope_kind == ScopeKind.BEAD.value and not assigned_ids:
             reasons.append("bead scope requires at least one assigned Bead")
-        if scope_kind == ScopeKind.SELF_CONTAINED.value and (assigned_ids or carrier.get("dispositions") != []):
-            reasons.append("self_contained scope cannot declare assigned Beads or dispositions")
+        if scope_kind == ScopeKind.SELF_CONTAINED.value and (
+            assigned_ids or mutated_ids or carrier.get("dispositions") != []
+        ):
+            reasons.append("self_contained scope cannot declare or mutate Beads")
     if is_draft:
         reasons.append("PR is draft; publish a non-draft PR before validation")
 
@@ -414,6 +417,7 @@ def validate_carrier(
         reasons.append(f"cannot resolve declared Bead records: {exc}")
     if is_v1 and expected_beads_digest is not None and carrier.get("beads_digest") != expected_beads_digest:
         reasons.append("carrier beads_digest is stale for the canonical assigned Bead records")
+    actual_mutations: list[str] = []
     if base_sha is not None:
         try:
             actual_mutations = changed_bead_ids(base_sha=base_sha, beads_path=beads_path)
@@ -425,7 +429,33 @@ def validate_carrier(
             elif not is_v1 and actual_mutations != sorted(mutated_ids):
                 reasons.append("mutated_beads does not match the complete Bead mutation set")
 
-    _validate_dispositions(carrier.get("dispositions"), assigned_ids=assigned_ids, records=records, reasons=reasons)
+    disposition_records = records
+    dispositions = carrier.get("dispositions")
+    disposition_entries = dispositions if isinstance(dispositions, list) else []
+    successor_ids = {
+        successor
+        for entry in disposition_entries
+        if isinstance(entry, dict)
+        for successor in entry.get("successors", [])
+        if isinstance(entry.get("successors"), list) and isinstance(successor, str)
+    }
+    if base_sha is not None and successor_ids:
+        try:
+            disposition_records = _bead_records_at(base_sha)
+            for bead_id in actual_mutations:
+                if bead_id in records:
+                    disposition_records[bead_id] = records[bead_id]
+                else:
+                    disposition_records.pop(bead_id, None)
+        except (OSError, ValueError, json.JSONDecodeError, subprocess.SubprocessError) as exc:
+            reasons.append(f"cannot resolve prospective Bead state: {exc}")
+
+    _validate_dispositions(
+        dispositions,
+        assigned_ids=assigned_ids,
+        records=disposition_records,
+        reasons=reasons,
+    )
     return ScopeVerdict(
         ok=not reasons,
         reasons=reasons,
@@ -458,7 +488,7 @@ def render_carrier(carrier: dict[str, Any]) -> str:
 def build_carrier(input_payload: dict[str, Any], *, head_sha: str, beads_path: Path = _BEADS_PATH) -> dict[str, Any]:
     carrier = dict(input_payload)
     version = carrier.get("version", _VERSION if "scope_kind" in carrier else _V1)
-    if version not in {_V1, _VERSION}:
+    if type(version) is not int or version not in {_V1, _VERSION}:
         raise ValueError(f"input version must be {_V1} or {_VERSION}")
     carrier["version"] = version
     carrier.pop("scope_digest", None)
@@ -497,6 +527,25 @@ def attestation_payload(scope: ScopeVerdict, *, head_sha: str, base_sha: str | N
 def _git_head_sha() -> str:
     result = subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True)
     return result.stdout.strip()
+
+
+def _beads_snapshot_matches_head(beads_path: Path) -> bool:
+    """Return whether ``beads_path`` is exactly the blob committed at HEAD."""
+    root_result = subprocess.run(["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True, check=False)
+    if root_result.returncode != 0:
+        return False
+    root = Path(root_result.stdout.strip()).resolve()
+    try:
+        relative = beads_path.resolve().relative_to(root)
+    except ValueError:
+        return False
+    blob = subprocess.run(["git", "show", f"HEAD:{relative.as_posix()}"], capture_output=True, check=False)
+    if blob.returncode != 0:
+        return False
+    try:
+        return beads_path.read_bytes() == blob.stdout
+    except OSError:
+        return False
 
 
 def _repository_from_remote(remote: str) -> str | None:
@@ -874,6 +923,8 @@ def main(argv: list[str] | None = None) -> int:
             metadata = fetch_pr_metadata(args.pr, repository=repository)
             if _git_head_sha() != metadata.head_sha:
                 raise ValueError("current checkout HEAD does not match the fetched PR head")
+            if not _beads_snapshot_matches_head(args.beads_path):
+                raise ValueError("Beads snapshot does not match the committed PR head")
             verdict = validate_pr_body(
                 metadata.body,
                 head_sha=metadata.head_sha,

--- a/devtools/pr_scope.py
+++ b/devtools/pr_scope.py
@@ -379,13 +379,15 @@ def validate_carrier(
         reasons.append(f"cannot resolve declared Bead records: {exc}")
     if is_v1 and expected_beads_digest is not None and carrier.get("beads_digest") != expected_beads_digest:
         reasons.append("carrier beads_digest is stale for the canonical assigned Bead records")
-    if not is_v1 and base_sha is not None:
+    if base_sha is not None:
         try:
             actual_mutations = changed_bead_ids(base_sha=base_sha, beads_path=beads_path)
         except (OSError, ValueError, json.JSONDecodeError, subprocess.SubprocessError) as exc:
             reasons.append(f"cannot resolve Bead mutation scope: {exc}")
         else:
-            if actual_mutations != sorted(mutated_ids):
+            if is_v1 and actual_mutations:
+                reasons.append("legacy v1 carrier cannot omit Bead mutations; render a v2 carrier")
+            elif not is_v1 and actual_mutations != sorted(mutated_ids):
                 reasons.append("mutated_beads does not match the complete Bead mutation set")
 
     _validate_dispositions(carrier.get("dispositions"), assigned_ids=assigned_ids, records=records, reasons=reasons)

--- a/devtools/pr_scope.py
+++ b/devtools/pr_scope.py
@@ -260,15 +260,40 @@ def _ensure_local_commit(revision: str) -> None:
         raise ValueError(f"fetched base revision {revision[:8]} is not a local commit")
 
 
+def _merge_base(base_sha: str) -> str:
+    """Resolve the PR merge base, recovering complete history in shallow CI clones."""
+    result = subprocess.run(["git", "merge-base", base_sha, "HEAD"], capture_output=True, text=True, check=False)
+    if result.returncode == 0 and _GIT_OBJECT_PATTERN.fullmatch(result.stdout.strip()):
+        return result.stdout.strip()
+
+    shallow = subprocess.run(
+        ["git", "rev-parse", "--is-shallow-repository"], capture_output=True, text=True, check=False
+    )
+    if shallow.returncode == 0 and shallow.stdout.strip() == "true":
+        fetched = subprocess.run(
+            ["git", "fetch", "--no-tags", "--quiet", "--unshallow", "origin"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=120,
+        )
+        if fetched.returncode != 0:
+            detail = fetched.stderr.strip()
+            suffix = f": {detail}" if detail else ""
+            raise ValueError(f"cannot deepen shallow history from origin{suffix}")
+        result = subprocess.run(["git", "merge-base", base_sha, "HEAD"], capture_output=True, text=True, check=False)
+        if result.returncode == 0 and _GIT_OBJECT_PATTERN.fullmatch(result.stdout.strip()):
+            return result.stdout.strip()
+
+    raise ValueError(f"cannot resolve PR merge base from base revision {base_sha[:8]}")
+
+
 def changed_bead_ids(*, base_sha: str, beads_path: Path = _BEADS_PATH) -> list[str]:
     """Return the complete Bead-record mutation set from the PR merge base."""
     if not _GIT_OBJECT_PATTERN.fullmatch(base_sha):
         raise ValueError("base revision must be a hexadecimal Git object name")
     _ensure_local_commit(base_sha)
-    merge_base = subprocess.run(["git", "merge-base", base_sha, "HEAD"], capture_output=True, text=True, check=False)
-    if merge_base.returncode != 0 or not _GIT_OBJECT_PATTERN.fullmatch(merge_base.stdout.strip()):
-        raise ValueError(f"cannot resolve PR merge base from base revision {base_sha[:8]}")
-    before = _bead_records_at(merge_base.stdout.strip())
+    before = _bead_records_at(_merge_base(base_sha))
     after = load_bead_records(beads_path)
     return sorted(bead_id for bead_id in set(before) | set(after) if before.get(bead_id) != after.get(bead_id))
 
@@ -547,6 +572,14 @@ def _beads_snapshot_matches_head(beads_path: Path) -> bool:
         return beads_path.read_bytes() == blob.stdout
     except OSError:
         return False
+
+
+def _require_checkout_authority(*, head_sha: str, beads_path: Path) -> None:
+    """Require validation inputs to be the exact committed PR revision."""
+    if _git_head_sha() != head_sha:
+        raise ValueError("current checkout HEAD does not match the fetched PR head")
+    if not _beads_snapshot_matches_head(beads_path):
+        raise ValueError("Beads snapshot does not match the committed PR head")
 
 
 def _repository_from_remote(remote: str) -> str | None:
@@ -922,10 +955,7 @@ def main(argv: list[str] | None = None) -> int:
         try:
             repository = resolve_repository(args.repo)
             metadata = fetch_pr_metadata(args.pr, repository=repository)
-            if _git_head_sha() != metadata.head_sha:
-                raise ValueError("current checkout HEAD does not match the fetched PR head")
-            if not _beads_snapshot_matches_head(args.beads_path):
-                raise ValueError("Beads snapshot does not match the committed PR head")
+            _require_checkout_authority(head_sha=metadata.head_sha, beads_path=args.beads_path)
             verdict = validate_pr_body(
                 metadata.body,
                 head_sha=metadata.head_sha,
@@ -953,8 +983,7 @@ def main(argv: list[str] | None = None) -> int:
             head_sha = metadata.head_sha
             is_draft = metadata.is_draft
             base_sha = metadata.base_sha
-            if _git_head_sha() != head_sha:
-                raise ValueError("current checkout HEAD does not match the fetched PR head")
+            _require_checkout_authority(head_sha=head_sha, beads_path=args.beads_path)
         else:
             if not args.head_sha:
                 raise ValueError("--head-sha is required with --body-file")
@@ -965,6 +994,8 @@ def main(argv: list[str] | None = None) -> int:
             extracted_carrier, _carrier_reasons = extract_carrier(body)
             if extracted_carrier is not None and extracted_carrier.get("version") == _VERSION and base_sha is None:
                 raise ValueError("--base-sha is required with --body-file for a v2 carrier")
+            if extracted_carrier is not None and extracted_carrier.get("version") == _VERSION:
+                _require_checkout_authority(head_sha=head_sha, beads_path=args.beads_path)
         verdict = validate_pr_body(
             body,
             head_sha=head_sha,

--- a/devtools/pr_scope.py
+++ b/devtools/pr_scope.py
@@ -224,10 +224,45 @@ def _bead_records_at(base_sha: str) -> dict[str, dict[str, Any]]:
     return _parse_bead_records(result.stdout.splitlines(), line_label="base line")
 
 
+def _ensure_local_commit(revision: str) -> None:
+    """Ensure a Git commit reported by GitHub exists in this checkout.
+
+    Feature worktrees and shallow CI checkouts can have a current PR head while
+    lacking a target-branch tip that advanced after the checkout was created.
+    Mutation scope is defined from the merge base, so resolve that authority
+    explicitly instead of requiring an operator-side ``git fetch`` first.
+    """
+    present = subprocess.run(
+        ["git", "cat-file", "-e", f"{revision}^{{commit}}"],
+        capture_output=True,
+        check=False,
+    )
+    if present.returncode == 0:
+        return
+    fetched = subprocess.run(
+        ["git", "fetch", "--no-tags", "--quiet", "origin", revision],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if fetched.returncode != 0:
+        detail = fetched.stderr.strip()
+        suffix = f": {detail}" if detail else ""
+        raise ValueError(f"cannot fetch base revision {revision[:8]} from origin{suffix}")
+    present = subprocess.run(
+        ["git", "cat-file", "-e", f"{revision}^{{commit}}"],
+        capture_output=True,
+        check=False,
+    )
+    if present.returncode != 0:
+        raise ValueError(f"fetched base revision {revision[:8]} is not a local commit")
+
+
 def changed_bead_ids(*, base_sha: str, beads_path: Path = _BEADS_PATH) -> list[str]:
     """Return the complete Bead-record mutation set from the PR merge base."""
     if not _GIT_OBJECT_PATTERN.fullmatch(base_sha):
         raise ValueError("base revision must be a hexadecimal Git object name")
+    _ensure_local_commit(base_sha)
     merge_base = subprocess.run(["git", "merge-base", base_sha, "HEAD"], capture_output=True, text=True, check=False)
     if merge_base.returncode != 0 or not _GIT_OBJECT_PATTERN.fullmatch(merge_base.stdout.strip()):
         raise ValueError(f"cannot resolve PR merge base from base revision {base_sha[:8]}")

--- a/devtools/pr_scope.py
+++ b/devtools/pr_scope.py
@@ -245,6 +245,7 @@ def _ensure_local_commit(revision: str) -> None:
         capture_output=True,
         text=True,
         check=False,
+        timeout=120,
     )
     if fetched.returncode != 0:
         detail = fetched.stderr.strip()
@@ -961,6 +962,9 @@ def main(argv: list[str] | None = None) -> int:
             head_sha = args.head_sha
             is_draft = False
             base_sha = args.base_sha
+            extracted_carrier, _carrier_reasons = extract_carrier(body)
+            if extracted_carrier is not None and extracted_carrier.get("version") == _VERSION and base_sha is None:
+                raise ValueError("--base-sha is required with --body-file for a v2 carrier")
         verdict = validate_pr_body(
             body,
             head_sha=head_sha,

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -302,7 +302,7 @@ Catalog bypass audit sites are machine-checked across workflow runs, CI-owned np
 | `devtools workspace merge` | Merge boundary wrapper: refuses `gh pr merge` without a fresh merge-gate receipt. |
 | `devtools workspace merge-conductor` | Mechanical-conflict triage for the PR merge train (dry-run by default). |
 | `devtools workspace merge-gate` | Structural pre-merge safety check: fresh local-verification receipt + no late review comments. |
-| `devtools workspace pr-scope` | Render and validate the versioned PR Bead-scope carrier. |
+| `devtools workspace pr-scope` | Render stable PR scope intent and inspect its mutable merge attestation. |
 | `devtools workspace raw-append-chain-backfill-apply` | Promote membershipless append raws proven correct by live-source verification. |
 | `devtools workspace raw-authority-artifact-census` | Census quarantined raws into five authority buckets; apply pages raw_artifacts upserts and records durable receipts. |
 | `devtools workspace raw-authority-daemon-health-proof` | Prove daemon status/health HTTP responsiveness during a real raw-authority drain. |

--- a/tests/unit/devtools/test_merge_boundary.py
+++ b/tests/unit/devtools/test_merge_boundary.py
@@ -273,7 +273,9 @@ def test_merge_refuses_when_pr_not_open(monkeypatch: pytest.MonkeyPatch, tmp_pat
     assert exit_code == 1
 
 
-def test_merge_refuses_when_pr_scope_carrier_is_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_merge_refuses_when_pr_scope_carrier_is_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     monkeypatch.chdir(tmp_path)
     pr_view = _base_pr_view()
     pr_view["body"] = "## Summary\n\nNo carrier."
@@ -292,6 +294,9 @@ def test_merge_refuses_when_pr_scope_carrier_is_missing(monkeypatch: pytest.Monk
 
     assert exit_code == 2
     assert merge_boundary._read_ledger()["merges"] == []
+    stderr = capsys.readouterr().err
+    assert "invalid structured pr-scope carrier" in stderr
+    assert "no fresh merge-gate receipt" not in stderr
 
 
 def test_merge_refuses_when_late_unacked_review_comment_exists(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/unit/devtools/test_merge_boundary.py
+++ b/tests/unit/devtools/test_merge_boundary.py
@@ -151,6 +151,7 @@ def test_merge_refreshes_a_receipt_when_the_scope_attestation_changes(
     pr_view = _base_pr_view()
     pr_view["baseRefOid"] = "base-one"
     monkeypatch.setattr(subprocess, "run", _fake_run(pr_view))
+    monkeypatch.setattr(pr_scope, "changed_bead_ids", lambda **_kwargs: [])
 
     assert (
         merge_boundary.cmd_merge(

--- a/tests/unit/devtools/test_merge_boundary.py
+++ b/tests/unit/devtools/test_merge_boundary.py
@@ -307,6 +307,47 @@ def test_merge_refuses_when_local_verify_command_fails(monkeypatch: pytest.Monke
     assert ledger["merges"] == []
 
 
+def test_merge_replaces_a_recent_failed_receipt_instead_of_reusing_it(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    pr_view = _base_pr_view()
+    monkeypatch.setattr(subprocess, "run", _fake_run(pr_view, local_exit=2))
+
+    assert (
+        merge_boundary.cmd_merge(
+            42,
+            command="devtools test x",
+            max_age_s=3600,
+            poll_rounds=1,
+            poll_interval_s=0,
+            dry_run=True,
+            with_verify=False,
+            verify_command="devtools verify --all",
+        )
+        == 2
+    )
+    assert json.loads(merge_gate._receipt_path(42).read_text())["exit_code"] == 2
+
+    monkeypatch.setattr(subprocess, "run", _fake_run(pr_view, local_exit=0))
+    assert (
+        merge_boundary.cmd_merge(
+            42,
+            command="devtools test x",
+            max_age_s=3600,
+            poll_rounds=1,
+            poll_interval_s=0,
+            dry_run=True,
+            with_verify=False,
+            verify_command="devtools verify --all",
+        )
+        == 0
+    )
+    receipt = json.loads(merge_gate._receipt_path(42).read_text())
+    assert receipt["exit_code"] == 0
+    assert receipt["verification_scope"] == "affected"
+
+
 def test_merge_dry_run_never_calls_gh_pr_merge(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.chdir(tmp_path)
     pr_view = _base_pr_view()

--- a/tests/unit/devtools/test_merge_boundary.py
+++ b/tests/unit/devtools/test_merge_boundary.py
@@ -254,6 +254,41 @@ def test_merge_refuses_when_the_target_base_changes_after_validation(
     assert "base, or state changed" in capsys.readouterr().err
 
 
+def test_merge_refuses_when_the_scope_body_changes_after_validation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    initial = _base_pr_view()
+    changed = dict(initial, body="## Summary\n\nCarrier removed after validation.")
+    views = iter([initial, changed])
+    monkeypatch.setattr(merge_boundary, "_gh_json", lambda _args: next(views))
+    merge_calls: list[list[str]] = []
+    base_run = _fake_run(initial)
+
+    def run(cmd: list[str], **kwargs: Any) -> MagicMock:
+        if cmd[:3] == ["gh", "pr", "merge"]:
+            merge_calls.append(cmd)
+        return base_run(cmd, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", run)
+
+    assert (
+        merge_boundary.cmd_merge(
+            42,
+            command="devtools test x",
+            max_age_s=3600,
+            poll_rounds=1,
+            poll_interval_s=0,
+            dry_run=False,
+            with_verify=False,
+            verify_command="devtools verify --all",
+        )
+        == 1
+    )
+    assert not merge_calls
+    assert "structured scope changed" in capsys.readouterr().err
+
+
 def test_merge_refuses_when_pr_not_open(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.chdir(tmp_path)
     pr_view = _base_pr_view(state="MERGED")

--- a/tests/unit/devtools/test_merge_boundary.py
+++ b/tests/unit/devtools/test_merge_boundary.py
@@ -144,6 +144,46 @@ def test_merge_auto_records_when_no_fresh_receipt_then_merges(monkeypatch: pytes
     assert ledger["merges"][0]["title"] == "fix: thing (#42)"
 
 
+def test_merge_refreshes_a_receipt_when_the_scope_attestation_changes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    pr_view = _base_pr_view()
+    pr_view["baseRefOid"] = "base-one"
+    monkeypatch.setattr(subprocess, "run", _fake_run(pr_view))
+
+    assert (
+        merge_boundary.cmd_merge(
+            42,
+            command="devtools test x",
+            max_age_s=3600,
+            poll_rounds=1,
+            poll_interval_s=0,
+            dry_run=True,
+            with_verify=False,
+            verify_command="devtools verify --all",
+        )
+        == 0
+    )
+    capsys.readouterr()
+    pr_view["baseRefOid"] = "base-two"
+
+    assert (
+        merge_boundary.cmd_merge(
+            42,
+            command="devtools test x",
+            max_age_s=3600,
+            poll_rounds=1,
+            poll_interval_s=0,
+            dry_run=True,
+            with_verify=False,
+            verify_command="devtools verify --all",
+        )
+        == 0
+    )
+    assert "no fresh merge-gate receipt" in capsys.readouterr().err
+
+
 def test_merge_strips_doubled_pr_suffix_before_merging(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.chdir(tmp_path)
     pr_view = _base_pr_view(title="fix: thing (#42) (#42)")

--- a/tests/unit/devtools/test_merge_boundary.py
+++ b/tests/unit/devtools/test_merge_boundary.py
@@ -25,10 +25,11 @@ _SCOPE_BEAD = {
 
 
 @pytest.fixture(autouse=True)
-def _scope_bead_record(tmp_path: Path) -> None:
+def _scope_bead_record(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     beads_dir = tmp_path / ".beads"
     beads_dir.mkdir()
     (beads_dir / "issues.jsonl").write_text(json.dumps(_SCOPE_BEAD) + "\n")
+    monkeypatch.setattr(pr_scope, "changed_bead_ids", lambda **_kwargs: [])
 
 
 def _scope_body(head_sha: str) -> str:
@@ -53,6 +54,7 @@ def _scope_body(head_sha: str) -> str:
 def _base_pr_view(head_sha: str = "abc123", title: str = "fix: thing (#42)", state: str = "OPEN") -> dict[str, object]:
     return {
         "headRefOid": head_sha,
+        "baseRefOid": "b" * 40,
         "headRefName": "feature/x",
         "title": title,
         "state": state,
@@ -215,6 +217,41 @@ def test_merge_strips_doubled_pr_suffix_before_merging(monkeypatch: pytest.Monke
     assert captured["cmd"][subject_index] == "fix: thing (#42)"
     match_index = captured["cmd"].index("--match-head-commit") + 1
     assert captured["cmd"][match_index] == "abc123"
+
+
+def test_merge_refuses_when_the_target_base_changes_after_validation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    initial = _base_pr_view()
+    changed = dict(initial, baseRefOid="advanced-base")
+    views = iter([initial, changed])
+    monkeypatch.setattr(merge_boundary, "_gh_json", lambda _args: next(views))
+    merge_calls: list[list[str]] = []
+    base_run = _fake_run(initial)
+
+    def run(cmd: list[str], **kwargs: Any) -> MagicMock:
+        if cmd[:3] == ["gh", "pr", "merge"]:
+            merge_calls.append(cmd)
+        return base_run(cmd, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", run)
+
+    assert (
+        merge_boundary.cmd_merge(
+            42,
+            command="devtools test x",
+            max_age_s=3600,
+            poll_rounds=1,
+            poll_interval_s=0,
+            dry_run=False,
+            with_verify=False,
+            verify_command="devtools verify --all",
+        )
+        == 1
+    )
+    assert not merge_calls
+    assert "base, or state changed" in capsys.readouterr().err
 
 
 def test_merge_refuses_when_pr_not_open(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/unit/devtools/test_merge_gate.py
+++ b/tests/unit/devtools/test_merge_gate.py
@@ -343,6 +343,8 @@ def test_check_rejects_command_text_without_typed_scope_or_permission(
         ("pr_scope_digest", "changed-body-digest", "pr_scope_digest"),
         ("pr_scope_beads_digest", "stale", "pr_scope_beads_digest"),
         ("pr_scope_assigned_beads", ["polylogue-other"], "pr_scope_assigned_beads"),
+        ("pr_scope_mutated_beads", ["polylogue-unlisted"], "pr_scope_mutated_beads"),
+        ("pr_scope_attestation_digest", "stale-attestation", "pr_scope_attestation_digest"),
     ],
 )
 def test_check_blocks_when_receipt_scope_components_are_mutated(

--- a/tests/unit/devtools/test_merge_gate.py
+++ b/tests/unit/devtools/test_merge_gate.py
@@ -321,6 +321,30 @@ def test_check_ok_when_receipt_fresh_and_matches_head_with_no_late_comments(
     assert exit_code == 0
 
 
+def test_check_refuses_an_unrelated_local_checkout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    pr_view = _base_pr_view()
+    _record(monkeypatch, pr_view)
+    monkeypatch.setattr(subprocess, "run", _fake_run(pr_view, [], local_head_sha="other-head"))
+
+    assert merge_gate.cmd_check(42, max_age_s=3600, poll_rounds=1, poll_interval_s=0, as_json=False) == 1
+    assert "does not match PR #42's head" in capsys.readouterr().out
+
+
+def test_check_refuses_a_dirty_local_checkout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    pr_view = _base_pr_view()
+    _record(monkeypatch, pr_view)
+    monkeypatch.setattr(subprocess, "run", _fake_run(pr_view, [], dirty=True))
+
+    assert merge_gate.cmd_check(42, max_age_s=3600, poll_rounds=1, poll_interval_s=0, as_json=False) == 1
+    assert "has uncommitted changes" in capsys.readouterr().out
+
+
 def test_check_rejects_command_text_without_typed_scope_or_permission(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -655,6 +679,7 @@ def test_check_post_status_posts_failure_with_block_reason_for_block_verdict(
 
     status_calls: list[list[str]] = []
     monkeypatch.setattr(subprocess, "run", _fake_run_with_status_capture(pr_view, [], status_calls=status_calls))
+    monkeypatch.setattr(merge_gate, "_git_head_sha", lambda: "def456")
 
     exit_code = merge_gate.cmd_check(
         42, max_age_s=3600, poll_rounds=1, poll_interval_s=0, as_json=False, post_status=True

--- a/tests/unit/devtools/test_pr_scope.py
+++ b/tests/unit/devtools/test_pr_scope.py
@@ -216,6 +216,26 @@ def test_v2_check_rejects_an_unlisted_bead_mutation_via_the_production_command(
     )
     assert "mutated_beads does not match the complete Bead mutation set" in capsys.readouterr().out
 
+    legacy_body_path = repository / "legacy-body.md"
+    legacy_body_path.write_text(_body(_input(), beads_path))
+    assert (
+        pr_scope.main(
+            [
+                "check",
+                "--body-file",
+                str(legacy_body_path),
+                "--head-sha",
+                HEAD_SHA,
+                "--base-sha",
+                base_sha,
+                "--beads-path",
+                str(beads_path),
+            ]
+        )
+        == 1
+    )
+    assert "legacy v1 carrier cannot omit Bead mutations" in capsys.readouterr().out
+
 
 def test_v2_self_contained_scope_can_declare_a_real_bead_mutation(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -475,6 +495,7 @@ def test_pr_check_uses_public_github_rest_without_cli_auth(
     monkeypatch.delenv("GH_TOKEN", raising=False)
     monkeypatch.setattr(request, "urlopen", _urlopen)
     monkeypatch.setattr(pr_scope, "_git_head_sha", lambda: HEAD_SHA)
+    monkeypatch.setattr(pr_scope, "changed_bead_ids", lambda **_kwargs: [])
 
     exit_code = pr_scope.main(["check", "--pr", "42", "--repo", "Sinity/polylogue", "--beads-path", str(beads_path)])
 
@@ -789,6 +810,7 @@ def test_ci_check_bootstraps_once_when_base_has_no_validator(
         is_draft=False,
     )
     monkeypatch.setattr(pr_scope, "fetch_base_validator_source", lambda **_kwargs: None)
+    monkeypatch.setattr(pr_scope, "changed_bead_ids", lambda **_kwargs: [])
 
     assert (
         pr_scope.check_ci_metadata(

--- a/tests/unit/devtools/test_pr_scope.py
+++ b/tests/unit/devtools/test_pr_scope.py
@@ -90,6 +90,13 @@ def _check(
     return f"{exit_code}\n{output}"
 
 
+def _validate_rendered_without_mutation_scope(body: str, beads_path: Path, *, head_sha: str) -> pr_scope.ScopeVerdict:
+    carrier, reasons = pr_scope.extract_carrier(body)
+    assert not reasons
+    assert carrier is not None
+    return pr_scope.validate_carrier(carrier, head_sha=head_sha, is_draft=False, beads_path=beads_path)
+
+
 class _FakeHttpResponse:
     def __init__(self, payload: bytes) -> None:
         self.payload = payload
@@ -133,7 +140,7 @@ def test_v2_rendered_carrier_stays_valid_when_the_head_changes(
 
     assert "head_sha" not in rendered
     assert "beads_digest" not in rendered
-    assert _check(rendered, beads_path, tmp_path, capsys, head_sha="b" * 40).startswith("0\npr-scope OK")
+    assert _validate_rendered_without_mutation_scope(rendered, beads_path, head_sha="b" * 40).ok
 
 
 def test_v2_self_contained_scope_needs_no_invented_bead(
@@ -150,7 +157,56 @@ def test_v2_self_contained_scope_needs_no_invented_bead(
     )
     rendered = capsys.readouterr().out
 
-    assert _check(rendered, beads_path, tmp_path, capsys, head_sha="b" * 40).startswith("0\npr-scope OK")
+    assert _validate_rendered_without_mutation_scope(rendered, beads_path, head_sha="b" * 40).ok
+
+
+def test_v2_body_file_check_requires_base_revision(
+    beads_path: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    scope_input = tmp_path / "scope.json"
+    scope_input.write_text(json.dumps(_v2_input()))
+    assert (
+        pr_scope.main(["render", "--input", str(scope_input), "--head-sha", HEAD_SHA, "--beads-path", str(beads_path)])
+        == 0
+    )
+    body_path = tmp_path / "body.md"
+    body_path.write_text(capsys.readouterr().out)
+
+    assert (
+        pr_scope.main(
+            [
+                "check",
+                "--body-file",
+                str(body_path),
+                "--head-sha",
+                HEAD_SHA,
+                "--beads-path",
+                str(beads_path),
+            ]
+        )
+        == 2
+    )
+    assert "--base-sha is required" in capsys.readouterr().err
+
+
+def test_base_revision_fetch_has_a_finite_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[list[str], dict[str, object]]] = []
+    responses = [
+        MagicMock(returncode=1, stdout=b"", stderr=b""),
+        MagicMock(returncode=0, stdout="", stderr=""),
+        MagicMock(returncode=0, stdout=b"", stderr=b""),
+    ]
+
+    def _run(command: list[str], **kwargs: object) -> MagicMock:
+        calls.append((command, kwargs))
+        return responses.pop(0)
+
+    monkeypatch.setattr(pr_scope.subprocess, "run", _run)
+
+    pr_scope._ensure_local_commit("a" * 40)
+
+    assert calls[1][0][:2] == ["git", "fetch"]
+    assert calls[1][1]["timeout"] == 120
 
 
 @pytest.mark.parametrize("version", [True, 1.0])

--- a/tests/unit/devtools/test_pr_scope.py
+++ b/tests/unit/devtools/test_pr_scope.py
@@ -189,6 +189,38 @@ def test_v2_body_file_check_requires_base_revision(
     assert "--base-sha is required" in capsys.readouterr().err
 
 
+def test_v2_body_file_check_refuses_a_checkout_other_than_the_supplied_head(
+    monkeypatch: pytest.MonkeyPatch, beads_path: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    scope_input = tmp_path / "scope.json"
+    scope_input.write_text(json.dumps(_v2_input()))
+    assert (
+        pr_scope.main(["render", "--input", str(scope_input), "--head-sha", HEAD_SHA, "--beads-path", str(beads_path)])
+        == 0
+    )
+    body_path = tmp_path / "body.md"
+    body_path.write_text(capsys.readouterr().out)
+    monkeypatch.setattr(pr_scope, "_git_head_sha", lambda: "c" * 40)
+
+    assert (
+        pr_scope.main(
+            [
+                "check",
+                "--body-file",
+                str(body_path),
+                "--head-sha",
+                HEAD_SHA,
+                "--base-sha",
+                "b" * 40,
+                "--beads-path",
+                str(beads_path),
+            ]
+        )
+        == 2
+    )
+    assert "current checkout HEAD does not match" in capsys.readouterr().err
+
+
 def test_base_revision_fetch_has_a_finite_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[tuple[list[str], dict[str, object]]] = []
     responses = [
@@ -228,6 +260,7 @@ def test_render_rejects_non_integer_carrier_versions(
 def test_v2_check_rejects_an_unlisted_bead_mutation_via_the_production_command(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
+    monkeypatch.setattr(pr_scope, "_require_checkout_authority", lambda **_kwargs: None)
     repository = tmp_path / "repository"
     beads_path = repository / ".beads" / "issues.jsonl"
     beads_path.parent.mkdir(parents=True)
@@ -343,6 +376,7 @@ def test_v2_self_contained_scope_rejects_a_real_bead_mutation(
 def test_v2_deleted_mutated_bead_stays_in_bead_scope(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
+    monkeypatch.setattr(pr_scope, "_require_checkout_authority", lambda **_kwargs: None)
     repository = tmp_path / "repository"
     beads_path = repository / ".beads" / "issues.jsonl"
     beads_path.parent.mkdir(parents=True)
@@ -409,6 +443,7 @@ def test_v2_deleted_mutated_bead_stays_in_bead_scope(
 def test_v2_mutation_scope_uses_the_pr_merge_base_not_the_moved_target_tip(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
+    monkeypatch.setattr(pr_scope, "_require_checkout_authority", lambda **_kwargs: None)
     repository = tmp_path / "repository"
     beads_path = repository / ".beads" / "issues.jsonl"
     beads_path.parent.mkdir(parents=True)
@@ -554,6 +589,7 @@ def test_pr_check_uses_public_github_rest_without_cli_auth(
     monkeypatch.delenv("GH_TOKEN", raising=False)
     monkeypatch.setattr(request, "urlopen", _urlopen)
     monkeypatch.setattr(pr_scope, "_git_head_sha", lambda: HEAD_SHA)
+    monkeypatch.setattr(pr_scope, "_beads_snapshot_matches_head", lambda _path: True)
     monkeypatch.setattr(pr_scope, "changed_bead_ids", lambda **_kwargs: [])
 
     exit_code = pr_scope.main(["check", "--pr", "42", "--repo", "Sinity/polylogue", "--beads-path", str(beads_path)])
@@ -577,6 +613,21 @@ def test_pr_check_refuses_a_checkout_other_than_the_fetched_head(
 
     assert pr_scope.main(["check", "--pr", "42", "--repo", "Sinity/polylogue", "--beads-path", str(beads_path)]) == 2
     assert "current checkout HEAD does not match the fetched PR head" in capsys.readouterr().err
+
+
+def test_pr_check_refuses_uncommitted_bead_contents(
+    monkeypatch: pytest.MonkeyPatch, beads_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    metadata = pr_scope.PullRequestMetadata(
+        body=_body(_input(), beads_path), head_sha=HEAD_SHA, base_sha="b" * 40, is_draft=False
+    )
+    monkeypatch.setattr(pr_scope, "resolve_repository", lambda _repo: "Sinity/polylogue")
+    monkeypatch.setattr(pr_scope, "fetch_pr_metadata", lambda *_args, **_kwargs: metadata)
+    monkeypatch.setattr(pr_scope, "_git_head_sha", lambda: HEAD_SHA)
+    monkeypatch.setattr(pr_scope, "_beads_snapshot_matches_head", lambda _path: False)
+
+    assert pr_scope.main(["check", "--pr", "42", "--repo", "Sinity/polylogue", "--beads-path", str(beads_path)]) == 2
+    assert "Beads snapshot does not match the committed PR head" in capsys.readouterr().err
 
 
 def test_ci_resolves_pr_from_exact_head_when_circle_pr_url_is_absent(
@@ -928,6 +979,38 @@ def test_changed_bead_ids_fetches_missing_target_commit_before_merge_base(
     assert calls.index(["git", "fetch", "--no-tags", "--quiet", "origin", base_sha]) < calls.index(
         ["git", "merge-base", base_sha, "HEAD"]
     )
+
+
+def test_changed_bead_ids_unshallows_before_retrying_the_merge_base(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_sha = "b" * 40
+    calls: list[tuple[list[str], dict[str, object]]] = []
+    merge_base_attempts = 0
+
+    def run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        nonlocal merge_base_attempts
+        calls.append((argv, kwargs))
+        if argv[:3] == ["git", "cat-file", "-e"]:
+            return subprocess.CompletedProcess(argv, 0, "", "")
+        if argv[:2] == ["git", "merge-base"]:
+            merge_base_attempts += 1
+            output = "a" * 40 + "\n" if merge_base_attempts == 2 else ""
+            return subprocess.CompletedProcess(argv, 0 if output else 1, output, "")
+        if argv == ["git", "rev-parse", "--is-shallow-repository"]:
+            return subprocess.CompletedProcess(argv, 0, "true\n", "")
+        if argv[:2] == ["git", "fetch"]:
+            return subprocess.CompletedProcess(argv, 0, "", "")
+        raise AssertionError(f"unexpected command: {argv}")
+
+    monkeypatch.setattr(subprocess, "run", run)
+    monkeypatch.setattr(pr_scope, "_bead_records_at", lambda _sha: {})
+    monkeypatch.setattr(pr_scope, "load_bead_records", lambda _path: {})
+
+    assert pr_scope.changed_bead_ids(base_sha=base_sha) == []
+    unshallow = next(item for item in calls if "--unshallow" in item[0])
+    assert unshallow[1]["timeout"] == 120
+    assert merge_base_attempts == 2
 
 
 def test_check_rejects_carrier_bound_to_a_different_head_sha(

--- a/tests/unit/devtools/test_pr_scope.py
+++ b/tests/unit/devtools/test_pr_scope.py
@@ -799,6 +799,35 @@ def test_ci_check_refuses_draft_before_fetching_base(
     fetch_base.assert_not_called()
 
 
+def test_ci_check_refuses_uncommitted_bead_contents_before_fetching_base(
+    monkeypatch: pytest.MonkeyPatch,
+    beads_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    metadata = pr_scope.PullRequestMetadata(
+        body=_body(_input(), beads_path),
+        head_sha=HEAD_SHA,
+        base_sha="b" * 40,
+        is_draft=False,
+    )
+    fetch_base = MagicMock()
+    monkeypatch.setattr(pr_scope, "fetch_base_validator_source", fetch_base)
+    monkeypatch.setattr(pr_scope, "_beads_snapshot_matches_head", lambda _path: False)
+
+    assert (
+        pr_scope.check_ci_metadata(
+            metadata,
+            repository="Sinity/polylogue",
+            beads_path=beads_path,
+            checkout_head_sha=HEAD_SHA,
+            expected_head_sha=HEAD_SHA,
+        )
+        == 2
+    )
+    assert "Beads snapshot does not match the committed PR head" in capsys.readouterr().err
+    fetch_base.assert_not_called()
+
+
 def test_ci_accepts_authoritative_dependabot_dependency_only_pr(
     monkeypatch: pytest.MonkeyPatch,
     beads_path: Path,
@@ -815,6 +844,7 @@ def test_ci_accepts_authoritative_dependabot_dependency_only_pr(
     )
     fetch_base = MagicMock()
     monkeypatch.setattr(pr_scope, "fetch_base_validator_source", fetch_base)
+    monkeypatch.setattr(pr_scope, "_beads_snapshot_matches_head", lambda _path: True)
 
     assert (
         pr_scope.check_ci_metadata(
@@ -868,6 +898,7 @@ def test_ci_rejects_spoofed_or_extra_file_automated_scope(
     fetch_base.return_value = b"not a validator"
     monkeypatch.setattr(pr_scope, "fetch_base_validator_source", fetch_base)
     monkeypatch.setattr(pr_scope, "_run_validator_source", lambda *_args, **_kwargs: 1)
+    monkeypatch.setattr(pr_scope, "_beads_snapshot_matches_head", lambda _path: True)
 
     assert (
         pr_scope.check_ci_metadata(
@@ -896,6 +927,7 @@ def test_ci_check_executes_base_revision_validator(
     current_validator = MagicMock(return_value=pr_scope.ScopeVerdict(ok=True))
     monkeypatch.setattr(pr_scope, "fetch_base_validator_source", lambda **_kwargs: base_source)
     monkeypatch.setattr(pr_scope, "validate_pr_body", current_validator)
+    monkeypatch.setattr(pr_scope, "_beads_snapshot_matches_head", lambda _path: True)
 
     exit_code = pr_scope.check_ci_metadata(
         metadata,
@@ -921,6 +953,7 @@ def test_ci_check_bootstraps_once_when_base_has_no_validator(
     )
     monkeypatch.setattr(pr_scope, "fetch_base_validator_source", lambda **_kwargs: None)
     monkeypatch.setattr(pr_scope, "changed_bead_ids", lambda **_kwargs: [])
+    monkeypatch.setattr(pr_scope, "_beads_snapshot_matches_head", lambda _path: True)
 
     assert (
         pr_scope.check_ci_metadata(

--- a/tests/unit/devtools/test_pr_scope.py
+++ b/tests/unit/devtools/test_pr_scope.py
@@ -51,6 +51,22 @@ def _input(disposition: str = "satisfied", successors: list[str] | None = None) 
     }
 
 
+def _v2_input() -> dict[str, object]:
+    return {
+        "scope_kind": "bead",
+        "assigned_beads": [ASSIGNED],
+        "mutated_beads": [],
+        "dispositions": [
+            {
+                "bead_id": ASSIGNED,
+                "disposition": "satisfied",
+                "evidence": [{"kind": "test", "ref": "tests/unit/devtools/test_pr_scope.py"}],
+                "successors": [],
+            }
+        ],
+    }
+
+
 def _body(input_payload: dict[str, object], beads_path: Path, *, head_sha: str = HEAD_SHA) -> str:
     carrier = dict(input_payload)
     carrier["version"] = 1
@@ -101,6 +117,125 @@ def test_rendered_carrier_passes_the_production_check_command(
     rendered = capsys.readouterr().out
 
     assert _check(rendered, beads_path, tmp_path, capsys).startswith("0\npr-scope OK")
+
+
+def test_v2_rendered_carrier_stays_valid_when_the_head_changes(
+    beads_path: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    scope_input = tmp_path / "scope.json"
+    scope_input.write_text(json.dumps(_v2_input()))
+
+    assert (
+        pr_scope.main(["render", "--input", str(scope_input), "--head-sha", HEAD_SHA, "--beads-path", str(beads_path)])
+        == 0
+    )
+    rendered = capsys.readouterr().out
+
+    assert "head_sha" not in rendered
+    assert "beads_digest" not in rendered
+    assert _check(rendered, beads_path, tmp_path, capsys, head_sha="b" * 40).startswith("0\npr-scope OK")
+
+
+def test_v2_self_contained_scope_needs_no_invented_bead(
+    beads_path: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    scope_input = tmp_path / "scope.json"
+    scope_input.write_text(
+        json.dumps({"scope_kind": "self_contained", "assigned_beads": [], "mutated_beads": [], "dispositions": []})
+    )
+
+    assert (
+        pr_scope.main(["render", "--input", str(scope_input), "--head-sha", HEAD_SHA, "--beads-path", str(beads_path)])
+        == 0
+    )
+    rendered = capsys.readouterr().out
+
+    assert _check(rendered, beads_path, tmp_path, capsys, head_sha="b" * 40).startswith("0\npr-scope OK")
+
+
+def test_v2_check_rejects_an_unlisted_bead_mutation_via_the_production_command(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repository = tmp_path / "repository"
+    beads_path = repository / ".beads" / "issues.jsonl"
+    beads_path.parent.mkdir(parents=True)
+    beads_path.write_text(json.dumps(_record(ASSIGNED)) + "\n")
+    subprocess.run(["git", "init", "-q", str(repository)], check=True)
+    subprocess.run(["git", "-C", str(repository), "add", ".beads/issues.jsonl"], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repository),
+            "-c",
+            "user.name=Polylogue test",
+            "-c",
+            "user.email=polylogue-test@example.invalid",
+            "commit",
+            "-qm",
+            "base Bead state",
+        ],
+        check=True,
+    )
+    base_sha = subprocess.run(
+        ["git", "-C", str(repository), "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    changed = _record(ASSIGNED, title="changed tracker record")
+    beads_path.write_text(json.dumps(changed) + "\n")
+    scope_input = repository / "scope.json"
+    scope_input.write_text(json.dumps(_v2_input()))
+    monkeypatch.chdir(repository)
+
+    assert (
+        pr_scope.main(["render", "--input", str(scope_input), "--head-sha", HEAD_SHA, "--beads-path", str(beads_path)])
+        == 0
+    )
+    rendered = capsys.readouterr().out
+    body_path = repository / "body.md"
+    body_path.write_text(rendered)
+
+    assert (
+        pr_scope.main(
+            [
+                "check",
+                "--body-file",
+                str(body_path),
+                "--head-sha",
+                HEAD_SHA,
+                "--base-sha",
+                base_sha,
+                "--beads-path",
+                str(beads_path),
+            ]
+        )
+        == 1
+    )
+    assert "mutated_beads does not match the complete Bead mutation set" in capsys.readouterr().out
+
+
+def test_sync_reports_a_head_bound_attestation_without_rewriting_the_body(
+    monkeypatch: pytest.MonkeyPatch, beads_path: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    scope_input = tmp_path / "scope.json"
+    scope_input.write_text(json.dumps(_v2_input()))
+    assert (
+        pr_scope.main(["render", "--input", str(scope_input), "--head-sha", HEAD_SHA, "--beads-path", str(beads_path)])
+        == 0
+    )
+    body = capsys.readouterr().out
+    metadata = pr_scope.PullRequestMetadata(body=body, head_sha=HEAD_SHA, base_sha="b" * 40, is_draft=False)
+    monkeypatch.setattr(pr_scope, "fetch_pr_metadata", lambda *_args, **_kwargs: metadata)
+    monkeypatch.setattr(pr_scope, "resolve_repository", lambda _repo: "Sinity/polylogue")
+    monkeypatch.setattr(pr_scope, "changed_bead_ids", lambda **_kwargs: [])
+
+    assert pr_scope.main(["sync", "--pr", "42", "--repo", "Sinity/polylogue", "--beads-path", str(beads_path)]) == 0
+    attestation = json.loads(capsys.readouterr().out)
+
+    assert attestation["head_sha"] == HEAD_SHA
+    assert attestation["beads_digest"] == pr_scope.canonical_beads_digest(
+        pr_scope.load_bead_records(beads_path), [ASSIGNED], carrier_version=2
+    )
+    assert attestation["attestation_digest"]
 
 
 def test_pr_check_uses_public_github_rest_without_cli_auth(

--- a/tests/unit/devtools/test_pr_scope.py
+++ b/tests/unit/devtools/test_pr_scope.py
@@ -201,7 +201,7 @@ def test_base_revision_fetch_has_a_finite_timeout(monkeypatch: pytest.MonkeyPatc
         calls.append((command, kwargs))
         return responses.pop(0)
 
-    monkeypatch.setattr(pr_scope.subprocess, "run", _run)
+    monkeypatch.setattr(subprocess, "run", _run)
 
     pr_scope._ensure_local_commit("a" * 40)
 

--- a/tests/unit/devtools/test_pr_scope.py
+++ b/tests/unit/devtools/test_pr_scope.py
@@ -841,6 +841,36 @@ def test_fetch_base_validator_prefers_local_base_object(
     github_fetch.assert_not_called()
 
 
+def test_changed_bead_ids_fetches_missing_target_commit_before_merge_base(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_sha = "b" * 40
+    calls: list[list[str]] = []
+    cat_file_attempts = 0
+
+    def run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        nonlocal cat_file_attempts
+        calls.append(argv)
+        if argv[:3] == ["git", "cat-file", "-e"]:
+            cat_file_attempts += 1
+            return subprocess.CompletedProcess(argv, 0 if cat_file_attempts == 2 else 1, "", "")
+        if argv[:2] == ["git", "fetch"]:
+            return subprocess.CompletedProcess(argv, 0, "", "")
+        if argv[:2] == ["git", "merge-base"]:
+            return subprocess.CompletedProcess(argv, 0, "a" * 40 + "\n", "")
+        raise AssertionError(f"unexpected command: {argv}")
+
+    monkeypatch.setattr(subprocess, "run", run)
+    monkeypatch.setattr(pr_scope, "_bead_records_at", lambda _sha: {})
+    monkeypatch.setattr(pr_scope, "load_bead_records", lambda _path: {})
+
+    assert pr_scope.changed_bead_ids(base_sha=base_sha) == []
+    assert ["git", "fetch", "--no-tags", "--quiet", "origin", base_sha] in calls
+    assert calls.index(["git", "fetch", "--no-tags", "--quiet", "origin", base_sha]) < calls.index(
+        ["git", "merge-base", base_sha, "HEAD"]
+    )
+
+
 def test_check_rejects_carrier_bound_to_a_different_head_sha(
     beads_path: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/unit/devtools/test_pr_scope.py
+++ b/tests/unit/devtools/test_pr_scope.py
@@ -153,6 +153,22 @@ def test_v2_self_contained_scope_needs_no_invented_bead(
     assert _check(rendered, beads_path, tmp_path, capsys, head_sha="b" * 40).startswith("0\npr-scope OK")
 
 
+@pytest.mark.parametrize("version", [True, 1.0])
+def test_render_rejects_non_integer_carrier_versions(
+    version: object, beads_path: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    scope_input = tmp_path / "scope.json"
+    payload = _v2_input()
+    payload["version"] = version
+    scope_input.write_text(json.dumps(payload))
+
+    assert (
+        pr_scope.main(["render", "--input", str(scope_input), "--head-sha", HEAD_SHA, "--beads-path", str(beads_path)])
+        == 2
+    )
+    assert "input version must be 1 or 2" in capsys.readouterr().err
+
+
 def test_v2_check_rejects_an_unlisted_bead_mutation_via_the_production_command(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -237,37 +253,13 @@ def test_v2_check_rejects_an_unlisted_bead_mutation_via_the_production_command(
     assert "legacy v1 carrier cannot omit Bead mutations" in capsys.readouterr().out
 
 
-def test_v2_self_contained_scope_can_declare_a_real_bead_mutation(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+def test_v2_self_contained_scope_rejects_a_real_bead_mutation(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     repository = tmp_path / "repository"
     beads_path = repository / ".beads" / "issues.jsonl"
     beads_path.parent.mkdir(parents=True)
     beads_path.write_text(json.dumps(_record(ASSIGNED)) + "\n")
-    subprocess.run(["git", "init", "-q", str(repository)], check=True)
-    subprocess.run(["git", "-C", str(repository), "add", ".beads/issues.jsonl"], check=True)
-    subprocess.run(
-        [
-            "git",
-            "-C",
-            str(repository),
-            "-c",
-            "user.name=Polylogue test",
-            "-c",
-            "user.email=polylogue-test@example.invalid",
-            "-c",
-            "commit.gpgsign=false",
-            "-c",
-            "core.hooksPath=",
-            "commit",
-            "-qm",
-            "base Bead state",
-        ],
-        check=True,
-    )
-    base_sha = subprocess.run(
-        ["git", "-C", str(repository), "rev-parse", "HEAD"], capture_output=True, text=True, check=True
-    ).stdout.strip()
     beads_path.write_text(json.dumps(_record(ASSIGNED, title="changed by a self-contained PR")) + "\n")
     scope_input = repository / "scope.json"
     scope_input.write_text(
@@ -275,41 +267,32 @@ def test_v2_self_contained_scope_can_declare_a_real_bead_mutation(
             {"scope_kind": "self_contained", "assigned_beads": [], "mutated_beads": [ASSIGNED], "dispositions": []}
         )
     )
-    monkeypatch.chdir(repository)
-
-    assert (
-        pr_scope.main(["render", "--input", str(scope_input), "--head-sha", HEAD_SHA, "--beads-path", str(beads_path)])
-        == 0
-    )
-    body_path = repository / "body.md"
-    body_path.write_text(capsys.readouterr().out)
-
     assert (
         pr_scope.main(
             [
-                "check",
-                "--body-file",
-                str(body_path),
+                "render",
+                "--input",
+                str(scope_input),
                 "--head-sha",
                 HEAD_SHA,
-                "--base-sha",
-                base_sha,
                 "--beads-path",
                 str(beads_path),
             ]
         )
-        == 0
+        == 2
     )
-    assert capsys.readouterr().out.startswith("pr-scope OK")
+    assert "self_contained scope cannot declare or mutate Beads" in capsys.readouterr().err
 
 
-def test_v2_deleted_mutated_bead_stays_in_the_mutation_scope(
+def test_v2_deleted_mutated_bead_stays_in_bead_scope(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     repository = tmp_path / "repository"
     beads_path = repository / ".beads" / "issues.jsonl"
     beads_path.parent.mkdir(parents=True)
-    beads_path.write_text(json.dumps(_record(ASSIGNED)) + "\n")
+    beads_path.write_text(
+        "\n".join(json.dumps(record) for record in [_record(ASSIGNED), _record(OTHER_ASSIGNED)]) + "\n"
+    )
     subprocess.run(["git", "init", "-q", str(repository)], check=True)
     subprocess.run(["git", "-C", str(repository), "add", ".beads/issues.jsonl"], check=True)
     subprocess.run(
@@ -334,13 +317,11 @@ def test_v2_deleted_mutated_bead_stays_in_the_mutation_scope(
     base_sha = subprocess.run(
         ["git", "-C", str(repository), "rev-parse", "HEAD"], capture_output=True, text=True, check=True
     ).stdout.strip()
-    beads_path.write_text("")
+    beads_path.write_text(json.dumps(_record(ASSIGNED)) + "\n")
     scope_input = repository / "scope.json"
-    scope_input.write_text(
-        json.dumps(
-            {"scope_kind": "self_contained", "assigned_beads": [], "mutated_beads": [ASSIGNED], "dispositions": []}
-        )
-    )
+    payload = _v2_input()
+    payload["mutated_beads"] = [OTHER_ASSIGNED]
+    scope_input.write_text(json.dumps(payload))
     monkeypatch.chdir(repository)
 
     assert (
@@ -460,6 +441,7 @@ def test_sync_reports_a_head_bound_attestation_without_rewriting_the_body(
     monkeypatch.setattr(pr_scope, "resolve_repository", lambda _repo: "Sinity/polylogue")
     monkeypatch.setattr(pr_scope, "_git_head_sha", lambda: HEAD_SHA)
     monkeypatch.setattr(pr_scope, "changed_bead_ids", lambda **_kwargs: [])
+    monkeypatch.setattr(pr_scope, "_beads_snapshot_matches_head", lambda _path: True)
 
     assert pr_scope.main(["sync", "--pr", "42", "--repo", "Sinity/polylogue", "--beads-path", str(beads_path)]) == 0
     attestation = json.loads(capsys.readouterr().out)
@@ -470,6 +452,27 @@ def test_sync_reports_a_head_bound_attestation_without_rewriting_the_body(
         pr_scope.load_bead_records(beads_path), [ASSIGNED], carrier_version=2
     )
     assert attestation["attestation_digest"]
+
+
+def test_sync_refuses_uncommitted_bead_contents(
+    monkeypatch: pytest.MonkeyPatch, beads_path: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    scope_input = tmp_path / "scope.json"
+    scope_input.write_text(json.dumps(_v2_input()))
+    assert (
+        pr_scope.main(["render", "--input", str(scope_input), "--head-sha", HEAD_SHA, "--beads-path", str(beads_path)])
+        == 0
+    )
+    metadata = pr_scope.PullRequestMetadata(
+        body=capsys.readouterr().out, head_sha=HEAD_SHA, base_sha="b" * 40, is_draft=False
+    )
+    monkeypatch.setattr(pr_scope, "fetch_pr_metadata", lambda *_args, **_kwargs: metadata)
+    monkeypatch.setattr(pr_scope, "resolve_repository", lambda _repo: "Sinity/polylogue")
+    monkeypatch.setattr(pr_scope, "_git_head_sha", lambda: HEAD_SHA)
+    monkeypatch.setattr(pr_scope, "_beads_snapshot_matches_head", lambda _path: False)
+
+    assert pr_scope.main(["sync", "--pr", "42", "--repo", "Sinity/polylogue", "--beads-path", str(beads_path)]) == 2
+    assert "Beads snapshot does not match the committed PR head" in capsys.readouterr().err
 
 
 def test_pr_check_uses_public_github_rest_without_cli_auth(
@@ -929,6 +932,49 @@ def test_check_accepts_linked_residual_successor(
     result = _check(_body(_input("partial", [OPEN_SUCCESSOR]), beads_path), beads_path, tmp_path, capsys)
 
     assert result.startswith("0\n")
+
+
+def test_check_uses_prospective_merge_state_for_residual_successor(
+    monkeypatch: pytest.MonkeyPatch, beads_path: Path
+) -> None:
+    head_records = [_record(ASSIGNED), _record(OPEN_SUCCESSOR)]
+    head_records[1]["dependencies"] = [
+        {"issue_id": OPEN_SUCCESSOR, "depends_on_id": ASSIGNED, "type": "discovered-from"}
+    ]
+    beads_path.write_text("\n".join(json.dumps(record) for record in head_records) + "\n")
+    carrier = pr_scope.build_carrier(
+        {
+            "scope_kind": "bead",
+            "assigned_beads": [ASSIGNED],
+            "mutated_beads": [],
+            "dispositions": [
+                {
+                    "bead_id": ASSIGNED,
+                    "disposition": "partial",
+                    "evidence": [{"kind": "test", "ref": "prospective successor regression"}],
+                    "successors": [OPEN_SUCCESSOR],
+                }
+            ],
+        },
+        head_sha=HEAD_SHA,
+        beads_path=beads_path,
+    )
+    target_records = {record["id"]: record for record in head_records}
+    target_records[OPEN_SUCCESSOR] = _record(OPEN_SUCCESSOR, "closed")
+    target_records[OPEN_SUCCESSOR]["dependencies"] = head_records[1]["dependencies"]
+    monkeypatch.setattr(pr_scope, "changed_bead_ids", lambda **_kwargs: [])
+    monkeypatch.setattr(pr_scope, "_bead_records_at", lambda _revision: target_records)
+
+    verdict = pr_scope.validate_carrier(
+        carrier,
+        head_sha=HEAD_SHA,
+        is_draft=False,
+        beads_path=beads_path,
+        base_sha="b" * 40,
+    )
+
+    assert not verdict.ok
+    assert any(f"successor {OPEN_SUCCESSOR} is closed" in reason for reason in verdict.reasons)
 
 
 def test_check_rejects_stale_canonical_beads_digest(

--- a/tests/unit/devtools/test_pr_scope.py
+++ b/tests/unit/devtools/test_pr_scope.py
@@ -171,6 +171,10 @@ def test_v2_check_rejects_an_unlisted_bead_mutation_via_the_production_command(
             "user.name=Polylogue test",
             "-c",
             "user.email=polylogue-test@example.invalid",
+            "-c",
+            "commit.gpgsign=false",
+            "-c",
+            "core.hooksPath=",
             "commit",
             "-qm",
             "base Bead state",
@@ -213,6 +217,214 @@ def test_v2_check_rejects_an_unlisted_bead_mutation_via_the_production_command(
     assert "mutated_beads does not match the complete Bead mutation set" in capsys.readouterr().out
 
 
+def test_v2_self_contained_scope_can_declare_a_real_bead_mutation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repository = tmp_path / "repository"
+    beads_path = repository / ".beads" / "issues.jsonl"
+    beads_path.parent.mkdir(parents=True)
+    beads_path.write_text(json.dumps(_record(ASSIGNED)) + "\n")
+    subprocess.run(["git", "init", "-q", str(repository)], check=True)
+    subprocess.run(["git", "-C", str(repository), "add", ".beads/issues.jsonl"], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repository),
+            "-c",
+            "user.name=Polylogue test",
+            "-c",
+            "user.email=polylogue-test@example.invalid",
+            "-c",
+            "commit.gpgsign=false",
+            "-c",
+            "core.hooksPath=",
+            "commit",
+            "-qm",
+            "base Bead state",
+        ],
+        check=True,
+    )
+    base_sha = subprocess.run(
+        ["git", "-C", str(repository), "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    beads_path.write_text(json.dumps(_record(ASSIGNED, title="changed by a self-contained PR")) + "\n")
+    scope_input = repository / "scope.json"
+    scope_input.write_text(
+        json.dumps(
+            {"scope_kind": "self_contained", "assigned_beads": [], "mutated_beads": [ASSIGNED], "dispositions": []}
+        )
+    )
+    monkeypatch.chdir(repository)
+
+    assert (
+        pr_scope.main(["render", "--input", str(scope_input), "--head-sha", HEAD_SHA, "--beads-path", str(beads_path)])
+        == 0
+    )
+    body_path = repository / "body.md"
+    body_path.write_text(capsys.readouterr().out)
+
+    assert (
+        pr_scope.main(
+            [
+                "check",
+                "--body-file",
+                str(body_path),
+                "--head-sha",
+                HEAD_SHA,
+                "--base-sha",
+                base_sha,
+                "--beads-path",
+                str(beads_path),
+            ]
+        )
+        == 0
+    )
+    assert capsys.readouterr().out.startswith("pr-scope OK")
+
+
+def test_v2_deleted_mutated_bead_stays_in_the_mutation_scope(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repository = tmp_path / "repository"
+    beads_path = repository / ".beads" / "issues.jsonl"
+    beads_path.parent.mkdir(parents=True)
+    beads_path.write_text(json.dumps(_record(ASSIGNED)) + "\n")
+    subprocess.run(["git", "init", "-q", str(repository)], check=True)
+    subprocess.run(["git", "-C", str(repository), "add", ".beads/issues.jsonl"], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repository),
+            "-c",
+            "user.name=Polylogue test",
+            "-c",
+            "user.email=polylogue-test@example.invalid",
+            "-c",
+            "commit.gpgsign=false",
+            "-c",
+            "core.hooksPath=",
+            "commit",
+            "-qm",
+            "base Bead state",
+        ],
+        check=True,
+    )
+    base_sha = subprocess.run(
+        ["git", "-C", str(repository), "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    beads_path.write_text("")
+    scope_input = repository / "scope.json"
+    scope_input.write_text(
+        json.dumps(
+            {"scope_kind": "self_contained", "assigned_beads": [], "mutated_beads": [ASSIGNED], "dispositions": []}
+        )
+    )
+    monkeypatch.chdir(repository)
+
+    assert (
+        pr_scope.main(["render", "--input", str(scope_input), "--head-sha", HEAD_SHA, "--beads-path", str(beads_path)])
+        == 0
+    )
+    body_path = repository / "body.md"
+    body_path.write_text(capsys.readouterr().out)
+
+    assert (
+        pr_scope.main(
+            [
+                "check",
+                "--body-file",
+                str(body_path),
+                "--head-sha",
+                HEAD_SHA,
+                "--base-sha",
+                base_sha,
+                "--beads-path",
+                str(beads_path),
+            ]
+        )
+        == 0
+    )
+    assert capsys.readouterr().out.startswith("pr-scope OK")
+
+
+def test_v2_mutation_scope_uses_the_pr_merge_base_not_the_moved_target_tip(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repository = tmp_path / "repository"
+    beads_path = repository / ".beads" / "issues.jsonl"
+    beads_path.parent.mkdir(parents=True)
+    beads_path.write_text(
+        "\n".join(json.dumps(record) for record in [_record(ASSIGNED), _record(OTHER_ASSIGNED)]) + "\n"
+    )
+    subprocess.run(["git", "init", "-q", str(repository)], check=True)
+    subprocess.run(["git", "-C", str(repository), "add", ".beads/issues.jsonl"], check=True)
+    commit = [
+        "git",
+        "-C",
+        str(repository),
+        "-c",
+        "user.name=Polylogue test",
+        "-c",
+        "user.email=polylogue-test@example.invalid",
+        "-c",
+        "commit.gpgsign=false",
+        "-c",
+        "core.hooksPath=",
+        "commit",
+        "-qm",
+    ]
+    subprocess.run([*commit, "shared base"], check=True)
+    shared_base = subprocess.run(
+        ["git", "-C", str(repository), "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    beads_path.write_text(
+        "\n".join(
+            json.dumps(record) for record in [_record(ASSIGNED), _record(OTHER_ASSIGNED, title="upstream change")]
+        )
+        + "\n"
+    )
+    subprocess.run(["git", "-C", str(repository), "add", ".beads/issues.jsonl"], check=True)
+    subprocess.run([*commit, "target branch changed Bead"], check=True)
+    moved_target = subprocess.run(
+        ["git", "-C", str(repository), "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    subprocess.run(["git", "-C", str(repository), "checkout", "-q", "-b", "feature", shared_base], check=True)
+    beads_path.write_text(
+        "\n".join(json.dumps(record) for record in [_record(ASSIGNED, title="feature change"), _record(OTHER_ASSIGNED)])
+        + "\n"
+    )
+    scope_input = repository / "scope.json"
+    scope_input.write_text(json.dumps(_v2_input() | {"mutated_beads": [ASSIGNED]}))
+    monkeypatch.chdir(repository)
+
+    assert (
+        pr_scope.main(["render", "--input", str(scope_input), "--head-sha", HEAD_SHA, "--beads-path", str(beads_path)])
+        == 0
+    )
+    body_path = repository / "body.md"
+    body_path.write_text(capsys.readouterr().out)
+
+    assert (
+        pr_scope.main(
+            [
+                "check",
+                "--body-file",
+                str(body_path),
+                "--head-sha",
+                HEAD_SHA,
+                "--base-sha",
+                moved_target,
+                "--beads-path",
+                str(beads_path),
+            ]
+        )
+        == 0
+    )
+    assert capsys.readouterr().out.startswith("pr-scope OK")
+
+
 def test_sync_reports_a_head_bound_attestation_without_rewriting_the_body(
     monkeypatch: pytest.MonkeyPatch, beads_path: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -226,12 +438,14 @@ def test_sync_reports_a_head_bound_attestation_without_rewriting_the_body(
     metadata = pr_scope.PullRequestMetadata(body=body, head_sha=HEAD_SHA, base_sha="b" * 40, is_draft=False)
     monkeypatch.setattr(pr_scope, "fetch_pr_metadata", lambda *_args, **_kwargs: metadata)
     monkeypatch.setattr(pr_scope, "resolve_repository", lambda _repo: "Sinity/polylogue")
+    monkeypatch.setattr(pr_scope, "_git_head_sha", lambda: HEAD_SHA)
     monkeypatch.setattr(pr_scope, "changed_bead_ids", lambda **_kwargs: [])
 
     assert pr_scope.main(["sync", "--pr", "42", "--repo", "Sinity/polylogue", "--beads-path", str(beads_path)]) == 0
     attestation = json.loads(capsys.readouterr().out)
 
     assert attestation["head_sha"] == HEAD_SHA
+    assert attestation["base_sha"] == "b" * 40
     assert attestation["beads_digest"] == pr_scope.canonical_beads_digest(
         pr_scope.load_bead_records(beads_path), [ASSIGNED], carrier_version=2
     )
@@ -260,6 +474,7 @@ def test_pr_check_uses_public_github_rest_without_cli_auth(
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.delenv("GH_TOKEN", raising=False)
     monkeypatch.setattr(request, "urlopen", _urlopen)
+    monkeypatch.setattr(pr_scope, "_git_head_sha", lambda: HEAD_SHA)
 
     exit_code = pr_scope.main(["check", "--pr", "42", "--repo", "Sinity/polylogue", "--beads-path", str(beads_path)])
 
@@ -268,6 +483,20 @@ def test_pr_check_uses_public_github_rest_without_cli_auth(
     assert len(requests) == 1
     assert requests[0].full_url == "https://api.github.com/repos/Sinity/polylogue/pulls/42"
     assert requests[0].get_header("Authorization") is None
+
+
+def test_pr_check_refuses_a_checkout_other_than_the_fetched_head(
+    monkeypatch: pytest.MonkeyPatch, beads_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    metadata = pr_scope.PullRequestMetadata(
+        body=_body(_input(), beads_path), head_sha=HEAD_SHA, base_sha="b" * 40, is_draft=False
+    )
+    monkeypatch.setattr(pr_scope, "resolve_repository", lambda _repo: "Sinity/polylogue")
+    monkeypatch.setattr(pr_scope, "fetch_pr_metadata", lambda *_args, **_kwargs: metadata)
+    monkeypatch.setattr(pr_scope, "_git_head_sha", lambda: "c" * 40)
+
+    assert pr_scope.main(["check", "--pr", "42", "--repo", "Sinity/polylogue", "--beads-path", str(beads_path)]) == 2
+    assert "current checkout HEAD does not match the fetched PR head" in capsys.readouterr().err
 
 
 def test_ci_resolves_pr_from_exact_head_when_circle_pr_url_is_absent(
@@ -507,6 +736,7 @@ def test_ci_rejects_spoofed_or_extra_file_automated_scope(
     fetch_base = MagicMock()
     fetch_base.return_value = b"not a validator"
     monkeypatch.setattr(pr_scope, "fetch_base_validator_source", fetch_base)
+    monkeypatch.setattr(pr_scope, "_run_validator_source", lambda *_args, **_kwargs: 1)
 
     assert (
         pr_scope.check_ci_metadata(


### PR DESCRIPTION
## Summary

Keep PR scope intent stable across commits. The v2 carrier leaves exact head and canonical Bead bindings to the existing merge-gate receipt, adds complete tracker-mutation scope, and supports explicitly self-contained PRs.

## Problem

The v1 PR-body carrier embeds `head_sha` and `beads_digest`. Each commit therefore requires a body edit before CircleCI can validate the pushed head, even though GitHub metadata and merge-gate receipts already identify the current commit. The carrier also had no structured self-contained form and could not declare all changed Bead records.

Ref `polylogue-pr-scope-contract`.

## Solution

`devtools/pr_scope.py` accepts v1 during transition only when the Bead mutation set is empty, then renders v2 stable intent for all tracker changes. `sync --pr` reports a current head-bound attestation without editing the PR body. `merge_gate.py` now refuses an unrelated or dirty checkout, and `merge_boundary.py` refreshes receipts when the attestation changes. Mutation comparison uses the PR merge base, not a moved target tip. The PR template, command catalog, generated reference, CLAUDE.md, and lane guidance document the v2 publication flow.

The PR body uses a v1 carrier only for this transition because the current base-revision validator is v1. Once this PR is on master, new PRs can use v2 without body churn.

## Verification

- `devtools test tests/unit/devtools/test_pr_scope.py tests/unit/devtools/test_merge_gate.py tests/unit/devtools/test_merge_boundary.py`: `126 passed in 2.34s`.
- `mypy devtools/pr_scope.py devtools/merge_gate.py`: `Success: no issues found in 2 source files`.
- `git diff --check`: no output.
- The pre-push quick baseline passed format, lint, and mypy before publication.

The fresh `devtools verify --seed-testmon --skip-slow` discovery run was stopped after it made no test progress; its completed static, render, documentation, and policy steps are retained in the local receipt. It is not claimed as a passing baseline.

## Bead disposition matrix

| Assigned Bead | Whole-Bead disposition | Evidence refs | Named successor for residual work |
| --- | --- | --- | --- |
| `polylogue-pr-scope-contract` | partial | `commit:558be6773`, `commit:3e14b3c22`, `commit:f9e39e8a6`, `commit:a6b67f5dc`, `commit:c8f8c23d7`, `commit:6b6ea6767`, `commit:f2d0518ad`, `commit:7566a7ee8`, `commit:d6211df13`, `commit:e08e4d122`, `test:126 focused tests`, `command:mypy` | `polylogue-inygw` |

<!-- polylogue-pr-scope:v1
{
  "assigned_beads": [
    "polylogue-pr-scope-contract"
  ],
  "beads_digest": "2fcc5983e78955d7eca8a80a68715d220eb29d502bc6070adf377f79fd57ac06",
  "dispositions": [
    {
      "bead_id": "polylogue-pr-scope-contract",
      "disposition": "partial",
      "evidence": [
        {
          "kind": "commit",
          "ref": "558be67734fa2c98c4cc327f6fddeb19f50fa8f1"
        },
        {
          "kind": "commit",
          "ref": "3e14b3c22fc70458f08d918b0ee9eb2181f31c88"
        },
        {
          "kind": "commit",
          "ref": "f9e39e8a61a6f79fb599b99070af726802a8e69c"
        },
        {
          "kind": "commit",
          "ref": "a6b67f5dcb23aa181062020579c327f7782a116e"
        },
        {
          "kind": "test",
          "ref": "devtools test tests/unit/devtools/test_pr_scope.py tests/unit/devtools/test_merge_gate.py tests/unit/devtools/test_merge_boundary.py: 126 passed"
        },
        {
          "kind": "command",
          "ref": "mypy devtools/pr_scope.py devtools/merge_gate.py devtools/merge_boundary.py: Success: no issues found in 3 source files"
        },
        {
          "kind": "commit",
          "ref": "c8f8c23d7c9fe81b599a10a5e0731b82d9490f5a"
        },
        {
          "kind": "commit",
          "ref": "6b6ea6767714fe79aae811d95092c2506c01d272"
        },
        {
          "kind": "commit",
          "ref": "f2d0518addd60dfa7d52b6782f6cc46852722109"
        },
        {
          "kind": "commit",
          "ref": "7566a7ee810dff2c8e1fa7fcd49a995f08e8a509"
        },
        {
          "kind": "commit",
          "ref": "d6211df13e45b566d66402b23f46fa51c73d3d89"
        },
        {
          "kind": "commit",
          "ref": "e08e4d122863d2f7d305dea29af37f205d586336"
        },
        {
          "kind": "test",
          "ref": "devtools test tests/unit/devtools/test_pr_scope.py tests/unit/devtools/test_merge_gate.py: 79 passed"
        }
      ],
      "successors": [
        "polylogue-inygw"
      ]
    }
  ],
  "head_sha": "686b3253ba37664dd3c14bfa76a622bad675923a",
  "scope_digest": "82d391352aa26875a847822ede6537282d674c063800597cc2ca9dcfba97aad1",
  "version": 1
}
-->
