### PR TITLE
test: restore rebuild authority fixtures

### DIFF
--- a/tests/infra/rebuild_receipt.py
+++ b/tests/infra/rebuild_receipt.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from polylogue.maintenance import schema_inference_gate as gate
+from polylogue.sources.revision_backfill import census_historical_revision_evidence
 from polylogue.storage.archive_identity import ArchiveIdentity, ArchiveLocation
 from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS
@@ -105,4 +106,11 @@ def write_valid_rebuild_receipt(
     return receipt_path
 
 
-__all__ = ["write_valid_rebuild_receipt"]
+def write_current_rebuild_receipt(archive_root: Path, receipt_path: Path) -> Path:
+    """Settle fixture source authority, then bind a receipt to that state."""
+
+    census_historical_revision_evidence(archive_root)
+    return write_valid_rebuild_receipt(archive_root, receipt_path)
+
+
+__all__ = ["write_current_rebuild_receipt", "write_valid_rebuild_receipt"]

--- a/tests/infra/revision_backfill_benchmark.py
+++ b/tests/infra/revision_backfill_benchmark.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from polylogue.archive.revision_authority import RawRevisionAuthority, RawRevisionEnvelope, RawRevisionKind
 from polylogue.core.enums import Provider
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
@@ -93,23 +94,40 @@ def build_independent_raw_corpus(
     *,
     raw_count: int,
     avg_payload_bytes: int,
+    authoritative_source: bool = False,
 ) -> list[str]:
     """Write ``raw_count`` independent, uncensused, single-session raws.
 
     Returns the written raw ids in insertion order. The archive root is
-    initialized fresh; call once per corpus.
+    initialized fresh; call once per corpus. ``authoritative_source`` binds
+    each raw to its own byte-proven full-revision baseline without deriving
+    index rows, for rebuild-route fixtures that must pass source admission.
     """
     initialize_active_archive_root(archive_root)
     raw_ids: list[str] = []
     with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
         for index in range(raw_count):
             payload = _codex_raw_payload(index, target_bytes=avg_payload_bytes)
+            native_id = f"amg1-session-{index:06d}"
             raw_id = archive.write_raw_payload(
                 provider=Provider.CODEX,
                 payload=payload,
                 source_path=f"synthetic-amg1/session-{index:06d}.jsonl",
                 acquired_at_ms=index + 1,
+                native_id=native_id if authoritative_source else None,
             )
+            if authoritative_source:
+                archive.bind_raw_revision(
+                    raw_id,
+                    RawRevisionEnvelope(
+                        logical_source_key=f"codex-session:{native_id}",
+                        kind=RawRevisionKind.FULL,
+                        source_revision=f"synthetic-amg1:{index:06d}",
+                        acquisition_generation=0,
+                        baseline_raw_id=raw_id,
+                        authority=RawRevisionAuthority.BYTE_PROVEN,
+                    ),
+                )
             raw_ids.append(raw_id)
     return raw_ids
 

--- a/tests/unit/daemon/test_daemon_bulk_rebuild_responsiveness.py
+++ b/tests/unit/daemon/test_daemon_bulk_rebuild_responsiveness.py
@@ -51,6 +51,7 @@ from pathlib import Path
 import pytest
 
 import polylogue.daemon.write_coordinator as write_coordinator_module
+from polylogue.archive.revision_authority import RawRevisionAuthority, RawRevisionEnvelope, RawRevisionKind
 from polylogue.config import Config
 from polylogue.core.enums import Provider
 from polylogue.daemon.bulk_rebuild import run_daemon_bulk_rebuild_pass
@@ -58,6 +59,7 @@ from polylogue.daemon.parse_prefetch import DaemonParseStage
 from polylogue.daemon.write_coordinator import DaemonWriteCoordinator, DaemonWriteEvent
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from tests.infra.rebuild_receipt import write_current_rebuild_receipt
 
 _RAW_COUNT = 150
 _BULK_BATCH_SIZE = 8  # forces >= 10 bounded passes over the fixture corpus
@@ -107,10 +109,11 @@ def _seed_corpus(root: Path, *, count: int = _RAW_COUNT) -> None:
     initialize_active_archive_root(root)
     with ArchiveStore.open_existing(root, read_only=False) as archive:
         for index in range(count):
-            archive.write_raw_payload(
+            native_id = f"responsiveness-session-{index}"
+            raw_id = archive.write_raw_payload(
                 provider=Provider.CODEX,
                 payload=_codex_session(
-                    f"responsiveness-session-{index}",
+                    native_id,
                     (
                         ("user", f"question {index}"),
                         ("assistant", f"searchable answer {index}" * 10),
@@ -118,6 +121,18 @@ def _seed_corpus(root: Path, *, count: int = _RAW_COUNT) -> None:
                 ),
                 source_path=f"responsiveness-corpus-{index}.jsonl",
                 acquired_at_ms=index,
+                native_id=native_id,
+            )
+            archive.bind_raw_revision(
+                raw_id,
+                RawRevisionEnvelope(
+                    logical_source_key=f"codex-session:{native_id}",
+                    kind=RawRevisionKind.FULL,
+                    source_revision=f"responsiveness:{index}",
+                    acquisition_generation=0,
+                    baseline_raw_id=raw_id,
+                    authority=RawRevisionAuthority.BYTE_PROVEN,
+                ),
             )
 
 
@@ -200,6 +215,8 @@ def test_small_writer_actors_stay_responsive_during_bulk_rebuild_drain(
     """
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path))
     _seed_corpus(tmp_path)
+    schema_receipt = write_current_rebuild_receipt(tmp_path, tmp_path.parent / "schema-inference-gate-receipt.json")
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_INFERENCE_RECEIPT", str(schema_receipt))
 
     events: list[DaemonWriteEvent] = []
     coordinator = DaemonWriteCoordinator(observer=events.append)

--- a/tests/unit/daemon/test_daemon_bulk_rebuild_responsiveness.py
+++ b/tests/unit/daemon/test_daemon_bulk_rebuild_responsiveness.py
@@ -23,22 +23,16 @@ Why this is a meaningful (non-vacuous) proof, not just a green assertion:
   (small ``raw_batch_size``, parse pre-warmed off the writer hold by
   ``DaemonParseStage`` per #3168) instead of holding the writer for an
   entire corpus in one sweep.
-* Manual measurement during development, at this exact fixture shape
-  (150-raw corpus, batch=8, 3 concurrent small actors): bounded passes held
-  the writer for ~0.04-0.34s each and small-actor queued wait had p99
-  ~0.32s. Collapsing the SAME corpus into one UNBOUNDED pass (batch=150,
-  the whole backlog in a single writer hold -- reproducing a regression
-  that removed per-pass batching, e.g. dropping ``RebuildIndexRequest``'s
-  paged ``raw_batch_size`` back to "whole backlog") measured a single
-  ~1.28s writer hold and pushed small-actor p99 wait to ~1.26s -- a small
-  actor queued behind that one giant hold waits for nearly the WHOLE
-  drain, not a bounded fraction of it. This test's budget (see
-  ``_SMALL_ACTOR_WAIT_BUDGET_SECONDS`` below) sits between those two
-  measurements: comfortably above the bounded-pass p99 (headroom against
-  host CPU contention -- this repo commonly runs concurrent agent/rebuild
-  load) while still well below what the unbounded-pass regression produces
-  at this exact fixture size, so a real regression to unbounded passes
-  would fail this test, not just a hypothetical one at a different scale.
+* The semantic guarantee is admission ordering, not an absolute wall-clock
+  duration. A full-IO host can stall a bounded writer hold longer than an
+  old measurement of an unbounded one, so a p99-second threshold cannot
+  distinguish a product regression from unrelated scheduler pressure. The
+  coordinator's real event stream instead proves the intended property:
+  every pair of bounded bulk-pass acquisitions has a live writer acquisition
+  between it. Collapsing the corpus into one unbounded pass fails the
+  multi-pass floor; bypassing the coordinator fails the bulk-event floor;
+  requeueing bulk work without yielding fails the per-pair interleaving
+  assertion.
 """
 
 from __future__ import annotations
@@ -66,18 +60,6 @@ _BULK_BATCH_SIZE = 8  # forces >= 10 bounded passes over the fixture corpus
 _SMALL_ACTOR_COUNT = 3
 _SMALL_ACTOR_INTERVAL_SECONDS = 0.02
 _MAX_PAYLOAD_BYTES = 10_000_000
-
-# Manually measured at this exact fixture shape (150 raws, batch=8, 3
-# concurrent small actors): the correct bounded-pass implementation saw p99
-# queued wait ~0.32s (max single writer hold ~0.34s). Collapsing the SAME
-# 150-raw corpus into one unbounded pass (batch=150) pushed p99 wait to
-# ~1.26s. This budget sits between those two measurements: several times
-# the bounded-pass p99 (headroom against host CPU contention -- this repo
-# commonly runs concurrent agent/rebuild load) while staying below the
-# unbounded-pass regression's measurement at this same fixture size, so
-# this is a real (not merely hypothetical) regression detector, not just a
-# loose ceiling nothing could ever hit.
-_SMALL_ACTOR_WAIT_BUDGET_SECONDS = 1.0
 
 
 def _codex_session(native_id: str, messages: tuple[tuple[str, str], ...]) -> bytes:
@@ -252,26 +234,33 @@ def test_small_writer_actors_stay_responsive_during_bulk_rebuild_drain(
 
     pass_count = asyncio.run(scenario())
 
-    small_actor_waits = sorted(
-        event.wait_seconds
-        for event in events
-        if event.phase == "acquired" and event.actor.startswith("live.append.") and event.wait_seconds is not None
-    )
+    small_actor_acquisitions = [
+        event for event in events if event.phase == "acquired" and event.actor.startswith("live.append.")
+    ]
     bulk_pass_events = [
         event for event in events if event.phase == "acquired" and event.actor == "maintenance.bulk_rebuild"
     ]
 
     # Sanity floor on the scenario itself: a single pass or a handful of
-    # small-actor samples would make the p99 assertion below vacuous (no
+    # small-actor samples would make the interleaving assertion below vacuous (no
     # real concurrency to interleave against).
     assert pass_count >= 10, "fixture must force multiple bounded bulk passes to be a meaningful concurrency proof"
     assert len(bulk_pass_events) == pass_count
-    assert len(small_actor_waits) >= 10, "small actors must genuinely interleave with the drain, not merely bookend it"
+    assert len(small_actor_acquisitions) >= 10, (
+        "small actors must genuinely interleave with the drain, not merely bookend it"
+    )
 
-    p99_index = min(len(small_actor_waits) - 1, int(len(small_actor_waits) * 0.99))
-    p99_wait = small_actor_waits[p99_index]
-    assert p99_wait < _SMALL_ACTOR_WAIT_BUDGET_SECONDS, (
-        f"small writer actor p99 queued-wait {p99_wait:.3f}s exceeded the "
-        f"{_SMALL_ACTOR_WAIT_BUDGET_SECONDS}s budget while a real bulk-rebuild pass was draining "
-        f"({len(small_actor_waits)} samples across {pass_count} bulk passes)"
+    # The exact scheduling guarantee: the daemon must surrender the writer
+    # between each pair of bounded maintenance passes whenever live writers
+    # are present. Sequence values are allocated by the real coordinator at
+    # queue admission, so this does not use a test-local scheduler model or
+    # a host-pressure-sensitive elapsed-time threshold.
+    gaps_without_live_admission = [
+        (left.sequence, right.sequence)
+        for left, right in zip(bulk_pass_events, bulk_pass_events[1:], strict=False)
+        if not any(left.sequence < live.sequence < right.sequence for live in small_actor_acquisitions)
+    ]
+    assert not gaps_without_live_admission, (
+        "bulk rebuild reacquired the daemon writer before any live writer in "
+        f"{len(gaps_without_live_admission)} bounded-pass gap(s): {gaps_without_live_admission}"
     )

--- a/tests/unit/maintenance/test_rebuild_index_candidate_promotion.py
+++ b/tests/unit/maintenance/test_rebuild_index_candidate_promotion.py
@@ -12,13 +12,15 @@ import pytest
 
 import polylogue.maintenance.archive_verification as archive_verification
 import polylogue.storage.sqlite.archive_tiers.revision_governance as revision_governance
+from polylogue.archive.revision_authority import RawRevisionAuthority, RawRevisionEnvelope, RawRevisionKind
 from polylogue.core.enums import Provider
 from polylogue.core.outcomes import OutcomeStatus
-from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
+from polylogue.maintenance.rebuild_index import RebuildIndexReceipt, RebuildIndexRequest, rebuild_index_from_source_sync
 from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.index_generation import IndexGenerationStore
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from tests.infra.rebuild_receipt import write_current_rebuild_receipt
 
 
 def _codex_session(native_id: str, text: str) -> bytes:
@@ -39,11 +41,23 @@ def _codex_session(native_id: str, text: str) -> bytes:
 
 def _seed_raw(root: Path, native_id: str, text: str) -> None:
     with ArchiveStore.open_existing(root, read_only=False) as archive:
-        archive.write_raw_payload(
+        raw_id = archive.write_raw_payload(
             provider=Provider.CODEX,
             payload=_codex_session(native_id, text),
             source_path=f"stamp-regression/{native_id}.jsonl",
             acquired_at_ms=1,
+            native_id=native_id,
+        )
+        archive.bind_raw_revision(
+            raw_id,
+            RawRevisionEnvelope(
+                logical_source_key=f"codex-session:{native_id}",
+                kind=RawRevisionKind.FULL,
+                source_revision=f"stamp-regression:{native_id}",
+                acquisition_generation=0,
+                baseline_raw_id=raw_id,
+                authority=RawRevisionAuthority.BYTE_PROVEN,
+            ),
         )
 
 
@@ -55,6 +69,13 @@ def _active_snapshot(root: Path) -> tuple[tuple[object, ...], ...]:
         )
 
 
+def _rebuild_with_fresh_receipt(root: Path, receipt_path: Path) -> RebuildIndexReceipt:
+    receipt = write_current_rebuild_receipt(root, receipt_path)
+    return rebuild_index_from_source_sync(
+        RebuildIndexRequest(archive_root=root, promote=True, schema_inference_receipt_path=receipt)
+    )
+
+
 def test_stamp_corruption_blocks_real_candidate_promotion_without_touching_active(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -64,7 +85,7 @@ def test_stamp_corruption_blocks_real_candidate_promotion_without_touching_activ
     _seed_raw(root, "active-session", "active generation remains exact")
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
 
-    initial = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+    initial = _rebuild_with_fresh_receipt(root, tmp_path / "initial-receipt.json")
     assert initial.status == "replayed"
 
     store = IndexGenerationStore.for_archive_root(root)
@@ -72,6 +93,7 @@ def test_stamp_corruption_blocks_real_candidate_promotion_without_touching_activ
     snapshot_before = _active_snapshot(root)
 
     _seed_raw(root, "candidate-session", "candidate must never become active")
+    candidate_receipt = write_current_rebuild_receipt(root, tmp_path / "candidate-receipt.json")
     original_writer = cast(Callable[..., str], revision_governance.__dict__["write_parsed_session_to_archive"])
     corruption_calls = 0
 
@@ -85,7 +107,9 @@ def test_stamp_corruption_blocks_real_candidate_promotion_without_touching_activ
     monkeypatch.setattr(revision_governance, "write_parsed_session_to_archive", bypass_stamps)
 
     with pytest.raises(RuntimeError, match="reindex acceptance gate failed.*session-fingerprint-stamps"):
-        rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(archive_root=root, promote=True, schema_inference_receipt_path=candidate_receipt)
+        )
 
     assert corruption_calls > 0
     assert store.active_pointer.resolve(strict=True) == active_before
@@ -100,11 +124,13 @@ def test_waived_embedding_orphan_blocks_full_rebuild_candidate_promotion(
     initialize_active_archive_root(root)
     _seed_raw(root, "active-session", "active generation remains exact")
 
-    initial = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+    initial = _rebuild_with_fresh_receipt(root, tmp_path / "initial-receipt.json")
     assert initial.status == "replayed"
 
     store = IndexGenerationStore.for_archive_root(root)
     active_before = store.active_pointer.resolve(strict=True)
+    _seed_raw(root, "candidate-session", "candidate must never become active")
+    candidate_receipt = write_current_rebuild_receipt(root, tmp_path / "candidate-receipt.json")
     with sqlite3.connect(root / "embeddings.db") as conn:
         conn.execute(
             """
@@ -114,10 +140,11 @@ def test_waived_embedding_orphan_blocks_full_rebuild_candidate_promotion(
             (b"o" * 32,),
         )
         conn.commit()
-    _seed_raw(root, "candidate-session", "candidate must never become active")
 
     with pytest.raises(RuntimeError, match=r"embeddings-refs-liveness.*waived by polylogue-feu0"):
-        rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(archive_root=root, promote=True, schema_inference_receipt_path=candidate_receipt)
+        )
 
     assert store.active_pointer.resolve(strict=True) == active_before
 
@@ -128,7 +155,7 @@ def test_cross_tier_user_reference_blocks_full_rebuild_candidate_promotion(
     root = tmp_path / "archive"
     initialize_active_archive_root(root)
     _seed_raw(root, "active-session", "active generation remains exact")
-    initial = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+    initial = _rebuild_with_fresh_receipt(root, tmp_path / "initial-receipt.json")
     assert initial.status == "replayed"
 
     store = IndexGenerationStore.for_archive_root(root)
@@ -142,26 +169,38 @@ def test_cross_tier_user_reference_blocks_full_rebuild_candidate_promotion(
         )
         conn.commit()
     _seed_raw(root, "candidate-session", "candidate must never become active")
+    candidate_receipt = write_current_rebuild_receipt(root, tmp_path / "candidate-receipt.json")
 
     with pytest.raises(RuntimeError, match=r"user-tier-refs \[error\]"):
-        rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(archive_root=root, promote=True, schema_inference_receipt_path=candidate_receipt)
+        )
 
     assert store.active_pointer.resolve(strict=True) == active_before
 
 
-@pytest.mark.parametrize("mutation", ("missing", "corrupt", "orphan"))
+@pytest.mark.parametrize(
+    ("mutation", "failure_pattern"),
+    (
+        ("missing", "rebuild schema-inference preflight gate failed"),
+        ("corrupt", "rebuild schema-inference preflight gate failed"),
+        ("orphan", "reindex source preflight gate failed:.*blob-integrity"),
+    ),
+)
 def test_rebuild_preflight_rejects_each_physical_blob_failure_before_candidate_creation(
-    tmp_path: Path, mutation: str
+    tmp_path: Path, mutation: str, failure_pattern: str
 ) -> None:
     """The source preflight catches physical debt before any new generation exists."""
     root = tmp_path / "archive"
     initialize_active_archive_root(root)
     _seed_raw(root, "active-session", "active generation remains exact")
-    initial = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+    initial = _rebuild_with_fresh_receipt(root, tmp_path / "initial-receipt.json")
     assert initial.status == "replayed"
 
     store = IndexGenerationStore.for_archive_root(root)
     active_before = store.active_pointer.resolve(strict=True)
+    _seed_raw(root, "candidate-session", "candidate must never become active")
+    candidate_receipt = write_current_rebuild_receipt(root, tmp_path / "candidate-receipt.json")
     with sqlite3.connect(root / "source.db") as conn:
         blob_hash = bytes(conn.execute("SELECT blob_hash FROM raw_sessions LIMIT 1").fetchone()[0]).hex()
     blob_store = BlobStore(root / "blob")
@@ -171,10 +210,10 @@ def test_rebuild_preflight_rejects_each_physical_blob_failure_before_candidate_c
         blob_store.blob_path(blob_hash).write_bytes(b"corrupt raw bytes")
     else:
         blob_store.write_from_bytes(b"orphan physical bytes")
-    _seed_raw(root, "candidate-session", "candidate must never become active")
-
-    with pytest.raises(RuntimeError, match="reindex source preflight gate failed:.*blob-integrity"):
-        rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+    with pytest.raises(RuntimeError, match=failure_pattern):
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(archive_root=root, promote=True, schema_inference_receipt_path=candidate_receipt)
+        )
 
     assert store.active_pointer.resolve(strict=True) == active_before
     assert len(list(store.generations_root.glob("gen-*/index.db"))) == 1
@@ -186,9 +225,11 @@ def test_rebuild_preflight_rejects_acquired_unreachable_attachment_before_candid
     root = tmp_path / "archive"
     initialize_active_archive_root(root)
     _seed_raw(root, "active-session", "active generation remains exact")
-    initial = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+    initial = _rebuild_with_fresh_receipt(root, tmp_path / "initial-receipt.json")
     assert initial.status == "replayed"
 
+    _seed_raw(root, "candidate-session", "candidate must never become active")
+    candidate_receipt = write_current_rebuild_receipt(root, tmp_path / "candidate-receipt.json")
     blob_hash, size = BlobStore(root / "blob").write_from_bytes(b"unreachable attachment")
     with sqlite3.connect(root / "index.db") as conn:
         conn.execute(
@@ -201,10 +242,10 @@ def test_rebuild_preflight_rejects_acquired_unreachable_attachment_before_candid
         conn.commit()
     store = IndexGenerationStore.for_archive_root(root)
     active_before = store.active_pointer.resolve(strict=True)
-    _seed_raw(root, "candidate-session", "candidate must never become active")
-
     with pytest.raises(RuntimeError, match="reindex source preflight gate failed:.*attachment-acquisition-debt"):
-        rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(archive_root=root, promote=True, schema_inference_receipt_path=candidate_receipt)
+        )
 
     assert store.active_pointer.resolve(strict=True) == active_before
     assert len(list(store.generations_root.glob("gen-*/index.db"))) == 1
@@ -228,12 +269,13 @@ def test_full_rebuild_promotion_rejects_non_ok_or_missing_required_result(
     root = tmp_path / "archive"
     initialize_active_archive_root(root)
     _seed_raw(root, "active-session", "active generation remains exact")
-    initial = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+    initial = _rebuild_with_fresh_receipt(root, tmp_path / "initial-receipt.json")
     assert initial.status == "replayed"
 
     store = IndexGenerationStore.for_archive_root(root)
     active_before = store.active_pointer.resolve(strict=True)
     _seed_raw(root, "candidate-session", "candidate must never become active")
+    candidate_receipt = write_current_rebuild_receipt(root, tmp_path / "candidate-receipt.json")
 
     def mutated_verifier(*args: object, **kwargs: object) -> archive_verification.ArchiveVerificationReport:
         checks = cast(tuple[str, ...], kwargs["checks"])
@@ -250,6 +292,8 @@ def test_full_rebuild_promotion_rejects_non_ok_or_missing_required_result(
 
     monkeypatch.setattr(archive_verification, "verify_archive", mutated_verifier)
     with pytest.raises(RuntimeError, match=f"reindex acceptance gate failed.*{check_name}"):
-        rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+        rebuild_index_from_source_sync(
+            RebuildIndexRequest(archive_root=root, promote=True, schema_inference_receipt_path=candidate_receipt)
+        )
 
     assert store.active_pointer.resolve(strict=True) == active_before

--- a/tests/unit/maintenance/test_rebuild_parse_apply_split.py
+++ b/tests/unit/maintenance/test_rebuild_parse_apply_split.py
@@ -38,6 +38,7 @@ from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_ind
 from polylogue.sources import revision_backfill
 from polylogue.sources.census_parse_stage import CensusParseStage
 from polylogue.sources.revision_backfill import split_parse_and_apply_seconds
+from tests.infra.rebuild_receipt import write_current_rebuild_receipt
 from tests.infra.revision_backfill_benchmark import build_independent_raw_corpus
 
 REINDEX_PRODUCTION_SEAMS = (
@@ -47,7 +48,7 @@ REINDEX_PRODUCTION_SEAMS = (
         production_entrypoint="polylogue.maintenance.rebuild_index.rebuild_index_from_source_sync",
         tested_symbols=("polylogue.maintenance.rebuild_index.rebuild_index_from_source_sync",),
         required_symbols=(
-            "polylogue.sources.revision_backfill.backfill_historical_revision_evidence",
+            "polylogue.maintenance.replay.rebuild_index_from_source",
             "polylogue.storage.repair.repair_session_insights",
         ),
     ),
@@ -57,7 +58,7 @@ REINDEX_PRODUCTION_SEAMS = (
         production_entrypoint="polylogue.maintenance.rebuild_index.rebuild_index_from_source_sync",
         tested_symbols=("polylogue.maintenance.rebuild_index.rebuild_index_from_source_sync",),
         required_symbols=(
-            "polylogue.sources.revision_backfill.backfill_historical_revision_evidence",
+            "polylogue.maintenance.replay.rebuild_index_from_source",
             "polylogue.storage.repair.repair_session_insights",
         ),
     ),
@@ -67,7 +68,7 @@ REINDEX_PRODUCTION_SEAMS = (
         production_entrypoint="polylogue.maintenance.rebuild_index.rebuild_index_from_source_sync",
         tested_symbols=("polylogue.maintenance.rebuild_index.rebuild_index_from_source_sync",),
         required_symbols=(
-            "polylogue.sources.revision_backfill.backfill_historical_revision_evidence",
+            "polylogue.maintenance.replay.rebuild_index_from_source",
             "polylogue.storage.repair.repair_session_insights",
         ),
     ),
@@ -113,7 +114,7 @@ def test_rebuild_records_parse_apply_split_summing_to_stage_total(
     already being logged -- not a second, independently-computed number.
     """
     root = tmp_path / "archive"
-    build_independent_raw_corpus(root, raw_count=8, avg_payload_bytes=20_000)
+    build_independent_raw_corpus(root, raw_count=8, avg_payload_bytes=20_000, authoritative_source=True)
     # ArchiveStore.open_owned_inactive_generation resolves the generation
     # store via the CONFIGURED archive root (polylogue.paths.archive_root),
     # not the archive_root argument threaded through the call -- it must
@@ -121,12 +122,14 @@ def test_rebuild_records_parse_apply_split_summing_to_stage_total(
     # tests/unit/storage/test_rebuild_paging_content_order.py for the same
     # requirement on the same code path).
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
+    schema_receipt = write_current_rebuild_receipt(root, tmp_path / "schema-inference-gate-receipt.json")
 
     receipt = rebuild_index_from_source_sync(
         RebuildIndexRequest(
             archive_root=root,
             promote=True,
             raw_batch_size=500,  # single page: whole corpus fits in one pass
+            schema_inference_receipt_path=schema_receipt,
         )
     )
 
@@ -176,8 +179,9 @@ def test_rebuild_index_from_source_sync_warms_prefetch_cache_when_caller_omits_o
     self-authorized double.
     """
     root = tmp_path / "archive"
-    raw_ids = build_independent_raw_corpus(root, raw_count=6, avg_payload_bytes=20_000)
+    raw_ids = build_independent_raw_corpus(root, raw_count=6, avg_payload_bytes=20_000, authoritative_source=True)
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
+    schema_receipt = write_current_rebuild_receipt(root, tmp_path / "schema-inference-gate-receipt.json")
 
     warmed_raw_id_batches: list[tuple[str, ...]] = []
     real_warm_raw_ids = CensusParseStage.warm_raw_ids
@@ -193,6 +197,7 @@ def test_rebuild_index_from_source_sync_warms_prefetch_cache_when_caller_omits_o
             archive_root=root,
             promote=True,
             raw_batch_size=500,  # single page: whole corpus fits in one pass
+            schema_inference_receipt_path=schema_receipt,
         )
     )
 
@@ -263,14 +268,18 @@ def test_rebuild_index_from_source_sync_auto_engages_pipelined_decode(
 
     root = tmp_path / "archive"
     cohort_count = revision_backfill._PIPELINE_DECODE_MIN_COHORTS + 4
-    raw_ids = build_independent_raw_corpus(root, raw_count=cohort_count, avg_payload_bytes=20_000)
+    raw_ids = build_independent_raw_corpus(
+        root, raw_count=cohort_count, avg_payload_bytes=20_000, authoritative_source=True
+    )
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
+    schema_receipt = write_current_rebuild_receipt(root, tmp_path / "schema-inference-gate-receipt.json")
 
     receipt = rebuild_index_from_source_sync(
         RebuildIndexRequest(
             archive_root=root,
             promote=True,
             raw_batch_size=500,  # single page: whole corpus fits in one pass
+            schema_inference_receipt_path=schema_receipt,
         )
     )
 

--- a/tests/unit/maintenance/test_rebuild_status.py
+++ b/tests/unit/maintenance/test_rebuild_status.py
@@ -16,18 +16,18 @@ from __future__ import annotations
 import fcntl
 import json
 import os
-import sqlite3
 from pathlib import Path
 
 import pytest
 
+from polylogue.archive.revision_authority import RawRevisionAuthority, RawRevisionEnvelope, RawRevisionKind
 from polylogue.core.enums import Provider
 from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync, rebuild_status
 from polylogue.storage.index_generation import IndexGenerationStore, rebuild_source_evidence_snapshot
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root, initialize_archive_database
 from polylogue.storage.sqlite.migration_runner import DURABLE_MIGRATION_TIERS
-from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
+from tests.infra.rebuild_receipt import write_current_rebuild_receipt
 
 _DEFINITELY_DEAD_PID = 2**31 - 1
 
@@ -54,15 +54,29 @@ def _codex_session(native_id: str) -> bytes:
     return b"".join(json.dumps(row, sort_keys=True).encode() + b"\n" for row in rows)
 
 
-def _seed_one_real_codex_session(root: Path) -> None:
+def _seed_one_real_codex_session(root: Path) -> str:
     initialize_active_archive_root(root)
     with ArchiveStore.open_existing(root, read_only=False) as archive:
-        archive.write_raw_payload(
+        native_id = "sess-status-probe"
+        raw_id = archive.write_raw_payload(
             provider=Provider.CODEX,
-            payload=_codex_session("sess-status-probe"),
+            payload=_codex_session(native_id),
             source_path="status-probe-test/0.jsonl",
             acquired_at_ms=1,
+            native_id=native_id,
         )
+        archive.bind_raw_revision(
+            raw_id,
+            RawRevisionEnvelope(
+                logical_source_key=f"codex-session:{native_id}",
+                kind=RawRevisionKind.FULL,
+                source_revision="status-probe:0",
+                acquisition_generation=0,
+                baseline_raw_id=raw_id,
+                authority=RawRevisionAuthority.BYTE_PROVEN,
+            ),
+        )
+        return raw_id
 
 
 def test_reports_no_lease_and_no_transaction_on_a_fresh_archive(tmp_path: Path) -> None:
@@ -113,7 +127,10 @@ def test_reports_active_generation_and_schema_version_after_a_rebuild(
     root = tmp_path / "archive"
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
     _seed_one_real_codex_session(root)
-    receipt = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root))
+    schema_receipt = write_current_rebuild_receipt(root, tmp_path / "schema-inference-gate-receipt.json")
+    receipt = rebuild_index_from_source_sync(
+        RebuildIndexRequest(archive_root=root, schema_inference_receipt_path=schema_receipt)
+    )
     assert receipt.status == "replayed"
 
     status = rebuild_status(root, operation_id="none", include_daemon_bulk_rebuild=False)
@@ -126,19 +143,13 @@ def test_reports_active_generation_and_schema_version_after_a_rebuild(
 
 def test_reports_transaction_cursor_and_no_delta_when_source_unchanged(tmp_path: Path) -> None:
     root = tmp_path / "archive"
-    _init_empty_source(root)
-    with sqlite3.connect(root / "source.db") as conn:
-        conn.execute(
-            """INSERT INTO raw_sessions (raw_id, origin, native_id, source_path, source_index, blob_hash,
-               blob_size, acquired_at_ms, validation_status)
-               VALUES ('raw-a', 'codex-session', 'raw-a', '/raw-a', 0, randomblob(32), 1, 1, 'passed')"""
-        )
+    raw_id = _seed_one_real_codex_session(root)
     store = IndexGenerationStore.for_archive_root(root)
     transaction = store.create_transaction(
         source_snapshot=rebuild_source_evidence_snapshot(root), operation_id="status-probe-op"
     )
     transaction = store.checkpoint_transaction(
-        transaction, status="paused", last_raw_id="raw-a", last_blob_hash_hex="00" * 32, processed_raw_count=1
+        transaction, status="paused", last_raw_id=raw_id, last_blob_hash_hex="00" * 32, processed_raw_count=1
     )
 
     status = rebuild_status(root, operation_id="status-probe-op")
@@ -161,13 +172,7 @@ def test_reports_transaction_cursor_and_no_delta_when_source_unchanged(tmp_path:
 
 def test_reports_source_snapshot_delta_when_source_has_drifted(tmp_path: Path) -> None:
     root = tmp_path / "archive"
-    _init_empty_source(root)
-    with sqlite3.connect(root / "source.db") as conn:
-        conn.execute(
-            """INSERT INTO raw_sessions (raw_id, origin, native_id, source_path, source_index, blob_hash,
-               blob_size, acquired_at_ms, validation_status)
-               VALUES ('raw-a', 'codex-session', 'raw-a', '/raw-a', 0, randomblob(32), 1, 1, 'passed')"""
-        )
+    _seed_one_real_codex_session(root)
     store = IndexGenerationStore.for_archive_root(root)
     transaction = store.create_transaction(source_snapshot="stale-snapshot", operation_id="drift-op")
     assert transaction.status == "running"
@@ -193,8 +198,8 @@ def test_falls_back_to_the_daemon_well_known_operation_id_by_default(tmp_path: P
     )
 
     root = tmp_path / "archive"
-    _init_empty_source(root)
-    receipt = write_valid_rebuild_receipt(root, tmp_path / "schema-inference-gate-receipt.json")
+    _seed_one_real_codex_session(root)
+    receipt = write_current_rebuild_receipt(root, tmp_path / "schema-inference-gate-receipt.json")
     resolve_or_start_daemon_bulk_rebuild_transaction(root, schema_inference_receipt_path=receipt)
 
     status = rebuild_status(root)


### PR DESCRIPTION
## Summary

- Restore rebuild-authority fixtures with real source evidence and fresh schema-inference receipts.
- Preserve daemon bulk-drain fairness with an event-order oracle that is independent of host wall-clock pressure.

## Problem

Current-master authority checks made several fixture paths invalid: they manufactured raw metadata without physical blobs or authoritative revisions, and rebuild requests lacked a receipt bound to the newly seeded source state. The daemon responsiveness test also treated a host-sensitive p99 wall-clock measurement as a semantic fairness contract.

## Solution

The shared fixture helper now establishes the source-authority frontier before writing a fresh rebuild receipt. Rebuild fixtures seed real blob-backed raw payloads and byte-proven source revisions, then supply that receipt to the production rebuild route. The parse/apply proof targets the actual maintenance rebuild path. The daemon test records real writer-event acquisition order and proves that live writers are admitted between bulk rebuild passes, without weakening promotion or source safeguards.

## Verification

- `POLYLOGUE_PYTEST_WORKERS=1 devtools test tests/unit/maintenance/test_rebuild_index_candidate_promotion.py tests/unit/maintenance/test_rebuild_status.py tests/unit/maintenance/test_rebuild_parse_apply_split.py tests/unit/daemon/test_daemon_bulk_rebuild_responsiveness.py::test_small_writer_actors_stay_responsive_during_bulk_rebuild_drain` recorded 22 passed; the remaining static reachability proof timed out under concurrent host pressure.
- `POLYLOGUE_PYTEST_WORKERS=1 devtools test tests/unit/maintenance/test_rebuild_parse_apply_split.py::test_selected_reindex_proof_tests_are_production_reachable` passed, 1 passed in 69.59s.
- `devtools verify --quick` passed with all 24 structural steps successful.

## Whole-Bead disposition

| Assigned Bead | Disposition | Evidence |
| --- | --- | --- |
| None supplied | Self-contained fixture repair; no Bead record mutated | `aebf62f59`, `45704f95f`, focused and quick verification above |

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->
