### PR TITLE
test: cover aggregate invalid-json warning

### DIFF
--- a/tests/unit/sources/test_source_laws.py
+++ b/tests/unit/sources/test_source_laws.py
@@ -376,9 +376,11 @@ def test_iter_json_stream_jsonl_invalid_line_logging_contract(monkeypatch: pytes
     items = list(_iter_json_stream(BytesIO(raw), "test.jsonl"))
 
     assert items == [{"id": 1}]
-    # First 3 non-trailing broken lines get warning level
-    assert len(warnings) == 3
-    assert all("Skipping invalid JSON line in test.jsonl" in w for w in warnings)
+    # The first 3 non-trailing broken lines get individual warnings, followed
+    # by the decoder's aggregate warning for further malformed records.
+    assert len(warnings) == 4
+    assert all("Skipping invalid JSON line in test.jsonl" in w for w in warnings[:3])
+    assert warnings[3] == "Skipped 4 invalid JSON lines in test.jsonl"
     # Trailing broken line gets debug (in-progress file truncation tolerance)
     assert any("Skipping truncated trailing line in test.jsonl" in d for d in debugs)
 


### PR DESCRIPTION
## Summary
Align the JSONL decoder regression test with the existing aggregate warning emitted after multiple malformed records.

## Problem
The current master test expects only three warning records, but the production decoder intentionally emits three per-line warnings plus a fourth aggregate count warning. This leaves the current source-law suite red without indicating a decoder defect.

## Solution
Assert the three individual warnings and the exact aggregate warning while retaining the trailing-line debug assertion. No production behavior changes.

## Verification
- `devtools test tests/unit/sources/test_source_laws.py` — 133 passed
- `devtools verify --quick` — all 25 steps passed
- No Beads state was changed; this is a self-contained correction to a stale oracle.

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->
