### PR TITLE
fix(testmon): stop seed admission after harness failures

### DIFF
--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -1834,6 +1834,21 @@ def _stop_after_failed_step(label: str) -> bool:
     return label.startswith("pytest") or label in {"lab smoke", "bench slo"}
 
 
+def _seed_shard_failure_requires_stop(step: Mapping[str, Any]) -> bool:
+    """Stop shard admission after harness failure while retaining red-test evidence.
+
+    A normal pytest exit 1 with a structured ``pytest_failed`` diagnosis is
+    useful seed evidence: later shards can still populate the resumable
+    dependency graph. Timeouts, resource refusals, worker/internal errors,
+    usage errors, and unclassified failures mean the harness is no longer
+    healthy enough to admit another expensive shard.
+    """
+    exit_code = step.get("exit")
+    if exit_code == 0:
+        return False
+    return not (exit_code == 1 and step.get("diagnosis") == "pytest_failed")
+
+
 # ── step builder ────────────────────────────────────────────────────
 
 
@@ -3440,8 +3455,11 @@ def main(argv: list[str] | None = None) -> int:
                     shard_index=shard_index,
                     step=shard_result,
                 )
-                if shard_rc != 0 and exit_code == 0:
-                    exit_code = shard_rc
+                if shard_rc != 0:
+                    if exit_code == 0:
+                        exit_code = shard_rc
+                    if _seed_shard_failure_requires_stop(shard_result):
+                        break
             continue
         if label in {"pytest testmon", "pytest testmon (broad)"} and not args.seed_testmon and not full_pytest:
             _refresh_testmon_selection_attempt(step=step_result, run=verify_run, exit_code=rc)

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -3456,9 +3456,13 @@ def main(argv: list[str] | None = None) -> int:
                     step=shard_result,
                 )
                 if shard_rc != 0:
-                    if exit_code == 0:
+                    stop_seed = _seed_shard_failure_requires_stop(shard_result)
+                    if exit_code == 0 or stop_seed:
+                        # A later infrastructure failure is the terminal
+                        # condition even when an earlier shard recorded
+                        # ordinary red-test evidence.
                         exit_code = shard_rc
-                    if _seed_shard_failure_requires_stop(shard_result):
+                    if stop_seed:
                         break
             continue
         if label in {"pytest testmon", "pytest testmon (broad)"} and not args.seed_testmon and not full_pytest:

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -1834,7 +1834,7 @@ def _stop_after_failed_step(label: str) -> bool:
     return label.startswith("pytest") or label in {"lab smoke", "bench slo"}
 
 
-def _seed_shard_failure_requires_stop(step: Mapping[str, Any]) -> bool:
+def _seed_shard_failure_requires_stop(step: Mapping[str, Any], *, shard_complete: bool) -> bool:
     """Stop shard admission after harness failure while retaining red-test evidence.
 
     A normal pytest exit 1 with a structured ``pytest_failed`` diagnosis is
@@ -1846,7 +1846,7 @@ def _seed_shard_failure_requires_stop(step: Mapping[str, Any]) -> bool:
     exit_code = step.get("exit")
     if exit_code == 0:
         return False
-    return not (exit_code == 1 and step.get("diagnosis") == "pytest_failed")
+    return not (exit_code == 1 and step.get("diagnosis") == "pytest_failed" and shard_complete)
 
 
 # ── step builder ────────────────────────────────────────────────────
@@ -3455,8 +3455,19 @@ def main(argv: list[str] | None = None) -> int:
                     shard_index=shard_index,
                     step=shard_result,
                 )
+                checkpointed_shards = prepared_seed_attempt.get("shards")
+                if (
+                    not isinstance(checkpointed_shards, list)
+                    or shard_index > len(checkpointed_shards)
+                    or not isinstance(checkpointed_shards[shard_index - 1], Mapping)
+                ):
+                    raise RuntimeError("testmon seed shard checkpoint is malformed")
+                shard_complete = checkpointed_shards[shard_index - 1].get("status") == SeedShardStatus.COMPLETE.value
                 if shard_rc != 0:
-                    stop_seed = _seed_shard_failure_requires_stop(shard_result)
+                    stop_seed = _seed_shard_failure_requires_stop(
+                        shard_result,
+                        shard_complete=shard_complete,
+                    )
                     if exit_code == 0 or stop_seed:
                         # A later infrastructure failure is the terminal
                         # condition even when an earlier shard recorded
@@ -3499,13 +3510,21 @@ def main(argv: list[str] | None = None) -> int:
         "total_duration_s": total_duration,
         "exit_code": exit_code,
     }
-    pytest_diagnosis = next(
+    fallback_pytest_diagnosis = next(
         (
             str(step["diagnosis"])
-            for step in step_results
+            for step in reversed(step_results)
             if str(step.get("name", "")).startswith("pytest") and "diagnosis" in step
         ),
         None,
+    )
+    pytest_diagnosis = next(
+        (
+            str(step["diagnosis"])
+            for step in reversed(step_results)
+            if str(step.get("name", "")).startswith("pytest") and step.get("exit") == exit_code and "diagnosis" in step
+        ),
+        fallback_pytest_diagnosis,
     )
     if pytest_diagnosis is not None:
         history_entry["diagnosis"] = pytest_diagnosis

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -3162,22 +3162,31 @@ def test_verify_stops_after_failed_heavy_step(capsys: pytest.CaptureFixture[str]
 
 
 @pytest.mark.parametrize(
-    ("shard_results", "expected_exit", "expected_statuses"),
+    ("shard_results", "expected_exit", "expected_diagnosis", "expected_statuses"),
     [
         (
             [(124, "pytest_timeout"), (0, "pytest_passed")],
             124,
+            "pytest_timeout",
             ["incomplete", "pending"],
         ),
         (
             [(1, "pytest_failed"), (0, "pytest_passed")],
             1,
+            "pytest_failed",
             ["complete", "complete"],
         ),
         (
             [(1, "pytest_failed"), (124, "pytest_timeout")],
             124,
+            "pytest_timeout",
             ["complete", "incomplete"],
+        ),
+        (
+            [(1, "pytest_failed"), (0, "pytest_passed")],
+            1,
+            "pytest_failed",
+            ["incomplete", "pending"],
         ),
     ],
 )
@@ -3187,6 +3196,7 @@ def test_seed_testmon_stops_only_after_infrastructure_failed_shard(
     capsys: pytest.CaptureFixture[str],
     shard_results: list[tuple[int, str]],
     expected_exit: int,
+    expected_diagnosis: str,
     expected_statuses: list[str],
 ) -> None:
     nodeids = ["tests/test_seed.py::test_one", "tests/test_seed.py::test_two"]
@@ -3223,12 +3233,7 @@ def test_seed_testmon_stops_only_after_infrastructure_failed_shard(
         assert isinstance(raw_shards, list)
         assert all(isinstance(shard, dict) for shard in raw_shards)
         shards = [dict(shard) for shard in raw_shards]
-        shard_exit, diagnosis = shard_results[shard_index - 1]
-        shards[shard_index - 1]["status"] = (
-            "incomplete"
-            if verify._seed_shard_failure_requires_stop({"exit": shard_exit, "diagnosis": diagnosis})
-            else "complete"
-        )
+        shards[shard_index - 1]["status"] = expected_statuses[shard_index - 1]
         return {**prepared, "shards": shards}
 
     def fake_finalize(
@@ -3282,7 +3287,9 @@ def test_seed_testmon_stops_only_after_infrastructure_failed_shard(
     ]
     assert checkpointed == list(range(1, executed_shards + 1))
     assert finalized_shard_statuses == expected_statuses
-    assert json.loads(capsys.readouterr().out)["exit_code"] == expected_exit
+    output = json.loads(capsys.readouterr().out)
+    assert output["exit_code"] == expected_exit
+    assert output["diagnosis"] == expected_diagnosis
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -3162,6 +3162,117 @@ def test_verify_stops_after_failed_heavy_step(capsys: pytest.CaptureFixture[str]
 
 
 @pytest.mark.parametrize(
+    ("first_exit", "first_diagnosis", "expected_calls", "expected_statuses"),
+    [
+        (
+            124,
+            "pytest_timeout",
+            ["pytest seed-testmon collect", "pytest seed-testmon shard 1/2"],
+            ["incomplete", "pending"],
+        ),
+        (
+            1,
+            "pytest_failed",
+            [
+                "pytest seed-testmon collect",
+                "pytest seed-testmon shard 1/2",
+                "pytest seed-testmon shard 2/2",
+            ],
+            ["complete", "complete"],
+        ),
+    ],
+)
+def test_seed_testmon_stops_only_after_infrastructure_failed_shard(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    first_exit: int,
+    first_diagnosis: str,
+    expected_calls: list[str],
+    expected_statuses: list[str],
+) -> None:
+    nodeids = ["tests/test_seed.py::test_one", "tests/test_seed.py::test_two"]
+    collection_dir = tmp_path / "collection"
+    collection_dir.mkdir()
+    (collection_dir / "selection.json").write_text(
+        json.dumps(
+            {
+                "selected_count": len(nodeids),
+                "selected_nodeids": nodeids,
+                "selected_nodeids_omitted": 0,
+            }
+        )
+    )
+    calls: list[str] = []
+    checkpointed: list[int] = []
+    finalized_shard_statuses: list[str] = []
+
+    def fake_run(label: str, command: list[str], **kwargs: object) -> tuple[int, float, dict[str, object]]:
+        del command, kwargs
+        calls.append(label)
+        if label == "pytest seed-testmon collect":
+            return 0, 0.01, {"artifact_dir": str(collection_dir)}
+        if label == "pytest seed-testmon shard 1/2":
+            return first_exit, 0.01, {"diagnosis": first_diagnosis}
+        if label == "pytest seed-testmon shard 2/2":
+            return 0, 0.01, {"diagnosis": "pytest_passed"}
+        pytest.fail(f"unexpected seed step: {label}")
+
+    def fake_checkpoint(*, prepared: dict[str, object], shard_index: int, step: dict[str, object]) -> dict[str, object]:
+        del step
+        checkpointed.append(shard_index)
+        shards = [dict(shard) for shard in prepared["shards"]]  # type: ignore[union-attr]
+        shards[shard_index - 1]["status"] = "incomplete" if shard_index == 1 and first_exit == 124 else "complete"
+        return {**prepared, "shards": shards}
+
+    def fake_finalize(
+        *, prepared: dict[str, object], step_results: list[dict[str, object]], exit_code: int
+    ) -> dict[str, object]:
+        del step_results
+        assert exit_code == first_exit
+        finalized_shard_statuses.extend(str(shard["status"]) for shard in prepared["shards"])  # type: ignore[union-attr]
+        return {
+            "status": "incomplete" if first_exit == 124 else "complete",
+            "outcome": "resource_timeout" if first_exit == 124 else "red-baseline",
+            "resume": False,
+            "expected_count": len(nodeids),
+            "release_baseline_allowed": False,
+        }
+
+    monkeypatch.setattr(verify, "TESTMON_SEED_SHARD_SIZE", 1)
+    with (
+        patch("devtools.verify._anchor_verification_paths"),
+        patch("devtools.verify.maybe_bootstrap_testmon_seed", return_value=None),
+        patch("devtools.verify._run", side_effect=fake_run),
+        patch(
+            "devtools.verify.build_verify_steps",
+            return_value=[("pytest seed-testmon collect", ["pytest", "--collect-only"])],
+        ),
+        patch("devtools.verify._git_head", return_value="head"),
+        patch("devtools.verify._git_committed_tree", return_value="tree"),
+        patch(
+            "devtools.verify._testmon_seed_identity",
+            return_value={"git_head": "head", "git_tree": "tree", "skip_slow": False, "lab": False},
+        ),
+        patch("devtools.verify._testmon_seed_can_resume", return_value=False),
+        patch("devtools.verify._checkpoint_testmon_seed_shard", side_effect=fake_checkpoint),
+        patch("devtools.verify._finalize_testmon_seed_attempt", side_effect=fake_finalize),
+        patch("devtools.verify._testmon_release_baseline_permission", return_value=False),
+        patch("devtools.verify._warn_low_memory"),
+        patch("devtools.verify._save_history"),
+        patch("devtools.verify._stamp_head"),
+        patch("devtools.verify._notify"),
+    ):
+        rc = main(["--seed-testmon", "--json"])
+
+    assert rc == first_exit
+    assert calls == expected_calls
+    assert checkpointed == list(range(1, len(expected_calls)))
+    assert finalized_shard_statuses == expected_statuses
+    assert json.loads(capsys.readouterr().out)["exit_code"] == first_exit
+
+
+@pytest.mark.parametrize(
     ("argv", "expected_scope", "expected_permission"),
     [
         (["--all", "--skip-slow"], "narrow-terminal", False),

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -3221,7 +3221,10 @@ def test_seed_testmon_stops_only_after_infrastructure_failed_shard(
     def fake_checkpoint(*, prepared: dict[str, object], shard_index: int, step: dict[str, object]) -> dict[str, object]:
         del step
         checkpointed.append(shard_index)
-        shards = [dict(shard) for shard in prepared["shards"]]  # type: ignore[union-attr]
+        raw_shards = prepared["shards"]
+        assert isinstance(raw_shards, list)
+        assert all(isinstance(shard, dict) for shard in raw_shards)
+        shards = [dict(shard) for shard in raw_shards]
         shards[shard_index - 1]["status"] = "incomplete" if shard_index == 1 and first_exit == 124 else "complete"
         return {**prepared, "shards": shards}
 
@@ -3230,7 +3233,10 @@ def test_seed_testmon_stops_only_after_infrastructure_failed_shard(
     ) -> dict[str, object]:
         del step_results
         assert exit_code == first_exit
-        finalized_shard_statuses.extend(str(shard["status"]) for shard in prepared["shards"])  # type: ignore[union-attr]
+        raw_shards = prepared["shards"]
+        assert isinstance(raw_shards, list)
+        assert all(isinstance(shard, dict) for shard in raw_shards)
+        finalized_shard_statuses.extend(str(shard["status"]) for shard in raw_shards)
         return {
             "status": "incomplete" if first_exit == 124 else "complete",
             "outcome": "resource_timeout" if first_exit == 124 else "red-baseline",

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -3162,23 +3162,22 @@ def test_verify_stops_after_failed_heavy_step(capsys: pytest.CaptureFixture[str]
 
 
 @pytest.mark.parametrize(
-    ("first_exit", "first_diagnosis", "expected_calls", "expected_statuses"),
+    ("shard_results", "expected_exit", "expected_statuses"),
     [
         (
+            [(124, "pytest_timeout"), (0, "pytest_passed")],
             124,
-            "pytest_timeout",
-            ["pytest seed-testmon collect", "pytest seed-testmon shard 1/2"],
             ["incomplete", "pending"],
         ),
         (
+            [(1, "pytest_failed"), (0, "pytest_passed")],
             1,
-            "pytest_failed",
-            [
-                "pytest seed-testmon collect",
-                "pytest seed-testmon shard 1/2",
-                "pytest seed-testmon shard 2/2",
-            ],
             ["complete", "complete"],
+        ),
+        (
+            [(1, "pytest_failed"), (124, "pytest_timeout")],
+            124,
+            ["complete", "incomplete"],
         ),
     ],
 )
@@ -3186,9 +3185,8 @@ def test_seed_testmon_stops_only_after_infrastructure_failed_shard(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
-    first_exit: int,
-    first_diagnosis: str,
-    expected_calls: list[str],
+    shard_results: list[tuple[int, str]],
+    expected_exit: int,
     expected_statuses: list[str],
 ) -> None:
     nodeids = ["tests/test_seed.py::test_one", "tests/test_seed.py::test_two"]
@@ -3212,10 +3210,10 @@ def test_seed_testmon_stops_only_after_infrastructure_failed_shard(
         calls.append(label)
         if label == "pytest seed-testmon collect":
             return 0, 0.01, {"artifact_dir": str(collection_dir)}
-        if label == "pytest seed-testmon shard 1/2":
-            return first_exit, 0.01, {"diagnosis": first_diagnosis}
-        if label == "pytest seed-testmon shard 2/2":
-            return 0, 0.01, {"diagnosis": "pytest_passed"}
+        if label.startswith("pytest seed-testmon shard "):
+            shard_index = int(label.rsplit(" ", 1)[1].split("/", 1)[0])
+            shard_exit, diagnosis = shard_results[shard_index - 1]
+            return shard_exit, 0.01, {"diagnosis": diagnosis}
         pytest.fail(f"unexpected seed step: {label}")
 
     def fake_checkpoint(*, prepared: dict[str, object], shard_index: int, step: dict[str, object]) -> dict[str, object]:
@@ -3225,21 +3223,26 @@ def test_seed_testmon_stops_only_after_infrastructure_failed_shard(
         assert isinstance(raw_shards, list)
         assert all(isinstance(shard, dict) for shard in raw_shards)
         shards = [dict(shard) for shard in raw_shards]
-        shards[shard_index - 1]["status"] = "incomplete" if shard_index == 1 and first_exit == 124 else "complete"
+        shard_exit, diagnosis = shard_results[shard_index - 1]
+        shards[shard_index - 1]["status"] = (
+            "incomplete"
+            if verify._seed_shard_failure_requires_stop({"exit": shard_exit, "diagnosis": diagnosis})
+            else "complete"
+        )
         return {**prepared, "shards": shards}
 
     def fake_finalize(
         *, prepared: dict[str, object], step_results: list[dict[str, object]], exit_code: int
     ) -> dict[str, object]:
         del step_results
-        assert exit_code == first_exit
+        assert exit_code == expected_exit
         raw_shards = prepared["shards"]
         assert isinstance(raw_shards, list)
         assert all(isinstance(shard, dict) for shard in raw_shards)
         finalized_shard_statuses.extend(str(shard["status"]) for shard in raw_shards)
         return {
-            "status": "incomplete" if first_exit == 124 else "complete",
-            "outcome": "resource_timeout" if first_exit == 124 else "red-baseline",
+            "status": "incomplete" if "incomplete" in expected_statuses else "complete",
+            "outcome": "resource_timeout" if expected_exit == 124 else "red-baseline",
             "resume": False,
             "expected_count": len(nodeids),
             "release_baseline_allowed": False,
@@ -3271,11 +3274,15 @@ def test_seed_testmon_stops_only_after_infrastructure_failed_shard(
     ):
         rc = main(["--seed-testmon", "--json"])
 
-    assert rc == first_exit
-    assert calls == expected_calls
-    assert checkpointed == list(range(1, len(expected_calls)))
+    assert rc == expected_exit
+    executed_shards = sum(status != "pending" for status in expected_statuses)
+    assert calls == [
+        "pytest seed-testmon collect",
+        *(f"pytest seed-testmon shard {index}/2" for index in range(1, executed_shards + 1)),
+    ]
+    assert checkpointed == list(range(1, executed_shards + 1))
     assert finalized_shard_statuses == expected_statuses
-    assert json.loads(capsys.readouterr().out)["exit_code"] == first_exit
+    assert json.loads(capsys.readouterr().out)["exit_code"] == expected_exit
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Stop resumable testmon seed admission after an infrastructure-fatal shard while preserving continued dependency capture after ordinary red tests.

## Problem

The failed seed run at `/realm/worktrees/polylogue-testmon-final/.cache/verify/runs/20260812T114200Z-seed-testmon-55347-bc4afc5f` timed out shard 1 after 2,700.84 seconds, then immediately attempted shard 2. At timeout, the shard had completed 3,860/4,096 nodes, peaked at 2,568,784 KiB process-tree RSS and 2,221,538 KiB PSS, used 571,952 KiB swap PSS, and issued 27,789,180,928 bytes of writes while the basetemp peaked at only 97,570 KiB. Admitting more work after that bounded resource stop produced no trustworthy release baseline and obscured the original terminal condition.

Ordinary assertion failures are different: their testmon rows remain useful, and later shards should continue to populate the resumable graph.

PR #3960 owns bounded response-file argv and managed worker execution. This change is intentionally disjoint: it controls admission after a shard has already returned.

## Solution

- classify shard results at the seed-loop boundary;
- continue only for a structured ordinary pytest red result (`exit 1`, `pytest_failed`);
- checkpoint and stop before another shard after timeouts, resource refusals, worker/internal errors, usage errors, or unclassified failures;
- cover both mutations: removing the stop re-admits work after timeout, while an unconditional stop loses useful dependency evidence after red tests.

## Verification

- `.venv/bin/python -m devtools test tests/unit/devtools/test_verify.py -k 'stops_only_after_infrastructure_failed_shard or seed_resource_timeout_has_a_distinct_typed_terminal_outcome'` — 5 passed, 149 deselected in 1.81s.
- `.venv/bin/python -m devtools test tests/unit/devtools/test_verify.py` — 154 passed in 19.93s.
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m devtools verify --quick` — all 25 steps passed in 196.05s at exact head `6aa95bea4`; strict mypy passed over 2,735 files.
- Real-route diagnostic: `devtools test` over the oversized annotation-batch API node and lexical archive-query node — 1 passed, 1 pre-existing failure in 7.94s. The query call took 6.2385s versus 28.4543s in the serial testmon shard. The existing API failure is `ReadOnlyArchiveError: read-only archive evidence cannot mutate user.db`; it is retained unchanged.
- Default `devtools verify` — refused before tests because this linked worktree has no completed testmon seed. No replacement multi-hour seed was started while PR #3960 owns that repair.

## Residual baseline

The supplied seed artifact is not green: it includes existing API/reindex/convergence failures and terminated before completing the 20,965-node corpus. This PR neither excludes those nodes nor grants release authority.

## Bead disposition

| Scope | Disposition | Evidence |
| --- | --- | --- |
| Self-contained harness fix | Satisfied | Commits `85e0b3512`, `1c4959e76`, `d11742db0`, `6aa95bea4`; focused and module verification above |
| Beads | Unchanged | No assigned or mutated Beads |

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->
