### PR TITLE
docs: fix stale devtools verify --all reference; point at campaign control plane

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,6 +322,17 @@ source-origin public filters or payloads.
 
 These override default agent behavior.
 
+### Active campaign: devtools/harness overhaul → reindex readiness
+
+A multi-week campaign is coordinated from a gitignored control plane at
+`.agent/campaigns/2026-08-overhaul/` (`INDEX.md` first — reload protocol,
+workstream table, next action). If asked to continue "the campaign" or "the
+overhaul," read that before anything else; it supersedes the reindex plan and
+raw bead scanning for sequencing. The one rule that changes default behavior:
+**for this campaign, individual Beads are references, not units of work** —
+ship large thematic PRs per workstream and close many beads at once with
+evidence, rather than one bead per PR.
+
 ### Beads issue tracking
 
 This repo uses `bd` (Beads) for durable task state AND as the devloop: `bd
@@ -677,7 +688,8 @@ Core loop:
   changing docs, CLI help, or schema. **Gotcha:** `render all --check` can print
   per-surface `sync OK` yet still exit 1 — grep the output for `out of sync`,
   don't trust the tail line.
-- `devtools verify [--quick|--all|--lab]` — see
+- `devtools verify [--quick|--lab]` — plain (no flag) is the complete-corpus
+  attested gate; see
   [Verification](#verification--testmon-inner-loop-never-blanket-run).
 - `devtools test <sel>` — focused pytest through the managed harness. Forwards
   arbitrary pytest args and is faster than bare pytest; see Verification.


### PR DESCRIPTION
## Summary
- Fix a self-contradiction in CLAUDE.md: the devtools core-loop bullet still
  listed `devtools verify --all` two paragraphs after the file's own
  Verification section says "There is no --all flag anymore" (both accurate
  post the 2026-08-18 --all fold; the bullet was simply missed at the time).
- Add a short pointer to the new gitignored campaign control plane at
  `.agent/campaigns/2026-08-overhaul/` so a fresh session asked to continue
  "the campaign" finds it before re-deriving state from beads.

## Problem
Found while auditing CLAUDE.md for the campaign; the stale flag reference
would mislead an agent into trying `--all` again.

## Solution
Two small, independent doc edits in CLAUDE.md; no code changes.

## Verification
`devtools verify --quick` — exit 0, all static gates green.

## Bead disposition
Self-contained; no Beads assigned or mutated.

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->
