### PR TITLE
fix(devtools): run the terminal verify in place at the merged target

### DIFF
--- a/devtools/merge_boundary.py
+++ b/devtools/merge_boundary.py
@@ -550,8 +550,33 @@ def _run_post_merge_terminal_verify(
     *,
     ledger_snapshot: tuple[dict[str, Any], float, int] | None = None,
 ) -> int:
-    """Run terminal verification in a detached worktree at the fetched target."""
+    """Run terminal verification at the fetched target, in place when possible.
+
+    The detached-worktree route has no virtualenv and a direnv-blocked
+    ``.envrc``, so on a workstation the child either dies before running
+    anything or the checkout guard (correctly) refuses the main venv's code
+    against the temp tree -- observed 2026-08-18: the terminal verify failed
+    in 2.6s without executing a single test. When the invoking checkout is
+    ALREADY at the fetched target with a clean tree -- the ordinary state at
+    the end of a merge train, right after pulling merged master -- running in
+    place is attestation-equivalent and actually works. The worktree route
+    remains for a checkout that has moved on or is dirty.
+    """
     repo_root = Path.cwd()
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"], capture_output=True, text=True, timeout=30, cwd=repo_root
+    ).stdout.strip()
+    dirty = subprocess.run(
+        ["git", "status", "--porcelain"], capture_output=True, text=True, timeout=30, cwd=repo_root
+    ).stdout.strip()
+    if head == target_sha and not dirty:
+        return cmd_record_full_verify(
+            command,
+            target_sha=target_sha,
+            cwd=repo_root,
+            execution_root=repo_root,
+            ledger_snapshot=ledger_snapshot,
+        )
     with tempfile.TemporaryDirectory(prefix="polylogue-merge-terminal-") as raw_worktree:
         worktree = Path(raw_worktree)
         add = subprocess.run(

--- a/tests/unit/devtools/test_merge_boundary.py
+++ b/tests/unit/devtools/test_merge_boundary.py
@@ -790,6 +790,10 @@ def test_post_merge_terminal_verify_uses_target_checkout_devshell(
 
     def run(cmd: list[str], **kwargs: Any) -> MagicMock:
         commands.append(cmd)
+        if cmd[:3] == ["git", "rev-parse", "HEAD"]:
+            return MagicMock(returncode=0, stdout="elsewhere\n", stderr="")
+        if cmd[:3] == ["git", "status", "--porcelain"]:
+            return MagicMock(returncode=0, stdout="", stderr="")
         if cmd[:3] == ["git", "worktree", "add"]:
             return MagicMock(returncode=0, stdout="", stderr="")
         if cmd[:2] == ["direnv", "exec"]:
@@ -1352,12 +1356,45 @@ def test_external_merge_completion_write_failure_keeps_recovery_latch(
     assert merge_boundary.cmd_train_status(as_json=False) == 1
 
 
+def test_terminal_verify_runs_in_place_when_head_matches_clean_target(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """At the fetched target with a clean tree, no bare worktree is materialized.
+
+    The detached-worktree route has no venv and a direnv-blocked .envrc, so on
+    a workstation it failed in seconds without running a test (2026-08-18)."""
+    monkeypatch.chdir(tmp_path)
+    seen: dict[str, Any] = {}
+
+    def run(cmd: list[str], **_kwargs: Any) -> MagicMock:
+        if cmd[:3] == ["git", "rev-parse", "HEAD"]:
+            return MagicMock(returncode=0, stdout="merged-master\n", stderr="")
+        if cmd[:3] == ["git", "status", "--porcelain"]:
+            return MagicMock(returncode=0, stdout="", stderr="")
+        raise AssertionError(cmd)
+
+    def record(command: str, **kwargs: Any) -> int:
+        seen["cwd"] = kwargs["cwd"]
+        seen["execution_root"] = kwargs["execution_root"]
+        return 0
+
+    monkeypatch.setattr(subprocess, "run", run)
+    monkeypatch.setattr(merge_boundary, "cmd_record_full_verify", record)
+    assert merge_boundary._run_post_merge_terminal_verify("devtools verify --all", "merged-master") == 0
+    assert seen["cwd"] == tmp_path
+    assert seen["execution_root"] == tmp_path
+
+
 def test_detached_worktree_add_failure_attempts_cleanup(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.chdir(tmp_path)
     commands: list[list[str]] = []
 
     def run(cmd: list[str], **_kwargs: Any) -> MagicMock:
         commands.append(cmd)
+        if cmd[:3] == ["git", "rev-parse", "HEAD"]:
+            return MagicMock(returncode=0, stdout="elsewhere\n", stderr="")
+        if cmd[:3] == ["git", "status", "--porcelain"]:
+            return MagicMock(returncode=0, stdout="", stderr="")
         if cmd[:3] == ["git", "worktree", "add"]:
             return MagicMock(returncode=1, stdout="", stderr="add failed")
         if cmd[:3] == ["git", "worktree", "remove"]:
@@ -1373,6 +1410,10 @@ def test_detached_worktree_cleanup_failure_is_explicit(monkeypatch: pytest.Monke
     monkeypatch.chdir(tmp_path)
 
     def run(cmd: list[str], **_kwargs: Any) -> MagicMock:
+        if cmd[:3] == ["git", "rev-parse", "HEAD"]:
+            return MagicMock(returncode=0, stdout="elsewhere\n", stderr="")
+        if cmd[:3] == ["git", "status", "--porcelain"]:
+            return MagicMock(returncode=0, stdout="", stderr="")
         if cmd[:3] == ["git", "worktree", "add"]:
             return MagicMock(returncode=0, stdout="", stderr="")
         if cmd[:3] == ["git", "worktree", "remove"]:


### PR DESCRIPTION
## Summary

The merge-train's terminal full-suite verify now runs in the invoking checkout
when it already sits at the fetched merged-master target with a clean tree.

## Problem

`record-full-verify` always materialized a bare detached worktree: no
virtualenv, a direnv-blocked `.envrc`. The 2026-08-18 train's terminal
`devtools verify --all` therefore failed in 2.6 seconds without executing a
single test -- and had the child gotten further, the checkout guard would
rightly have refused the main venv's code against the temp tree.

## Solution

`_run_post_merge_terminal_verify` probes `git rev-parse HEAD` and
`git status --porcelain`; when HEAD equals the fetched target and the tree is
clean (the ordinary end-of-train state right after pulling merged master), it
records in place -- attestation-equivalent, same sha. The detached-worktree
route remains the fallback for a checkout that has moved on or is dirty.

## Verification

```
devtools test tests/unit/devtools/test_merge_boundary.py   51 passed
  (new: test_terminal_verify_runs_in_place_when_head_matches_clean_target;
   the three worktree-route tests' fakes now answer the in-place probe with
   a moved-on HEAD so they still exercise the fallback)
mypy devtools/merge_boundary.py   clean
```
<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->
