### PR TITLE
chore(agents): lane self-provisions its worktree via lane-init adopt

### DIFF
--- a/.claude/agents/lane.md
+++ b/.claude/agents/lane.md
@@ -10,6 +10,24 @@ your own isolated git worktree. This file is your standing contract — it
 applies to every task you are given here, in addition to whatever
 task-specific instructions accompany the dispatch.
 
+## Step 0 — self-provision (before ANY other command)
+
+Harness-created worktrees reuse the shared venv, and the checkout guard
+refuses devtools/pytest there. Provision this worktree first, every time:
+
+```
+branch="$(git branch --show-current)"
+[ -n "$branch" ] || { branch="lane/$(basename "$PWD")"; git checkout -b "$branch"; }
+devtools workspace lane-init "$PWD" --branch "$branch"
+export VIRTUAL_ENV="$PWD/.venv"; export PATH="$PWD/.venv/bin:$PATH"
+```
+
+lane-init adopts an existing worktree (measured 2026-08-19: ~5s with a warm
+uv cache — venv, checkout-guard verification, warm testmon-graph seed,
+ledger registration). If it fails, STOP and report the error — do not run
+devtools/pytest from an unprovisioned worktree, and do not work around the
+guard.
+
 ## Worktree discipline
 
 - Confirm your current branch is not `master` before doing anything


### PR DESCRIPTION
## Summary

The `lane` agent contract now self-provisions its worktree (Step 0: `devtools
workspace lane-init "$PWD"` + venv env export) before running anything, and
refuses to proceed if provisioning fails.

## Problem

Harness-created worktrees (Agent-tool `isolation: worktree` and Workflow
worktree agents alike) skip `lane-init`, so the lane reuses the shared venv;
the editable-install `.pth` points at the main checkout and the checkout
guard refuses every `devtools`/`pytest` invocation (exit 125). The contract's
Verification section assumed devtools works in the lane, but nothing
provisioned it — a lane dispatched through the harness could not verify its
own work.

## Solution

`lane-init` already adopts an existing worktree (`_ensure_worktree` probes
`git rev-parse --show-toplevel` and proceeds straight to provisioning), so no
devtools change was needed — the contract gains a mandatory Step 0 invoking
it, with a branch fallback for detached-HEAD harness worktrees, and a hard
stop on failure ("do not work around the guard"). One mechanism covers both
Agent-tool lanes and Workflow `agentType: lane` worktrees.

## Verification

Live end-to-end on this host (2026-08-19): `git worktree add
/realm/worktrees/lane-adopt-proof` → `devtools workspace lane-init
/realm/worktrees/lane-adopt-proof --branch lane/adopt-proof --json` →
`"status": "provisioned", "venv": true, "testmon_graph": "seeded from main
checkout (lane verifies start warm)"` in **4.9s** (warm uv cache), then
`devtools status` inside the lane with the lane venv on PATH → exit 0.
Worktree removed after the proof. Not run: no test-suite gate — the change
is an agent-contract markdown file outside every digest input and every
production route.

## Bead disposition

Self-contained; no beads assigned or mutated.

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->
