### PR TITLE
fix(ops): admit adopted audit during relocation

### DIFF
--- a/polylogue/operations/archive_root_relocation.py
+++ b/polylogue/operations/archive_root_relocation.py
@@ -1151,6 +1151,16 @@ def _durable_trains(
         snapshot = snapshots_by_tier[tier.value]
         manifests = _released_train_manifests_by_target(manifest_root, tier)
         expected_targets = set(range(DURABLE_MIGRATION_ADOPTION_FLOORS[tier] + 1, snapshot.user_version + 1))
+        if tier is ArchiveTier.AUDIT and not manifests:
+            # Established archives can carry a verified adopted audit image
+            # before source v32 publishes the source-backed continuity head.
+            # It has no train manifest to rebind yet; the adoption receipt and
+            # full-evidence tier check remain the authority for this narrow
+            # transitional state.
+            from polylogue.operations.durable_change_train import validate_audit_adoption_receipt
+
+            if validate_audit_adoption_receipt(root) is not None:
+                continue
         if set(manifests) != expected_targets:
             raise ArchiveRootRelocationError(f"archive-root relocation found an unexpected {tier.value} train target")
         if manifests:


### PR DESCRIPTION
## Summary

Allow the authenticated adopted-audit transition during archive-root relocation.

## Problem

The relocated archive has a verified audit v2 image and adoption receipt but no audit train manifest yet; source v32 is the migration that publishes the source-backed continuity half. Relocation planning rejected this narrow transitional state before it could rebind the existing source and user train identities.

## Solution

The relocation planner now omits only the audit train when the adopted-audit receipt is present and no audit train manifests exist. It still validates the audit tier through the full-evidence backup, and all source/user train manifests remain required and fully identity-bound.

## Verification

- `devtools test tests/unit/storage/test_archive_root_relocation.py -q` — 57 passed.
- `devtools verify --quick` — all 10 steps passed in 24.0s.

No live relocation mutation was performed by this commit.

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->
