### PR TITLE
fix(migrations): project historical durable schemas correctly

### DIFF
--- a/polylogue/storage/sqlite/durable_change_train.py
+++ b/polylogue/storage/sqlite/durable_change_train.py
@@ -2019,7 +2019,9 @@ def _runtime_consumer_results(
                         raise DurableChangeTrainError(
                             f"runtime consumer {consumer.consumer_id} is source-tier-only: {reference}"
                         )
-                    detail = _probe_raw_failure_lifecycle(cast(Callable[..., object], value), archive_root)
+                    detail = _probe_raw_failure_lifecycle(
+                        cast(Callable[..., object], value), archive_root, train.target_version
+                    )
                 elif reference.endswith(":apply_raw_failure_dispositions"):
                     if train.tier is not ArchiveTier.SOURCE:
                         raise DurableChangeTrainError(
@@ -2050,6 +2052,18 @@ def _runtime_consumer_results(
                             f"runtime consumer {consumer.consumer_id} is source-tier-only: {reference}"
                         )
                     detail = _probe_raw_record_hydration(cast(Callable[..., object], value))
+                elif reference.endswith(":upsert_raw_artifact"):
+                    if train.tier is not ArchiveTier.SOURCE:
+                        raise DurableChangeTrainError(
+                            f"runtime consumer {consumer.consumer_id} is source-tier-only: {reference}"
+                        )
+                    detail = _probe_raw_artifact_upsert(cast(Callable[..., object], value), train.target_version)
+                elif reference.endswith(":_raw_materialization_candidate_ids"):
+                    if train.tier is not ArchiveTier.SOURCE:
+                        raise DurableChangeTrainError(
+                            f"runtime consumer {consumer.consumer_id} is source-tier-only: {reference}"
+                        )
+                    detail = _probe_raw_materialization_candidates(cast(Callable[..., object], value))
                 elif reference.endswith(":AuditRepository.reconcile_continuity"):
                     from polylogue.operations.audit import AuditRepository
 
@@ -2162,6 +2176,75 @@ def _probe_source_hook_event_writer(writer: Callable[..., object]) -> str:
     if hook_row != expected_hook_row or blob_ref_row != expected_blob_ref_row or raw_session_count != (0,):
         raise DurableChangeTrainError("source hook writer probe did not persist the expected hook payload contract")
     return "wrote and read back a hook payload in a fresh source tier"
+
+
+def _probe_raw_artifact_upsert(upsert: Callable[..., object], target_version: int) -> str:
+    """Exercise raw-artifact admission against the train's projected source schema."""
+    from polylogue.core.enums import ArtifactSupportStatus, Origin
+    from polylogue.storage.sqlite.archive_tiers.source_write import (
+        ArchiveSourceArtifact,
+        deterministic_blob_hash,
+        write_source_raw_session_blob_ref,
+    )
+
+    source_path = "/durable-change-train/raw-artifact-probe.jsonl"
+    payload = b'{"probe":"raw-artifact"}'
+    raw_id = "durable-change-train-raw-artifact-raw"
+    blob_hash = deterministic_blob_hash(payload)
+    artifact = ArchiveSourceArtifact(
+        artifact_id="durable-change-train-raw-artifact",
+        origin=Origin.CODEX_SESSION,
+        source_path=source_path,
+        source_index=0,
+        artifact_kind="agent_transcript",
+        classification_reason="durable-change-train probe",
+        support_status=ArtifactSupportStatus.SUPPORTED_PARSEABLE,
+        first_observed_at_ms=1_780_000_000_000,
+        last_observed_at_ms=1_780_000_000_000,
+    )
+    with _runtime_probe_source_connection(target_version) as probe:
+        write_source_raw_session_blob_ref(
+            probe,
+            origin=Origin.CODEX_SESSION,
+            source_path=source_path,
+            source_index=0,
+            blob_hash=blob_hash,
+            blob_size=len(payload),
+            acquired_at_ms=1_780_000_000_000,
+            raw_id=raw_id,
+        )
+        upsert(probe, raw_id, artifact)
+        row = probe.execute(
+            "SELECT artifact_id, raw_id, origin, source_path, source_index, artifact_kind, support_status "
+            "FROM raw_artifacts"
+        ).fetchone()
+    expected = (
+        artifact.artifact_id,
+        raw_id,
+        Origin.CODEX_SESSION.value,
+        source_path,
+        0,
+        artifact.artifact_kind,
+        ArtifactSupportStatus.SUPPORTED_PARSEABLE.value,
+    )
+    if row != expected:
+        raise DurableChangeTrainError("raw-artifact upsert probe did not persist the expected artifact contract")
+    return "wrote and read back one raw artifact in the projected source tier"
+
+
+def _probe_raw_materialization_candidates(candidates: Callable[..., object]) -> str:
+    """Exercise the raw replay candidate query against an empty archive fixture."""
+    from polylogue.config import Config
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+
+    with tempfile.TemporaryDirectory(prefix="polylogue-durable-train-probe-") as temporary:
+        root = Path(temporary)
+        initialize_archive_database(root / "source.db", ArchiveTier.SOURCE)
+        initialize_archive_database(root / "index.db", ArchiveTier.INDEX)
+        result = candidates(Config(archive_root=root, render_root=root, sources=[]))
+    if getattr(result, "raw_ids", None) != [] or getattr(result, "missing_blobs", None) != 0:
+        raise DurableChangeTrainError("raw-materialization candidate probe found unexpected replay debt")
+    return "enumerated an empty source/index archive without replay debt"
 
 
 def _runtime_probe_source_connection(target_version: int) -> sqlite3.Connection:
@@ -2475,6 +2558,17 @@ def _probe_raw_record_hydration(mapper: Callable[..., object]) -> str:
 def _probe_raw_failure_lifecycle(reader: Callable[..., object], archive_root: Path) -> str:
     """Exercise the source-tier failure lifecycle reader against live bytes."""
     snapshot = reader(archive_root / "source.db", sample_limit=1)
+def _probe_raw_failure_lifecycle(reader: Callable[..., object], archive_root: Path, target_version: int) -> str:
+    """Exercise the source-tier failure lifecycle reader against its projected schema."""
+    del archive_root
+    with tempfile.TemporaryDirectory(prefix="polylogue-durable-train-failure-") as directory:
+        source_path = Path(directory) / "source.db"
+        with sqlite3.connect(source_path) as connection:
+            from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+
+            initialize_archive_tier(connection, ArchiveTier.SOURCE)
+            _migration_runner._prepare_fresh_connection_for_target(connection, ArchiveTier.SOURCE, target_version)
+        snapshot = reader(source_path, sample_limit=1)
     if not getattr(snapshot, "available", False):
         raise DurableChangeTrainError("raw failure lifecycle probe could not read source.db")
     return f"read raw failure lifecycle state={getattr(snapshot, 'state', 'unknown')}"

--- a/polylogue/storage/sqlite/durable_change_train.py
+++ b/polylogue/storage/sqlite/durable_change_train.py
@@ -2064,6 +2064,12 @@ def _runtime_consumer_results(
                             f"runtime consumer {consumer.consumer_id} is source-tier-only: {reference}"
                         )
                     detail = _probe_raw_materialization_candidates(cast(Callable[..., object], value))
+                elif reference.endswith(":run_raw_authority_artifact_census"):
+                    if train.tier is not ArchiveTier.SOURCE:
+                        raise DurableChangeTrainError(
+                            f"runtime consumer {consumer.consumer_id} is source-tier-only: {reference}"
+                        )
+                    detail = _probe_raw_authority_artifact_census(train.target_version)
                 elif reference.endswith(":AuditRepository.reconcile_continuity"):
                     from polylogue.operations.audit import AuditRepository
 
@@ -2245,6 +2251,24 @@ def _probe_raw_materialization_candidates(candidates: Callable[..., object]) -> 
     if getattr(result, "raw_ids", None) != [] or getattr(result, "missing_blobs", None) != 0:
         raise DurableChangeTrainError("raw-materialization candidate probe found unexpected replay debt")
     return "enumerated an empty source/index archive without replay debt"
+
+
+def _probe_raw_authority_artifact_census(target_version: int) -> str:
+    """Exercise the read-only artifact census against the projected source tier."""
+    from polylogue.maintenance.raw_authority_artifact_census import run_raw_authority_artifact_census
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+
+    with tempfile.TemporaryDirectory(prefix="polylogue-durable-train-census-probe-") as temporary:
+        root = Path(temporary)
+        initialize_archive_database(root / "source.db", ArchiveTier.SOURCE)
+        initialize_archive_database(root / "index.db", ArchiveTier.INDEX)
+        with sqlite3.connect(root / "source.db") as source:
+            _migration_runner._prepare_fresh_connection_for_target(source, ArchiveTier.SOURCE, target_version)
+            source.commit()
+        report = run_raw_authority_artifact_census(root, receipt_path=root / "census-receipt.json")
+    if report.mode != "dry_run" or report.observations_written != 0:
+        raise DurableChangeTrainError("raw-authority artifact census probe changed the empty archive")
+    return "ran a read-only raw-authority artifact census against an empty projected source tier"
 
 
 def _runtime_probe_source_connection(target_version: int) -> sqlite3.Connection:
@@ -2555,9 +2579,6 @@ def _probe_raw_record_hydration(mapper: Callable[..., object]) -> str:
     return "hydrated a raw record preserving both acquisition origin and detected provider"
 
 
-def _probe_raw_failure_lifecycle(reader: Callable[..., object], archive_root: Path) -> str:
-    """Exercise the source-tier failure lifecycle reader against live bytes."""
-    snapshot = reader(archive_root / "source.db", sample_limit=1)
 def _probe_raw_failure_lifecycle(reader: Callable[..., object], archive_root: Path, target_version: int) -> str:
     """Exercise the source-tier failure lifecycle reader against its projected schema."""
     del archive_root

--- a/polylogue/storage/sqlite/migration_runner.py
+++ b/polylogue/storage/sqlite/migration_runner.py
@@ -37,6 +37,12 @@ _VERIFICATION_RECEIPT_FILE = "verification-receipt.json"
 _SQLITE_SIDECAR_SUFFIXES = ("-wal", "-shm", "-journal")
 _ADDITIVE_NO_BACKUP_MARKER = "-- migration-safety: additive-no-backup"
 _SQL_TRANSACTION_CONTROL_RE = re.compile(r"^(?:BEGIN|COMMIT|END|ROLLBACK|SAVEPOINT|RELEASE)\b", re.IGNORECASE)
+_CREATE_SCHEMA_OBJECT_RE = re.compile(
+    r"\bCREATE\s+(?:UNIQUE\s+)?(?P<kind>TABLE|INDEX|TRIGGER|VIEW)\s+"
+    r"(?:IF\s+NOT\s+EXISTS\s+)?"
+    r"(?:\"(?P<double>[^\"]+)\"|`(?P<backtick>[^`]+)`|\[(?P<bracket>[^\]]+)\]|(?P<bare>[A-Za-z_][A-Za-z0-9_]*))",
+    re.IGNORECASE,
+)
 DURABLE_CHANGE_TRAIN_FORMAT: Final = "polylogue.durable-change-train.v1"
 DURABLE_MIGRATION_COLLISION_REPORT_FORMAT: Final = "polylogue.durable-migration-collisions.v1"
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
@@ -264,9 +270,41 @@ def _prepare_fresh_connection_for_target(
         for rider in sidecar.train.riders
         for schema_object in rider.schema_objects
     }
+
+    # A later train may *replace* an object which already existed at the
+    # historical target.  Such an object must remain in the projected
+    # historical schema: dropping it would turn a v30 index replacement into
+    # a fictitious "object introduced at v30".  The train carrier lists the
+    # post-train object, so recover the earlier existence from the numbered
+    # migration SQL itself.  Objects that have no earlier CREATE are genuinely
+    # future-only and can be removed below.
+    historical_create_sql: dict[str, str] = {}
+    for step in steps:
+        if step.version > target_version:
+            continue
+        for match in _CREATE_SCHEMA_OBJECT_RE.finditer(step.sql):
+            name = next(value for value in match.group("double", "backtick", "bracket", "bare") if value is not None)
+            object_ref = f"{match.group('kind').lower()}:{name}"
+            statement_end = step.sql.find(";", match.start())
+            if statement_end >= 0:
+                historical_create_sql[object_ref] = step.sql[match.start() : statement_end + 1]
+    historically_created = set(historical_create_sql)
+    replaced_refs = future_refs & historically_created
+    future_refs.difference_update(historically_created)
+
+    # ALTER TABLE ... ADD COLUMN is represented in a train as a column
+    # object, while SQLite's canonical DDL necessarily contains the newest
+    # table definition.  Remove those future columns from the in-memory
+    # projection before inventory capture.  This is deliberately confined to
+    # the fresh connection used for parity; it never mutates an archive.
+    future_columns = {
+        schema_object.removeprefix("column:")
+        for schema_object in future_refs
+        if schema_object.startswith("column:") and "." in schema_object.removeprefix("column:")
+    }
     drop_order = {"index": 0, "trigger": 0, "view": 0, "table": 1}
     for schema_object in sorted(
-        future_refs,
+        future_refs | replaced_refs,
         key=lambda item: (drop_order.get(item.partition(":")[0], 2), item),
     ):
         object_type, separator, object_name = schema_object.partition(":")
@@ -274,7 +312,28 @@ def _prepare_fresh_connection_for_target(
             continue
         quoted_name = '"' + object_name.replace('"', '""') + '"'
         connection.execute(f"DROP {object_type.upper()} IF EXISTS {quoted_name}")
-    if future_refs:
+    # Reapply the historical definition for a later train that replaced an
+    # object which was already present at this target.  In particular, v30
+    # replaces this index with a partial uniqueness domain; v28 must retain
+    # the earlier unconditional uniqueness definition.
+    for schema_object in sorted(replaced_refs):
+        statement = historical_create_sql.get(schema_object)
+        if statement is not None:
+            connection.execute(statement)
+    for qualified_column in sorted(future_columns):
+        table_name, _, column_name = qualified_column.partition(".")
+        if not table_name or not column_name:
+            continue
+        table_exists = connection.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (table_name,),
+        ).fetchone()
+        if table_exists is None:
+            continue
+        quoted_table = '"' + table_name.replace('"', '""') + '"'
+        quoted_column = '"' + column_name.replace('"', '""') + '"'
+        connection.execute(f"ALTER TABLE {quoted_table} DROP COLUMN {quoted_column}")
+    if future_refs or replaced_refs or future_columns:
         connection.execute(f"PRAGMA user_version = {target_version}")
         connection.commit()
 

--- a/tests/unit/storage/test_durable_change_train.py
+++ b/tests/unit/storage/test_durable_change_train.py
@@ -3343,6 +3343,23 @@ def test_canonical_inventory_preserves_trigger_literal_whitespace() -> None:
     assert spaced != changed_literal
 
 
+def test_historical_source_inventory_removes_only_future_schema_objects() -> None:
+    """Historical parity keeps replaced v28 objects and removes v29+ additions."""
+    connection = sqlite3.connect(":memory:")
+    try:
+        connection.executescript(ARCHIVE_DDL_BY_TIER[ArchiveTier.SOURCE])
+        migration_runner._prepare_fresh_connection_for_target(connection, ArchiveTier.SOURCE, 28)
+        inventory = migration_runner.capture_durable_schema_inventory(connection)
+    finally:
+        connection.close()
+
+    refs = {item.object_ref for item in inventory.objects}
+    assert "index:idx_raw_artifacts_source_identity" in refs
+    assert "index:idx_raw_artifacts_failure_identity" not in refs
+    assert "table:raw_container_coordinates" not in refs
+    assert "column:raw_sessions.detected_provider" not in refs
+
+
 def test_admission_rejects_stale_current_and_target_versions() -> None:
     train = _declared(ArchiveTier.SOURCE)
     with pytest.raises(DurableChangeTrainError, match="stale durable train current"):

--- a/tests/unit/storage/test_durable_change_train.py
+++ b/tests/unit/storage/test_durable_change_train.py
@@ -345,6 +345,20 @@ def test_source_v29_sidecar_proves_failure_lifecycle_consumers_against_fresh_sch
     assert results[1].detail == "validated one raw failure disposition without mutation"
 
 
+def test_source_v30_sidecar_proves_raw_artifact_upsert_against_fresh_schema(tmp_path: Path) -> None:
+    sidecar = durable_migration_sidecar_for_slot(ArchiveTier.SOURCE, 30)
+    assert sidecar is not None
+
+    results = _runtime_consumer_results(sidecar.train, tmp_path)
+
+    assert [(result.consumer_id, result.passed) for result in results] == [
+        ("raw-artifact-upsert", True),
+        ("raw-failure-lifecycle", True),
+        ("raw-materialization-replay", True),
+    ]
+    assert results[0].detail == "wrote and read back one raw artifact in the projected source tier"
+
+
 def test_applied_train_release_requires_the_source_hook_event_writer_probe(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Project historical durable schemas correctly and add file-backed runtime probes for source v30 consumers so released source trains can be migrated without exposing future DDL or reading the wrong live tier.

## Problem

The source migration gate projected current DDL into historical source versions. A v28 archive therefore appeared to have future indexes/columns, and runtime probes for v30 consumers either had no adapter or read the live archive instead of the projected target schema. That made the fail-closed migration gate reject a valid historical source and left probe coverage incomplete.

## Solution

- Replay the numbered durable migration history when constructing a historical source projection, preserving historical replacements and removing future-only objects/columns.
- Add file-backed probes for the v30 raw-artifact upsert, raw-materialization candidate selector, and raw-failure lifecycle reader.
- Keep all probes isolated from the live archive and retain fail-closed schema/identity checks.

## Verification

- `devtools test tests/unit/storage/test_durable_change_train.py -k 'source_v30_sidecar or historical_source_inventory or source_v29_sidecar'` — 3 passed, 100 deselected.
- `devtools verify --quick` — all 10 steps passed locally.
- `git diff --check` — clean.
- CircleCI quick-gate must validate the published structured scope carrier below.

## Bead disposition

This PR is self-contained implementation work. It closes no Bead and does not authorize a production migration.

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->

## Risks and Follow-ups

The live source remains at v30 until each later train has its own verified full-evidence backup and migration receipt. This PR does not perform or claim that production transition.
