### PR TITLE
fix: preserve retained raw replay authority

### DIFF
--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -714,6 +714,7 @@ def _census_historical_revision_evidence(
                         [],
                         parser_fingerprint=RAW_AUTHORITY_PARSER_FINGERPRINT,
                         censused_at_ms=0,
+                        retire_full_revision_governance=revision_kind is not RawRevisionKind.UNKNOWN,
                         manage_transaction=False,
                     )
                     if not terminalized:
@@ -802,7 +803,7 @@ def _census_historical_revision_evidence(
                 rows = archive.raw_membership_census_rows(census_selection)
                 for raw_id, _source_index, _terminal_non_session, _raw_rowid in sorted(
                     rows,
-                    key=lambda row: (archive.raw_revision_observed_at_ms(row[0]), row[3]),
+                    key=lambda row: archive.raw_revision_observation_order(row[0]),
                 ):
                     if raw_id in state.censused or not _replay_retained_codex_state_evidence(archive, raw_id):
                         continue

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -14,7 +14,6 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import closing, contextmanager, nullcontext
 from dataclasses import dataclass, field
 from io import BytesIO
-from itertools import chain, islice
 from pathlib import Path
 from types import TracebackType
 from typing import BinaryIO, Final, Literal, cast
@@ -59,6 +58,7 @@ from polylogue.sources.parsers import antigravity, codex_state, hermes_state, he
 from polylogue.sources.parsers.base import ParsedSession
 from polylogue.sources.sqlite_snapshot import looks_like_sqlite_bytes
 from polylogue.storage.archive_identity import ArchiveLocation
+from polylogue.storage.artifacts.inspection import artifact_observation_id
 from polylogue.storage.raw.models import RawSessionStateUpdate
 from polylogue.storage.raw_authority import (
     RAW_AUTHORITY_PARSER_FINGERPRINT,
@@ -68,9 +68,14 @@ from polylogue.storage.raw_authority import (
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.revision_governance import (
     FrozenSourceRemediationRequiredError,
+    _raw_parse_success_state,
     record_current_parser_source_census,
 )
-from polylogue.storage.sqlite.archive_tiers.source_write import apply_source_raw_state_update
+from polylogue.storage.sqlite.archive_tiers.source_write import (
+    ArchiveSourceArtifact,
+    apply_source_raw_state_update,
+    upsert_raw_artifact,
+)
 from polylogue.storage.sqlite.archive_tiers.write import PreparedSessionRows, prepare_session_rows
 
 _LOGGER = _polylogue_logging.get_logger(__name__)
@@ -674,6 +679,15 @@ def _census_historical_revision_evidence(
                 state=RawSessionStateUpdate(payload_provider=Provider.from_string(sessions[0].source_name)),
                 manage_transaction=not batched,
             )
+        if not sessions:
+            _persist_terminal_non_session_artifact(
+                archive,
+                raw_id,
+                provider=stored_provider,
+                source_path=_source_path,
+                source_index=source_index,
+                manage_transaction=not batched,
+            )
         state.classified += int(len(sessions) == 1)
         spill.add(raw_id, sessions, payload_bytes=payload_bytes)
         if len(sessions) == 1 and revision_kind is RawRevisionKind.UNKNOWN:
@@ -750,7 +764,7 @@ def _census_historical_revision_evidence(
                 rows = archive.raw_membership_census_rows(census_selection)
                 for raw_id, _source_index, _terminal_non_session in sorted(
                     rows,
-                    key=lambda row: (archive.raw_revision_acquired_at_ms(row[0]), row[1], row[0]),
+                    key=lambda row: (archive.raw_revision_observed_at_ms(row[0]), row[1], row[0]),
                 ):
                     if raw_id in state.censused or not _replay_retained_codex_state_evidence(archive, raw_id):
                         continue
@@ -1977,6 +1991,12 @@ def census_parse_worker(
                     )
                 return raw_id, sessions, None
             payload = publisher.read_all(blob_hash)
+            if provider is Provider.UNKNOWN:
+                provider, _evidence = detect_provider_from_raw_bytes_evidence(
+                    payload,
+                    Path(source_path).name,
+                    provider,
+                )
             payload_path = None
             if provider is Provider.HERMES:
                 candidate_path = publisher.blob_path(blob_hash)
@@ -2412,6 +2432,12 @@ def parse_retained_raw_sessions(archive: ArchiveStore, raw_id: str) -> list[Pars
             with archive.open_raw_revision_material(raw_id) as (_stream_provider, payload, stream_path, _stream_kind):
                 return _parse_stream(provider, payload, stream_path, fallback_id_override=fallback_id_override)
         _provider, eager_payload, _source_path, _eager_kind = archive.raw_revision_material(raw_id)
+        if provider is Provider.UNKNOWN:
+            provider, _evidence = detect_provider_from_raw_bytes_evidence(
+                eager_payload,
+                Path(source_path).name,
+                provider,
+            )
         payload_path = archive.blob_path_for_hash(blob_hash) if provider is Provider.HERMES else None
         return _parse_one(
             provider,
@@ -2458,7 +2484,7 @@ def _replay_retained_codex_state_evidence(archive: ArchiveStore, raw_id: str) ->
             archive,
             codex_state.parse_codex_state_db(state_path, immutable=True),
             source_path=source_path,
-            acquired_at_ms=archive.raw_revision_acquired_at_ms(raw_id),
+            acquired_at_ms=archive.raw_revision_observed_at_ms(raw_id),
         )
     archive.replace_raw_membership_census(
         raw_id,
@@ -3212,6 +3238,64 @@ def _declared_non_session_artifact_classification(
     return classification if not classification.parse_as_session else None
 
 
+def _persist_terminal_non_session_artifact(
+    archive: ArchiveStore,
+    raw_id: str,
+    *,
+    provider: Provider,
+    source_path: str,
+    source_index: int,
+    manage_transaction: bool,
+) -> None:
+    """Record replay-confirmed source-only artifact authority once.
+
+    A declared JSONL fact path can contain a real session, so it receives a
+    full rolling eligibility scan before replay may terminalize it.  A
+    non-session result then follows the same typed artifact row and parse
+    lifecycle used by live acquisition instead of remaining pending forever.
+    """
+    if provider is Provider.UNKNOWN:
+        return
+    classification = _declared_non_session_artifact_classification(provider, source_path)
+    if classification is None:
+        return
+    if is_jsonl_source_path(source_path):
+        from polylogue.archive.raw_payload.decode import jsonl_session_artifact
+
+        with archive.open_raw_revision_material(raw_id) as (_provider, payload, _path, _kind):
+            if jsonl_session_artifact(payload, provider=provider) is not None:
+                return
+    origin = origin_from_provider(provider)
+    observed_at_ms = archive.raw_revision_observed_at_ms(raw_id)
+    upsert_raw_artifact(
+        archive._ensure_source_conn(),
+        raw_id,
+        ArchiveSourceArtifact(
+            artifact_id=artifact_observation_id(
+                source_name=origin.value,
+                source_path=source_path,
+                source_index=source_index,
+            ),
+            origin=origin,
+            source_path=source_path,
+            source_index=source_index,
+            artifact_kind=classification.cohort,
+            classification_reason=classification.reason,
+            parse_as_session=False,
+            schema_eligible=classification.schema_eligible,
+            first_observed_at_ms=observed_at_ms,
+            last_observed_at_ms=observed_at_ms,
+        ),
+        manage_transaction=manage_transaction,
+    )
+    apply_source_raw_state_update(
+        archive._ensure_source_conn(),
+        raw_id,
+        state=_raw_parse_success_state(provider),
+        manage_transaction=manage_transaction,
+    )
+
+
 def _is_declared_non_session_artifact(
     provider: Provider,
     source_path: str,
@@ -3376,21 +3460,9 @@ def _parse_stream_raw(
     source_name = Path(source_path).name
     fallback_id = fallback_id_override or Path(source_path).stem
     stream = _iter_json_stream(payload, source_name)
-    # Multi-GiB Claude Code JSONL must stay memory-bounded (module docstring:
-    # "a memory-bounded streaming path exists for multi-GiB Claude Code
-    # JSONL"), so only the first 64 records -- the same sample bound the live
-    # ingest gate uses -- are materialized for content classification; the
-    # rest of the stream is chained back on unread.
-    sample = list(islice(stream, 64))
-    sample_sessions = parse_stream_payload(provider, sample, fallback_id, source_path=source_path)
-    sample_has_session_evidence = bool(
-        require_positive_conversational_evidence(sample_sessions, provider=provider, source_path=source_path)
-    )
-    if not sample_has_session_evidence and _is_declared_non_session_artifact(provider, source_path, sample=sample):
-        return []
     return parse_stream_payload(
         provider,
-        chain(sample, stream),
+        stream,
         fallback_id,
         source_path=source_path,
     )

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -680,14 +680,35 @@ def _census_historical_revision_evidence(
                 manage_transaction=not batched,
             )
         if not sessions:
-            _persist_terminal_non_session_artifact(
+            provider = _detected_provider_for_empty_replay(
                 archive,
                 raw_id,
-                provider=stored_provider,
+                stored_provider=stored_provider,
                 source_path=_source_path,
-                source_index=source_index,
-                manage_transaction=not batched,
             )
+            # A terminal artifact makes this raw ineligible for future census
+            # work. Its artifact carrier, parse state, and both census receipts
+            # must therefore become durable as one source-tier transaction.
+            with archive._ensure_source_conn():
+                terminalized = _persist_terminal_non_session_artifact(
+                    archive,
+                    raw_id,
+                    provider=provider,
+                    source_path=_source_path,
+                    source_index=source_index,
+                    manage_transaction=False,
+                )
+                if terminalized:
+                    archive.replace_raw_membership_census(
+                        raw_id,
+                        [],
+                        parser_fingerprint=RAW_AUTHORITY_PARSER_FINGERPRINT,
+                        censused_at_ms=0,
+                        manage_transaction=False,
+                    )
+            if terminalized:
+                commit_unit()
+                return
         state.classified += int(len(sessions) == 1)
         spill.add(raw_id, sessions, payload_bytes=payload_bytes)
         if len(sessions) == 1 and revision_kind is RawRevisionKind.UNKNOWN:
@@ -3238,6 +3259,34 @@ def _declared_non_session_artifact_classification(
     return classification if not classification.parse_as_session else None
 
 
+def _detected_provider_for_empty_replay(
+    archive: ArchiveStore,
+    raw_id: str,
+    *,
+    stored_provider: Provider,
+    source_path: str,
+) -> Provider:
+    """Resolve a provider before terminalizing an empty retained replay."""
+    if stored_provider is not Provider.UNKNOWN:
+        return stored_provider
+    with archive.open_raw_revision_material(raw_id) as (_provider, payload, _path, _kind):
+        provider, _evidence = detect_provider_from_raw_bytes_evidence(
+            payload.read(_REPLAY_PROVIDER_DETECTION_PREFIX_BYTES),
+            Path(source_path).name,
+            stored_provider,
+            truncated_tail_ok=True,
+        )
+    if provider is not Provider.UNKNOWN:
+        return provider
+    _provider, full_payload, _path, _kind = archive.raw_revision_material(raw_id)
+    provider, _evidence = detect_provider_from_raw_bytes_evidence(
+        full_payload,
+        Path(source_path).name,
+        stored_provider,
+    )
+    return provider
+
+
 def _persist_terminal_non_session_artifact(
     archive: ArchiveStore,
     raw_id: str,
@@ -3246,25 +3295,19 @@ def _persist_terminal_non_session_artifact(
     source_path: str,
     source_index: int,
     manage_transaction: bool,
-) -> None:
+) -> bool:
     """Record replay-confirmed source-only artifact authority once.
 
-    A declared JSONL fact path can contain a real session, so it receives a
-    full rolling eligibility scan before replay may terminalize it.  A
-    non-session result then follows the same typed artifact row and parse
-    lifecycle used by live acquisition instead of remaining pending forever.
+    Replay reaches this function only after the real parser has consumed the
+    complete stream and produced no conversational session. The terminal
+    receipt therefore follows that one authoritative parse result instead of
+    reclassifying the raw through a second, weaker JSONL shape scan.
     """
     if provider is Provider.UNKNOWN:
-        return
+        return False
     classification = _declared_non_session_artifact_classification(provider, source_path)
     if classification is None:
-        return
-    if is_jsonl_source_path(source_path):
-        from polylogue.archive.raw_payload.decode import jsonl_session_artifact
-
-        with archive.open_raw_revision_material(raw_id) as (_provider, payload, _path, _kind):
-            if jsonl_session_artifact(payload, provider=provider) is not None:
-                return
+        return False
     origin = origin_from_provider(provider)
     observed_at_ms = archive.raw_revision_observed_at_ms(raw_id)
     upsert_raw_artifact(
@@ -3294,6 +3337,7 @@ def _persist_terminal_non_session_artifact(
         state=_raw_parse_success_state(provider),
         manage_transaction=manage_transaction,
     )
+    return True
 
 
 def _is_declared_non_session_artifact(

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -793,9 +793,9 @@ def _census_historical_revision_evidence(
             census_selection = initial_selection
             while True:
                 rows = archive.raw_membership_census_rows(census_selection)
-                for raw_id, _source_index, _terminal_non_session in sorted(
+                for raw_id, _source_index, _terminal_non_session, _raw_rowid in sorted(
                     rows,
-                    key=lambda row: (archive.raw_revision_observed_at_ms(row[0]), row[1], row[0]),
+                    key=lambda row: (archive.raw_revision_observed_at_ms(row[0]), row[3]),
                 ):
                     if raw_id in state.censused or not _replay_retained_codex_state_evidence(archive, raw_id):
                         continue
@@ -803,14 +803,14 @@ def _census_historical_revision_evidence(
                     state.censused.add(raw_id)
                     commit_unit()
                 terminal_raw_ids = {
-                    raw_id for raw_id, _source_index, terminal_non_session in rows if terminal_non_session
+                    raw_id for raw_id, _source_index, terminal_non_session, _raw_rowid in rows if terminal_non_session
                 }
                 for raw_id in terminal_raw_ids - state.censused:
                     state.scanned += 1
                     state.censused.add(raw_id)
                 pending_rows = [
                     (raw_id, source_index)
-                    for raw_id, source_index, terminal_non_session in rows
+                    for raw_id, source_index, terminal_non_session, _raw_rowid in rows
                     if raw_id not in state.censused and not terminal_non_session
                 ]
                 if max_payload_bytes is not None:
@@ -903,7 +903,7 @@ def _load_frozen_revision_evidence(
     rows = archive.raw_membership_census_rows(expanded_raw_ids if selected_raw_ids is not None else None)
     if max_payload_bytes is not None:
         payload_sizes = archive.raw_payload_sizes(
-            [raw_id for raw_id, _source_index, terminal_non_session in rows if not terminal_non_session]
+            [raw_id for raw_id, _source_index, terminal_non_session, _raw_rowid in rows if not terminal_non_session]
         )
         total_payload_bytes = sum(payload_sizes.values())
         oversized = [raw_id for raw_id, size in payload_sizes.items() if size > max_payload_bytes]
@@ -912,7 +912,9 @@ def _load_frozen_revision_evidence(
                 sorted(oversized or payload_sizes), max_payload_bytes, total_payload_bytes
             )
     parseable_raw_ids = [
-        raw_id for raw_id, source_index, terminal_non_session in rows if source_index >= 0 and not terminal_non_session
+        raw_id
+        for raw_id, source_index, terminal_non_session, _raw_rowid in rows
+        if source_index >= 0 and not terminal_non_session
     ]
     parsed_outcomes = _parse_retained_raws(
         archive,
@@ -921,7 +923,7 @@ def _load_frozen_revision_evidence(
         prefetch_cache=prefetch_cache,
     )
     state = _RevisionCensusState(0, 0, 0, set(), {}, {})
-    for raw_id, source_index, terminal_non_session in rows:
+    for raw_id, source_index, terminal_non_session, _raw_rowid in rows:
         state.scanned += 1
         state.censused.add(raw_id)
         if terminal_non_session:

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -708,7 +708,7 @@ def _census_historical_revision_evidence(
                     source_index=source_index,
                     manage_transaction=False,
                 )
-                if terminalized:
+                if provider is not Provider.UNKNOWN:
                     archive.replace_raw_membership_census(
                         raw_id,
                         [],
@@ -716,7 +716,14 @@ def _census_historical_revision_evidence(
                         censused_at_ms=0,
                         manage_transaction=False,
                     )
-            if terminalized:
+                    if not terminalized:
+                        apply_source_raw_state_update(
+                            archive._ensure_source_conn(),
+                            raw_id,
+                            state=_raw_parse_success_state(provider),
+                            manage_transaction=False,
+                        )
+            if provider is not Provider.UNKNOWN:
                 commit_unit()
                 return
         state.classified += int(len(sessions) == 1)

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -689,7 +689,17 @@ def _census_historical_revision_evidence(
             # A terminal artifact makes this raw ineligible for future census
             # work. Its artifact carrier, parse state, and both census receipts
             # must therefore become durable as one source-tier transaction.
-            with archive._ensure_source_conn():
+            # Batches retain that transaction until their existing commit
+            # boundary instead of forcing one SQLite commit per empty raw.
+            transaction = nullcontext() if batched else archive._ensure_source_conn()
+            with transaction:
+                if stored_provider is Provider.UNKNOWN and provider is not Provider.UNKNOWN:
+                    apply_source_raw_state_update(
+                        archive._ensure_source_conn(),
+                        raw_id,
+                        state=RawSessionStateUpdate(payload_provider=provider),
+                        manage_transaction=False,
+                    )
                 terminalized = _persist_terminal_non_session_artifact(
                     archive,
                     raw_id,
@@ -865,7 +875,7 @@ def _census_historical_revision_evidence(
                     break
                 census_selection = expanded
     except BaseException:
-        if batched and pending_commits > 0:
+        if batched:
             archive.rollback()
         raise
     if batched and pending_commits > 0:

--- a/polylogue/storage/raw_retention.py
+++ b/polylogue/storage/raw_retention.py
@@ -12,7 +12,7 @@ from typing import Literal
 
 from polylogue.core.raw_failure_evidence import RAW_FAILURE_EVIDENCE_KINDS, RawFailureEvidenceKind
 from polylogue.logging import get_logger
-from polylogue.storage.archive_identity import resolve_active_index_path
+from polylogue.storage.archive_identity import ArchiveLocationError, resolve_active_index_path
 from polylogue.storage.blob_store import BlobStore, get_blob_store
 from polylogue.storage.introspection import column_exists as _column_exists
 from polylogue.storage.introspection import table_exists as _table_exists
@@ -1184,7 +1184,10 @@ def raw_frontier_integrity_projection(
         raw_materialization_readiness,
         sample_limit=sample_limit,
     )
-    index_db_path = resolve_active_index_path(archive_root)
+    try:
+        index_db_path = resolve_active_index_path(archive_root)
+    except ArchiveLocationError as exc:
+        return unknown_raw_frontier_integrity_projection(f"active index pointer unavailable: {exc}")
     source_db_path = archive_root / "source.db"
     ops_db_path = archive_root / "ops.db"
     snapshot = _unavailable_frontier_integrity_snapshot(f"source tier is unavailable: {source_db_path}")

--- a/polylogue/storage/raw_retention.py
+++ b/polylogue/storage/raw_retention.py
@@ -1271,7 +1271,7 @@ def unknown_raw_frontier_integrity_projection(
         missing_source_raw_status=missing_source_raw_status,
         missing_source_raw_count=missing_source_raw_count,
         missing_source_raw_samples=missing_source_raw_samples,
-        missing_source_raw_reason=missing_source_raw_reason or reason,
+        missing_source_raw_reason=reason if missing_source_raw_reason is None else missing_source_raw_reason,
         cursor_ahead_status=snapshot.cursor_ahead_status,
         cursor_ahead_count=snapshot.cursor_ahead_count,
         cursor_ahead_checked_count=snapshot.cursor_ahead_checked_count,

--- a/polylogue/storage/raw_retention.py
+++ b/polylogue/storage/raw_retention.py
@@ -1187,7 +1187,13 @@ def raw_frontier_integrity_projection(
     try:
         index_db_path = resolve_active_index_path(archive_root)
     except ArchiveLocationError as exc:
-        return unknown_raw_frontier_integrity_projection(f"active index pointer unavailable: {exc}")
+        return unknown_raw_frontier_integrity_projection(
+            f"active index pointer unavailable: {exc}",
+            missing_source_raw_status=missing_status,
+            missing_source_raw_count=missing_count,
+            missing_source_raw_samples=missing_samples,
+            missing_source_raw_reason=missing_reason,
+        )
     source_db_path = archive_root / "source.db"
     ops_db_path = archive_root / "ops.db"
     snapshot = _unavailable_frontier_integrity_snapshot(f"source tier is unavailable: {source_db_path}")
@@ -1237,7 +1243,14 @@ def raw_frontier_integrity_projection(
     )
 
 
-def unknown_raw_frontier_integrity_projection(reason: str) -> RawFrontierIntegrityProjection:
+def unknown_raw_frontier_integrity_projection(
+    reason: str,
+    *,
+    missing_source_raw_status: RawFrontierIntegrityStatus = "unknown",
+    missing_source_raw_count: int = 0,
+    missing_source_raw_samples: tuple[Mapping[str, object], ...] = (),
+    missing_source_raw_reason: str | None = None,
+) -> RawFrontierIntegrityProjection:
     """Return the canonical explicit-unknown projection for an unavailable read.
 
     Cache and presentation adapters use this instead of inventing partial
@@ -1246,18 +1259,19 @@ def unknown_raw_frontier_integrity_projection(reason: str) -> RawFrontierIntegri
     """
 
     snapshot = _unavailable_frontier_integrity_snapshot(reason)
+    statuses = (snapshot.broken_head_status, missing_source_raw_status, snapshot.cursor_ahead_status)
     return RawFrontierIntegrityProjection(
         available=False,
-        overall_status="unknown",
+        overall_status=combine_raw_frontier_integrity_statuses(*statuses),
         broken_head_status=snapshot.broken_head_status,
         broken_head_count=snapshot.broken_head_count,
         broken_head_checked_count=snapshot.broken_head_checked_count,
         broken_head_samples=snapshot.broken_head_samples,
         broken_head_reason=snapshot.broken_head_reason,
-        missing_source_raw_status="unknown",
-        missing_source_raw_count=0,
-        missing_source_raw_samples=(),
-        missing_source_raw_reason=reason,
+        missing_source_raw_status=missing_source_raw_status,
+        missing_source_raw_count=missing_source_raw_count,
+        missing_source_raw_samples=missing_source_raw_samples,
+        missing_source_raw_reason=missing_source_raw_reason or reason,
         cursor_ahead_status=snapshot.cursor_ahead_status,
         cursor_ahead_count=snapshot.cursor_ahead_count,
         cursor_ahead_checked_count=snapshot.cursor_ahead_checked_count,

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -61,6 +61,7 @@ from polylogue.storage.message_type_backfill import (
     count_unclassified_message_type_sync,
 )
 from polylogue.storage.raw_authority import (
+    RAW_AUTHORITY_PARSER_FINGERPRINT,
     RAW_REPLAY_NO_PROGRESS_REASON,
     SUPERSEDED_MEMBERSHIP_FINGERPRINTS,
     RawAuthorityCensusReceipt,
@@ -3933,6 +3934,15 @@ def _raw_materialization_candidate_ids(
                    , EXISTS (
                        SELECT 1
                        FROM raw_membership_census AS c
+                       WHERE c.raw_id = r.raw_id
+                         AND c.parser_fingerprint = ?
+                         AND c.status = 'non_session'
+                         AND r.parsed_at_ms IS NOT NULL
+                         AND r.parse_error IS NULL
+                   ) AS membership_non_session_terminal
+                   , EXISTS (
+                       SELECT 1
+                       FROM raw_membership_census AS c
                        JOIN raw_session_memberships AS m ON m.raw_id = c.raw_id
                        WHERE c.raw_id = r.raw_id
                          AND c.status = 'complete'
@@ -4023,6 +4033,7 @@ def _raw_materialization_candidate_ids(
             [
                 *sorted(RAW_FAILURE_REPLAY_AUTHORITY_EVIDENCE_KINDS),
                 RAW_FAILURE_DEFERRED_SUPPORT_STATUS,
+                RAW_AUTHORITY_PARSER_FINGERPRINT,
                 BYTE_AUTHORITY_CENSUS_DETAIL,
                 BYTE_AUTHORITY_CENSUS_DETAIL,
                 *sorted(RAW_FAILURE_REPLAY_AUTHORITY_EVIDENCE_KINDS),
@@ -4071,6 +4082,8 @@ def _raw_materialization_candidate_ids(
             ):
                 continue
             if _raw_materialized_by_source_path_native(materialized_aliases, row):
+                continue
+            if bool(row["membership_non_session_terminal"]):
                 continue
             if _raw_materialization_parsed_non_session_artifact(archive_root, row):
                 continue

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -216,6 +216,7 @@ from polylogue.storage.sqlite.archive_tiers.revision_governance import (
     raw_revision_descriptor,
     raw_revision_head_raw_id,
     raw_revision_material,
+    raw_revision_observation_order,
     raw_revision_observed_at_ms,
     raw_revision_rebuild_selection,
     raw_revision_replay_adoptable,
@@ -2767,6 +2768,9 @@ class ArchiveStore:
 
     def raw_revision_observed_at_ms(self, raw_id: str) -> int:
         return raw_revision_observed_at_ms(self, raw_id)
+
+    def raw_revision_observation_order(self, raw_id: str) -> tuple[int, int]:
+        return raw_revision_observation_order(self, raw_id)
 
     def raw_membership_rebuild_raw_ids(self, logical_source_key: str) -> tuple[str, ...]:
         return raw_membership_rebuild_raw_ids(self, logical_source_key)

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -216,6 +216,7 @@ from polylogue.storage.sqlite.archive_tiers.revision_governance import (
     raw_revision_descriptor,
     raw_revision_head_raw_id,
     raw_revision_material,
+    raw_revision_observed_at_ms,
     raw_revision_rebuild_selection,
     raw_revision_replay_adoptable,
     raw_revision_replay_plan,
@@ -2761,6 +2762,9 @@ class ArchiveStore:
 
     def raw_revision_acquired_at_ms(self, raw_id: str) -> int:
         return raw_revision_acquired_at_ms(self, raw_id)
+
+    def raw_revision_observed_at_ms(self, raw_id: str) -> int:
+        return raw_revision_observed_at_ms(self, raw_id)
 
     def raw_membership_rebuild_raw_ids(self, logical_source_key: str) -> tuple[str, ...]:
         return raw_membership_rebuild_raw_ids(self, logical_source_key)

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -2700,7 +2700,9 @@ class ArchiveStore:
     ) -> tuple[tuple[tuple[str, int], ...], tuple[str, ...]]:
         return raw_revision_rebuild_selection(self, raw_ids)
 
-    def raw_membership_census_rows(self, raw_ids: Sequence[str] | None = None) -> tuple[tuple[str, int, bool], ...]:
+    def raw_membership_census_rows(
+        self, raw_ids: Sequence[str] | None = None
+    ) -> tuple[tuple[str, int, bool, int], ...]:
         return raw_membership_census_rows(self, raw_ids)
 
     def raw_payload_sizes(self, raw_ids: Sequence[str]) -> dict[str, int]:

--- a/polylogue/storage/sqlite/archive_tiers/revision_governance.py
+++ b/polylogue/storage/sqlite/archive_tiers/revision_governance.py
@@ -1715,16 +1715,26 @@ def raw_membership_census_rows(
     columns = """
         r.raw_id,
         r.source_index,
-        EXISTS(SELECT 1 FROM raw_artifacts AS a WHERE a.raw_id = r.raw_id AND a.parse_as_session = 0),
+        (
+            EXISTS(SELECT 1 FROM raw_artifacts AS a WHERE a.raw_id = r.raw_id AND a.parse_as_session = 0)
+            OR EXISTS(
+                SELECT 1 FROM raw_membership_census AS c
+                WHERE c.raw_id = r.raw_id
+                  AND c.parser_fingerprint = ?
+                  AND c.status = 'non_session'
+            )
+        ),
         r.rowid
     """
     if raw_ids is None:
-        rows = conn.execute(f"SELECT {columns} FROM raw_sessions AS r ORDER BY r.raw_id").fetchall()
+        rows = conn.execute(
+            f"SELECT {columns} FROM raw_sessions AS r ORDER BY r.raw_id", (RAW_AUTHORITY_PARSER_FINGERPRINT,)
+        ).fetchall()
     elif raw_ids:
         placeholders = ",".join("?" for _ in raw_ids)
         rows = conn.execute(
             f"SELECT {columns} FROM raw_sessions AS r WHERE r.raw_id IN ({placeholders}) ORDER BY r.raw_id",
-            tuple(raw_ids),
+            (RAW_AUTHORITY_PARSER_FINGERPRINT, *raw_ids),
         ).fetchall()
     else:
         rows = []

--- a/polylogue/storage/sqlite/archive_tiers/revision_governance.py
+++ b/polylogue/storage/sqlite/archive_tiers/revision_governance.py
@@ -1709,13 +1709,14 @@ def raw_revision_rebuild_selection(
 
 def raw_membership_census_rows(
     store: RawRevisionGovernanceHost, raw_ids: Sequence[str] | None = None
-) -> tuple[tuple[str, int, bool], ...]:
+) -> tuple[tuple[str, int, bool, int], ...]:
     """Return retained raws and whether durable evidence says they are non-sessions."""
     conn = store._ensure_source_conn()
     columns = """
         r.raw_id,
         r.source_index,
-        EXISTS(SELECT 1 FROM raw_artifacts AS a WHERE a.raw_id = r.raw_id AND a.parse_as_session = 0)
+        EXISTS(SELECT 1 FROM raw_artifacts AS a WHERE a.raw_id = r.raw_id AND a.parse_as_session = 0),
+        r.rowid
     """
     if raw_ids is None:
         rows = conn.execute(f"SELECT {columns} FROM raw_sessions AS r ORDER BY r.raw_id").fetchall()
@@ -1727,7 +1728,7 @@ def raw_membership_census_rows(
         ).fetchall()
     else:
         rows = []
-    return tuple((str(row[0]), int(row[1]), bool(row[2])) for row in rows)
+    return tuple((str(row[0]), int(row[1]), bool(row[2]), int(row[3])) for row in rows)
 
 
 def raw_payload_sizes(store: RawRevisionGovernanceHost, raw_ids: Sequence[str]) -> dict[str, int]:

--- a/polylogue/storage/sqlite/archive_tiers/revision_governance.py
+++ b/polylogue/storage/sqlite/archive_tiers/revision_governance.py
@@ -1722,6 +1722,8 @@ def raw_membership_census_rows(
                 WHERE c.raw_id = r.raw_id
                   AND c.parser_fingerprint = ?
                   AND c.status = 'non_session'
+                  AND r.parsed_at_ms IS NOT NULL
+                  AND r.parse_error IS NULL
             )
         ),
         r.rowid
@@ -1778,8 +1780,6 @@ def replace_raw_membership_census(
             ).fetchone()
             if revision is None:
                 raise RuntimeError(f"membership census raw is missing: {raw_id}")
-            if revision[0] is not None and str(revision[1]) != RawRevisionKind.FULL.value:
-                raise RuntimeError("only self-contained full raws can move to membership governance")
             dependent = conn.execute(
                 """
                 SELECT 1 FROM raw_sessions
@@ -2211,18 +2211,28 @@ def raw_revision_observed_at_ms(store: RawRevisionGovernanceHost, raw_id: str) -
     ``blob_refs`` raw-payload receipt instead, which is the ordering authority
     for replaying mutable state snapshots.
     """
+    return raw_revision_observation_order(store, raw_id)[0]
+
+
+def raw_revision_observation_order(store: RawRevisionGovernanceHost, raw_id: str) -> tuple[int, int]:
+    """Return the latest observation timestamp and its durable receipt order."""
     conn = store._ensure_source_conn()
     row = conn.execute(
         """
-        SELECT MAX(acquired_at_ms)
+        SELECT acquired_at_ms, rowid
         FROM blob_refs
         WHERE ref_id = ? AND ref_type = 'raw_payload'
+        ORDER BY acquired_at_ms DESC, rowid DESC
+        LIMIT 1
         """,
         (raw_id,),
     ).fetchone()
-    if row is not None and row[0] is not None:
-        return int(row[0])
-    return raw_revision_acquired_at_ms(store, raw_id)
+    if row is not None:
+        return int(row[0]), int(row[1])
+    row = conn.execute("SELECT acquired_at_ms, rowid FROM raw_sessions WHERE raw_id = ?", (raw_id,)).fetchone()
+    if row is None:
+        raise KeyError(f"unknown raw revision {raw_id}")
+    return int(row[0]), int(row[1])
 
 
 def raw_membership_rebuild_raw_ids(store: RawRevisionGovernanceHost, logical_source_key: str) -> tuple[str, ...]:

--- a/polylogue/storage/sqlite/archive_tiers/revision_governance.py
+++ b/polylogue/storage/sqlite/archive_tiers/revision_governance.py
@@ -2192,6 +2192,28 @@ def raw_revision_acquired_at_ms(store: RawRevisionGovernanceHost, raw_id: str) -
     return int(row[0])
 
 
+def raw_revision_observed_at_ms(store: RawRevisionGovernanceHost, raw_id: str) -> int:
+    """Return the latest durable observation receipt for a retained raw.
+
+    ``raw_sessions.acquired_at_ms`` is deliberately immutable because the raw
+    id is content-derived.  Re-observing identical bytes refreshes the
+    ``blob_refs`` raw-payload receipt instead, which is the ordering authority
+    for replaying mutable state snapshots.
+    """
+    conn = store._ensure_source_conn()
+    row = conn.execute(
+        """
+        SELECT MAX(acquired_at_ms)
+        FROM blob_refs
+        WHERE ref_id = ? AND ref_type = 'raw_payload'
+        """,
+        (raw_id,),
+    ).fetchone()
+    if row is not None and row[0] is not None:
+        return int(row[0])
+    return raw_revision_acquired_at_ms(store, raw_id)
+
+
 def raw_membership_rebuild_raw_ids(store: RawRevisionGovernanceHost, logical_source_key: str) -> tuple[str, ...]:
     """Return census candidates excluding quarantined full rows with another authority key."""
     rows = (

--- a/polylogue/storage/sqlite/archive_tiers/source_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/source_write.py
@@ -1292,13 +1292,21 @@ def upsert_raw_artifact(
     with conn if manage_transaction else nullcontext():
         existing = conn.execute(
             f"""
-            SELECT artifact_id
+            SELECT artifact_id, first_observed_at_ms, last_observed_at_ms
             FROM raw_artifacts
             WHERE {coordinate_predicate}
             """,
             coordinate_params,
         ).fetchone()
         if existing is not None:
+            # One coordinate has one authority carrier. A delayed census of
+            # stale retained bytes must not replace a carrier observed later.
+            if int(existing[2]) >= artifact.last_observed_at_ms:
+                conn.execute(
+                    "UPDATE raw_artifacts SET first_observed_at_ms = MIN(first_observed_at_ms, ?) WHERE artifact_id = ?",
+                    (artifact.first_observed_at_ms, str(existing[0])),
+                )
+                return
             artifact = replace(artifact, artifact_id=str(existing[0]))
         _insert_artifact(conn, raw_id, artifact)
 

--- a/polylogue/storage/sqlite/archive_tiers/source_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/source_write.py
@@ -1273,9 +1273,9 @@ def upsert_raw_artifact(
     """
     failure_kind = _is_raw_failure_artifact_kind(artifact.artifact_kind)
     coordinate_predicate = (
-        "raw_id = ? AND origin = ? AND source_path = ? AND source_index = ?"
+        "a.raw_id = ? AND a.origin = ? AND a.source_path = ? AND a.source_index = ?"
         if failure_kind
-        else "origin = ? AND source_path = ? AND source_index = ? AND artifact_kind NOT IN ("
+        else "a.origin = ? AND a.source_path = ? AND a.source_index = ? AND a.artifact_kind NOT IN ("
         + ", ".join("?" for _ in RAW_FAILURE_EVIDENCE_KINDS)
         + ")"
     )
@@ -1292,8 +1292,9 @@ def upsert_raw_artifact(
     with conn if manage_transaction else nullcontext():
         existing = conn.execute(
             f"""
-            SELECT artifact_id, first_observed_at_ms, last_observed_at_ms
-            FROM raw_artifacts
+            SELECT a.artifact_id, a.first_observed_at_ms, a.last_observed_at_ms, r.rowid
+            FROM raw_artifacts AS a
+            JOIN raw_sessions AS r ON r.raw_id = a.raw_id
             WHERE {coordinate_predicate}
             """,
             coordinate_params,
@@ -1301,7 +1302,10 @@ def upsert_raw_artifact(
         if existing is not None:
             # One coordinate has one authority carrier. A delayed census of
             # stale retained bytes must not replace a carrier observed later.
-            if int(existing[2]) >= artifact.last_observed_at_ms:
+            incoming_row = conn.execute("SELECT rowid FROM raw_sessions WHERE raw_id = ?", (raw_id,)).fetchone()
+            if incoming_row is None:
+                raise KeyError(raw_id)
+            if (int(existing[2]), int(existing[3])) >= (artifact.last_observed_at_ms, int(incoming_row[0])):
                 conn.execute(
                     "UPDATE raw_artifacts SET first_observed_at_ms = MIN(first_observed_at_ms, ?) WHERE artifact_id = ?",
                     (artifact.first_observed_at_ms, str(existing[0])),

--- a/polylogue/storage/sqlite/archive_tiers/source_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/source_write.py
@@ -1303,10 +1303,34 @@ def upsert_raw_artifact(
             # One coordinate has one authority carrier. A delayed census of
             # stale retained bytes must not replace a carrier observed later.
             if str(existing[1]) != raw_id:
-                incoming_row = conn.execute("SELECT rowid FROM raw_sessions WHERE raw_id = ?", (raw_id,)).fetchone()
+                incoming_row = conn.execute(
+                    """
+                    SELECT acquired_at_ms, rowid FROM blob_refs
+                    WHERE ref_id = ? AND ref_type = 'raw_payload'
+                    ORDER BY acquired_at_ms DESC, rowid DESC LIMIT 1
+                    """,
+                    (raw_id,),
+                ).fetchone()
+                if incoming_row is None:
+                    incoming_row = conn.execute(
+                        "SELECT acquired_at_ms, rowid FROM raw_sessions WHERE raw_id = ?", (raw_id,)
+                    ).fetchone()
                 if incoming_row is None:
                     raise KeyError(raw_id)
-                if (int(existing[3]), int(existing[4])) >= (artifact.last_observed_at_ms, int(incoming_row[0])):
+                existing_observation = conn.execute(
+                    """
+                    SELECT acquired_at_ms, rowid FROM blob_refs
+                    WHERE ref_id = ? AND ref_type = 'raw_payload'
+                    ORDER BY acquired_at_ms DESC, rowid DESC LIMIT 1
+                    """,
+                    (str(existing[1]),),
+                ).fetchone()
+                existing_order = (
+                    (int(existing_observation[0]), int(existing_observation[1]))
+                    if existing_observation is not None
+                    else (int(existing[3]), int(existing[4]))
+                )
+                if existing_order >= (int(incoming_row[0]), int(incoming_row[1])):
                     conn.execute(
                         "UPDATE raw_artifacts SET first_observed_at_ms = MIN(first_observed_at_ms, ?) WHERE artifact_id = ?",
                         (artifact.first_observed_at_ms, str(existing[0])),

--- a/polylogue/storage/sqlite/archive_tiers/source_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/source_write.py
@@ -1292,7 +1292,7 @@ def upsert_raw_artifact(
     with conn if manage_transaction else nullcontext():
         existing = conn.execute(
             f"""
-            SELECT a.artifact_id, a.first_observed_at_ms, a.last_observed_at_ms, r.rowid
+            SELECT a.artifact_id, a.raw_id, a.first_observed_at_ms, a.last_observed_at_ms, r.rowid
             FROM raw_artifacts AS a
             JOIN raw_sessions AS r ON r.raw_id = a.raw_id
             WHERE {coordinate_predicate}
@@ -1302,15 +1302,16 @@ def upsert_raw_artifact(
         if existing is not None:
             # One coordinate has one authority carrier. A delayed census of
             # stale retained bytes must not replace a carrier observed later.
-            incoming_row = conn.execute("SELECT rowid FROM raw_sessions WHERE raw_id = ?", (raw_id,)).fetchone()
-            if incoming_row is None:
-                raise KeyError(raw_id)
-            if (int(existing[2]), int(existing[3])) >= (artifact.last_observed_at_ms, int(incoming_row[0])):
-                conn.execute(
-                    "UPDATE raw_artifacts SET first_observed_at_ms = MIN(first_observed_at_ms, ?) WHERE artifact_id = ?",
-                    (artifact.first_observed_at_ms, str(existing[0])),
-                )
-                return
+            if str(existing[1]) != raw_id:
+                incoming_row = conn.execute("SELECT rowid FROM raw_sessions WHERE raw_id = ?", (raw_id,)).fetchone()
+                if incoming_row is None:
+                    raise KeyError(raw_id)
+                if (int(existing[3]), int(existing[4])) >= (artifact.last_observed_at_ms, int(incoming_row[0])):
+                    conn.execute(
+                        "UPDATE raw_artifacts SET first_observed_at_ms = MIN(first_observed_at_ms, ?) WHERE artifact_id = ?",
+                        (artifact.first_observed_at_ms, str(existing[0])),
+                    )
+                    return
             artifact = replace(artifact, artifact_id=str(existing[0]))
         _insert_artifact(conn, raw_id, artifact)
 

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -544,6 +544,38 @@ def test_backfill_replays_codex_state_by_latest_raw_observation(tmp_path: Path) 
     assert json.loads(str(payload_json[0]))["title"] == "title A"
 
 
+def test_backfill_replays_equal_time_codex_state_by_raw_acquisition_order(tmp_path: Path) -> None:
+    """Equal-time Codex snapshots retain the later raw insertion as authority."""
+    initialize_active_archive_root(tmp_path)
+    source_path = str(tmp_path / "codex" / "state_5.sqlite")
+    older_snapshot = _codex_thread_state_snapshot_bytes(tmp_path, "older title")
+    newer_snapshot = _codex_thread_state_snapshot_bytes(tmp_path, "newer title")
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=older_snapshot,
+            source_path=source_path,
+            acquired_at_ms=1,
+            raw_id="z-older-state",
+        )
+        archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=newer_snapshot,
+            source_path=source_path,
+            acquired_at_ms=1,
+            raw_id="a-newer-state",
+        )
+
+    census_historical_revision_evidence(tmp_path)
+
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        payload_json = conn.execute(
+            "SELECT payload_json FROM raw_hook_events WHERE hook_event_id = 'codex-thread-title:codex-state-thread'"
+        ).fetchone()
+    assert payload_json is not None
+    assert json.loads(str(payload_json[0]))["title"] == "newer title"
+
+
 def test_backfill_terminalizes_source_only_declared_artifact(tmp_path: Path) -> None:
     """Replay turns a decoded fact-sidecar raw into terminal source authority.
 

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -657,10 +657,13 @@ def test_backfill_persists_detected_provider_for_empty_ordinary_session_path(tmp
     census_historical_revision_evidence(tmp_path)
 
     with sqlite3.connect(tmp_path / "source.db") as conn:
-        assert conn.execute("SELECT origin FROM raw_sessions WHERE raw_id = ?", (raw_id,)).fetchone() == (
-            "claude-code-session",
-        )
+        assert conn.execute(
+            "SELECT origin, parsed_at_ms IS NOT NULL FROM raw_sessions WHERE raw_id = ?", (raw_id,)
+        ).fetchone() == ("claude-code-session", 1)
         assert conn.execute("SELECT COUNT(*) FROM raw_artifacts WHERE raw_id = ?", (raw_id,)).fetchone() == (0,)
+        assert conn.execute("SELECT status FROM raw_membership_census WHERE raw_id = ?", (raw_id,)).fetchone() == (
+            "non_session",
+        )
 
 
 def test_terminal_artifact_receipts_roll_back_together(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -782,6 +785,13 @@ def test_backfill_preserves_latest_terminal_artifact_observation(tmp_path: Path)
     with sqlite3.connect(tmp_path / "source.db") as conn:
         assert conn.execute("SELECT raw_id, last_observed_at_ms FROM raw_artifacts").fetchone() == (newer_raw_id, 2)
         assert older_raw_id > newer_raw_id
+        assert conn.execute(
+            "SELECT COUNT(*) FROM raw_sessions WHERE raw_id IN (?, ?) AND parsed_at_ms IS NOT NULL",
+            (older_raw_id, newer_raw_id),
+        ).fetchone() == (2,)
+
+    with ArchiveStore.open_existing(tmp_path, read_only=True) as archive:
+        assert all(row[2] for row in archive.raw_membership_census_rows([older_raw_id, newer_raw_id]))
 
 
 def test_backfill_uses_raw_observation_order_for_equal_time_artifacts(tmp_path: Path) -> None:

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -189,6 +189,30 @@ def test_unknown_retained_stream_replay_detects_from_prefix_without_eager_payloa
     assert [session.provider_session_id for session in sessions] == ["unknown-stream"]
 
 
+def test_unknown_retained_document_replays_after_complete_payload_detection(tmp_path: Path) -> None:
+    """A complete ChatGPT document must retry UNKNOWN prefix detection.
+
+    The raw is intentionally a source-only UNKNOWN ``conversations.json``
+    whose first complete array item is larger than the replay detection
+    prefix.  This drives the historical replay chokepoint against a real
+    archive, rather than testing the detector in isolation.
+    """
+    initialize_active_archive_root(tmp_path)
+    payload = _bundle(_chatgpt_session("large-document", "x" * 9_000))
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        archive.write_raw_payload(
+            provider=Provider.UNKNOWN,
+            payload=payload,
+            source_path="export/conversations.json",
+            acquired_at_ms=1,
+        )
+
+    backfill_historical_revision_evidence(tmp_path)
+
+    with sqlite3.connect(tmp_path / "index.db") as conn:
+        assert conn.execute("SELECT session_id FROM sessions").fetchall() == [("chatgpt-export:large-document",)]
+
+
 def test_parsed_session_spill_uses_the_pinned_active_index_directory(tmp_path: Path) -> None:
     """Repair spill churn follows the generation being repaired, not a shadow index."""
     archive_root = tmp_path / "archive"
@@ -272,6 +296,37 @@ def test_parse_stream_recovery_accepts_session_evidence_at_a_declared_fact_path(
 
     assert len(sessions) == 1
     assert [message.text for message in sessions[0].messages] == ["recover me", "recovered"]
+
+
+def test_backfill_scans_declared_stream_past_non_session_prefix(tmp_path: Path) -> None:
+    """Later Claude records outrank an arbitrarily long fact-artifact prefix.
+
+    The production backfill route must not turn the first 64 non-session
+    records into permanent artifact authority when later records prove a
+    session.  The archive assertion fails if replay rejects that bounded
+    prefix before parsing the rest of the retained JSONL.
+    """
+    initialize_active_archive_root(tmp_path)
+    source_path = str(tmp_path / ".claude" / "projects" / "proj" / "subagents" / "workflows" / "wf" / "journal.jsonl")
+    payload = _relationship_index_jsonl_bytes(64) + (
+        b'{"parentUuid":null,"type":"user","sessionId":"late-session","message":{"role":"user","content":"late evidence"},'
+        b'"uuid":"late-user","timestamp":"2025-01-01T00:00:00Z"}\n'
+        b'{"parentUuid":"late-user","type":"assistant","sessionId":"late-session","message":{"role":"assistant",'
+        b'"content":[{"type":"text","text":"late reply"}]},"uuid":"late-assistant",'
+        b'"timestamp":"2025-01-01T00:00:01Z"}\n'
+    )
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        archive.write_raw_payload(
+            provider=Provider.CLAUDE_CODE,
+            payload=payload,
+            source_path=source_path,
+            acquired_at_ms=1,
+        )
+
+    backfill_historical_revision_evidence(tmp_path)
+
+    with sqlite3.connect(tmp_path / "index.db") as conn:
+        assert conn.execute("SELECT session_id FROM sessions").fetchall() == [("claude-code-session:late-session",)]
 
 
 def _relationship_index_jsonl_bytes(count: int = 8) -> bytes:
@@ -432,6 +487,94 @@ def test_historical_backfill_streams_codex_raw_without_eager_blob_read(
 
     assert result.scanned == 1
     assert result.replayed_logical_sources == 1
+
+
+def _codex_thread_state_snapshot_bytes(tmp_path: Path, title: str) -> bytes:
+    state_path = tmp_path / f"{title}.sqlite"
+    with sqlite3.connect(state_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE threads (
+                id TEXT PRIMARY KEY, title TEXT, cwd TEXT, created_at_ms INTEGER,
+                updated_at_ms INTEGER, source TEXT, model TEXT, agent_nickname TEXT,
+                agent_role TEXT, archived INTEGER
+            );
+            CREATE TABLE thread_spawn_edges (
+                parent_thread_id TEXT, child_thread_id TEXT, status TEXT
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO threads VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("codex-state-thread", title, "/work", 1, 1, "cli", None, None, None, 0),
+        )
+        conn.commit()
+    return state_path.read_bytes()
+
+
+def test_backfill_replays_codex_state_by_latest_raw_observation(tmp_path: Path) -> None:
+    """A retained A -> B -> A state sequence leaves A's title current.
+
+    Reacquiring A reuses its content-derived raw id, so this proves replay
+    orders its snapshot application by the latest durable raw-payload receipt,
+    not ``raw_sessions.acquired_at_ms`` from A's first observation.
+    """
+    initialize_active_archive_root(tmp_path)
+    source_path = str(tmp_path / "codex" / "state_5.sqlite")
+    snapshot_a = _codex_thread_state_snapshot_bytes(tmp_path, "title A")
+    snapshot_b = _codex_thread_state_snapshot_bytes(tmp_path, "title B")
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        archive.write_raw_payload(
+            provider=Provider.CODEX, payload=snapshot_a, source_path=source_path, acquired_at_ms=1
+        )
+        archive.write_raw_payload(
+            provider=Provider.CODEX, payload=snapshot_b, source_path=source_path, acquired_at_ms=2
+        )
+        archive.write_raw_payload(
+            provider=Provider.CODEX, payload=snapshot_a, source_path=source_path, acquired_at_ms=3
+        )
+
+    census_historical_revision_evidence(tmp_path)
+
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        payload_json = conn.execute(
+            "SELECT payload_json FROM raw_hook_events WHERE hook_event_id = 'codex-thread-title:codex-state-thread'"
+        ).fetchone()
+    assert payload_json is not None
+    assert json.loads(str(payload_json[0]))["title"] == "title A"
+
+
+def test_backfill_terminalizes_source_only_declared_artifact(tmp_path: Path) -> None:
+    """Replay turns a decoded fact-sidecar raw into terminal source authority.
+
+    This exercises the same retained-raw replay path as recovery: the
+    source-only raw starts pending, the parser confirms it is a workflow
+    artifact, and the source tier must retain both typed artifact evidence and
+    a successful parse receipt so it is not selected forever.
+    """
+    initialize_active_archive_root(tmp_path)
+    source_path = str(tmp_path / ".claude" / "projects" / "proj" / "subagents" / "workflows" / "wf" / "journal.jsonl")
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        raw_id = archive.write_raw_payload(
+            provider=Provider.CLAUDE_CODE,
+            payload=b'{"contentKey":"workflow-artifact","agentId":"agent"}\n',
+            source_path=source_path,
+            acquired_at_ms=1,
+        )
+
+    backfill_historical_revision_evidence(tmp_path)
+
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        assert conn.execute(
+            "SELECT parsed_at_ms IS NOT NULL FROM raw_sessions WHERE raw_id = ?", (raw_id,)
+        ).fetchone() == (1,)
+        assert conn.execute("SELECT parse_as_session FROM raw_artifacts WHERE raw_id = ?", (raw_id,)).fetchone() == (0,)
+        assert conn.execute("SELECT status FROM raw_membership_census WHERE raw_id = ?", (raw_id,)).fetchone() == (
+            "non_session",
+        )
+        assert conn.execute(
+            "SELECT status, logical_keys_json FROM raw_authority_parser_census WHERE raw_id = ?", (raw_id,)
+        ).fetchone() == ("complete", "[]")
 
 
 def test_historical_backfill_selects_prefix_newest_independent_of_acquisition_order(tmp_path: Path) -> None:

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -607,6 +607,30 @@ def test_backfill_terminalizes_detected_unknown_empty_artifact(tmp_path: Path) -
         ).fetchone() == ("complete", "[]")
 
 
+def test_backfill_persists_detected_provider_for_empty_ordinary_session_path(tmp_path: Path) -> None:
+    """Provider detection survives even when a session path is not terminalized."""
+    initialize_active_archive_root(tmp_path)
+    source_path = str(tmp_path / ".claude" / "projects" / "proj" / "history-only-session.jsonl")
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        raw_id = archive.write_raw_payload(
+            provider=Provider.UNKNOWN,
+            payload=(
+                b'{"type":"file-history-snapshot","messageId":"history-message",'
+                b'"sessionId":"history-only-session","snapshot":{"trackedFileBackups":{}}}\n'
+            ),
+            source_path=source_path,
+            acquired_at_ms=1,
+        )
+
+    census_historical_revision_evidence(tmp_path)
+
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        assert conn.execute("SELECT origin FROM raw_sessions WHERE raw_id = ?", (raw_id,)).fetchone() == (
+            "claude-code-session",
+        )
+        assert conn.execute("SELECT COUNT(*) FROM raw_artifacts WHERE raw_id = ?", (raw_id,)).fetchone() == (0,)
+
+
 def test_terminal_artifact_receipts_roll_back_together(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A failed terminal census cannot expose only its artifact carrier."""
     initialize_active_archive_root(tmp_path)
@@ -631,6 +655,73 @@ def test_terminal_artifact_receipts_roll_back_together(tmp_path: Path, monkeypat
         assert conn.execute("SELECT parsed_at_ms FROM raw_sessions WHERE raw_id = ?", (raw_id,)).fetchone() == (None,)
         assert conn.execute(
             "SELECT COUNT(*) FROM raw_authority_parser_census WHERE raw_id = ?", (raw_id,)
+        ).fetchone() == (0,)
+
+
+def test_batched_terminal_artifact_receipts_roll_back_together(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Batched empty outcomes retain one transaction through their batch boundary."""
+    initialize_active_archive_root(tmp_path)
+    raw_ids: list[str] = []
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        for index in range(2):
+            raw_ids.append(
+                archive.write_raw_payload(
+                    provider=Provider.CLAUDE_CODE,
+                    payload=f'{{"contentKey":"workflow-{index}","agentId":"agent"}}\n'.encode(),
+                    source_path=str(
+                        tmp_path
+                        / ".claude"
+                        / "projects"
+                        / "proj"
+                        / "subagents"
+                        / "workflows"
+                        / f"wf-{index}"
+                        / "journal.jsonl"
+                    ),
+                    acquired_at_ms=index + 1,
+                )
+            )
+
+    original_replace = ArchiveStore.replace_raw_membership_census
+    calls = 0
+
+    def fail_second_census(
+        self: ArchiveStore,
+        raw_id: str,
+        sessions: list[ParsedSession] | None,
+        *,
+        parser_fingerprint: str,
+        censused_at_ms: int,
+        detail: str = "",
+        retire_full_revision_governance: bool = False,
+        manage_transaction: bool = True,
+    ) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("injected second terminal census failure")
+        original_replace(
+            self,
+            raw_id,
+            sessions,
+            parser_fingerprint=parser_fingerprint,
+            censused_at_ms=censused_at_ms,
+            detail=detail,
+            retire_full_revision_governance=retire_full_revision_governance,
+            manage_transaction=manage_transaction,
+        )
+
+    monkeypatch.setattr(ArchiveStore, "replace_raw_membership_census", fail_second_census)
+    with pytest.raises(RuntimeError, match="injected second terminal census failure"):
+        census_historical_revision_evidence(tmp_path, commit_batch_size=2)
+
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        placeholders = ", ".join("?" for _ in raw_ids)
+        assert conn.execute(
+            f"SELECT COUNT(*) FROM raw_artifacts WHERE raw_id IN ({placeholders})", raw_ids
+        ).fetchone() == (0,)
+        assert conn.execute(
+            f"SELECT COUNT(*) FROM raw_authority_parser_census WHERE raw_id IN ({placeholders})", raw_ids
         ).fetchone() == (0,)
 
 
@@ -659,6 +750,33 @@ def test_backfill_preserves_latest_terminal_artifact_observation(tmp_path: Path)
     with sqlite3.connect(tmp_path / "source.db") as conn:
         assert conn.execute("SELECT raw_id, last_observed_at_ms FROM raw_artifacts").fetchone() == (newer_raw_id, 2)
         assert older_raw_id > newer_raw_id
+
+
+def test_backfill_uses_raw_observation_order_for_equal_time_artifacts(tmp_path: Path) -> None:
+    """Equal observation times use the durable raw insertion order, not raw-id order."""
+    initialize_active_archive_root(tmp_path)
+    source_path = str(tmp_path / ".claude" / "projects" / "proj" / "subagents" / "workflows" / "wf" / "journal.jsonl")
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        older_raw_id = archive.write_raw_payload(
+            provider=Provider.CLAUDE_CODE,
+            payload=b'{"contentKey":"workflow-artifact","agentId":"old"}\n',
+            source_path=source_path,
+            acquired_at_ms=1,
+            raw_id="a-older-artifact",
+        )
+        newer_raw_id = archive.write_raw_payload(
+            provider=Provider.CLAUDE_CODE,
+            payload=b'{"contentKey":"workflow-artifact","agentId":"new"}\n',
+            source_path=source_path,
+            acquired_at_ms=1,
+            raw_id="z-newer-artifact",
+        )
+
+    backfill_historical_revision_evidence(tmp_path)
+
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        assert conn.execute("SELECT raw_id, last_observed_at_ms FROM raw_artifacts").fetchone() == (newer_raw_id, 1)
+        assert older_raw_id < newer_raw_id
 
 
 def test_historical_backfill_selects_prefix_newest_independent_of_acquisition_order(tmp_path: Path) -> None:

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -577,6 +577,90 @@ def test_backfill_terminalizes_source_only_declared_artifact(tmp_path: Path) -> 
         ).fetchone() == ("complete", "[]")
 
 
+def test_backfill_terminalizes_detected_unknown_empty_artifact(tmp_path: Path) -> None:
+    """Detected provider evidence must survive an empty retained replay."""
+    initialize_active_archive_root(tmp_path)
+    source_path = str(tmp_path / ".claude" / "projects" / "proj" / "subagents" / "workflows" / "wf" / "journal.jsonl")
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        raw_id = archive.write_raw_payload(
+            provider=Provider.UNKNOWN,
+            payload=(
+                b'{"type":"file-history-snapshot","messageId":"history-message",'
+                b'"sessionId":"history-only-session","snapshot":{"trackedFileBackups":{}}}\n'
+            ),
+            source_path=source_path,
+            acquired_at_ms=1,
+        )
+
+    backfill_historical_revision_evidence(tmp_path)
+
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        assert conn.execute(
+            "SELECT origin, parsed_at_ms IS NOT NULL FROM raw_sessions WHERE raw_id = ?", (raw_id,)
+        ).fetchone() == (
+            "claude-code-session",
+            1,
+        )
+        assert conn.execute("SELECT parse_as_session FROM raw_artifacts WHERE raw_id = ?", (raw_id,)).fetchone() == (0,)
+        assert conn.execute(
+            "SELECT status, logical_keys_json FROM raw_authority_parser_census WHERE raw_id = ?", (raw_id,)
+        ).fetchone() == ("complete", "[]")
+
+
+def test_terminal_artifact_receipts_roll_back_together(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failed terminal census cannot expose only its artifact carrier."""
+    initialize_active_archive_root(tmp_path)
+    source_path = str(tmp_path / ".claude" / "projects" / "proj" / "subagents" / "workflows" / "wf" / "journal.jsonl")
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        raw_id = archive.write_raw_payload(
+            provider=Provider.CLAUDE_CODE,
+            payload=b'{"contentKey":"workflow-artifact","agentId":"agent"}\n',
+            source_path=source_path,
+            acquired_at_ms=1,
+        )
+
+    def fail_census(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("injected terminal census failure")
+
+    monkeypatch.setattr(ArchiveStore, "replace_raw_membership_census", fail_census)
+    with pytest.raises(RuntimeError, match="injected terminal census failure"):
+        backfill_historical_revision_evidence(tmp_path)
+
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        assert conn.execute("SELECT COUNT(*) FROM raw_artifacts WHERE raw_id = ?", (raw_id,)).fetchone() == (0,)
+        assert conn.execute("SELECT parsed_at_ms FROM raw_sessions WHERE raw_id = ?", (raw_id,)).fetchone() == (None,)
+        assert conn.execute(
+            "SELECT COUNT(*) FROM raw_authority_parser_census WHERE raw_id = ?", (raw_id,)
+        ).fetchone() == (0,)
+
+
+def test_backfill_preserves_latest_terminal_artifact_observation(tmp_path: Path) -> None:
+    """A delayed older replay cannot replace a newer coordinate carrier."""
+    initialize_active_archive_root(tmp_path)
+    source_path = str(tmp_path / ".claude" / "projects" / "proj" / "subagents" / "workflows" / "wf" / "journal.jsonl")
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        older_raw_id = archive.write_raw_payload(
+            provider=Provider.CLAUDE_CODE,
+            payload=b'{"contentKey":"workflow-artifact","agentId":"old"}\n',
+            source_path=source_path,
+            acquired_at_ms=1,
+            raw_id="z-older-artifact",
+        )
+        newer_raw_id = archive.write_raw_payload(
+            provider=Provider.CLAUDE_CODE,
+            payload=b'{"contentKey":"workflow-artifact","agentId":"new"}\n',
+            source_path=source_path,
+            acquired_at_ms=2,
+            raw_id="a-newer-artifact",
+        )
+
+    backfill_historical_revision_evidence(tmp_path)
+
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        assert conn.execute("SELECT raw_id, last_observed_at_ms FROM raw_artifacts").fetchone() == (newer_raw_id, 2)
+        assert older_raw_id > newer_raw_id
+
+
 def test_historical_backfill_selects_prefix_newest_independent_of_acquisition_order(tmp_path: Path) -> None:
     initialize_active_archive_root(tmp_path)
     baseline = (

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -528,10 +528,10 @@ def test_backfill_replays_codex_state_by_latest_raw_observation(tmp_path: Path) 
             provider=Provider.CODEX, payload=snapshot_a, source_path=source_path, acquired_at_ms=1
         )
         archive.write_raw_payload(
-            provider=Provider.CODEX, payload=snapshot_b, source_path=source_path, acquired_at_ms=2
+            provider=Provider.CODEX, payload=snapshot_b, source_path=source_path, acquired_at_ms=1
         )
         archive.write_raw_payload(
-            provider=Provider.CODEX, payload=snapshot_a, source_path=source_path, acquired_at_ms=3
+            provider=Provider.CODEX, payload=snapshot_a, source_path=source_path, acquired_at_ms=1
         )
 
     census_historical_revision_evidence(tmp_path)
@@ -664,6 +664,56 @@ def test_backfill_persists_detected_provider_for_empty_ordinary_session_path(tmp
         assert conn.execute("SELECT status FROM raw_membership_census WHERE raw_id = ?", (raw_id,)).fetchone() == (
             "non_session",
         )
+
+    with ArchiveStore.open_existing(tmp_path, read_only=True) as archive:
+        assert archive.raw_membership_census_rows([raw_id])[0][2]
+
+
+def test_backfill_leaves_undetected_empty_raw_replayable(tmp_path: Path) -> None:
+    """An unknown shape is not terminal merely because it produced no sessions."""
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        raw_id = archive.write_raw_payload(
+            provider=Provider.UNKNOWN,
+            payload=b'{"future_provider_shape":true}\n',
+            source_path=str(tmp_path / "future.jsonl"),
+            acquired_at_ms=1,
+        )
+
+    census_historical_revision_evidence(tmp_path)
+
+    with ArchiveStore.open_existing(tmp_path, read_only=True) as archive:
+        assert not archive.raw_membership_census_rows([raw_id])[0][2]
+
+
+def test_backfill_retires_stale_revision_governance_for_empty_replay(tmp_path: Path) -> None:
+    """A current zero-session parse cannot remain in a stale full-revision plan."""
+    initialize_active_archive_root(tmp_path)
+    source_path = str(tmp_path / ".claude" / "projects" / "proj" / "history-only-session.jsonl")
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        raw_id = archive.write_raw_payload(
+            provider=Provider.CLAUDE_CODE,
+            payload=b'{"type":"file-history-snapshot","sessionId":"history-only","snapshot":{}}\n',
+            source_path=source_path,
+            acquired_at_ms=1,
+        )
+        archive.bind_raw_revision(
+            raw_id,
+            RawRevisionEnvelope(
+                logical_source_key="claude-code-session:stale-session",
+                kind=RawRevisionKind.FULL,
+                source_revision=raw_id,
+                acquisition_generation=0,
+                authority=RawRevisionAuthority.QUARANTINED,
+            ),
+        )
+
+    census_historical_revision_evidence(tmp_path)
+
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        assert conn.execute(
+            "SELECT logical_source_key, revision_kind, revision_authority FROM raw_sessions WHERE raw_id = ?", (raw_id,)
+        ).fetchone() == (None, "unknown", "quarantined")
 
 
 def test_terminal_artifact_receipts_roll_back_together(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/storage/test_archive_tiers_source_write.py
+++ b/tests/unit/storage/test_archive_tiers_source_write.py
@@ -276,6 +276,56 @@ def test_source_artifact_upsert_keeps_coordinate_deduplication_and_raw_failure_f
     assert tuple(ordinary) == ("ordinary-coordinate", raw_ids[0], "session_export")
 
 
+def test_source_artifact_upsert_refreshes_current_equal_time_carrier(tmp_path: Path) -> None:
+    """The current raw may refine its own coordinate even at the same timestamp."""
+    conn = _connect(tmp_path / "source.db")
+    raw_id = write_source_raw_session(
+        conn,
+        origin=Origin.CODEX_SESSION,
+        source_path="/tmp/current.jsonl",
+        source_index=0,
+        payload=b"current",
+        acquired_at_ms=1,
+    )
+    upsert_raw_artifact(
+        conn,
+        raw_id,
+        ArchiveSourceArtifact(
+            artifact_id="deferred-current",
+            origin=Origin.CODEX_SESSION,
+            source_path="/tmp/current.jsonl",
+            source_index=0,
+            artifact_kind="deferred_cas_frontier",
+            classification_reason="deferred",
+            support_status=ArtifactSupportStatus.PARTIAL_DECODE,
+        ),
+    )
+    upsert_raw_artifact(
+        conn,
+        raw_id,
+        ArchiveSourceArtifact(
+            artifact_id="terminal-current",
+            origin=Origin.CODEX_SESSION,
+            source_path="/tmp/current.jsonl",
+            source_index=0,
+            artifact_kind="terminal_corrupt_input",
+            classification_reason="corrupt",
+            support_status=ArtifactSupportStatus.DECODE_FAILED,
+        ),
+    )
+
+    row = conn.execute(
+        "SELECT artifact_id, artifact_kind, support_status, classification_reason FROM raw_artifacts"
+    ).fetchone()
+    assert row is not None
+    assert tuple(row) == (
+        "deferred-current",
+        "terminal_corrupt_input",
+        ArtifactSupportStatus.DECODE_FAILED.value,
+        "corrupt",
+    )
+
+
 def test_archive_tiers_source_writer_replays_hook_events_idempotently(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "source.db")
     payload = b'{"kind":"session","messages":["hello"]}'

--- a/tests/unit/storage/test_raw_retention.py
+++ b/tests/unit/storage/test_raw_retention.py
@@ -38,6 +38,17 @@ def _write_blob(store: BlobStore, payload: bytes) -> tuple[str, int]:
     return store.write_from_bytes(payload)
 
 
+def test_unavailable_frontier_preserves_empty_healthy_source_reason() -> None:
+    """A healthy source check must not inherit an unrelated pointer failure."""
+    projection = raw_retention_mod.unknown_raw_frontier_integrity_projection(
+        "active index pointer unavailable",
+        missing_source_raw_status="healthy",
+        missing_source_raw_reason="",
+    )
+
+    assert projection.missing_source_raw_reason == ""
+
+
 def _ensure_archive_source_schema(conn: sqlite3.Connection) -> None:
     conn.execute(
         """CREATE TABLE raw_sessions (

--- a/tests/unit/storage/test_raw_retention.py
+++ b/tests/unit/storage/test_raw_retention.py
@@ -2476,6 +2476,22 @@ def test_raw_frontier_integrity_projection_follows_active_index_pointer(tmp_path
     assert projection.available is True
 
 
+def test_raw_frontier_integrity_projection_reports_malformed_active_pointer(tmp_path: Path) -> None:
+    """Status reads degrade to an unavailable projection when a pointer is invalid."""
+    initialize_archive_database(tmp_path / "source.db", ArchiveTier.SOURCE)
+    initialize_archive_database(tmp_path / "ops.db", ArchiveTier.OPS)
+    (tmp_path / ".index-active-pointer").write_text("relative/index.db\n", encoding="utf-8")
+
+    projection = raw_frontier_integrity_projection(
+        tmp_path,
+        {"available": True, "lost_source_evidence_count": 0},
+    )
+
+    assert projection.available is False
+    assert projection.overall_status == "unknown"
+    assert "active index pointer" in projection.broken_head_reason
+
+
 @pytest.mark.parametrize("index_kind", ["missing", "malformed"])
 def test_raw_frontier_integrity_snapshot_unavailable_index_tier_is_unknown_never_healthy(
     tmp_path: Path,

--- a/tests/unit/storage/test_raw_retention.py
+++ b/tests/unit/storage/test_raw_retention.py
@@ -2492,6 +2492,28 @@ def test_raw_frontier_integrity_projection_reports_malformed_active_pointer(tmp_
     assert "active index pointer" in projection.broken_head_reason
 
 
+def test_raw_frontier_projection_retains_known_missing_source_violation_when_pointer_is_invalid(tmp_path: Path) -> None:
+    """An unavailable active pointer cannot erase known source-tier loss."""
+    initialize_archive_database(tmp_path / "source.db", ArchiveTier.SOURCE)
+    initialize_archive_database(tmp_path / "ops.db", ArchiveTier.OPS)
+    (tmp_path / ".index-active-pointer").write_text("relative/index.db\n", encoding="utf-8")
+
+    projection = raw_frontier_integrity_projection(
+        tmp_path,
+        {
+            "available": True,
+            "lost_source_evidence_count": 1,
+            "lost_source_evidence_samples": [{"session_id": "missing-session"}],
+        },
+    )
+
+    assert projection.available is False
+    assert projection.overall_status == "violated"
+    assert projection.missing_source_raw_status == "violated"
+    assert projection.missing_source_raw_count == 1
+    assert projection.missing_source_raw_samples == ({"session_id": "missing-session"},)
+
+
 @pytest.mark.parametrize("index_kind", ["missing", "malformed"])
 def test_raw_frontier_integrity_snapshot_unavailable_index_tier_is_unknown_never_healthy(
     tmp_path: Path,

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -12,7 +12,7 @@ from typing import Any, cast
 import pytest
 
 from polylogue.config import Config
-from polylogue.core.enums import ArtifactSupportStatus
+from polylogue.core.enums import ArtifactSupportStatus, Provider
 from polylogue.core.errors import RawCASFrontierError
 from polylogue.core.json import json_document
 from polylogue.core.raw_failure_evidence import RawFailureEvidenceKind
@@ -1637,6 +1637,24 @@ def test_raw_materialization_split_root_classifies_parsed_sidecar_from_routed_bl
     assert result.success is True
     assert result.repaired_count == 0
     assert result.metrics["raw_materialization_candidate_count"] == 0.0
+
+
+def test_raw_materialization_skips_current_non_session_census(tmp_path: Path) -> None:
+    """A successful zero-session census settles an otherwise unknown sidecar shape."""
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        raw_id = archive.write_raw_payload(
+            provider=Provider.CLAUDE_CODE,
+            payload=b'{"type":"queue-operation","operation":"compact"}\n',
+            source_path=str(tmp_path / "ordinary.jsonl"),
+            acquired_at_ms=1,
+        )
+
+    census_historical_revision_evidence(tmp_path)
+
+    assert raw_id not in repair_mod._raw_materialization_candidate_ids(_config(tmp_path)).raw_ids
 
 
 def test_superseded_raw_cleanup_protects_split_index_referenced_raw_ids(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Preserve retained raw replay authority across complete-document detection, long JSONL streams, re-observed Codex snapshots, invalid active pointers, and terminal source-only artifacts.

## Problem

Exact-head review of #3952 found five replay paths where bounded inspection, first-acquisition ordering, or an unhandled storage error could lose materialized sessions or leave retained raw evidence indefinitely non-terminal.

## Solution

- Retry UNKNOWN document detection from complete retained bytes after the bounded prefix misses, in both sequential and worker replay paths.
- Stream declared JSONL artifacts to exhaustion before deciding whether conversational evidence is absent.
- Order retained Codex snapshots by their latest durable raw observation receipt.
- Project malformed or unreadable active index pointers as unavailable raw retention instead of raising.
- Persist confirmed non-session artifacts and their successful parser census through the existing raw-artifact and source-state paths.

## Verification

- `devtools test tests/unit/sources/test_revision_backfill.py::test_unknown_retained_document_replays_after_complete_payload_detection tests/unit/sources/test_revision_backfill.py::test_backfill_scans_declared_stream_past_non_session_prefix tests/unit/sources/test_revision_backfill.py::test_backfill_replays_codex_state_by_latest_raw_observation tests/unit/sources/test_revision_backfill.py::test_backfill_terminalizes_source_only_declared_artifact tests/unit/storage/test_raw_retention.py::test_raw_frontier_integrity_projection_reports_malformed_active_pointer`: `5 passed in 13.74s`.
- `ruff format --check` and `ruff check` on the changed production and test files: passed.
- `mypy`: `Success: no issues found in 2743 source files`.
- `devtools test tests/unit/scenarios/test_codex_804_live_proof.py::test_sanitized_codex_804_revision_recovery_proof`: fails before its checkpoint seam because one retained raw lacks a complete current-parser census. This PR does not alter that frozen-census precondition.

## Scope

No Bead records are assigned or mutated by this exact-head review lane.

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->
