### PR TITLE
fix: bootstrap durable operation fixtures

### DIFF
--- a/polylogue/operations/durable_change_train.py
+++ b/polylogue/operations/durable_change_train.py
@@ -723,9 +723,14 @@ def _audit_file_identity(path: Path) -> tuple[int, int]:
     return metadata.st_dev, metadata.st_ino
 
 
-def _audit_live_metadata(audit_path: Path) -> tuple[int, int, tuple[str, ...]]:
-    """Read the durable markers that remain valid after an in-place migration."""
-    uri = f"{audit_path.resolve(strict=False).as_uri()}?mode=ro"
+def _audit_live_metadata(
+    audit_path: Path,
+    *,
+    immutable: bool = False,
+) -> tuple[int, int, tuple[str, ...]]:
+    """Read durable markers, without mutating an immutable backup artifact."""
+    mode = "?mode=ro&immutable=1" if immutable else "?mode=ro"
+    uri = f"{audit_path.resolve(strict=False).as_uri()}{mode}"
     with closing(sqlite3.connect(uri, uri=True)) as connection:
         version = int(connection.execute("PRAGMA user_version").fetchone()[0] or 0)
         application_id = int(connection.execute("PRAGMA application_id").fetchone()[0] or 0)
@@ -1372,7 +1377,10 @@ def restore_adopted_audit_tier(
     expected_initial_version = adoption.get("audit_user_version")
     if not isinstance(expected_application_id, int) or not isinstance(expected_initial_version, int):
         raise MigrationError("audit adoption receipt lacks its durable SQLite markers")
-    backup_version, backup_application_id, backup_quick_check = _audit_live_metadata(manifest_path.parent / "audit.db")
+    backup_version, backup_application_id, backup_quick_check = _audit_live_metadata(
+        manifest_path.parent / "audit.db",
+        immutable=True,
+    )
     if (
         backup_version != artifact_version
         or backup_version != ARCHIVE_VERSION_BY_TIER[ArchiveTier.AUDIT]

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -3638,6 +3638,8 @@ def test_migrate_tier_cli_restores_adopted_audit_from_verified_full_evidence(
     assert restored.exit_code == 0, restored.output
     payload = json.loads(restored.stdout)
     assert payload["restore_receipt"].endswith(".committed.json")
+    backup_audit = Path(verified.output_path) / "audit.db"
+    assert all(not Path(f"{backup_audit}{suffix}").exists() for suffix in ("-wal", "-shm", "-journal"))
     with sqlite3.connect(audit_path) as connection:
         assert connection.execute("PRAGMA user_version").fetchone() == (ARCHIVE_VERSION_BY_TIER[ArchiveTier.AUDIT],)
         assert connection.execute("SELECT generation FROM audit_continuity_head").fetchone() == (2,)

--- a/tests/unit/cli/test_reset.py
+++ b/tests/unit/cli/test_reset.py
@@ -12,7 +12,7 @@ import pytest
 from click.testing import CliRunner
 
 from polylogue.cli import cli
-from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root, initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from tests.infra.cli_subprocess import run_cli, setup_isolated_workspace
 
@@ -30,10 +30,9 @@ RESET_DELETION_CASES = [
 
 
 def _seed_archive_session(archive_root: Path, *, native_id: str, source_path: Path | None = None) -> str:
+    initialize_active_archive_root(archive_root)
     source_db = archive_root / "source.db"
     index_db = archive_root / "index.db"
-    initialize_archive_database(source_db, ArchiveTier.SOURCE)
-    initialize_archive_database(index_db, ArchiveTier.INDEX)
     session_id = f"codex-session:{native_id}"
     raw_id = f"raw-{native_id}"
     with sqlite3.connect(source_db) as conn:

--- a/tests/unit/cli/test_reset.py
+++ b/tests/unit/cli/test_reset.py
@@ -12,6 +12,7 @@ import pytest
 from click.testing import CliRunner
 
 from polylogue.cli import cli
+from polylogue.storage.archive_identity import ArchiveLocation
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root, initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from tests.infra.cli_subprocess import run_cli, setup_isolated_workspace
@@ -32,7 +33,8 @@ RESET_DELETION_CASES = [
 def _seed_archive_session(archive_root: Path, *, native_id: str, source_path: Path | None = None) -> str:
     initialize_active_archive_root(archive_root)
     source_db = archive_root / "source.db"
-    index_db = archive_root / "index.db"
+    index_db = ArchiveLocation.resolve(archive_root).active_index_path
+    initialize_archive_database(index_db, ArchiveTier.INDEX)
     session_id = f"codex-session:{native_id}"
     raw_id = f"raw-{native_id}"
     with sqlite3.connect(source_db) as conn:
@@ -413,6 +415,9 @@ class TestResetCommandDeletion:
 
         archive_root = tmp_path / "archive"
         archive_root.mkdir()
+        active_index = tmp_path / "index-generation" / "index.db"
+        active_index.parent.mkdir()
+        (archive_root / ".index-active-pointer").write_text(str(active_index), encoding="utf-8")
         session_id = _seed_archive_session(archive_root, native_id="reset-one")
 
         with patch("polylogue.cli.commands.reset.archive_root", return_value=archive_root):
@@ -422,8 +427,10 @@ class TestResetCommandDeletion:
         assert result.exit_code == 0
         assert "1 suppression" in result.output
         assert "1 archive row" in result.output
-        with sqlite3.connect(archive_root / "index.db") as conn:
+        with sqlite3.connect(active_index) as conn:
             assert conn.execute("SELECT COUNT(*) FROM sessions WHERE session_id = ?", (session_id,)).fetchone()[0] == 0
+        with sqlite3.connect(archive_root / "index.db") as conn:
+            assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 0
         with sqlite3.connect(archive_root / "user.db") as conn:
             row = conn.execute(
                 "SELECT body_text, json_extract(value_json, '$.mode') FROM assertions WHERE kind = 'suppression' AND target_ref = ?",

--- a/tests/unit/storage/test_raw.py
+++ b/tests/unit/storage/test_raw.py
@@ -21,7 +21,7 @@ from polylogue.core.enums import Provider
 from polylogue.storage.raw.models import RawSessionStateUpdate
 from polylogue.storage.repository import SessionRepository
 from polylogue.storage.runtime import RawSessionRecord
-from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root, initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
 from polylogue.storage.sqlite.queries.raw_reads import get_capture_mode_resolution
@@ -70,8 +70,7 @@ class TestRawSessionStorage:
             assert row[0] == 1
 
     async def test_repository_update_raw_state_uses_source_tier(self, tmp_path: Path) -> None:
-        initialize_archive_database(tmp_path / "source.db", ArchiveTier.SOURCE)
-        initialize_archive_database(tmp_path / "index.db", ArchiveTier.INDEX)
+        initialize_active_archive_root(tmp_path)
         source_backend = SQLiteBackend(db_path=tmp_path / "source.db")
         try:
             await source_backend.save_raw_session(

--- a/tests/unit/storage/test_store_ops.py
+++ b/tests/unit/storage/test_store_ops.py
@@ -1782,14 +1782,21 @@ class TestRepositoryVectorAsyncBoundary:
 class TestInfraTagAssignment:
     """Property-based tests using the full TagAssignmentSpec strategy."""
 
-    @given(infra_tag_assignment_strategy(min_sessions=2, max_sessions=4))
+    @given(spec=infra_tag_assignment_strategy(min_sessions=2, max_sessions=4))
     @settings(max_examples=10, deadline=None)
-    async def test_tag_assignment_roundtrip_and_counts(self, spec: TagAssignmentSpec) -> None:
+    async def test_tag_assignment_roundtrip_and_counts(
+        self,
+        spec: TagAssignmentSpec,
+        empty_archive_template: Path,
+    ) -> None:
         """Strategy-generated tags are retrievable and counted consistently."""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            from tests.infra.archive_scenarios import archive_for_scenario_db, native_session_id_for
+        from tests.conftest import _clone_archive_template
+        from tests.infra.archive_scenarios import archive_for_scenario_db, native_session_id_for
 
-            db_path = Path(tmp_dir) / "index.db"
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            archive_root = Path(tmp_dir) / "archive"
+            _clone_archive_template(empty_archive_template, archive_root)
+            db_path = archive_root / "index.db"
             seed_session_graph(db_path, spec.sessions)
 
             repo = archive_for_scenario_db(db_path)


### PR DESCRIPTION
## Summary

Bootstrap durable-operation fixtures as complete archive roots and prevent audit-restore inspection from contaminating verified backup artifacts.

## Problem

Full-suite run `20260813T085908Z-full-476637-b3117ddd` exposed durable-operation fixtures that created only `source.db` and `index.db`. Current durable authority rules correctly reject those partial roots before the tests reach their intended production routes. The adopted-audit restore path also opened the backup SQLite database read-only without `immutable=1`; in WAL mode that can create a `audit.db-shm` sidecar beside the verified artifact, making exact revalidation reject the backup. The property tag roundtrip rebuilt a bare archive per Hypothesis example and exceeded its test timeout under the same lifecycle work.

## Solution

- Initialize source-tier and reset fixtures with the production complete-root bootstrap.
- Clone the existing complete archive template for each independent tag property example, then exercise the actual session, tag, and count APIs.
- Read a verified audit backup immutably during restore validation and assert that its SQLite sidecar set remains empty.

## Verification

- `direnv exec /realm/worktrees/polylogue-durable-fixtures devtools test tests/unit/cli/test_archive_maintenance_cli.py::test_migrate_tier_cli_restores_adopted_audit_from_verified_full_evidence tests/unit/cli/test_reset.py::TestResetCommandDeletion::test_reset_session_records_archive_suppression_and_deletes_archive_row tests/unit/storage/test_raw.py::TestRawSessionStorage::test_repository_update_raw_state_uses_source_tier tests/unit/storage/test_store_ops.py::TestInfraTagAssignment::test_tag_assignment_roundtrip_and_counts` -> `4 passed in 80.29s (0:01:20)`.
- `direnv exec /realm/worktrees/polylogue-durable-fixtures devtools verify --seed-testmon --skip-slow` completed every static and policy gate and collected `21088/21119` tests, but the new lane had no seed and shard 1/9 was terminated after unrelated query/annotation failures and archive-bootstrap I/O timeouts. The verifier correctly recorded `testmon_seed: incomplete` and did not grant release-baseline permission. This is unresolved verification uncertainty, not a passing baseline.

## Bead disposition

This is a self-contained fixture and lifecycle repair. No Beads were assigned or mutated, as directed for this lane.

## Adversarial review notes

- Manual exact-head review at `0cc02157b6b31682e1dd2c95aa54a9d604f96119`: no legitimate gaps found across DF-1 through DF-4.
- Independent reviewer iteration 1 could not produce a verdict: the complete source packet exceeded the operating system argument limit, then the reduced diff packet exited from the local Claude transport without stderr. Receipts: `898ff0e4-8a3e-4cf7-bd9f-dc9223ee7375` and `5948db81-7fff-4a3e-a38c-16eaa2c90b4e`.

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->
