### PR TITLE
fix(ops): keep continuity evidence temp b-trees in memory

### DIFF
--- a/polylogue/operations/historical_source_continuity_recovery.py
+++ b/polylogue/operations/historical_source_continuity_recovery.py
@@ -77,6 +77,22 @@ RECEIPT_FORMAT: Literal["polylogue.historical-source-continuity-recovery-receipt
 _HISTORICAL_OPERATION_EVIDENCE_RESOURCE = "historical-source-continuity-operation-20260807.json"
 
 
+def _immutable_read_connection(path: Path) -> sqlite3.Connection:
+    """Open an immutable evidence DB without depending on filesystem temp space.
+
+    The continuity proof runs against large read-only SQLite images.  Several
+    of its deterministic joins and ordered digests need temporary b-trees;
+    SQLite's default temp-file mode can fail with ``disk I/O error`` when the
+    archive is being checked from a read-only overlay or a constrained tmpfs.
+    The proof is bounded by the caller's RAM budget and must not create
+    incidental files beside authenticated evidence, so keep those structures
+    in SQLite's memory temp store.
+    """
+    connection = sqlite3.connect(f"file:{path}?mode=ro&immutable=1", uri=True)
+    connection.execute("PRAGMA temp_store=MEMORY")
+    return connection
+
+
 class HistoricalSourceContinuityRecoveryError(DurableChangeTrainError):
     """Historical evidence cannot prove this one recovery transition."""
 
@@ -334,7 +350,7 @@ def _backup_source_evidence(
     if any(fingerprint.get(key) != value or artifact.get(key) != value for key, value in actual.items()):
         raise HistoricalSourceContinuityRecoveryError("historical backup source bytes differ from its receipt")
     try:
-        with sqlite3.connect(f"file:{backup_source}?mode=ro&immutable=1", uri=True) as connection:
+        with _immutable_read_connection(backup_source) as connection:
             evidence = capture_durable_database_evidence(connection, ArchiveTier.SOURCE)
     except sqlite3.Error as exc:
         raise HistoricalSourceContinuityRecoveryError("historical backup source is unreadable") from exc
@@ -589,7 +605,7 @@ def _current_evidence(root: Path) -> DurableDatabaseEvidence:
                 "historical continuity recovery refuses source SQLite sidecars"
             )
     try:
-        with sqlite3.connect(f"file:{root / 'source.db'}?mode=ro&immutable=1", uri=True) as connection:
+        with _immutable_read_connection(root / "source.db") as connection:
             return capture_durable_database_evidence(connection, ArchiveTier.SOURCE)
     except sqlite3.Error as exc:
         raise HistoricalSourceContinuityRecoveryError("cannot read current source evidence") from exc
@@ -673,8 +689,8 @@ def _assert_complete_source_semantic_delta(pre_source: Path, post_source: Path) 
     """Require every non-blob-ref schema object and relation to be identical."""
     try:
         with (
-            sqlite3.connect(f"file:{pre_source}?mode=ro&immutable=1", uri=True) as pre,
-            sqlite3.connect(f"file:{post_source}?mode=ro&immutable=1", uri=True) as post,
+            _immutable_read_connection(pre_source) as pre,
+            _immutable_read_connection(post_source) as post,
         ):
             if capture_durable_schema_inventory(pre) != capture_durable_schema_inventory(post):
                 raise HistoricalSourceContinuityRecoveryError("pre/post backups have source schema or object drift")
@@ -701,8 +717,8 @@ def _assert_exact_liveness_delta(
     candidate_keys = {(candidate.blob_hash.lower(), candidate.ref_type, candidate.ref_id) for candidate in candidates}
     try:
         with (
-            sqlite3.connect(f"file:{pre_source}?mode=ro&immutable=1", uri=True) as pre,
-            sqlite3.connect(f"file:{post_source}?mode=ro&immutable=1", uri=True) as post,
+            _immutable_read_connection(pre_source) as pre,
+            _immutable_read_connection(post_source) as post,
         ):
             pre_has_blob_refs = (
                 pre.execute("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'blob_refs'").fetchone()
@@ -884,9 +900,7 @@ def prepare_historical_source_continuity_recovery(
         post_source=post_backup_manifest.parent / "source.db",
     )
     try:
-        with sqlite3.connect(
-            f"file:{pre_backup_manifest.parent / 'source.db'}?mode=ro&immutable=1", uri=True
-        ) as connection:
+        with _immutable_read_connection(pre_backup_manifest.parent / "source.db") as connection:
             prior = classify_blob_ref_liveness(connection)
     except sqlite3.Error as exc:
         raise HistoricalSourceContinuityRecoveryError("cannot recompute historical liveness candidates") from exc

--- a/tests/unit/storage/test_archive_root_relocation.py
+++ b/tests/unit/storage/test_archive_root_relocation.py
@@ -47,6 +47,7 @@ from polylogue.operations.historical_source_continuity_recovery import (
     _assert_complete_source_semantic_delta,
     _assert_exact_liveness_delta,
     _current_evidence,
+    _immutable_read_connection,
     _sha256,
     _table_content_digest,
     _verify_historical_operation_evidence,
@@ -102,6 +103,30 @@ from polylogue.storage.sqlite.migration_runner import (
     release_durable_change_train,
     write_durable_change_train_manifest,
 )
+
+
+def test_historical_evidence_reads_keep_sqlite_temp_btrees_off_the_filesystem(tmp_path: Path) -> None:
+    """Read-only continuity evidence remains executable on constrained roots."""
+    source = tmp_path / "source.db"
+    with sqlite3.connect(source) as connection:
+        connection.executescript(
+            """
+            CREATE TABLE blob_refs (
+                blob_hash BLOB NOT NULL,
+                ref_type TEXT NOT NULL,
+                ref_id TEXT NOT NULL
+            );
+            INSERT INTO blob_refs VALUES (X'01', 'raw_payload', 'raw-1');
+            INSERT INTO blob_refs VALUES (X'02', 'raw_payload', 'raw-2');
+            INSERT INTO blob_refs VALUES (X'03', 'attachment', 'att-1');
+            """
+        )
+
+    with _immutable_read_connection(source) as connection:
+        assert connection.execute("PRAGMA temp_store").fetchone() == (2,)
+        assert connection.execute(
+            "SELECT ref_type, COUNT(*) FROM blob_refs GROUP BY ref_type ORDER BY ref_type"
+        ).fetchall() == [("attachment", 1), ("raw_payload", 2)]
 
 
 @contextmanager


### PR DESCRIPTION
## Summary

Keep every immutable SQLite evidence connection used by historical source-continuity recovery in SQLite's memory temp store, and add a regression test for grouped liveness queries on a read-only database.

## Problem

The continuity plan opened authenticated evidence with `mode=ro&immutable=1`, then ran grouped joins and ordered digests. SQLite's default temp-file mode attempted to create temporary b-trees in the filesystem and failed with `sqlite3.OperationalError: disk I/O error` on the constrained/read-only evidence path. This made a valid continuity proof fail before it reached the intentional archive-identity decision.

## Solution

- Add one private immutable-evidence connection helper that sets `PRAGMA temp_store=MEMORY`.
- Route all historical backup, live-source, exact-delta, semantic-delta, and liveness-recomputation readers through it.
- Add a file-backed regression test that executes a grouped liveness query and asserts the memory temp-store contract.

The change does not weaken archive identity, source continuity, backup, or foreign-copy checks. It changes only where SQLite places read-only query intermediates.

## Verification

- `devtools test tests/unit/storage/test_archive_root_relocation.py -k historical_evidence_reads_keep_sqlite_temp_btrees_off_the_filesystem` — 1 passed.
- `devtools test tests/unit/storage/test_archive_root_relocation.py` — 56 passed in 6.59s.
- `devtools verify --quick` — all 10 substantive steps passed in 26.67s.
- Pre-push quick verification — all 10 substantive steps passed in 26.13s.

## Bead disposition

This is a self-contained correctness repair supporting the live relocation/continuity work tracked by `polylogue-hgfre`. It does not close that Bead: live relocation authorization, deployment, observation, and backlog drain remain outstanding.

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->
