### PR TITLE
test(storage): stop DDL-patching tests sharing a poisoned tier prototype

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1431,3 +1431,47 @@ def synthetic_source(
         return Source(name=f"{provider}-test", path=written.files[0])
 
     return _factory
+
+
+@pytest.fixture
+def clear_tier_prototypes() -> Iterator[None]:
+    """Drop the cached SOURCE tier prototype around a DDL-patching test.
+
+    ``bootstrap.initialize_archive_tier`` caches one materialized prototype
+    database per ``(tier, version)`` and page-copies it into every later empty
+    connection, which keeps ~0.8s of DDL parsing off thousands of tests. The
+    cache key does NOT include the DDL itself, because in production
+    ``ARCHIVE_DDL_BY_TIER`` is a constant: there is only ever one DDL for a
+    given tier and version.
+
+    A test that monkeypatches ``ARCHIVE_DDL_BY_TIER`` breaks that premise. Its
+    synthetic DDL is recorded as *the* prototype for ``(tier, version)``, and
+    the next test to build a fresh database at that version silently receives
+    the previous test's schema -- monkeypatch restores the dict, but not the
+    prototype minted from it.
+
+    That is the mechanism behind polylogue-s5iyt's long-standing
+    "order-dependent" durable-change-train failures: whichever DDL-patching
+    test ran first won, and later tests compared their own admitted fresh-DDL
+    parity proof against that first test's schema.
+
+    Scoped to SOURCE deliberately. The two modules that patch bootstrap's own
+    ``ARCHIVE_DDL_BY_TIER`` (this fixture's only users) target
+    ``ArchiveTier.SOURCE`` exclusively, and clearing the whole cache is not a free
+    "safer" choice: ``test_audit_adoption_receipt_recovers_interrupted_publication_during_bootstrap``
+    then fails on its own, because a page-copy restore and a fresh
+    ``executescript`` do not produce byte-identical databases and that test
+    compares an audit image against a canonical recoverable one. Dropping only
+    the poisoned key fixes the SOURCE poisoning without disturbing tiers no
+    test here rewrites.
+    """
+    from polylogue.storage.sqlite.archive_tiers import bootstrap
+    from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+    def drop_source_prototypes() -> None:
+        for key in [key for key in bootstrap._TIER_PROTOTYPES if key[0] == ArchiveTier.SOURCE.value]:
+            del bootstrap._TIER_PROTOTYPES[key]
+
+    drop_source_prototypes()
+    yield
+    drop_source_prototypes()

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -53,6 +53,11 @@ from polylogue.storage.sqlite.archive_tiers.user import USER_SCHEMA_VERSION
 from polylogue.storage.sqlite.archive_tiers.user_write import AssertionKind, upsert_assertion
 from tests.infra.rebuild_receipt import write_valid_rebuild_receipt
 
+#: Tests in this module monkeypatch ``ARCHIVE_DDL_BY_TIER``, so no test here may
+#: inherit or export a tier prototype minted from a synthetic DDL -- see
+#: ``clear_tier_prototypes`` (tests/conftest.py) and polylogue-s5iyt.
+pytestmark = pytest.mark.usefixtures("clear_tier_prototypes")
+
 _ARCHIVE_TIERS = tuple(spec.filename for spec in ARCHIVE_TIER_SPECS.values())
 
 

--- a/tests/unit/storage/test_durable_change_train.py
+++ b/tests/unit/storage/test_durable_change_train.py
@@ -80,6 +80,11 @@ from polylogue.storage.sqlite.migration_runner import (
 )
 from tests.infra.durable_schema_reset import reset_source_fixture_to_version
 
+#: Tests in this module monkeypatch ``ARCHIVE_DDL_BY_TIER``, so no test here may
+#: inherit or export a tier prototype minted from a synthetic DDL -- see
+#: ``clear_tier_prototypes`` (tests/conftest.py) and polylogue-s5iyt.
+pytestmark = pytest.mark.usefixtures("clear_tier_prototypes")
+
 _CURRENT_VERSION = 1
 _TARGET_VERSION = 2
 _EMPTY_LIVENESS_DIGEST = hashlib.sha256(b"[]").hexdigest()


### PR DESCRIPTION
## Summary

Two `test_durable_change_train.py` tests have been failing on master in whole-module runs since long before tonight, characterized in `polylogue-s5iyt` as an order-dependent flake. The cause is a process-wide tier-prototype cache in `bootstrap.initialize_archive_tier` whose key does not include the DDL, so a test that monkeypatches `ARCHIVE_DDL_BY_TIER` mints a prototype from its synthetic schema and every later test at that version silently receives it. Dropping the poisoned key around the two modules that patch bootstrap's DDL fixes it. Test-only.

## Problem

Reproduction, deterministic, 3 node ids, ~1 second:

```
devtools test tests/unit/storage/test_durable_change_train.py \
  ::test_maintenance_route_persists_and_proves_a_future_train \
  ::test_bootstrap_reconciles_and_persists_interrupted_train_evidence \
  ::test_bootstrap_finishes_persisted_applied_train_without_reapplying -p no:randomly
-> 2 failed, 1 passed
```
Drop the first test and the other two pass. Both victims fail with `DurableChangeTrainError: actual post-apply bytes do not have admitted fresh-DDL parity`.

**Mechanism.** `initialize_archive_tier` caches one materialized prototype database per `(tier, version)` and page-copies it into every later empty connection — that reuse keeps ~0.8s of DDL parsing off thousands of tests. The cache key deliberately excludes the DDL, because in production `ARCHIVE_DDL_BY_TIER` is a constant: one DDL per tier and version, always.

A test that monkeypatches the DDL breaks that premise. `test_maintenance_route_persists_and_proves_a_future_train` patches SOURCE to a synthetic `base_items + future_items` schema at version 2 and, being first, records *that* as the prototype for `(source, 2)`. The bootstrap victims patch SOURCE to `base_items + durable_items` at the same version, then build a fresh database — and get the first test's schema by page copy. `monkeypatch` restores the dict; it cannot restore a prototype minted from it. Their admitted fresh-DDL parity proof (built from a synthetic in-memory target) then disagrees with the recovered image, which is exactly what the parity check exists to refuse.

Instrumenting the comparison showed only one field diverging (`fresh_vs_admitted=False`, computed `b98a8df2…` vs admitted `5b173b1b…`) through an identical call path in both orders — same code, different bytes, which is the signature of cached state rather than a branch difference.

## Solution

A `clear_tier_prototypes` fixture in `tests/conftest.py`, requested via `pytestmark = pytest.mark.usefixtures(...)` by the two modules that patch **bootstrap's own** `ARCHIVE_DDL_BY_TIER` — `test_durable_change_train.py` and `test_archive_maintenance_cli.py`. It drops the SOURCE prototype on both sides of each test, so such a module neither inherits nor exports a poisoned prototype.

Two scoping decisions, both forced by measurement rather than taste:

- **SOURCE only, not the whole cache.** Clearing every tier is not a free "safer" choice: it makes `test_audit_adoption_receipt_recovers_interrupted_publication_during_bootstrap` fail *on its own*, because a page-copy restore and a fresh `executescript` do not produce byte-identical databases and that test compares an audit image against a canonical recoverable one. Every assignment in the DDL-patching modules targets `ArchiveTier.SOURCE`, so dropping only the poisoned key is both sufficient and non-disruptive.
- **`test_workload_artifacts.py` deliberately excluded**, though it also appears in a `setattr.*ARCHIVE_DDL_BY_TIER` grep. Its single patch targets `tests.infra.workload_artifacts.ARCHIVE_DDL_BY_TIER` — a test-infra reference, not bootstrap's — so it never mints a prototype from a synthetic DDL and cannot poison the cache. Adding the marker there was strictly harmful: it broke `test_seeded_archive_corruption_is_refused_by_a_fresh_process`, which relies on the cache.

The production cache is untouched. In production its premise holds, and the perf win is the reason it exists.

## Verification

```
# 3-node reproduction, red -> green
devtools test <3 node ids> -p no:randomly            -> 3 passed in 0.98s   (was 2 failed, 1 passed)

# whole module, deterministic order
devtools test tests/unit/storage/test_durable_change_train.py -p no:randomly
                                                      -> 103 passed in 11.41s (was 2 failed, 101 passed)

# whole module, randomized
devtools test tests/unit/storage/test_durable_change_train.py
                                                      -> 103 passed in 9.51s

devtools verify --quick                               -> exit 0, zero "out of sync"
```

**No failure traded.** Across all three DDL-adjacent modules together, deterministic order:

| | result |
| --- | --- |
| master | **5 failed**, 258 passed |
| this branch | **3 failed**, 260 passed |

The two durable-change-train failures are fixed; the three remaining (`test_rebuild_index_source_replay_expands_every_execution_selection_to_authority_cohorts[all|only-missing|explicit]`) are **pre-existing on master**, confirmed by running the identical selection on a stashed tree. They are untouched by this change and out of scope here.

## Bisect: what this is not

`polylogue-s5iyt` was raised tonight as possibly a new master red introduced by #4015's v68 `CONSTRAINT_ONLY` delta. It is not. Whole-module runs at `7b671755b` (pre-#4015), `70a3ca2ad` (#4015 itself), `f93a8b87c`, and current master HEAD all produce the identical 2 failures. The v68 CHECK widening is not implicated, and the failure long predates it.

Two disproved hypotheses, recorded so nobody re-runs them:
- **Not the split DDL reference.** The victims patch only `bootstrap` while the polluter patches both `bootstrap` and `migration_runner`. Adding the missing `migration_runner` patch to the victims does **not** fix it.
- **Not `sys.modules` leakage.** The polluter's fixed-name `fixture_migrations_maintenance` package does leak into `sys.modules` and survive teardown (verified), and the module's own helper builds unique per-`tmp_path` names — a real inconsistency. But purging those entries between tests does **not** fix it either.

Ref polylogue-s5iyt

## Not in scope

- The three pre-existing `test_archive_maintenance_cli.py` cohort failures.
- The fixed-vs-unique fixture package-name inconsistency in `test_durable_change_train.py` — real, but not the cause, and changing it would be unmotivated churn in this PR.
- Making the prototype cache key DDL-aware. That would fix the class in production rather than per test module, but it changes a hot production path for a test-only symptom; worth its own discussion, not this PR.
<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->
