### PR TITLE
fix(verify): one canonical test nodeid across lane shapes

### DIFF
--- a/devtools/testmon_bootstrap.py
+++ b/devtools/testmon_bootstrap.py
@@ -733,6 +733,22 @@ def inspect_native_testmon_environment(
     return NativeTestmonState("valid", "native environment is current", environment)
 
 
+def canonical_test_nodeid(nodeid: str) -> str:
+    """One id per test across lane shapes.
+
+    xdist loadgroup runs record ``path::test[param]@group`` while single-process
+    lanes record ``path::test[param]``; graph rows, certificates, and coverage
+    math must compare on ONE form or every cross-shape comparison invents
+    phantom missing/attested tests (509 of them, observed 2026-08-18). Only a
+    trailing ``@group`` outside any param bracket is stripped, so params that
+    themselves contain ``@`` survive.
+    """
+    base, sep, suffix = nodeid.rpartition("@")
+    if sep and suffix and "]" not in suffix and ":" not in suffix and "/" not in suffix:
+        return base
+    return nodeid
+
+
 _CERTIFIED_CORPUS_TABLE = "polylogue_certified_corpus"
 
 
@@ -770,7 +786,7 @@ def write_certified_corpus(repo_root: Path, environment_name: str, nodeids: Iter
     data_path = repo_root.resolve() / TESTMON_DATA_RELPATH
     if not data_path.exists():
         return False
-    payload = json.dumps(sorted(set(nodeids)))
+    payload = json.dumps(sorted({canonical_test_nodeid(nodeid) for nodeid in nodeids}))
     try:
         with contextlib.closing(sqlite3.connect(data_path)) as connection:
             connection.execute(
@@ -810,7 +826,12 @@ def certified_attestation_violation(
     certified = read_certified_corpus(root / TESTMON_DATA_RELPATH, environment_name)
     if certified is None:
         return "no completed covered run has certified this environment's corpus"
-    lost = {nodeid for nodeid in certified.difference(current_nodeids) if (root / nodeid.split("::", 1)[0]).is_file()}
+    current = {canonical_test_nodeid(nodeid) for nodeid in current_nodeids}
+    lost = {
+        nodeid
+        for nodeid in {canonical_test_nodeid(entry) for entry in certified} - current
+        if (root / nodeid.split("::", 1)[0]).is_file()
+    }
     if lost:
         sample = ", ".join(sorted(lost)[:5])
         return f"{len(lost)} certified test(s) are missing from the graph (e.g. {sample})"

--- a/devtools/verify_runs.py
+++ b/devtools/verify_runs.py
@@ -30,6 +30,7 @@ from typing import Any, Final, ParamSpec, TextIO, TypeVar
 import watchfiles
 
 from devtools.cloud_sentinels import CLOUD_SENTINELS, running_in_cloud_sandbox
+from devtools.testmon_bootstrap import canonical_test_nodeid
 from polylogue.core.metrics import read_cgroup_memory_headroom_bytes
 
 VERIFY_CACHE = Path(".cache/verify")
@@ -1402,12 +1403,13 @@ def aggregate_native_testmon_run(
 
     for outcome in outcome_by_node.values():
         outcomes[outcome] = outcomes.get(outcome, 0) + 1
-    native_corpus = tuple(sorted(set(corpus_nodeids)))
+    native_corpus = tuple(sorted({canonical_test_nodeid(nodeid) for nodeid in corpus_nodeids}))
     complete_mode = selection_mode in {"bootstrap", "full"}
     corpus = native_corpus
     corpus_set = set(corpus)
     lane_names = [lane["lane"] for lane in lanes]
-    executed_nodes = set(outcome_by_node)
+    executed_nodes = {canonical_test_nodeid(nodeid) for nodeid in outcome_by_node}
+    selected_union = {canonical_test_nodeid(nodeid) for nodeid in selected_union}
     # "full" now runs under forceselect: a graph-recorded test testmon did not
     # select is attested by its unchanged recorded deps and green last outcome
     # (testmon always reselects failures), so coverage = executed now UNION

--- a/tests/unit/devtools/test_testmon_bootstrap.py
+++ b/tests/unit/devtools/test_testmon_bootstrap.py
@@ -10,6 +10,7 @@ from devtools.testmon_bootstrap import (
     NativeTestmonDeadlineError,
     NativeTestmonRepairError,
     _testmon_schema_version,
+    canonical_test_nodeid,
     classify_native_testmon_changes,
     classify_source_ast,
     executable_python_paths,
@@ -658,3 +659,20 @@ def test_an_interrupted_bootstrap_does_not_delete_every_environments_graph(tmp_p
     with sqlite3.connect(data) as connection:
         rows = connection.execute("SELECT COUNT(*) FROM environment").fetchone()
     assert rows[0] == 1, "other environments' rows must be untouched"
+
+
+@pytest.mark.parametrize(
+    ("nodeid", "canonical"),
+    [
+        ("tests/test_a.py::test_plain", "tests/test_a.py::test_plain"),
+        ("tests/test_a.py::test_p[chatgpt]@chatgpt", "tests/test_a.py::test_p[chatgpt]"),
+        ("tests/test_a.py::test_p[user@example.com]", "tests/test_a.py::test_p[user@example.com]"),
+        ("tests/test_a.py::test_p[a@b]@group", "tests/test_a.py::test_p[a@b]"),
+        ("tests/test_a.py::test_p[x]", "tests/test_a.py::test_p[x]"),
+    ],
+)
+def test_canonical_test_nodeid_strips_only_loadgroup_suffix(nodeid: str, canonical: str) -> None:
+    # xdist loadgroup lanes record `id@group`, single-process lanes record `id`;
+    # comparing across shapes without one canonical form invented 509 phantom
+    # missing/attested tests and a permanent re-execution treadmill.
+    assert canonical_test_nodeid(nodeid) == canonical


### PR DESCRIPTION
## Summary
Canonicalize test nodeids (strip the xdist loadgroup `@group` suffix) in the certificate write/check and the coverage aggregate's corpus/executed/selected sets.

## Problem
xdist loadgroup lanes record `test[chatgpt]@chatgpt`; single-process lanes record `test[chatgpt]`. Mixing the forms produced 509 phantom corpus rows that every full run reported as attested-never-executed, and — once corpus certificates existed (#3994) — a permanent re-execution treadmill: the certificate held both forms, the graph held one, and the subset check refused attestation with `509 certified test(s) are missing from the graph` on every warm run (observed live, two consecutive ~35-minute full re-executions).

## Solution
`canonical_test_nodeid` strips exactly one trailing `@group` outside any param bracket (params containing `@` survive; pinned in `test_canonical_test_nodeid_strips_only_loadgroup_suffix`). Applied at certificate write, certificate violation check, and the aggregate's corpus/executed/selected normalization. Live certificates for all four environments rewritten canonically (active env: 21,027 → 20,518 rows — the 509 collapse measured directly).

## Verification
- `devtools test tests/unit/devtools/test_testmon_bootstrap.py tests/unit/devtools/test_verify.py tests/unit/devtools/test_merge_boundary.py` — 299 passed.
- The post-merge plain `devtools verify` (next step) is the live validation: with canonical certificates it must run warm, reselect only the 4 recorded standalone-green flakes plus changed-file dependents, and self-record the merge-train terminal ledger entry.

## Scope
```json
{"carrier": "pr-scope", "version": 2, "kind": "self_contained", "assigned_beads": [], "mutated_beads": [], "dispositions": [], "evidence": [], "successors": []}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWcPJJJvuF25CqVwTFgSQC