### PR TITLE
test: make pathology mutations behavior-sensitive

### DIFF
--- a/tests/infra/pathology_zoo.py
+++ b/tests/infra/pathology_zoo.py
@@ -121,22 +121,22 @@ _PATHOLOGY_ZOO_MUTATIONS: dict[str, PathologyZooMutation] = {
     "claude-vintage-live-proof": PathologyZooMutation(
         "source",
         """
-        DELETE FROM raw_sessions
+        UPDATE raw_session_memberships
+        SET decision = 'superseded_prefix'
         WHERE raw_id = (
             SELECT r.raw_id
             FROM raw_sessions AS r
             JOIN raw_session_memberships AS m ON m.raw_id = r.raw_id
             WHERE r.origin = ?
               AND m.logical_source_key = ?
-              AND r.source_path LIKE ?
-            ORDER BY r.source_path DESC
+              AND m.decision = 'superseded_equivalent'
+            ORDER BY r.source_path
             LIMIT 1
         )
         """,
         (
             Origin.CLAUDE_AI_EXPORT.value,
             f"claude-ai:{CLAUDE_VINTAGE_LIVE_PROOF_SESSION_ID}",
-            "%claude-live-proof-new.json",
         ),
     ),
     "lifecycle-anchor-drift": PathologyZooMutation(

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -2084,27 +2084,10 @@ def test_pathology_zoo_contract_is_production_owned_and_registered() -> None:
     from polylogue.maintenance.pathology_zoo import PATHOLOGY_ZOO_MANIFEST, pathology_zoo_manifest
 
     registered_manifest = pathology_zoo_manifest()
-    expected_member_ids = (
-        "whale-component",
-        "append-self-describing",
-        "append-opaque",
-        "fork-prefix-tail",
-        "lineage-cycle",
-        "grouped-jsonl",
-        "quarantined-head",
-        "empty-session",
-        "hook-event",
-        "claude-design",
-        "vintage-reorder",
-        "claude-vintage-live-proof",
-        "lifecycle-anchor-drift",
-        "non-stream-safe",
-        "attachment-with-bytes",
-        "attachment-without-bytes",
-        "events-sidecars",
-    )
     assert registered_manifest is PATHOLOGY_ZOO_MANIFEST
-    assert tuple(member.member_id for member in registered_manifest) == expected_member_ids
+    assert registered_manifest
+    assert len({member.member_id for member in registered_manifest}) == len(registered_manifest)
+    assert all(member.motivating_beads for member in registered_manifest)
     assert "pathology-zoo-invariants" in ARCHIVE_VERIFICATION_CHECK_NAMES
 
 

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -2088,6 +2088,7 @@ def test_pathology_zoo_contract_is_production_owned_and_registered() -> None:
     assert registered_manifest
     assert len({member.member_id for member in registered_manifest}) == len(registered_manifest)
     assert all(member.motivating_beads for member in registered_manifest)
+    assert {"append-self-describing", "append-opaque"} <= {member.member_id for member in registered_manifest}
     assert "pathology-zoo-invariants" in ARCHIVE_VERIFICATION_CHECK_NAMES
 
 
@@ -2405,11 +2406,11 @@ def test_pathology_zoo_claude_vintage_registered_invariant_rejects_each_semantic
                     "UPDATE raw_session_memberships SET decision = 'superseded_prefix' WHERE raw_id = ?",
                     (raw_id,),
                 )
+            elif drift == "missing":
+                conn.execute("DELETE FROM raw_sessions WHERE raw_id = ?", (rows[0][0],))
             conn.commit()
 
-        if drift == "missing":
-            make_pathology_zoo_member_red(mutated_root, "claude-vintage-live-proof")
-        elif drift == "overpopulation":
+        if drift == "overpopulation":
             extra_raw_id = _insert_claude_vintage_extra_revision(mutated_root / "source.db")
             with sqlite3.connect(mutated_root / "source.db") as conn:
                 aggregate = conn.execute(


### PR DESCRIPTION
## Summary

- Make the Claude vintage pathology red twin corrupt the membership verdict that the production invariant actually observes.
- Replace the duplicated 17-member fixture tuple with manifest-derived checks while independently requiring both append semantics.
- Exercise missing-member drift by deleting the scoped source row directly, keeping that oracle independent from verdict mutation.

## Problem

The generic Claude vintage mutation deleted a raw row, which could fail for reasons outside the membership authority the invariant is intended to protect. Archive verification also copied every pathology member ID into a second hard-coded registry, creating a maintenance-only test that drifted whenever the production manifest grew.

## Solution

`tests/infra/pathology_zoo.py` now changes the registered verdict from `superseded_equivalent` to `superseded_prefix`, so the red twin directly exercises the semantic membership decision. The missing-member mutation separately deletes the scoped raw row, proving deletion detection through a distinct path. `tests/unit/maintenance/test_archive_verification.py` now verifies the production manifest is non-empty, unique, fully linked to motivating Beads, and contains both self-describing and opaque append members without duplicating the complete registry.

This satisfies the implementation and test scope of `polylogue-kmt1c`. It does not claim a live cohort receipt or production archive mutation.

## Verification

- `devtools test --json tests/unit/infra/test_pathology_zoo.py tests/unit/infra/test_claude_vintage_live_proof.py tests/unit/maintenance/test_archive_verification.py::test_pathology_zoo_contract_is_production_owned_and_registered tests/unit/maintenance/test_archive_verification.py::test_pathology_zoo_invariants_red_twin tests/unit/maintenance/test_archive_verification.py::test_pathology_zoo_claude_vintage_registered_invariant_rejects_each_semantic_drift`
  - 13 passed in 28.54s.
- `devtools verify --quick --json`
  - 25 checks passed in 128.62s at exact head `58378a76b3d86e033159d8b8ab597475c8c2bfd2`.

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [
    "polylogue-kmt1c"
  ],
  "dispositions": [
    {
      "bead_id": "polylogue-kmt1c",
      "disposition": "satisfied",
      "evidence": [
        {
          "kind": "commit",
          "ref": "58378a76b3d86e033159d8b8ab597475c8c2bfd2"
        },
        {
          "kind": "test",
          "ref": ".cache/verify/runs/20260812T221236Z-focused-test-3609594-38224003/run.json"
        },
        {
          "kind": "receipt",
          "ref": ".cache/verify/runs/20260812T221351Z-quick-3621540-44225142/run.json"
        }
      ],
      "successors": []
    }
  ],
  "mutated_beads": [],
  "scope_digest": "8da2d347e4e4c49678957a78d06b2ac52f85cee66974ffa5f587ef2761d33f50",
  "scope_kind": "bead",
  "version": 2
}
-->
