### PR TITLE
fix: close the terminal full run's three real failures + mid-run head-movement receipt loss

### DIFF
--- a/devtools/pytest_progress_plugin.py
+++ b/devtools/pytest_progress_plugin.py
@@ -295,6 +295,17 @@ def pytest_sessionstart(session: Any) -> None:
 @pytest.hookimpl
 def pytest_collection(session: Any) -> None:
     """Record collection start so selected-test runs expose import/collection cost."""
+    if os.environ.get("POLYLOGUE_TESTMON_COMPLETE_COLLECTION") == "1":
+        # testmon skips collecting whole files when every RECORDED test in them
+        # is stable -- which silently hides tests the graph has never seen (a
+        # marker-split lane records only its own lane, so the other lane's
+        # tests in the same file are invisible to a later forceselect run).
+        # Full-mode lanes claim complete-corpus coverage, so they must collect
+        # every file and let per-test deselection (which keeps unknown tests)
+        # do the narrowing.
+        select_plugin = session.config.pluginmanager.get_plugin("TestmonSelect")
+        if select_plugin is not None and getattr(select_plugin, "deselected_files", None):
+            select_plugin.deselected_files = []
     del session
     global _COLLECTION_STARTED_AT
     _COLLECTION_STARTED_AT = time.monotonic()

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -2118,6 +2118,13 @@ def _run_step(
             # with the native environment corpus before granting release
             # authority. Keep the complete node set in these bounded artifacts.
             env["POLYLOGUE_PYTEST_SELECTION_NODEID_LIMIT"] = "50000"
+            if label.endswith("(full)"):
+                # Full-mode lanes claim complete-corpus coverage, so testmon's
+                # file-level collection skip must be disabled: it hides tests
+                # the graph has never recorded when they share a file with
+                # stable recorded ones (the marker-split lanes make that
+                # systematic). Per-test deselection still narrows execution.
+                env["POLYLOGUE_TESTMON_COMPLETE_COLLECTION"] = "1"
         if run is not None and artifacts is not None:
             env = env_for_pytest_step(env, run=run, artifacts=artifacts)
         if owns_pytest_environment:

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -3482,7 +3482,17 @@ def _main(argv: list[str] | None = None) -> int:
             if checkout_fingerprint_unavailable
             else "checkout_mutation_monitor_unavailable"
         )
-    elif final_head != head or final_checkout_fingerprint != checkout_fingerprint:
+    elif (final_head != head or final_checkout_fingerprint != checkout_fingerprint) and not os.environ.get(
+        _ISOLATION_SENTINEL
+    ):
+        # Under snapshot isolation the pytest lanes verified the frozen
+        # launch content; only .git is live-bound, so a commit or merge
+        # landing mid-run moves final_head without touching what ran. The
+        # receipt keeps its launch-head binding (consumers compare that
+        # against their current head and correctly treat it as stale for
+        # newer commits). Observed 2026-08-18: an 82-minute green-baseline
+        # terminal run was discarded because an unrelated PR merged while
+        # it ran.
         checkout_stable = False
         diagnosis = "checkout_changed_during_verification"
     elif (preparation_mutation_observation.changed or mutation_observation.changed) and not os.environ.get(

--- a/devtools/why.py
+++ b/devtools/why.py
@@ -57,8 +57,8 @@ _EXPLANATIONS: dict[str, Explanation] = {
     ),
     "checkout_changed_during_verification": Explanation(
         "The working tree changed while the run was in flight, so the receipt could not attest to fixed content.",
-        "Should no longer occur: devtools verify now runs against a frozen snapshot by default. If you see this "
-        "on a current build, the run was started with --no-isolated or on a host without bwrap.",
+        "Occurs only on unisolated runs (--no-isolated, or a host without bwrap): isolated runs verify the "
+        "frozen launch snapshot, so live-tree movement mid-run leaves the launch-head receipt binding intact.",
     ),
     "checkout_changed_during_focused_test": Explanation(
         "The working tree changed during a focused test run.",

--- a/polylogue/storage/search/query_support.py
+++ b/polylogue/storage/search/query_support.py
@@ -94,10 +94,12 @@ def escape_fts5_query(query: str) -> str:
         # appears in a non-prefix position (e.g. *word, w*rd).
         if "*" in query:
             # A ``*`` is only a valid FTS5 prefix when it suffixes a word token
-            # (``word*``). Bare asterisks (``*``, ``* *``) are not valid prefix
-            # syntax and must be quoted, so only strip word-suffixed ``*`` here.
-            without_prefix = re.sub(r"(\w)\*(\s|$)", r"\1\2", query).rstrip("*")
-            if _FTS5_SPECIAL.search(without_prefix):
+            # (``word*``) exactly once. Bare (``*``, ``* *``) and doubled
+            # (``word**``) asterisks are syntax errors and must be quoted, so
+            # strip exactly one word-suffixed ``*`` per token and quote if any
+            # asterisk survives.
+            without_prefix = re.sub(r"(\w)\*(?=\s|$)", r"\1", query)
+            if "*" in without_prefix or _FTS5_SPECIAL.search(without_prefix):
                 return _quoted(query)
             # Only special char was * in prefix position — don't quote
             # for that, but still check operator edge cases below.

--- a/tests/integration/devtools/test_native_testmon_lifecycle.py
+++ b/tests/integration/devtools/test_native_testmon_lifecycle.py
@@ -487,8 +487,8 @@ def test_production_verify_all_grants_release_authority_after_complete_two_lane_
     assert [step["semantic_lane"] for step in lanes] == ["parallel", "serial"]
     assert [step["name"] for step in lanes] == ["pytest native parallel (full)", "pytest native serial (full)"]
     for step in lanes:
-        assert "--testmon-noselect" in step["statistics"]["command"]
-        assert "--testmon-forceselect" not in step["statistics"]["command"]
+        assert "--testmon-forceselect" in step["statistics"]["command"]
+        assert "--testmon-noselect" not in step["statistics"]["command"]
         assert "--override-ini=addopts=" in step["statistics"]["command"]
         assert step["external_addopts_neutralized"] is True
         assert step["external_plugins_neutralized"] is True

--- a/tests/integration/test_installed_package_smoke.py
+++ b/tests/integration/test_installed_package_smoke.py
@@ -44,6 +44,21 @@ requires_uv = pytest.mark.skipif(
 )
 
 
+def _uv_env() -> dict[str, str]:
+    """Ambient env minus host-interpreter coupling.
+
+    The dev interpreter is a Nix free-threaded CPython whose
+    ``_PYTHON_SYSCONFIGDATA_NAME`` names a ``_sysconfigdata_t_*`` module that
+    uv's managed (non-free-threaded) interpreters do not ship; inheriting it
+    makes every sysconfig lookup inside the fresh venv fail. The other vars
+    couple subprocesses to the dev venv the same way.
+    """
+    env = dict(os.environ)
+    for key in ("_PYTHON_SYSCONFIGDATA_NAME", "PYTHONHOME", "PYTHONPATH", "VIRTUAL_ENV"):
+        env.pop(key, None)
+    return env
+
+
 def _build_wheel(work_dir: Path) -> Path:
     """Build a wheel from the repo checkout into ``work_dir/dist``."""
     dist_dir = work_dir / "dist"
@@ -51,6 +66,7 @@ def _build_wheel(work_dir: Path) -> Path:
     _run(
         ("uv", "build", "--out-dir", str(dist_dir), "--wheel", str(REPO_ROOT)),
         cwd=REPO_ROOT,
+        env=_uv_env(),
     )
     wheels = sorted(dist_dir.glob("*.whl"))
     assert len(wheels) == 1, f"expected exactly one wheel in {dist_dir}, got {wheels!r}"
@@ -64,11 +80,12 @@ def _install_wheel(wheel: Path, install_dir: Path) -> Path:
     """
     install_dir.mkdir(parents=True, exist_ok=True)
     venv_dir = install_dir / "venv"
-    _run(("uv", "venv", str(venv_dir)), cwd=install_dir)
+    _run(("uv", "venv", str(venv_dir)), cwd=install_dir, env=_uv_env())
     python = venv_dir / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
     _run(
         ("uv", "pip", "install", "--python", str(python), str(wheel)),
         cwd=install_dir,
+        env=_uv_env(),
     )
     return venv_dir / ("Scripts" if os.name == "nt" else "bin")
 

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -3942,8 +3942,23 @@ def test_transient_mutation_invalidates_only_unisolated_runs(
         assert stability[0]["transient_checkout_mutation"] is True
 
 
-def test_verify_rejects_git_head_change_with_matching_worktree_fingerprints(
+@pytest.mark.parametrize(
+    ("isolated", "expected_rc"),
+    [
+        # Isolated runs verified the frozen launch snapshot; only .git is
+        # live-bound, so a commit or merge landing mid-run moves the final
+        # head without touching what actually ran. The receipt keeps its
+        # launch-head binding. Unisolated, a moved head means the lanes may
+        # have seen mixed content, so the strict rejection holds.
+        (True, 0),
+        (False, 125),
+    ],
+)
+def test_git_head_change_invalidates_only_unisolated_runs(
+    monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
+    isolated: bool,
+    expected_rc: int,
 ) -> None:
     class _StableMonitor:
         def __init__(self, _root: Path) -> None:
@@ -3955,6 +3970,10 @@ def test_verify_rejects_git_head_change_with_matching_worktree_fingerprints(
         def finish(self) -> CheckoutMutationObservation:
             return CheckoutMutationObservation(changed=False, unavailable=False)
 
+    if isolated:
+        monkeypatch.setenv("POLYLOGUE_VERIFY_ISOLATED", "1")
+    else:
+        monkeypatch.delenv("POLYLOGUE_VERIFY_ISOLATED", raising=False)
     with (
         patch("devtools.verify._run", return_value=(0, 0.01, {})),
         patch("devtools.verify._git_head", side_effect=("start-head", "different-head")),
@@ -3964,13 +3983,17 @@ def test_verify_rejects_git_head_change_with_matching_worktree_fingerprints(
         patch("devtools.verify._notify"),
         patch("devtools.verify.worktree_fingerprint", return_value="stable"),
     ):
-        assert main(["--quick", "--json"]) == 125
+        assert main(["--quick", "--json"]) == expected_rc
 
     payload = json.loads(capsys.readouterr().out)
-    checkout_step = next(step for step in payload["steps"] if step["name"] == "checkout stability")
-    assert checkout_step["diagnosis"] == "checkout_changed_during_verification"
-    assert checkout_step["initial_git_head"] == "start-head"
-    assert checkout_step["final_git_head"] == "different-head"
+    stability = [step for step in payload["steps"] if step["name"] == "checkout stability"]
+    if expected_rc == 0:
+        assert stability == []
+        assert payload["final_git_head"] == "different-head"
+    else:
+        assert stability[0]["diagnosis"] == "checkout_changed_during_verification"
+        assert stability[0]["initial_git_head"] == "start-head"
+        assert stability[0]["final_git_head"] == "different-head"
 
 
 def test_verify_keeps_checkout_monitor_active_through_final_authority_samples(

--- a/tests/unit/storage/test_fts5_query_correctness.py
+++ b/tests/unit/storage/test_fts5_query_correctness.py
@@ -409,6 +409,12 @@ def test_fts5_boolean_query() -> None:
         "?",
         "!",
         "...",
+        # Doubled/misplaced prefix asterisks are syntax errors unless quoted
+        "0**",
+        "word**",
+        "foo* bar**",
+        "*word",
+        "w*rd",
         # FTS5 column filter syntax (should be escaped)
         "title:something",
         "role:user",


### PR DESCRIPTION
## Summary
The first attested-coverage terminal `devtools verify --all` (18,689 executed, 2,292 attested, 82.6 min) surfaced nine non-green tests and then discarded its own receipt. Three of the nine were load flakes that pass standalone (`durable_change_train` pair, `archive_tiers` c03, codex_804 whale at 436.9s standalone vs its 900s cap under full-run IO); the other six trace to three real defects fixed here, plus the receipt-loss defect.

## Problem
- `SessionFilter.contains('0**')` raised `sqlite3.OperationalError: fts5: syntax error` (hypothesis-found): `escape_fts5_query` stripped ALL trailing asterisks before checking for leftover specials, so doubled word-suffix asterisks passed unquoted.
- Full-mode lanes silently omitted never-recorded tests: testmon skips collecting whole files whose recorded tests are all stable, hiding tests the graph never saw — systematic under the parallel/serial marker split (repro: serial lane collected 0 items, corpus 1 of 2).
- `installed_package_smoke` inherited `_PYTHON_SYSCONFIGDATA_NAME` (Nix free-threaded) into uv's managed non-free-threaded CPython → `ModuleNotFoundError: _sysconfigdata_t_...`.
- An isolated run failed with `checkout_changed_during_verification` when an unrelated PR merged mid-run, although the lanes verified the frozen launch snapshot.

## Solution
- `query_support.py`: strip exactly one word-suffixed `*` per token; quote if any asterisk survives. Regression cases in `test_fts5_query_correctness.py`.
- Full lanes set `POLYLOGUE_TESTMON_COMPLETE_COLLECTION=1`; the progress plugin clears testmon's file-level skip so per-test deselection (which keeps unknown tests) is the only narrowing. Lifecycle production pins updated noselect→forceselect.
- Smoke tests run uv subprocesses with interpreter-coupling vars removed.
- Head/fingerprint movement invalidates only unisolated runs; isolated receipts keep the launch-head binding. `devtools why` text updated.

## Verification
- `devtools verify --quick` — green.
- `devtools test tests/unit/devtools/test_verify.py` — 209 passed (includes new isolation-parametrized head-change test).
- `devtools test tests/integration/devtools/test_native_testmon_lifecycle.py::test_production_verify_all_grants_release_authority_after_complete_two_lane_run ...owns_complete_test_root...` — 2 passed (previously corpus 1/2 and 2/3).
- `devtools test tests/integration/test_installed_package_smoke.py` — ok (12.1s).
- `devtools test tests/unit/storage/test_fts5_query_correctness.py tests/property/test_sql_injection_boundary.py::test_contains_never_raises_sql_error` — 99 passed.
- `devtools test tests/unit/scenarios/test_codex_804_live_proof.py::test_sanitized_codex_804_revision_recovery_proof` — passed standalone (436.9s).
- Not run pre-merge: full corpus (the post-merge terminal verify is the next step in this train).

## Scope
```json
{"carrier": "pr-scope", "version": 2, "kind": "self_contained", "assigned_beads": [], "mutated_beads": [], "dispositions": [], "evidence": [], "successors": []}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWcPJJJvuF25CqVwTFgSQC