### PR TITLE
perf(test): reuse immutable archive fixtures

### DIFF
--- a/tests/infra/archive_templates.py
+++ b/tests/infra/archive_templates.py
@@ -2,17 +2,67 @@
 
 from __future__ import annotations
 
+import contextlib
+import gc
 import shutil
+import sqlite3
 import stat
 import subprocess
+import time
 from pathlib import Path
 
 
-def freeze_archive_template(root: Path) -> None:
+def _journal_mode_delete_with_retry(conn: sqlite3.Connection, *, path: Path) -> None:
+    """Finish a SQLite snapshot despite a deferred same-process close."""
+    deadline = time.monotonic() + 5.0
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            mode = conn.execute("PRAGMA journal_mode=DELETE").fetchone()
+        except sqlite3.OperationalError as exc:
+            if "locked" not in str(exc).lower() or time.monotonic() >= deadline:
+                raise
+            gc.collect()
+            time.sleep(min(0.05 * attempt, 0.5))
+            continue
+        if mode != ("delete",):
+            raise RuntimeError(f"could not normalize template database {path} to DELETE journal mode")
+        return
+
+
+def quiesce_archive_template(root: Path) -> None:
+    """Validate every physical SQLite tier and collapse it into one snapshot."""
+    databases = tuple(path for path in sorted(root.rglob("*.db")) if path.is_file() and not path.is_symlink())
+    for path in databases:
+        with contextlib.closing(sqlite3.connect(path)) as conn, conn:
+            quick = conn.execute("PRAGMA quick_check").fetchone()
+            foreign = conn.execute("PRAGMA foreign_key_check").fetchall()
+            if quick != ("ok",) or foreign:
+                raise RuntimeError(f"invalid template database {path}")
+            checkpoint = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+            if checkpoint is None or checkpoint[0] != 0:
+                raise RuntimeError(f"could not checkpoint template database {path}: {checkpoint!r}")
+            _journal_mode_delete_with_retry(conn, path=path)
+        for suffix in ("-wal", "-shm"):
+            sidecar = path.with_name(f"{path.name}{suffix}")
+            if sidecar.exists():
+                sidecar.unlink()
+
+
+def _freeze_archive_template(root: Path) -> None:
     """Make a completed fixture archive immutable before test-local cloning."""
     for path in sorted(root.rglob("*"), reverse=True):
+        if path.is_symlink():
+            continue
         path.chmod(path.stat().st_mode & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH))
     root.chmod(root.stat().st_mode & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH))
+
+
+def finalize_archive_template(root: Path) -> None:
+    """Publish a reusable archive template only after a verified SQLite snapshot."""
+    quiesce_archive_template(root)
+    _freeze_archive_template(root)
 
 
 def clone_archive_template(template: Path, destination: Path) -> None:
@@ -41,4 +91,4 @@ def clone_archive_template(template: Path, destination: Path) -> None:
         _record_fresh_durable_bootstrap(destination)
 
 
-__all__ = ["clone_archive_template", "freeze_archive_template"]
+__all__ = ["clone_archive_template", "finalize_archive_template", "quiesce_archive_template"]

--- a/tests/infra/archive_templates.py
+++ b/tests/infra/archive_templates.py
@@ -1,0 +1,44 @@
+"""Immutable archive templates for SQLite-heavy real-route tests."""
+
+from __future__ import annotations
+
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+
+def freeze_archive_template(root: Path) -> None:
+    """Make a completed fixture archive immutable before test-local cloning."""
+    for path in sorted(root.rglob("*"), reverse=True):
+        path.chmod(path.stat().st_mode & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH))
+    root.chmod(root.stat().st_mode & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH))
+
+
+def clone_archive_template(template: Path, destination: Path) -> None:
+    """Clone an immutable archive into a private writable destination."""
+    destination.mkdir(parents=True, exist_ok=True)
+    try:
+        subprocess.run(
+            ["cp", "-a", "--reflink=auto", f"{template}/.", str(destination)],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=10,
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        shutil.copytree(template, destination, dirs_exist_ok=True, symlinks=True)
+    for path in destination.rglob("*"):
+        if path.is_symlink():
+            continue
+        path.chmod(path.stat().st_mode | stat.S_IWUSR)
+    destination.chmod(destination.stat().st_mode | stat.S_IWUSR)
+    bootstrap_marker = destination / ".maintenance-state" / "durable-change-trains" / ".bootstrap"
+    if bootstrap_marker.is_file():
+        from polylogue.storage.sqlite.durable_change_train import _record_fresh_durable_bootstrap
+
+        bootstrap_marker.unlink()
+        _record_fresh_durable_bootstrap(destination)
+
+
+__all__ = ["clone_archive_template", "freeze_archive_template"]

--- a/tests/unit/cli/test_reindex_canary_cli.py
+++ b/tests/unit/cli/test_reindex_canary_cli.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import shutil
 import sqlite3
-from collections.abc import Mapping, Sequence
+from collections.abc import Generator, Mapping, Sequence
 from pathlib import Path
 from typing import IO, Any, cast
 
@@ -42,7 +42,10 @@ from polylogue.storage.archive_identity import ArchiveLocation
 from polylogue.storage.index_generation import IndexGenerationStore, RebuildLease
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from tests.infra.archive_templates import clone_archive_template, freeze_archive_template
 from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
+
+_DEFAULT_CANARY_TEMPLATE: Path | None = None
 
 
 @pytest.fixture(autouse=True)
@@ -82,6 +85,54 @@ def _run_cli_canary_tests_through_real_rebuild_service(monkeypatch: pytest.Monke
 
 def _schema_receipt_path(root: Path) -> Path:
     return root.parent / f"{root.name}-schema-inference-gate-receipt.json"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _default_canary_template(tmp_path_factory: pytest.TempPathFactory) -> Generator[None]:
+    """Build the default real archive once, then clone it for each canary test."""
+    global _DEFAULT_CANARY_TEMPLATE
+    template = tmp_path_factory.mktemp("reindex-canary-template") / "archive"
+    _seed_isolated_canary(template)
+    freeze_archive_template(template)
+    _DEFAULT_CANARY_TEMPLATE = template
+    try:
+        yield
+    finally:
+        _DEFAULT_CANARY_TEMPLATE = None
+
+
+def _rebase_canary_template(template: Path, root: Path) -> None:
+    """Point copied generation metadata and links at this test's private clone."""
+    for path in root.rglob("*"):
+        if not path.is_symlink():
+            continue
+        target = path.readlink()
+        if target.is_absolute() and target.is_relative_to(template):
+            target_is_directory = target.is_dir()
+            path.unlink()
+            path.symlink_to(root / target.relative_to(template), target_is_directory=target_is_directory)
+    pointer = root / ".index-active-pointer"
+    if pointer.is_file():
+        target = Path(pointer.read_text(encoding="utf-8").strip())
+        if target.is_absolute() and target.is_relative_to(template):
+            pointer.write_text(str(root / target.relative_to(template)), encoding="utf-8")
+    for metadata_path in root.glob(".index-generations/gen-*/generation.json"):
+        payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+        payload["archive_root"] = str(root.resolve())
+        index_path = Path(str(payload["index_path"]))
+        if index_path.is_relative_to(template):
+            payload["index_path"] = str(root / index_path.relative_to(template))
+        metadata_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _clone_default_canary_template(root: Path) -> bool:
+    template = _DEFAULT_CANARY_TEMPLATE
+    if template is None:
+        return False
+    clone_archive_template(template, root)
+    _rebase_canary_template(template, root)
+    write_valid_rebuild_receipt(root, _schema_receipt_path(root))
+    return True
 
 
 class _CanaryCliRunner(_ClickCliRunner):
@@ -191,6 +242,8 @@ def _seed_isolated_canary(
     session_names: tuple[str, ...] = ("isolated-canary",),
     membership_names: tuple[str, ...] = (),
 ) -> None:
+    if session_names == ("isolated-canary",) and not membership_names and _clone_default_canary_template(root):
+        return
     initialize_active_archive_root(root)
     with ArchiveStore.open_existing(root, read_only=False) as archive:
         for acquired_at_ms, name in enumerate(session_names, start=1):

--- a/tests/unit/cli/test_reindex_canary_cli.py
+++ b/tests/unit/cli/test_reindex_canary_cli.py
@@ -42,7 +42,7 @@ from polylogue.storage.archive_identity import ArchiveLocation
 from polylogue.storage.index_generation import IndexGenerationStore, RebuildLease
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
-from tests.infra.archive_templates import clone_archive_template, freeze_archive_template
+from tests.infra.archive_templates import clone_archive_template, finalize_archive_template
 from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
 
 _DEFAULT_CANARY_TEMPLATE: Path | None = None
@@ -93,7 +93,7 @@ def _default_canary_template(tmp_path_factory: pytest.TempPathFactory) -> Genera
     global _DEFAULT_CANARY_TEMPLATE
     template = tmp_path_factory.mktemp("reindex-canary-template") / "archive"
     _seed_isolated_canary(template)
-    freeze_archive_template(template)
+    finalize_archive_template(template)
     _DEFAULT_CANARY_TEMPLATE = template
     try:
         yield

--- a/tests/unit/infra/test_archive_templates.py
+++ b/tests/unit/infra/test_archive_templates.py
@@ -1,0 +1,77 @@
+"""Regression coverage for reusable SQLite archive templates."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import sqlite3
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+from tests.infra.archive_templates import clone_archive_template, finalize_archive_template
+
+
+def _leave_crash_recovered_wal(database: Path) -> None:
+    writer = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            """
+import sqlite3
+import sys
+
+conn = sqlite3.connect(sys.argv[1])
+assert conn.execute(\"PRAGMA journal_mode=WAL\").fetchone() == (\"wal\",)
+conn.execute(\"CREATE TABLE entries (value TEXT)\")
+conn.execute(\"INSERT INTO entries VALUES ('written-through-wal')\")
+conn.commit()
+print(\"ready\", flush=True)
+sys.stdin.read()
+""",
+            str(database),
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    assert writer.stdout is not None
+    assert writer.stdout.readline() == "ready\n"
+    writer.terminate()
+    assert writer.wait(timeout=5) != 0
+
+
+def test_finalized_template_checkpoints_real_wal_before_freezing_and_cloning(tmp_path: Path) -> None:
+    """A crash-left WAL must become a self-contained, immutable clone source.
+
+    Anti-vacuity: removing the quiescence phase leaves the real ``-wal`` and
+    ``-shm`` files plus WAL journal mode behind, so the sidecar and journal
+    assertions below fail before the production clone path can read the row.
+    """
+    template = tmp_path / "template"
+    template.mkdir()
+    database = template / "source.db"
+    _leave_crash_recovered_wal(database)
+
+    assert (template / "source.db-wal").exists()
+    assert (template / "source.db-shm").exists()
+
+    finalize_archive_template(template)
+    clone = tmp_path / "clone"
+    clone_archive_template(template, clone)
+
+    for root in (template, clone):
+        assert not (root / "source.db-wal").exists()
+        assert not (root / "source.db-shm").exists()
+    assert not (database.stat().st_mode & stat.S_IWUSR)
+    assert clone.joinpath("source.db").stat().st_mode & stat.S_IWUSR
+
+    with contextlib.closing(sqlite3.connect(f"file:{database}?mode=ro", uri=True)) as conn:
+        assert conn.execute("PRAGMA journal_mode").fetchone() == ("delete",)
+        assert conn.execute("PRAGMA quick_check").fetchone() == ("ok",)
+        assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+    with contextlib.closing(sqlite3.connect(clone / "source.db")) as conn:
+        assert conn.execute("SELECT value FROM entries").fetchall() == [("written-through-wal",)]
+
+    assert not (template.stat().st_mode & os.W_OK)

--- a/tests/unit/maintenance/test_rebuild_index_ownership.py
+++ b/tests/unit/maintenance/test_rebuild_index_ownership.py
@@ -12,6 +12,7 @@ holding the general archive-location ownership lock.
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Generator
 from pathlib import Path
 from typing import cast
 
@@ -34,17 +35,42 @@ from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_a
 from polylogue.storage.sqlite.archive_tiers.source import SOURCE_SCHEMA_VERSION
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.migration_runner import DURABLE_MIGRATION_TIERS
+from tests.infra.archive_templates import clone_archive_template, freeze_archive_template
 from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
+
+_EMPTY_SOURCE_TEMPLATE: Path | None = None
+_ACTIVE_ARCHIVE_TEMPLATE: Path | None = None
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _archive_templates(tmp_path_factory: pytest.TempPathFactory) -> Generator[None]:
+    """Build durable and active archive layouts once for isolated clones."""
+    global _ACTIVE_ARCHIVE_TEMPLATE, _EMPTY_SOURCE_TEMPLATE
+    templates = tmp_path_factory.mktemp("rebuild-ownership-templates")
+    empty_source = templates / "empty-source"
+    for tier in sorted(DURABLE_MIGRATION_TIERS, key=lambda item: item.value):
+        initialize_archive_database(empty_source / f"{tier.value}.db", tier)
+    active_archive = templates / "active-archive"
+    initialize_active_archive_root(active_archive)
+    freeze_archive_template(empty_source)
+    freeze_archive_template(active_archive)
+    _EMPTY_SOURCE_TEMPLATE = empty_source
+    _ACTIVE_ARCHIVE_TEMPLATE = active_archive
+    try:
+        yield
+    finally:
+        _EMPTY_SOURCE_TEMPLATE = None
+        _ACTIVE_ARCHIVE_TEMPLATE = None
 
 
 def _init_empty_source(root: Path) -> None:
-    root.mkdir(parents=True, exist_ok=True)
-    for tier in sorted(DURABLE_MIGRATION_TIERS, key=lambda item: item.value):
-        initialize_archive_database(root / f"{tier.value}.db", tier)
+    assert _EMPTY_SOURCE_TEMPLATE is not None
+    clone_archive_template(_EMPTY_SOURCE_TEMPLATE, root)
 
 
 def _init_nonempty_source(root: Path) -> None:
-    initialize_active_archive_root(root)
+    assert _ACTIVE_ARCHIVE_TEMPLATE is not None
+    clone_archive_template(_ACTIVE_ARCHIVE_TEMPLATE, root)
     payload = (
         b'{"type":"session_meta","payload":{"id":"owned-session"}}\n'
         b'{"type":"response_item","payload":{"type":"message","role":"user",'

--- a/tests/unit/maintenance/test_rebuild_index_ownership.py
+++ b/tests/unit/maintenance/test_rebuild_index_ownership.py
@@ -35,7 +35,7 @@ from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_a
 from polylogue.storage.sqlite.archive_tiers.source import SOURCE_SCHEMA_VERSION
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.migration_runner import DURABLE_MIGRATION_TIERS
-from tests.infra.archive_templates import clone_archive_template, freeze_archive_template
+from tests.infra.archive_templates import clone_archive_template, finalize_archive_template
 from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
 
 _EMPTY_SOURCE_TEMPLATE: Path | None = None
@@ -52,8 +52,8 @@ def _archive_templates(tmp_path_factory: pytest.TempPathFactory) -> Generator[No
         initialize_archive_database(empty_source / f"{tier.value}.db", tier)
     active_archive = templates / "active-archive"
     initialize_active_archive_root(active_archive)
-    freeze_archive_template(empty_source)
-    freeze_archive_template(active_archive)
+    finalize_archive_template(empty_source)
+    finalize_archive_template(active_archive)
     _EMPTY_SOURCE_TEMPLATE = empty_source
     _ACTIVE_ARCHIVE_TEMPLATE = active_archive
     try:

--- a/tests/unit/storage/test_index_generation.py
+++ b/tests/unit/storage/test_index_generation.py
@@ -6,6 +6,7 @@ import logging
 import multiprocessing
 import os
 import sqlite3
+from collections.abc import Generator
 from dataclasses import replace
 from pathlib import Path
 
@@ -28,6 +29,24 @@ _DEFINITELY_DEAD_PID = 2**31 - 1
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from tests.infra.archive_templates import clone_archive_template, freeze_archive_template
+
+_ARCHIVE_TEMPLATE: Path | None = None
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _archive_template(tmp_path_factory: pytest.TempPathFactory) -> Generator[None]:
+    """Build the deterministic five-tier fixture once, then clone per test."""
+    global _ARCHIVE_TEMPLATE
+    template = tmp_path_factory.mktemp("index-generation-template") / "archive"
+    for tier in (ArchiveTier.SOURCE, ArchiveTier.USER, ArchiveTier.EMBEDDINGS, ArchiveTier.OPS, ArchiveTier.INDEX):
+        initialize_archive_database(template / f"{tier.value}.db", tier)
+    freeze_archive_template(template)
+    _ARCHIVE_TEMPLATE = template
+    try:
+        yield
+    finally:
+        _ARCHIVE_TEMPLATE = None
 
 
 def _hold_lease(
@@ -39,8 +58,8 @@ def _hold_lease(
 
 
 def _archive(root: Path) -> None:
-    for tier in (ArchiveTier.SOURCE, ArchiveTier.USER, ArchiveTier.EMBEDDINGS, ArchiveTier.OPS, ArchiveTier.INDEX):
-        initialize_archive_database(root / f"{tier.value}.db", tier)
+    assert _ARCHIVE_TEMPLATE is not None
+    clone_archive_template(_ARCHIVE_TEMPLATE, root)
 
 
 def test_rebuild_lease_excludes_competing_process(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_index_generation.py
+++ b/tests/unit/storage/test_index_generation.py
@@ -29,7 +29,7 @@ _DEFINITELY_DEAD_PID = 2**31 - 1
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
-from tests.infra.archive_templates import clone_archive_template, freeze_archive_template
+from tests.infra.archive_templates import clone_archive_template, finalize_archive_template
 
 _ARCHIVE_TEMPLATE: Path | None = None
 
@@ -41,7 +41,7 @@ def _archive_template(tmp_path_factory: pytest.TempPathFactory) -> Generator[Non
     template = tmp_path_factory.mktemp("index-generation-template") / "archive"
     for tier in (ArchiveTier.SOURCE, ArchiveTier.USER, ArchiveTier.EMBEDDINGS, ArchiveTier.OPS, ArchiveTier.INDEX):
         initialize_archive_database(template / f"{tier.value}.db", tier)
-    freeze_archive_template(template)
+    finalize_archive_template(template)
     _ARCHIVE_TEMPLATE = template
     try:
         yield


### PR DESCRIPTION
## Summary

Reuse immutable archive templates across the canary, index-generation, and rebuild-ownership fixture families, while cloning a private writable archive for every test.

Ref polylogue-lvz6. This is a self-contained performance improvement; the exact-master full-suite and reusable testmon baseline remain outside this PR.

## Problem

The three modules repeatedly rebuilt equivalent SQLite archive tiers, and canary tests rebuilt the same active archive before every test. Fixture construction dominated execution time and amplified storage use without increasing behavioral coverage.

## Solution

- Add reusable immutable archive-template support in `tests/infra/archive_templates.py`.
- Clone private writable SQLite archives per test.
- Rebase copied generation metadata and regenerate the identity-bound durable bootstrap marker.
- Keep the production rebuild, promotion, ownership, and canary routes under test.

## Verification

- `direnv exec . devtools test tests/unit/cli/test_reindex_canary_cli.py tests/unit/storage/test_index_generation.py tests/unit/maintenance/test_rebuild_index_ownership.py --durations=20` — 84 passed in 95.08s.
- `direnv exec . mypy tests/infra/archive_templates.py tests/unit/cli/test_reindex_canary_cli.py tests/unit/storage/test_index_generation.py tests/unit/maintenance/test_rebuild_index_ownership.py` — no issues in 4 files.
- Push quick gate — green.

Representative reviewed-canary runtime fell from 13.74s to 3.62s. The tests remain anti-vacuous because they invoke `rebuild_index_from_source_sync` and `run_reindex_canary` against real private SQLite files; breaking those production paths fails result, receipt, generation, and lifecycle assertions.

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->
