### PR TITLE
test(status): complete parser census fixtures

### DIFF
--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -90,6 +90,7 @@ def _completed_raw_materialization_readiness() -> dict[str, Any]:
         "total": 0,
         "affected_total": 0,
         "raw_authority_frontier": {"lifecycle_status": "completed"},
+        "raw_authority_parser_census": {"available": True},
     }
 
 

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -72,6 +72,15 @@ def _complete_healthy_frontier() -> JSONDocument:
     }
 
 
+def _complete_raw_materialization_readiness() -> status_module.RawMaterializationReadiness:
+    """Return the complete source evidence required to isolate claim signals."""
+    return status_module.RawMaterializationReadiness(
+        available=True,
+        raw_authority_frontier={"lifecycle_status": "completed"},
+        raw_authority_parser_census={"available": True},
+    )
+
+
 def test_status_snapshot_serves_cached_payload_without_rebuilding_status(monkeypatch: pytest.MonkeyPatch) -> None:
     payload: JSONDocument = {"ok": True, "daemon_liveness": True, "checked_at": "cached"}
     refresh_status_snapshot(payload=payload)
@@ -1677,10 +1686,7 @@ def test_build_daemon_status_claim_guard_blocks_pending_or_unknown_convergence_d
         archive_schema_ready=True,
         present_tiers=["source", "index", "embeddings", "user", "ops"],
     )
-    raw_readiness = status_module.RawMaterializationReadiness(
-        available=True,
-        raw_authority_frontier={"lifecycle_status": "completed"},
-    )
+    raw_readiness = _complete_raw_materialization_readiness()
     frontier = status_module.RawFrontierIntegrity(available=True, overall_status="healthy")
     if debt_setup == "pending":
         initialize_archive_database(tmp_path / "ops.db", ArchiveTier.OPS)
@@ -1767,10 +1773,7 @@ def test_build_daemon_status_claim_guard_uses_real_registry_convergence_snapshot
         archive_schema_ready=True,
         present_tiers=["source", "index", "embeddings", "user", "ops"],
     )
-    raw_readiness = status_module.RawMaterializationReadiness(
-        available=True,
-        raw_authority_frontier={"lifecycle_status": "completed"},
-    )
+    raw_readiness = _complete_raw_materialization_readiness()
     frontier = status_module.RawFrontierIntegrity(available=True, overall_status="healthy")
 
     def convergence_collector(*_args: object, **_kwargs: object) -> status_module.ConvergenceDebtSummary:
@@ -2048,10 +2051,7 @@ def test_daemon_and_direct_claim_guard_share_mixed_frontier_summary(tmp_path: Pa
         archive_schema_ready=True,
         present_tiers=["source", "index", "embeddings", "user", "ops"],
     )
-    raw_readiness = status_module.RawMaterializationReadiness(
-        available=True,
-        raw_authority_frontier={"lifecycle_status": "completed"},
-    )
+    raw_readiness = _complete_raw_materialization_readiness()
     daemon_guard = status_module._daemon_claim_guard(
         archive_storage=storage,
         raw_materialization_readiness=raw_readiness,


### PR DESCRIPTION
## Summary

Complete the source parser-census evidence in status test fixtures so claim-guard tests reach the convergence-debt and raw-frontier assertions they were written to exercise.

## Problem

Current-master status tests construct a healthy raw-materialization fixture with a completed authority frontier but no parser-census receipt. Production correctly treats that missing receipt as `source parser census unavailable`, so it prevents the intended claim-guard branch from being evaluated. The focused pre-fix run failed 13 of 18 selected tests for that reason.

## Solution

`tests/unit/cli/test_status.py` adds the complete parser-census receipt to its existing complete-readiness fixture. `tests/unit/daemon/test_daemon_status.py` centralizes the same complete evidence in a local helper and uses it in convergence-debt and cross-route frontier tests. No production status semantics changed. Archive-facade, archive-CLI, and archive-runtime-path catalog tests were not touched.

## Verification

`direnv exec /realm/worktrees/polylogue-status-census devtools test tests/unit/daemon/test_daemon_status.py tests/unit/cli/test_status.py -k 'claim_guard or parser_census'`

Result: `18 passed, 157 deselected in 4.55s`.

`direnv exec /realm/worktrees/polylogue-status-census devtools verify --seed-testmon --skip-slow`

The required fresh testmon seed could not finish. Shard 1 reported 18 unrelated API, annotation, and durable-migration failures; shard 3 exceeded the managed 2,700-second cap. The receipt is `.cache/verify/runs/20260813T095848Z-seed-testmon-841315-79494a31/` in the lane. Formatting, lint, mypy, rendering, layering, graph, schema, and policy stages completed before the seed failure.

## Independent review

Current-head independent review, Codex `gpt-5.6-terra` at high reasoning, returned `APPROVE: no legitimate findings`. It confirmed that the fixtures pass the production `raw_materialization_ready()` parser-census gate, while the existing tests exercise real direct and daemon claim-guard behavior.

## Bead disposition

| Assigned Bead | Disposition |
| --- | --- |
| None | Self-contained test fixture correction. No Beads were read or mutated. |

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->
