### PR TITLE
fix(maintenance): follow configured archive root

### DIFF
--- a/polylogue/cli/commands/maintenance/_cursor_authority.py
+++ b/polylogue/cli/commands/maintenance/_cursor_authority.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import click
 
+from polylogue.paths import archive_root
+
 
 @click.command("cursor-authority-reconcile")
 @click.option("--source-path-file", type=click.Path(path_type=Path, dir_okay=False), default=None)
@@ -37,13 +39,24 @@ def cursor_authority_reconcile_command(
                 raise click.UsageError("--apply requires --plan, --backup-manifest, and --receipt")
             if source_path_file is not None or output_plan is not None:
                 raise click.UsageError("--apply does not accept --source-path-file or --output-plan")
-            result = apply_reconciliation(plan_path=plan_path, backup_manifest=backup_manifest, receipt=receipt)
+            root = archive_root()
+            result = apply_reconciliation(
+                plan_path=plan_path,
+                backup_manifest=backup_manifest,
+                receipt=receipt,
+                archive_root=root,
+            )
         else:
             if source_path_file is None or output_plan is None:
                 raise click.UsageError("dry-run requires --source-path-file and --output-plan")
             if plan_path is not None or backup_manifest is not None or receipt is not None:
                 raise click.UsageError("dry-run accepts only --source-path-file and --output-plan")
-            result = build_reconciliation_plan(source_path_file=source_path_file, output_plan=output_plan)
+            root = archive_root()
+            result = build_reconciliation_plan(
+                source_path_file=source_path_file,
+                output_plan=output_plan,
+                archive_root=root,
+            )
     except CursorAuthorityReconciliationError as exc:
         raise click.ClickException(str(exc)) from exc
     click.echo(json.dumps(result, indent=2, sort_keys=True))

--- a/polylogue/maintenance/corpus_fidelity.py
+++ b/polylogue/maintenance/corpus_fidelity.py
@@ -14,17 +14,10 @@ pass for a genuinely missing message.
 
 from __future__ import annotations
 
-import argparse
 import collections
-import json
 import sqlite3
-from pathlib import Path
 from typing import Any
 
-from polylogue.storage.archive_identity import resolve_active_index_path
-from polylogue.storage.sqlite.connection_profile import open_readonly_connection
-
-DEFAULT_ROOT = Path("/realm/db/polylogue")
 DEFAULT_SAMPLE_LIMIT = 10
 
 
@@ -228,89 +221,9 @@ def audit_revision_fidelity(
     }
 
 
-def audit_corpus_fidelity(archive_root: Path, *, sample_limit: int = DEFAULT_SAMPLE_LIMIT) -> dict[str, Any]:
-    """Run all corpus measurements against the active production tiers."""
-    source_path = archive_root / "source.db"
-    index_path = resolve_active_index_path(archive_root)
-    with open_readonly_connection(source_path) as source, open_readonly_connection(index_path) as index:
-        return {
-            "archive_root": str(archive_root),
-            "absences": audit_absences(source, index, sample_limit=sample_limit),
-            "attachment_fidelity": audit_attachment_fidelity(index),
-            "revision_fidelity": audit_revision_fidelity(source, index, sample_limit=sample_limit),
-        }
-
-
-def _failing_measures(report: dict[str, Any]) -> dict[str, int]:
-    absence = report["absences"]
-    attachment = report["attachment_fidelity"]
-    revision = report["revision_fidelity"]
-    failures = {
-        "absent_documents": int(absence["absent_total"]),
-        "raws_without_attributable_identity": int(absence["raws_without_attributable_identity"]),
-        "unfetched_attachment_refs": int(attachment["refs_unfetched"]),
-        "unprovenanced_unavailable_attachment_refs": int(attachment["refs_unavailable_without_provenance"]),
-        "unexplained_revision_shortfall": int(revision["unexplained_shortfall"]),
-    }
-    return {key: value for key, value in failures.items() if value}
-
-
-def format_report(report: dict[str, Any]) -> str:
-    """Render the operator-facing report used by the compatibility script."""
-    absence = report["absences"]
-    attachment = report["attachment_fidelity"]
-    revision = report["revision_fidelity"]
-    lines = [
-        f"archive: {report['archive_root']}",
-        f"\nABSENCES  {absence['absent_total']} of {absence['documents_known']} known documents",
-    ]
-    lines.extend(f"    {count:6d}  {key}" for key, count in absence["absent_by_origin_cause"].items())
-    if absence["raws_without_attributable_identity"]:
-        lines.append(f"    {absence['raws_without_attributable_identity']:6d}  raws-without-attributable-identity")
-    lines.append(
-        f"\nATTACHMENT FIDELITY  acquired={attachment['refs_acquired']} not-acquired={attachment['refs_not_acquired']}"
-    )
-    lines.extend(
-        f"    {count:6d}  {key}"
-        for key, count in sorted(attachment["breakdown"].items(), key=lambda item: -item[1])[:8]
-    )
-    lines.append(
-        f"\nREVISION FIDELITY  {revision['unexplained_shortfall']} unexplained, "
-        f"{revision['explained_by_event_reclassification']} explained by event reclassification"
-    )
-    lines.extend(
-        f"    {count:6d}  {origin}  (unexplained)" for origin, count in revision["unexplained_by_origin"].items()
-    )
-    failing = _failing_measures(report)
-    if failing:
-        lines.append("\nFAILING MEASURES")
-        lines.extend(f"    {value:8d}  {key}" for key, value in failing.items())
-    lines.append(f"\nVERDICT: {'PASS' if not failing else 'FAIL'}")
-    return "\n".join(lines)
-
-
-def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--archive-root", type=Path, default=DEFAULT_ROOT)
-    parser.add_argument("--json", type=Path, default=None)
-    args = parser.parse_args(argv)
-    report = audit_corpus_fidelity(args.archive_root)
-    failing = _failing_measures(report)
-    report["failing_measures"] = failing
-    report["verdict"] = "PASS" if not failing else "FAIL"
-    if args.json:
-        args.json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    print(format_report(report))
-    return 0 if not failing else 1
-
-
 __all__ = [
-    "DEFAULT_ROOT",
     "DEFAULT_SAMPLE_LIMIT",
     "audit_absences",
     "audit_attachment_fidelity",
-    "audit_corpus_fidelity",
     "audit_revision_fidelity",
-    "format_report",
-    "main",
 ]

--- a/polylogue/maintenance/cursor_authority_reconcile.py
+++ b/polylogue/maintenance/cursor_authority_reconcile.py
@@ -25,6 +25,7 @@ from polylogue.api import Polylogue
 from polylogue.config import Config
 from polylogue.core.enums import IngestOutcome
 from polylogue.operations.durable_change_train import acquire_durable_archive_ownership
+from polylogue.paths import archive_root as configured_archive_root
 from polylogue.pipeline.ingest_outcomes import IngestAttemptDisposition
 from polylogue.sources.live.batch import (
     LiveBatchProcessor,
@@ -41,7 +42,6 @@ from polylogue.storage.raw_retention import RawFrontierIntegrityProjection, raw_
 
 PLAN_FORMAT = "polylogue.cursor-authority-reconciliation-plan.v1"
 RECEIPT_FORMAT = "polylogue.cursor-authority-reconciliation-receipt.v1"
-ARCHIVE_ROOT = Path("/realm/db/polylogue")
 _REQUIRED_TIERS = ("source", "index", "ops", "audit")
 
 
@@ -95,14 +95,10 @@ def _stat_observation(path: Path) -> tuple[int, int, int, int, int]:
     return value.st_dev, value.st_ino, value.st_size, value.st_mtime_ns, value.st_ctime_ns
 
 
-def _archive_root() -> Path:
-    """Return the fixed archive root for this command.
+def _archive_root(explicit: Path | None = None) -> Path:
+    """Resolve one archive authority for the complete operation."""
 
-    This deliberately does not call ``polylogue.paths.archive_root`` or read
-    any ambient archive-root environment variable.
-    """
-
-    return ARCHIVE_ROOT
+    return explicit if explicit is not None else configured_archive_root()
 
 
 def _read_private_source_path(path_file: Path) -> Path:
@@ -549,7 +545,12 @@ def _validated_blob_inventory(
     }
 
 
-def _validate_backup(manifest_path: Path, plan: Mapping[str, object]) -> dict[str, object]:
+def _validate_backup(
+    manifest_path: Path,
+    plan: Mapping[str, object],
+    *,
+    archive_root: Path | None = None,
+) -> dict[str, object]:
     root = _backup_root(manifest_path)
     try:
         manifest = json.loads((root / "manifest.json").read_text(encoding="utf-8"))
@@ -569,10 +570,10 @@ def _validate_backup(manifest_path: Path, plan: Mapping[str, object]) -> dict[st
         raise CursorAuthorityReconciliationError("backup lacks complete blob rollback evidence")
     if not (root / "blob").is_dir() or not (root / "blob-inventory.json").is_file():
         raise CursorAuthorityReconciliationError("backup lacks blob rollback evidence")
-    archive_root = _archive_root()
-    location = ArchiveLocation.resolve(archive_root)
+    resolved_archive_root = _archive_root(archive_root)
+    location = ArchiveLocation.resolve(resolved_archive_root)
     expected_active_index = plan.get("active_index")
-    if expected_active_index is not None and expected_active_index != _active_index_binding(archive_root):
+    if expected_active_index is not None and expected_active_index != _active_index_binding(resolved_archive_root):
         raise CursorAuthorityReconciliationError("active index generation changed since planning")
     try:
         verify_verification_receipt(
@@ -681,8 +682,13 @@ def _require_daemon_stopped(root: Path) -> None:
         raise CursorAuthorityReconciliationError("daemon must be stopped for cursor-authority reconciliation")
 
 
-def build_reconciliation_plan(*, source_path_file: Path, output_plan: Path) -> dict[str, object]:
-    root = _archive_root()
+def build_reconciliation_plan(
+    *,
+    source_path_file: Path,
+    output_plan: Path,
+    archive_root: Path | None = None,
+) -> dict[str, object]:
+    root = _archive_root(archive_root)
     _require_daemon_stopped(root)
     source_path = _read_private_source_path(source_path_file)
     plan = _build_plan(root, source_path)
@@ -913,18 +919,24 @@ def _receipt_payload(
     }
 
 
-def apply_reconciliation(*, plan_path: Path, backup_manifest: Path, receipt: Path) -> dict[str, object]:
+def apply_reconciliation(
+    *,
+    plan_path: Path,
+    backup_manifest: Path,
+    receipt: Path,
+    archive_root: Path | None = None,
+) -> dict[str, object]:
     plan = _load_plan(plan_path)
     if plan.get("status") != "planned":
         raise CursorAuthorityReconciliationError("only a planned one-path reconciliation can be applied")
-    root = _archive_root()
+    root = _archive_root(archive_root)
     _require_daemon_stopped(root)
     if receipt.exists():
         raise CursorAuthorityReconciliationError(f"output path already exists: {receipt}")
     before_projection = _before_projection(plan)
     owner = acquire_durable_archive_ownership(root, owner_id=f"cursor-authority-reconcile:{os.getpid()}")
     with owner:
-        backup_evidence = _validate_backup(backup_manifest, plan)
+        backup_evidence = _validate_backup(backup_manifest, plan, archive_root=root)
         current_path = _find_path_by_digest(root, str(plan["selected_path_digest"]))
         _require_selected_path_in_before_projection(plan, current_path)
         try:
@@ -1063,7 +1075,6 @@ def apply_reconciliation(*, plan_path: Path, backup_manifest: Path, receipt: Pat
 
 
 __all__ = [
-    "ARCHIVE_ROOT",
     "PLAN_FORMAT",
     "RECEIPT_FORMAT",
     "CursorAuthorityReconciliationError",

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -1862,9 +1862,18 @@ def test_cursor_authority_reconcile_cli_accepts_verified_backup_directory(
     backup.mkdir()
     (backup / "manifest.json").write_text("{}", encoding="utf-8")
     observed: dict[str, Path] = {}
+    configured_root = tmp_path / "configured-archive"
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(configured_root))
 
-    def fake_apply(*, plan_path: Path, backup_manifest: Path, receipt: Path) -> dict[str, object]:
+    def fake_apply(
+        *,
+        plan_path: Path,
+        backup_manifest: Path,
+        receipt: Path,
+        archive_root: Path,
+    ) -> dict[str, object]:
         observed["backup"] = backup_manifest
+        observed["archive_root"] = archive_root
         return {"verdict": "failed"}
 
     monkeypatch.setattr(cursor_authority_reconcile, "apply_reconciliation", fake_apply)
@@ -1888,6 +1897,49 @@ def test_cursor_authority_reconcile_cli_accepts_verified_backup_directory(
 
     assert result.exit_code == 0
     assert observed["backup"] == backup
+    assert observed["archive_root"] == configured_root
+
+
+def test_cursor_authority_reconcile_cli_passes_configured_root_to_plan(
+    cli_runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from polylogue.maintenance import cursor_authority_reconcile
+
+    configured_root = tmp_path / "configured-archive"
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(configured_root))
+    observed: dict[str, Path] = {}
+
+    def fake_build(*, source_path_file: Path, output_plan: Path, archive_root: Path) -> dict[str, object]:
+        observed["source_path_file"] = source_path_file
+        observed["output_plan"] = output_plan
+        observed["archive_root"] = archive_root
+        return {"status": "planned"}
+
+    monkeypatch.setattr(cursor_authority_reconcile, "build_reconciliation_plan", fake_build)
+    source_path_file = tmp_path / "selected-path"
+    output_plan = tmp_path / "plan.json"
+
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "cursor-authority-reconcile",
+            "--source-path-file",
+            str(source_path_file),
+            "--output-plan",
+            str(output_plan),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert observed == {
+        "source_path_file": source_path_file,
+        "output_plan": output_plan,
+        "archive_root": configured_root,
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/maintenance/test_cursor_authority_reconcile.py
+++ b/tests/unit/maintenance/test_cursor_authority_reconcile.py
@@ -22,18 +22,24 @@ def _private_path_file(path: Path, source: Path) -> None:
 
 def test_dry_run_plan_is_deterministic_and_does_not_store_private_path(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from tests.unit.sources.test_live_watcher import _live_archive_snapshot, _seed_live_cursor_authority_case
 
     _processor, watcher, _cursor, source_path = _seed_live_cursor_authority_case(tmp_path)
-    monkeypatch.setattr(reconcile, "ARCHIVE_ROOT", tmp_path)
     path_file = tmp_path / "selected-path"
     _private_path_file(path_file, source_path)
     before = _live_archive_snapshot(tmp_path)
 
-    first = reconcile.build_reconciliation_plan(source_path_file=path_file, output_plan=tmp_path / "plan-1.json")
-    second = reconcile.build_reconciliation_plan(source_path_file=path_file, output_plan=tmp_path / "plan-2.json")
+    first = reconcile.build_reconciliation_plan(
+        source_path_file=path_file,
+        output_plan=tmp_path / "plan-1.json",
+        archive_root=tmp_path,
+    )
+    second = reconcile.build_reconciliation_plan(
+        source_path_file=path_file,
+        output_plan=tmp_path / "plan-2.json",
+        archive_root=tmp_path,
+    )
 
     assert first | {"observed_at_ms": None, "plan_digest": None} == second | {
         "observed_at_ms": None,
@@ -94,18 +100,17 @@ async def test_scoped_authorization_rejects_a_different_path_without_mutation(tm
     watcher.stop()
 
 
-def test_plan_refuses_overwrite(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_plan_refuses_overwrite(tmp_path: Path) -> None:
     from tests.unit.sources.test_live_watcher import _seed_live_cursor_authority_case
 
     _processor, watcher, _cursor, source_path = _seed_live_cursor_authority_case(tmp_path)
-    monkeypatch.setattr(reconcile, "ARCHIVE_ROOT", tmp_path)
     path_file = tmp_path / "selected-path"
     _private_path_file(path_file, source_path)
     output = tmp_path / "plan.json"
-    reconcile.build_reconciliation_plan(source_path_file=path_file, output_plan=output)
+    reconcile.build_reconciliation_plan(source_path_file=path_file, output_plan=output, archive_root=tmp_path)
 
     with pytest.raises(reconcile.CursorAuthorityReconciliationError, match="already exists"):
-        reconcile.build_reconciliation_plan(source_path_file=path_file, output_plan=output)
+        reconcile.build_reconciliation_plan(source_path_file=path_file, output_plan=output, archive_root=tmp_path)
     watcher.stop()
 
 
@@ -465,6 +470,7 @@ def test_recovery_attempt_requires_a_later_completed_observation(tmp_path: Path)
 def test_backup_validation_rehashes_and_rejects_mismatched_tier(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    monkeypatch.setattr(reconcile, "configured_archive_root", lambda: tmp_path)
     backup = tmp_path / "backup"
     backup.mkdir()
     blob_payload = b"blob"
@@ -517,9 +523,8 @@ def test_backup_validation_rehashes_and_rejects_mismatched_tier(
         ],
     }
     (backup / "verification-receipt.json").write_text(json.dumps(receipt_payload), encoding="utf-8")
-    monkeypatch.setattr(reconcile, "ARCHIVE_ROOT", tmp_path)
     with pytest.raises(reconcile.CursorAuthorityReconciliationError, match="attestation"):
-        reconcile._validate_backup(backup, plan)
+        reconcile._validate_backup(backup, plan, archive_root=tmp_path)
     monkeypatch.setattr(reconcile, "verify_verification_receipt", lambda *args, **kwargs: None)
     validated = reconcile._validate_backup(backup, plan)
     assert isinstance(validated["root"], dict)
@@ -655,9 +660,12 @@ def test_typed_deferred_apply_receipt_is_metric_backed_and_does_not_claim_cursor
     receipt_path = tmp_path / "receipt.json"
     plan_path = tmp_path / "plan.json"
     plan_path.write_text(json.dumps(plan), encoding="utf-8")
-    monkeypatch.setattr(reconcile, "ARCHIVE_ROOT", tmp_path)
     monkeypatch.setattr(reconcile, "_require_daemon_stopped", lambda root: None)
-    monkeypatch.setattr(reconcile, "_validate_backup", lambda manifest, plan: {"root": "backup"})
+    monkeypatch.setattr(
+        reconcile,
+        "_validate_backup",
+        lambda manifest, plan, *, archive_root: {"root": "backup"},
+    )
     monkeypatch.setattr(reconcile, "_find_path_by_digest", lambda root, digest: source_path)
     monkeypatch.setattr(reconcile, "_build_plan", lambda root, path: plan)
 
@@ -679,6 +687,7 @@ def test_typed_deferred_apply_receipt_is_metric_backed_and_does_not_claim_cursor
         plan_path=plan_path,
         backup_manifest=tmp_path / "backup",
         receipt=receipt_path,
+        archive_root=tmp_path,
     )
 
     assert result["verdict"] == "typed_deferred"
@@ -712,9 +721,12 @@ def test_observed_recovery_receipt_does_not_claim_local_cursor_mutation(
     receipt_path = tmp_path / "receipt.json"
     plan_path = tmp_path / "plan.json"
     plan_path.write_text(json.dumps(plan), encoding="utf-8")
-    monkeypatch.setattr(reconcile, "ARCHIVE_ROOT", tmp_path)
     monkeypatch.setattr(reconcile, "_require_daemon_stopped", lambda root: None)
-    monkeypatch.setattr(reconcile, "_validate_backup", lambda manifest, plan: {"root": "backup"})
+    monkeypatch.setattr(
+        reconcile,
+        "_validate_backup",
+        lambda manifest, plan, *, archive_root: {"root": "backup"},
+    )
     monkeypatch.setattr(reconcile, "_find_path_by_digest", lambda root, digest: source_path)
     monkeypatch.setattr(reconcile, "_build_plan", lambda root, path: None)
     monkeypatch.setattr(
@@ -734,6 +746,7 @@ def test_observed_recovery_receipt_does_not_claim_local_cursor_mutation(
         plan_path=plan_path,
         backup_manifest=tmp_path / "backup",
         receipt=receipt_path,
+        archive_root=tmp_path,
     )
 
     assert result["verdict"] == "reconciled"
@@ -757,9 +770,12 @@ def test_unexpected_post_ingest_failure_writes_typed_audit_receipt(
     plan_path.write_text(json.dumps(plan), encoding="utf-8")
     projection = replace(reconcile._projection_for(tmp_path), broken_head_count=1)
     receipt_path = tmp_path / "receipt.json"
-    monkeypatch.setattr(reconcile, "ARCHIVE_ROOT", tmp_path)
     monkeypatch.setattr(reconcile, "_require_daemon_stopped", lambda root: None)
-    monkeypatch.setattr(reconcile, "_validate_backup", lambda manifest, plan: {"root": "backup"})
+    monkeypatch.setattr(
+        reconcile,
+        "_validate_backup",
+        lambda manifest, plan, *, archive_root: {"root": "backup"},
+    )
     monkeypatch.setattr(reconcile, "_find_path_by_digest", lambda root, digest: source_path)
     monkeypatch.setattr(reconcile, "_build_plan", lambda root, path: plan)
 
@@ -778,7 +794,12 @@ def test_unexpected_post_ingest_failure_writes_typed_audit_receipt(
     monkeypatch.setattr(reconcile, "_quick_checks", lambda root: {})
 
     with pytest.raises(reconcile.CursorAuthorityReconciliationError, match="raw-frontier worsening"):
-        reconcile.apply_reconciliation(plan_path=plan_path, backup_manifest=tmp_path / "backup", receipt=receipt_path)
+        reconcile.apply_reconciliation(
+            plan_path=plan_path,
+            backup_manifest=tmp_path / "backup",
+            receipt=receipt_path,
+            archive_root=tmp_path,
+        )
 
     payload = json.loads(receipt_path.read_text(encoding="utf-8"))
     assert payload["verdict"] == "failed"


### PR DESCRIPTION
## Summary

Make cursor-authority reconciliation follow the configured archive root for both planning and apply, so relocation cannot leave the maintenance route pointed at the former archive. Remove the unregistered duplicate corpus-fidelity CLI that independently hardcoded the old path.

## Problem

The production cursor-authority module fixed its archive root at `/realm/db/polylogue`. After the archive moved to its configured state root, a maintenance invocation could inspect or mutate the obsolete location even while every other runtime surface used the selected archive authority. The same module family also retained a second, unregistered corpus-fidelity CLI with another hardcoded production path, duplicating the registered devtools route.

## Solution

- Resolve `polylogue.paths.archive_root()` once in the maintenance CLI and pass that exact `Path` through plan/apply and backup validation.
- Keep direct operation functions injectable for tests and explicit composition, while defaulting to the canonical configured resolver.
- Remove the dead duplicate corpus-fidelity parser, formatter, runner, hardcoded root, and unused exports; retain the three measurement functions consumed by the registered archive-verification route.
- Exercise both dry-run and apply CLI paths with a non-default configured root.

## Verification

- `direnv exec . devtools test tests/unit/maintenance/test_cursor_authority_reconcile.py tests/unit/cli/test_archive_maintenance_cli.py`: **150 passed in 24.73s**.
- `direnv exec . devtools test -k cursor_authority_reconcile_cli tests/unit/cli/test_archive_maintenance_cli.py`: **9 passed, 114 deselected in 1.37s**.
- `direnv exec . devtools verify --quick` on exact rebased head `f232901c278fea0d3b2972c5399a015abdf8d045`: **all 25 checks passed in 182.05s**.
- The pre-push hook completed the same exact-head quick gate successfully.

Anti-vacuity: the CLI regressions set `POLYLOGUE_ARCHIVE_ROOT` to a non-default path and require the production plan/apply boundary to receive that exact value. Removing the new argument wiring or restoring the fixed root fails those tests.

## Bead disposition matrix

| Assigned Bead | Whole-Bead disposition | Evidence refs | Named successor for residual work |
| --- | --- | --- | --- |
| n/a | self-contained | `test:cursor_authority_reconcile`, `command:devtools verify --quick` | n/a |

No Bead records are changed. This code closes only the configured-root part of `polylogue-hgfre`; that Bead remains open for authenticated live relocation continuity and service convergence.

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->

## Changelog

Internal maintenance authority repair; no user-facing changelog entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Archive maintenance and reconciliation now consistently use the configured archive location.
  * Reconciliation operations support an optional archive-location override for greater flexibility.
  * Improved validation of backups during reconciliation workflows.

* **Maintenance**
  * Simplified corpus-fidelity auditing to focus on its individual audit checks.

* **Tests**
  * Expanded coverage for configured archive locations in planning and application workflows.
  * Updated reconciliation tests to verify explicit archive-location handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->