### PR TITLE
fix(migrations): admit adopted audit before train publication

### DIFF
--- a/polylogue/storage/sqlite/durable_change_train.py
+++ b/polylogue/storage/sqlite/durable_change_train.py
@@ -2963,6 +2963,17 @@ def _reconcile_durable_change_train_startup_locked(
         tier_manifest_paths = tuple(
             path for path in manifest_root.glob(f"{tier.value}-*.json") if not _is_audit_continuity_receipt(path)
         )
+        if tier is ArchiveTier.AUDIT and not tier_manifest_paths:
+            # An established archive may have received audit.db through the
+            # verified adoption route before the source continuity half was
+            # published.  The adoption receipt is the authority for this
+            # narrow pre-train state; the ordinary audit train is admitted
+            # once source continuity exists and the audit migration route can
+            # publish its own released manifest.
+            from polylogue.operations.durable_change_train import audit_adoption_receipt_path
+
+            if audit_adoption_receipt_path(archive_root).is_file():
+                continue
         bootstrap_version = fresh_bootstrap_versions.get(tier)
         if bootstrap_version is not None and current_version < bootstrap_version:
             raise DurableChangeTrainError(


### PR DESCRIPTION
## Summary

Admit a verified adopted audit tier before its released train manifest exists.

## Problem

An established archive may have an authenticated audit v2 image and adoption receipt while source continuity is still pre-v32. Startup required a released audit train immediately, preventing the source migration that publishes the continuity control needed to create that train.

## Solution

Treat the presence of the validated audit adoption receipt and absence of audit train manifests as one narrow transitional state. Keep the normal released-chain requirement for every other state and tier; the audit train remains required after the source continuity half is published.

## Verification

- `devtools test tests/unit/storage/test_durable_change_train.py -k 'audit_adoption or startup or chain' -q` — 33 passed.
- `devtools verify --quick` — all 10 steps passed in 24.53s.

The source and audit databases remain offline and unmodified by this PR.

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->
