### PR TITLE
fix(storage): cover append chains in raw authority verdicts

### DIFF
--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -1041,13 +1041,6 @@ def make_raw_authority_verdict_cache_stage(db_path: Path) -> ConvergenceStage:
     def work() -> RawAuthorityVerdictCacheWork | None:
         return find_raw_authority_verdict_cache_work(db_path.parent)
 
-    def log_skipped_append_cohorts(discovered: RawAuthorityVerdictCacheWork) -> None:
-        if discovered.skipped_append_cohorts:
-            logger.info(
-                "raw_authority_verdict_cache: skipped append cohorts=%d; append authority uses a separate proof",
-                discovered.skipped_append_cohorts,
-            )
-
     def check(_path: Path) -> bool:
         try:
             discovered = work()
@@ -1056,7 +1049,6 @@ def make_raw_authority_verdict_cache_stage(db_path: Path) -> ConvergenceStage:
             return True
         if discovered is None:
             return False
-        log_skipped_append_cohorts(discovered)
         return bool(discovered.pending_logical_source_keys)
 
     def check_many(paths: Sequence[Path]) -> set[Path]:
@@ -1069,7 +1061,6 @@ def make_raw_authority_verdict_cache_stage(db_path: Path) -> ConvergenceStage:
             return set(paths)
         if discovered is None:
             return set()
-        log_skipped_append_cohorts(discovered)
         return set(paths) if discovered.pending_logical_source_keys else set()
 
     def execute(_path: Path) -> StageExecuteReturn:
@@ -1086,16 +1077,15 @@ def make_raw_authority_verdict_cache_stage(db_path: Path) -> ConvergenceStage:
             logger.warning("raw_authority_verdict_cache: bounded warmup failed", exc_info=True)
             return False
         logger.info(
-            "raw_authority_verdict_cache: warmed cohorts=%d skipped_append=%d pending=%s",
+            "raw_authority_verdict_cache: warmed cohorts=%d pending=%s",
             outcome.warmed_cohorts,
-            outcome.skipped_append_cohorts,
             outcome.pending_cohorts,
         )
         return not outcome.pending_cohorts
 
     return ConvergenceStage(
         name="raw_authority_verdict_cache",
-        description="Warm content-keyed raw-authority verdicts for full/unknown cohorts",
+        description="Warm content-keyed raw-authority verdicts for every revision cohort",
         check=check,
         execute=execute,
         check_many=check_many,

--- a/polylogue/storage/raw_authority_verdict_cache.py
+++ b/polylogue/storage/raw_authority_verdict_cache.py
@@ -43,7 +43,6 @@ class RawAuthorityVerdictCacheWork:
     """Bounded cache-warming work discovered from one source-tier snapshot."""
 
     pending_logical_source_keys: tuple[str, ...]
-    skipped_append_cohorts: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -51,22 +50,22 @@ class RawAuthorityVerdictCacheWarmup:
     """Outcome of one bounded proactive cache-warming pass."""
 
     warmed_cohorts: int
-    skipped_append_cohorts: int
     pending_cohorts: bool
 
 
 def _current_cohort_rows_from_connection(
     conn: sqlite3.Connection, logical_source_key: str
-) -> list[tuple[str, str, str]]:
+) -> list[tuple[str, str, str, str, str]]:
     rows = conn.execute(
         """
-        SELECT raw_id, revision_kind, lower(hex(blob_hash))
+        SELECT raw_id, revision_kind, lower(hex(blob_hash)), revision_authority,
+               COALESCE(predecessor_raw_id, '')
         FROM raw_sessions
         WHERE logical_source_key = ?
         """,
         (logical_source_key,),
     ).fetchall()
-    return [(str(row[0]), str(row[1]), str(row[2])) for row in rows]
+    return [(str(row[0]), str(row[1]), str(row[2]), str(row[3]), str(row[4])) for row in rows]
 
 
 def _read_cached_raw_authority_verdicts_from_connection(
@@ -94,18 +93,14 @@ def _read_cached_raw_authority_verdicts_from_connection(
 def find_raw_authority_verdict_cache_work(
     conn: sqlite3.Connection, *, max_cohorts: int | None = None
 ) -> RawAuthorityVerdictCacheWork:
-    """Find stale full/unknown cohorts without reading blob payloads.
+    """Find stale cohorts without reading blob payloads.
 
-    Append cohorts are deliberately excluded because the Phase 2 projection
-    has a different proof shape for contiguous append authority. They are
-    counted so the daemon can report that they were intentionally skipped.
-    ``max_cohorts`` bounds returned work, while the skip count still covers
-    the complete source-tier snapshot.
+    ``max_cohorts`` bounds returned work. Append fragments share the same
+    cache now that the projection reads their persisted byte-authority links.
     """
     rows = conn.execute(
         """
-        SELECT logical_source_key,
-               MAX(CASE WHEN revision_kind = 'append' THEN 1 ELSE 0 END) AS has_append
+        SELECT logical_source_key
         FROM raw_sessions
         WHERE logical_source_key IS NOT NULL
           AND logical_source_key != ''
@@ -114,28 +109,24 @@ def find_raw_authority_verdict_cache_work(
         """
     ).fetchall()
     pending: list[str] = []
-    skipped_append_cohorts = 0
-    for logical_source_key, has_append in rows:
+    for (logical_source_key,) in rows:
         key = str(logical_source_key)
-        if bool(has_append):
-            skipped_append_cohorts += 1
-            continue
         if _read_cached_raw_authority_verdicts_from_connection(conn, key) is not None:
             continue
         if max_cohorts is None or len(pending) < max_cohorts:
             pending.append(key)
-    return RawAuthorityVerdictCacheWork(tuple(pending), skipped_append_cohorts)
+    return RawAuthorityVerdictCacheWork(tuple(pending))
 
 
 def _current_cohort_rows(
     store: RawAuthorityVerdictProjectionHost, logical_source_key: str
-) -> list[tuple[str, str, str]]:
-    """Return every ``(raw_id, revision_kind, blob_hash_hex)`` row for a cohort."""
+) -> list[tuple[str, str, str, str, str]]:
+    """Return every verdict-defining raw row for a cohort."""
     return _current_cohort_rows_from_connection(store._ensure_source_conn(), logical_source_key)
 
 
-def _cohort_fingerprint(rows: list[tuple[str, str, str]]) -> bytes:
-    """SHA-256 over the sorted ``(raw_id, revision_kind, blob_hash)`` rows defining a cohort.
+def _cohort_fingerprint(rows: list[tuple[str, str, str, str, str]]) -> bytes:
+    """SHA-256 over every raw fact the projection uses to derive a verdict.
 
     Sorting first makes the fingerprint independent of SQL row order. Each
     field is length-delimited by a trailing NUL/SOH-style separator byte
@@ -144,12 +135,10 @@ def _cohort_fingerprint(rows: list[tuple[str, str, str]]) -> bytes:
     ``revision_kind="bc"``.
     """
     hasher = hashlib.sha256()
-    for raw_id, revision_kind, blob_hash in sorted(rows):
-        hasher.update(raw_id.encode("utf-8"))
-        hasher.update(b"\x00")
-        hasher.update(revision_kind.encode("utf-8"))
-        hasher.update(b"\x00")
-        hasher.update(blob_hash.encode("utf-8"))
+    for row in sorted(rows):
+        for value in row:
+            hasher.update(value.encode("utf-8"))
+            hasher.update(b"\x00")
         hasher.update(b"\x01")
     return hasher.digest()
 
@@ -247,7 +236,6 @@ def warm_raw_authority_verdict_cache(
     remaining = find_raw_authority_verdict_cache_work(conn, max_cohorts=1)
     return RawAuthorityVerdictCacheWarmup(
         warmed_cohorts=len(work.pending_logical_source_keys),
-        skipped_append_cohorts=work.skipped_append_cohorts,
         pending_cohorts=bool(remaining.pending_logical_source_keys),
     )
 

--- a/polylogue/storage/raw_authority_verdict_projection.py
+++ b/polylogue/storage/raw_authority_verdict_projection.py
@@ -2,20 +2,12 @@
 
 Phase 2 of the raw-authority redesign (polylogue-w6hql). This is a **read-only
 consumer** of the existing revision-authority evidence -- it issues no writes
-to ``raw_sessions`` or any of the fragmented census/blocker/plan tables, and
-reuses the exact same byte-proof machinery (``classify_historical_full_
-revision_streams``) the real classifier (``classify_raw_revision_cohort`` in
-``storage/sqlite/archive_tiers/revision_governance.py``) already uses, so its
-verdicts cannot silently diverge from what governance actually proved.
-
-Scope of this phase: ``revision_kind = 'full'`` cohorts only, matching
-``classify_raw_revision_cohort``'s own current scope. Append-only cohorts
-(``revision_kind = 'append'``) are out of scope for this projection and raise
-``NotImplementedError`` rather than silently returning a wrong verdict --
-their authority is governed by contiguous-append promotion
-(``_promote_contiguous_append_evidence``), a different proof shape that this
-phase does not attempt to collapse (see polylogue-w6hql notes for the
-follow-up this is filed under).
+to ``raw_sessions`` or any of the fragmented census/blocker/plan tables. Full
+snapshots reuse the exact byte-proof machinery (``classify_historical_full_
+revision_streams``) used by the real classifier. Append fragments reuse the
+same persisted byte-proven predecessor links written by contiguous-append
+promotion in that classifier, so verdicts cannot silently diverge from the
+authority that replay already accepts.
 """
 
 from __future__ import annotations
@@ -26,6 +18,7 @@ from typing import BinaryIO, Protocol
 from polylogue.archive.raw_authority_verdict import derive_raw_authority_verdict
 from polylogue.archive.revision_authority import (
     HistoricalRawRevisionStream,
+    RawRevisionAuthority,
     classify_historical_full_revision_streams,
 )
 from polylogue.core.enums import RawAuthorityVerdict
@@ -44,18 +37,22 @@ def project_raw_authority_verdicts(
     store: RawAuthorityVerdictProjectionHost,
     logical_source_key: str,
 ) -> dict[str, RawAuthorityVerdict]:
-    """Return the closed verdict for every ``revision_kind='full'`` raw in a cohort.
+    """Return the closed verdict for every raw in a cohort without writing it.
 
-    Read-only: opens the source connection and blob store for reading only,
-    issues no writes. Raises ``NotImplementedError`` if the cohort contains
-    any ``revision_kind != 'full'`` row (see module docstring).
+    Full snapshots are reclassified from their bytes. Append fragments cannot
+    be compared as complete snapshots, so their verdict comes from the
+    byte-proven predecessor chain the production classifier already persisted:
+    an accepted fragment is VERIFIED at the chain head and SUPERSEDED once a
+    later accepted fragment names it as predecessor. ASSERTED fragments remain
+    UNCHECKED; QUARANTINED fragments are DIVERGED.
     """
     if store._blob_publisher is None:
         raise RuntimeError("raw authority verdict projection requires a readable blob publisher")
     source_conn = store._ensure_source_conn()
     rows = source_conn.execute(
         """
-        SELECT raw_id, lower(hex(blob_hash)) AS blob_hash, blob_size, revision_kind
+        SELECT raw_id, lower(hex(blob_hash)) AS blob_hash, blob_size, revision_kind,
+               revision_authority, predecessor_raw_id
         FROM raw_sessions
         WHERE logical_source_key = ?
         """,
@@ -67,19 +64,15 @@ def project_raw_authority_verdicts(
     # 'unknown' is the pre-governance default (DDL:
     # revision_kind NOT NULL DEFAULT 'unknown') -- identity/kind resolution
     # has not run over this raw yet, so no verdict can be proven.
-    unresolved = [str(row[0]) for row in rows if str(row[3]) == "unknown"]
-    non_full_resolved = [str(row[0]) for row in rows if str(row[3]) not in ("full", "unknown")]
-    if non_full_resolved:
-        raise NotImplementedError(
-            f"raw authority verdict projection is scoped to revision_kind='full' cohorts "
-            f"this phase; logical_source_key={logical_source_key!r} contains non-full raw_ids "
-            f"{non_full_resolved!r} (see polylogue-w6hql)"
-        )
-
-    verdicts: dict[str, RawAuthorityVerdict] = dict.fromkeys(unresolved, RawAuthorityVerdict.UNCHECKED)
+    verdicts: dict[str, RawAuthorityVerdict] = {
+        str(row[0]): RawAuthorityVerdict.UNCHECKED for row in rows if str(row[3]) == "unknown"
+    }
+    byte_proven_successors = {
+        str(row[5]) for row in rows if str(row[4]) == RawRevisionAuthority.BYTE_PROVEN.value and row[5] is not None
+    }
     provable: list[HistoricalRawRevisionStream] = []
     for row in rows:
-        raw_id, blob_hash, blob_size, revision_kind = row
+        raw_id, blob_hash, blob_size, revision_kind, _authority, _predecessor_raw_id = row
         if str(revision_kind) != "full":
             continue
 
@@ -99,6 +92,27 @@ def project_raw_authority_verdicts(
     if provable:
         decisions = classify_historical_full_revision_streams(provable)
         verdicts.update(derive_raw_authority_verdict(decisions))
+    for raw_id, _blob_hash, _blob_size, revision_kind, authority, _predecessor_raw_id in rows:
+        raw_id_text = str(raw_id)
+        kind = str(revision_kind)
+        if kind == "append":
+            if str(authority) == RawRevisionAuthority.BYTE_PROVEN.value:
+                verdicts[raw_id_text] = (
+                    RawAuthorityVerdict.SUPERSEDED
+                    if raw_id_text in byte_proven_successors
+                    else RawAuthorityVerdict.VERIFIED
+                )
+            elif str(authority) == RawRevisionAuthority.QUARANTINED.value:
+                verdicts[raw_id_text] = RawAuthorityVerdict.DIVERGED
+            else:
+                verdicts[raw_id_text] = RawAuthorityVerdict.UNCHECKED
+        elif (
+            kind == "full"
+            and str(authority) == RawRevisionAuthority.BYTE_PROVEN.value
+            and raw_id_text in byte_proven_successors
+            and verdicts.get(raw_id_text) in (RawAuthorityVerdict.SOLE_COPY, RawAuthorityVerdict.VERIFIED)
+        ):
+            verdicts[raw_id_text] = RawAuthorityVerdict.SUPERSEDED
     return verdicts
 
 

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -132,9 +132,9 @@ def test_raw_authority_verdict_cache_stage_warms_in_bounded_batches_and_reports_
         cached_cohorts = {
             str(row[0]) for row in conn.execute("SELECT DISTINCT logical_source_key FROM raw_authority_verdicts")
         }
-    assert len(cached_cohorts) == stages._DAEMON_RAW_AUTHORITY_CACHE_MAX_COHORTS + 1
-    assert "codex:append" not in cached_cohorts
-    assert "skipped append cohorts=1" in caplog.text
+    assert len(cached_cohorts) == stages._DAEMON_RAW_AUTHORITY_CACHE_MAX_COHORTS + 2
+    assert "codex:append" in cached_cohorts
+    assert "raw_authority_verdict_cache: warmed cohorts=" in caplog.text
 
     import polylogue.storage.raw_authority_verdict_cache as cache_module
 

--- a/tests/unit/storage/test_raw_authority_verdict_cache.py
+++ b/tests/unit/storage/test_raw_authority_verdict_cache.py
@@ -136,6 +136,50 @@ def test_changed_content_fingerprint_invalidates_the_cache(tmp_path: Path) -> No
     }
 
 
+def test_append_authority_promotion_invalidates_the_cache(tmp_path: Path) -> None:
+    """The cache must follow the persisted byte-proof links used by append verdicts."""
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        _bind_full(archive, raw_id="baseline", payload=b"one\n", logical_source_key="codex:s1")
+        append_id = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=b"two\n",
+            source_path="session.jsonl",
+            source_index=-1,
+            acquired_at_ms=1,
+            raw_id="append",
+        )
+        archive.bind_raw_revision(
+            append_id,
+            RawRevisionEnvelope(
+                "codex:s1",
+                RawRevisionKind.APPEND,
+                "revision-append",
+                1,
+                predecessor_source_revision="revision-baseline",
+                append_start_offset=len(b"one\n"),
+                append_end_offset=len(b"one\ntwo\n"),
+                authority=RawRevisionAuthority.QUARANTINED,
+            ),
+        )
+
+        initial = get_or_compute_raw_authority_verdicts(archive, "codex:s1", now_ms=1000)
+        archive.classify_raw_revision_cohort_for_live_watch("codex:s1")
+
+        stale = read_cached_raw_authority_verdicts(archive, "codex:s1")
+        promoted = get_or_compute_raw_authority_verdicts(archive, "codex:s1", now_ms=2000)
+
+    assert initial == {
+        "baseline": RawAuthorityVerdict.SOLE_COPY,
+        "append": RawAuthorityVerdict.DIVERGED,
+    }
+    assert stale is None
+    assert promoted == {
+        "baseline": RawAuthorityVerdict.SUPERSEDED,
+        "append": RawAuthorityVerdict.VERIFIED,
+    }
+
+
 def test_write_requires_full_cohort_and_replaces_prior_rows(tmp_path: Path) -> None:
     """A rewrite must clear the cohort's whole prior row set, not accumulate."""
     initialize_active_archive_root(tmp_path)
@@ -177,7 +221,7 @@ def test_missing_cohort_returns_no_verdicts_and_no_cache_write(tmp_path: Path) -
     assert rows[0][0] == 0
 
 
-def test_warmup_is_bounded_and_skips_append_cohorts(tmp_path: Path) -> None:
+def test_warmup_is_bounded_and_caches_append_cohorts(tmp_path: Path) -> None:
     initialize_active_archive_root(tmp_path)
     with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
         _bind_full(archive, raw_id="full-oldest", payload=b"one\n", logical_source_key="codex:full")
@@ -208,19 +252,20 @@ def test_warmup_is_bounded_and_skips_append_cohorts(tmp_path: Path) -> None:
 
         work = find_raw_authority_verdict_cache_work(archive._ensure_source_conn(), max_cohorts=1)
         assert isinstance(work, RawAuthorityVerdictCacheWork)
-        assert work.pending_logical_source_keys == ("codex:full",)
-        assert work.skipped_append_cohorts == 1
+        assert work.pending_logical_source_keys == ("codex:append",)
 
         first = warm_raw_authority_verdict_cache(archive, max_cohorts=1, now_ms=1000)
         assert isinstance(first, RawAuthorityVerdictCacheWarmup)
         assert first.warmed_cohorts == 1
         assert first.pending_cohorts is True
-        assert first.skipped_append_cohorts == 1
 
         second = warm_raw_authority_verdict_cache(archive, max_cohorts=1, now_ms=2000)
         assert second.warmed_cohorts == 1
-        assert second.pending_cohorts is False
-        assert second.skipped_append_cohorts == 1
+        assert second.pending_cohorts is True
+
+        third = warm_raw_authority_verdict_cache(archive, max_cohorts=1, now_ms=3000)
+        assert third.warmed_cohorts == 1
+        assert third.pending_cohorts is False
 
         cached_keys = {
             str(row[0])
@@ -229,12 +274,13 @@ def test_warmup_is_bounded_and_skips_append_cohorts(tmp_path: Path) -> None:
             .fetchall()
         }
         cached_verdicts = {
-            key: read_cached_raw_authority_verdicts(archive, key) for key in ("codex:full", "codex:full-single")
+            key: read_cached_raw_authority_verdicts(archive, key)
+            for key in ("codex:append", "codex:full", "codex:full-single")
         }
-        assert read_cached_raw_authority_verdicts(archive, "codex:append") is None
 
-    assert cached_keys == {"codex:full", "codex:full-single"}
+    assert cached_keys == {"codex:append", "codex:full", "codex:full-single"}
     assert cached_verdicts == {
+        "codex:append": {"append-only": RawAuthorityVerdict.UNCHECKED},
         "codex:full": {
             "full-oldest": RawAuthorityVerdict.SUPERSEDED,
             "full-newest": RawAuthorityVerdict.VERIFIED,

--- a/tests/unit/storage/test_raw_authority_verdict_projection.py
+++ b/tests/unit/storage/test_raw_authority_verdict_projection.py
@@ -13,8 +13,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from polylogue.archive.revision_authority import (
     RawRevisionAuthority,
     RawRevisionEnvelope,
@@ -37,6 +35,42 @@ def _bind_full(archive: ArchiveStore, *, raw_id: str, payload: bytes, logical_so
     archive.bind_raw_revision(
         written_id,
         RawRevisionEnvelope(logical_source_key, RawRevisionKind.FULL, f"revision-{raw_id}", 0),
+    )
+    return written_id
+
+
+def _bind_append(
+    archive: ArchiveStore,
+    *,
+    raw_id: str,
+    payload: bytes,
+    logical_source_key: str,
+    source_revision: str,
+    predecessor_source_revision: str,
+    append_start_offset: int,
+    append_end_offset: int,
+    acquisition_generation: int,
+) -> str:
+    written_id = archive.write_raw_payload(
+        provider=Provider.CODEX,
+        payload=payload,
+        source_path="session.jsonl",
+        source_index=-1,
+        acquired_at_ms=1,
+        raw_id=raw_id,
+    )
+    archive.bind_raw_revision(
+        written_id,
+        RawRevisionEnvelope(
+            logical_source_key,
+            RawRevisionKind.APPEND,
+            source_revision,
+            acquisition_generation,
+            predecessor_source_revision=predecessor_source_revision,
+            append_start_offset=append_start_offset,
+            append_end_offset=append_end_offset,
+            authority=RawRevisionAuthority.QUARANTINED,
+        ),
     )
     return written_id
 
@@ -103,35 +137,43 @@ def test_unresolved_kind_projects_unchecked_alongside_a_proven_sibling(tmp_path:
     }
 
 
-def test_append_kind_in_the_cohort_is_out_of_scope_this_phase(tmp_path: Path) -> None:
-    """Deferred scope (see module docstring): raising loudly beats a silently
-    wrong verdict for a proof shape this phase does not attempt to collapse."""
+def test_live_append_chain_projects_the_same_closed_verdict_vocabulary(tmp_path: Path) -> None:
+    """The production classifier proves an append chain before projection reads it."""
     initialize_active_archive_root(tmp_path)
     with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
         _bind_full(archive, raw_id="baseline", payload=b"one\n", logical_source_key="codex:s1")
-        append_raw_id = archive.write_raw_payload(
-            provider=Provider.CODEX,
-            payload=b"suffix",
-            source_path="session.jsonl",
-            source_index=-1,
-            acquired_at_ms=1,
+        _bind_append(
+            archive,
+            raw_id="append-one",
+            payload=b"two\n",
+            logical_source_key="codex:s1",
+            source_revision="revision-append-one",
+            predecessor_source_revision="revision-baseline",
+            append_start_offset=len(b"one\n"),
+            append_end_offset=len(b"one\ntwo\n"),
+            acquisition_generation=1,
         )
-        archive.bind_raw_revision(
-            append_raw_id,
-            RawRevisionEnvelope(
-                "codex:s1",
-                RawRevisionKind.APPEND,
-                "revision-append",
-                0,
-                predecessor_source_revision="revision-baseline",
-                append_start_offset=4,
-                append_end_offset=10,
-                authority=RawRevisionAuthority.QUARANTINED,
-            ),
+        _bind_append(
+            archive,
+            raw_id="append-two",
+            payload=b"three\n",
+            logical_source_key="codex:s1",
+            source_revision="revision-append-two",
+            predecessor_source_revision="revision-append-one",
+            append_start_offset=len(b"one\ntwo\n"),
+            append_end_offset=len(b"one\ntwo\nthree\n"),
+            acquisition_generation=2,
         )
 
-        with pytest.raises(NotImplementedError, match="revision_kind='full'"):
-            project_raw_authority_verdicts(archive, "codex:s1")
+        plan = archive.classify_raw_revision_cohort_for_live_watch("codex:s1")
+        verdicts = project_raw_authority_verdicts(archive, "codex:s1")
+
+    assert set(plan.accepted_raw_ids) == {"baseline", "append-one", "append-two"}
+    assert verdicts == {
+        "baseline": RawAuthorityVerdict.SUPERSEDED,
+        "append-one": RawAuthorityVerdict.SUPERSEDED,
+        "append-two": RawAuthorityVerdict.VERIFIED,
+    }
 
 
 def test_missing_cohort_projects_no_verdicts(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Extend `RawAuthorityVerdict` projection through byte-proven append chains and make the verdict cache invalidate when classifier promotion changes the authority graph.

## Problem

The production live classifier could accept a contiguous append chain for replay, while `project_raw_authority_verdicts` still raised `NotImplementedError` for that same cohort. The cache also fingerprinted only raw ID, revision kind, and blob hash, so a cached provisional append verdict survived a later authority promotion.

## Solution

- Project `sole_copy`, `superseded`, `verified`, `unchecked`, and `diverged` verdicts for the classifier-proven append route.
- Include revision authority and predecessor raw ID in cache identity, and warm eligible append cohorts.
- Exercise the real archive writer, live classifier, replay-plan acceptance, projection, cache, and convergence-stage paths with file-backed SQLite fixtures.
- Preserve raw evidence and retain every source-authority writer and reader whose canonical route is not yet proven retired. This PR contains no source-tier migration, destructive change, live archive operation, reindex, or window operation.

## Verification

Pre-fix reproductions:

- `VIRTUAL_ENV="$PWD/.venv" PATH="$PWD/.venv/bin:$PATH" devtools test tests/unit/storage/test_raw_authority_verdict_projection.py::test_live_append_chain_projects_the_same_closed_verdict_vocabulary` -> failed with `NotImplementedError` for `['append-one', 'append-two']`.
- `VIRTUAL_ENV="$PWD/.venv" PATH="$PWD/.venv/bin:$PATH" devtools test tests/unit/storage/test_raw_authority_verdict_cache.py::test_append_authority_promotion_invalidates_the_cache` -> failed because the stale cached `{'baseline': SOLE_COPY, 'append': DIVERGED}` result was returned.

Post-fix:

- `VIRTUAL_ENV="$PWD/.venv" PATH="$PWD/.venv/bin:$PATH" devtools test tests/unit/storage/test_raw_authority_verdict_projection.py tests/unit/storage/test_raw_authority_verdict_cache.py tests/unit/storage/test_blob_gc_raw_authority_verdict_invariant.py tests/unit/daemon/test_convergence_stages.py` -> `69 passed in 22.00s` (run `20260820T170127Z-focused-test-3385247-848aa9ac`).
- `VIRTUAL_ENV="$PWD/.venv" PATH="$PWD/.venv/bin:$PATH" devtools verify --quick` -> `status: success` in `99.88s` (run `20260820T170218Z-quick-3387525-8f9731c3`).

## Whole-Bead disposition

| Bead | Disposition | Evidence | Remaining scope |
| --- | --- | --- | --- |
| `polylogue-w6hql` | Partial | Commit `59a28c429`; focused projection/cache/replay coverage; quick gate | Consumer migration and writer/table retirement remain in open successor `polylogue-lr6dx`. |
| `polylogue-lr6dx` | Partial | Caller census proves `raw_authority_parser_census`, `raw_membership_census`, and reconciliation-ledger routes remain active | Retirement gates remain in open successor `polylogue-2qx` and its dependency chain. |
| `polylogue-ds4b4` | Satisfied | Existing commit `a584cc62e`; focused `test_blob_gc_raw_authority_verdict_invariant.py` | The existing row-reference invariant enumerates every `RawAuthorityVerdict` and is stronger than a third verdict-specific GC query, so no redundant reader was added. |

## Adversarial review

Manual review checked projection semantics for full and append children, all cache fingerprint inputs, classifier-to-replay wiring, active source-authority callers, and negative unproven-append paths. No legitimate gap remained.

The cold-review helper did not return a verdict: two attempts hit `OSError: [Errno 7] Argument list too long`, and a reduced context attempt ended in a transport/process failure (receipt `039d2dd2-a02c-40f7-bd2e-a0550d22509c`). This PR does not claim a cold-review pass.

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [
    "polylogue-w6hql",
    "polylogue-lr6dx",
    "polylogue-ds4b4"
  ],
  "dispositions": [
    {
      "bead_id": "polylogue-w6hql",
      "disposition": "partial",
      "evidence": [
        {
          "kind": "commit",
          "ref": "59a28c429"
        },
        {
          "kind": "test",
          "ref": "focused-test 20260820T170127Z-focused-test-3385247-848aa9ac: 69 passed in 22.00s"
        },
        {
          "kind": "command",
          "ref": "quick 20260820T170218Z-quick-3387525-8f9731c3: success in 99.88s"
        }
      ],
      "successors": [
        "polylogue-lr6dx"
      ]
    },
    {
      "bead_id": "polylogue-lr6dx",
      "disposition": "partial",
      "evidence": [
        {
          "kind": "diff",
          "ref": "59a28c429 leaves active raw_authority_parser_census, raw_membership_census, and reconciler ledger writers intact"
        },
        {
          "kind": "review",
          "ref": "manual caller census: readiness, replay, and reconciler retain production readers"
        }
      ],
      "successors": [
        "polylogue-2qx"
      ]
    },
    {
      "bead_id": "polylogue-ds4b4",
      "disposition": "satisfied",
      "evidence": [
        {
          "kind": "commit",
          "ref": "a584cc62e"
        },
        {
          "kind": "test",
          "ref": "tests/unit/storage/test_blob_gc_raw_authority_verdict_invariant.py via focused-test 20260820T170127Z-focused-test-3385247-848aa9ac"
        }
      ],
      "successors": []
    }
  ],
  "mutated_beads": [],
  "scope_digest": "7ef3142eadbf9a279f3d0bbe5b3a4ef9a706b5b0e40d3be80dc8474cd9a45250",
  "scope_kind": "bead",
  "version": 2
}
-->
