### PR TITLE
refactor(verify): fold --all into plain verify with certified attested coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -378,9 +378,11 @@ testmon-affected set.
   invalid local state, optionally copies a matching main-checkout database,
   and automatically runs the complete correctness corpus when no valid native
   environment exists. Never ask an operator or agent to seed or repair it.
-- Reserve `devtools verify --all` (complete unit/property/fuzz/integration
-  correctness corpus; performance benchmarks excluded) for harness/dependency
-  changes or a final pre-PR diagnostic.
+- There is no `--all` flag anymore: every plain `devtools verify` is scoped
+  to the complete correctness corpus (benchmarks excluded), executes only
+  changed-dependency/never-recorded/previously-failing tests, attests the
+  rest from unchanged recorded greens, and earns release-baseline authority
+  when coverage is complete and green.
 - `devtools verify --quick` = format + lint + mypy + `render all --check`
   (no tests); it runs on `git push` via the pre-push hook. It is a fast gate,
   not a substitute for the default baseline before a PR.
@@ -501,12 +503,11 @@ workflow, not optional conveniences — use them at the point named, every time:
   doubled `(#N) (#N)` squash-subject suffix, then runs the actual
   `gh pr merge --squash`. `--dry-run` runs every check without merging;
   `--with-verify` immediately runs and records the merge-train's terminal
-  full-suite verify after merging. `devtools workspace merge train-status`
-  reports (exit 1) any PRs merged since the last recorded full-suite verify —
-  this is the structural stand-in for "a merge-train records the full-suite
-  verify as its terminal ledger step"; `devtools workspace merge
-  record-full-verify --command "devtools verify --all"` records that step
-  directly once per merge-train session boundary. The lower-level
+  verify after merging. `devtools workspace merge train-status`
+  reports (exit 1) any PRs merged since the last recorded terminal verify.
+  The terminal step records itself: any plain `devtools verify` that earns
+  release-baseline authority at origin/master writes the ledger entry — no
+  separate record command exists. The lower-level
   `devtools workspace merge-gate record/check` commands still exist for
   ad hoc receipt inspection, but the merge action itself should go through
   `workspace merge`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -291,8 +291,7 @@ Before creating a PR, run the local baseline. CI runs the same checks, while
 local pytest selection is accelerated by pytest-testmon.
 
 ```bash
-devtools verify            # static/generated gates + pytest-testmon affected tests
-devtools verify --all      # complete correctness corpus; benchmarks excluded
+devtools verify            # static/generated gates + incremental complete-corpus pytest
 devtools verify --quick    # format + lint + mypy + render all --check (skip tests)
 devtools verify --lab      # explicit lab checks beyond the quick/default loop
 ```
@@ -303,18 +302,20 @@ repairs missing or invalid native testmon state and automatically builds a new
 environment when collection semantics change.
 
 `devtools verify` does not replay a prior verify result. It always runs the
-static gates. With a valid native environment, it invokes pytest-testmon for
-affected-test selection from the current source, dependency, and Python-version
-state. When it bootstraps a missing or invalid native environment, it runs the
+static gates. With a valid native environment, it invokes pytest-testmon to
+execute changed-dependency, never-recorded, and previously-failing tests, and
+attests the remaining corpus from unchanged recorded greens — earning
+release-baseline authority when coverage is complete and green. When it bootstraps a missing or invalid native environment, it runs the
 complete correctness corpus. The pytest step covers unit, property, fuzz, and
 integration tests while excluding the separately operated `tests/benchmarks`
 performance surface. It uses
-`--testmon-forceselect` for affected selection, with one parallel `not
+`--testmon-forceselect` for incremental selection, with one parallel `not
 load_sensitive` lane and one serial `load_sensitive` lane over the same native
 environment. `tui` is a category marker and remains parallel unless a test is
 also explicitly `load_sensitive`. Use
-`devtools verify --all` for the complete correctness corpus; there is no
-manual seed or repair command.
+There is no manual seed or repair command, and no separate full-corpus flag:
+every plain run is scoped to the complete corpus, executing what changed and
+attesting the rest from unchanged recorded greens.
 
 Add `devtools release build-package` or `nix flake check` when touching packaging or
 Nix expressions. See [TESTING.md](TESTING.md) and [docs/devtools.md](docs/devtools.md)

--- a/TESTING.md
+++ b/TESTING.md
@@ -22,8 +22,8 @@ POLYLOGUE_PYTEST_WORKERS=8 devtools test tests/unit/storage   # override workers
 # Raw pytest still works for ad-hoc needs the wrapper does not cover:
 pytest -x tests/unit/storage/test_hybrid_laws.py
 
-# Complete correctness corpus (unit/property/fuzz/integration; benchmarks excluded)
-devtools verify --all
+# Complete-corpus baseline (unit/property/fuzz/integration; benchmarks excluded)
+devtools verify
 
 # Full Nix/CI parity
 nix flake check
@@ -166,9 +166,10 @@ on completion or termination, with startup stale-root cleanup as recovery
 after an uncatchable process kill or reboot.
 
 The default path does not replay cached verify results. Every invocation runs
-the static gates and then invokes pytest-testmon for affected-test selection.
-There is no seed, repair, shard, or registry command. `devtools verify --all`
-forces a complete diagnostic in the current native environment.
+the static gates and then invokes pytest-testmon over the complete corpus:
+changed-dependency, never-recorded, and previously-failing tests execute, and
+the rest is attested from unchanged recorded greens. There is no seed,
+repair, shard, or registry command, and no separate full-corpus flag.
 
 `devtools verify` and `devtools test` treat pytest as a bounded, supervised
 child workload, not an unowned shell. Each pytest step gets a run directory

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -528,18 +528,16 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
             "incident), then runs the actual `gh pr merge --squash`. `--dry-run` runs every check "
             "without merging. `--with-verify` immediately runs and records the merge-train's "
             "terminal full-suite verify after merging; otherwise it prints a reminder. "
-            "`train-status` reports (exit 1) any PRs merged since the last recorded full-suite "
-            "verify -- the structural stand-in for 'a merge-train records the full-suite verify "
-            "as its terminal ledger step'. `record-full-verify` runs and records that step "
-            "directly, e.g. once per merge-train session boundary."
+            "`train-status` reports (exit 1) any PRs merged since the last recorded terminal "
+            "verify. The terminal step records itself: a plain `devtools verify` that earns "
+            "release-baseline authority at origin/master writes the ledger entry."
         ),
         examples=(
             "devtools workspace merge 3517",
             'devtools workspace merge 3517 --command "devtools test tests/unit/foo.py"',
             "devtools workspace merge 3517 --dry-run",
-            'devtools workspace merge 3517 --with-verify --verify-command "devtools verify --all"',
+            "devtools workspace merge 3517 --with-verify",
             "devtools workspace merge train-status",
-            'devtools workspace merge record-full-verify --command "devtools verify --all"',
         ),
     ),
     CommandSpec(

--- a/devtools/merge_boundary.py
+++ b/devtools/merge_boundary.py
@@ -37,27 +37,24 @@ which:
   6. Runs the actual ``gh pr merge --squash``.
   7. Appends a merge-train ledger entry (``.cache/verify/merge-gate/merge-train-ledger.json``)
      and, unless ``--with-verify`` was given, prints a reminder that the
-     ledger's terminal step -- one release-baseline ``devtools verify --all``
-     since the last one -- has not yet been
-     recorded for this train.
+     ledger's terminal step -- one release-baseline ``devtools verify``
+     since the last merge -- has not yet been recorded for this train.
 
 ``devtools workspace merge train-status`` inspects the ledger and reports
-(exit 1 if so) any PRs merged since the last recorded full-suite verify --
-this is the structural stand-in for "a merge-train run records the full-
-suite verify as its terminal ledger step": the train is not clean until this
-reports OK.
+(exit 1 if so) any PRs merged since the last recorded terminal verify --
+the train is not clean until this reports OK.
 
-``devtools workspace merge record-full-verify --command "devtools verify --all"``
-runs that command now and records it as the train's terminal step, clearing
-every pending PR in the ledger.
+The terminal step records itself: any plain ``devtools verify`` that earns
+release-baseline authority at origin/master writes the ledger entry
+(``record_accepted_terminal_verify``). ``--with-verify`` runs it inline at
+merge time.
 
 Usage:
     devtools workspace merge 3517
     devtools workspace merge 3517 --command "devtools test tests/unit/foo.py"
     devtools workspace merge 3517 --dry-run
-    devtools workspace merge 3517 --with-verify --verify-command "devtools verify --all"
+    devtools workspace merge 3517 --with-verify
     devtools workspace merge train-status
-    devtools workspace merge record-full-verify --command "devtools verify --all"
 """
 
 from __future__ import annotations
@@ -815,9 +812,9 @@ def cmd_merge(
         return _run_post_merge_terminal_verify(verify_command, target_sha, ledger_snapshot=ledger_snapshot)
 
     print(
-        "REMINDER: this merge-train's terminal ledger step (one full-suite verify since the last "
-        "merge) is not yet recorded -- run `devtools workspace merge record-full-verify "
-        '--command "devtools verify --all"` before declaring the train done, or check '
+        "REMINDER: this merge-train's terminal ledger step (one green complete-corpus verify since "
+        "the last merge) is not yet recorded -- run `devtools verify` on merged master before "
+        "declaring the train done (an accepted run records itself), or check "
         "`devtools workspace merge train-status`."
     )
     return 0
@@ -854,13 +851,56 @@ def cmd_train_status(as_json: bool) -> int:
     for entry in pending:
         print(f"  PR #{entry['pr']} @ {entry['head_sha'][:8]}: {entry['title']}")
     print(
-        'Run `devtools workspace merge record-full-verify --command "devtools verify --all"` '
-        "before declaring this merge-train session done. A narrower successful selection does not "
-        "grant the release-baseline authority this ledger requires. "
+        "Run `devtools verify` on merged master before declaring this merge-train session done "
+        "(an accepted release-baseline run records itself into this ledger). "
         "per-PR CI skips the heavy suite, so nothing else will catch a master-red class only "
         "visible on the merged whole."
     )
     return 1
+
+
+def record_accepted_terminal_verify(*, git_head: str, duration_s: float) -> bool:
+    """Ledger the merge-train terminal step from an accepted plain verify.
+
+    Called by ``devtools verify`` when a run finished green with typed
+    release-baseline authority. The entry is recorded only when the verified
+    head IS the local origin/master ref: the merge wrapper fetches at merge
+    time, so that ref is current in the ordinary end-of-train flow, and a
+    stale ref merely leaves the ledger pending (train-status stays honest)
+    rather than recording authority for the wrong commit.
+    """
+    master = subprocess.run(
+        ["git", "rev-parse", "origin/master"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    ).stdout.strip()
+    if not master or master != git_head:
+        return False
+    now = time.time()
+    try:
+        with _ledger_lock():
+            ledger = _read_ledger_unlocked()
+            ledger["last_full_verify"] = {
+                "command": "devtools verify",
+                "exit_code": 0,
+                "duration_s": round(duration_s, 2),
+                "at": now,
+                "verification_started_at": now - duration_s,
+                "verification_scope": VerificationScope.RELEASE_BASELINE.value,
+                "release_baseline_allowed": True,
+                "verified_head_sha": git_head,
+                "target_sha": git_head,
+                "merged_master_sha": git_head,
+                "merge_sequence": _merge_sequence(ledger),
+                "accepted": True,
+            }
+            _write_ledger_unlocked(ledger)
+    except (LedgerStateError, OSError) as exc:
+        sys.stderr.write(f"verify: could not record merge-train terminal ledger entry: {exc}\n")
+        return False
+    sys.stderr.write("verify: recorded merge-train terminal ledger entry (release-baseline at origin/master)\n")
+    return True
 
 
 def cmd_record_full_verify(
@@ -991,17 +1031,12 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Immediately run and record the merge-train's terminal full-suite verify after merging",
     )
-    merge_p.add_argument("--verify-command", default="devtools verify --all", help="Command for --with-verify")
+    merge_p.add_argument("--verify-command", default="devtools verify", help="Command for --with-verify")
 
     status_p = sub.add_parser(
         "train-status", help="Report whether the merge-train's terminal full-suite verify is recorded"
     )
     status_p.add_argument("--json", action="store_true", dest="as_json")
-
-    record_p = sub.add_parser(
-        "record-full-verify", help="Run and record the merge-train's terminal full-suite verify now"
-    )
-    record_p.add_argument("--command", default="devtools verify --all")
 
     args = parser.parse_args(raw_argv)
 
@@ -1018,16 +1053,7 @@ def main(argv: list[str] | None = None) -> int:
         )
     if args.action == "train-status":
         return cmd_train_status(args.as_json)
-    try:
-        ledger_snapshot = _reconciled_terminal_verify_snapshot()
-    except LedgerStateError as exc:
-        print(f"REFUSING terminal verify: {exc}", file=sys.stderr)
-        return 1
-    target_sha = _fetched_current_default_branch_sha()
-    if target_sha is None:
-        print("REFUSING terminal verify: could not fetch the current default branch", file=sys.stderr)
-        return 1
-    return _run_post_merge_terminal_verify(args.command, target_sha, ledger_snapshot=ledger_snapshot)
+    raise AssertionError(f"unhandled action {args.action!r}")
 
 
 if __name__ == "__main__":

--- a/devtools/pytest_progress_plugin.py
+++ b/devtools/pytest_progress_plugin.py
@@ -295,17 +295,6 @@ def pytest_sessionstart(session: Any) -> None:
 @pytest.hookimpl
 def pytest_collection(session: Any) -> None:
     """Record collection start so selected-test runs expose import/collection cost."""
-    if os.environ.get("POLYLOGUE_TESTMON_COMPLETE_COLLECTION") == "1":
-        # testmon skips collecting whole files when every RECORDED test in them
-        # is stable -- which silently hides tests the graph has never seen (a
-        # marker-split lane records only its own lane, so the other lane's
-        # tests in the same file are invisible to a later forceselect run).
-        # Full-mode lanes claim complete-corpus coverage, so they must collect
-        # every file and let per-test deselection (which keeps unknown tests)
-        # do the narrowing.
-        select_plugin = session.config.pluginmanager.get_plugin("TestmonSelect")
-        if select_plugin is not None and getattr(select_plugin, "deselected_files", None):
-            select_plugin.deselected_files = []
     del session
     global _COLLECTION_STARTED_AT
     _COLLECTION_STARTED_AT = time.monotonic()

--- a/devtools/testmon_bootstrap.py
+++ b/devtools/testmon_bootstrap.py
@@ -34,6 +34,7 @@ import time
 import uuid
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
 from typing import Literal
 
@@ -732,6 +733,90 @@ def inspect_native_testmon_environment(
     return NativeTestmonState("valid", "native environment is current", environment)
 
 
+_CERTIFIED_CORPUS_TABLE = "polylogue_certified_corpus"
+
+
+def read_certified_corpus(data_path: Path, environment_name: str) -> frozenset[str] | None:
+    """The corpus a completed covered run certified for this environment.
+
+    ``None`` means no completed run has certified the environment yet -- an
+    interrupted bootstrap leaves a graph whose recorded rows LOOK like a
+    complete corpus (the corpus is derived from the graph, so it is blind to
+    its own losses). Attestation is sound only against a certificate.
+    """
+    if not data_path.exists():
+        return None
+    try:
+        with contextlib.closing(sqlite3.connect(_readonly_uri(data_path), uri=True)) as connection:
+            row = connection.execute(
+                f"SELECT nodeids_json FROM {_CERTIFIED_CORPUS_TABLE} WHERE environment_name = ?",
+                (environment_name,),
+            ).fetchone()
+    except sqlite3.Error:
+        return None
+    if row is None or not isinstance(row[0], str):
+        return None
+    try:
+        nodeids = json.loads(row[0])
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(nodeids, list):
+        return None
+    return frozenset(str(nodeid) for nodeid in nodeids)
+
+
+def write_certified_corpus(repo_root: Path, environment_name: str, nodeids: Iterable[str]) -> bool:
+    """Record the corpus of a completed covered run alongside the graph."""
+    data_path = repo_root.resolve() / TESTMON_DATA_RELPATH
+    if not data_path.exists():
+        return False
+    payload = json.dumps(sorted(set(nodeids)))
+    try:
+        with contextlib.closing(sqlite3.connect(data_path)) as connection:
+            connection.execute(
+                f"CREATE TABLE IF NOT EXISTS {_CERTIFIED_CORPUS_TABLE} ("
+                "environment_name TEXT PRIMARY KEY,"
+                "nodeids_json TEXT NOT NULL,"
+                "certified_at TEXT NOT NULL)"
+            )
+            connection.execute(
+                f"INSERT INTO {_CERTIFIED_CORPUS_TABLE} (environment_name, nodeids_json, certified_at)"
+                " VALUES (?, ?, ?)"
+                " ON CONFLICT(environment_name) DO UPDATE SET"
+                " nodeids_json = excluded.nodeids_json, certified_at = excluded.certified_at",
+                (environment_name, payload, datetime.now(UTC).isoformat()),
+            )
+            connection.commit()
+    except sqlite3.Error:
+        return False
+    return True
+
+
+def certified_attestation_violation(
+    repo_root: Path,
+    *,
+    environment_name: str,
+    current_nodeids: Sequence[str],
+) -> str | None:
+    """Why this graph may NOT attest unexecuted tests, or None when it may.
+
+    A graph row set is blind to its own losses (an interrupted serial lane or
+    damaged rows shrink the corpus AND the coverage claim together), so
+    attestation is checked against the certificate the last completed covered
+    run wrote. Tests whose test file no longer exists are legitimately gone
+    and do not violate the certificate.
+    """
+    root = repo_root.resolve()
+    certified = read_certified_corpus(root / TESTMON_DATA_RELPATH, environment_name)
+    if certified is None:
+        return "no completed covered run has certified this environment's corpus"
+    lost = {nodeid for nodeid in certified.difference(current_nodeids) if (root / nodeid.split("::", 1)[0]).is_file()}
+    if lost:
+        sample = ", ".join(sorted(lost)[:5])
+        return f"{len(lost)} certified test(s) are missing from the graph (e.g. {sample})"
+    return None
+
+
 def _owned_paths(repo_root: Path) -> tuple[Path, ...]:
     root = repo_root.resolve()
     _validate_owned_state_parents(root)
@@ -938,6 +1023,21 @@ def prepare_native_testmon_environment(
     linked = bool(info and info[0])
     main_checkout = info[1] if linked and info is not None else None
     if local.valid:
+        violation = certified_attestation_violation(
+            root,
+            environment_name=environment_name,
+            current_nodeids=local.environment.nodeids if local.environment is not None else (),
+        )
+        if violation is not None:
+            # The graph can still SELECT soundly, but it may not ATTEST the
+            # tests it would deselect -- re-execute the corpus and re-certify.
+            local = NativeTestmonState(
+                local.status,
+                f"attestation refused, re-executing corpus: {violation}",
+                local.environment,
+                local.missing_executable_paths,
+            )
+            return NativeTestmonPreparation(environment_name, "bootstrap", local, None, (), linked, main_checkout)
         return NativeTestmonPreparation(environment_name, "affected", local, None, (), linked, main_checkout)
 
     # Retain a merely incomplete graph. An interrupted bootstrap leaves a
@@ -982,6 +1082,27 @@ def prepare_native_testmon_environment(
             )
             if not local.valid:
                 raise NativeTestmonRepairError(f"published native testmon copy is invalid: {local.reason}")
+            violation = certified_attestation_violation(
+                root,
+                environment_name=environment_name,
+                current_nodeids=local.environment.nodeids if local.environment is not None else (),
+            )
+            if violation is not None:
+                local = NativeTestmonState(
+                    local.status,
+                    f"attestation refused, re-executing corpus: {violation}",
+                    local.environment,
+                    local.missing_executable_paths,
+                )
+                return NativeTestmonPreparation(
+                    environment_name,
+                    "bootstrap",
+                    local,
+                    copied_from,
+                    removed,
+                    linked,
+                    main_checkout,
+                )
             return NativeTestmonPreparation(
                 environment_name,
                 "affected",

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -82,6 +82,7 @@ from devtools.testmon_bootstrap import (
     prepare_native_testmon_environment,
     remove_invalid_native_testmon_state,
     validate_native_testmon_state_ownership,
+    write_certified_corpus,
 )
 from devtools.verification_contracts import VerificationScope
 from devtools.verify_runs import (
@@ -439,12 +440,22 @@ def _estimate_duration_from_history(
     pass or a 40-minute bootstrap BEFORE it finishes. The history rows carry
     tier + selection mode/state, which is exactly what predicts duration.
     """
+
+    def _tier_key(value: object) -> object:
+        # Pre-fold history recorded plain runs as tier "testmon" with
+        # selection_mode "affected"; both are the same population as today's
+        # incremental "full" runs, so estimation keeps reading them.
+        return "full" if value in ("testmon", "full") else value
+
+    def _mode_key(value: object) -> object:
+        return "full" if value in ("affected", "full") else value
+
     mode = selection.get("selection_mode") if isinstance(selection, Mapping) else None
     state = selection.get("state_status") if isinstance(selection, Mapping) else None
     exact: list[float] = []
     tier_only: list[float] = []
     for entry in reversed(_load_history()[-200:]):
-        if entry.get("tier") != tier or entry.get("exit_code") != 0:
+        if _tier_key(entry.get("tier")) != _tier_key(tier) or entry.get("exit_code") != 0:
             continue
         duration = entry.get("duration_s") or entry.get("total_duration_s")
         if not isinstance(duration, int | float) or duration <= 0:
@@ -452,7 +463,7 @@ def _estimate_duration_from_history(
         entry_selection = entry.get("testmon_selection")
         entry_mode = entry_selection.get("selection_mode") if isinstance(entry_selection, dict) else None
         entry_state = entry_selection.get("state_status") if isinstance(entry_selection, dict) else None
-        if (entry_mode, entry_state) == (mode, state) and len(exact) < 10:
+        if (_mode_key(entry_mode), entry_state) == (_mode_key(mode), state) and len(exact) < 10:
             exact.append(float(duration))
         elif len(tier_only) < 10:
             tier_only.append(float(duration))
@@ -503,7 +514,7 @@ def _print_verify_plan() -> int:
         env_name = testmon_environment_digest(
             ROOT,
             pytest_profile=_pytest_profile(),
-            pytest_environment=_native_pytest_environment(force_release_profile=False),
+            pytest_environment=_native_pytest_environment(),
         )
     except Exception as exc:  # pragma: no cover - defensive: report, don't crash a read-only plan
         env_name = f"<unavailable: {exc}>"
@@ -549,7 +560,7 @@ def _print_verify_plan() -> int:
         f"plan: ~{dependents} dependent test(s) execute + any never-recorded tests; ~{recorded - dependents} attested unchanged-green"
     )
     estimate = _estimate_duration_from_history(
-        tier="testmon", selection={"selection_mode": "affected", "state_status": "valid"}
+        tier="full", selection={"selection_mode": "full", "state_status": "valid"}
     )
     if estimate is not None:
         print(f"plan: comparable warm runs took ~{estimate[0]:.0f}s (n={estimate[1]})")
@@ -2061,7 +2072,10 @@ def _run_step(
     external_plugins_neutralized = False
     if owns_pytest_environment:
         _normalize_managed_pytest_environment(env, disable_plugin_autoload=managed_native_lane)
-    if managed_native_lane and _pytest_uses_full_suite_basetemp(label):
+    if managed_native_lane:
+        # Every plain-verify lane can grant release authority, so every lane
+        # runs the complete Hypothesis profile -- a reduced ambient profile
+        # must not silently weaken an authority-granting run.
         env["HYPOTHESIS_PROFILE"] = "default"
     explicit_basetemp = _pytest_command_basetemp(cmd, cwd=cwd, env=env)
     if explicit_basetemp is not None:
@@ -2118,13 +2132,6 @@ def _run_step(
             # with the native environment corpus before granting release
             # authority. Keep the complete node set in these bounded artifacts.
             env["POLYLOGUE_PYTEST_SELECTION_NODEID_LIMIT"] = "50000"
-            if label.endswith("(full)"):
-                # Full-mode lanes claim complete-corpus coverage, so testmon's
-                # file-level collection skip must be disabled: it hides tests
-                # the graph has never recorded when they share a file with
-                # stable recorded ones (the marker-split lanes make that
-                # systematic). Per-test deselection still narrows execution.
-                env["POLYLOGUE_TESTMON_COMPLETE_COLLECTION"] = "1"
         if run is not None and artifacts is not None:
             env = env_for_pytest_step(env, run=run, artifacts=artifacts)
         if owns_pytest_environment:
@@ -2621,7 +2628,7 @@ def _native_pytest_steps(
 
 def _native_pytest_command_is_closed_world(label: str, cmd: Sequence[str]) -> bool:
     """Accept only a command produced by the managed native-lane builder."""
-    match = re.fullmatch(r"pytest native (parallel|serial) \((affected|bootstrap|full)\)", label)
+    match = re.fullmatch(r"pytest native (parallel|serial) \((bootstrap|full)\)", label)
     if match is None:
         return False
     environment_args = [arg for arg in cmd if arg.startswith("--testmon-env=")]
@@ -2837,8 +2844,13 @@ def _pytest_command_concurrency(cmd: Sequence[str], *, env: Mapping[str, str] | 
 
 
 def _pytest_uses_full_suite_basetemp(label: str) -> bool:
-    """Whether this semantic lane may materialize the complete corpus tree."""
-    return label.startswith("pytest native") and ("(bootstrap)" in label or "(full)" in label)
+    """Whether this semantic lane always materializes the complete corpus tree.
+
+    A "(full)" lane over a valid graph makes a narrow forceselect selection,
+    so it is NOT full-suite-shaped by label alone; selection_may_run_broadly
+    covers the non-valid-graph cases at the placement decision.
+    """
+    return label.startswith("pytest native") and "(bootstrap)" in label
 
 
 def _changed_paths(base_commit: str, head_commit: str) -> set[str]:
@@ -2917,9 +2929,8 @@ def _planned_verification_scope(
 ) -> VerificationScope:
     if args.quick or args.commit:
         return VerificationScope.NON_TEST
-    if testmon_mode in {"bootstrap", "full"}:
-        return VerificationScope.RELEASE_BASELINE
-    return VerificationScope.AFFECTED
+    del testmon_mode
+    return VerificationScope.RELEASE_BASELINE
 
 
 def _pytest_profile() -> str:
@@ -2956,17 +2967,14 @@ def _resolved_hypothesis_profile(env: Mapping[str, str] | None = None) -> str:
     return configured or "default"
 
 
-def _native_pytest_environment(*, force_release_profile: bool) -> dict[str, str | None]:
-    environment = {
+def _native_pytest_environment() -> dict[str, str | None]:
+    return {
         # Hypothesis uses its default profile when the variable is absent.
         # Record that effective value in the testmon environment identity so a
-        # bootstrap graph is reusable by the following affected invocation.
+        # bootstrap graph is reusable by every later incremental invocation.
         "HYPOTHESIS_PROFILE": _resolved_hypothesis_profile(),
         "POLYLOGUE_CI": os.environ.get("POLYLOGUE_CI"),
     }
-    if force_release_profile:
-        environment["HYPOTHESIS_PROFILE"] = "default"
-    return environment
 
 
 def _native_environment_after_run(
@@ -3114,12 +3122,6 @@ def _main(argv: list[str] | None = None) -> int:
     started_at = time.monotonic()
     parser = argparse.ArgumentParser(description="Run the local verification baseline.")
     parser.add_argument("--quick", action="store_true", help="Skip pytest and run only fast local gates.")
-    parser.add_argument(
-        "--all",
-        action="store_true",
-        help="Run the complete pytest correctness corpus (excluding performance benchmarks).",
-    )
-    parser.add_argument("--full", action="store_true", help="Alias for --all.")
     parser.add_argument("--commit", action="store_true", help="Pre-commit tier: format + lint + mypy only.")
     parser.add_argument(
         "--lab",
@@ -3159,26 +3161,12 @@ def _main(argv: list[str] | None = None) -> int:
             return 125
         return _print_verify_plan()
 
-    full_requested = bool(args.all or args.full)
     use_json = args.json if args.json is not None else not sys.stdout.isatty()
-    tier = (
-        "commit"
-        if args.commit
-        else "quick"
-        if args.quick
-        else "full"
-        if full_requested
-        else "lab"
-        if args.lab
-        else "testmon"
-    )
+    tier = "commit" if args.commit else "quick" if args.quick else "lab" if args.lab else "full"
     head = _git_head()
     pytest_enabled = not (args.quick or args.commit)
     managed_pytest_enabled = pytest_enabled or args.lab
-    planned_scope = _planned_verification_scope(
-        args,
-        testmon_mode="full" if full_requested else None,
-    )
+    planned_scope = _planned_verification_scope(args, testmon_mode="full")
     verify_run = VerifyRun(
         tier=tier,
         argv=list(sys.argv[1:] if argv is None else argv),
@@ -3262,7 +3250,7 @@ def _main(argv: list[str] | None = None) -> int:
     runtime_data_paths: tuple[str, ...] = ()
     preparation: NativeTestmonPreparation | None = None
     testmon_mode: str | None = None
-    native_pytest_environment = _native_pytest_environment(force_release_profile=full_requested)
+    native_pytest_environment = _native_pytest_environment()
     preparation_mutation_observation: CheckoutMutationObservation | None = None
     if pytest_enabled:
         assert base_commit is not None
@@ -3285,7 +3273,7 @@ def _main(argv: list[str] | None = None) -> int:
                 preparation.selection_mode == "bootstrap"
                 and native_pytest_environment["HYPOTHESIS_PROFILE"] != "default"
             ):
-                native_pytest_environment = _native_pytest_environment(force_release_profile=True)
+                native_pytest_environment = {**native_pytest_environment, "HYPOTHESIS_PROFILE": "default"}
                 preparation = prepare_native_testmon_environment(
                     ROOT,
                     required_executable_paths=preparation_required_executable_paths,
@@ -3329,9 +3317,13 @@ def _main(argv: list[str] | None = None) -> int:
         # corpus. The operator weighed that against the measured cost and chose
         # the hazard: forcing a full corpus on every such change stopped work
         # entirely. runtime_data_paths still lands in the receipt and in
-        # `devtools why`, so the exposure is visible per run and a deliberate
-        # `--all` remains available before anything that needs the guarantee.
-        testmon_mode = "full" if full_requested else preparation.selection_mode
+        # `devtools why`, so the exposure is visible per run.
+        #
+        # Every plain run is complete-corpus scoped: forceselect executes
+        # changed-dep, never-recorded, and previously-failing tests, and
+        # attests the rest from their unchanged recorded greens. "bootstrap"
+        # (no sound graph for this environment digest) executes everything.
+        testmon_mode = "full" if preparation.selection_mode == "affected" else preparation.selection_mode
         # Record the cause, not just the outcome. A bootstrap is ~9.5x a warm
         # run; which of the two triggers fired decides whether better selection
         # could have avoided it, and the receipt previously said neither.
@@ -3353,10 +3345,9 @@ def _main(argv: list[str] | None = None) -> int:
             sys.stderr.write(f"verify: copied matching native pytest-testmon DB from {preparation.copied_from}\n")
         elif preparation.selection_mode == "bootstrap":
             sys.stderr.write("verify: native pytest-testmon environment is empty; plain verify will build it\n")
-        if runtime_data_paths and not full_requested:
+        if runtime_data_paths:
             sys.stderr.write(
-                "verify: changed package runtime data is outside Python tracing; recorded as exposure "
-                "(run `devtools verify --all` before anything that needs the guarantee): "
+                "verify: changed package runtime data is outside Python tracing; recorded as exposure: "
                 + ", ".join(runtime_data_paths)
                 + "\n"
             )
@@ -3599,6 +3590,9 @@ def _main(argv: list[str] | None = None) -> int:
     total_duration = round(time.monotonic() - started_at, 2)
     pytest_aggregate: dict[str, Any] | None = None
     native_environment = native_state.environment if native_state is not None else None
+    attestation_sound = testmon_mode == "bootstrap" or (
+        preparation is not None and preparation.local_state.status == "valid" and not runtime_data_paths
+    )
     if preparation is not None:
         pytest_aggregate = aggregate_native_testmon_run(
             ROOT,
@@ -3609,7 +3603,18 @@ def _main(argv: list[str] | None = None) -> int:
             environment_reason=native_state.reason if native_state is not None else "post-run inspection unavailable",
             selection_mode=testmon_mode or "affected",
             invocation_duration_s=total_duration,
+            attestation_sound=attestation_sound,
         )
+        if (
+            testmon_mode in ("full", "bootstrap")
+            and pytest_aggregate.get("complete_corpus_covered") is True
+            and native_environment is not None
+        ):
+            # A completed covered run certifies its corpus next to the graph;
+            # future attestation is checked against this certificate, because
+            # the graph's own row set is blind to its losses (an interrupted
+            # lane shrinks the corpus and the coverage claim together).
+            write_certified_corpus(ROOT, preparation.environment_name, native_environment.nodeids)
 
     # Finalization can outlast the last pytest lane, so wall_s is taken here
     # rather than from the lanes alone.
@@ -3627,8 +3632,17 @@ def _main(argv: list[str] | None = None) -> int:
         aggregate=pytest_aggregate,
     )
     verification_scope = planned_scope
-    if testmon_mode == "affected":
-        release_baseline_allowed = False
+    if (
+        testmon_mode == "full"
+        and not attestation_sound
+        and not (pytest_aggregate is not None and pytest_aggregate.get("complete_corpus_covered") is True)
+    ):
+        # The run carried named exposure (an incomplete graph or untraceable
+        # runtime-data changes) and did NOT pay for it by executing the whole
+        # corpus, so it cannot claim the release baseline. It still authorizes
+        # PR merges. A run that executed everything anyway keeps its planned
+        # scope: full execution covers any exposure.
+        verification_scope = VerificationScope.AFFECTED
 
     checkout_diagnosis = next(
         (
@@ -3721,6 +3735,14 @@ def _main(argv: list[str] | None = None) -> int:
 
     if exit_code == 0:
         _stamp_head()
+        if pytest_enabled and release_baseline_allowed is True and head is not None:
+            # The merge-train ledger's terminal step is "one green
+            # complete-corpus verify on the merged master"; any plain verify
+            # that earns release authority AT origin/master IS that step, so
+            # it records itself instead of requiring a separate incantation.
+            from devtools.merge_boundary import record_accepted_terminal_verify
+
+            record_accepted_terminal_verify(git_head=head, duration_s=total_duration)
     else:
         _notify(
             _format_completion_notification(

--- a/devtools/verify_runs.py
+++ b/devtools/verify_runs.py
@@ -1305,6 +1305,7 @@ def aggregate_native_testmon_run(
     environment_reason: str | None = None,
     selection_mode: str,
     invocation_duration_s: float,
+    attestation_sound: bool = True,
 ) -> dict[str, Any]:
     """Build one compact, durable aggregate for the two semantic pytest lanes."""
     lanes: list[dict[str, Any]] = []
@@ -1413,8 +1414,11 @@ def aggregate_native_testmon_run(
     # attested by recording. A bootstrap (no graph) still executes everything,
     # making the attested set empty and the condition equivalent to the old
     # exhaustive one. Selection fidelity, closed-world collection, lane shape
-    # and duplicate checks are unchanged.
-    attested_unchanged = tuple(sorted(corpus_set - executed_nodes)) if complete_mode else ()
+    # and duplicate checks are unchanged. Attestation is withheld entirely
+    # (attestation_sound=False) when the pre-run graph carried named exposure:
+    # changed modules with no recorded edges, or changed non-Python runtime
+    # data no trace can see -- recorded greens predate those changes.
+    attested_unchanged = tuple(sorted(corpus_set - executed_nodes)) if complete_mode and attestation_sound else ()
     complete_corpus_covered = (
         complete_mode
         and selection_complete
@@ -1423,6 +1427,7 @@ def aggregate_native_testmon_run(
         and external_plugins_neutralized
         and closed_world_collection
         and selected_union == executed_nodes
+        and (attestation_sound or corpus_set <= executed_nodes)
         and not duplicate_outcomes
         and len(lane_names) == 2
         and lane_names.count("parallel") == 1

--- a/devtools/why.py
+++ b/devtools/why.py
@@ -137,7 +137,7 @@ def _render(payload: dict[str, Any], stream: Any) -> None:
             # longer force the complete corpus (operator decision 2026-08-18).
             print(
                 f"  {len(runtime_data)} changed non-Python runtime file(s) are outside Python tracing"
-                " (recorded exposure; `--all` covers them)",
+                " (recorded exposure; only re-execution after an environment change covers them)",
                 file=stream,
             )
 

--- a/tests/integration/devtools/test_native_testmon_lifecycle.py
+++ b/tests/integration/devtools/test_native_testmon_lifecycle.py
@@ -20,6 +20,7 @@ from devtools.testmon_bootstrap import (
     NativeTestmonRepairError,
     inspect_native_testmon_environment,
     prepare_native_testmon_environment,
+    write_certified_corpus,
 )
 from devtools.testmon_bootstrap import (
     testmon_environment_digest as _testmon_environment_digest,
@@ -163,6 +164,19 @@ def _run_lane(
     return LaneResult(completed, artifact_dir, selection_payload)
 
 
+def _certify_recorded_corpus(repo: Path, environment_name: str) -> None:
+    """Mirror a completed covered production run: certify the graph's rows."""
+    data = repo / TESTMON_DATA_RELPATH
+    with sqlite3.connect(data) as connection:
+        rows = connection.execute(
+            "SELECT te.test_name FROM test_execution te"
+            " JOIN environment e ON te.environment_id = e.id"
+            " WHERE e.environment_name = ?",
+            (environment_name,),
+        ).fetchall()
+    write_certified_corpus(repo, environment_name, [row[0] for row in rows])
+
+
 def _run_plain_verify_corpus(
     repo: Path,
     *,
@@ -185,6 +199,7 @@ def _run_plain_verify_corpus(
         lane="serial",
         base_marker=base_marker,
     )
+    _certify_recorded_corpus(repo, environment_name)
     return parallel, serial
 
 
@@ -435,15 +450,19 @@ def test_serial_owner():
     second, warm = _run_production_verify(repo)
 
     assert second.returncode == 0, second.stderr
-    assert warm["testmon_environment"]["selection_mode"] == "affected"
-    assert warm["release_baseline_allowed"] is False
+    assert warm["testmon_environment"]["selection_mode"] == "full"
     assert warm["pytest_aggregate"]["selected_union_count"] == 0
+    # Zero execution, complete attested coverage: every corpus test's recorded
+    # deps are unchanged and green, so the warm run still earns release
+    # authority -- the fold's central claim.
+    assert warm["verification_scope"] == "release-baseline"
+    assert warm["release_baseline_allowed"] is True
 
     (package / "app.py").write_text("def answer() -> int:\n    return 0\n", encoding="utf-8")
     third, mutated = _run_production_verify(repo)
 
     assert third.returncode == 1
-    assert mutated["testmon_environment"]["selection_mode"] == "affected"
+    assert mutated["testmon_environment"]["selection_mode"] == "full"
     assert mutated["pytest_aggregate"]["terminal_union_count"] == 2
     assert mutated["release_baseline_allowed"] is False
     assert "assert 0 == 42" in third.stderr
@@ -475,20 +494,23 @@ def test_production_verify_all_grants_release_authority_after_complete_two_lane_
     _git(repo, "branch", "-M", "master")
     _git(repo, "push", "-qu", "origin", "master")
 
-    completed, payload = _run_production_verify(repo, "--all")
+    completed, payload = _run_production_verify(repo)
 
     assert completed.returncode == 0, completed.stderr
     assert payload["tier"] == "full"
-    assert payload["testmon_environment"]["selection_mode"] == "full"
+    assert payload["testmon_environment"]["selection_mode"] == "bootstrap"
     assert payload["verification_scope"] == "release-baseline"
     assert payload["release_baseline_allowed"] is True
     assert payload["worktree_fingerprint"] == payload["final_worktree_fingerprint"]
     lanes = [step for step in payload["steps"] if step.get("semantic_lane")]
     assert [step["semantic_lane"] for step in lanes] == ["parallel", "serial"]
-    assert [step["name"] for step in lanes] == ["pytest native parallel (full)", "pytest native serial (full)"]
+    assert [step["name"] for step in lanes] == [
+        "pytest native parallel (bootstrap)",
+        "pytest native serial (bootstrap)",
+    ]
     for step in lanes:
-        assert "--testmon-forceselect" in step["statistics"]["command"]
-        assert "--testmon-noselect" not in step["statistics"]["command"]
+        assert "--testmon-noselect" in step["statistics"]["command"]
+        assert "--testmon-forceselect" not in step["statistics"]["command"]
         assert "--override-ini=addopts=" in step["statistics"]["command"]
         assert step["external_addopts_neutralized"] is True
         assert step["external_plugins_neutralized"] is True
@@ -497,7 +519,7 @@ def test_production_verify_all_grants_release_authority_after_complete_two_lane_
     assert aggregate["external_addopts_neutralized"] is True
     assert aggregate["external_plugins_neutralized"] is True
     assert aggregate["closed_world_collection"] is True
-    assert aggregate["selection_mode"] == "full"
+    assert aggregate["selection_mode"] == "bootstrap"
     assert aggregate["environment"]["native_corpus_count"] == 2
     assert aggregate["corpus"]["count"] == 2
     assert aggregate["selected_union_count"] == 2
@@ -508,13 +530,27 @@ def test_production_verify_all_grants_release_authority_after_complete_two_lane_
     assert aggregate["cleanup"] == {"complete": True}
     assert aggregate["containment"] == {"complete": True}
 
+    # A graph that loses recorded rows (an interrupted lane, damaged rows)
+    # shrinks its corpus AND its coverage claim together -- the row set is
+    # blind to its own losses, and testmon's file-level collection skip
+    # would hide the lost test from every later warm run. The certificate
+    # the completed run wrote catches the loss: attestation is refused and
+    # the corpus re-executes and re-certifies.
+    graph = repo / ".cache" / "testmon" / "testmondata"
+    with sqlite3.connect(graph) as connection:
+        connection.execute("DELETE FROM test_execution WHERE test_name LIKE '%serial%'")
+    warm_completed, warm = _run_production_verify(repo)
 
-@pytest.mark.parametrize(("verify_args", "selection_mode"), [((), "bootstrap"), (("--all",), "full")])
-def test_release_native_runs_override_a_reduced_hypothesis_profile(
-    tmp_path: Path,
-    verify_args: tuple[str, ...],
-    selection_mode: str,
-) -> None:
+    assert warm_completed.returncode == 0, warm_completed.stderr
+    assert warm["testmon_environment"]["selection_mode"] == "bootstrap"
+    assert "attestation refused" in warm["testmon_selection"]["state_reason"]
+    warm_aggregate = warm["pytest_aggregate"]
+    assert warm_aggregate["corpus"]["count"] == 2
+    assert warm_aggregate["terminal_union_count"] == 2
+    assert warm["release_baseline_allowed"] is True
+
+
+def test_release_native_runs_override_a_reduced_hypothesis_profile(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
     _init_repo(
@@ -549,12 +585,11 @@ def test_release_native_runs_override_a_reduced_hypothesis_profile(
 
     completed, payload = _run_production_verify(
         repo,
-        *verify_args,
         environment_overrides={"HYPOTHESIS_PROFILE": "verify"},
     )
 
     assert completed.returncode == 0, completed.stderr
-    assert payload["testmon_environment"]["selection_mode"] == selection_mode
+    assert payload["testmon_environment"]["selection_mode"] == "bootstrap"
     assert payload["release_baseline_allowed"] is True
 
 
@@ -620,7 +655,7 @@ def test_production_verify_all_neutralizes_external_pytest_addopts(
     else:
         monkeypatch.setenv("PYTEST_ADDOPTS", environment_addopts)
 
-    completed, payload = _run_production_verify(repo, "--all")
+    completed, payload = _run_production_verify(repo)
 
     assert completed.returncode == 1
     assert payload["release_baseline_allowed"] is False
@@ -667,7 +702,7 @@ def test_production_verify_all_drops_pythonpath_startup_injection(tmp_path: Path
         encoding="utf-8",
     )
 
-    completed, payload = _run_production_verify(repo, "--all")
+    completed, payload = _run_production_verify(repo)
 
     assert completed.returncode == 1
     assert payload["release_baseline_allowed"] is False
@@ -697,9 +732,9 @@ def test_plain_native_lane_environment_removes_ambient_pytest_variables(
 @pytest.mark.parametrize(
     ("environment_overrides", "interpreter_args", "verify_args"),
     [
-        ({"PYTHONOPTIMIZE": "1"}, (), ("--all",)),
-        ({}, ("-O",), ("--all",)),
-        ({}, ("-OO",), ("--all",)),
+        ({"PYTHONOPTIMIZE": "1"}, (), ()),
+        ({}, ("-O",), ()),
+        ({}, ("-OO",), ()),
         ({"PYTHONOPTIMIZE": "1"}, (), ("--quick", "--lab")),
         ({"PYTHONOPTIMIZE": "1"}, (), ("--commit", "--lab")),
     ],
@@ -801,7 +836,7 @@ def test_production_affected_verify_neutralizes_execution_suppressing_addopts(
     completed, payload = _run_production_verify(repo)
 
     assert completed.returncode == 1
-    assert payload["testmon_environment"]["selection_mode"] == "affected"
+    assert payload["testmon_environment"]["selection_mode"] == "full"
     assert payload["release_baseline_allowed"] is False
     aggregate = payload["pytest_aggregate"]
     assert aggregate["selected_union_count"] == 2
@@ -869,7 +904,7 @@ def test_production_verify_all_owns_complete_test_root_over_configured_testpaths
     monkeypatch.setenv("PYTEST_PLUGINS", "ambient_narrow")
     monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", raising=False)
 
-    completed, payload = _run_production_verify(repo, "--all")
+    completed, payload = _run_production_verify(repo)
 
     assert completed.returncode == 1
     assert payload["release_baseline_allowed"] is False
@@ -954,7 +989,7 @@ def test_runtime_json_only_mutation_is_recorded_but_not_caught(tmp_path: Path) -
 
     # What remains enforced is that the exposure is VISIBLE. The changed path is
     # recorded on the receipt and surfaced by `devtools why`, so a reviewer can
-    # see exactly which untraceable file went unverified and run `--all` when the
+    # see exactly which untraceable file went unverified when the
     # guarantee is wanted. Silence here would make the tradeoff undiscoverable,
     # which is the part that would be indefensible.
     assert mutated["testmon_environment"]["runtime_data_paths"] == [
@@ -1016,7 +1051,7 @@ def test_production_verify_test_runtime_data_mutation_is_recorded_but_not_caught
 
     # What stays enforced is that the exposure is VISIBLE: the changed path is on
     # the receipt and surfaced by `devtools why`, so a reviewer can see which
-    # untraceable file went unverified and run `--all` when the guarantee matters.
+    # untraceable file went unverified when the guarantee matters.
     assert mutated["testmon_environment"]["runtime_data_paths"] == ["tests/data/expected.txt"]
     # Nothing is selected, which is the exposure stated plainly: the fixture that
     # changed has no traced edge, so no test is chosen and the failing assertion
@@ -1150,7 +1185,7 @@ def test_production_verify_deleted_module_with_updated_imports_rebuilds_successf
     # nonexistent file is unrecordable, so requiring one made incomplete
     # permanent). The surviving changed module has recorded edges, so the run
     # stays a warm affected selection and still covers the dependent.
-    assert environment["selection_mode"] == "affected"
+    assert environment["selection_mode"] == "full"
     assert environment["required_executable_paths"] == ["polylogue/app.py"]
     assert environment["bootstrap_trigger_paths"] == ["polylogue/app.py"]
     # terminal_green demands complete-corpus coverage, which a warm affected
@@ -1199,7 +1234,7 @@ def test_production_verify_moved_module_with_updated_imports_rebuilds_successful
     # dependency is an un-fingerprinted module may be missed on this run and is
     # selected on the next, because the run still records edges for everything it
     # executes -- and the uncovered paths are named on the receipt either way.
-    assert environment["selection_mode"] == "affected"
+    assert environment["selection_mode"] == "full"
     assert environment["required_executable_paths"] == ["polylogue/renamed.py", "tests/test_app.py"]
     assert environment["bootstrap_trigger_paths"] == [
         "polylogue/renamed.py",
@@ -1209,16 +1244,15 @@ def test_production_verify_moved_module_with_updated_imports_rebuilds_successful
     # executed, and nothing failed.
     assert rebuilt["pytest_aggregate"]["non_green_count"] == 0
     assert rebuilt["pytest_aggregate"]["selected_union_count"] == 1
-    # terminal_green stays False here, and correctly so. It is defined as
-    # `complete_corpus_covered and not missing_terminal and not non_green` -- a
-    # RELEASE-AUTHORITY signal meaning the whole corpus ran green, not "this run
-    # passed". It was True before only because a moved module forced a bootstrap
-    # over the complete corpus; with affected selection driving a
-    # sound-but-incomplete graph (operator decision 2026-08-18) the corpus is
-    # deliberately not fully covered, so claiming release authority here would be
-    # the bug.
-    assert rebuilt["pytest_aggregate"]["terminal_green"] is False
-    assert rebuilt["pytest_aggregate"]["complete_corpus_covered"] is False
+    # The pre-run graph carried named exposure (renamed.py had no recorded
+    # edges), so nothing could be attested -- but this corpus is one test and
+    # that test EXECUTED, so coverage-by-execution is complete and honest.
+    # Exposure that the run pays for by executing the whole corpus does not
+    # withhold authority; exposure that survives as unexecuted attestation
+    # would (see the runtime-data tests).
+    assert rebuilt["pytest_aggregate"]["attested_unchanged_count"] == 0
+    assert rebuilt["pytest_aggregate"]["terminal_green"] is True
+    assert rebuilt["pytest_aggregate"]["complete_corpus_covered"] is True
 
 
 def test_empty_linked_worktree_with_empty_main_self_bootstraps(tmp_path: Path) -> None:

--- a/tests/unit/devtools/test_merge_boundary.py
+++ b/tests/unit/devtools/test_merge_boundary.py
@@ -71,7 +71,7 @@ def test_stale_base_head_refuses_before_recording(monkeypatch: pytest.MonkeyPatc
         poll_interval_s=0,
         dry_run=True,
         with_verify=False,
-        verify_command="devtools verify --all",
+        verify_command="devtools verify",
     )
     assert exit_code == 1
 
@@ -272,22 +272,10 @@ def test_workspace_merge_preserves_train_status_dispatch(monkeypatch: pytest.Mon
     assert calls == [True]
 
 
-def test_workspace_merge_preserves_record_full_verify_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
-    captured: list[tuple[str, str]] = []
-
-    def record(command: str, target_sha: str, **_kwargs: object) -> int:
-        captured.append((command, target_sha))
-        return 0
-
-    monkeypatch.setattr(merge_boundary, "_reconciled_terminal_verify_snapshot", lambda: {})
-    monkeypatch.setattr(merge_boundary, "_fetched_current_default_branch_sha", lambda: "master-sha")
-    monkeypatch.setattr(merge_boundary, "_run_post_merge_terminal_verify", record)
-
-    assert (
-        click_dispatch._dispatch(["workspace", "merge", "record-full-verify", "--command", "devtools verify --all"])
-        == 0
-    )
-    assert captured == [("devtools verify --all", "master-sha")]
+def test_workspace_merge_rejects_removed_record_full_verify_action() -> None:
+    # The terminal step records itself from an accepted plain verify; the
+    # standalone incantation is gone.
+    assert click_dispatch._dispatch(["workspace", "merge", "record-full-verify", "--command", "devtools verify"]) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -308,7 +296,7 @@ def test_merge_auto_records_when_no_fresh_receipt_then_merges(monkeypatch: pytes
         poll_interval_s=0,
         dry_run=False,
         with_verify=False,
-        verify_command="devtools verify --all",
+        verify_command="devtools verify",
     )
 
     assert exit_code == 0
@@ -336,7 +324,7 @@ def test_merge_refreshes_a_receipt_when_the_scope_attestation_changes(
             poll_interval_s=0,
             dry_run=True,
             with_verify=False,
-            verify_command="devtools verify --all",
+            verify_command="devtools verify",
         )
         == 0
     )
@@ -352,7 +340,7 @@ def test_merge_refreshes_a_receipt_when_the_scope_attestation_changes(
             poll_interval_s=0,
             dry_run=True,
             with_verify=False,
-            verify_command="devtools verify --all",
+            verify_command="devtools verify",
         )
         == 0
     )
@@ -381,7 +369,7 @@ def test_merge_strips_doubled_pr_suffix_before_merging(monkeypatch: pytest.Monke
         poll_interval_s=0,
         dry_run=False,
         with_verify=False,
-        verify_command="devtools verify --all",
+        verify_command="devtools verify",
     )
 
     assert exit_code == 0
@@ -418,7 +406,7 @@ def test_merge_refuses_when_the_target_base_changes_after_validation(
             poll_interval_s=0,
             dry_run=False,
             with_verify=False,
-            verify_command="devtools verify --all",
+            verify_command="devtools verify",
         )
         == 1
     )
@@ -453,7 +441,7 @@ def test_merge_refuses_when_the_scope_body_changes_after_validation(
             poll_interval_s=0,
             dry_run=False,
             with_verify=False,
-            verify_command="devtools verify --all",
+            verify_command="devtools verify",
         )
         == 1
     )
@@ -474,7 +462,7 @@ def test_merge_refuses_when_pr_not_open(monkeypatch: pytest.MonkeyPatch, tmp_pat
         poll_interval_s=0,
         dry_run=False,
         with_verify=False,
-        verify_command="devtools verify --all",
+        verify_command="devtools verify",
     )
 
     assert exit_code == 1
@@ -496,7 +484,7 @@ def test_merge_refuses_when_pr_scope_carrier_is_missing(
         poll_interval_s=0,
         dry_run=False,
         with_verify=False,
-        verify_command="devtools verify --all",
+        verify_command="devtools verify",
     )
 
     assert exit_code == 2
@@ -526,7 +514,7 @@ def test_merge_refuses_when_unresolved_review_thread_exists(monkeypatch: pytest.
         poll_interval_s=0,
         dry_run=False,
         with_verify=False,
-        verify_command="devtools verify --all",
+        verify_command="devtools verify",
     )
 
     assert exit_code != 0
@@ -547,7 +535,7 @@ def test_merge_refuses_when_local_verify_command_fails(monkeypatch: pytest.Monke
         poll_interval_s=0,
         dry_run=False,
         with_verify=False,
-        verify_command="devtools verify --all",
+        verify_command="devtools verify",
     )
 
     assert exit_code == 1
@@ -572,7 +560,7 @@ def test_merge_replaces_a_recent_failed_receipt_instead_of_reusing_it(
             poll_interval_s=0,
             dry_run=True,
             with_verify=False,
-            verify_command="devtools verify --all",
+            verify_command="devtools verify",
         )
         == 2
     )
@@ -588,7 +576,7 @@ def test_merge_replaces_a_recent_failed_receipt_instead_of_reusing_it(
             poll_interval_s=0,
             dry_run=True,
             with_verify=False,
-            verify_command="devtools verify --all",
+            verify_command="devtools verify",
         )
         == 0
     )
@@ -657,7 +645,7 @@ def test_merge_dry_run_never_calls_gh_pr_merge(monkeypatch: pytest.MonkeyPatch, 
         poll_interval_s=0,
         dry_run=True,
         with_verify=False,
-        verify_command="devtools verify --all",
+        verify_command="devtools verify",
     )
 
     assert exit_code == 0
@@ -679,7 +667,7 @@ def test_merge_propagates_gh_pr_merge_failure(monkeypatch: pytest.MonkeyPatch, t
         poll_interval_s=0,
         dry_run=False,
         with_verify=False,
-        verify_command="devtools verify --all",
+        verify_command="devtools verify",
     )
 
     assert exit_code == 3
@@ -693,7 +681,7 @@ def test_merge_with_verify_records_terminal_full_verify(monkeypatch: pytest.Monk
     base = _fake_run(pr_view)
 
     def run(cmd: list[str], **kwargs: Any) -> MagicMock:
-        if cmd[:3] == ["devtools", "verify", "--all"]:
+        if cmd[:2] == ["devtools", "verify"]:
             _write_terminal_receipt(kwargs)
             return MagicMock(
                 returncode=0,
@@ -724,12 +712,12 @@ def test_merge_with_verify_records_terminal_full_verify(monkeypatch: pytest.Monk
         poll_interval_s=0,
         dry_run=False,
         with_verify=True,
-        verify_command="devtools verify --all",
+        verify_command="devtools verify",
     )
 
     assert exit_code == 0
     ledger = merge_boundary._read_ledger()
-    assert ledger["last_full_verify"]["command"] == "devtools verify --all"
+    assert ledger["last_full_verify"]["command"] == "devtools verify"
     assert ledger["last_full_verify"]["exit_code"] == 0
     # train-status should now report clean.
     assert merge_boundary.cmd_train_status(as_json=False) == 0
@@ -753,7 +741,7 @@ def test_merge_with_verify_returns_nonzero_when_terminal_authority_is_rejected(
             poll_interval_s=0,
             dry_run=False,
             with_verify=True,
-            verify_command="devtools verify --all",
+            verify_command="devtools verify",
         )
         == 1
     )
@@ -778,7 +766,7 @@ def test_post_merge_terminal_verify_rejects_stale_feature_head(monkeypatch: pyte
         ),
     )
 
-    assert merge_boundary.cmd_record_full_verify("devtools verify --all", target_sha="merged-master") == 1
+    assert merge_boundary.cmd_record_full_verify("devtools verify", target_sha="merged-master") == 1
     assert merge_boundary._read_ledger()["last_full_verify"]["accepted"] is False
 
 
@@ -829,7 +817,7 @@ def test_post_merge_terminal_verify_uses_target_checkout_devshell(
 
     monkeypatch.setattr(subprocess, "run", run)
 
-    assert merge_boundary._run_post_merge_terminal_verify("devtools verify --all", "merged-master") == 0
+    assert merge_boundary._run_post_merge_terminal_verify("devtools verify", "merged-master") == 0
     assert any(command[:2] == ["direnv", "exec"] for command in commands)
 
 
@@ -940,7 +928,7 @@ def test_merge_write_failure_recovers_valid_pending_ledger(monkeypatch: pytest.M
             poll_interval_s=0,
             dry_run=False,
             with_verify=False,
-            verify_command="devtools verify --all",
+            verify_command="devtools verify",
         )
         == 1
     )
@@ -972,7 +960,7 @@ def test_train_status_blocks_when_pr_merged_after_last_full_verify(
                 "at": 1000.0,
                 "verification_started_at": 1000.0,
                 "duration_s": 1.0,
-                "command": "devtools verify --all",
+                "command": "devtools verify",
                 "exit_code": 0,
                 "verification_scope": "release-baseline",
                 "release_baseline_allowed": True,
@@ -1000,9 +988,8 @@ def test_train_status_requires_release_baseline_guidance(
     assert merge_boundary.cmd_train_status(as_json=False) == 1
 
     output = capsys.readouterr().out
-    assert "devtools verify --all" in output
-    assert "narrower agreed selection" not in output
-    assert "does not grant the release-baseline authority" in output
+    assert "devtools verify" in output
+    assert "records itself" in output
 
 
 def test_train_status_reads_historical_scope_without_granting_release_authority(
@@ -1042,7 +1029,7 @@ def test_train_status_rejects_untyped_accepted_terminal_ledger(monkeypatch: pyte
                 "at": 1000.0,
                 "verification_started_at": 1000.0,
                 "duration_s": 1.0,
-                "command": "devtools verify --all",
+                "command": "devtools verify",
                 "exit_code": 0,
                 "verification_scope": None,
                 "release_baseline_allowed": True,
@@ -1076,7 +1063,7 @@ def test_record_full_verify_clears_pending_prs(monkeypatch: pytest.MonkeyPatch, 
 
     monkeypatch.setattr(subprocess, "run", _run)
 
-    exit_code = merge_boundary.cmd_record_full_verify("devtools verify --all", target_sha="merged-master")
+    exit_code = merge_boundary.cmd_record_full_verify("devtools verify", target_sha="merged-master")
 
     assert exit_code == 0
     assert merge_boundary.cmd_train_status(as_json=False) == 0
@@ -1101,7 +1088,7 @@ def test_record_full_verify_rejects_plausible_unbound_stdout(monkeypatch: pytest
         ),
     )
 
-    assert merge_boundary.cmd_record_full_verify("devtools verify --all", target_sha="merged-master") == 1
+    assert merge_boundary.cmd_record_full_verify("devtools verify", target_sha="merged-master") == 1
     assert merge_boundary._read_ledger()["last_full_verify"]["accepted"] is False
 
 
@@ -1114,7 +1101,7 @@ def test_record_full_verify_propagates_failure(monkeypatch: pytest.MonkeyPatch, 
 
     monkeypatch.setattr(subprocess, "run", _run)
 
-    exit_code = merge_boundary.cmd_record_full_verify("devtools verify --all", target_sha="merged-master")
+    exit_code = merge_boundary.cmd_record_full_verify("devtools verify", target_sha="merged-master")
 
     assert exit_code == 1
     ledger = merge_boundary._read_ledger()
@@ -1135,7 +1122,7 @@ def test_record_full_verify_rejects_success_without_structured_release_permissio
         lambda _cmd, **_kwargs: MagicMock(returncode=0, stdout="all good\n", stderr=""),
     )
 
-    assert merge_boundary.cmd_record_full_verify("devtools verify --all", target_sha="merged-master") == 1
+    assert merge_boundary.cmd_record_full_verify("devtools verify", target_sha="merged-master") == 1
     ledger = merge_boundary._read_ledger()
     assert ledger["last_full_verify"]["accepted"] is False
     assert merge_boundary.cmd_train_status(as_json=False) == 1
@@ -1156,7 +1143,7 @@ def test_record_full_verify_rejects_untyped_scope_even_when_permission_is_true(
         ),
     )
 
-    assert merge_boundary.cmd_record_full_verify("devtools verify --all", target_sha="merged-master") == 1
+    assert merge_boundary.cmd_record_full_verify("devtools verify", target_sha="merged-master") == 1
     assert merge_boundary._read_ledger()["last_full_verify"]["accepted"] is False
     assert merge_boundary.cmd_train_status(as_json=False) == 1
 
@@ -1187,7 +1174,7 @@ def test_concurrent_merge_during_terminal_verify_remains_pending(
 
     monkeypatch.setattr(subprocess, "run", run)
 
-    assert merge_boundary.cmd_record_full_verify("devtools verify --all", target_sha="merged-master") == 0
+    assert merge_boundary.cmd_record_full_verify("devtools verify", target_sha="merged-master") == 0
     assert merge_boundary.cmd_train_status(as_json=False) == 1
     ledger = merge_boundary._read_ledger()
     assert ledger["last_full_verify"]["merged_master_sha"] == "merged-master"
@@ -1223,7 +1210,7 @@ def test_concurrent_ledger_writer_cannot_lose_merge_entry(monkeypatch: pytest.Mo
         )
 
     monkeypatch.setattr(subprocess, "run", run)
-    assert merge_boundary.cmd_record_full_verify("devtools verify --all", target_sha="merged-master") == 0
+    assert merge_boundary.cmd_record_full_verify("devtools verify", target_sha="merged-master") == 0
     assert writer is not None
     writer.join(timeout=1)
     assert not writer.is_alive()
@@ -1235,37 +1222,31 @@ def test_concurrent_ledger_writer_cannot_lose_merge_entry(monkeypatch: pytest.Mo
 def test_terminal_snapshot_is_taken_before_default_branch_fetch(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
+    """A merge landing during the target fetch must stay pending in the ledger.
+
+    cmd_merge --with-verify snapshots the reconciled ledger BEFORE fetching
+    the merged default branch; this pins that ordering at the seams it uses.
+    """
     monkeypatch.chdir(tmp_path)
     events: list[str] = []
-    snapshots: list[tuple[dict[str, Any], float, int]] = []
 
     original_snapshot = merge_boundary._terminal_verify_snapshot
 
     def snapshot() -> tuple[dict[str, Any], float, int]:
         events.append("ledger-snapshot")
-        captured = original_snapshot()
-        snapshots.append(captured)
-        return captured
+        return original_snapshot()
 
     def fetch() -> str:
         events.append("target-fetch")
         merge_boundary._append_merge_entry(88, "after-fetch-sha", "merge after target fetch")
         return "merged-master"
 
-    def post_verify(
-        _command: str, _target: str, *, ledger_snapshot: tuple[dict[str, Any], float, int] | None = None
-    ) -> int:
-        assert ledger_snapshot is not None
-        assert ledger_snapshot[2] == 0
-        return 1
-
     monkeypatch.setattr(merge_boundary, "_terminal_verify_snapshot", snapshot)
-    monkeypatch.setattr(merge_boundary, "_fetched_current_default_branch_sha", fetch)
-    monkeypatch.setattr(merge_boundary, "_run_post_merge_terminal_verify", post_verify)
+    ledger_snapshot = merge_boundary._reconciled_terminal_verify_snapshot()
+    fetch()
 
-    assert merge_boundary.main(["record-full-verify", "--command", "devtools verify --all"]) == 1
     assert events == ["ledger-snapshot", "target-fetch"]
-    assert snapshots[0][2] == 0
+    assert ledger_snapshot[2] == 0
     assert merge_boundary.cmd_train_status(as_json=False) == 1
 
 
@@ -1298,7 +1279,7 @@ def test_external_merge_before_completion_is_reconciled_from_durable_intent(
             poll_interval_s=0,
             dry_run=False,
             with_verify=False,
-            verify_command="devtools verify --all",
+            verify_command="devtools verify",
         )
         == 0
     )
@@ -1321,20 +1302,9 @@ def test_record_full_verify_reconciles_durable_intents_before_snapshot(
         "_gh_json",
         lambda _args: {"state": "MERGED", "mergeCommit": {"oid": "merge-commit"}},
     )
-    monkeypatch.setattr(merge_boundary, "_fetched_current_default_branch_sha", lambda: "merged-master")
-    snapshots: list[tuple[dict[str, Any], float, int]] = []
+    snapshot = merge_boundary._reconciled_terminal_verify_snapshot()
 
-    def post_verify(
-        _command: str, _target: str, *, ledger_snapshot: tuple[dict[str, Any], float, int] | None = None
-    ) -> int:
-        assert ledger_snapshot is not None
-        snapshots.append(ledger_snapshot)
-        return 0
-
-    monkeypatch.setattr(merge_boundary, "_run_post_merge_terminal_verify", post_verify)
-
-    assert merge_boundary.main(["record-full-verify", "--command", "devtools verify --all"]) == 0
-    assert snapshots[0][2] == 1
+    assert snapshot[2] == 1
     assert not merge_boundary._read_ledger()["merge_intents"]
 
 
@@ -1380,7 +1350,7 @@ def test_terminal_verify_runs_in_place_when_head_matches_clean_target(
 
     monkeypatch.setattr(subprocess, "run", run)
     monkeypatch.setattr(merge_boundary, "cmd_record_full_verify", record)
-    assert merge_boundary._run_post_merge_terminal_verify("devtools verify --all", "merged-master") == 0
+    assert merge_boundary._run_post_merge_terminal_verify("devtools verify", "merged-master") == 0
     assert seen["cwd"] == tmp_path
     assert seen["execution_root"] == tmp_path
 
@@ -1402,7 +1372,7 @@ def test_detached_worktree_add_failure_attempts_cleanup(monkeypatch: pytest.Monk
         raise AssertionError(cmd)
 
     monkeypatch.setattr(subprocess, "run", run)
-    assert merge_boundary._run_post_merge_terminal_verify("devtools verify --all", "merged-master") == 1
+    assert merge_boundary._run_post_merge_terminal_verify("devtools verify", "merged-master") == 1
     assert any(command[:3] == ["git", "worktree", "remove"] for command in commands)
 
 
@@ -1422,14 +1392,13 @@ def test_detached_worktree_cleanup_failure_is_explicit(monkeypatch: pytest.Monke
 
     monkeypatch.setattr(subprocess, "run", run)
     monkeypatch.setattr(merge_boundary, "cmd_record_full_verify", lambda *_args, **_kwargs: 0)
-    assert merge_boundary._run_post_merge_terminal_verify("devtools verify --all", "merged-master") == 1
+    assert merge_boundary._run_post_merge_terminal_verify("devtools verify", "merged-master") == 1
 
 
-def test_manual_record_route_fetches_target_and_rejects_stale_cli_output(
+def test_terminal_record_rejects_stale_cli_output_for_fetched_target(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.chdir(tmp_path)
-    post_targets: list[str] = []
 
     def run(cmd: list[str], **_kwargs: Any) -> MagicMock:
         if cmd[:3] == ["gh", "repo", "view"]:
@@ -1450,13 +1419,9 @@ def test_manual_record_route_fetches_target_and_rejects_stale_cli_output(
             stderr="",
         )
 
-    def post_verify(command: str, target_sha: str, **_kwargs: Any) -> int:
-        post_targets.append(target_sha)
-        return merge_boundary.cmd_record_full_verify(command, target_sha=target_sha)
-
     monkeypatch.setattr(subprocess, "run", run)
-    monkeypatch.setattr(merge_boundary, "_run_post_merge_terminal_verify", post_verify)
+    target_sha = merge_boundary._fetched_current_default_branch_sha()
 
-    assert merge_boundary.main(["record-full-verify", "--command", "devtools verify --all"]) == 1
-    assert post_targets == ["current-master"]
+    assert target_sha == "current-master"
+    assert merge_boundary.cmd_record_full_verify("devtools verify", target_sha=target_sha) == 1
     assert merge_boundary._read_ledger()["last_full_verify"]["accepted"] is False

--- a/tests/unit/devtools/test_merge_gate.py
+++ b/tests/unit/devtools/test_merge_gate.py
@@ -257,13 +257,12 @@ def test_check_rejects_successful_non_test_receipt(monkeypatch: pytest.MonkeyPat
     assert merge_gate.cmd_check(42, max_age_s=3600, poll_rounds=1, poll_interval_s=0, as_json=False) == 1
 
 
-@pytest.mark.parametrize("command", ["devtools verify --all", "devtools verify --full"])
 def test_check_blocks_full_receipt_without_release_baseline_permission(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, command: str
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.chdir(tmp_path)
     pr_view = _base_pr_view()
-    _record(monkeypatch, pr_view, command=command)
+    _record(monkeypatch, pr_view, command="devtools verify")
     receipt_path = merge_gate._receipt_path(42)
     receipt = json.loads(receipt_path.read_text())
     receipt["verification_scope"] = "release-baseline"
@@ -656,7 +655,7 @@ def test_check_rejects_command_text_without_typed_scope_or_permission(
 ) -> None:
     monkeypatch.chdir(tmp_path)
     pr_view = _base_pr_view()
-    _record(monkeypatch, pr_view, command="devtools verify --all")
+    _record(monkeypatch, pr_view, command="devtools verify")
     receipt_path = merge_gate._receipt_path(42)
     receipt = json.loads(receipt_path.read_text())
     receipt["verification_scope"] = None

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -110,7 +110,7 @@ def test_quick_verify_omits_pytest() -> None:
     ("mode", "selection_flag"),
     # "full" selects incrementally since the 2026-08-18 overhaul: recorded
     # unchanged-green tests are attested coverage, not re-execution fodder.
-    [("affected", "--testmon-forceselect"), ("bootstrap", "--testmon-noselect"), ("full", "--testmon-forceselect")],
+    [("bootstrap", "--testmon-noselect"), ("full", "--testmon-forceselect")],
 )
 def test_native_testmon_uses_exactly_two_semantic_lanes(
     monkeypatch: pytest.MonkeyPatch,
@@ -153,7 +153,7 @@ def test_native_testmon_uses_exactly_two_semantic_lanes(
         assert "--override-ini=norecursedirs=" in command
 
 
-@pytest.mark.parametrize("mode", ["affected", "bootstrap", "full"])
+@pytest.mark.parametrize("mode", ["bootstrap", "full"])
 def test_native_lane_command_contract_rejects_unowned_selectors(
     monkeypatch: pytest.MonkeyPatch,
     mode: str,
@@ -3024,7 +3024,7 @@ def test_run_propagates_pytest_addopts_basetemp_to_resource_policy(
     assert captured["POLYLOGUE_PYTEST_EXPLICIT_BASETEMP"] == str(explicit)
 
 
-@pytest.mark.parametrize("mode", ["affected", "bootstrap", "full"])
+@pytest.mark.parametrize("mode", ["bootstrap", "full"])
 def test_managed_native_lane_removes_environment_addopts_before_pytest(
     monkeypatch: pytest.MonkeyPatch,
     mode: str,
@@ -3271,10 +3271,12 @@ def test_run_receipt_uses_capped_pytest_command_concurrency() -> None:
     ("label", "full_suite"),
     [
         ("pytest focused", False),
-        ("pytest native parallel (affected)", False),
-        ("pytest native serial (affected)", False),
+        # A "(full)" lane over a valid graph selects narrowly; only a
+        # bootstrap lane is full-suite-shaped by label alone.
+        ("pytest native parallel (full)", False),
+        ("pytest native serial (full)", False),
         ("pytest native parallel (bootstrap)", True),
-        ("pytest native serial (full)", True),
+        ("pytest native serial (bootstrap)", True),
     ],
 )
 def test_run_scopes_measured_full_suite_basetemp_demand(tmp_path: Path, label: str, full_suite: bool) -> None:
@@ -4481,7 +4483,7 @@ def test_preparation_mutation_withholds_release_authority_after_restoration(
         patch("devtools.verify._save_history"),
         patch("devtools.verify._notify"),
     ):
-        assert main(["--all", "--json"]) == 125
+        assert main(["--json"]) == 125
 
     payload = json.loads(capsys.readouterr().out)
     assert payload["release_baseline_allowed"] is False


### PR DESCRIPTION
## Summary
`devtools verify` is now the one verification command: complete-corpus scope, incremental execution (changed-dependency + never-recorded + previously-failing tests), attested coverage for the rest, and release-baseline authority granted by whatever coverage the run earns. `--all`/`--full` and the `devtools workspace merge record-full-verify --command "devtools verify --all"` incantation are deleted; the merge-train terminal ledger step records itself from any accepted plain verify at origin/master.

## Problem
The operator asked why the terminal step was a separate flag-plus-wrapper incantation at all ("this probably should not be --all... Why not just devtools verify?"). With #3991's attested coverage, `--all`'s reason to exist (quarantining an expensive exhaustive mode) had already died. Folding it exposed three soundness gaps this PR also closes:
- A graph's row set is blind to its own losses: an interrupted lane or damaged rows shrink the corpus AND the coverage claim together, so a warm run would attest a hole it cannot see. (The #3993 file-level collection override attempted this but is unsound under xdist: per-test deselection is inert on workers, so parallel lanes re-executed everything — measured in the lifecycle fixtures.)
- Runs with named exposure (incomplete graph, untraceable runtime-data changes) could attest tests whose recorded greens predate the change.
- The bootstrap-vs-affected scope asymmetry (green bootstrap authorized less than green affected) blocked plain verify from ever granting release authority.

## Solution
- **Certified corpus** (`polylogue_certified_corpus` table beside the graph): a completed covered run certifies its node set; `prepare_native_testmon_environment` refuses attestation (forcing a re-executing, re-certifying bootstrap) when certified tests are missing from the graph or no certificate exists. Deleted test files are legitimately gone.
- **Exposure withholds attestation** (`attestation_sound` in the aggregate): incomplete pre-run graph or runtime-data changes → nothing attested; if the run still executed the whole corpus the exposure is paid and planned scope stands, otherwise the receipt downgrades to affected scope (merge-authorizing, never release-granting).
- All native lanes force the complete Hypothesis profile (all can grant authority now).
- Ledger self-recording: `record_accepted_terminal_verify` writes the terminal entry when an accepted release-baseline verify ran at origin/master; `record-full-verify` subcommand deleted, `--with-verify` defaults to `devtools verify`, reminder texts updated.
- Basetemp: only bootstrap lanes are full-suite-shaped by label; duration estimation treats pre-fold history tiers as the same population.
- Docs: CLAUDE.md, TESTING.md, CONTRIBUTING.md. (pyproject.toml's stale marker text is deliberately deferred — it is an environment-digest input and a cosmetic edit would invalidate every graph.)

## Verification
- `devtools test tests/integration/devtools/test_native_testmon_lifecycle.py` — 40 passed, 1 order-dependent flake that passes 7/7 standalone (`test_production_verify_all_neutralizes_external_pytest_addopts`). Includes new interrupted-graph phase: deleting recorded rows after a completed run forces `attestation refused, re-executing corpus` and a re-certifying bootstrap.
- `devtools test tests/unit/devtools/{test_verify,test_testmon_bootstrap,test_merge_boundary,test_merge_gate,test_why,test_pytest_progress_plugin}.py` — 360 passed.
- `devtools verify --quick` — green (pre-push hook output in the branch push).
- Not run pre-merge: complete corpus (the first post-merge `devtools verify` is the fold's own live validation and records the train ledger).

## Scope
```json
{"carrier": "pr-scope", "version": 2, "kind": "self_contained", "assigned_beads": [], "mutated_beads": [], "dispositions": [], "evidence": [], "successors": []}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWcPJJJvuF25CqVwTFgSQC