### PR TITLE
Pair a re-anchored generation_lifecycle event with itself

### DIFF
--- a/polylogue/archive/session_revision_membership.py
+++ b/polylogue/archive/session_revision_membership.py
@@ -205,6 +205,63 @@ def _axis_relation(
     return "equal"
 
 
+def _event_axis_relation(
+    a: SessionRevisionProjection,
+    b: SessionRevisionProjection,
+) -> _Relation:
+    """Compare the event axis, pairing an event whose anchor moved with itself.
+
+    ChatGPT re-anchors a ``generation_lifecycle`` event to a different
+    ``source_message_provider_id`` between export vintages of one unchanged
+    conversation. Event identity is keyed on (event_type, anchoring message),
+    so the same logical event lands as two disjoint identities: each side then
+    holds something the other lacks and an unchanged conversation compares as
+    a fork (polylogue-uqwd -- measured as 10 of 136 real ambiguous ChatGPT
+    cohorts still reaching a conflict verdict after polylogue-oycw's fix).
+
+    Only events the projection marked anchor-free are eligible, which is the
+    provider-remeasured shape alone; every other event keeps strict anchor
+    semantics. Pairing is one-to-one and consumes both sides, so two unmatched
+    events on one side against one on the other still leaves a genuine
+    surplus, and a real added event is still richness rather than a silent
+    merge.
+    """
+    identities_a = _identities(a.event_contents)
+    identities_b = _identities(b.event_contents)
+    anchor_free_a = dict(a.anchor_free_event_identities)
+    anchor_free_b = dict(b.anchor_free_event_identities)
+
+    unmatched_a = identities_a - identities_b
+    unmatched_b = identities_b - identities_a
+    paired_a: set[bytes] = set()
+    paired_b: set[bytes] = set()
+    available: dict[bytes, list[bytes]] = {}
+    for identity in sorted(unmatched_b):
+        key = anchor_free_b.get(identity)
+        if key is not None:
+            available.setdefault(key, []).append(identity)
+    for identity in sorted(unmatched_a):
+        key = anchor_free_a.get(identity)
+        if key is None:
+            continue
+        candidates = available.get(key)
+        if not candidates:
+            continue
+        paired_a.add(identity)
+        paired_b.add(candidates.pop(0))
+
+    if not paired_a and not paired_b:
+        return _axis_relation(identities_a, a.event_contents, identities_b, b.event_contents)
+
+    # Re-run the ordinary comparison with the moved events removed from both
+    # sides. They are the same slot carrying the same content modulo the
+    # anchor -- equal anchor-free identity already means equal type, timestamp
+    # and payload -- so dropping the pair changes neither side's evidence.
+    kept_a = frozenset((identity, content) for identity, content in a.event_contents if identity not in paired_a)
+    kept_b = frozenset((identity, content) for identity, content in b.event_contents if identity not in paired_b)
+    return _axis_relation(_identities(kept_a), kept_a, _identities(kept_b), kept_b)
+
+
 def _relation(a: SessionRevisionProjection, b: SessionRevisionProjection) -> _Relation:
     """Combine the message/attachment/event axes into one overall relation.
 
@@ -222,9 +279,7 @@ def _relation(a: SessionRevisionProjection, b: SessionRevisionProjection) -> _Re
             mutable_identities=a.mutable_message_identities | b.mutable_message_identities,
         ),
         _axis_relation(a.attachment_identities, a.attachment_contents, b.attachment_identities, b.attachment_contents),
-        _axis_relation(
-            _identities(a.event_contents), a.event_contents, _identities(b.event_contents), b.event_contents
-        ),
+        _event_axis_relation(a, b),
     )
     if "conflict" in axes:
         return "conflict"

--- a/polylogue/pipeline/ids.py
+++ b/polylogue/pipeline/ids.py
@@ -107,6 +107,18 @@ class SessionRevisionProjection:
     # when their mutable content changes. Native-id axes retain strict content
     # conflict semantics in ``session_revision_membership``.
     mutable_message_identities: frozenset[bytes] = frozenset()
+    #: ``(event_identity, anchor_free_identity)`` for events whose anchoring
+    #: message is provider-remeasured rather than content. ChatGPT re-anchors
+    #: a ``generation_lifecycle`` event to a different
+    #: ``source_message_provider_id`` between export vintages of the SAME
+    #: conversation, so its identity -- keyed on (event_type, anchoring
+    #: message) -- reads as two disjoint events instead of one, and the
+    #: revision axis calls an unchanged conversation a fork (polylogue-uqwd).
+    #: The anchor-free identity lets ``session_revision_membership`` recognise
+    #: the moved event as the same slot. Comparison-layer only: this value is
+    #: never persisted and never enters ``session_hash``, so nothing here
+    #: changes stored identity or requires a reparse.
+    anchor_free_event_identities: frozenset[tuple[bytes, bytes]] = frozenset()
 
 
 def _normalize_nested_for_hash(value: object) -> object:
@@ -554,6 +566,22 @@ _EVENT_CONTENT_PAYLOAD_ALLOWLIST: dict[str, frozenset[str]] = {
 }
 
 
+def _anchor_is_remeasured(event: ParsedSessionEvent) -> bool:
+    """Whether this event's anchoring message is provider measurement, not content.
+
+    True only for an event type carrying a payload allowlist AND declaring
+    ``duration_semantics == "provider_reported_elapsed"`` -- the ChatGPT
+    generation_lifecycle shape. Same two-part test
+    :func:`_event_content_payload` uses to strip remeasured payload fields, so
+    the anchor tolerance can never be broader than the payload tolerance.
+    """
+    allowlist = _EVENT_CONTENT_PAYLOAD_ALLOWLIST.get(event.event_type)
+    return (
+        allowlist is not None
+        and event.payload.get(_PROVIDER_REPORTED_ELAPSED_MARKER_KEY) == _PROVIDER_REPORTED_ELAPSED_MARKER_VALUE
+    )
+
+
 def _event_content_payload(event: ParsedSessionEvent) -> dict[str, JSONValue]:
     """Build the position- and measurement-independent CONTENT payload for one event.
 
@@ -624,6 +652,28 @@ def event_base_identity_hash(*, event_type: JSONValue, source_message_provider_i
     """
     return bytes.fromhex(
         hash_payload({"event_type": event_type, "source_message_provider_id": source_message_provider_id})
+    )
+
+
+def event_anchor_free_identity_hash(content_payload: Mapping[str, JSONValue]) -> bytes:
+    """Identity for an event whose anchoring message is itself remeasured.
+
+    Same content payload as the ordinary identity, minus
+    ``source_message_provider_id``. ChatGPT anchors a ``generation_lifecycle``
+    event to a different message id in different exports of one unchanged
+    conversation (polylogue-uqwd), so the anchor is provider measurement on
+    that shape, not content -- exactly the distinction
+    ``_event_content_payload``'s allowlist already draws for the event's own
+    duration and timestamp.
+
+    Deliberately NOT the event's stored identity: dropping the anchor there
+    would merge genuinely distinct events that differ only by which message
+    they hang off, and would be a stored-identity change requiring a reparse.
+    This value exists purely so the revision-membership comparison can pair a
+    moved event with itself.
+    """
+    return bytes.fromhex(
+        hash_payload({key: value for key, value in content_payload.items() if key != "source_message_provider_id"})
     )
 
 
@@ -801,6 +851,7 @@ def session_revision_projection(convo: ParsedSession) -> SessionRevisionProjecti
     event_hashes: list[bytes] = []
     event_base_identities: list[bytes] = []
     event_content_hashes: list[bytes] = []
+    event_anchor_free_identities: list[bytes | None] = []
     for payload, event in zip(session_events_payload, convo.session_events, strict=True):
         event_hashes.append(bytes.fromhex(hash_payload(payload)))
         content_payload = _event_content_payload(event)
@@ -811,8 +862,21 @@ def session_revision_projection(convo: ParsedSession) -> SessionRevisionProjecti
             )
         )
         event_content_hashes.append(bytes.fromhex(hash_payload(content_payload)))
+        # Narrowed to the same shape the payload allowlist targets: an event
+        # type with a registered allowlist that declares itself
+        # provider-remeasured. That is the ChatGPT generation_lifecycle shape
+        # whose anchor was observed to move between export vintages
+        # (polylogue-uqwd). Browser-capture emits the same event_type without
+        # the marker, and its anchor is a real first-party observation, so it
+        # is deliberately excluded and keeps strict anchor semantics.
+        event_anchor_free_identities.append(
+            event_anchor_free_identity_hash(content_payload) if _anchor_is_remeasured(event) else None
+        )
     event_contents: set[tuple[bytes, bytes]] = set()
-    for base_identity, content_hash in zip(event_base_identities, event_content_hashes, strict=True):
+    anchor_free_pairs: set[tuple[bytes, bytes]] = set()
+    for base_identity, content_hash, anchor_free in zip(
+        event_base_identities, event_content_hashes, event_anchor_free_identities, strict=True
+    ):
         # A base identity (event type + anchoring message) is ambiguous
         # whenever it is EVER possible for more than one event to share it
         # (e.g. one chatgpt_block_metadata event per block on a message), so
@@ -832,6 +896,8 @@ def session_revision_projection(convo: ParsedSession) -> SessionRevisionProjecti
         # correctly collapse to one set entry either way.
         canonical_identity = event_canonical_identity_hash(base_identity=base_identity, content_hash=content_hash)
         event_contents.add((canonical_identity, content_hash))
+        if anchor_free is not None:
+            anchor_free_pairs.add((canonical_identity, anchor_free))
     return SessionRevisionProjection(
         session_hash=bytes.fromhex(session_hash_hex),
         message_hashes=tuple(message_hashes),
@@ -842,5 +908,6 @@ def session_revision_projection(convo: ParsedSession) -> SessionRevisionProjecti
         attachment_contents=frozenset(attachment_contents),
         event_hashes=tuple(event_hashes),
         event_contents=frozenset(event_contents),
+        anchor_free_event_identities=frozenset(anchor_free_pairs),
         mutable_message_identities=frozenset(mutable_message_identities),
     )

--- a/tests/unit/archive/test_session_revision_membership.py
+++ b/tests/unit/archive/test_session_revision_membership.py
@@ -506,7 +506,7 @@ def test_refuses_to_equate_colliding_attachment_identities_with_different_bytes(
 # ---------------------------------------------------------------------------
 
 
-def _generation_lifecycle_revision(raw_id: str, elapsed_duration_ms: int) -> MembershipRevision:
+def _generation_lifecycle_revision(raw_id: str, elapsed_duration_ms: int, *, anchor: str = "0") -> MembershipRevision:
     """A ChatGPT-shaped session with one `generation_lifecycle` event."""
     session = ParsedSession(
         source_name=Provider.CHATGPT,
@@ -516,7 +516,7 @@ def _generation_lifecycle_revision(raw_id: str, elapsed_duration_ms: int) -> Mem
             ParsedSessionEvent(
                 event_type="generation_lifecycle",
                 timestamp=str(elapsed_duration_ms / 1000),
-                source_message_provider_id="0",
+                source_message_provider_id=anchor,
                 payload={
                     "state": "completed",
                     "evidence_source": "provider_native",
@@ -1220,3 +1220,96 @@ def test_observation_order_preserves_newer_mutable_idless_revision_without_provi
     assert result.accepted_raw_ids == ("raw-a-new",)
     assert result.equivalent_raw_ids == ("raw-z-old",)
     assert result.ambiguous_raw_ids == ()
+
+
+def test_accepts_generation_lifecycle_anchor_move_as_equivalent() -> None:
+    """Same event, re-anchored to a different message id by a later export.
+
+    ChatGPT anchors a `generation_lifecycle` event to a different
+    `source_message_provider_id` between export vintages of one unchanged
+    conversation. Event identity is keyed on (event_type, anchoring message),
+    so the moved event lands as two disjoint identities, each side holds
+    something the other lacks, and an unchanged conversation compares as a
+    fork. Measured on the live archive as 10 of 136 real ambiguous ChatGPT
+    cohorts still reaching a conflict verdict after polylogue-oycw's fix
+    (polylogue-uqwd) -- one traced example had all 46 messages identical
+    across three revisions, with the conflict coming entirely from this axis.
+    """
+    first_export = _generation_lifecycle_revision("raw-first", 13000, anchor="986a3a7e")
+    second_export = _generation_lifecycle_revision("raw-second", 13000, anchor="1175c3a7")
+
+    # The anchor really does move identity: this is not a no-op fixture.
+    assert first_export.projection.event_contents != second_export.projection.event_contents
+    assert _relation(first_export.projection, second_export.projection) == "equal"
+
+    result = classify_membership_revisions([first_export, second_export])
+
+    assert result.accepted_raw_ids == ("raw-first",)
+    assert result.equivalent_raw_ids == ("raw-second",)
+    assert result.ambiguous_raw_ids == ()
+
+
+def test_anchor_tolerance_does_not_launder_a_genuinely_added_event() -> None:
+    """One side gaining a second event is richness, not an anchor move.
+
+    Pairing is one-to-one and consumes both sides, so a surplus event still
+    reads as containment rather than being silently absorbed.
+    """
+    single = _generation_lifecycle_revision("raw-single", 13000, anchor="986a3a7e")
+    two_events = ParsedSession(
+        source_name=Provider.CHATGPT,
+        provider_session_id="session",
+        messages=[ParsedMessage(provider_message_id="0", role=Role.ASSISTANT, text="answer")],
+        session_events=[
+            ParsedSessionEvent(
+                event_type="generation_lifecycle",
+                timestamp="13.0",
+                source_message_provider_id=anchor,
+                payload={
+                    "state": "completed",
+                    "evidence_source": "provider_native",
+                    "fidelity": "exact",
+                    "duration_semantics": "provider_reported_elapsed",
+                    "elapsed_duration_ms": 13000,
+                },
+            )
+            for anchor in ("1175c3a7", "44448888")
+        ],
+    )
+    richer = MembershipRevision("raw-richer", session_revision_projection(two_events))
+
+    assert _relation(single.projection, richer.projection) == "b_contains_a"
+
+
+def test_anchor_tolerance_is_scoped_to_the_provider_remeasured_shape() -> None:
+    """An event without the provider-remeasured marker keeps strict anchoring.
+
+    Browser capture emits the same event_type from its own DOM observation,
+    where the anchoring message is a real first-party fact rather than
+    something the provider recomputes per export, so a moved anchor there is
+    genuine divergence and must still conflict.
+    """
+
+    def _dom_observed(raw_id: str, anchor: str) -> MembershipRevision:
+        session = ParsedSession(
+            source_name=Provider.CHATGPT,
+            provider_session_id="session",
+            messages=[ParsedMessage(provider_message_id="0", role=Role.ASSISTANT, text="answer")],
+            session_events=[
+                ParsedSessionEvent(
+                    event_type="generation_lifecycle",
+                    timestamp="13.0",
+                    source_message_provider_id=anchor,
+                    payload={
+                        "state": "completed",
+                        "evidence_source": "browser_capture",
+                        "fidelity": "exact",
+                        "duration_semantics": "dom_observed_wall",
+                        "elapsed_duration_ms": 13000,
+                    },
+                )
+            ],
+        )
+        return MembershipRevision(raw_id, session_revision_projection(session))
+
+    assert _relation(_dom_observed("a", "986a3a7e").projection, _dom_observed("b", "1175c3a7").projection) == "conflict"

--- a/tests/unit/sources/test_parsers_chatgpt.py
+++ b/tests/unit/sources/test_parsers_chatgpt.py
@@ -1666,10 +1666,17 @@ def test_chatgpt_mapping_order_does_not_create_revision_conflict() -> None:
     ]
     assert historical_left.session_events[0].source_message_provider_id == "node_a"
     assert historical_right.session_events[0].source_message_provider_id == "node_b"
-    assert _relation(historical_revisions[0].projection, historical_revisions[1].projection) == "conflict"
+    # The historical parser anchored the same provider-remeasured
+    # generation_lifecycle event to whichever timed message the mapping order
+    # surfaced first, so these two parses genuinely disagree on the anchor.
+    # Since polylogue-uqwd the comparison layer pairs an anchor-moved
+    # remeasured event with itself, so an unchanged conversation no longer
+    # classifies as a conflict on this axis alone.
+    assert _relation(historical_revisions[0].projection, historical_revisions[1].projection) == "equal"
     historical_result = classify_membership_revisions(historical_revisions, existing_accepted_raw_id="raw-left")
-    assert historical_result.accepted_raw_ids == ()
-    assert historical_result.ambiguous_raw_ids == ("raw-left", "raw-right")
+    assert historical_result.accepted_raw_ids == ("raw-left",)
+    assert historical_result.equivalent_raw_ids == ("raw-right",)
+    assert historical_result.ambiguous_raw_ids == ()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Stops a re-anchored ChatGPT `generation_lifecycle` event from making an
unchanged conversation compare as a fork. Comparison-layer only: no stored
identity changes, no schema bump, no reparse.

## Problem

Event identity is keyed on `(event_type, anchoring message)`. ChatGPT anchors
a `generation_lifecycle` event to a different `source_message_provider_id`
between export vintages of the *same* conversation, so one logical event lands
as two disjoint identities: each revision then holds something the other
lacks, and `_relation` returns `conflict`.

Measured on the live archive (`polylogue-uqwd`): after `polylogue-oycw`'s fix,
125 of 136 real ambiguous chatgpt-export cohorts resolved cleanly and **10
still reached a `conflict` verdict**. One traced cohort had all 46 messages
identical across three revisions, with the conflict coming entirely from this
axis — same payload shape, same `state: completed`, only the anchor differing.

This is the same shape `polylogue-nuec` fixed for the event's payload content,
on the anchor field instead.

## Solution

- `pipeline/ids.py`: `event_anchor_free_identity_hash` plus a new
  `anchor_free_event_identities` field on `SessionRevisionProjection`.
  `session_revision_projection` is computed on demand and never persisted, so
  this adds no stored column, never enters `session_hash`, and needs no
  reparse. Stored identity is deliberately unchanged — dropping the anchor
  there would merge genuinely distinct events that differ only in which
  message they hang off.
- `archive/session_revision_membership.py`: `_event_axis_relation` pairs an
  unmatched event on each side by anchor-free identity before computing
  richness, then defers to the ordinary `_axis_relation`.

Two deliberate limits:

- **Scoped to the provider-remeasured shape** — an event type carrying a
  payload allowlist *and* declaring `duration_semantics ==
  "provider_reported_elapsed"`, the same two-part test `_event_content_payload`
  already uses. The anchor tolerance can therefore never be broader than the
  payload tolerance. Browser capture emits the same `event_type` from its own
  DOM observation without that marker, where the anchor is a real first-party
  fact, and keeps strict anchoring.
- **Pairing is one-to-one and consumes both sides**, so a genuinely added
  event is still richness rather than a silent merge.

## Verification

```
pytest tests/unit/archive/test_session_revision_membership.py -> 46 passed
mypy --strict polylogue/pipeline/ids.py polylogue/archive/session_revision_membership.py -> clean
```

Anti-vacuity: two of the three new tests fail against the previous
`_axis_relation` call, asserted by reverting that single line. The third
asserts the browser-capture case still returns `conflict`, so it guards the
tolerance against being widened rather than detecting the fix.

Not claimed: the live conflict rate has **not** been re-measured against the
current archive. `uqwd`'s named repro cohorts no longer exist there (a
read-only re-run of its own tool returned 0 of 5 conflicting cohorts after the
archive relocation), so AC1 as written is unsatisfiable and the residual
belongs to a successor.

## Bead disposition

| Bead | Disposition | Why |
| --- | --- | --- |
| `polylogue-uqwd` | partial | The comparison-layer fix lands and is unit-verified with a stated anti-vacuity argument. Its AC1 is unsatisfiable as written — the named repro cohorts no longer exist on the relocated archive — so the live re-measurement moves to a named successor rather than being claimed here. |
| `polylogue-acewa` | successor | Owns re-deriving the ambiguous chatgpt-export cohort population against `/realm/state/polylogue` and reporting the conflict rate attributable to the re-anchored-event shape. Read-only; the campaign stays frozen. |

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [
    "polylogue-uqwd"
  ],
  "dispositions": [
    {
      "bead_id": "polylogue-uqwd",
      "disposition": "partial",
      "evidence": [
        {
          "kind": "commit",
          "ref": "a4b18e4f8"
        },
        {
          "kind": "command",
          "ref": "pytest tests/unit/archive/test_session_revision_membership.py -> 46 passed"
        },
        {
          "kind": "command",
          "ref": "mypy --strict polylogue/pipeline/ids.py polylogue/archive/session_revision_membership.py -> clean"
        }
      ],
      "successors": [
        "polylogue-acewa"
      ]
    }
  ],
  "mutated_beads": [],
  "scope_digest": "7b6b5e16bf3a4821f0efd61ce141ea9c8ab688ed63c21d2b2323d040d71219fe",
  "scope_kind": "bead",
  "version": 2
}
-->

