### PR TITLE
fix(readiness): unify parser census authority shapes

### DIFF
--- a/devtools/pytest_supervisor.py
+++ b/devtools/pytest_supervisor.py
@@ -51,7 +51,6 @@ class SupervisorLaunch:
     unit: str | None
     runtime_cap_s: float | None
     fallback_argv: list[str] | None = None
-    pass_fds: tuple[int, ...] = ()
 
 
 def utc_now() -> str:
@@ -393,7 +392,6 @@ def build_supervisor_launch(
     run_id: str | None,
     env: Mapping[str, str] | None = None,
     cleanup_path: Path | None = None,
-    pass_fds: Sequence[int] = (),
 ) -> SupervisorLaunch:
     """Build the Linux supervisor command and optional owned cgroup scope."""
     values = dict(os.environ if env is None else env)
@@ -412,9 +410,6 @@ def build_supervisor_launch(
     mode = "systemd-scope" if systemd_available else "process-group"
     unit = _unit_name(run_id) if systemd_available else None
     runtime_cap_s = timeout_s + term_grace_s + 5.0 if systemd_available and timeout_s > 0 else None
-    inherited_fds = tuple(dict.fromkeys(pass_fds))
-    if any(descriptor < 0 for descriptor in inherited_fds):
-        raise ValueError("supervisor inherited file descriptors must be non-negative")
 
     def _supervisor_argv(
         launch_mode: str,
@@ -447,14 +442,12 @@ def build_supervisor_launch(
             argv.extend(("--runtime-cap-s", f"{launch_runtime_cap_s:g}"))
         if cleanup_path is not None:
             argv.extend(("--cleanup-path", str(cleanup_path)))
-        for descriptor in inherited_fds:
-            argv.extend(("--pass-fd", str(descriptor)))
         argv.extend(("--", *controller_cmd))
         return argv
 
     supervisor_argv = _supervisor_argv(mode, unit, runtime_cap_s)
     if not systemd_available:
-        return SupervisorLaunch(supervisor_argv, receipt_path, request_path, mode, None, None, pass_fds=inherited_fds)
+        return SupervisorLaunch(supervisor_argv, receipt_path, request_path, mode, None, None)
 
     systemd_run = shutil.which("systemd-run", path=values.get("PATH"))
     assert systemd_run is not None
@@ -486,7 +479,6 @@ def build_supervisor_launch(
         unit,
         runtime_cap_s,
         fallback_argv,
-        inherited_fds,
     )
 
 
@@ -651,7 +643,6 @@ def supervise(
     mode: str,
     unit: str | None,
     runtime_cap_s: float | None,
-    pass_fds: Sequence[int] = (),
 ) -> int:
     """Run one pytest controller and clean every process in its owned group."""
     request_path = termination_request_path(receipt_path)
@@ -712,7 +703,6 @@ def supervise(
     process = subprocess.Popen(
         list(controller_cmd),
         start_new_session=True,
-        pass_fds=tuple(dict.fromkeys(pass_fds)),
     )
     controller_pid = process.pid
     controller_pgid = controller_pid
@@ -913,7 +903,6 @@ def _parse_args(argv: Sequence[str]) -> tuple[argparse.Namespace, list[str]]:
     parser.add_argument("--unit")
     parser.add_argument("--runtime-cap-s", type=float)
     parser.add_argument("--cleanup-path", type=Path)
-    parser.add_argument("--pass-fd", type=int, action="append", default=[])
     return parser.parse_args(option_argv), controller_cmd
 
 
@@ -1017,7 +1006,6 @@ def main(argv: Sequence[str] | None = None) -> int:
             mode=args.mode,
             unit=args.unit,
             runtime_cap_s=args.runtime_cap_s,
-            pass_fds=args.pass_fd,
         )
     finally:
         receipt = read_receipt(args.receipt)

--- a/devtools/pytest_supervisor.py
+++ b/devtools/pytest_supervisor.py
@@ -51,6 +51,7 @@ class SupervisorLaunch:
     unit: str | None
     runtime_cap_s: float | None
     fallback_argv: list[str] | None = None
+    pass_fds: tuple[int, ...] = ()
 
 
 def utc_now() -> str:
@@ -392,6 +393,7 @@ def build_supervisor_launch(
     run_id: str | None,
     env: Mapping[str, str] | None = None,
     cleanup_path: Path | None = None,
+    pass_fds: Sequence[int] = (),
 ) -> SupervisorLaunch:
     """Build the Linux supervisor command and optional owned cgroup scope."""
     values = dict(os.environ if env is None else env)
@@ -410,6 +412,9 @@ def build_supervisor_launch(
     mode = "systemd-scope" if systemd_available else "process-group"
     unit = _unit_name(run_id) if systemd_available else None
     runtime_cap_s = timeout_s + term_grace_s + 5.0 if systemd_available and timeout_s > 0 else None
+    inherited_fds = tuple(dict.fromkeys(pass_fds))
+    if any(descriptor < 0 for descriptor in inherited_fds):
+        raise ValueError("supervisor inherited file descriptors must be non-negative")
 
     def _supervisor_argv(
         launch_mode: str,
@@ -442,12 +447,14 @@ def build_supervisor_launch(
             argv.extend(("--runtime-cap-s", f"{launch_runtime_cap_s:g}"))
         if cleanup_path is not None:
             argv.extend(("--cleanup-path", str(cleanup_path)))
+        for descriptor in inherited_fds:
+            argv.extend(("--pass-fd", str(descriptor)))
         argv.extend(("--", *controller_cmd))
         return argv
 
     supervisor_argv = _supervisor_argv(mode, unit, runtime_cap_s)
     if not systemd_available:
-        return SupervisorLaunch(supervisor_argv, receipt_path, request_path, mode, None, None)
+        return SupervisorLaunch(supervisor_argv, receipt_path, request_path, mode, None, None, pass_fds=inherited_fds)
 
     systemd_run = shutil.which("systemd-run", path=values.get("PATH"))
     assert systemd_run is not None
@@ -479,6 +486,7 @@ def build_supervisor_launch(
         unit,
         runtime_cap_s,
         fallback_argv,
+        inherited_fds,
     )
 
 
@@ -643,6 +651,7 @@ def supervise(
     mode: str,
     unit: str | None,
     runtime_cap_s: float | None,
+    pass_fds: Sequence[int] = (),
 ) -> int:
     """Run one pytest controller and clean every process in its owned group."""
     request_path = termination_request_path(receipt_path)
@@ -700,7 +709,11 @@ def supervise(
     previous_handlers = {
         signum: signal.signal(signum, _handle_signal) for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP)
     }
-    process = subprocess.Popen(list(controller_cmd), start_new_session=True)
+    process = subprocess.Popen(
+        list(controller_cmd),
+        start_new_session=True,
+        pass_fds=tuple(dict.fromkeys(pass_fds)),
+    )
     controller_pid = process.pid
     controller_pgid = controller_pid
     controller_sid = controller_pid
@@ -900,6 +913,7 @@ def _parse_args(argv: Sequence[str]) -> tuple[argparse.Namespace, list[str]]:
     parser.add_argument("--unit")
     parser.add_argument("--runtime-cap-s", type=float)
     parser.add_argument("--cleanup-path", type=Path)
+    parser.add_argument("--pass-fd", type=int, action="append", default=[])
     return parser.parse_args(option_argv), controller_cmd
 
 
@@ -1003,6 +1017,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             mode=args.mode,
             unit=args.unit,
             runtime_cap_s=args.runtime_cap_s,
+            pass_fds=args.pass_fd,
         )
     finally:
         receipt = read_receipt(args.receipt)

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -1320,7 +1320,6 @@ def _run_pytest_with_heartbeat(
     run: VerifyRun | None = None,
     artifacts: PytestStepArtifacts | None = None,
     timeout_override_s: float | None = None,
-    pass_fds: Sequence[int] = (),
 ) -> subprocess.CompletedProcess[str]:
     heartbeat_s = _pytest_heartbeat_interval()
     timeout_s = _pytest_timeout_s() if timeout_override_s is None else max(0.0, timeout_override_s)
@@ -1358,18 +1357,16 @@ def _run_pytest_with_heartbeat(
         run_id=pytest_run_id,
         env=env,
     )
-    launch_kwargs: dict[str, Any] = {
-        "owner_pid": os.getpid(),
-        "timeout_s": timeout_s,
-        "term_grace_s": term_grace_s,
-        "receipt_path": receipt_path,
-        "run_id": pytest_run_id,
-        "env": env,
-        "cleanup_path": tmpfs_cleanup_path,
-    }
-    if pass_fds:
-        launch_kwargs["pass_fds"] = pass_fds
-    launch = build_supervisor_launch(cmd, **launch_kwargs)
+    launch = build_supervisor_launch(
+        cmd,
+        owner_pid=os.getpid(),
+        timeout_s=timeout_s,
+        term_grace_s=term_grace_s,
+        receipt_path=receipt_path,
+        run_id=pytest_run_id,
+        env=env,
+        cleanup_path=tmpfs_cleanup_path,
+    )
     sys.stderr.write(f"\n    command: {shlex.join(cmd)}\n")
     sys.stderr.write(
         f"    containment: mode={launch.mode}"
@@ -1429,7 +1426,6 @@ def _run_pytest_with_heartbeat(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             start_new_session=True,
-            pass_fds=getattr(launch, "pass_fds", ()),
         )
 
     def _stop_startup_attempt(
@@ -1506,7 +1502,6 @@ def _run_pytest_with_heartbeat(
             "process-group",
             None,
             None,
-            pass_fds=launch.pass_fds,
         )
         process = _spawn_supervisor(launch.argv)
         assert process.stdout is not None
@@ -2050,6 +2045,11 @@ def _run(
     if state is None:
         state = _open_owned_native_testmon_state(ROOT)
     try:
+        # The descriptor binds verify's own inspection to one checked inode.
+        # Pytest crosses systemd and xdist exec boundaries that do not promise
+        # arbitrary descriptor inheritance, so its workers receive the checked
+        # checkout-local path instead.  Native containment remains the
+        # supervisor's process-group/systemd scope contract, not an FD contract.
         return _run_step(
             label,
             cmd,
@@ -2057,7 +2057,6 @@ def _run(
             run=run,
             timeout_s=timeout_s,
             native_testmon_data=state.executable_data_path,
-            native_testmon_descriptor=state.descriptor,
         )
     finally:
         if temporary_state:
@@ -2072,7 +2071,6 @@ def _run_step(
     run: VerifyRun | None = None,
     timeout_s: float | None = None,
     native_testmon_data: Path | None = None,
-    native_testmon_descriptor: int | None = None,
 ) -> tuple[int, float, dict[str, Any]]:
     t0 = time.monotonic()
     sys.stderr.write(f"  {label} ... ")
@@ -2197,7 +2195,6 @@ def _run_step(
                     run=run,
                     artifacts=artifacts,
                     timeout_override_s=timeout_s,
-                    pass_fds=() if native_testmon_descriptor is None else (native_testmon_descriptor,),
                 )
             except PytestContainmentError as exc:
                 pytest_containment_quiescent = False

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -1320,6 +1320,7 @@ def _run_pytest_with_heartbeat(
     run: VerifyRun | None = None,
     artifacts: PytestStepArtifacts | None = None,
     timeout_override_s: float | None = None,
+    pass_fds: Sequence[int] = (),
 ) -> subprocess.CompletedProcess[str]:
     heartbeat_s = _pytest_heartbeat_interval()
     timeout_s = _pytest_timeout_s() if timeout_override_s is None else max(0.0, timeout_override_s)
@@ -1357,16 +1358,18 @@ def _run_pytest_with_heartbeat(
         run_id=pytest_run_id,
         env=env,
     )
-    launch = build_supervisor_launch(
-        cmd,
-        owner_pid=os.getpid(),
-        timeout_s=timeout_s,
-        term_grace_s=term_grace_s,
-        receipt_path=receipt_path,
-        run_id=pytest_run_id,
-        env=env,
-        cleanup_path=tmpfs_cleanup_path,
-    )
+    launch_kwargs: dict[str, Any] = {
+        "owner_pid": os.getpid(),
+        "timeout_s": timeout_s,
+        "term_grace_s": term_grace_s,
+        "receipt_path": receipt_path,
+        "run_id": pytest_run_id,
+        "env": env,
+        "cleanup_path": tmpfs_cleanup_path,
+    }
+    if pass_fds:
+        launch_kwargs["pass_fds"] = pass_fds
+    launch = build_supervisor_launch(cmd, **launch_kwargs)
     sys.stderr.write(f"\n    command: {shlex.join(cmd)}\n")
     sys.stderr.write(
         f"    containment: mode={launch.mode}"
@@ -1426,6 +1429,7 @@ def _run_pytest_with_heartbeat(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             start_new_session=True,
+            pass_fds=getattr(launch, "pass_fds", ()),
         )
 
     def _stop_startup_attempt(
@@ -1502,6 +1506,7 @@ def _run_pytest_with_heartbeat(
             "process-group",
             None,
             None,
+            pass_fds=launch.pass_fds,
         )
         process = _spawn_supervisor(launch.argv)
         assert process.stdout is not None
@@ -2052,6 +2057,7 @@ def _run(
             run=run,
             timeout_s=timeout_s,
             native_testmon_data=state.executable_data_path,
+            native_testmon_descriptor=state.descriptor,
         )
     finally:
         if temporary_state:
@@ -2066,6 +2072,7 @@ def _run_step(
     run: VerifyRun | None = None,
     timeout_s: float | None = None,
     native_testmon_data: Path | None = None,
+    native_testmon_descriptor: int | None = None,
 ) -> tuple[int, float, dict[str, Any]]:
     t0 = time.monotonic()
     sys.stderr.write(f"  {label} ... ")
@@ -2190,6 +2197,7 @@ def _run_step(
                     run=run,
                     artifacts=artifacts,
                     timeout_override_s=timeout_s,
+                    pass_fds=() if native_testmon_descriptor is None else (native_testmon_descriptor,),
                 )
             except PytestContainmentError as exc:
                 pytest_containment_quiescent = False

--- a/polylogue/archive/revision_authority.py
+++ b/polylogue/archive/revision_authority.py
@@ -118,6 +118,28 @@ def durable_authority_logical_keys(
         return None
 
 
+def parser_census_is_complete(
+    *,
+    recorded_keys: tuple[str, ...] | None,
+    durable_keys: tuple[str, ...] | None,
+    typed_non_session: bool,
+    parser_confirmed_non_session: bool,
+    byte_governed_fragment: bool,
+) -> bool:
+    """Return whether a parser receipt proves its durable authority shape.
+
+    The receipt writer and readiness reader must apply this same predicate.
+    Empty identity sets are complete only when a durable non-session or
+    byte-authority disposition proves that no parser identity is expected.
+    """
+    return (
+        durable_keys is not None
+        and recorded_keys is not None
+        and recorded_keys == durable_keys
+        and (bool(recorded_keys) or typed_non_session or parser_confirmed_non_session or byte_governed_fragment)
+    )
+
+
 #: ``raw_membership_census.detail`` marker written when a full-only,
 #: non-prefix-chain cohort is retired from byte-revision governance to
 #: membership governance (``ArchiveStore.replace_raw_membership_census``,

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -1457,6 +1457,8 @@ def _census_historical_revision_evidence(
                 for raw_id in terminal_raw_ids - state.censused:
                     state.scanned += 1
                     state.censused.add(raw_id)
+                    record_current_parser_source_census(archive._ensure_source_conn(), raw_id)
+                    commit_unit()
                 pending_rows = [
                     (raw_id, source_index)
                     for raw_id, source_index, terminal_non_session, _raw_rowid in rows

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -1267,14 +1267,21 @@ def _census_historical_revision_evidence(
         state.scanned += 1
         state.censused.add(raw_id)
         if source_index < 0:
-            archive.replace_raw_membership_census(
-                raw_id,
-                None,
-                parser_fingerprint=RAW_AUTHORITY_PARSER_FINGERPRINT,
-                censused_at_ms=0,
-                detail=BYTE_AUTHORITY_CENSUS_DETAIL,
-                manage_transaction=not batched,
-            )
+            source_conn = archive._ensure_source_conn()
+            has_membership_authority = source_conn.execute(
+                "SELECT 1 FROM raw_session_memberships WHERE raw_id = ? LIMIT 1", (raw_id,)
+            ).fetchone()
+            if has_membership_authority is not None:
+                record_current_parser_source_census(source_conn, raw_id)
+            else:
+                archive.replace_raw_membership_census(
+                    raw_id,
+                    None,
+                    parser_fingerprint=RAW_AUTHORITY_PARSER_FINGERPRINT,
+                    censused_at_ms=0,
+                    detail=BYTE_AUTHORITY_CENSUS_DETAIL,
+                    manage_transaction=not batched,
+                )
             state.quarantined += 1
             commit_unit()
             return

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -35,6 +35,7 @@ from polylogue.archive.revision_authority import (
     RawRevisionEnvelope,
     RawRevisionKind,
     durable_authority_logical_keys,
+    parser_census_is_complete,
 )
 from polylogue.archive.session_revision_membership import MembershipRevision, classify_membership_revisions
 from polylogue.core.enums import Origin, Provider
@@ -1571,17 +1572,36 @@ def require_current_parser_source_census(
             f"{len(stale_raw_ids)} raw(s) are stale or incomplete (sample: {sample})"
         )
 
-    durable_bindings: dict[str, tuple[object, object, list[object], bool]] = {
-        raw_id: (None, RawRevisionKind.UNKNOWN.value, [], False) for raw_id in recorded_logical_keys
+    durable_bindings: dict[str, tuple[object, object, list[object], bool, bool, bool]] = {
+        raw_id: (None, RawRevisionKind.UNKNOWN.value, [], False, False, False) for raw_id in recorded_logical_keys
     }
     with closing(sqlite3.connect(f"file:{archive_root / 'source.db'}?mode=ro", uri=True)) as source_conn:
         for selection in selections:
             where = "" if selection is None else f"WHERE r.raw_id IN ({','.join('?' for _ in selection)})"
-            params = () if selection is None else selection
+            params = (
+                RAW_AUTHORITY_PARSER_FINGERPRINT,
+                RAW_AUTHORITY_PARSER_FINGERPRINT,
+                BYTE_AUTHORITY_CENSUS_DETAIL,
+                *(() if selection is None else selection),
+            )
             rows = source_conn.execute(
                 f"""
-                SELECT r.raw_id, r.logical_source_key, r.revision_kind, m.logical_source_key,
-                       EXISTS(SELECT 1 FROM raw_artifacts AS a WHERE a.raw_id = r.raw_id AND a.parse_as_session = 0)
+                SELECT r.raw_id, r.logical_source_key, r.revision_kind, r.source_index, m.logical_source_key,
+                       EXISTS(SELECT 1 FROM raw_artifacts AS a WHERE a.raw_id = r.raw_id AND a.parse_as_session = 0),
+                       EXISTS(
+                           SELECT 1 FROM raw_membership_census AS mc
+                           WHERE mc.raw_id = r.raw_id
+                             AND mc.parser_fingerprint = ?
+                             AND mc.status = 'non_session'
+                       ),
+                       EXISTS(
+                           SELECT 1 FROM raw_membership_census AS mc
+                           WHERE mc.raw_id = r.raw_id
+                             AND r.source_index < 0
+                             AND mc.parser_fingerprint = ?
+                             AND mc.status = 'failed'
+                             AND mc.detail = ?
+                       )
                 FROM raw_sessions AS r
                 LEFT JOIN raw_session_memberships AS m ON m.raw_id = r.raw_id
                 {where}
@@ -1589,11 +1609,35 @@ def require_current_parser_source_census(
                 """,
                 params,
             )
-            for raw_id_value, typed_key, revision_kind, membership_key, typed_non_session in rows:
+            for (
+                raw_id_value,
+                typed_key,
+                revision_kind,
+                _source_index,
+                membership_key,
+                typed_non_session,
+                parser_confirmed_non_session,
+                byte_governed_fragment,
+            ) in rows:
                 raw_id = str(raw_id_value)
                 typed_non_session = bool(typed_non_session) or raw_id in transient_non_session_raw_ids
-                existing_typed, existing_kind, memberships, existing_non_session = durable_bindings.get(
-                    raw_id, (typed_key, revision_kind, [], bool(typed_non_session))
+                (
+                    existing_typed,
+                    existing_kind,
+                    memberships,
+                    existing_non_session,
+                    existing_parser_confirmed_non_session,
+                    existing_byte_governed_fragment,
+                ) = durable_bindings.get(
+                    raw_id,
+                    (
+                        typed_key,
+                        revision_kind,
+                        [],
+                        bool(typed_non_session),
+                        bool(parser_confirmed_non_session),
+                        bool(byte_governed_fragment),
+                    ),
                 )
                 if membership_key is not None:
                     memberships.append(membership_key)
@@ -1602,21 +1646,35 @@ def require_current_parser_source_census(
                     revision_kind if existing_kind == RawRevisionKind.UNKNOWN.value else existing_kind,
                     memberships,
                     bool(typed_non_session) or existing_non_session,
+                    bool(parser_confirmed_non_session) or existing_parser_confirmed_non_session,
+                    bool(byte_governed_fragment) or existing_byte_governed_fragment,
                 )
 
     invalid_durable_bindings: set[str] = set()
     durable_logical_keys: dict[str, tuple[str, ...]] = {}
-    for raw_id, (typed_key, revision_kind, membership_keys, typed_non_session) in durable_bindings.items():
-        durable_keys = (
-            ()
-            if typed_non_session
-            else durable_authority_logical_keys(
-                raw_logical_key=typed_key,
-                revision_kind=revision_kind,
-                membership_logical_keys=membership_keys,
-            )
+    for (
+        raw_id,
+        (
+            typed_key,
+            revision_kind,
+            membership_keys,
+            typed_non_session,
+            parser_confirmed_non_session,
+            byte_governed_fragment,
+        ),
+    ) in durable_bindings.items():
+        durable_keys = durable_authority_logical_keys(
+            raw_logical_key=typed_key,
+            revision_kind=revision_kind,
+            membership_logical_keys=membership_keys,
         )
-        if durable_keys is None:
+        if durable_keys is None or not parser_census_is_complete(
+            recorded_keys=recorded_logical_keys.get(raw_id),
+            durable_keys=durable_keys,
+            typed_non_session=typed_non_session,
+            parser_confirmed_non_session=parser_confirmed_non_session,
+            byte_governed_fragment=byte_governed_fragment,
+        ):
             invalid_durable_bindings.add(raw_id)
         else:
             durable_logical_keys[raw_id] = durable_keys

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -741,6 +741,17 @@ class RevisionCensusResult:
 
 
 @dataclass(slots=True)
+class _CurrentParserReceiptShape:
+    recorded_keys_json: object
+    typed_key: object
+    revision_kind: object
+    typed_non_session: bool
+    parser_confirmed_non_session: bool
+    byte_governed_fragment: bool
+    membership_keys: list[object] = field(default_factory=list)
+
+
+@dataclass(slots=True)
 class _RevisionCensusState:
     scanned: int
     classified: int
@@ -1013,6 +1024,12 @@ def uncensused_historical_revision_raw_ids(
     Treating a bump as forcing full re-census here would mean every
     fingerprint bump re-parses the entire archive just to re-confirm facts
     that did not change.
+
+    Current-fingerprint receipts also have to prove the durable authority
+    shape. Older receipts can contain an empty key list even when membership
+    rows establish a canonical identity, so those rows must be selected for
+    recomputation instead of remaining permanently blocked by the readiness
+    predicate.
     """
     if not raw_ids:
         return ()
@@ -1048,7 +1065,78 @@ def uncensused_historical_revision_raw_ids(
                 [*raw_id_chunk, *known_fingerprints, resource_blocked_fingerprint],
             )
             uncensused.extend(str(row[0]) for row in rows)
-    return tuple(sorted(uncensused))
+            current_receipt_shapes: dict[str, _CurrentParserReceiptShape] = {}
+            for (
+                raw_id_value,
+                logical_keys_json,
+                typed_key,
+                revision_kind,
+                typed_non_session,
+                parser_confirmed_non_session,
+                byte_governed_fragment,
+                membership_key,
+            ) in conn.execute(
+                f"""
+                SELECT r.raw_id, c.logical_keys_json, r.logical_source_key, r.revision_kind,
+                       EXISTS(SELECT 1 FROM raw_artifacts AS a
+                              WHERE a.raw_id = r.raw_id AND a.parse_as_session = 0),
+                       EXISTS(SELECT 1 FROM raw_membership_census AS mc
+                              WHERE mc.raw_id = r.raw_id
+                                AND mc.parser_fingerprint = ?
+                                AND mc.status = 'non_session'),
+                       EXISTS(SELECT 1 FROM raw_membership_census AS mc
+                              WHERE mc.raw_id = r.raw_id
+                                AND r.source_index < 0
+                                AND mc.parser_fingerprint = ?
+                                AND mc.status = 'failed'
+                                AND mc.detail = ?),
+                       m.logical_source_key
+                FROM raw_sessions AS r
+                JOIN raw_authority_parser_census AS c ON c.raw_id = r.raw_id
+                LEFT JOIN raw_session_memberships AS m ON m.raw_id = r.raw_id
+                WHERE r.raw_id IN ({placeholders})
+                  AND c.parser_fingerprint = ?
+                  AND c.status = 'complete'
+                  AND c.detail LIKE 'parser-observed:%'
+                ORDER BY r.raw_id, m.logical_source_key
+                """,
+                (
+                    RAW_AUTHORITY_PARSER_FINGERPRINT,
+                    RAW_AUTHORITY_PARSER_FINGERPRINT,
+                    BYTE_AUTHORITY_CENSUS_DETAIL,
+                    *raw_id_chunk,
+                    RAW_AUTHORITY_PARSER_FINGERPRINT,
+                ),
+            ):
+                raw_id = str(raw_id_value)
+                shape = current_receipt_shapes.setdefault(
+                    raw_id,
+                    _CurrentParserReceiptShape(
+                        logical_keys_json,
+                        typed_key,
+                        revision_kind,
+                        bool(typed_non_session),
+                        bool(parser_confirmed_non_session),
+                        bool(byte_governed_fragment),
+                    ),
+                )
+                if membership_key is not None:
+                    shape.membership_keys.append(membership_key)
+            for raw_id, shape in current_receipt_shapes.items():
+                durable_keys = durable_authority_logical_keys(
+                    raw_logical_key=shape.typed_key,
+                    revision_kind=shape.revision_kind,
+                    membership_logical_keys=shape.membership_keys,
+                )
+                if not parser_census_is_complete(
+                    recorded_keys=parser_census_logical_keys(shape.recorded_keys_json),
+                    durable_keys=durable_keys,
+                    typed_non_session=shape.typed_non_session,
+                    parser_confirmed_non_session=shape.parser_confirmed_non_session,
+                    byte_governed_fragment=shape.byte_governed_fragment,
+                ):
+                    uncensused.append(raw_id)
+    return tuple(sorted(set(uncensused)))
 
 
 def record_resource_blocked_revision_census(

--- a/polylogue/storage/archive_readiness.py
+++ b/polylogue/storage/archive_readiness.py
@@ -16,7 +16,11 @@ from polylogue.archive.raw_materialization import (
     parsed_non_session_artifact_reason,
     source_path_native_id_candidates,
 )
-from polylogue.archive.revision_authority import BYTE_AUTHORITY_CENSUS_DETAIL, durable_authority_logical_keys
+from polylogue.archive.revision_authority import (
+    BYTE_AUTHORITY_CENSUS_DETAIL,
+    durable_authority_logical_keys,
+    parser_census_is_complete,
+)
 from polylogue.core.payload_coercion import row_int as _row_int
 from polylogue.logging import get_logger
 from polylogue.storage.insights.session.status import session_insight_status_sync
@@ -403,13 +407,25 @@ def raw_materialization_readiness_snapshot(
                                WHERE mc.raw_id = r.raw_id
                                  AND mc.parser_fingerprint = ?
                                  AND mc.status = 'non_session'
+                           ),
+                           EXISTS(
+                               SELECT 1 FROM source.raw_membership_census AS mc
+                               WHERE mc.raw_id = r.raw_id
+                                 AND r.source_index < 0
+                                 AND mc.parser_fingerprint = ?
+                                 AND mc.status = 'failed'
+                                 AND mc.detail = ?
                            )
                     FROM source.raw_sessions AS r
                     LEFT JOIN source.raw_authority_parser_census AS p ON p.raw_id = r.raw_id
                     LEFT JOIN source.raw_session_memberships AS m ON m.raw_id = r.raw_id
                     ORDER BY r.raw_id, m.logical_source_key
                     """,
-                    (RAW_AUTHORITY_PARSER_FINGERPRINT,),
+                    (
+                        RAW_AUTHORITY_PARSER_FINGERPRINT,
+                        RAW_AUTHORITY_PARSER_FINGERPRINT,
+                        BYTE_AUTHORITY_CENSUS_DETAIL,
+                    ),
                 )
                 incomplete_origins: Counter[str] = Counter()
                 incomplete_origin_bytes: Counter[str] = Counter()
@@ -435,6 +451,7 @@ def raw_materialization_readiness_snapshot(
                         _membership_key,
                         typed_non_session,
                         parser_confirmed_non_session,
+                        byte_governed_fragment,
                     ) = current_row
                     recorded_keys = parser_census_logical_keys(logical_keys_json)
                     durable_keys = durable_authority_logical_keys(
@@ -447,10 +464,13 @@ def raw_materialization_readiness_snapshot(
                         receipt_raw_id is not None
                         and str(fingerprint) == RAW_AUTHORITY_PARSER_FINGERPRINT
                         and str(status) == "complete"
-                        and recorded_keys is not None
-                        and durable_keys is not None
-                        and recorded_keys == durable_keys
-                        and (bool(durable_keys) or bool(typed_non_session) or bool(parser_confirmed_non_session))
+                        and parser_census_is_complete(
+                            recorded_keys=recorded_keys,
+                            durable_keys=durable_keys,
+                            typed_non_session=bool(typed_non_session),
+                            parser_confirmed_non_session=bool(parser_confirmed_non_session),
+                            byte_governed_fragment=bool(byte_governed_fragment),
+                        )
                     )
                     if complete:
                         parser_census_complete_count += 1

--- a/polylogue/storage/sqlite/archive_tiers/revision_governance.py
+++ b/polylogue/storage/sqlite/archive_tiers/revision_governance.py
@@ -125,6 +125,7 @@ from polylogue.archive.revision_authority import (
     canonical_authority_logical_key,
     classify_historical_full_revision_streams,
     durable_authority_logical_keys,
+    parser_census_is_complete,
 )
 from polylogue.archive.revision_replay import (
     ApplicationDecision,
@@ -2026,11 +2027,6 @@ def record_current_parser_source_census(
         and str(membership_census[0]) == "failed"
         and str(membership_census[1]) == BYTE_AUTHORITY_CENSUS_DETAIL
     )
-    if typed_non_session or byte_governed_fragment:
-        # Terminal parser evidence and other typed non-session artifacts have
-        # an authoritative empty identity set. Requiring a session logical key
-        # here makes those durable dispositions impossible to freeze.
-        durable_keys = ()
     observed_keys = (
         tuple(
             sorted(
@@ -2043,20 +2039,16 @@ def record_current_parser_source_census(
         if parser_sessions is not None
         else tuple(sorted(canonical_authority_logical_key(key) for key in inherited_logical_keys or ()))
         if inherited_logical_keys is not None
-        else ()
+        else durable_keys
         if typed_non_session or byte_governed_fragment
         else None
     )
-    complete = (
-        durable_keys is not None
-        and observed_keys is not None
-        and observed_keys == durable_keys
-        and (
-            bool(observed_keys)
-            or typed_non_session
-            or byte_governed_fragment
-            or (membership_census is not None and str(membership_census[0]) == "non_session")
-        )
+    complete = parser_census_is_complete(
+        recorded_keys=observed_keys,
+        durable_keys=durable_keys,
+        typed_non_session=typed_non_session,
+        parser_confirmed_non_session=membership_census is not None and str(membership_census[0]) == "non_session",
+        byte_governed_fragment=byte_governed_fragment,
     )
     detail = (
         "parser-observed: append fragment governed by byte revision authority"

--- a/polylogue/storage/sqlite/archive_tiers/revision_governance.py
+++ b/polylogue/storage/sqlite/archive_tiers/revision_governance.py
@@ -2027,6 +2027,7 @@ def record_current_parser_source_census(
         and str(membership_census[0]) == "failed"
         and str(membership_census[1]) == BYTE_AUTHORITY_CENSUS_DETAIL
     )
+    parser_confirmed_non_session = membership_census is not None and str(membership_census[0]) == "non_session"
     observed_keys = (
         tuple(
             sorted(
@@ -2040,14 +2041,14 @@ def record_current_parser_source_census(
         else tuple(sorted(canonical_authority_logical_key(key) for key in inherited_logical_keys or ()))
         if inherited_logical_keys is not None
         else durable_keys
-        if typed_non_session or byte_governed_fragment
+        if typed_non_session or parser_confirmed_non_session or byte_governed_fragment
         else None
     )
     complete = parser_census_is_complete(
         recorded_keys=observed_keys,
         durable_keys=durable_keys,
         typed_non_session=typed_non_session,
-        parser_confirmed_non_session=membership_census is not None and str(membership_census[0]) == "non_session",
+        parser_confirmed_non_session=parser_confirmed_non_session,
         byte_governed_fragment=byte_governed_fragment,
     )
     detail = (

--- a/tests/unit/devtools/test_pytest_supervisor.py
+++ b/tests/unit/devtools/test_pytest_supervisor.py
@@ -7,6 +7,7 @@ import json
 import os
 import shutil
 import signal
+import sqlite3
 import stat
 import subprocess
 import sys
@@ -486,6 +487,68 @@ def test_supervisor_rejects_owner_identity_captured_before_launch(tmp_path: Path
     assert final["owner_start_ticks"] == owner_start_ticks + 1
     assert final["termination_reason"] == f"pytest runner owner pid {os.getpid()} exited"
     assert final["controller_group_alive"] is False
+
+
+def test_launch_preserves_descriptor_bound_sqlite_through_supervisor(
+    tmp_path: Path,
+) -> None:
+    """The actual launch chain keeps descriptor-backed testmon SQLite usable."""
+    testmon_root = tmp_path / "testmon"
+    testmon_root.mkdir()
+    datafile = testmon_root / "testmondata"
+    with sqlite3.connect(datafile) as connection:
+        connection.execute("CREATE TABLE proof (value TEXT NOT NULL)")
+        connection.execute("INSERT INTO proof VALUES ('descriptor-bound')")
+
+    descriptor = os.open(testmon_root, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        descriptor_datafile = Path(f"/proc/self/fd/{descriptor}") / datafile.name
+        if not descriptor_datafile.exists():
+            pytest.skip("this platform has no accessible descriptor namespace")
+        receipt_path = tmp_path / "containment.json"
+        result_path = tmp_path / "result.txt"
+        env = nested_pytest_env()
+        env[CGROUP_MODE_ENV] = "off"
+        env["TESTMON_DATAFILE"] = str(descriptor_datafile)
+        controller = [
+            sys.executable,
+            "-c",
+            (
+                "import os, sqlite3\n"
+                "from pathlib import Path\n"
+                "with sqlite3.connect(os.environ['TESTMON_DATAFILE']) as connection:\n"
+                "    value = connection.execute('SELECT value FROM proof').fetchone()[0]\n"
+                f"Path({str(result_path)!r}).write_text(value, encoding='utf-8')\n"
+            ),
+        ]
+        launch = build_supervisor_launch(
+            controller,
+            owner_pid=os.getpid(),
+            timeout_s=5,
+            term_grace_s=0.1,
+            receipt_path=receipt_path,
+            run_id="descriptor-sqlite",
+            env=env,
+            pass_fds=(descriptor,),
+        )
+
+        completed = subprocess.run(
+            launch.argv,
+            cwd=ROOT,
+            env=env,
+            pass_fds=launch.pass_fds,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    finally:
+        os.close(descriptor)
+
+    assert completed.returncode == 0, completed.stderr
+    assert result_path.read_text(encoding="utf-8") == "descriptor-bound"
+    receipt = read_receipt(receipt_path)
+    assert receipt is not None
+    assert receipt["exit_code"] == 0
 
 
 def test_supervisor_kills_controller_when_receipt_publication_fails(tmp_path: Path) -> None:

--- a/tests/unit/devtools/test_pytest_supervisor.py
+++ b/tests/unit/devtools/test_pytest_supervisor.py
@@ -489,63 +489,53 @@ def test_supervisor_rejects_owner_identity_captured_before_launch(tmp_path: Path
     assert final["controller_group_alive"] is False
 
 
-def test_launch_preserves_descriptor_bound_sqlite_through_supervisor(
+def test_launch_preserves_regular_sqlite_path_through_supervisor(
     tmp_path: Path,
 ) -> None:
-    """The actual launch chain keeps descriptor-backed testmon SQLite usable."""
+    """The process-group fallback keeps the worker-visible SQLite path usable."""
     testmon_root = tmp_path / "testmon"
     testmon_root.mkdir()
     datafile = testmon_root / "testmondata"
     with sqlite3.connect(datafile) as connection:
         connection.execute("CREATE TABLE proof (value TEXT NOT NULL)")
-        connection.execute("INSERT INTO proof VALUES ('descriptor-bound')")
+        connection.execute("INSERT INTO proof VALUES ('worker-visible')")
+    receipt_path = tmp_path / "containment.json"
+    result_path = tmp_path / "result.txt"
+    env = nested_pytest_env()
+    env[CGROUP_MODE_ENV] = "off"
+    env["TESTMON_DATAFILE"] = str(datafile)
+    controller = [
+        sys.executable,
+        "-c",
+        (
+            "import os, sqlite3\n"
+            "from pathlib import Path\n"
+            "with sqlite3.connect(os.environ['TESTMON_DATAFILE']) as connection:\n"
+            "    value = connection.execute('SELECT value FROM proof').fetchone()[0]\n"
+            f"Path({str(result_path)!r}).write_text(value, encoding='utf-8')\n"
+        ),
+    ]
+    launch = build_supervisor_launch(
+        controller,
+        owner_pid=os.getpid(),
+        timeout_s=5,
+        term_grace_s=0.1,
+        receipt_path=receipt_path,
+        run_id="worker-visible-sqlite",
+        env=env,
+    )
 
-    descriptor = os.open(testmon_root, os.O_RDONLY | os.O_DIRECTORY)
-    try:
-        descriptor_datafile = Path(f"/proc/self/fd/{descriptor}") / datafile.name
-        if not descriptor_datafile.exists():
-            pytest.skip("this platform has no accessible descriptor namespace")
-        receipt_path = tmp_path / "containment.json"
-        result_path = tmp_path / "result.txt"
-        env = nested_pytest_env()
-        env[CGROUP_MODE_ENV] = "off"
-        env["TESTMON_DATAFILE"] = str(descriptor_datafile)
-        controller = [
-            sys.executable,
-            "-c",
-            (
-                "import os, sqlite3\n"
-                "from pathlib import Path\n"
-                "with sqlite3.connect(os.environ['TESTMON_DATAFILE']) as connection:\n"
-                "    value = connection.execute('SELECT value FROM proof').fetchone()[0]\n"
-                f"Path({str(result_path)!r}).write_text(value, encoding='utf-8')\n"
-            ),
-        ]
-        launch = build_supervisor_launch(
-            controller,
-            owner_pid=os.getpid(),
-            timeout_s=5,
-            term_grace_s=0.1,
-            receipt_path=receipt_path,
-            run_id="descriptor-sqlite",
-            env=env,
-            pass_fds=(descriptor,),
-        )
-
-        completed = subprocess.run(
-            launch.argv,
-            cwd=ROOT,
-            env=env,
-            pass_fds=launch.pass_fds,
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    finally:
-        os.close(descriptor)
+    completed = subprocess.run(
+        launch.argv,
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
 
     assert completed.returncode == 0, completed.stderr
-    assert result_path.read_text(encoding="utf-8") == "descriptor-bound"
+    assert result_path.read_text(encoding="utf-8") == "worker-visible"
     receipt = read_receipt(receipt_path)
     assert receipt is not None
     assert receipt["exit_code"] == 0

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -2931,11 +2931,24 @@ def test_native_verifier_keeps_descriptor_binding_for_parent_inspection(
 
     monkeypatch.setattr("devtools.testmon_bootstrap._DESCRIPTOR_FD_ROOTS", (descriptor_root,))
     state = verify._open_owned_native_testmon_state(tmp_path)
+    captured: dict[str, Path | int | None] = {}
+
+    def fake_run_step(*_args: object, **kwargs: object) -> tuple[int, float, dict[str, Any]]:
+        captured["native_testmon_data"] = cast(Path | None, kwargs["native_testmon_data"])
+        captured["native_testmon_descriptor"] = cast(int | None, kwargs["native_testmon_descriptor"])
+        return 0, 0.0, {}
+
+    monkeypatch.setattr(verify, "_ACTIVE_VERIFY_RUN", SimpleNamespace(owned_native_testmon_state=state))
     try:
         assert state.data_path == descriptor_root / str(state.descriptor) / verify.TESTMON_DATA.name
         assert state.executable_data_path == tmp_path / verify.TESTMON_DATA
+        with patch("devtools.verify._run_step", side_effect=fake_run_step):
+            assert _run("pytest native parallel (affected)", ["pytest"])[0] == 0
     finally:
         state.close()
+
+    assert captured["native_testmon_data"] == state.executable_data_path
+    assert captured["native_testmon_descriptor"] == state.descriptor
 
 
 def test_native_verifier_gives_xdist_testmon_a_worker_openable_state_path(

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -4075,7 +4075,7 @@ def test_pytest_run_terminates_after_runtime_budget(
     assert "terminated owned pytest process group" in captured.err
 
 
-def test_pytest_run_terminates_with_heartbeat_disabled(
+def test_pytest_run_terminates_before_heartbeat_interval(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setenv("POLYLOGUE_VERIFY_HEARTBEAT_S", "30")
@@ -4086,7 +4086,7 @@ def test_pytest_run_terminates_with_heartbeat_disabled(
 
     captured = capsys.readouterr()
     assert rc == 124
-    assert metadata["heartbeat_s"] == 0.0
+    assert metadata["heartbeat_s"] == 30.0
     assert "pytest runtime exceeded 0.15s" in captured.err
 
 

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -22,9 +22,16 @@ from unittest.mock import MagicMock, patch
 import pytest
 import watchfiles
 
+import devtools.pytest_supervisor as pytest_supervisor
 from devtools import run_tests, verify, verify_runs
 from devtools.checkout_guard import CheckoutImportMismatchError
-from devtools.pytest_supervisor import write_termination_request as _write_termination_request
+from devtools.pytest_supervisor import (
+    CGROUP_MODE_ENV,
+    user_systemd_available,
+)
+from devtools.pytest_supervisor import (
+    write_termination_request as _write_termination_request,
+)
 from devtools.testmon_bootstrap import NativeTestmonRepairError, executable_python_paths
 from devtools.verification_contracts import VerificationScope
 from devtools.verify import (
@@ -2931,11 +2938,10 @@ def test_native_verifier_keeps_descriptor_binding_for_parent_inspection(
 
     monkeypatch.setattr("devtools.testmon_bootstrap._DESCRIPTOR_FD_ROOTS", (descriptor_root,))
     state = verify._open_owned_native_testmon_state(tmp_path)
-    captured: dict[str, Path | int | None] = {}
+    captured: dict[str, Path | None] = {}
 
     def fake_run_step(*_args: object, **kwargs: object) -> tuple[int, float, dict[str, Any]]:
         captured["native_testmon_data"] = cast(Path | None, kwargs["native_testmon_data"])
-        captured["native_testmon_descriptor"] = cast(int | None, kwargs["native_testmon_descriptor"])
         return 0, 0.0, {}
 
     monkeypatch.setattr(verify, "_ACTIVE_VERIFY_RUN", SimpleNamespace(owned_native_testmon_state=state))
@@ -2948,14 +2954,22 @@ def test_native_verifier_keeps_descriptor_binding_for_parent_inspection(
         state.close()
 
     assert captured["native_testmon_data"] == state.executable_data_path
-    assert captured["native_testmon_descriptor"] == state.descriptor
 
 
-def test_native_verifier_gives_xdist_testmon_a_worker_openable_state_path(
+@pytest.mark.uses_real_clock("The systemd scope and xdist worker are independent exec boundaries.")
+def test_native_verifier_gives_xdist_worker_a_real_sqlite_path_through_systemd(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A native xdist worker opens the testmon database through its real path."""
+    """A systemd-contained xdist worker can open the native testmon SQLite DB.
+
+    This intentionally exercises every launch boundary: verify -> systemd-run
+    -> supervisor -> pytest controller -> xdist worker.  The worker, not the
+    controller, opens SQLite, so a descriptor that vanishes at either exec
+    boundary cannot make this pass.
+    """
+    if not user_systemd_available():
+        pytest.skip("user systemd is unavailable on this host")
     descriptor_root = Path("/dev/fd")
     probe = os.open(tmp_path / "descriptor-probe", os.O_RDWR | os.O_CREAT, 0o600)
     try:
@@ -2966,14 +2980,20 @@ def test_native_verifier_gives_xdist_testmon_a_worker_openable_state_path(
 
     monkeypatch.setattr("devtools.testmon_bootstrap._DESCRIPTOR_FD_ROOTS", (descriptor_root,))
     monkeypatch.setattr(verify, "ROOT", tmp_path)
+    monkeypatch.setenv(CGROUP_MODE_ENV, "require")
     state = verify._open_owned_native_testmon_state(tmp_path)
-    observed = tmp_path / "contained-child.txt"
+    executable_data_path = state.executable_data_path
+    observed = tmp_path / "contained-worker.json"
     module = tmp_path / "test_xdist_testmon_state.py"
     module.write_text(
+        "import json\n"
         "import os\n"
+        "import sqlite3\n"
         "from pathlib import Path\n"
-        "def test_worker_receives_testmon_path():\n"
-        f"    Path({str(observed)!r}).write_text(os.environ['TESTMON_DATAFILE'])\n",
+        "def test_worker_opens_testmon_sqlite():\n"
+        "    with sqlite3.connect(os.environ['TESTMON_DATAFILE']) as connection:\n"
+        "        connection.execute('PRAGMA schema_version').fetchone()\n"
+        f"    Path({str(observed)!r}).write_text(json.dumps({{'pid': os.getpid(), 'datafile': os.environ['TESTMON_DATAFILE']}}))\n",
         encoding="utf-8",
     )
     monkeypatch.setattr(verify, "_ACTIVE_VERIFY_RUN", SimpleNamespace(owned_native_testmon_state=state))
@@ -3000,7 +3020,68 @@ def test_native_verifier_gives_xdist_testmon_a_worker_openable_state_path(
         state.close()
 
     assert rc == 0
-    assert observed.read_text(encoding="utf-8") == str(state.executable_data_path)
+    payload = json.loads(observed.read_text(encoding="utf-8"))
+    containment = json.loads((tmp_path / PYTEST_CONTAINMENT_PATH).read_text(encoding="utf-8"))
+    assert payload["datafile"] == str(executable_data_path)
+    assert payload["pid"] != containment["controller_pid"]
+    assert containment["mode"] == "systemd-scope"
+    assert containment["cgroup_owned"] is True
+
+
+@pytest.mark.uses_real_clock("The synthetic systemd launcher exercises descriptor closure across exec.")
+def test_native_verifier_does_not_depend_on_systemd_forwarding_testmon_descriptor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An older systemd-run-style launch may close every non-stdio descriptor."""
+    fake_systemd_run = tmp_path / "systemd-run"
+    fake_systemd_run.write_text(
+        "#!/usr/bin/env python3\n"
+        "import os, sys\n"
+        "os.closerange(3, 65536)\n"
+        "os.execv(sys.argv[sys.argv.index('--') + 1], sys.argv[sys.argv.index('--') + 1:])\n",
+        encoding="utf-8",
+    )
+    fake_systemd_run.chmod(0o755)
+    monkeypatch.setattr(pytest_supervisor, "user_systemd_available", lambda _env=None: True)
+    monkeypatch.setattr("devtools.pytest_supervisor.shutil.which", lambda _name, path=None: str(fake_systemd_run))
+    monkeypatch.setattr(verify, "ROOT", tmp_path)
+    monkeypatch.setenv(CGROUP_MODE_ENV, "require")
+
+    state = verify._open_owned_native_testmon_state(tmp_path)
+    observed = tmp_path / "closed-descriptor-worker.txt"
+    module = tmp_path / "test_closed_descriptor.py"
+    module.write_text(
+        "import os\n"
+        "import sqlite3\n"
+        "from pathlib import Path\n"
+        "def test_controller_opens_real_testmon_sqlite():\n"
+        "    with sqlite3.connect(os.environ['TESTMON_DATAFILE']) as connection:\n"
+        "        connection.execute('PRAGMA schema_version').fetchone()\n"
+        f"    Path({str(observed)!r}).write_text(os.environ['TESTMON_DATAFILE'])\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(verify, "_ACTIVE_VERIFY_RUN", SimpleNamespace(owned_native_testmon_state=state))
+    try:
+        rc, _elapsed, _metadata = _run(
+            "pytest native closed-descriptor systemd",
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-q",
+                "-p",
+                "pytest-testmon",
+                "--testmon",
+                str(module),
+            ],
+            cwd=str(tmp_path),
+        )
+    finally:
+        state.close()
+
+    assert rc == 0
+    assert observed.read_text(encoding="utf-8") == str(tmp_path / verify.TESTMON_DATA)
 
 
 def test_run_records_managed_basetemp_cleanup_metadata(tmp_path: Path) -> None:

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -157,6 +157,92 @@ def test_current_parser_receipt_reselection_repairs_legacy_empty_membership_keys
     assert uncensused_historical_revision_raw_ids(tmp_path, [legacy_raw_id, canonical_raw_id]) == (legacy_raw_id,)
 
 
+def test_fragment_repair_preserves_durable_membership_while_refreshing_legacy_receipt(tmp_path: Path) -> None:
+    """Re-census repairs a fragment receipt without erasing its authority key."""
+    initialize_active_archive_root(tmp_path)
+    logical_key = "codex-session:legacy-fragment"
+    baseline = (
+        b'{"type":"session_meta","payload":{"id":"legacy-fragment","timestamp":"2026-08-20T00:00:00Z"}}\n'
+        b'{"type":"response_item","payload":{"type":"message","role":"user","content":'
+        b'[{"type":"input_text","text":"baseline"}]}}\n'
+    )
+    fragment = b'{"type":"response_item","payload":{"type":"message","id":"legacy-suffix"}}\n'
+
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        baseline_raw_id = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=baseline,
+            source_path="legacy-fragment.jsonl",
+            acquired_at_ms=1,
+            revision=RawRevisionEnvelope(
+                logical_key, RawRevisionKind.FULL, "baseline", 0, authority=RawRevisionAuthority.BYTE_PROVEN
+            ),
+        )
+        raw_id = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=fragment,
+            source_path="legacy-fragment.jsonl",
+            source_index=-1,
+            acquired_at_ms=2,
+            revision=RawRevisionEnvelope(
+                logical_key,
+                RawRevisionKind.APPEND,
+                "append-1",
+                1,
+                predecessor_source_revision="baseline",
+                predecessor_raw_id=baseline_raw_id,
+                baseline_raw_id=baseline_raw_id,
+                append_start_offset=len(baseline),
+                append_end_offset=len(baseline) + len(fragment),
+                authority=RawRevisionAuthority.BYTE_PROVEN,
+            ),
+        )
+        archive.classify_raw_revision_cohort_for_rebuild_repair(logical_key)
+
+    census_historical_revision_evidence(tmp_path)
+
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        with archive._ensure_source_conn():
+            archive._ensure_source_conn().execute(
+                """
+                INSERT INTO raw_session_memberships (
+                    raw_id, logical_source_key, provider_session_id, source_revision,
+                    normalized_content_hash, message_count
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (raw_id, "codex-session:legacy-fragment", "legacy-fragment", "revision-1", bytes(32), 1),
+            )
+            archive._ensure_source_conn().execute(
+                """
+                UPDATE raw_authority_parser_census
+                SET parser_fingerprint = ?, status = 'complete', logical_keys_json = '[]',
+                    detail = 'parser-observed: legacy receipt shape', censused_at_ms = 1
+                WHERE raw_id = ?
+                """,
+                (RAW_AUTHORITY_PARSER_FINGERPRINT, raw_id),
+            )
+
+    assert uncensused_historical_revision_raw_ids(tmp_path, [raw_id]) == (raw_id,)
+
+    census_historical_revision_evidence(tmp_path, selected_raw_ids=[raw_id])
+
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        memberships = conn.execute(
+            "SELECT logical_source_key FROM raw_session_memberships WHERE raw_id = ?", (raw_id,)
+        ).fetchall()
+        receipt = conn.execute(
+            "SELECT status, logical_keys_json FROM raw_authority_parser_census WHERE raw_id = ?", (raw_id,)
+        ).fetchone()
+
+    assert memberships == [("codex-session:legacy-fragment",)]
+    assert receipt is not None
+    assert receipt[0] == "complete"
+    assert parser_census_logical_keys(receipt[1]) == ("codex-session:legacy-fragment",)
+    validate_frozen_source_authority(tmp_path, selected_raw_ids=[baseline_raw_id, raw_id])
+    census_historical_revision_evidence(tmp_path, selected_raw_ids=[raw_id])
+    assert uncensused_historical_revision_raw_ids(tmp_path, [raw_id]) == ()
+
+
 def test_terminal_non_session_reselection_repairs_legacy_parser_receipt(tmp_path: Path) -> None:
     """The real census path repairs stale terminal non-session receipts."""
     initialize_active_archive_root(tmp_path)

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -38,7 +38,7 @@ from polylogue.sources.revision_backfill import (
 from polylogue.storage.artifacts.inspection import inspect_raw_artifact
 from polylogue.storage.blob_publication import ArchiveBlobPublisher
 from polylogue.storage.blob_store import BlobStore
-from polylogue.storage.raw_authority import RAW_AUTHORITY_PARSER_FINGERPRINT
+from polylogue.storage.raw_authority import RAW_AUTHORITY_PARSER_FINGERPRINT, parser_census_logical_keys
 from polylogue.storage.raw_retention import RawRetentionAuthority, active_raw_retention_authority
 from polylogue.storage.sqlite.archive_tiers import revision_governance as archive_revision_governance
 from polylogue.storage.sqlite.archive_tiers import write as archive_tier_write
@@ -155,6 +155,48 @@ def test_current_parser_receipt_reselection_repairs_legacy_empty_membership_keys
         conn.commit()
 
     assert uncensused_historical_revision_raw_ids(tmp_path, [legacy_raw_id, canonical_raw_id]) == (legacy_raw_id,)
+
+
+def test_terminal_non_session_reselection_repairs_legacy_parser_receipt(tmp_path: Path) -> None:
+    """The real census path repairs stale terminal non-session receipts."""
+    initialize_active_archive_root(tmp_path)
+
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        raw_id = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=b"terminal non-session legacy receipt",
+            source_path="terminal-legacy.jsonl",
+            acquired_at_ms=1,
+        )
+
+    census_historical_revision_evidence(tmp_path, selected_raw_ids=[raw_id])
+
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        with archive._ensure_source_conn():
+            archive._ensure_source_conn().execute(
+                """
+                UPDATE raw_authority_parser_census
+                SET status = 'failed', logical_keys_json = '[]',
+                    detail = 'parser-observed: legacy incomplete receipt', censused_at_ms = 1
+                WHERE raw_id = ?
+                """,
+                (raw_id,),
+            )
+
+    assert uncensused_historical_revision_raw_ids(tmp_path, [raw_id]) == (raw_id,)
+
+    census_historical_revision_evidence(tmp_path, selected_raw_ids=[raw_id])
+
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        status, keys = conn.execute(
+            "SELECT status, logical_keys_json FROM raw_authority_parser_census WHERE raw_id = ?", (raw_id,)
+        ).fetchone()
+    assert status == "complete"
+    assert parser_census_logical_keys(keys) == ()
+
+    validate_frozen_source_authority(tmp_path, selected_raw_ids=[raw_id])
+    census_historical_revision_evidence(tmp_path, selected_raw_ids=[raw_id])
+    assert uncensused_historical_revision_raw_ids(tmp_path, [raw_id]) == ()
 
 
 def test_revision_reparse_preserves_beads_workspace_identity(tmp_path: Path) -> None:

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -32,6 +32,7 @@ from polylogue.sources.revision_backfill import (
     _parse_one,
     backfill_historical_revision_evidence,
     census_historical_revision_evidence,
+    uncensused_historical_revision_raw_ids,
     validate_frozen_source_authority,
 )
 from polylogue.storage.artifacts.inspection import inspect_raw_artifact
@@ -103,6 +104,57 @@ def test_browser_snapshot_fidelity_derives_from_parser_ingest_flags() -> None:
     assert _browser_snapshot_fidelity([COMPACT_BROWSER_CAPTURE_INGEST_FLAG]) == "native"
     # Native takes precedence if a parser somehow reports both.
     assert _browser_snapshot_fidelity([DOM_FALLBACK_INGEST_FLAG, NATIVE_BROWSER_CAPTURE_INGEST_FLAG]) == "native"
+
+
+def test_current_parser_receipt_reselection_repairs_legacy_empty_membership_keys(tmp_path: Path) -> None:
+    """Current receipts with legacy empty keys are re-censused when authority has a key."""
+    initialize_active_archive_root(tmp_path)
+
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        legacy_raw_id = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=b"legacy-empty-receipt",
+            source_path="legacy-empty.jsonl",
+            acquired_at_ms=1,
+            revision=RawRevisionEnvelope("codex:legacy-membership", RawRevisionKind.FULL, "legacy-v1", 0),
+        )
+        canonical_raw_id = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=b"canonical-receipt",
+            source_path="canonical.jsonl",
+            acquired_at_ms=2,
+            revision=RawRevisionEnvelope("codex:canonical-membership", RawRevisionKind.FULL, "canonical-v1", 0),
+        )
+
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        for raw_id, logical_key, receipt_keys in (
+            (legacy_raw_id, "codex-session:legacy-membership", "[]"),
+            (
+                canonical_raw_id,
+                "codex-session:canonical-membership",
+                json.dumps(["codex-session:canonical-membership"]),
+            ),
+        ):
+            conn.execute(
+                """
+                INSERT INTO raw_session_memberships (
+                    raw_id, logical_source_key, provider_session_id, source_revision,
+                    normalized_content_hash, message_count
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (raw_id, logical_key, logical_key.rsplit(":", 1)[1], "revision-1", bytes(32), 1),
+            )
+            conn.execute(
+                """
+                INSERT INTO raw_authority_parser_census (
+                    raw_id, parser_fingerprint, status, logical_keys_json, detail, censused_at_ms
+                ) VALUES (?, ?, 'complete', ?, 'parser-observed: legacy receipt shape', 1)
+                """,
+                (raw_id, RAW_AUTHORITY_PARSER_FINGERPRINT, receipt_keys),
+            )
+        conn.commit()
+
+    assert uncensused_historical_revision_raw_ids(tmp_path, [legacy_raw_id, canonical_raw_id]) == (legacy_raw_id,)
 
 
 def test_revision_reparse_preserves_beads_workspace_identity(tmp_path: Path) -> None:

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -1471,9 +1471,9 @@ def test_historical_backfill_selects_prefix_newest_independent_of_acquisition_or
             (RAW_AUTHORITY_PARSER_FINGERPRINT,),
         ).fetchall()
     # polylogue-39kcs: all three raws are census-complete, including the
-    # legacy append fragment. Its receipt records the authoritative empty
-    # identity set that byte revision governance gives it -- a ``failed``
-    # receipt there matched neither branch of
+    # legacy append fragment. Its receipt records the durable identity set
+    # available to byte revision governance (empty here because this fixture
+    # has no membership binding) -- a ``failed`` receipt there matched neither branch of
     # ``uncensused_historical_revision_raw_ids``'s gate, so the fragment was
     # re-selected for census forever and raw-replay planning never started.
     # The fragment is still ``quarantined`` (asserted above); only the

--- a/tests/unit/storage/test_archive_readiness.py
+++ b/tests/unit/storage/test_archive_readiness.py
@@ -537,6 +537,9 @@ def test_raw_materialization_snapshot_reads_append_census_writer_contract(tmp_pa
     assert snapshot["classified"] == 1
     assert snapshot["unchecked"] == 0
     assert _category_counts(snapshot)["append-authority-quarantined"] == 1
+    parser_census = cast(Mapping[str, object], snapshot["raw_authority_parser_census"])
+    assert parser_census["complete_count"] == 1
+    assert parser_census["incomplete_count"] == 0
 
 
 def test_raw_materialization_snapshot_ignores_skipped_raw_rows(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -2340,7 +2340,9 @@ def test_raw_materialization_reports_uncensused_append_fragments_as_pending_debt
     # The fragment is still debt -- just typed as the authority quarantine it
     # actually is, rather than as unfinished census work.
     assert targeted.census_receipt.quiescent is True
-    assert "append authority quarantine" in targeted.detail
+    assert targeted.metrics["raw_materialization_byte_authority_quarantined_count"] == 1
+    assert "1 append authority quarantine(s)" in targeted.detail
+    assert "0 append fragment(s) pending byte-authority adjudication" in targeted.detail
 
     with sqlite3.connect(tmp_path / "source.db") as source_conn:
         cursor = source_conn.execute(

--- a/tests/unit/storage/test_revision_replay.py
+++ b/tests/unit/storage/test_revision_replay.py
@@ -10,6 +10,7 @@ import pytest
 
 from polylogue.archive.message.roles import Role
 from polylogue.archive.revision_authority import (
+    BYTE_AUTHORITY_CENSUS_DETAIL,
     RawRevisionAuthority,
     RawRevisionEnvelope,
     RawRevisionKind,
@@ -274,6 +275,48 @@ def test_terminal_non_session_failure_has_complete_empty_parser_census(tmp_path:
     from polylogue.sources.revision_backfill import require_current_parser_source_census
 
     assert require_current_parser_source_census(tmp_path)[raw_id] == ()
+
+
+def test_byte_governed_fragment_parser_receipt_preserves_durable_membership_keys(tmp_path: Path) -> None:
+    """A byte-governed receipt cannot overclaim an empty durable identity set."""
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        raw_id = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=b'{"append":true}\n',
+            source_path="session.jsonl",
+            source_index=-1,
+            acquired_at_ms=1,
+        )
+        with archive._ensure_source_conn():
+            conn = archive._ensure_source_conn()
+            conn.execute(
+                """
+                INSERT INTO raw_session_memberships (
+                    raw_id, logical_source_key, provider_session_id, source_revision,
+                    normalized_content_hash, message_count
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (raw_id, "codex-session:durable-append", "durable-append", "revision-1", bytes(32), 1),
+            )
+            conn.execute(
+                """
+                INSERT INTO raw_membership_census (
+                    raw_id, parser_fingerprint, status, member_count, censused_at_ms, detail
+                ) VALUES (?, ?, 'failed', 1, 1, ?)
+                """,
+                (raw_id, RAW_AUTHORITY_PARSER_FINGERPRINT, BYTE_AUTHORITY_CENSUS_DETAIL),
+            )
+            archive_revision_governance.record_current_parser_source_census(conn, raw_id)
+
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        receipt = conn.execute(
+            "SELECT status, logical_keys_json FROM raw_authority_parser_census WHERE raw_id = ?", (raw_id,)
+        ).fetchone()
+
+    assert receipt is not None
+    assert receipt[0] == "complete"
+    assert parser_census_logical_keys(receipt[1]) == ("codex-session:durable-append",)
 
 
 def test_frozen_replay_skips_typed_terminal_non_session_raw(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_revision_replay.py
+++ b/tests/unit/storage/test_revision_replay.py
@@ -527,13 +527,17 @@ def test_membership_reselection_reuses_equivalent_superseded_receipt(tmp_path: P
             SELECT raw_id, decision, accepted_raw_id
             FROM raw_revision_applications
             WHERE logical_source_key = 'codex:session'
-            ORDER BY raw_id, decision
+            ORDER BY raw_id, decision, accepted_raw_id
             """
         ).fetchall()
+        # Revision receipts are append-only evidence. When ``accepted-a``
+        # becomes the new head, each equivalent member receives a current
+        # supersession receipt while its historical supersession remains.
         assert [tuple(row) for row in application_rows] == [
             ("accepted-a", "selected_baseline", "accepted-a"),
             ("equivalent-z", "selected_baseline", "equivalent-z"),
             ("equivalent-z", "superseded", "accepted-a"),
+            ("representative-b", "superseded", "accepted-a"),
             ("representative-b", "superseded", "equivalent-z"),
         ]
         matching_receipts = archive._conn.execute(

--- a/tests/unit/storage/test_revision_replay.py
+++ b/tests/unit/storage/test_revision_replay.py
@@ -319,6 +319,52 @@ def test_byte_governed_fragment_parser_receipt_preserves_durable_membership_keys
     assert parser_census_logical_keys(receipt[1]) == ("codex-session:durable-append",)
 
 
+def test_typed_non_session_receipt_preserves_durable_membership_on_restart(tmp_path: Path) -> None:
+    """Restart validation must use the same durable shape as receipt creation."""
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        raw_id = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=b"not valid codex jsonl",
+            source_path="terminal-corrupt.jsonl",
+            acquired_at_ms=1,
+        )
+        archive.record_raw_failure_evidence(
+            raw_id,
+            provider=Provider.CODEX,
+            source_path="terminal-corrupt.jsonl",
+            source_index=0,
+            acquired_at_ms=1,
+            kind=RawFailureEvidenceKind.TERMINAL_CORRUPT_INPUT,
+        )
+        with archive._ensure_source_conn():
+            conn = archive._ensure_source_conn()
+            conn.execute(
+                """
+                INSERT INTO raw_session_memberships (
+                    raw_id, logical_source_key, provider_session_id, source_revision,
+                    normalized_content_hash, message_count
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (raw_id, "codex-session:typed-membership", "typed-membership", "revision-1", bytes(32), 1),
+            )
+            archive_revision_governance.record_current_parser_source_census(conn, raw_id)
+
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        receipt = conn.execute(
+            "SELECT status, logical_keys_json FROM raw_authority_parser_census WHERE raw_id = ?", (raw_id,)
+        ).fetchone()
+
+    assert receipt is not None
+    assert receipt[0] == "complete"
+    expected_keys = ("codex-session:typed-membership",)
+    assert parser_census_logical_keys(receipt[1]) == expected_keys
+
+    from polylogue.sources.revision_backfill import require_current_parser_source_census
+
+    assert require_current_parser_source_census(tmp_path)[raw_id] == expected_keys
+
+
 def test_frozen_replay_skips_typed_terminal_non_session_raw(tmp_path: Path) -> None:
     """Terminal non-session evidence settles replay without dispatching its malformed bytes."""
 


### PR DESCRIPTION
## Summary

Unify parser-census completeness across receipt creation, readiness, re-census, terminal restart validation, and frozen-source checks. The same batch also makes the descriptor-backed testmon state survive the supervisor, systemd-scope, and xdist exec boundaries.

## Problem

Old parser-census receipts could state an empty identity set despite durable membership evidence, leaving readiness and frozen rebuilds in disagreement. The original descriptor handoff also passed a closed file descriptor into systemd and xdist child processes, causing `EBADF` or an invalid testmon database path.

## Solution

- Share the parser-census authority predicate across all consumers and rewrite old terminal receipt shapes without erasing fragment memberships.
- Preserve membership-derived keys for byte-governed fragments.
- Hand off descriptor-backed testmon state through exec boundaries using a durable child-safe path rather than an inherited descriptor.
- Cover the real systemd-scope and xdist worker routes, plus the process-group fallback.

## Verification

- Pre-fix parser-census and descriptor-closing regressions failed as expected.
- `devtools test tests/unit/storage/test_archive_readiness.py tests/unit/storage/test_revision_replay.py tests/unit/storage/test_repair.py tests/unit/sources/test_revision_backfill.py` passed (264 tests).
- `devtools test tests/unit/devtools/test_pytest_supervisor.py tests/unit/devtools/test_verify.py` passed (237 tests).
- Systemd/xdist SQLite route: `3 passed`; process-group/fallback/startup route: `4 passed`.
- `devtools verify --quick` passed in 43.1s; `git verify-commit HEAD` validates the final signed commit.
- The complete-corpus receipt is intentionally deferred to the single post-merge train verification on master.

## Bead disposition

| Bead | Disposition | Evidence | Residual |
| --- | --- | --- | --- |
| `polylogue-fb61x` | satisfied | rebased commits and focused production-route checks below | Tracker record was already closed on master, so this PR mutates no Bead export record. |

## Adversarial self-review

- Reviewed the descriptor lifetime through supervisor, systemd scope, controller, xdist worker, and process-group fallback. The new handoff does not rely on inherited arbitrary descriptors.
- The real-systemd regression skips only when no user manager exists; deterministic descriptor-closure coverage remains active there.

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [
    "polylogue-fb61x"
  ],
  "dispositions": [
    {
      "bead_id": "polylogue-fb61x",
      "disposition": "satisfied",
      "evidence": [
        {"kind": "commit", "ref": "15938b32a0f597fbf0e8ea1d28af762e8f181612"},
        {"kind": "commit", "ref": "36f4ec75e9cb66b0d9bf8ee463352f798c8bfc23"},
        {"kind": "commit", "ref": "79fdca6cac906b956f88ee572f0b4ab7c598f23b"},
        {"kind": "commit", "ref": "1d403dfbf0a2037b90d8f12886774ac089941f15"},
        {"kind": "commit", "ref": "51cc60df6186a107b5fbb329cfd6d23eff615e3a"},
        {"kind": "commit", "ref": "1dc43ba7ab03772c7e70415e5a2c2c744681c1cb"},
        {"kind": "commit", "ref": "44bd5b841ad2c83cd2280b0a3a4a5bfe323b9cb8"},
        {"kind": "test", "ref": "focused-test 20260820T154822Z-focused-test-3040922-11837510: 512 passed in 97.7s"},
        {"kind": "command", "ref": "quick 20260820T155040Z-quick-3047265-0c66e4aa: success in 41.3s"},
        {"kind": "review", "ref": "final Terra self-review of descriptor handoff and all PR #4030 threads"}
      ],
      "successors": []
    }
  ],
  "mutated_beads": [],
  "scope_digest": "6063de0bc49a3b067aa4b64ae7bfd0e1bb96eb8b11226d0ec26c4bb3623eecbe",
  "scope_kind": "bead",
  "version": 2
}
-->
