### PR TITLE
refactor: collapse four small verified dedups (WS-F F2)

### DIFF
--- a/polylogue/core/payload_coercion.py
+++ b/polylogue/core/payload_coercion.py
@@ -148,6 +148,32 @@ def row_int(value: object) -> int:
     return 0
 
 
+def row_iso_from_epoch_ms(value: object) -> str | None:
+    """Coerce an epoch-millisecond row value to a UTC ISO-8601 string, or None.
+
+    None, bool, and unparseable strings all coerce to None rather than a
+    default timestamp -- callers with a non-optional field pre-coerce with
+    :func:`row_int` (which always yields a plain ``int``) so this always
+    returns a string for them.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        epoch_ms = value
+    elif isinstance(value, float):
+        epoch_ms = int(value)
+    elif isinstance(value, str):
+        try:
+            epoch_ms = int(value)
+        except ValueError:
+            return None
+    else:
+        return None
+    return datetime.fromtimestamp(epoch_ms / 1000.0, UTC).isoformat()
+
+
 def row_float(value: object) -> float | None:
     """Coerce a value to float or None; strict on bool (returns None)."""
     if isinstance(value, bool):
@@ -203,6 +229,7 @@ __all__ = [
     "required_str",
     "row_float",
     "row_int",
+    "row_iso_from_epoch_ms",
     "string_int_mapping",
     "string_sequence",
 ]

--- a/polylogue/daemon/catchup_status.py
+++ b/polylogue/daemon/catchup_status.py
@@ -6,6 +6,7 @@ import json
 import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 
 from pydantic import BaseModel, Field
 
@@ -13,6 +14,7 @@ from polylogue.core.payload_coercion import optional_str as _optional_str
 from polylogue.core.payload_coercion import required_str as _required_str
 from polylogue.core.payload_coercion import row_float as _row_float
 from polylogue.core.payload_coercion import row_int as _row_int
+from polylogue.core.payload_coercion import row_iso_from_epoch_ms as _iso_from_epoch_ms
 from polylogue.logging import get_logger
 from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 
@@ -221,7 +223,10 @@ def _archive_catchup_stage_event_from_row(row: sqlite3.Row | tuple[object, ...])
     return CatchupStageEvent(
         attempt_id=_required_str(row[1]),
         sequence=_row_int(row[0]),
-        observed_at=_epoch_ms_to_iso(_row_int(row[2])),
+        # Negative epoch_ms values clamp to the epoch floor, matching the
+        # previous _epoch_ms_to_iso behavior; the shared helper's int branch
+        # then always returns a string, never None.
+        observed_at=cast(str, _iso_from_epoch_ms(max(_row_int(row[2]), 0))),
         phase=_payload_str(payload, "phase", default=_required_str(row[3])),
         status=_payload_str(payload, "status", default=_required_str(row[4])),
         queued_file_count=_payload_int(payload, "queued_file_count"),
@@ -296,10 +301,6 @@ def _payload_str(payload: dict[str, object], key: str, *, default: str) -> str:
 
 def _payload_optional_str(payload: dict[str, object], key: str) -> str | None:
     return _optional_str(payload.get(key))
-
-
-def _epoch_ms_to_iso(value: int) -> str:
-    return datetime.fromtimestamp(max(value, 0) / 1000.0, tz=UTC).isoformat()
 
 
 def _catchup_mode(latest: CatchupStageEvent | None, latest_attempt: object | None, convergence: object) -> str:

--- a/polylogue/daemon/convergence_debt_status.py
+++ b/polylogue/daemon/convergence_debt_status.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 
 from pydantic import BaseModel, Field
 
 from polylogue.core.payload_coercion import optional_str as _optional_str
 from polylogue.core.payload_coercion import required_str as _required_str
 from polylogue.core.payload_coercion import row_int as _row_int
+from polylogue.core.payload_coercion import row_iso_from_epoch_ms as _iso_from_epoch_ms
 from polylogue.logging import get_logger
 from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 
@@ -125,7 +127,9 @@ def _archive_convergence_debt_summary_info(dbf: Path, ops_db: Path) -> Convergen
                 subject_id=_required_str(row[2]),
                 status=_required_str(row[3]),
                 failure_count=_row_int(row[4]),
-                last_failed_at=_iso_from_epoch_ms(row[5]),
+                # row[5] is pre-coerced to a plain int, so the shared helper's
+                # int branch always returns a string, never None.
+                last_failed_at=cast(str, _iso_from_epoch_ms(_row_int(row[5]))),
                 next_retry_at=_optional_str(row[7]),
                 retry_due=False,
                 last_error=_optional_str(row[6]),
@@ -211,11 +215,6 @@ def _summary_from_parts(
         family_summaries=family_summaries,
         recent=recent,
     )
-
-
-def _iso_from_epoch_ms(value: object) -> str:
-    epoch_ms = _row_int(value)
-    return datetime.fromtimestamp(epoch_ms / 1000, tz=UTC).isoformat()
 
 
 def _retry_due(next_retry_at: str | None, *, now: datetime) -> bool:

--- a/polylogue/daemon/cursor_lag_status.py
+++ b/polylogue/daemon/cursor_lag_status.py
@@ -31,12 +31,13 @@ from __future__ import annotations
 import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Literal
+from typing import Literal, cast
 
 from pydantic import BaseModel, Field
 
 from polylogue.core.payload_coercion import required_str as _required_str
 from polylogue.core.payload_coercion import row_int as _row_int
+from polylogue.core.payload_coercion import row_iso_from_epoch_ms as _iso_from_epoch_ms
 from polylogue.logging import get_logger
 from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 
@@ -188,7 +189,9 @@ def _archive_cursor_lag_summary_info(ops_db: Path, *, now: datetime) -> CursorLa
             row[2],
             row[3],
             row[4],
-            _iso_from_epoch_ms(row[5]),
+            # row[5] is pre-coerced to a plain int, so the shared helper's
+            # int branch always returns a string, never None.
+            cast(str, _iso_from_epoch_ms(_row_int(row[5]))),
         )
         for row in rows
     ]
@@ -405,10 +408,6 @@ def _age_seconds(iso_value: str, *, now: datetime) -> float:
     if observed.tzinfo is None:
         observed = observed.replace(tzinfo=UTC)
     return max(0.0, (now - observed.astimezone(UTC)).total_seconds())
-
-
-def _iso_from_epoch_ms(value: object) -> str:
-    return datetime.fromtimestamp(_row_int(value) / 1000.0, UTC).isoformat()
 
 
 __all__ = [

--- a/polylogue/daemon/health.py
+++ b/polylogue/daemon/health.py
@@ -209,13 +209,26 @@ def _check_heartbeat_staleness_fast() -> HealthAlert:
         )
 
 
+def disk_free_bytes(path: Path) -> int:
+    """Return free bytes on the volume containing ``path``."""
+    st = os.statvfs(str(path))
+    return st.f_frsize * st.f_bavail
+
+
+def wal_size_bytes(db_path: Path) -> int:
+    """Return the byte size of ``db_path``'s ``-wal`` sidecar, or 0 if absent."""
+    wal = db_path.with_suffix(".db-wal")
+    if not wal.exists():
+        return 0
+    return wal.stat().st_size
+
+
 def _check_disk_space_fast() -> HealthAlert:
     """Check free disk space on the archive volume."""
     now = datetime.now(UTC).isoformat()
     try:
         root = archive_root()
-        st = os.statvfs(str(root))
-        free = st.f_frsize * st.f_bavail
+        free = disk_free_bytes(root)
         if free >= _DISK_FREE_WARN_BYTES:
             severity = HealthSeverity.OK
             message = f"disk free: {free / (1024**3):.1f} GB"
@@ -259,7 +272,7 @@ def _check_wal_size_fast() -> HealthAlert:
                 checked_at=now,
                 consecutive_failures=_record_failure("wal_size", True),
             )
-        size = wal.stat().st_size
+        size = wal_size_bytes(dbf)
         if size < _WAL_WARN_BYTES:
             severity = HealthSeverity.OK
             message = f"WAL size: {size / (1024**2):.1f} MB"
@@ -1796,6 +1809,8 @@ __all__ = [
     "_check_hook_flow_fast",
     "_check_schema_version_fast",
     "check_health",
+    "disk_free_bytes",
     "format_health_lines",
     "resolve_health_tiers",
+    "wal_size_bytes",
 ]

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -2719,6 +2719,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
 
     def _handle_health(self) -> None:
         from polylogue.config import load_polylogue_config
+        from polylogue.daemon.health import disk_free_bytes, wal_size_bytes
         from polylogue.paths import archive_root
         from polylogue.storage.archive_identity import resolve_active_index_path
         from polylogue.storage.sqlite.archive_tiers.index import INDEX_SCHEMA_VERSION
@@ -2726,16 +2727,10 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
 
         dbp = resolve_active_index_path(archive_root())
         db_size = dbp.stat().st_size if dbp.exists() else 0
-        wal_size = 0
-        wal = dbp.with_suffix(".db-wal")
-        if wal.exists():
-            wal_size = wal.stat().st_size
+        wal_size = wal_size_bytes(dbp)
         disk_free = 0
-        try:
-            st = os.statvfs(str(dbp.parent))
-            disk_free = st.f_frsize * st.f_bavail
-        except OSError:
-            pass
+        with contextlib.suppress(OSError):
+            disk_free = disk_free_bytes(dbp.parent)
 
         quick_check_ok = True
         try:

--- a/polylogue/daemon/metrics.py
+++ b/polylogue/daemon/metrics.py
@@ -391,29 +391,39 @@ def _convergence_debt_by_stage(conn: sqlite3.Connection, *, ops_db: Path | None 
 
 
 def _ops_convergence_debt_by_stage(ops_db: Path | None) -> list[tuple[str, str, int]]:
+    """Return (stage, status, count) triples from the durable ops-tier ledger.
+
+    Delegates to :func:`convergence_debt_status.convergence_debt_summary_info`
+    -- the same projection ``polylogue ops status`` and the ``/health``
+    envelope already use -- instead of re-running the ``GROUP BY stage,
+    status`` query by hand. This is NOT a pure drop-in for the query it
+    replaces: that projection validates every row's ``status`` against the
+    closed ``{failed, deferred}`` vocabulary and requires ``stage`` to be
+    non-NULL, raising internally (caught, logged, and surfaced as
+    ``available=False``) if the table ever contains something else, whereas
+    the raw SQL this replaces passed any stage/status value through
+    verbatim (coercing NULLs to the string ``"unknown"``). In the normal
+    case -- a convergence_debt table containing only failed/deferred rows
+    with a populated stage -- the two are equivalent; only already-anomalous
+    data changes behavior, and it changes toward surfacing the anomaly
+    (a warning + empty metrics) rather than silently minting an "unknown"
+    bucket.
+    """
     if ops_db is None or not ops_db.exists():
         return []
-    from polylogue.storage.sqlite.connection_profile import open_readonly_connection
+    from polylogue.daemon.convergence_debt_status import convergence_debt_summary_info
 
-    try:
-        conn = open_readonly_connection(ops_db)
-        try:
-            if not _table_exists(conn, "convergence_debt"):
-                return []
-            rows = conn.execute(
-                """
-                SELECT stage, status, COUNT(*)
-                FROM convergence_debt
-                GROUP BY stage, status
-                ORDER BY stage, status
-                """
-            ).fetchall()
-        finally:
-            conn.close()
-    except sqlite3.Error as exc:
-        logger.warning("metrics: ops convergence-debt-by-stage query failed for %s: %s", ops_db, exc, exc_info=True)
+    summary = convergence_debt_summary_info(ops_db, ops_db=ops_db)
+    if not summary.available:
         return []
-    return [(str(row[0] or "unknown"), str(row[1] or "unknown"), int(row[2] or 0)) for row in rows]
+    rows: list[tuple[str, str, int]] = []
+    for stage_summary in summary.stage_summaries:
+        if stage_summary.failed_count:
+            rows.append((stage_summary.stage, "failed", stage_summary.failed_count))
+        if stage_summary.deferred_count:
+            rows.append((stage_summary.stage, "deferred", stage_summary.deferred_count))
+    rows.sort()
+    return rows
 
 
 def _fts_trigger_presence(conn: sqlite3.Connection) -> dict[str, bool]:

--- a/polylogue/daemon/provenance.py
+++ b/polylogue/daemon/provenance.py
@@ -30,10 +30,10 @@ import base64
 import os
 import sqlite3
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Final
 
+from polylogue.core.payload_coercion import row_iso_from_epoch_ms as _iso_from_epoch_ms
 from polylogue.core.raw_state import raw_state_authority
 from polylogue.logging import get_logger
 from polylogue.paths import archive_root
@@ -86,25 +86,6 @@ def _display_source_path(raw_path: str | None) -> str | None:
     if home and home != "/" and (raw_path == home or raw_path.startswith(home + os.sep)):
         return "~" + raw_path[len(home) :]
     return raw_path
-
-
-def _iso_from_epoch_ms(value: object) -> str | None:
-    if value is None:
-        return None
-    if isinstance(value, bool):
-        return None
-    if isinstance(value, int):
-        epoch_ms = value
-    elif isinstance(value, float):
-        epoch_ms = int(value)
-    elif isinstance(value, str):
-        try:
-            epoch_ms = int(value)
-        except ValueError:
-            return None
-    else:
-        return None
-    return datetime.fromtimestamp(epoch_ms / 1000.0, UTC).isoformat()
 
 
 def _fetch_archive_provenance_row(

--- a/polylogue/storage/repository/insight/profile_reads.py
+++ b/polylogue/storage/repository/insight/profile_reads.py
@@ -74,6 +74,45 @@ class RepositoryInsightProfileReadMixin:
     ) -> list[SessionProfileRecord]:
         return await self.queries._list_session_profiles_query(query)
 
+    def _build_session_profile_list_query(
+        self,
+        *,
+        origin: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        first_message_since: str | None = None,
+        first_message_until: str | None = None,
+        session_date_since: str | None = None,
+        session_date_until: str | None = None,
+        min_wallclock_seconds: int | None = None,
+        max_wallclock_seconds: int | None = None,
+        workflow_shape: str | None = None,
+        terminal_state: str | None = None,
+        sort: str = "source",
+        tier: str = "merged",
+        limit: int | None = 50,
+        offset: int = 0,
+        query: str | None = None,
+    ) -> SessionProfileListQuery:
+        return SessionProfileListQuery(
+            origin=origin,
+            since=since,
+            until=until,
+            first_message_since=first_message_since,
+            first_message_until=first_message_until,
+            session_date_since=session_date_since,
+            session_date_until=session_date_until,
+            min_wallclock_seconds=min_wallclock_seconds,
+            max_wallclock_seconds=max_wallclock_seconds,
+            workflow_shape=workflow_shape,
+            terminal_state=terminal_state,
+            sort=sort,
+            tier=tier,
+            limit=limit,
+            offset=offset,
+            query=query,
+        )
+
     async def list_session_profiles(
         self,
         *,
@@ -95,7 +134,7 @@ class RepositoryInsightProfileReadMixin:
         query: str | None = None,
     ) -> list[SessionProfile]:
         records = await self._list_session_profile_records_query(
-            SessionProfileListQuery(
+            self._build_session_profile_list_query(
                 origin=origin,
                 since=since,
                 until=until,
@@ -137,7 +176,7 @@ class RepositoryInsightProfileReadMixin:
         query: str | None = None,
     ) -> list[SessionProfileRecord]:
         return await self._list_session_profile_records_query(
-            SessionProfileListQuery(
+            self._build_session_profile_list_query(
                 origin=origin,
                 since=since,
                 until=until,
@@ -178,7 +217,7 @@ class RepositoryInsightProfileReadMixin:
         query: str | None = None,
     ) -> list[SessionProfileRecord]:
         return await self._list_session_profile_records_query(
-            SessionProfileListQuery(
+            self._build_session_profile_list_query(
                 origin=origin,
                 since=since,
                 until=until,


### PR DESCRIPTION
## Summary

WS-F F2 (`.agent/campaigns/2026-08-overhaul/ws-f-shrink.md`, plan 2B.4):
four small, independently-verified dedups. Each collapses a duplicated
computation into one place; each is verified against master with the
exact recipe command before editing (all four anchors were re-verified
live and matched the ledger's line references within a few lines).

## Problem

Four small pieces of logic were each hand-rolled at multiple call sites
with no shared helper, named in the WS-F ledger as low-risk/high-confidence
dedup targets ahead of the larger F3-F5 structural work.

## Solution

1. **epoch_ms → ISO8601** (`core/payload_coercion.py`): four call sites
   each reimplemented the same epoch-millisecond → UTC ISO8601 string
   conversion — `convergence_debt_status.py:216`, `cursor_lag_status.py:410`,
   `catchup_status.py:301` (with an extra `max(value, 0)` floor clamp), and
   `daemon/provenance.py:91` (the most defensive variant: None/bool/
   unparseable inputs coerce to `None` instead of a default timestamp).
   Added `row_iso_from_epoch_ms` adopting provenance.py's defensive body,
   since it is a strict superset of what the other three need. The three
   non-optional callers pre-coerce with the existing `row_int` (which never
   returns `None`) before calling it, so the shared helper's `int` branch
   always returns a string for them — documented with a one-line comment at
   each `cast(str, ...)` call site rather than a silent unchecked cast.
2. **`SessionProfileListQuery` forwarders** (`storage/repository/insight/profile_reads.py`):
   `list_session_profiles`, `list_session_profile_records`, and
   `list_session_enrichment_records` each hand-rolled the same
   `SessionProfileListQuery(...)` construction block (15-17 lines apiece).
   Added `_build_session_profile_list_query` as the one place that
   constructs the query object; all three call it instead.
3. **`daemon/http.py::_handle_health`** inline `statvfs`/WAL-size math:
   duplicated the same byte computation `daemon/health.py`'s
   `_check_disk_space_fast`/`_check_wal_size_fast` already perform for the
   health-tier alerts. Extracted `disk_free_bytes(path)` and
   `wal_size_bytes(db_path)` as small public primitives in `health.py`;
   both the fast-tier checks and `_handle_health` now call them.
4. **`daemon/metrics.py`** convergence-debt-by-stage `GROUP BY` query:
   delegated to `convergence_debt_status.convergence_debt_summary_info` —
   the same projection `polylogue ops status` and the `/health` envelope
   already use — instead of re-running the query by hand against ops.db.

## Metrics-semantics difference found (dedup 4, not a pure drop-in)

Per the ledger's explicit warning, I diffed the two implementations before
unifying. They are **not** equivalent on anomalous data:

- The raw SQL this replaces (`SELECT stage, status, COUNT(*) FROM
  convergence_debt GROUP BY stage, status`) passes through **any**
  stage/status value verbatim, coercing a `NULL` stage or status to the
  literal string `"unknown"`.
- The delegated projection (`_archive_convergence_debt_summary_info`)
  validates every row's `status` against the closed `{failed, deferred}`
  vocabulary and requires `stage`/`target_type`/`target_id` to be
  non-`NULL` (`_required_str` raises on `None`). Either violation is
  caught by an outer `except Exception`, logged as a warning, and surfaced
  as `ConvergenceDebtSummary(available=False, ...)`.

My new `_ops_convergence_debt_by_stage` treats `available=False` as "return
no rows for this scrape." So: for a healthy `convergence_debt` table
(only failed/deferred rows, populated stage — which is the only shape the
writer, `archive_tiers/ops_write.py::add_convergence_debt`, ever produces),
the two are byte-identical. Only already-anomalous data changes behavior,
and it changes **toward** surfacing the anomaly (a logged warning + an
empty ops-tier metrics contribution for that scrape) rather than silently
minting an `"unknown"` bucket in the Prometheus output. The
`metrics.py::_convergence_debt_by_stage` caller's `live_convergence_debt`
legacy-table fallback (for archives that predate the ops.db `convergence_debt`
migration) is **unchanged** — still hand-written, still NULL-tolerant —
since only the ops.db-tier half of the duplication is unified, per the
ledger's explicit instruction to preserve it or retire it deliberately.

## LOC delta per dedup

| Dedup | Files | +/- |
| --- | --- | --- |
| 1. epoch_ms→ISO8601 | payload_coercion.py, catchup/convergence_debt/cursor_lag_status.py, provenance.py (5 files) | +44/-37 |
| 2. SessionProfileListQuery forwarders | profile_reads.py | +42/-3 |
| 3. health.py/http.py byte math | health.py, http.py | +22/-12 |
| 4. metrics.py convergence-debt-by-stage | metrics.py | +29/-19 |
| **Total** | 8 files | **+137/-71** |

Net LOC is up, not down — three of the four dedups replace a compact
inline block with a named, documented, reusable primitive plus its own
docstring/comment explaining the invariant it relies on (the point of the
dedup is fewer independently-maintained copies of the same logic, not raw
line count; the ledger's own "~200-250 LOC" estimate for F2 was a rough
plan-time guess, not a target).

## Verification

- `devtools verify --quick` → exit 0 after each of the four commits (format + lint + mypy --strict + `render all --check`)
- `devtools test tests/unit -k "convergence_debt or cursor_lag or catchup or provenance"` → 377 passed (dedup 1)
- `devtools test tests/unit -k "profile_reads or session_profile or list_session_profiles or list_session_enrichment"` → 66 passed (dedup 2)
- `devtools test tests/unit -k health` → 290 passed; `devtools test tests/unit/daemon/test_health_check_endpoint_tiers.py tests/unit/daemon/test_daemon_http_contracts.py tests/unit/daemon/test_uds_socket_scoping.py` → 61 passed (dedup 3, includes direct `/api/health` endpoint coverage)
- `devtools test tests/unit -k "metrics or convergence_debt"` → 149 passed, including `tests/unit/daemon/test_metrics_endpoint.py::test_convergence_debt_grouped_by_stage` (legacy `live_convergence_debt` fallback path) and `::test_convergence_debt_prefers_archive_ops` (ops.db delegated path) — both exercise the exact two code paths this dedup touches (dedup 4)
- `devtools verify` (full testmon-affected run, timeout 600000) → `exit_code: 0`, `terminal_green: true`, 385 passed + 1 pre-existing xfail, 0 non-green, `complete_corpus_covered: true`

All four anchors were re-verified against a fresh `origin/master` checkout
before editing (matched the ledger's line references within a few lines,
consistent with its "re-verified live 2026-08-19" note).

## Bead disposition matrix

No Beads assigned — WS-F F2 is a plan-reference item (2B.4), not a tracked
Bead. Self-contained scope carrier below.

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->

Ref polylogue-2B.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWcPJJJvuF25CqVwTFgSQC
