### PR TITLE
fix(githooks): preserve tracked worktree wrappers

### DIFF
--- a/scripts/configure-git-hooks
+++ b/scripts/configure-git-hooks
@@ -21,12 +21,11 @@ _polylogue_hooks_path="$_polylogue_common_root/.githooks"
 if [ -d "$_polylogue_common_root/.beads-hooks" ]; then
   _polylogue_hooks_path="$_polylogue_common_root/.beads-hooks"
 fi
-_polylogue_wrapper="$_polylogue_common_root/scripts/bd"
-_polylogue_wrapper_real=$(readlink -f "$_polylogue_wrapper" 2>/dev/null || true)
-
 # This is the shared installation anchor. The per-worktree values below are
 # higher-precedence guards against a branch-point shell hook restoring a
-# relative path in the common config.
+# relative path in the common config. Wrapper authority is resolved through
+# the common checkout by .envrc and the common hooks; never replace a tracked
+# path in a linked worktree to achieve that routing.
 git -C "$_polylogue_common_root" config --local extensions.worktreeConfig true
 git -C "$_polylogue_common_root" config --local core.hooksPath "$_polylogue_hooks_path"
 
@@ -34,15 +33,4 @@ while IFS= read -r _polylogue_worktree; do
   [ -n "$_polylogue_worktree" ] || continue
   [ -d "$_polylogue_worktree" ] || continue
   git -C "$_polylogue_worktree" config --worktree core.hooksPath "$_polylogue_hooks_path"
-  if [ "$_polylogue_worktree/scripts/bd" = "$_polylogue_wrapper" ] || [ ! -x "$_polylogue_wrapper" ]; then
-    continue
-  fi
-  _polylogue_worktree_scripts="$_polylogue_worktree/scripts"
-  _polylogue_worktree_wrapper="$_polylogue_worktree_scripts/bd"
-  mkdir -p "$_polylogue_worktree_scripts"
-  _polylogue_worktree_wrapper_real=$(readlink -f "$_polylogue_worktree_wrapper" 2>/dev/null || true)
-  if [ "$_polylogue_worktree_wrapper_real" != "$_polylogue_wrapper_real" ]; then
-    rm -f "$_polylogue_worktree_wrapper"
-    ln -s "$_polylogue_wrapper" "$_polylogue_worktree_wrapper"
-  fi
 done < <(git -C "$_polylogue_common_root" worktree list --porcelain | sed -n 's/^worktree //p')

--- a/tests/integration/test_beads_stale_worktree_guard.py
+++ b/tests/integration/test_beads_stale_worktree_guard.py
@@ -240,7 +240,7 @@ def _setup_stale_worktree(
     assert isinstance(issue_rows, list) and len(issue_rows) == 1
     issue_id = issue_rows[0]["id"]
 
-    _run(["git", "add", ".beads", ".beads-hooks", ".envrc"], repo, env)
+    _run(["git", "add", ".beads", ".beads-hooks", ".envrc", "scripts/bd"], repo, env)
     _run(["git", "commit", "-m", "historical Beads snapshot"], repo, env)
     _run(["git", "branch", "stale-lane"], repo, env)
     _run(["git", "worktree", "add", str(lane), "stale-lane"], repo, env)
@@ -269,7 +269,7 @@ def _setup_stale_worktree(
     assert lane_wrapper.is_file()
     assert not lane_wrapper.is_symlink()
     assert lane_wrapper.read_text() == _historical_file("scripts/bd", commit=BASE_COMMIT)
-    assert _run(["git", "status", "--porcelain"], lane, env).stdout == ""
+    assert _run(["git", "status", "--porcelain", "--", "scripts/bd"], lane, env).stdout == ""
     assert _run(["bash", "-c", "command -v bd"], lane, env).stdout.strip() == str((repo / "scripts" / "bd").resolve())
 
     _run([bd, "close", issue_id, "--reason", "coordinator close"], repo, env)

--- a/tests/integration/test_beads_stale_worktree_guard.py
+++ b/tests/integration/test_beads_stale_worktree_guard.py
@@ -22,7 +22,7 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
-BASE_COMMIT = "a516b3caa791ef84a1a4133d217e39c20123651a"
+BASE_COMMIT = "de9ca432fb6ef1a025dbe9dccd82a804522ed299"
 
 
 def _installed_bd() -> str | None:
@@ -266,11 +266,14 @@ def _setup_stale_worktree(
     _run([str(repo / "scripts" / "configure-git-hooks")], repo, env)
     env = _execute_historical_envrc(lane, env, tmp_path, bd)
     lane_wrapper = lane / "scripts" / "bd"
-    assert lane_wrapper.is_symlink()
-    assert lane_wrapper.resolve() == (repo / "scripts" / "bd").resolve()
+    assert lane_wrapper.is_file()
+    assert not lane_wrapper.is_symlink()
+    assert lane_wrapper.read_text() == _historical_file("scripts/bd", commit=BASE_COMMIT)
+    assert _run(["git", "status", "--porcelain"], lane, env).stdout == ""
+    assert _run(["bash", "-c", "command -v bd"], lane, env).stdout.strip() == str((repo / "scripts" / "bd").resolve())
 
     _run([bd, "close", issue_id, "--reason", "coordinator close"], repo, env)
-    assert (lane / "scripts" / "bd").is_symlink()
+    assert not (lane / "scripts" / "bd").is_symlink()
     assert (lane / ".envrc").read_text() == _historical_file(".envrc", commit=BASE_COMMIT)
     assert (lane / ".beads-hooks" / "post-checkout").read_text() == _historical_file(
         ".beads-hooks/post-checkout", commit=BASE_COMMIT

--- a/tests/integration/test_worktree_common_authority.py
+++ b/tests/integration/test_worktree_common_authority.py
@@ -1,0 +1,104 @@
+"""Linked worktrees keep tracked wrappers clean while routing through common authority.
+
+The production path exercised here is the deployed shell configurator and
+``.envrc``.  A real temporary Git repository gains a linked worktree on an
+older branch, then the common checkout configures every worktree.  Before the
+fix, the configurator replaced the lane's tracked ``scripts/bd`` file with a
+symlink, making ``git status --porcelain`` report ``T scripts/bd``.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run(command: list[str], cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(command, cwd=cwd, env=env, capture_output=True, text=True, timeout=30)
+    if result.returncode != 0:
+        raise AssertionError(
+            f"command failed ({result.returncode}): {command!r}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def _source_envrc_and_find_bd(lane: Path, env: dict[str, str]) -> str:
+    """Use the real envrc routing logic without invoking the Beads command."""
+    return _run(
+        [
+            "bash",
+            "-c",
+            'PATH_add() { PATH="$1:$PATH"; export PATH; }; use() { :; }; source .envrc; command -v bd',
+        ],
+        lane,
+        env,
+    ).stdout.strip()
+
+
+def test_common_authority_keeps_stale_linked_worktree_clean(tmp_path: Path) -> None:
+    """The common wrapper and hooks win without modifying a lane's tracked files."""
+    common = tmp_path / "coordinator"
+    lane = tmp_path / "stale-lane"
+    binary_dir = tmp_path / "bin"
+    setup_hooks = tmp_path / "setup-hooks"
+    probe = tmp_path / "hook-authority"
+    common.mkdir()
+    binary_dir.mkdir()
+    setup_hooks.mkdir()
+    (binary_dir / "bd").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    (binary_dir / "bd").chmod(0o755)
+
+    env = os.environ.copy()
+    for key in ("POLYLOGUE_BD_REAL", "VIRTUAL_ENV", "PYTHONHOME", "PYTHONPATH"):
+        env.pop(key, None)
+    env["PATH"] = os.pathsep.join((str(binary_dir), env["PATH"]))
+    env["WORKTREE_HOOK_PROBE"] = str(probe)
+
+    _run(["git", "init", "--initial-branch=main"], common, env)
+    _run(["git", "config", "user.email", "test@example.invalid"], common, env)
+    _run(["git", "config", "user.name", "worktree authority test"], common, env)
+    _run(["git", "config", "core.hooksPath", str(setup_hooks)], common, env)
+
+    for directory in (common / "polylogue", common / "tests", common / "devtools"):
+        directory.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(ROOT / ".envrc", common / ".envrc")
+    scripts = common / "scripts"
+    scripts.mkdir()
+    stale_wrapper = "#!/bin/sh\nprintf '%s\\n' stale-wrapper\n"
+    (scripts / "bd").write_text(stale_wrapper, encoding="utf-8")
+    (scripts / "bd").chmod(0o755)
+    shutil.copy2(ROOT / "scripts" / "configure-git-hooks", scripts / "configure-git-hooks")
+    (scripts / "configure-git-hooks").chmod(0o755)
+    hooks = common / ".githooks"
+    hooks.mkdir()
+    (hooks / "post-checkout").write_text(
+        "#!/bin/sh\nprintf '%s\\n' stale-hook > \"$WORKTREE_HOOK_PROBE\"\n", encoding="utf-8"
+    )
+    (hooks / "post-checkout").chmod(0o755)
+    _run(["git", "add", ".envrc", "scripts", ".githooks"], common, env)
+    _run(["git", "commit", "-m", "historical lane"], common, env)
+    _run(["git", "worktree", "add", "-b", "stale-lane", str(lane)], common, env)
+
+    shutil.copy2(ROOT / "scripts" / "bd", scripts / "bd")
+    (scripts / "bd").chmod(0o755)
+    (hooks / "post-checkout").write_text(
+        "#!/bin/sh\nprintf '%s\\n' common-hook > \"$WORKTREE_HOOK_PROBE\"\n", encoding="utf-8"
+    )
+    _run(["git", "add", "scripts/bd", ".githooks/post-checkout"], common, env)
+    _run(["git", "commit", "-m", "deploy common authority"], common, env)
+
+    _run([str(scripts / "configure-git-hooks")], common, env)
+
+    assert _run(["git", "status", "--porcelain"], lane, env).stdout == ""
+    lane_wrapper = lane / "scripts" / "bd"
+    assert not lane_wrapper.is_symlink()
+    assert lane_wrapper.read_text(encoding="utf-8") == stale_wrapper
+    assert _source_envrc_and_find_bd(lane, env) == str((common / "scripts" / "bd").resolve())
+    assert _run(["git", "config", "--get", "core.hooksPath"], lane, env).stdout.strip() == str(hooks.resolve())
+
+    _run(["git", "switch", "--detach", "HEAD"], lane, env)
+    assert probe.read_text(encoding="utf-8") == "common-hook\n"


### PR DESCRIPTION
## Summary

Keep every linked worktree's tracked `scripts/bd` file intact while routing current and reloaded worktree environments and Git hooks through the common checkout's authority.

## Problem

`scripts/configure-git-hooks` replaced each linked worktree's tracked `scripts/bd` with a symlink to the common checkout. That made clean feature worktrees report `T scripts/bd`, contaminated commits and merge preflights, and forced repeated manual restores. The routing authority already exists in `.envrc` and the common absolute hook path; changing tracked lane files was unnecessary.

## Solution

- Configure the common and per-worktree `core.hooksPath` values without replacing tracked wrappers.
- Resolve `bd` through the current common wrapper whenever a worktree environment is loaded or reloaded.
- Preserve each stale lane's historical wrapper bytes and Git cleanliness.
- Exercise the behavior in a real temporary Git repository with a linked stale worktree and the production configurator.
- Correct the older stale-worktree fixture so its historical wrapper is genuinely tracked and its cleanliness assertion targets that owned path.

An already-running shell retains the environment and command cache it loaded before deployment. Repository code cannot rewrite that process without changing tracked historical files or intercepting unrelated executables. Surviving pre-deployment lanes must reload after rebasing; this merge train removes those lanes after integration.

## Verification

- `devtools test tests/integration/test_worktree_common_authority.py tests/integration/test_beads_stale_worktree_guard.py`: **33 passed in 66.51s**.
- `devtools verify --quick`: **all 25 checks passed**.

Anti-vacuity: the real-repository regression invokes `scripts/configure-git-hooks`, checks the stale worktree's tracked wrapper bytes and Git status, resolves `bd` through the current `.envrc`, and proves a subsequent checkout executes the common hook. Restoring the wrapper-replacement loop makes the test report `T scripts/bd`.

## Bead disposition matrix

| Assigned Bead | Whole-Bead disposition | Evidence refs | Named successor for residual work |
| --- | --- | --- | --- |
| n/a | self-contained | `test:worktree_common_authority`, `command:devtools verify --quick` | n/a |

No Bead records are changed.

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->

## Changelog

Internal worktree-authority repair; no user-facing changelog entry.
