### PR TITLE
fix(migrations): defer audit continuity before source v32

### DIFF
--- a/polylogue/operations/durable_change_train.py
+++ b/polylogue/operations/durable_change_train.py
@@ -988,6 +988,27 @@ def _validate_audit_adoption_continuity(
     expected_initial_file_identity: tuple[int, int] | None,
 ) -> None:
     """Require the published audit path to retain its adopted live identity."""
+    # An adopted audit image can legitimately precede source v32: the source
+    # migration that publishes ``audit_continuity_control`` is what creates
+    # the first source-backed continuity head.  Do not make the startup
+    # validator prevent that migration from running.  Once the source claims
+    # the continuity schema, a missing control table remains a hard failure.
+    source_path = archive_root / "source.db"
+    try:
+        with closing(sqlite3.connect(f"file:{source_path}?mode=ro&immutable=1", uri=True)) as source:
+            source_version = int(source.execute("PRAGMA user_version").fetchone()[0] or 0)
+            has_control = (
+                source.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'audit_continuity_control'"
+                ).fetchone()
+                is not None
+            )
+    except sqlite3.DatabaseError as exc:
+        raise MigrationError("cannot inspect source schema for audit adoption continuity") from exc
+    if not has_control:
+        if source_version < 32:
+            return
+        raise MigrationError("audit adoption continuity requires source audit_continuity_control")
     continuity = _latest_audit_adoption_continuity(archive_root)
     if continuity is None:
         _write_audit_adoption_continuity(


### PR DESCRIPTION
## Summary

Allow an adopted audit image to coexist safely with an older source schema until the source migration publishes its continuity-control table.

## Problem

The current archive is source v28 with an adopted audit v2 image. Startup validation tried to bind audit continuity before source migration 032 could create `audit_continuity_control`, so the supported source migration route failed with `no such table`.

## Solution

Defer only the continuity binding while source is below v32. Once source claims v32 or newer, a missing control table remains a hard failure. Audit image hash, size, application id, schema version, and identity checks remain active.

## Verification

- `devtools test tests/unit/storage/test_durable_change_train.py -k audit_adoption -q` — 11 passed.
- `devtools verify --quick` — all 10 steps passed in 24.82s.

## Bead disposition

This is a self-contained migration-ordering fix. `polylogue-hgfre` remains open for live relocation observation and backlog drain.

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->
