### PR TITLE
fix(ops): authenticate post-move archive continuity

### DIFF
--- a/polylogue/cli/commands/maintenance/_archive_root_relocation.py
+++ b/polylogue/cli/commands/maintenance/_archive_root_relocation.py
@@ -10,6 +10,7 @@ import click
 
 from polylogue.operations.archive_root_relocation import (
     ArchiveRootRelocationError,
+    RelocationPostMoveWitness,
     apply_archive_root_relocation,
     load_archive_root_relocation_plan,
     prepare_archive_root_relocation,
@@ -31,11 +32,13 @@ def archive_root_relocation_command() -> None:
 @archive_root_relocation_command.command("plan")
 @click.option("--old-root", required=True, type=click.Path(path_type=Path))
 @click.option("--backup-manifest", required=True, type=click.Path(path_type=Path, exists=True))
+@click.option("--post-move-witness", type=click.Path(path_type=Path, exists=True), default=None)
 @click.option("--output", required=True, type=click.Path(path_type=Path))
 @click.option("--output-format", type=click.Choice(["plain", "json"]), default="plain", show_default=True)
 def archive_root_relocation_plan_command(
     old_root: Path,
     backup_manifest: Path,
+    post_move_witness: Path | None,
     output: Path,
     output_format: str,
 ) -> None:
@@ -46,12 +49,21 @@ def archive_root_relocation_plan_command(
     try:
         with acquire_durable_archive_ownership(root, owner_id=f"archive-root-relocation-plan:{os.getpid()}"):
             stopped = _require_stopped_daemon(root)
+            witness = None
+            if post_move_witness is not None:
+                try:
+                    witness = RelocationPostMoveWitness.model_validate_json(
+                        post_move_witness.read_text(encoding="utf-8")
+                    )
+                except (OSError, ValueError) as exc:
+                    raise ArchiveRootRelocationError("archive-root relocation post-move witness is invalid") from exc
             plan = prepare_archive_root_relocation(
                 old_root=old_root,
                 new_root=root,
                 backup_manifest=backup_manifest,
                 stopped_daemon_evidence_ref=stopped,
                 single_writer_evidence_ref="proof:archive-ownership-lock",
+                post_move_witness=witness,
             )
             write_archive_root_relocation_plan(plan, output)
     except (ArchiveOwnershipError, ArchiveRootRelocationError, OSError) as exc:

--- a/polylogue/cli/commands/maintenance/_source_continuity_recovery.py
+++ b/polylogue/cli/commands/maintenance/_source_continuity_recovery.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import click
 
+from polylogue.operations.archive_root_relocation import RelocationPostMoveWitness
 from polylogue.operations.durable_change_train import ArchiveOwnershipError, acquire_durable_archive_ownership
 from polylogue.operations.historical_source_continuity_recovery import (
     HistoricalSourceContinuityRecoveryError,
@@ -29,6 +30,7 @@ def source_continuity_recovery_command() -> None:
 @click.option("--mutation-receipt", required=True, type=click.Path(path_type=Path, exists=True))
 @click.option("--pre-backup-manifest", required=True, type=click.Path(path_type=Path, exists=True))
 @click.option("--post-backup-manifest", required=True, type=click.Path(path_type=Path, exists=True))
+@click.option("--post-move-witness", type=click.Path(path_type=Path, exists=True), default=None)
 @click.option("--output", required=True, type=click.Path(path_type=Path))
 @click.option("--output-format", type=click.Choice(["plain", "json"]), default="plain", show_default=True)
 def source_continuity_recovery_plan_command(
@@ -36,6 +38,7 @@ def source_continuity_recovery_plan_command(
     mutation_receipt: Path,
     pre_backup_manifest: Path,
     post_backup_manifest: Path,
+    post_move_witness: Path | None,
     output: Path,
     output_format: str,
 ) -> None:
@@ -48,6 +51,16 @@ def source_continuity_recovery_plan_command(
             root, owner_id=f"historical-source-continuity-recovery-plan:{os.getpid()}"
         ):
             stopped = _require_stopped_daemon(root)
+            witness = None
+            if post_move_witness is not None:
+                try:
+                    witness = RelocationPostMoveWitness.model_validate_json(
+                        post_move_witness.read_text(encoding="utf-8")
+                    )
+                except (OSError, ValueError) as exc:
+                    raise HistoricalSourceContinuityRecoveryError(
+                        "historical continuity post-move witness is invalid"
+                    ) from exc
             plan = prepare_historical_source_continuity_recovery(
                 old_root=old_root,
                 new_root=root,
@@ -56,6 +69,7 @@ def source_continuity_recovery_plan_command(
                 post_backup_manifest=post_backup_manifest,
                 stopped_daemon_evidence_ref=stopped,
                 single_writer_evidence_ref="proof:archive-ownership-lock",
+                post_move_witness=witness,
             )
             write_historical_source_continuity_recovery_plan(plan, output)
     except (ArchiveOwnershipError, HistoricalSourceContinuityRecoveryError, OSError) as exc:

--- a/polylogue/operations/archive_root_relocation.py
+++ b/polylogue/operations/archive_root_relocation.py
@@ -122,6 +122,28 @@ class RelocationActiveIndexPointer(BaseModel):
     inode: int
 
 
+class RelocationPostMoveWitness(BaseModel):
+    """Evidence from a mover that rewrote paths before Polylogue could plan.
+
+    The normal route observes an old-root-owned pointer directly.  A managed
+    storage move may instead rewrite the pointer and remove the old path
+    first.  This witness does not waive identity checks: it supplies the
+    historical device identity and binds the two configured roots so the
+    released train and the current inodes must still agree.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    format: Literal["polylogue.archive-root-relocation-post-move-witness.v1"]
+    old_configured_root: str
+    old_resolved_root: str
+    new_configured_root: str
+    new_resolved_root: str
+    legacy_device: int
+    source_inode: int
+    evidence_ref: str
+
+
 class RelocationIndexGenerationSymlink(BaseModel):
     """One generation-owned tier link whose absolute target moves with the root."""
 
@@ -177,6 +199,7 @@ class ArchiveRootRelocationPlan(BaseModel):
     backup_tier_inventory: tuple[str, ...]
     tiers: tuple[RelocationTierEvidence, ...]
     active_index_pointer: RelocationActiveIndexPointer | None
+    post_move_witness: RelocationPostMoveWitness | None = None
     index_generations: tuple[RelocationIndexGeneration, ...]
     durable_trains: tuple[RelocationDurableTrain, ...]
     stopped_daemon_evidence_ref: str
@@ -404,7 +427,9 @@ def _read_active_index_pointer(root: Path) -> tuple[Path, Path] | None:
     return pointer, Path(os.path.abspath(target))
 
 
-def _active_index_pointer_evidence(*, old_root: Path, new_root: Path) -> RelocationActiveIndexPointer | None:
+def _active_index_pointer_evidence(
+    *, old_root: Path, new_root: Path, post_move_witness: RelocationPostMoveWitness | None = None
+) -> RelocationActiveIndexPointer | None:
     """Map an old-root-owned target before the relocation can publish it anew."""
     pointer = _read_active_index_pointer(new_root)
     if pointer is None:
@@ -413,9 +438,16 @@ def _active_index_pointer_evidence(*, old_root: Path, new_root: Path) -> Relocat
     try:
         relative_target = old_target.relative_to(old_root)
     except ValueError as exc:
-        raise ArchiveRootRelocationError(
-            "archive-root relocation active index pointer target is not owned by the old root"
-        ) from exc
+        try:
+            moved_relative_target = old_target.relative_to(new_root)
+        except ValueError:
+            moved_relative_target = None
+        if post_move_witness is None or moved_relative_target is None:
+            raise ArchiveRootRelocationError(
+                "archive-root relocation active index pointer target is not owned by the old root"
+            ) from exc
+        relative_target = moved_relative_target
+        old_target = old_root / relative_target
     new_target = new_root / relative_target
     conventional_old_target: str | None = None
     conventional_new_target: str | None = None
@@ -426,9 +458,12 @@ def _active_index_pointer_evidence(*, old_root: Path, new_root: Path) -> Relocat
             try:
                 conventional_relative = raw_conventional_target.relative_to(old_root)
             except ValueError as exc:
-                raise ArchiveRootRelocationError(
-                    "archive-root relocation conventional index target is not owned by the old root"
-                ) from exc
+                try:
+                    conventional_relative = raw_conventional_target.relative_to(new_root)
+                except ValueError:
+                    raise ArchiveRootRelocationError(
+                        "archive-root relocation conventional index target is not owned by the old root"
+                    ) from exc
             conventional_new_target = str(new_root / conventional_relative)
             new_resolved_target = Path(conventional_new_target).resolve(strict=True)
         else:
@@ -1058,6 +1093,7 @@ def _durable_trains(
     *,
     old_root: Path,
     snapshots: tuple[RelocationTierEvidence, ...],
+    post_move_witness: RelocationPostMoveWitness | None = None,
 ) -> tuple[RelocationDurableTrain, ...]:
     manifest_root = root / ".maintenance-state" / "durable-change-trains"
     _real_directory(root / ".maintenance-state", label="maintenance state")
@@ -1088,6 +1124,27 @@ def _durable_trains(
         active_generation=configured_index_identity.stable_id,
     ).authority_identity_digest
     accepted_legacy_identities = {legacy_active_identity, legacy_configured_identity}
+    if post_move_witness is not None:
+        witness_tier_identities = tuple(
+            TierFileIdentity(
+                item.tier,
+                old_root / Path(item.configured_path).relative_to(root),
+                old_root / Path(item.resolved_path).relative_to(root)
+                if Path(item.resolved_path).is_relative_to(root)
+                else Path(item.resolved_path),
+                post_move_witness.legacy_device,
+                item.inode,
+            )
+            for item in snapshots
+        )
+        witness_index = next(item for item in witness_tier_identities if item.name == "index")
+        accepted_legacy_identities.add(
+            ArchiveIdentity(
+                configured_root=old_root,
+                tiers=witness_tier_identities,
+                active_generation=witness_index.stable_id,
+            ).authority_identity_digest
+        )
     snapshots_by_tier = {item.tier: item for item in snapshots}
     trains: list[RelocationDurableTrain] = []
     for tier in sorted(DURABLE_MIGRATION_TIERS, key=lambda item: item.value):
@@ -1235,6 +1292,7 @@ def prepare_archive_root_relocation(
     backup_manifest: Path,
     stopped_daemon_evidence_ref: str,
     single_writer_evidence_ref: str,
+    post_move_witness: RelocationPostMoveWitness | None = None,
 ) -> ArchiveRootRelocationPlan:
     """Capture immutable, read-only evidence for the one root transition."""
     old_configured = old_root.absolute()
@@ -1243,6 +1301,17 @@ def prepare_archive_root_relocation(
     new_resolved = _real_directory(new_root, label="new archive root")
     if old_resolved == new_resolved:
         raise ArchiveRootRelocationError("archive-root relocation requires distinct old and new roots")
+    if post_move_witness is not None:
+        if (
+            post_move_witness.old_configured_root != str(old_configured)
+            or post_move_witness.old_resolved_root != str(old_resolved)
+            or post_move_witness.new_configured_root != str(new_configured)
+            or post_move_witness.new_resolved_root != str(new_resolved)
+        ):
+            raise ArchiveRootRelocationError("archive-root relocation post-move witness root binding changed")
+        source_identity = TierFileIdentity.resolve("source", new_resolved / "source.db")
+        if source_identity.inode != post_move_witness.source_inode:
+            raise ArchiveRootRelocationError("archive-root relocation post-move witness source inode changed")
     _reject_sidecars(new_resolved)
     try:
         manifest_path, receipt_path, manifest, receipt = validate_full_evidence_backup_for_archive_root_relocation(
@@ -1256,7 +1325,9 @@ def prepare_archive_root_relocation(
         manifest.get("archive_root_source_identity"), label="archive root"
     )
     backup_tier_identities = _authenticated_backup_tier_identities(manifest)
-    active_index_pointer = _active_index_pointer_evidence(old_root=old_resolved, new_root=new_resolved)
+    active_index_pointer = _active_index_pointer_evidence(
+        old_root=old_resolved, new_root=new_resolved, post_move_witness=post_move_witness
+    )
     index_generations = _index_generation_evidence(
         old_root=old_resolved,
         new_root=new_resolved,
@@ -1277,6 +1348,7 @@ def prepare_archive_root_relocation(
         new_resolved,
         old_root=old_resolved,
         snapshots=snapshots,
+        post_move_witness=post_move_witness,
     )
     root_metadata = new_resolved.stat()
     _require_identity_continuity(
@@ -1303,6 +1375,7 @@ def prepare_archive_root_relocation(
         backup_tier_inventory=tuple(sorted(f"{tier}.db" for tier in _TIER_NAMES)),
         tiers=snapshots,
         active_index_pointer=active_index_pointer,
+        post_move_witness=post_move_witness,
         index_generations=index_generations,
         durable_trains=trains,
         stopped_daemon_evidence_ref=stopped_daemon_evidence_ref,

--- a/polylogue/operations/historical_source_continuity_recovery.py
+++ b/polylogue/operations/historical_source_continuity_recovery.py
@@ -33,6 +33,7 @@ from polylogue.maintenance.receipt_fs import (
     maintenance_receipt_directory,
     read_optional_receipt,
 )
+from polylogue.operations.archive_root_relocation import RelocationPostMoveWitness
 from polylogue.paths import render_root
 from polylogue.storage.archive_identity import (
     ArchiveIdentity,
@@ -103,6 +104,7 @@ class HistoricalSourceContinuityRecoveryPlan(BaseModel):
     format: Literal["polylogue.historical-source-continuity-recovery-plan.v2"] = PLAN_FORMAT
     old_configured_root: str
     old_resolved_root: str
+    post_move_witness: RelocationPostMoveWitness | None = None
     new_configured_root: str
     new_resolved_root: str
     mutation_receipt_path: str
@@ -374,7 +376,11 @@ def _require_source_identity(root: Path, *, device: int, inode: int, label: str)
 
 
 def _require_legacy_destination_train_identity(
-    train: DurableChangeTrain, identity: TierFileIdentity, *, old_configured_root: Path
+    train: DurableChangeTrain,
+    identity: TierFileIdentity,
+    *,
+    old_configured_root: Path,
+    post_move_witness: RelocationPostMoveWitness | None = None,
 ) -> None:
     """Use the pre-existing released train to distinguish a move from a copy."""
     if train.apply_evidence is None:
@@ -382,10 +388,17 @@ def _require_legacy_destination_train_identity(
             "historical continuity recovery requires released source authority"
         )
     live_archive_identity = ArchiveIdentity.resolve(identity.configured_path.parent)
+    legacy_device = post_move_witness.legacy_device if post_move_witness is not None else identity.device
+    if legacy_device is None:
+        raise HistoricalSourceContinuityRecoveryError("historical continuity recovery lacks legacy device identity")
+    legacy_tiers = tuple(
+        TierFileIdentity(item.name, item.configured_path, item.resolved_path, legacy_device, item.inode)
+        for item in live_archive_identity.tiers
+    )
     relocated_legacy_identity = ArchiveIdentity(
         configured_root=old_configured_root,
-        tiers=live_archive_identity.tiers,
-        active_generation=live_archive_identity.active_generation,
+        tiers=legacy_tiers,
+        active_generation=next(item for item in legacy_tiers if item.name == "index").stable_id,
     )
     actual_identities = {
         hashlib.sha256(identity.stable_id.encode("utf-8")).hexdigest(),
@@ -854,6 +867,7 @@ def prepare_historical_source_continuity_recovery(
     post_backup_manifest: Path,
     stopped_daemon_evidence_ref: str,
     single_writer_evidence_ref: str,
+    post_move_witness: RelocationPostMoveWitness | None = None,
 ) -> HistoricalSourceContinuityRecoveryPlan:
     """Seal a read-only recovery plan for the one historical liveness receipt."""
     old_configured = old_root.absolute()
@@ -863,6 +877,13 @@ def prepare_historical_source_continuity_recovery(
         raise HistoricalSourceContinuityRecoveryError(
             "historical continuity recovery requires distinct old and new roots"
         )
+    if post_move_witness is not None and (
+        post_move_witness.old_configured_root != str(old_configured)
+        or post_move_witness.old_resolved_root != str(old_resolved)
+        or post_move_witness.new_configured_root != str(new_root.absolute())
+        or post_move_witness.new_resolved_root != str(root)
+    ):
+        raise HistoricalSourceContinuityRecoveryError("historical continuity post-move witness root binding changed")
     old_source = old_resolved / "source.db"
     pre_receipt, _pre_manifest, pre, pre_identity = _backup_source_evidence(
         pre_backup_manifest, old_source_path=old_source
@@ -880,10 +901,24 @@ def prepare_historical_source_continuity_recovery(
             raise HistoricalSourceContinuityRecoveryError("historical continuity recovery source.db is missing")
     else:
         assert post_identity is not None
-        new_source_identity = _require_source_identity(
-            root, device=pre_identity[0], inode=pre_identity[1], label="pre backup"
-        )
-        _require_source_identity(root, device=post_identity[0], inode=post_identity[1], label="post backup")
+        if post_move_witness is not None:
+            if (
+                pre_identity[0] != post_move_witness.legacy_device
+                or post_identity[0] != post_move_witness.legacy_device
+                or pre_identity[1] != post_move_witness.source_inode
+                or post_identity[1] != post_move_witness.source_inode
+            ):
+                raise HistoricalSourceContinuityRecoveryError(
+                    "historical continuity post-move witness differs from authenticated backup identity"
+                )
+            new_source_identity = TierFileIdentity.resolve("source", root / "source.db")
+            if new_source_identity.inode != post_move_witness.source_inode:
+                raise HistoricalSourceContinuityRecoveryError("historical continuity post-move source inode changed")
+        else:
+            new_source_identity = _require_source_identity(
+                root, device=pre_identity[0], inode=pre_identity[1], label="pre backup"
+            )
+            _require_source_identity(root, device=post_identity[0], inode=post_identity[1], label="post backup")
     assert new_source_identity.device is not None and new_source_identity.inode is not None
     candidates, candidate_digest = _legacy_liveness_receipt(
         mutation_receipt, old_source_path=old_source, pre_manifest=pre_backup_manifest.absolute()
@@ -946,8 +981,13 @@ def prepare_historical_source_continuity_recovery(
     train_path = manifest_root / f"source-{train.slot:03d}.json"
     _real_file(train_path, label="current released source train")
     _, source_before = _assert_pre_train_authority(train_path, pre)
-    if pre_identity is None:
-        _require_legacy_destination_train_identity(train, new_source_identity, old_configured_root=old_configured)
+    if pre_identity is None or post_move_witness is not None:
+        _require_legacy_destination_train_identity(
+            train,
+            new_source_identity,
+            old_configured_root=old_configured,
+            post_move_witness=post_move_witness,
+        )
     if train.source_continuity_evidence is not None:
         raise HistoricalSourceContinuityRecoveryError("current released source train already has continuity authority")
     census = _census(root)
@@ -993,6 +1033,7 @@ def prepare_historical_source_continuity_recovery(
     return _sealed_plan(
         old_configured_root=str(old_configured),
         old_resolved_root=str(old_resolved),
+        post_move_witness=post_move_witness,
         new_configured_root=str(new_root.absolute()),
         new_resolved_root=str(root),
         mutation_receipt_path=str(mutation_receipt.absolute()),

--- a/tests/unit/storage/test_archive_root_relocation.py
+++ b/tests/unit/storage/test_archive_root_relocation.py
@@ -25,6 +25,7 @@ from polylogue.operations.archive_root_relocation import (
     ArchiveRootRelocationPlan,
     RelocationActiveIndexPointer,
     RelocationIndexGeneration,
+    RelocationPostMoveWitness,
     RelocationTierEvidence,
     _check_backup_against_live,
     apply_archive_root_relocation,
@@ -2960,6 +2961,47 @@ def test_plan_rejects_the_real_stale_source_train_shape_before_receipt_write(
 
     assert (new_root / manifest.relative_to(old_root)).read_bytes() == manifest_before
     assert not (new_root / ".maintenance-state" / "archive-root-relocations").exists()
+
+
+def test_relocation_accepts_a_mover_rewritten_pointer_only_with_a_bound_witness(
+    workspace_env: dict[str, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A mover may rewrite absolute pointers before Polylogue plans the move."""
+    old_root = workspace_env["archive_root"]
+    manifest = _released_moved_source_train(old_root, monkeypatch)
+    _activate_movable_index_generation(old_root)
+    _attach_retained_source_continuity(old_root, manifest)
+    new_root = tmp_path / "moved"
+    source_inode = (old_root / "source.db").stat().st_ino
+    legacy_device = (old_root / "source.db").stat().st_dev
+    os.rename(old_root, new_root)
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(new_root))
+    backup = backup_archive(output_dir=tmp_path / "backups", profile="full_evidence", verify=True)
+    assert backup.ok and backup.output_path is not None
+    (new_root / ".index-active-pointer").write_text(str(new_root / "index.db"), encoding="utf-8")
+    witness = RelocationPostMoveWitness(
+        format="polylogue.archive-root-relocation-post-move-witness.v1",
+        old_configured_root=str(old_root.absolute()),
+        old_resolved_root=str(old_root.absolute()),
+        new_configured_root=str(new_root.absolute()),
+        new_resolved_root=str(new_root.resolve()),
+        legacy_device=legacy_device,
+        source_inode=source_inode,
+        evidence_ref="test:mover-rewritten-pointer",
+    )
+
+    plan = prepare_archive_root_relocation(
+        old_root=old_root,
+        new_root=new_root,
+        backup_manifest=Path(backup.output_path) / "manifest.json",
+        stopped_daemon_evidence_ref="proof:daemon-stopped",
+        single_writer_evidence_ref="proof:archive-ownership-lock",
+        post_move_witness=witness,
+    )
+
+    assert plan.post_move_witness == witness
+    assert plan.active_index_pointer is not None
+    assert plan.active_index_pointer.old_target == str(old_root / "index.db")
 
 
 def test_historical_continuity_recovery_cli_rejects_a_byte_identical_copied_archive(


### PR DESCRIPTION
## Summary

Authenticate the post-move archive-root and historical source-continuity path after the Sinnix state-root relocation.

## Problem

The managed move rewrote the active index pointer and removed the old path before Polylogue could plan the transition. The released source train still records the pre-move device identity, so the normal fail-closed identity checks correctly reject the relocated archive. The historical 69,340-row liveness mutation also predates the current continuity receipt format.

## Solution

- Add a root-bound, typed post-move witness carrying the independently observed legacy device and source inode.
- Accept a rewritten new-root pointer only when the witness binds both roots and current inode; retain byte, schema, train, backup, and foreign-copy checks.
- Thread the same witness through the historical source-continuity bridge so the pre/post backups and released train remain authenticated.
- Add regression coverage for the rewritten pointer path.

This is implementation closure for the relocation bridge only. `polylogue-hgfre` remains open until the selected deployed package applies the retained plan, survives bounded observation, and drains backlog.

## Verification

- `devtools test tests/unit/storage/test_archive_root_relocation.py -q` — 57 passed.
- `devtools verify --quick` — all 10 steps passed in 24.14s.
- Live read-only continuity plan — 69,340 candidates, zero orphaned refs across 48,145 remaining refs, source inode 1515046 preserved.

## Bead disposition

| Bead | Disposition | Evidence | Residual |
| --- | --- | --- | --- |
| `polylogue-hgfre` | partial | focused suite, quick gate, retained continuity plan | live apply/observation/backlog drain remains open |

Ref `polylogue-hgfre`.

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->
