### PR TITLE
feat(verify): make --all incremental via attested coverage

### DIFF
--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -2472,7 +2472,18 @@ def _native_pytest_steps(
     pytest_cmd.extend(_PYTEST_MANAGED_PLUGIN_ARGS)
     pytest_cmd.extend(_PYTEST_CLOSED_WORLD_COLLECTION_ARGS)
     native_args = ["--testmon", f"--testmon-env={testmon_environment}"]
-    if testmon_mode == "affected":
+    if testmon_mode in ("affected", "full"):
+        # "full" (--all) used to re-execute every test unconditionally, which
+        # made every terminal validation a from-scratch ~45-minute run even
+        # when a green recording of the identical content existed minutes
+        # earlier (2026-08-18: a cap-killed 93%-complete run was followed by
+        # two complete reruns of the same bytes). forceselect executes what
+        # changed or was never recorded; a recorded test testmon deselects is
+        # BY MECHANISM one whose recorded deps all match and whose last
+        # outcome was green (failures are always reselected) -- the same
+        # soundness premise every affected-gated merge already trusts. A
+        # digest change (deps, harness, profile) voids the recording and
+        # falls back to executing everything, unchanged.
         native_args.append("--testmon-forceselect")
     else:
         native_args.append("--testmon-noselect")

--- a/devtools/verify_runs.py
+++ b/devtools/verify_runs.py
@@ -1406,21 +1406,29 @@ def aggregate_native_testmon_run(
     corpus = native_corpus
     corpus_set = set(corpus)
     lane_names = [lane["lane"] for lane in lanes]
+    executed_nodes = set(outcome_by_node)
+    # "full" now runs under forceselect: a graph-recorded test testmon did not
+    # select is attested by its unchanged recorded deps and green last outcome
+    # (testmon always reselects failures), so coverage = executed now UNION
+    # attested by recording. A bootstrap (no graph) still executes everything,
+    # making the attested set empty and the condition equivalent to the old
+    # exhaustive one. Selection fidelity, closed-world collection, lane shape
+    # and duplicate checks are unchanged.
+    attested_unchanged = tuple(sorted(corpus_set - executed_nodes)) if complete_mode else ()
     complete_corpus_covered = (
         complete_mode
         and selection_complete
-        and bool(corpus)
+        and bool(corpus_set | executed_nodes)
         and external_addopts_neutralized
         and external_plugins_neutralized
         and closed_world_collection
-        and selected_union == corpus_set
-        and set(outcome_by_node) == corpus_set
+        and selected_union == executed_nodes
         and not duplicate_outcomes
         and len(lane_names) == 2
         and lane_names.count("parallel") == 1
         and lane_names.count("serial") == 1
     )
-    missing_terminal = tuple(sorted(corpus_set - set(outcome_by_node))) if complete_mode else ()
+    missing_terminal = tuple(sorted(selected_union - executed_nodes)) if complete_mode else ()
     non_green = tuple(
         sorted(nodeid for nodeid, outcome in outcome_by_node.items() if outcome not in _GREEN_TERMINAL_OUTCOMES)
     )
@@ -1458,6 +1466,7 @@ def aggregate_native_testmon_run(
         "non_green_sample": list(non_green[:20]),
         "duplicate_outcome_count": len(duplicate_outcomes),
         "complete_corpus_covered": complete_corpus_covered,
+        "attested_unchanged_count": len(attested_unchanged),
         "terminal_green": terminal_green,
         "wall_s": round(invocation_duration_s, 4),
         "collection_wall_s": round(collection_wall_s, 4),

--- a/devtools/why.py
+++ b/devtools/why.py
@@ -153,8 +153,13 @@ def _render(payload: dict[str, Any], stream: Any) -> None:
                 print(f"  ... and {count - 15} more", file=stream)
         selected = aggregate.get("selected_union_count")
         if selected is not None:
+            attested = aggregate.get("attested_unchanged_count")
+            attested_text = (
+                f" ({attested} attested by unchanged recorded green)" if isinstance(attested, int) and attested else ""
+            )
             print(
-                f"\nselected {selected} test(s); complete corpus covered: {aggregate.get('complete_corpus_covered')}",
+                f"\nselected {selected} test(s); complete corpus covered: "
+                f"{aggregate.get('complete_corpus_covered')}{attested_text}",
                 file=stream,
             )
 

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -108,7 +108,9 @@ def test_quick_verify_omits_pytest() -> None:
 
 @pytest.mark.parametrize(
     ("mode", "selection_flag"),
-    [("affected", "--testmon-forceselect"), ("bootstrap", "--testmon-noselect"), ("full", "--testmon-noselect")],
+    # "full" selects incrementally since the 2026-08-18 overhaul: recorded
+    # unchanged-green tests are attested coverage, not re-execution fodder.
+    [("affected", "--testmon-forceselect"), ("bootstrap", "--testmon-noselect"), ("full", "--testmon-forceselect")],
 )
 def test_native_testmon_uses_exactly_two_semantic_lanes(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

`devtools verify --all` becomes incremental: tests whose recorded dependencies
are unchanged and whose last recorded outcome was green count as attested
coverage; only changed or never-recorded tests execute.

## Problem

`full` mode re-executed every test unconditionally, so each terminal
validation was a from-scratch ~45-minute run even when a green recording of
identical content existed minutes earlier. On 2026-08-18 that meant a
cap-killed 93%-complete run followed by two complete re-runs of the same
bytes -- "why do we have to start over again?" had no good answer.

## Solution

Full lanes run under `--testmon-forceselect`. Soundness rides testmon's own
mechanism: it can only deselect a test whose recorded deps all match and whose
last outcome was green (failures are always reselected) -- the premise every
affected-gated merge already trusts. Coverage = executed-now UNION
attested-by-recording; the aggregate carries `attested_unchanged_count`;
`devtools why` prints it. Digest changes (deps/conftest/harness/profile) void
recordings and fall back to executing everything. Bootstraps are unchanged.

## Verification

```
devtools test tests/unit/devtools/test_verify.py tests/unit/devtools/test_why.py   214 passed
mypy devtools/verify.py devtools/verify_runs.py devtools/why.py   clean
```

Merged without a test-gated receipt on explicit operator instruction; the
deferred terminal `--all` on master exercises this change directly.
<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->
