### PR TITLE
fix(nix): bind bootstrap venv to devshell Python

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -485,18 +485,22 @@
           # older interpreter survived a toolchain bump forever and shadowed
           # the nix-provided python on PATH -- recreate whenever the
           # interpreter identity moves (version + free-threaded flag).
-          devshell_python_id="$(python3 -c 'import sys; print(sys.version.split()[0], sys._is_gil_enabled())')"
+          devshell_python="$(command -v python3)"
+          devshell_python_id="$("$devshell_python" -c 'import sys; print(sys.version.split()[0], sys._is_gil_enabled())')"
+          create_devshell_venv() {
+            uv venv --python "$devshell_python"
+          }
           venv_python_id=""
           if [ -x .venv/bin/python ]; then
             venv_python_id="$(.venv/bin/python -c 'import sys; print(sys.version.split()[0], getattr(sys, "_is_gil_enabled", lambda: True)())' 2>/dev/null || true)"
           fi
           if [ ! -d .venv ]; then
             echo "devshell: creating virtual environment ($devshell_python_id)" >&2
-            uv venv
+            create_devshell_venv
           elif [ "$venv_python_id" != "$devshell_python_id" ]; then
             echo "devshell: interpreter changed ($venv_python_id -> $devshell_python_id); recreating .venv" >&2
             rm -rf .venv
-            uv venv
+            create_devshell_venv
           fi
 
           # Activate venv

--- a/tests/unit/test_flake_devshell_bootstrap.py
+++ b/tests/unit/test_flake_devshell_bootstrap.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_BOOTSTRAP_START = "          # The venv must track the devShell interpreter."
+_BOOTSTRAP_END = "          # Activate venv"
+
+
+def _bootstrap_block() -> str:
+    flake = (REPO_ROOT / "flake.nix").read_text(encoding="utf-8")
+    start = flake.index(_BOOTSTRAP_START)
+    end = flake.index(_BOOTSTRAP_END, start)
+    return textwrap.dedent(flake[start:end])
+
+
+def _write_identity_python(path: Path, identity: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' {identity!r}\n",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+@pytest.mark.parametrize(
+    ("existing_identity", "expected_notice"),
+    [
+        pytest.param(None, "creating virtual environment", id="initial-creation"),
+        pytest.param("3.14.5 True", "interpreter changed", id="identity-repair"),
+    ],
+)
+def test_devshell_venv_bootstrap_binds_uv_to_active_python(
+    tmp_path: Path,
+    existing_identity: str | None,
+    expected_notice: str,
+) -> None:
+    """Execute the literal flake hook for creation and interpreter repair.
+
+    The fake uv intentionally creates no environment unless it receives the
+    active devshell executable via ``--python``. This fails against a bare
+    ``uv venv`` invocation, so it protects the real route where uv otherwise
+    selects its managed GIL interpreter instead of the Nix free-threaded one.
+    """
+    bin_dir = tmp_path / "bin"
+    active_python = bin_dir / "python3"
+    _write_identity_python(active_python, "3.14.4 False")
+    if existing_identity is not None:
+        _write_identity_python(tmp_path / ".venv" / "bin" / "python", existing_identity)
+
+    uv_args = tmp_path / "uv-args"
+    uv = bin_dir / "uv"
+    uv.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        'printf \'%s\\n\' "$@" > "$UV_ARGS"\n'
+        'test "${1:-}" = venv\n'
+        'test "${2:-}" = --python\n'
+        'test "${3:-}" = "$EXPECTED_PYTHON"\n'
+        "mkdir -p .venv/bin\n"
+        "printf '%s\\n' '#!/usr/bin/env bash' \"printf '%s\\\\n' '3.14.4 False'\" > .venv/bin/python\n"
+        "chmod +x .venv/bin/python\n",
+        encoding="utf-8",
+    )
+    uv.chmod(0o755)
+
+    result = subprocess.run(
+        ["bash", "-c", _bootstrap_block()],
+        cwd=tmp_path,
+        env=os.environ
+        | {
+            "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+            "UV_ARGS": str(uv_args),
+            "EXPECTED_PYTHON": str(active_python),
+        },
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert expected_notice in result.stderr
+    assert uv_args.read_text(encoding="utf-8").splitlines() == [
+        "venv",
+        "--python",
+        str(active_python),
+    ]


### PR DESCRIPTION
## Summary

Bind each checkout's bootstrap virtual environment to the exact Python interpreter supplied by the Nix devshell. This makes fresh and drifted worktrees converge onto an import-compatible environment automatically.

## Problem

The shell hook invoked bare `uv venv`. On this host that selected Python 3.14.5 with the GIL while the Nix devshell supplied Python 3.14.4 free-threaded modules, producing missing `_sysconfigdata_t_linux_x86_64-linux-gnu` and then missing-package failures. A linked worktree could therefore become unable to run its own devtools, tests, or pre-push gate.

## Solution

- Capture the devshell's absolute `python3` before inspecting or creating the checkout-local venv.
- Create and repair the venv with `uv venv --python "$devshell_python"`.
- Add a shell-hook regression that exercises both initial creation and interpreter-identity repair and rejects a return to bare `uv venv`.

## Verification

- `direnv allow && direnv exec . devtools test tests/unit/test_flake_devshell_bootstrap.py`: **2 passed in 1.08s**.
- `direnv exec . devtools verify --quick`: **all 25 checks passed in 170.8s**.
- The exact pushed head reused that fresh pre-push receipt and pushed successfully.

## Bead disposition matrix

| Assigned Bead | Whole-Bead disposition | Evidence refs | Named successor for residual work |
| --- | --- | --- | --- |
| n/a | self-contained | `test:tests/unit/test_flake_devshell_bootstrap.py`, `command:devtools verify --quick` | n/a |

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->

## Changelog

Internal development-environment repair; no user-facing changelog entry.
