### PR TITLE
Make the verify fast path structural: seeded lanes, guarded merges, whale-aware tmpfs

### DIFF
--- a/devtools/lane_init.py
+++ b/devtools/lane_init.py
@@ -197,6 +197,38 @@ def _guard_check(worktree: Path) -> str | None:
     return None
 
 
+def _seed_testmon_graph(root: Path, worktree: Path) -> str:
+    """Copy the main checkout's testmon graph into a fresh lane.
+
+    A lane without a graph pays a complete-corpus bootstrap (~9.5x a warm
+    run) on its first verify. The verify preflight can copy the graph
+    lazily, but only when the main checkout's copy is valid AT THAT MOMENT;
+    seeding at provision time makes the lane warm from the start and
+    independent of later main-checkout state. Failure is a note, not an
+    error -- the lazy preflight copy remains as fallback.
+    """
+    from devtools.testmon_bootstrap import TESTMON_DATA_RELPATH
+
+    source = root / TESTMON_DATA_RELPATH
+    if not source.is_file():
+        return "no main-checkout graph to seed (first lane verify will bootstrap or copy later)"
+    destination = worktree / TESTMON_DATA_RELPATH
+    import sqlite3
+
+    try:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        for suffix in ("-wal", "-shm", "-journal"):
+            Path(f"{destination}{suffix}").unlink(missing_ok=True)
+        with (
+            sqlite3.connect(f"file:{source}?mode=ro", uri=True, timeout=30) as source_conn,
+            sqlite3.connect(destination, timeout=30) as destination_conn,
+        ):
+            source_conn.backup(destination_conn)
+    except (OSError, sqlite3.Error) as exc:
+        return f"graph seed failed ({exc}); first lane verify will copy or bootstrap"
+    return "seeded from main checkout (lane verifies start warm)"
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     root = repo_root()
@@ -238,6 +270,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print("lane-init: verify-worktree failed", file=sys.stderr)
         return 1
 
+    graph_note = _seed_testmon_graph(root, worktree)
     base_sha = _run(["git", "-C", str(worktree), "rev-parse", "--short=9", "HEAD"]).stdout.strip()
     workers = recommended_workers(args.expected_lanes)
     record = lane_record(
@@ -248,6 +281,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         venv=not args.no_venv,
         workers=workers,
     )
+    record["testmon_graph"] = graph_note
     ledger_path = append_ledger(coordinator_root(root), record)
 
     if args.as_json:
@@ -258,6 +292,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(
             f"  venv: {'provisioned (guard-verified)' if not args.no_venv else 'SKIPPED -- lane cannot run devtools/pytest'}"
         )
+        print(f"  testmon graph: {graph_note}")
         if beads:
             print(f"  beads: {', '.join(beads)}")
         print(f"  ledger: {ledger_path}")

--- a/devtools/merge_boundary.py
+++ b/devtools/merge_boundary.py
@@ -575,6 +575,45 @@ def _run_post_merge_terminal_verify(
         return result if _remove_detached_worktree(repo_root, worktree) else 1
 
 
+def _head_missing_master_tip(head_sha: str) -> str | None:
+    """Return a refusal reason when ``head_sha`` does not contain origin/master.
+
+    Fetches first so the ancestry answer reflects the remote's current tip,
+    not a stale local ref. Unavailable git evidence refuses (fail closed):
+    merging with unknown ancestry is exactly the stale-base hazard.
+    """
+    repo_root = merge_gate._repository_root()
+    try:
+        subprocess.run(
+            ["git", "fetch", "--quiet", "origin", "master", head_sha],
+            capture_output=True,
+            timeout=120,
+            cwd=repo_root,
+            check=True,
+        )
+        master_tip = subprocess.run(
+            ["git", "rev-parse", "origin/master"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            cwd=repo_root,
+            check=True,
+        ).stdout.strip()
+        contains = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", master_tip, head_sha],
+            capture_output=True,
+            timeout=30,
+            cwd=repo_root,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return f"could not establish base ancestry against origin/master: {exc}"
+    if contains.returncode == 0:
+        return None
+    if contains.returncode == 1:
+        return f"head {head_sha[:8]} does not contain origin/master tip {master_tip[:8]} (stale base)"
+    return f"git merge-base --is-ancestor failed (exit {contains.returncode})"
+
+
 def cmd_merge(
     pr: int,
     *,
@@ -605,6 +644,22 @@ def cmd_merge(
         return 1
 
     head_sha = info["headRefOid"]
+    # A receipt recorded on a stale-based head verifies the OLD tree: its
+    # environment digest predates the current graph, so the "receipt" is a
+    # complete-corpus bootstrap of code master no longer contains (observed
+    # 2026-08-18: a dependabot branch cut three days earlier cost a 40-minute
+    # full rebuild to attest one workflow-file change). Require the head to
+    # contain master's tip so the receipt run reuses the warm graph and
+    # attests the tree that will actually land.
+    stale_base_error = _head_missing_master_tip(head_sha)
+    if stale_base_error is not None:
+        print(f"REFUSING to merge PR #{pr}: {stale_base_error}", file=sys.stderr)
+        print(
+            f"  update the branch first: gh api -X PUT repos/{{owner}}/{{repo}}/pulls/{pr}/update-branch"
+            " (then re-run this merge at the new head)",
+            file=sys.stderr,
+        )
+        return 1
     checkout_root = merge_gate._repository_root()
     scope = merge_gate._scope_verdict(
         pr,

--- a/devtools/pytest_progress_plugin.py
+++ b/devtools/pytest_progress_plugin.py
@@ -36,6 +36,12 @@ _CONTROLLER_COLLECTION_PAYLOAD: dict[str, Any] | None = None
 _SLOW_REPORT_LIMIT = 20
 _DEFAULT_SELECTION_NODEID_LIMIT = 500
 _COLLECTION_FACT_SUFFIX = ".collection.json"
+_COUNTS_SUFFIX = ".counts.json"
+#: Completed/failed tallies flushed every N completions so the supervisor
+#: heartbeat can print live progress and an ETA without replaying event logs.
+_COUNTS_FLUSH_EVERY = 20
+_COMPLETED_COUNT = 0
+_FAILED_COUNT = 0
 _ARTIFACT_ENV_NAMES = (_EVENTS_ENV, _EVENTS_DIR_ENV, _SELECTION_ENV, _SUMMARY_ENV)
 
 
@@ -385,8 +391,43 @@ def _record_phase_report(report: Any, *, write_event: bool = True) -> None:
     if payload["outcome"] == "failed":
         payload["longrepr"] = str(getattr(report, "longrepr", ""))
     _remember_report(payload)
+    global _COMPLETED_COUNT, _FAILED_COUNT
+    if outcome == "failed":
+        _FAILED_COUNT += 1
+        _flush_counts(force=True)
+    if when == "teardown":
+        _COMPLETED_COUNT += 1
+        _flush_counts()
     if write_event:
         _write_event(payload)
+
+
+def _flush_counts(*, force: bool = False) -> None:
+    """Publish this worker's completed/failed tallies as one tiny atomic file."""
+    if not force and _COMPLETED_COUNT % _COUNTS_FLUSH_EVERY != 0:
+        return
+    raw_dir = os.environ.get(_EVENTS_DIR_ENV)
+    if not raw_dir:
+        return
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "controller").replace("/", "-")
+    path = Path(raw_dir) / f"{worker}-{os.getpid()}{_COUNTS_SUFFIX}"
+    payload = json.dumps({"completed": _COMPLETED_COUNT, "failed": _FAILED_COUNT})
+    with contextlib.suppress(OSError):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+        temporary.write_text(payload, encoding="utf-8")
+        os.replace(temporary, path)
+
+
+def read_progress_counts(events_dir: Path) -> tuple[int, int]:
+    """Sum every worker's published (completed, failed) tallies."""
+    completed = failed = 0
+    for path in events_dir.glob(f"*{_COUNTS_SUFFIX}"):
+        with contextlib.suppress(OSError, json.JSONDecodeError, TypeError, ValueError):
+            data = json.loads(path.read_text(encoding="utf-8"))
+            completed += int(data.get("completed", 0))
+            failed += int(data.get("failed", 0))
+    return completed, failed
 
 
 @pytest.hookimpl(hookwrapper=True)
@@ -413,6 +454,7 @@ def pytest_runtest_logreport(report: Any) -> None:
 def pytest_sessionfinish(session: Any, exitstatus: int) -> None:
     """Write a compact post-run diagnosis artifact independent of pytest-json-report."""
     del session
+    _flush_counts(force=True)
     try:
         # Worker processes have their own in-memory slowest lists. The controller
         # receives the forwarded timings and is the only writer for the shared

--- a/devtools/testmon_bootstrap.py
+++ b/devtools/testmon_bootstrap.py
@@ -604,6 +604,20 @@ def inspect_native_testmon_environment(
             return NativeTestmonState("invalid", f"cannot inspect native testmon sidecar {sidecar}: {exc}")
         if not stat.S_ISREG(sidecar_state.st_mode) or sidecar_state.st_nlink != 1:
             return NativeTestmonState("invalid", f"native testmon sidecar is not a single-link regular file: {sidecar}")
+    # A killed writer (supervisor SIGTERM, operator interrupt) leaves a WAL
+    # that only a read-WRITE connection can replay -- the read-only URI below
+    # fails with SQLITE_READONLY_RECOVERY, the state is judged invalid, and
+    # removal then destroys EVERY environment's accumulated graph in the
+    # shared file (observed 2026-08-18: one killed bootstrap cost the warm
+    # master graph and a 20,500-test rebuild). Checkpoint first so ordinary
+    # crash recovery happens instead.
+    if any(path.exists() for path in sidecars):
+        with contextlib.suppress(sqlite3.Error, OSError):
+            recovery = sqlite3.connect(data_path, timeout=_remaining_timeout(deadline_monotonic, 10))
+            try:
+                recovery.execute("PRAGMA wal_checkpoint(PASSIVE)")
+            finally:
+                recovery.close()
     try:
         with (
             contextlib.closing(

--- a/devtools/testmon_bootstrap.py
+++ b/devtools/testmon_bootstrap.py
@@ -831,6 +831,14 @@ def _atomic_copy_sqlite_database(
             os.fsync(descriptor)
         finally:
             os.close(descriptor)
+        # Remove the DESTINATION's sidecars before the replace: a stale -wal
+        # from a previous database under the same name is read as this new
+        # database's write-ahead log, and quick_check then fails with page
+        # corruption ("Rowid out of order" -- observed 2026-08-18 in a lane
+        # worktree whose fresh copy sat beside a -wal from an earlier run).
+        for suffix in TESTMON_SIDECAR_SUFFIXES:
+            with contextlib.suppress(FileNotFoundError):
+                Path(f"{destination}{suffix}").unlink()
         os.replace(temporary, destination)
         _fsync_directory(destination.parent)
         _ensure_deadline(deadline_monotonic)

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -428,6 +428,39 @@ DEFAULT_PYTEST_TERM_GRACE_S = 5.0
 DEFAULT_PYTEST_RESOURCE_INTERVAL_S = 2.0
 
 
+def _estimate_duration_from_history(
+    *,
+    tier: str,
+    selection: Mapping[str, Any] | None,
+) -> tuple[float, int] | None:
+    """Median duration of recent green runs with the same tier and selection shape.
+
+    An operator watching a run deserves to know whether it is a 30-second warm
+    pass or a 40-minute bootstrap BEFORE it finishes. The history rows carry
+    tier + selection mode/state, which is exactly what predicts duration.
+    """
+    mode = selection.get("selection_mode") if isinstance(selection, Mapping) else None
+    state = selection.get("state_status") if isinstance(selection, Mapping) else None
+    durations: list[float] = []
+    for entry in reversed(_load_history()[-200:]):
+        if entry.get("tier") != tier or entry.get("exit_code") != 0:
+            continue
+        entry_selection = entry.get("testmon_selection")
+        entry_mode = entry_selection.get("selection_mode") if isinstance(entry_selection, dict) else None
+        entry_state = entry_selection.get("state_status") if isinstance(entry_selection, dict) else None
+        if (entry_mode, entry_state) != (mode, state):
+            continue
+        duration = entry.get("duration_s") or entry.get("total_duration_s")
+        if isinstance(duration, int | float) and duration > 0:
+            durations.append(float(duration))
+        if len(durations) >= 10:
+            break
+    if not durations:
+        return None
+    durations.sort()
+    return durations[len(durations) // 2], len(durations)
+
+
 def _load_history() -> list[dict[str, Any]]:
     if not HISTORY_PATH.exists():
         return []
@@ -1639,8 +1672,31 @@ def _run_pytest_with_heartbeat(
                 receipt = read_receipt(launch.receipt_path)
                 controller_pid = receipt.get("controller_pid") if receipt is not None else None
                 controller_text = f", controller={controller_pid}" if isinstance(controller_pid, int) else ""
+                progress_counts_text = ""
+                if events_dir is not None:
+                    from devtools.pytest_progress_plugin import read_progress_counts
+
+                    done_count, failed_count = read_progress_counts(events_dir)
+                    if done_count:
+                        selected_total: int | None = None
+                        if artifacts is not None:
+                            selection_artifact = _read_json_artifact(artifacts.selection_path)
+                            if isinstance(selection_artifact, dict):
+                                raw_selected = selection_artifact.get("selected_count")
+                                if isinstance(raw_selected, int) and raw_selected >= done_count:
+                                    selected_total = raw_selected
+                        rate = done_count / max(sample_now - t0, 1e-6)
+                        eta_text = (
+                            f", eta~{(selected_total - done_count) / rate:.0f}s"
+                            if selected_total is not None and rate > 0
+                            else ""
+                        )
+                        total_text = f"/{selected_total}" if selected_total is not None else ""
+                        fail_text = f", failed={failed_count}" if failed_count else ""
+                        progress_counts_text = f", tests={done_count}{total_text}{fail_text}{eta_text}"
                 sys.stderr.write(
-                    f"    still running: supervisor={process.pid}{controller_text}, elapsed={sample_now - t0:.0f}s, "
+                    f"    still running: supervisor={process.pid}{controller_text}, elapsed={sample_now - t0:.0f}s"
+                    f"{progress_counts_text}, "
                     f"idle={sample_now - last_output:.0f}s{progress_idle_text}{state_text}{cpu_text}{rss_text}{node_text}\n"
                 )
                 sys.stderr.flush()
@@ -3141,6 +3197,13 @@ def _main(argv: list[str] | None = None) -> int:
 
     if not use_json:
         sys.stderr.write("verify: running local verification baseline\n")
+        estimate = _estimate_duration_from_history(
+            tier=tier,
+            selection=_ACTIVE_VERIFY_RUN.run.testmon_selection if preparation is not None else None,
+        )
+        if estimate is not None:
+            median_s, comparable = estimate
+            sys.stderr.write(f"verify: expecting ~{median_s:.0f}s based on {comparable} comparable green run(s)\n")
     if pytest_enabled:
         _warn_low_memory()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,6 +188,7 @@ markers = [
     "live: marks operator-run live archive validation lanes",
     "xdist_group(group_name): distribute parametrized tests within a file across workers (#1026)",
     "load_sensitive: wall-clock-bound tests (timing budgets, loopback sockets) routed into the isolated single-process lane of `devtools verify --all` so xdist worker contention cannot flake them (#1775)",
+    "storage_scale: tests whose single tmp_path tree exceeds the supervised tmpfs budget (incident-scale fixtures); their tmp_path is redirected to NVMe scratch so every other test keeps the fast tmpfs lane",
 ]
 filterwarnings = [
     "ignore::DeprecationWarning:dateparser",  # dateparser strptime deprecation (external)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import sqlite3
 import stat
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 import uuid
@@ -487,6 +488,35 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
                 clear_managed_pytest_basetemp_claim(basetemp_path)
     finally:
         _release_basetemp_claim_lock(basetemp_path)
+
+
+@pytest.fixture
+def tmp_path(tmp_path: Path, request: pytest.FixtureRequest) -> Iterator[Path]:
+    """Redirect ``storage_scale``-marked tests' private trees to NVMe scratch.
+
+    One incident-scale test can hold >2 GiB live inside a single tmp_path
+    (the codex-804 proof measured 2.3 GiB), which no per-test reclaim can
+    help -- the tree is live while the test runs. Placing whole runs on NVMe
+    because one whale MIGHT be selected forfeits the tmpfs lane for the other
+    ~20,000 tests, so the whale itself moves instead: marked tests write
+    under the NVMe scratch root and everything else keeps tmpfs. Falls back
+    to the run's normal basetemp where the NVMe root is unavailable (cloud
+    sandboxes).
+    """
+    if request.node.get_closest_marker("storage_scale") is None:
+        yield tmp_path
+        return
+    root = verify_runs.DEFAULT_PYTEST_BASETEMP_ROOT / "storage-scale"
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        private = Path(tempfile.mkdtemp(prefix=f"{request.node.name[:40]}-", dir=root))
+    except OSError:
+        yield tmp_path
+        return
+    try:
+        yield private
+    finally:
+        shutil.rmtree(private, ignore_errors=True)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/devtools/test_native_testmon_lifecycle.py
+++ b/tests/integration/devtools/test_native_testmon_lifecycle.py
@@ -1062,7 +1062,11 @@ def test_production_verify_deleted_module_rebuilds_and_fails_dependents(tmp_path
     # under test -- that the dependent is selected and fails -- is asserted
     # directly above and below and is unaffected.
     assert mutated["testmon_environment"]["required_executable_paths"] == []
-    assert mutated["testmon_environment"]["bootstrap_trigger_paths"] == ["polylogue/app.py"]
+    # A deleted path is excluded from the required/trigger sets entirely
+    # (polylogue-#3988): no rebuild can ever fingerprint a nonexistent file,
+    # so requiring one made incomplete permanent. The dependent is still
+    # selected through its own stale recorded fingerprint, asserted below.
+    assert mutated["testmon_environment"]["bootstrap_trigger_paths"] == []
     assert mutated["pytest_aggregate"]["selected_union_count"] == 1
     assert mutated["pytest_aggregate"]["terminal_union_count"] == 1
     assert "ModuleNotFoundError" in completed.stderr
@@ -1101,10 +1105,11 @@ def test_production_verify_moved_module_rebuilds_and_fails_dependents(tmp_path: 
     # under test -- that the dependent is selected and fails -- is asserted
     # directly above and below and is unaffected.
     assert mutated["testmon_environment"]["required_executable_paths"] == ["polylogue/renamed.py"]
-    assert mutated["testmon_environment"]["bootstrap_trigger_paths"] == [
-        "polylogue/app.py",
-        "polylogue/renamed.py",
-    ]
+    # A deleted path is excluded from the required/trigger sets entirely
+    # (polylogue-#3988): no rebuild can ever fingerprint a nonexistent file,
+    # so requiring one made incomplete permanent. The dependent is still
+    # selected through its own stale recorded fingerprint, asserted below.
+    assert mutated["testmon_environment"]["bootstrap_trigger_paths"] == ["polylogue/renamed.py"]
     assert mutated["pytest_aggregate"]["selected_union_count"] == 1
     assert mutated["pytest_aggregate"]["terminal_union_count"] == 1
     assert "ModuleNotFoundError" in completed.stderr
@@ -1141,13 +1146,18 @@ def test_production_verify_deleted_module_with_updated_imports_rebuilds_successf
 
     assert completed.returncode == 0, completed.stderr
     environment = rebuilt["testmon_environment"]
-    # A DELETED path stays a bootstrap trigger: there is no graph edge to reuse
-    # for a module that no longer exists, so this case is untouched by the
-    # incomplete-graph decision.
-    assert environment["selection_mode"] == "bootstrap"
+    # The deleted module is no longer a bootstrap trigger (an edge for a
+    # nonexistent file is unrecordable, so requiring one made incomplete
+    # permanent). The surviving changed module has recorded edges, so the run
+    # stays a warm affected selection and still covers the dependent.
+    assert environment["selection_mode"] == "affected"
     assert environment["required_executable_paths"] == ["polylogue/app.py"]
-    assert environment["bootstrap_trigger_paths"] == ["polylogue/app.py", "polylogue/old.py"]
-    assert rebuilt["pytest_aggregate"]["terminal_green"] is True
+    assert environment["bootstrap_trigger_paths"] == ["polylogue/app.py"]
+    # terminal_green demands complete-corpus coverage, which a warm affected
+    # selection definitionally lacks; "rebuilds successfully" means the
+    # dependent was selected and nothing failed.
+    assert rebuilt["pytest_aggregate"]["selected_union_count"] == 1
+    assert rebuilt["pytest_aggregate"]["non_green_count"] == 0
 
 
 def test_production_verify_moved_module_with_updated_imports_rebuilds_successfully(tmp_path: Path) -> None:
@@ -1192,7 +1202,6 @@ def test_production_verify_moved_module_with_updated_imports_rebuilds_successful
     assert environment["selection_mode"] == "affected"
     assert environment["required_executable_paths"] == ["polylogue/renamed.py", "tests/test_app.py"]
     assert environment["bootstrap_trigger_paths"] == [
-        "polylogue/old.py",
         "polylogue/renamed.py",
         "tests/test_app.py",
     ]

--- a/tests/unit/cli/test_embed_activation.py
+++ b/tests/unit/cli/test_embed_activation.py
@@ -632,12 +632,24 @@ class TestBackfillCommand:
 
         index_db = tmp_path / "index.db"
         sqlite3.connect(index_db).close()
-        fake_embed = MagicMock(
-            side_effect=[
-                EmbedSessionOutcome(status="embedded", session_id="conv-1", embedded_message_count=1),
-                EmbedSessionOutcome(status="embedded", session_id="conv-2", embedded_message_count=1),
-            ]
-        )
+        # Event-driven fake clock: scripted read sequences broke twice (a
+        # StopIteration when the command read the clock an extra time, then a
+        # second embed when an extra read consumed the past-deadline value).
+        # Advancing the clock AS A SIDE EFFECT of the first embed makes any
+        # number of reads at any point correct by construction: every read
+        # before embed #1 sees 0.0, every read after it sees 2.0.
+        clock = {"now": 0.0}
+        outcomes = [
+            EmbedSessionOutcome(status="embedded", session_id="conv-1", embedded_message_count=1),
+            EmbedSessionOutcome(status="embedded", session_id="conv-2", embedded_message_count=1),
+        ]
+
+        def embed_then_pass_deadline(*_args: Any, **_kwargs: Any) -> EmbedSessionOutcome:
+            outcome = outcomes.pop(0)
+            clock["now"] = 2.0
+            return outcome
+
+        fake_embed = MagicMock(side_effect=embed_then_pass_deadline)
         pending = [
             PendingSession(session_id="conv-1", title="A", message_count=1),
             PendingSession(session_id="conv-2", title="B", message_count=1),
@@ -654,15 +666,7 @@ class TestBackfillCommand:
                 return_value=pending,
             ),
             patch("polylogue.storage.embeddings.materialization.embed_archive_session_sync", fake_embed),
-            # A finite side_effect list here raised StopIteration whenever the
-            # command read the clock one more time than the script predicted
-            # (an intermittent gate failure twice on 2026-08-18). The deadline
-            # semantics only need "started at 0, past the limit from the third
-            # read onward" -- hold the final value instead of running dry.
-            patch(
-                "polylogue.cli.commands.embed.time.monotonic",
-                side_effect=lambda _readings=iter([0.0, 0.0]): next(_readings, 2.0),
-            ),
+            patch("polylogue.cli.commands.embed.time.monotonic", side_effect=lambda: clock["now"]),
         ):
             result = cli_runner.invoke(
                 embed_command,

--- a/tests/unit/devtools/test_merge_boundary.py
+++ b/tests/unit/devtools/test_merge_boundary.py
@@ -40,6 +40,40 @@ def _scope_bead_record(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(pr_scope, "_bead_records_at", canonical_records)
     monkeypatch.setattr(pr_scope, "changed_bead_ids", lambda **_kwargs: [])
+    # Placeholder PR SHAs cannot answer real ancestry; the stale-base guard
+    # has its own dedicated tests below.
+    monkeypatch.setattr(merge_boundary, "_head_missing_master_tip", lambda _head: None)
+
+
+def test_stale_base_head_refuses_before_recording(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A head that does not contain origin/master refuses with the update remedy.
+
+    A receipt recorded on a stale-based head attests the OLD tree -- its
+    environment digest predates the current graph, so 'recording' becomes a
+    complete-corpus bootstrap of code master no longer contains (a dependabot
+    branch cut three days earlier cost a 40-minute rebuild to attest one
+    workflow-file change, 2026-08-18).
+    """
+    monkeypatch.chdir(tmp_path)
+    pr_view = _base_pr_view()
+    monkeypatch.setattr(subprocess, "run", _fake_run(pr_view))
+    monkeypatch.setattr(
+        merge_boundary,
+        "_head_missing_master_tip",
+        lambda head: f"head {head[:8]} does not contain origin/master tip aaaaaaaa (stale base)",
+    )
+
+    exit_code = merge_boundary.cmd_merge(
+        42,
+        command="devtools test x",
+        max_age_s=3600,
+        poll_rounds=1,
+        poll_interval_s=0,
+        dry_run=True,
+        with_verify=False,
+        verify_command="devtools verify --all",
+    )
+    assert exit_code == 1
 
 
 def _scope_body(head_sha: str) -> str:

--- a/tests/unit/infra/test_storage_scale_tmp.py
+++ b/tests/unit/infra/test_storage_scale_tmp.py
@@ -1,0 +1,24 @@
+"""The storage_scale marker moves a test's private tree off the tmpfs lane."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from devtools import verify_runs
+
+_NVME_ROOT = verify_runs.DEFAULT_PYTEST_BASETEMP_ROOT / "storage-scale"
+
+
+@pytest.mark.storage_scale
+def test_storage_scale_tmp_path_is_redirected_to_scratch(tmp_path: Path) -> None:
+    if not verify_runs.DEFAULT_PYTEST_BASETEMP_ROOT.parent.is_dir():
+        pytest.skip("NVMe scratch root unavailable (cloud sandbox); fallback path covered below")
+    assert tmp_path.is_dir()
+    assert tmp_path.is_relative_to(_NVME_ROOT)
+
+
+def test_unmarked_tmp_path_stays_on_the_run_basetemp(tmp_path: Path) -> None:
+    assert tmp_path.is_dir()
+    assert not tmp_path.is_relative_to(_NVME_ROOT)

--- a/tests/unit/scenarios/test_codex_804_live_proof.py
+++ b/tests/unit/scenarios/test_codex_804_live_proof.py
@@ -31,6 +31,12 @@ from pathlib import Path
 
 import pytest
 
+# One proof run materializes 804 full-snapshot acquisitions with a ~90 MB
+# terminal snapshot -- >2 GiB live in a single tmp_path (measured 2315 MiB,
+# 2026-08-18), which no per-test reclaim helps. storage_scale moves this
+# module's trees to NVMe scratch so every other test keeps the tmpfs lane.
+pytestmark = pytest.mark.storage_scale
+
 from polylogue.config import Config
 from polylogue.product import raw_authority
 from polylogue.scenarios import (


### PR DESCRIPTION
## Summary

Makes the verify fast path structural rather than fortunate: fresh lanes start
warm, merges refuse stale-based heads before paying for them, the one
storage-whale test moves off tmpfs instead of evicting every other test from
it, a killed writer's WAL no longer costs the whole graph, and long runs
report live progress with an ETA.

## Problem

All observed on 2026-08-18 while running the merge train:

1. A merge-gate receipt recorded on a dependabot head cut three days earlier
   verified the OLD tree -- its environment digest predated the graph, so
   attesting one workflow-file change cost a 40-minute complete-corpus
   bootstrap.
2. Killing that run destroyed the warm graph for EVERY environment: a
   read-only inspection cannot replay a killed writer's WAL
   (SQLITE_READONLY_RECOVERY), so the shared file inspected as unreadable,
   was judged invalid, and was removed -- forcing the next 20,500-test rebuild.
3. A narrow, valid-graph receipt run was SIGTERMed at the 2 GiB tmpfs cap
   because one selected test (the codex-804 incident proof) holds 2315 MiB
   live in a single tmp_path -- no per-test reclaim can help a tree that is
   live while its test runs.
4. A fresh lane worktree's first verify always bootstrapped; the lazy
   graph copy also corrupted when a stale destination -wal sat beside a
   fresh database copy ("Rowid out of order").
5. A 37-minute run's only console signal was a spinner-grade "still running"
   line -- no test counts, no ETA, no upfront duration expectation.

## Solution

- `tests/conftest.py` + `storage_scale` marker (pyproject): marked tests'
  tmp_path redirects to NVMe scratch (reclaimed per test); codex-804 module
  marked. tmpfs stays the default lane for everything else, no overrides.
- `devtools/merge_boundary.py`: `cmd_merge` refuses a head that does not
  contain origin/master, with the update-branch remedy printed.
- `devtools/lane_init.py`: seeds the main checkout's graph into the lane at
  provision time (sidecar-safe backup copy).
- `devtools/testmon_bootstrap.py`: destination sidecars removed before a
  copy lands; passive WAL checkpoint on a read-write connection before
  read-only inspection so crash recovery happens instead of file removal.
- `devtools/pytest_progress_plugin.py` + `devtools/verify.py`: workers
  publish completed/failed tallies (atomic counts files, flushed every 20
  tests); the heartbeat prints `tests=done/selected, failed=N, eta~Ns`; verify
  prints an upfront estimate from the median of comparable green runs.

## Verification

```
devtools test tests/unit/infra/test_storage_scale_tmp.py tests/unit/devtools/test_verify.py \
  tests/unit/devtools/test_testmon_bootstrap.py tests/unit/devtools/test_pytest_progress_plugin.py
  262 passed
devtools test tests/unit/devtools/test_merge_boundary.py tests/unit/devtools/test_lane_init.py
  57 passed  (includes the new stale-base refusal test)
mypy devtools/verify.py devtools/pytest_progress_plugin.py devtools/merge_boundary.py \
  devtools/testmon_bootstrap.py devtools/lane_init.py   clean
```

Not run here: the full corpus (this PR's conftest/plugin changes shift the
environment digest by design; the merge-train's terminal
`devtools verify --all` on merged master is the planned single full run).
<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->
