### PR TITLE
test: reduce inferred corpus fixture setup

### DIFF
--- a/tests/property/test_inferred_corpus_loop.py
+++ b/tests/property/test_inferred_corpus_loop.py
@@ -102,7 +102,8 @@ def _inferred_selection() -> tuple[CorpusSpec, SyntheticSchemaSelection]:
     registry = SchemaRegistry(storage_root=SCHEMA_DIR)
     manifest = compile_inferred_corpus_manifest(
         registry=registry,
-        wire_support_receipt=build_wire_support_receipt(registry=registry),
+        providers=("codex",),
+        wire_support_receipt=build_wire_support_receipt(registry=registry, providers=("codex",)),
     )
     handoff = build_inferred_corpus_convergence_handoff(manifest)
     for spec, selection in zip(handoff.specs, handoff.selections, strict=True):

--- a/tests/unit/schemas/test_inferred_corpus_manifest.py
+++ b/tests/unit/schemas/test_inferred_corpus_manifest.py
@@ -205,9 +205,6 @@ def test_all_provider_campaign_round_trip_preserves_unsupported_wire_authority(t
         registry=cast(Any, registry),
         package_receipt=package_receipt.to_payload(),
         wire_support_receipt=wire_support,
-        campaign_mode=True,
-        gate_receipt_path=gate_receipt_path,
-        archive_root=archive_root,
     )
 
     antigravity_entries = [entry for entry in manifest.entries if entry.key.provider == "antigravity"]

--- a/tests/unit/storage/test_schema_drift_samples.py
+++ b/tests/unit/storage/test_schema_drift_samples.py
@@ -91,7 +91,30 @@ class TestSchemaDriftSamples:
     def test_row_cap_prunes_oldest_first(self, tmp_path: Path) -> None:
         conn = _ops_conn(tmp_path)
         try:
-            for i in range(SCHEMA_DRIFT_SAMPLE_ROW_CAP + 5):
+            # Model a real, already-full telemetry table directly, then exercise
+            # the production writer for every record that crosses the cap.
+            conn.executemany(
+                """
+                INSERT INTO schema_drift_samples (
+                    sample_id, origin, element_kind, classification,
+                    unseen_key_signature, native_id_example, raw_id, observed_at_ms
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    (
+                        f"historical-{i}",
+                        "codex-session",
+                        "session_record",
+                        "new_field",
+                        "x",
+                        f"raw-{i}",
+                        f"raw-{i}",
+                        i,
+                    )
+                    for i in range(SCHEMA_DRIFT_SAMPLE_ROW_CAP)
+                ),
+            )
+            for i in range(SCHEMA_DRIFT_SAMPLE_ROW_CAP, SCHEMA_DRIFT_SAMPLE_ROW_CAP + 5):
                 record_schema_drift_sample(
                     conn,
                     origin="codex-session",


### PR DESCRIPTION
## Summary

Reduce the inferred-corpus and schema-drift timeout cluster while retaining its real archive, campaign, and SQLite cap-crossing routes.

Ref polylogue-lvz6

## Problem

The retained slow-node sample reported 69–122 second timeouts. Exact-node profiling showed duplicate all-provider campaign validation dominated the inferred-corpus tests: the all-provider wire-support receipt was validated before persistence and again on the persisted campaign read, while the Codex-only lineage route also constructed all providers. The row-cap test constructed a full historical telemetry table by committing and retaining every one of 20,005 fixture rows through the production writer before exercising the threshold behavior. Concurrent pytest workers were also observed in uninterruptible I/O, so the historical timeout values include host contention.

## Solution

- Keep the all-provider campaign round trip at the persisted-read boundary, where it still validates authoritative wire support and unsupported-provider authority.
- Build a Codex-scoped inferred manifest for the Codex lineage/reindex property route.
- Seed historical schema-drift telemetry directly into the file-backed SQLite fixture, then use the production writer for every insert that crosses the row cap.

The production routes remain non-vacuous: the lineage test performs raw ingest, retained-raw reindex, convergence, and archive equality; the campaign test performs persisted all-provider campaign validation; and the cap test invokes `record_schema_drift_sample` across the pruning threshold.

## Verification

`direnv exec . devtools test tests/property/test_inferred_corpus_loop.py::test_inferred_lineage_reindex_preserves_composition_and_detects_tail_mutation tests/unit/storage/test_schema_drift_samples.py::TestSchemaDriftSamples::test_row_cap_prunes_oldest_first tests/unit/schemas/test_inferred_corpus_manifest.py::test_all_provider_campaign_round_trip_preserves_unsupported_wire_authority tests/unit/schemas/test_inferred_corpus_manifest.py::test_campaign_rejects_tampered_ground_truth_denominators_after_digest_recompute --durations=10`

Result: `4 passed in 77.29s`; the equivalent pre-change run took `133.40s`.

`git diff --check`

Result: clean.

`direnv exec . devtools verify --seed-testmon --skip-slow`

The format, lint, mypy, rendering, layering, schema, policy, and collection stages passed. The selected broad pytest shards were intentionally stopped before completion because this PR's focused acceptance route had already passed and the merge train owns the terminal exact-master seed.

## Bead disposition

| Bead | Disposition | Evidence |
| --- | --- | --- |
| polylogue-lvz6 | satisfied | 42318571f; focused four-node verification above |

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [
    "polylogue-lvz6"
  ],
  "dispositions": [
    {
      "bead_id": "polylogue-lvz6",
      "disposition": "satisfied",
      "evidence": [
        {
          "kind": "commit",
          "ref": "42318571f"
        },
        {
          "kind": "test",
          "ref": "devtools test tests/property/test_inferred_corpus_loop.py::test_inferred_lineage_reindex_preserves_composition_and_detects_tail_mutation tests/unit/storage/test_schema_drift_samples.py::TestSchemaDriftSamples::test_row_cap_prunes_oldest_first tests/unit/schemas/test_inferred_corpus_manifest.py::test_all_provider_campaign_round_trip_preserves_unsupported_wire_authority tests/unit/schemas/test_inferred_corpus_manifest.py::test_campaign_rejects_tampered_ground_truth_denominators_after_digest_recompute --durations=10 (4 passed in 77.29s)"
        }
      ],
      "successors": []
    }
  ],
  "mutated_beads": [],
  "scope_digest": "7907773c80bbd118848c0de8720abf82b8da5dc49c50ef799ad583e30390b4eb",
  "scope_kind": "bead",
  "version": 2
}
-->
