### PR TITLE
perf(testmon): coarsen resumable seed shards

### DIFF
--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -221,7 +221,11 @@ TESTMON_SEED_STAMP = Path(".cache/testmon/seed.json")
 TESTMON_SEED_ATTEMPT = Path(".cache/testmon/seed-attempt.json")
 TESTMON_AFFECTED_STAMP = Path(".cache/testmon/affected.json")
 TESTMON_SEED_PROTOCOL_VERSION = 7
-TESTMON_SEED_SHARD_SIZE = 256
+# Keep resumable checkpoints coarse enough that controller startup and
+# per-shard testmon initialization do not dominate the seed.  The seed still
+# records every node outcome, so a failed shard remains retryable at node
+# resolution; this size yields six shards for the current correctness corpus.
+TESTMON_SEED_SHARD_SIZE = 4096
 PYTEST_REPORT_DIR = Path(".cache/verify")
 PYTEST_REPORT_PATH = PYTEST_REPORT_DIR / "last-pytest.json"
 PYTEST_JUNIT_REPORT_DIR = Path(".cache/test-reports")
@@ -2643,12 +2647,12 @@ def _prepare_testmon_seed_shards(
 
 
 def _seed_shard_command(collection_command: Sequence[str], shard: Mapping[str, Any]) -> list[str]:
-    """Build a serial, explicit-node pytest-testmon invocation for one shard."""
+    """Build a dynamically balanced explicit-node pytest-testmon invocation."""
     nodeids = shard.get("nodeids")
     if not isinstance(nodeids, list) or not nodeids:
         raise ValueError("testmon seed shard is missing nodeids")
     command = [argument for argument in collection_command if argument != "--collect-only"]
-    command.extend(["--testmon", "--testmon-noselect", *nodeids])
+    command.extend(["--dist=worksteal", "--testmon", "--testmon-noselect", *nodeids])
     return command
 
 

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -326,7 +326,7 @@ def test_seed_shards_are_deterministic_and_use_one_testmon_writer(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.chdir(tmp_path)
-    expected = [f"tests/test_seed.py::test_{index:03d}" for index in range(TESTMON_SEED_SHARD_SIZE + 2)]
+    expected = sorted(f"tests/test_seed.py::test_{index:03d}" for index in range(TESTMON_SEED_SHARD_SIZE + 2))
     prepared = _prepare_testmon_seed_shards(
         {"resume": False, "expected_nodeids": []},
         selection={
@@ -345,6 +345,7 @@ def test_seed_shards_are_deterministic_and_use_one_testmon_writer(
     assert command[command.index("-n") + 1] == "0"
     assert "--testmon" in command
     assert "--testmon-noselect" in command
+    assert "--dist=worksteal" in command
     assert command[-TESTMON_SEED_SHARD_SIZE:] == expected[:TESTMON_SEED_SHARD_SIZE]
 
 


### PR DESCRIPTION
## Summary

Make the resumable testmon seed operationally bounded on the current correctness corpus.

## Problem

The merged seed protocol split 20,964 nodes into 82 serial 256-node controllers. A single property-heavy shard took 9.5 minutes, making a complete seed multi-hour despite healthy tmpfs, memory, and xdist workers. Fixed node chunks also left expensive tests unevenly scheduled.

## Solution

- increase the resumable checkpoint size to 4,096 nodes, producing six shards for the current corpus;
- use xdist `worksteal` within each shard to keep workers productive around long property fixtures;
- retain per-node event/outcome recording and resumability;
- align the shard determinism regression with the canonical lexicographic node ordering.

## Verification

- `.venv/bin/python -m devtools test tests/unit/devtools/test_verify.py` — 150 passed;
- `.venv/bin/python -m devtools verify --quick` — all 25 steps passed at `a1b78b775`;
- terminal baseline diagnostic on merged master demonstrated the prior 256-node serial-shard bottleneck and preserved its partial ledger.

This is a self-contained test-harness performance fix; it does not claim the full suite is green.

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->
