### PR TITLE
refactor(sources): compile detectors from OriginSpecs

### DIFF
--- a/polylogue/sources/detection.py
+++ b/polylogue/sources/detection.py
@@ -12,7 +12,7 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from enum import StrEnum
 from importlib import import_module
-from typing import Protocol
+from typing import Protocol, cast
 
 from polylogue.core.enums import Origin, Provider
 
@@ -43,11 +43,20 @@ class DetectorBinding:
 
 
 class _OriginSpecLike(Protocol):
-    origin: Origin
-    lifecycle: str
-    provider_wires: tuple[Provider, ...]
-    detector_tightness: int | None
-    detector_bindings: tuple[DetectorBinding, ...]
+    @property
+    def origin(self) -> Origin: ...
+
+    @property
+    def lifecycle(self) -> str: ...
+
+    @property
+    def provider_wires(self) -> tuple[Provider, ...]: ...
+
+    @property
+    def detector_tightness(self) -> int | None: ...
+
+    @property
+    def detector_bindings(self) -> tuple[DetectorBinding, ...]: ...
 
 
 Predicate = Callable[[object], bool]
@@ -83,6 +92,10 @@ class CompiledDetectorRegistry:
             )
             if provider is None:
                 return None, compiled.binding.evidence_label
+            if compiled.provider_resolver is not None and not isinstance(provider, Provider):
+                raise DetectorBindingError(
+                    f"{compiled.binding.binding_id}: dynamic provider resolver returned {provider!r}, not a Provider"
+                )
             if provider not in compiled.binding.dynamic_provider_allowlist and compiled.provider_resolver is not None:
                 raise DetectorBindingError(
                     f"{compiled.binding.binding_id}: dynamic provider {provider.value!r} is outside its declared "
@@ -121,6 +134,30 @@ def _validate_unary_callable(value: object, *, binding_id: str, role: str) -> Ca
     return value
 
 
+def _resolve_predicate(path: str, *, binding_id: str) -> Predicate:
+    """Resolve a declaration's unary predicate after its signature is checked."""
+    return cast(
+        Predicate,
+        _validate_unary_callable(
+            _resolve_symbol(path, binding_id=binding_id, role="predicate"),
+            binding_id=binding_id,
+            role="predicate",
+        ),
+    )
+
+
+def _resolve_provider_resolver(path: str, *, binding_id: str) -> ProviderResolver:
+    """Resolve a declaration's unary provider resolver after its signature is checked."""
+    return cast(
+        ProviderResolver,
+        _validate_unary_callable(
+            _resolve_symbol(path, binding_id=binding_id, role="dynamic provider resolver"),
+            binding_id=binding_id,
+            role="dynamic provider resolver",
+        ),
+    )
+
+
 def _compile_binding(spec: _OriginSpecLike, binding: DetectorBinding) -> _CompiledBinding:
     prefix = f"{spec.origin.value}/{binding.binding_id}"
     if not binding.binding_id:
@@ -145,22 +182,14 @@ def _compile_binding(spec: _OriginSpecLike, binding: DetectorBinding) -> _Compil
         if not binding.dynamic_provider_allowlist:
             raise DetectorBindingError(f"{prefix}: dynamic provider resolver requires a non-empty allowlist")
 
-    predicate = _validate_unary_callable(
-        _resolve_symbol(binding.predicate_path, binding_id=prefix, role="predicate"),
-        binding_id=prefix,
-        role="predicate",
-    )
+    predicate = _resolve_predicate(binding.predicate_path, binding_id=prefix)
     resolver: ProviderResolver | None = None
     if binding.dynamic_provider_path is not None:
-        resolver = _validate_unary_callable(
-            _resolve_symbol(binding.dynamic_provider_path, binding_id=prefix, role="dynamic provider resolver"),
-            binding_id=prefix,
-            role="dynamic provider resolver",
-        )
+        resolver = _resolve_provider_resolver(binding.dynamic_provider_path, binding_id=prefix)
     return _CompiledBinding(
         binding=binding,
-        predicate=predicate,  # type: ignore[arg-type]
-        provider_resolver=resolver,  # type: ignore[assignment]
+        predicate=predicate,
+        provider_resolver=resolver,
     )
 
 

--- a/polylogue/sources/detection.py
+++ b/polylogue/sources/detection.py
@@ -1,0 +1,207 @@
+"""Compiled executable detector bindings declared by ``OriginSpec``.
+
+The parser modules continue to own their structural predicates.  This module
+only validates and orders the declaration-owned bindings that decide which
+predicate runs for an acquired JSON record or record stream.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from enum import StrEnum
+from importlib import import_module
+from typing import Protocol
+
+from polylogue.core.enums import Origin, Provider
+
+
+class DetectionMode(StrEnum):
+    """The normalized payload shape to which a detector binding applies."""
+
+    RECORD = "record"
+    SEQUENCE_DOCUMENT = "sequence-document"
+    SEQUENCE_RECORD_STREAM = "sequence-record-stream"
+
+
+@dataclass(frozen=True, slots=True)
+class DetectorBinding:
+    """One lazy, evidence-labelled provider claim owned by an ``OriginSpec``."""
+
+    binding_id: str
+    mode: DetectionMode
+    predicate_path: str
+    local_rank: int
+    evidence_label: str
+    #: Optional mode-specific precedence when a stream intentionally differs
+    #: from the origin-wide record tightness order.
+    mode_rank: int | None = None
+    fixed_provider: Provider | None = None
+    dynamic_provider_path: str | None = None
+    dynamic_provider_allowlist: tuple[Provider, ...] = ()
+
+
+class _OriginSpecLike(Protocol):
+    origin: Origin
+    lifecycle: str
+    provider_wires: tuple[Provider, ...]
+    detector_tightness: int | None
+    detector_bindings: tuple[DetectorBinding, ...]
+
+
+Predicate = Callable[[object], bool]
+ProviderResolver = Callable[[object], Provider | None]
+
+
+class DetectorBindingError(ValueError):
+    """A declaration error with the owning origin and binding in its message."""
+
+
+@dataclass(frozen=True, slots=True)
+class _CompiledBinding:
+    binding: DetectorBinding
+    predicate: Predicate
+    provider_resolver: ProviderResolver | None
+
+
+@dataclass(frozen=True, slots=True)
+class CompiledDetectorRegistry:
+    """Validated detector bindings, ordered independently for each payload mode."""
+
+    by_mode: dict[DetectionMode, tuple[_CompiledBinding, ...]]
+
+    def detect(self, mode: DetectionMode, payload: object) -> tuple[Provider | None, str | None]:
+        """Return the first declared detector result and its exact evidence label."""
+        for compiled in self.by_mode.get(mode, ()):  # pragma: no branch - every enum mode is initialized
+            if not compiled.predicate(payload):
+                continue
+            provider = (
+                compiled.binding.fixed_provider
+                if compiled.provider_resolver is None
+                else compiled.provider_resolver(payload)
+            )
+            if provider is None:
+                return None, compiled.binding.evidence_label
+            if provider not in compiled.binding.dynamic_provider_allowlist and compiled.provider_resolver is not None:
+                raise DetectorBindingError(
+                    f"{compiled.binding.binding_id}: dynamic provider {provider.value!r} is outside its declared "
+                    "allowlist"
+                )
+            return provider, compiled.binding.evidence_label
+        return None, None
+
+
+def _resolve_symbol(path: str, *, binding_id: str, role: str) -> object:
+    module_name, separator, symbol_path = path.partition(":")
+    if not separator or not module_name or not symbol_path:
+        raise DetectorBindingError(f"{binding_id}: {role} path must be 'module:Symbol', got {path!r}")
+    try:
+        resolved: object = import_module(module_name)
+        for attribute in symbol_path.split("."):
+            resolved = getattr(resolved, attribute)
+    except (AttributeError, ImportError) as exc:
+        raise DetectorBindingError(f"{binding_id}: cannot resolve {role} {path!r}: {exc}") from exc
+    return resolved
+
+
+def _validate_unary_callable(value: object, *, binding_id: str, role: str) -> Callable[[object], object]:
+    if not callable(value):
+        raise DetectorBindingError(f"{binding_id}: {role} is not callable")
+    try:
+        signature = inspect.signature(value)
+    except (TypeError, ValueError) as exc:
+        raise DetectorBindingError(f"{binding_id}: cannot inspect {role} signature: {exc}") from exc
+    parameters = tuple(signature.parameters.values())
+    if len(parameters) != 1 or parameters[0].kind not in {
+        inspect.Parameter.POSITIONAL_ONLY,
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+    }:
+        raise DetectorBindingError(f"{binding_id}: {role} must accept exactly one payload argument")
+    return value
+
+
+def _compile_binding(spec: _OriginSpecLike, binding: DetectorBinding) -> _CompiledBinding:
+    prefix = f"{spec.origin.value}/{binding.binding_id}"
+    if not binding.binding_id:
+        raise DetectorBindingError(f"{spec.origin.value}: detector binding id must be non-empty")
+    if binding.local_rank < 0:
+        raise DetectorBindingError(f"{prefix}: local rank must be non-negative")
+    if not binding.evidence_label:
+        raise DetectorBindingError(f"{prefix}: evidence label must be non-empty")
+    has_fixed = binding.fixed_provider is not None
+    has_dynamic = binding.dynamic_provider_path is not None
+    if has_fixed == has_dynamic:
+        raise DetectorBindingError(f"{prefix}: declare exactly one fixed provider or dynamic provider resolver")
+    if has_fixed:
+        assert binding.fixed_provider is not None
+        if binding.fixed_provider not in spec.provider_wires:
+            raise DetectorBindingError(
+                f"{prefix}: fixed provider {binding.fixed_provider.value!r} is not declared by {spec.origin.value}"
+            )
+        if binding.dynamic_provider_allowlist:
+            raise DetectorBindingError(f"{prefix}: fixed provider binding cannot declare a dynamic allowlist")
+    else:
+        if not binding.dynamic_provider_allowlist:
+            raise DetectorBindingError(f"{prefix}: dynamic provider resolver requires a non-empty allowlist")
+
+    predicate = _validate_unary_callable(
+        _resolve_symbol(binding.predicate_path, binding_id=prefix, role="predicate"),
+        binding_id=prefix,
+        role="predicate",
+    )
+    resolver: ProviderResolver | None = None
+    if binding.dynamic_provider_path is not None:
+        resolver = _validate_unary_callable(
+            _resolve_symbol(binding.dynamic_provider_path, binding_id=prefix, role="dynamic provider resolver"),
+            binding_id=prefix,
+            role="dynamic provider resolver",
+        )
+    return _CompiledBinding(
+        binding=binding,
+        predicate=predicate,  # type: ignore[arg-type]
+        provider_resolver=resolver,  # type: ignore[assignment]
+    )
+
+
+def compile_detector_registry(specs: Iterable[_OriginSpecLike]) -> CompiledDetectorRegistry:
+    """Compile executable OriginSpec bindings once, rejecting ambiguous declarations."""
+    compiled: dict[DetectionMode, list[tuple[int, int, str, _CompiledBinding]]] = {mode: [] for mode in DetectionMode}
+    binding_ids: set[str] = set()
+    for spec in specs:
+        if spec.lifecycle != "executable" and not spec.detector_bindings:
+            continue
+        if spec.lifecycle == "executable" and not spec.detector_bindings:
+            raise DetectorBindingError(f"{spec.origin.value}: executable origin requires at least one detector binding")
+        if spec.lifecycle == "executable" and spec.detector_tightness is None:
+            raise DetectorBindingError(f"{spec.origin.value}: executable origin requires detector tightness")
+        for binding in spec.detector_bindings:
+            if binding.binding_id in binding_ids:
+                raise DetectorBindingError(f"duplicate detector binding id {binding.binding_id!r}")
+            binding_ids.add(binding.binding_id)
+            compiled_binding = _compile_binding(spec, binding)
+            compiled[binding.mode].append(
+                (
+                    binding.mode_rank
+                    if binding.mode_rank is not None
+                    else (spec.detector_tightness if spec.detector_tightness is not None else -1),
+                    binding.local_rank,
+                    binding.binding_id,
+                    compiled_binding,
+                )
+            )
+    return CompiledDetectorRegistry(
+        by_mode={
+            mode: tuple(item[-1] for item in sorted(bindings, key=lambda item: item[:3]))
+            for mode, bindings in compiled.items()
+        }
+    )
+
+
+__all__ = [
+    "CompiledDetectorRegistry",
+    "DetectionMode",
+    "DetectorBinding",
+    "DetectorBindingError",
+    "compile_detector_registry",
+]

--- a/polylogue/sources/dispatch.py
+++ b/polylogue/sources/dispatch.py
@@ -17,6 +17,8 @@ from polylogue.core.payload_coercion import optional_string
 from polylogue.logging import get_logger
 
 from .decoders import _decode_json_bytes, _iter_json_stream
+from .detection import DetectionMode
+from .origin_specs import detector_registry
 from .parsers import (
     antigravity,
     beads,
@@ -53,23 +55,6 @@ GROUP_PROVIDERS = frozenset(
 )
 STREAM_RECORD_PROVIDERS = frozenset({Provider.CLAUDE_CODE, Provider.CODEX, Provider.BEADS, Provider.HERMES})
 DRIVE_LIKE_PROVIDERS = frozenset({Provider.GEMINI, Provider.DRIVE})
-# The explicit record-shape branch order below remains the production
-# implementation during the OriginSpec migration.  OriginSpec validates its
-# declared detector tightness against this projection so a new declaration
-# cannot silently contradict a stronger existing detector.
-RECORD_DETECTOR_PROVIDER_ORDER = (
-    Provider.GEMINI_CLI,
-    Provider.HERMES,
-    Provider.ANTIGRAVITY,
-    Provider.BEADS,
-    Provider.CODEX,
-    Provider.CLAUDE_CODE,
-    Provider.CHATGPT,
-    Provider.CLAUDE_AI,
-    Provider.CLAUDE_DESIGN,
-    Provider.GROK,
-    Provider.GEMINI,
-)
 _MAX_PARSE_DEPTH = 10
 
 PayloadRecord: TypeAlias = JSONDocument
@@ -193,145 +178,178 @@ def _looks_like_gemini_mapping(record: PayloadRecord) -> bool:
     return drive.looks_like(record)
 
 
-def _detect_provider_from_record_evidence(record: PayloadRecord) -> tuple[Provider | None, str]:
-    """Detect a provider from a single record, tagging the deciding evidence.
-
-    Sole implementation of the record-level detector order; ``_detect_provider_from_record``
-    below is a thin wrapper that discards the evidence label, so this is the
-    single source of truth -- there is no separate "logging" copy of the
-    decision tree that can silently drift from the real one (observability
-    gap fix, mission item 1).
-    """
-    if browser_capture.looks_like(record):
-        session = record.get("session")
-        provider = session.get("provider") if isinstance(session, dict) else None
-        return Provider.from_string(provider if isinstance(provider, str) else None), "browser_capture.looks_like"
-    # Local-agent JSON session documents share enough generic message keys with
-    # Claude Code that they must be recognized before broader validators.
-    if local_agent.looks_like_gemini_cli(record):
-        return Provider.GEMINI_CLI, "local_agent.looks_like_gemini_cli"
-    if hermes_state.looks_like_state_db_payload(record):
-        return Provider.HERMES, "hermes_state.looks_like_state_db_payload"
-    if hermes_verification.looks_like_verification_evidence_db_payload(record):
-        return Provider.HERMES, "hermes_verification.looks_like_verification_evidence_db_payload"
-    if hermes_spans.looks_like_atif_payload(record):
-        return Provider.HERMES, "hermes_spans.looks_like_atif_payload"
-    if hermes_spans.looks_like_atof_payload(record):
-        return Provider.HERMES, "hermes_spans.looks_like_atof_payload"
-    if local_agent.looks_like_hermes(record):
-        return Provider.HERMES, "local_agent.looks_like_hermes"
-    if antigravity.looks_like_markdown_export(record):
-        return Provider.ANTIGRAVITY, "antigravity.looks_like_markdown_export"
-    if antigravity.looks_like_brain_metadata(record, None):
-        return Provider.ANTIGRAVITY, "antigravity.looks_like_brain_metadata"
-    if beads.looks_like(record):
-        return Provider.BEADS, "beads.looks_like"
-    # Specific type-level checks first (Codex uses Pydantic validation;
-    # Claude Code uses a dict-key/type shape check, not Pydantic, despite
-    # ClaudeCodeRecord existing as a separate typed parse-time model), then
-    # weaker dict-key checks (ChatGPT, Claude AI, Gemini).
-    if codex.looks_like([dict(record)]):
-        return Provider.CODEX, "codex.looks_like (pydantic record validation)"
-    if claude.looks_like_code([dict(record)]):
-        return Provider.CLAUDE_CODE, "claude.looks_like_code (envelope marker, #3428)"
-    # A single record here may be an intentionally partial ChatGPT fragment
-    # (e.g. one line of a streamed JSONL sniff), not a whole assembled
-    # export document, so this uses the fragment-level check rather than
-    # ``chatgpt.looks_like``'s document-identity requirements (polylogue-t0ta).
-    if chatgpt.looks_like_fragment(record):
-        return Provider.CHATGPT, "chatgpt.looks_like_fragment (mapping node shape)"
-    # A ChatGPT shared-page (chatgpt.com/share/<id>) stream decode has no
-    # "mapping" key at all -- a flattened top-level "messages" list instead
-    # (polylogue-4zqh3). Checked here, ahead of the generic "has a messages
-    # list" fallback used elsewhere in dispatch, which would otherwise
-    # silently accept-then-drop it (no payload-asserted "id" field).
-    if chatgpt.looks_like_shared_decode(record):
-        return Provider.CHATGPT, "chatgpt.looks_like_shared_decode (shared-page stream decode)"
-    # Claude Design (bd polylogue-tbun) checked before the general claude.ai
-    # detector: its shape (messages + project, no chat_messages, camelCase
-    # contentBlocks) is a distinct, tighter product signature -- not a
-    # claude.ai variant.
-    if claude.looks_like_claude_design(record):
-        return Provider.CLAUDE_DESIGN, "claude.looks_like_claude_design"
-    if claude.looks_like_claude_memories(record):
-        return Provider.CLAUDE_AI, "claude.looks_like_claude_memories"
-    if claude.looks_like_ai(record):
-        return Provider.CLAUDE_AI, "claude.looks_like_ai (non-empty plausible chat_messages)"
-    if grok.looks_like_export(record):
-        return Provider.GROK, "grok.looks_like_export"
-    if _looks_like_gemini_mapping(record):
-        return Provider.GEMINI, "drive.looks_like (chunkedPrompt/chunks)"
-    return None, "no detector matched (single record)"
+def _first_sequence_record(payload: object) -> PayloadRecord | None:
+    if not isinstance(payload, list) or not payload:
+        return None
+    return _payload_record(payload[0])
 
 
-def _detect_provider_from_record(record: PayloadRecord) -> Provider | None:
-    return _detect_provider_from_record_evidence(record)[0]
+def _looks_like_browser_capture_record(payload: object) -> bool:
+    record = _payload_record(payload)
+    return record is not None and browser_capture.looks_like(record)
 
 
-def _detect_provider_from_sequence_evidence(payloads: PayloadSequence) -> tuple[Provider | None, str]:
-    """Detect a provider from a payload sequence, tagging the deciding evidence.
-
-    Sole implementation of the sequence-level detector order; see
-    ``_detect_provider_from_record_evidence`` for the equivalent single-record
-    rationale.
-    """
-    if not payloads:
-        return None, "empty sequence"
-
-    first_record = _payload_record(payloads[0])
-    if first_record is not None:
-        # A one-document Gemini CLI JSON file reaches detection as a
-        # one-element sequence on the stream path. Preserve the established
-        # Claude-Code-before-Codex sequence ordering while restoring this
-        # stronger local-session discriminator ahead of weaker family shapes.
-        # Gemini CLI's ``.jsonl`` chat-log checkpoint format is a genuinely
-        # different multi-line shape: a session-open stub record (no
-        # ``messages`` key -- see ``local_agent.looks_like_gemini_cli``)
-        # followed by one JSON object per turn/event, so it reaches here as
-        # a many-element sequence whose bare ``sessionId`` field otherwise
-        # collides with Claude Code's own ``_STRONG_SESSION_KEYS`` (#3428
-        # sibling gap, polylogue-hs3y). Trust the stub shape at any sequence
-        # length; keep the ``messages``-embedded shape restricted to the
-        # single-document case above, unchanged.
-        if local_agent.looks_like_gemini_cli(first_record) and (
-            len(payloads) == 1 or not isinstance(first_record.get("messages"), list)
-        ):
-            return Provider.GEMINI_CLI, "local_agent.looks_like_gemini_cli (stub record)"
-        if browser_capture.looks_like(first_record):
-            provider, evidence = _detect_provider_from_record_evidence(first_record)
-            return provider, f"sequence[0] browser_capture.looks_like -> {evidence}"
-        if hermes_spans.looks_like_atof_payload(first_record):
-            return Provider.HERMES, "hermes_spans.looks_like_atof_payload (sequence[0])"
-        if beads.looks_like(first_record):
-            return Provider.BEADS, "beads.looks_like (sequence[0])"
-        # The first record of a *sequence* is a whole assembled document
-        # (e.g. one conversation from a ChatGPT bundle array), not a
-        # partial per-line fragment, so this uses the strict document-level
-        # check rather than ``looks_like_fragment`` (polylogue-t0ta).
-        if chatgpt.looks_like(first_record):
-            return Provider.CHATGPT, "chatgpt.looks_like (sequence[0] whole-document)"
-        if isinstance(first_record.get("chat_messages"), list):
-            return Provider.CLAUDE_AI, "sequence[0] chat_messages dict-key present"
-        # Claude AI account memory export (memories.json, bd polylogue-zng9)
-        # arrives as a bare top-level JSON array of one-per-account records.
-        if claude.looks_like_claude_memories(first_record):
-            return Provider.CLAUDE_AI, "claude.looks_like_claude_memories (sequence[0])"
-        if claude.looks_like_claude_design(first_record):
-            return Provider.CLAUDE_DESIGN, "claude.looks_like_claude_design (sequence[0])"
-        if grok.looks_like_export(first_record):
-            return Provider.GROK, "grok.looks_like_export (sequence[0])"
-        if _looks_like_gemini_mapping(first_record):
-            return Provider.GEMINI, "drive.looks_like (sequence[0])"
-
-    if claude.looks_like_code(payloads):
-        return Provider.CLAUDE_CODE, "claude.looks_like_code (record stream envelope markers)"
-    if codex.looks_like(payloads):
-        return Provider.CODEX, "codex.looks_like (pydantic record stream validation)"
-    return None, "no detector matched (sequence)"
+def _browser_capture_provider(payload: object) -> Provider | None:
+    record = _payload_record(payload)
+    session = record.get("session") if record is not None else None
+    provider = session.get("provider") if isinstance(session, dict) else None
+    return Provider.from_string(provider if isinstance(provider, str) else None)
 
 
-def _detect_provider_from_sequence(payloads: PayloadSequence) -> Provider | None:
-    return _detect_provider_from_sequence_evidence(payloads)[0]
+def _looks_like_browser_capture_sequence(payload: object) -> bool:
+    record = _first_sequence_record(payload)
+    return record is not None and browser_capture.looks_like(record)
+
+
+def _browser_capture_sequence_provider(payload: object) -> Provider | None:
+    return _browser_capture_provider(_first_sequence_record(payload))
+
+
+def _looks_like_gemini_cli_record(payload: object) -> bool:
+    record = _payload_record(payload)
+    return record is not None and local_agent.looks_like_gemini_cli(record)
+
+
+def _looks_like_gemini_cli_sequence_stub(payload: object) -> bool:
+    record = _first_sequence_record(payload)
+    return (
+        record is not None
+        and local_agent.looks_like_gemini_cli(record)
+        and (len(payload) == 1 or not isinstance(record.get("messages"), list))
+    )
+
+
+def _looks_like_hermes_state_record(payload: object) -> bool:
+    record = _payload_record(payload)
+    return record is not None and hermes_state.looks_like_state_db_payload(record)
+
+
+def _looks_like_hermes_verification_record(payload: object) -> bool:
+    record = _payload_record(payload)
+    return record is not None and hermes_verification.looks_like_verification_evidence_db_payload(record)
+
+
+def _looks_like_hermes_atif_record(payload: object) -> bool:
+    record = _payload_record(payload)
+    return record is not None and hermes_spans.looks_like_atif_payload(record)
+
+
+def _looks_like_hermes_atof_record(payload: object) -> bool:
+    record = _payload_record(payload)
+    return record is not None and hermes_spans.looks_like_atof_payload(record)
+
+
+def _looks_like_hermes_local_agent_record(payload: object) -> bool:
+    record = _payload_record(payload)
+    return record is not None and local_agent.looks_like_hermes(record)
+
+
+def _looks_like_hermes_atof_sequence(payload: object) -> bool:
+    record = _first_sequence_record(payload)
+    return record is not None and hermes_spans.looks_like_atof_payload(record)
+
+
+def _looks_like_antigravity_markdown_record(payload: object) -> bool:
+    record = _payload_record(payload)
+    return record is not None and antigravity.looks_like_markdown_export(record)
+
+
+def _looks_like_antigravity_brain_record(payload: object) -> bool:
+    record = _payload_record(payload)
+    return record is not None and antigravity.looks_like_brain_metadata(record, None)
+
+
+def _looks_like_beads_record(payload: object) -> bool:
+    record = _payload_record(payload)
+    return record is not None and beads.looks_like(record)
+
+
+def _looks_like_beads_sequence(payload: object) -> bool:
+    record = _first_sequence_record(payload)
+    return record is not None and beads.looks_like(record)
+
+
+def _looks_like_codex_record(payload: object) -> bool:
+    record = _payload_record(payload)
+    return record is not None and codex.looks_like([dict(record)])
+
+
+def _looks_like_codex_stream(payload: object) -> bool:
+    return isinstance(payload, list) and codex.looks_like(payload)
+
+
+def _looks_like_claude_code_record(payload: object) -> bool:
+    record = _payload_record(payload)
+    return record is not None and claude.looks_like_code([dict(record)])
+
+
+def _looks_like_claude_code_stream(payload: object) -> bool:
+    return isinstance(payload, list) and claude.looks_like_code(payload)
+
+
+def _looks_like_chatgpt_fragment_record(payload: object) -> bool:
+    record = _payload_record(payload)
+    return record is not None and chatgpt.looks_like_fragment(record)
+
+
+def _looks_like_chatgpt_shared_decode_record(payload: object) -> bool:
+    record = _payload_record(payload)
+    return record is not None and chatgpt.looks_like_shared_decode(record)
+
+
+def _looks_like_chatgpt_sequence_document(payload: object) -> bool:
+    record = _first_sequence_record(payload)
+    return record is not None and chatgpt.looks_like(record)
+
+
+def _looks_like_claude_design_record(payload: object) -> bool:
+    record = _payload_record(payload)
+    return record is not None and claude.looks_like_claude_design(record)
+
+
+def _looks_like_claude_design_sequence(payload: object) -> bool:
+    record = _first_sequence_record(payload)
+    return record is not None and claude.looks_like_claude_design(record)
+
+
+def _looks_like_claude_memories_record(payload: object) -> bool:
+    record = _payload_record(payload)
+    return record is not None and claude.looks_like_claude_memories(record)
+
+
+def _looks_like_claude_memories_sequence(payload: object) -> bool:
+    record = _first_sequence_record(payload)
+    return record is not None and claude.looks_like_claude_memories(record)
+
+
+def _looks_like_claude_ai_record(payload: object) -> bool:
+    record = _payload_record(payload)
+    return record is not None and claude.looks_like_ai(record)
+
+
+def _looks_like_claude_ai_sequence(payload: object) -> bool:
+    record = _first_sequence_record(payload)
+    return record is not None and isinstance(record.get("chat_messages"), list)
+
+
+def _looks_like_grok_record(payload: object) -> bool:
+    record = _payload_record(payload)
+    return record is not None and grok.looks_like_export(record)
+
+
+def _looks_like_grok_sequence(payload: object) -> bool:
+    record = _first_sequence_record(payload)
+    return record is not None and grok.looks_like_export(record)
+
+
+def _looks_like_gemini_mapping_record(payload: object) -> bool:
+    record = _payload_record(payload)
+    return record is not None and _looks_like_gemini_mapping(record)
+
+
+def _looks_like_gemini_mapping_sequence(payload: object) -> bool:
+    record = _first_sequence_record(payload)
+    return record is not None and _looks_like_gemini_mapping(record)
 
 
 def detect_provider_evidence(payload: object, path: object | None = None) -> tuple[Provider | None, str]:
@@ -345,10 +363,17 @@ def detect_provider_evidence(payload: object, path: object | None = None) -> tup
     del path
 
     if record := _payload_record(payload):
-        return _detect_provider_from_record_evidence(record)
+        provider, evidence = detector_registry().detect(DetectionMode.RECORD, record)
+        return provider, evidence or "no detector matched (single record)"
     payloads = _payload_sequence(payload)
     if payloads is not None:
-        return _detect_provider_from_sequence_evidence(payloads)
+        if not payloads:
+            return None, "empty sequence"
+        provider, evidence = detector_registry().detect(DetectionMode.SEQUENCE_DOCUMENT, payloads)
+        if evidence is not None:
+            return provider, evidence
+        provider, evidence = detector_registry().detect(DetectionMode.SEQUENCE_RECORD_STREAM, payloads)
+        return provider, evidence or "no detector matched (sequence)"
     return None, "payload is not a JSON document or sequence"
 
 
@@ -1289,7 +1314,7 @@ def _lower_payload_specs(
     shaped_payload = _schema_guided_payload(runtime_provider, payload, schema_resolution)
     record = _payload_record(shaped_payload)
     if record is not None and browser_capture.looks_like(record):
-        provider = _detect_provider_from_record(record) or runtime_provider
+        provider = detect_provider(record) or runtime_provider
         return [
             LoweredPayloadSpec(
                 provider=provider,
@@ -1306,7 +1331,7 @@ def _lower_payload_specs(
             if item_record is None or not browser_capture.looks_like(item_record):
                 browser_capture_specs = []
                 break
-            provider = _detect_provider_from_record(item_record) or runtime_provider
+            provider = detect_provider(item_record) or runtime_provider
             browser_capture_specs.append(
                 LoweredPayloadSpec(
                     provider=provider,

--- a/polylogue/sources/dispatch.py
+++ b/polylogue/sources/dispatch.py
@@ -211,6 +211,8 @@ def _looks_like_gemini_cli_record(payload: object) -> bool:
 
 
 def _looks_like_gemini_cli_sequence_stub(payload: object) -> bool:
+    if not isinstance(payload, list):
+        return False
     record = _first_sequence_record(payload)
     return (
         record is not None

--- a/polylogue/sources/origin_specs.py
+++ b/polylogue/sources/origin_specs.py
@@ -40,6 +40,12 @@ from polylogue.declarations import (
     OutputSpec,
     validate_registry,
 )
+from polylogue.sources.detection import (
+    CompiledDetectorRegistry,
+    DetectionMode,
+    DetectorBinding,
+    compile_detector_registry,
+)
 
 OriginLifecycle = Literal["executable", "reserved", "unsupported", "compatibility-only"]
 OriginCompletenessMaturity = Literal["accepted", "proposed", "reserved", "unsupported"]
@@ -48,6 +54,7 @@ ArtifactParsePolicy = Literal["session", "fact", "raw-only"]
 _SOURCE_ROOT = Path(__file__).resolve().parents[2]
 _LOWERING_FINGERPRINT_PATHS: tuple[str, ...] = (
     "polylogue/sources/dispatch.py",
+    "polylogue/sources/detection.py",
     "polylogue/sources/emitter.py",
     "polylogue/pipeline/ids.py",
     "polylogue/storage/sqlite/archive_tiers/write.py",
@@ -397,6 +404,9 @@ class OriginSpec:
     #: CLI ``--origin`` shell completion). Declared here so no surface keeps a
     #: second hand-maintained per-origin description inventory.
     display_description: str
+    #: Ordered executable detector claims. Parser modules keep their shape
+    #: predicates; this declaration owns which predicates may classify input.
+    detector_bindings: tuple[DetectorBinding, ...] = ()
     artifact_rules: tuple[OriginArtifactRule, ...] = ()
     completeness_modes: tuple[OriginCompletenessMode, ...] = ()
     #: ``"module/path.py:ClassName"`` for the ``ProviderAssemblySpec`` this
@@ -484,6 +494,8 @@ class OriginSpecRegistry:
         if spec.lifecycle == "executable":
             if spec.detector_tightness is None:
                 raise ValueError(f"{spec.origin.value}: executable origin requires detector tightness")
+            if not spec.detector_bindings:
+                raise ValueError(f"{spec.origin.value}: executable origin requires detector binding")
             if not spec.parser_paths:
                 raise ValueError(f"{spec.origin.value}: executable origin requires parser binding")
             for rule in spec.artifact_rules:
@@ -1463,8 +1475,294 @@ _ORIGIN_COMPLETENESS_MODES: dict[Origin, tuple[OriginCompletenessMode, ...]] = {
 }
 
 
-def _with_completeness_modes(spec: OriginSpec) -> OriginSpec:
-    return replace(spec, completeness_modes=_ORIGIN_COMPLETENESS_MODES[spec.origin])
+_ALL_BROWSER_CAPTURE_PROVIDERS = tuple(Provider)
+
+_ORIGIN_DETECTOR_BINDINGS: dict[Origin, tuple[DetectorBinding, ...]] = {
+    Origin.CLAUDE_CODE_SESSION: (
+        DetectorBinding(
+            "claude-code-record-envelope",
+            DetectionMode.RECORD,
+            "polylogue.sources.dispatch:_looks_like_claude_code_record",
+            0,
+            "claude.looks_like_code (envelope marker, #3428)",
+            fixed_provider=Provider.CLAUDE_CODE,
+        ),
+        DetectorBinding(
+            "claude-code-record-stream",
+            DetectionMode.SEQUENCE_RECORD_STREAM,
+            "polylogue.sources.dispatch:_looks_like_claude_code_stream",
+            0,
+            "claude.looks_like_code (record stream envelope markers)",
+            mode_rank=0,
+            fixed_provider=Provider.CLAUDE_CODE,
+        ),
+    ),
+    Origin.CODEX_SESSION: (
+        DetectorBinding(
+            "codex-record-pydantic",
+            DetectionMode.RECORD,
+            "polylogue.sources.dispatch:_looks_like_codex_record",
+            0,
+            "codex.looks_like (pydantic record validation)",
+            fixed_provider=Provider.CODEX,
+        ),
+        DetectorBinding(
+            "codex-record-stream",
+            DetectionMode.SEQUENCE_RECORD_STREAM,
+            "polylogue.sources.dispatch:_looks_like_codex_stream",
+            0,
+            "codex.looks_like (pydantic record stream validation)",
+            mode_rank=1,
+            fixed_provider=Provider.CODEX,
+        ),
+    ),
+    Origin.GEMINI_CLI_SESSION: (
+        DetectorBinding(
+            "gemini-cli-record",
+            DetectionMode.RECORD,
+            "polylogue.sources.dispatch:_looks_like_gemini_cli_record",
+            0,
+            "local_agent.looks_like_gemini_cli",
+            fixed_provider=Provider.GEMINI_CLI,
+        ),
+        DetectorBinding(
+            "gemini-cli-sequence-stub",
+            DetectionMode.SEQUENCE_DOCUMENT,
+            "polylogue.sources.dispatch:_looks_like_gemini_cli_sequence_stub",
+            0,
+            "local_agent.looks_like_gemini_cli (stub record)",
+            fixed_provider=Provider.GEMINI_CLI,
+        ),
+    ),
+    Origin.HERMES_SESSION: (
+        DetectorBinding(
+            "hermes-state-db-record",
+            DetectionMode.RECORD,
+            "polylogue.sources.dispatch:_looks_like_hermes_state_record",
+            0,
+            "hermes_state.looks_like_state_db_payload",
+            fixed_provider=Provider.HERMES,
+        ),
+        DetectorBinding(
+            "hermes-verification-record",
+            DetectionMode.RECORD,
+            "polylogue.sources.dispatch:_looks_like_hermes_verification_record",
+            1,
+            "hermes_verification.looks_like_verification_evidence_db_payload",
+            fixed_provider=Provider.HERMES,
+        ),
+        DetectorBinding(
+            "hermes-atif-record",
+            DetectionMode.RECORD,
+            "polylogue.sources.dispatch:_looks_like_hermes_atif_record",
+            2,
+            "hermes_spans.looks_like_atif_payload",
+            fixed_provider=Provider.HERMES,
+        ),
+        DetectorBinding(
+            "hermes-atof-record",
+            DetectionMode.RECORD,
+            "polylogue.sources.dispatch:_looks_like_hermes_atof_record",
+            3,
+            "hermes_spans.looks_like_atof_payload",
+            fixed_provider=Provider.HERMES,
+        ),
+        DetectorBinding(
+            "hermes-local-agent-record",
+            DetectionMode.RECORD,
+            "polylogue.sources.dispatch:_looks_like_hermes_local_agent_record",
+            4,
+            "local_agent.looks_like_hermes",
+            fixed_provider=Provider.HERMES,
+        ),
+        DetectorBinding(
+            "hermes-atof-sequence",
+            DetectionMode.SEQUENCE_DOCUMENT,
+            "polylogue.sources.dispatch:_looks_like_hermes_atof_sequence",
+            0,
+            "hermes_spans.looks_like_atof_payload (sequence[0])",
+            fixed_provider=Provider.HERMES,
+        ),
+    ),
+    Origin.ANTIGRAVITY_SESSION: (
+        DetectorBinding(
+            "antigravity-markdown-record",
+            DetectionMode.RECORD,
+            "polylogue.sources.dispatch:_looks_like_antigravity_markdown_record",
+            0,
+            "antigravity.looks_like_markdown_export",
+            fixed_provider=Provider.ANTIGRAVITY,
+        ),
+        DetectorBinding(
+            "antigravity-brain-record",
+            DetectionMode.RECORD,
+            "polylogue.sources.dispatch:_looks_like_antigravity_brain_record",
+            1,
+            "antigravity.looks_like_brain_metadata",
+            fixed_provider=Provider.ANTIGRAVITY,
+        ),
+    ),
+    Origin.BEADS_ISSUE: (
+        DetectorBinding(
+            "beads-record",
+            DetectionMode.RECORD,
+            "polylogue.sources.dispatch:_looks_like_beads_record",
+            0,
+            "beads.looks_like",
+            fixed_provider=Provider.BEADS,
+        ),
+        DetectorBinding(
+            "beads-sequence",
+            DetectionMode.SEQUENCE_DOCUMENT,
+            "polylogue.sources.dispatch:_looks_like_beads_sequence",
+            0,
+            "beads.looks_like (sequence[0])",
+            fixed_provider=Provider.BEADS,
+        ),
+    ),
+    Origin.CHATGPT_EXPORT: (
+        DetectorBinding(
+            "chatgpt-record-fragment",
+            DetectionMode.RECORD,
+            "polylogue.sources.dispatch:_looks_like_chatgpt_fragment_record",
+            0,
+            "chatgpt.looks_like_fragment (mapping node shape)",
+            fixed_provider=Provider.CHATGPT,
+        ),
+        DetectorBinding(
+            "chatgpt-record-shared-decode",
+            DetectionMode.RECORD,
+            "polylogue.sources.dispatch:_looks_like_chatgpt_shared_decode_record",
+            1,
+            "chatgpt.looks_like_shared_decode (shared-page stream decode)",
+            fixed_provider=Provider.CHATGPT,
+        ),
+        DetectorBinding(
+            "chatgpt-sequence-document",
+            DetectionMode.SEQUENCE_DOCUMENT,
+            "polylogue.sources.dispatch:_looks_like_chatgpt_sequence_document",
+            0,
+            "chatgpt.looks_like (sequence[0] whole-document)",
+            fixed_provider=Provider.CHATGPT,
+        ),
+    ),
+    Origin.CLAUDE_AI_EXPORT: (
+        DetectorBinding(
+            "claude-ai-record-memories",
+            DetectionMode.RECORD,
+            "polylogue.sources.dispatch:_looks_like_claude_memories_record",
+            0,
+            "claude.looks_like_claude_memories",
+            fixed_provider=Provider.CLAUDE_AI,
+        ),
+        DetectorBinding(
+            "claude-ai-record",
+            DetectionMode.RECORD,
+            "polylogue.sources.dispatch:_looks_like_claude_ai_record",
+            1,
+            "claude.looks_like_ai (non-empty plausible chat_messages)",
+            fixed_provider=Provider.CLAUDE_AI,
+        ),
+        DetectorBinding(
+            "claude-ai-sequence-chat-messages",
+            DetectionMode.SEQUENCE_DOCUMENT,
+            "polylogue.sources.dispatch:_looks_like_claude_ai_sequence",
+            0,
+            "sequence[0] chat_messages dict-key present",
+            fixed_provider=Provider.CLAUDE_AI,
+        ),
+        DetectorBinding(
+            "claude-ai-sequence-memories",
+            DetectionMode.SEQUENCE_DOCUMENT,
+            "polylogue.sources.dispatch:_looks_like_claude_memories_sequence",
+            1,
+            "claude.looks_like_claude_memories (sequence[0])",
+            fixed_provider=Provider.CLAUDE_AI,
+        ),
+    ),
+    Origin.CLAUDE_DESIGN_SESSION: (
+        DetectorBinding(
+            "claude-design-record",
+            DetectionMode.RECORD,
+            "polylogue.sources.dispatch:_looks_like_claude_design_record",
+            0,
+            "claude.looks_like_claude_design",
+            fixed_provider=Provider.CLAUDE_DESIGN,
+        ),
+        DetectorBinding(
+            "claude-design-sequence",
+            DetectionMode.SEQUENCE_DOCUMENT,
+            "polylogue.sources.dispatch:_looks_like_claude_design_sequence",
+            0,
+            "claude.looks_like_claude_design (sequence[0])",
+            fixed_provider=Provider.CLAUDE_DESIGN,
+        ),
+    ),
+    Origin.GROK_EXPORT: (
+        DetectorBinding(
+            "grok-record",
+            DetectionMode.RECORD,
+            "polylogue.sources.dispatch:_looks_like_grok_record",
+            0,
+            "grok.looks_like_export",
+            fixed_provider=Provider.GROK,
+        ),
+        DetectorBinding(
+            "grok-sequence",
+            DetectionMode.SEQUENCE_DOCUMENT,
+            "polylogue.sources.dispatch:_looks_like_grok_sequence",
+            0,
+            "grok.looks_like_export (sequence[0])",
+            fixed_provider=Provider.GROK,
+        ),
+    ),
+    Origin.AISTUDIO_DRIVE: (
+        DetectorBinding(
+            "aistudio-drive-record",
+            DetectionMode.RECORD,
+            "polylogue.sources.dispatch:_looks_like_gemini_mapping_record",
+            0,
+            "drive.looks_like (chunkedPrompt/chunks)",
+            fixed_provider=Provider.GEMINI,
+        ),
+        DetectorBinding(
+            "aistudio-drive-sequence",
+            DetectionMode.SEQUENCE_DOCUMENT,
+            "polylogue.sources.dispatch:_looks_like_gemini_mapping_sequence",
+            0,
+            "drive.looks_like (sequence[0])",
+            fixed_provider=Provider.GEMINI,
+        ),
+    ),
+    Origin.UNKNOWN_EXPORT: (
+        DetectorBinding(
+            "browser-capture-record",
+            DetectionMode.RECORD,
+            "polylogue.sources.dispatch:_looks_like_browser_capture_record",
+            0,
+            "browser_capture.looks_like",
+            dynamic_provider_path="polylogue.sources.dispatch:_browser_capture_provider",
+            dynamic_provider_allowlist=_ALL_BROWSER_CAPTURE_PROVIDERS,
+        ),
+        DetectorBinding(
+            "browser-capture-sequence",
+            DetectionMode.SEQUENCE_DOCUMENT,
+            "polylogue.sources.dispatch:_looks_like_browser_capture_sequence",
+            0,
+            "sequence[0] browser_capture.looks_like -> browser_capture.looks_like",
+            dynamic_provider_path="polylogue.sources.dispatch:_browser_capture_sequence_provider",
+            dynamic_provider_allowlist=_ALL_BROWSER_CAPTURE_PROVIDERS,
+        ),
+    ),
+}
+
+
+def _with_declaration_fields(spec: OriginSpec) -> OriginSpec:
+    return replace(
+        spec,
+        completeness_modes=_ORIGIN_COMPLETENESS_MODES[spec.origin],
+        detector_bindings=_ORIGIN_DETECTOR_BINDINGS.get(spec.origin, ()),
+    )
 
 
 ORIGIN_SPEC_REGISTRY = OriginSpecRegistry()
@@ -1482,9 +1780,19 @@ for _spec in (
     _aistudio_drive_spec(),
     _unknown_spec(),
 ):
-    ORIGIN_SPEC_REGISTRY.register(_with_completeness_modes(_spec))
+    ORIGIN_SPEC_REGISTRY.register(_with_declaration_fields(_spec))
 ORIGIN_SPECS = ORIGIN_SPEC_REGISTRY.specs()
 _ORIGIN_SPECS_BY_ORIGIN = {spec.origin: spec for spec in ORIGIN_SPECS}
+
+
+@lru_cache(maxsize=8)
+def _compiled_detector_registry(specs: tuple[OriginSpec, ...]) -> CompiledDetectorRegistry:
+    return compile_detector_registry(specs)
+
+
+def detector_registry() -> CompiledDetectorRegistry:
+    """Return the one validated executable detector registry for current OriginSpecs."""
+    return _compiled_detector_registry(ORIGIN_SPECS)
 
 
 def origin_specs() -> tuple[OriginSpec, ...]:
@@ -1497,42 +1805,6 @@ def parser_fingerprint_for_origin(origin: Origin | str) -> str:
     """Return the current parser fingerprint for one normalized archive origin."""
     normalized = Origin.from_string(origin)
     return _ORIGIN_SPECS_BY_ORIGIN[normalized].parser_fingerprint()
-
-
-def validate_dispatch_precedence(provider_order: tuple[Provider, ...]) -> tuple[OriginSpecDiagnostic, ...]:
-    """Check that the legacy detector branch order honors declared tightness."""
-
-    positions = {provider: index for index, provider in enumerate(provider_order)}
-    diagnostics: list[OriginSpecDiagnostic] = []
-    executable = [spec for spec in ORIGIN_SPECS if spec.lifecycle == "executable"]
-    for spec in executable:
-        if not spec.provider_wires or spec.provider_wires[0] not in positions:
-            diagnostics.append(
-                OriginSpecDiagnostic(
-                    code="missing_dispatch_provider",
-                    message=f"{spec.origin.value}: provider is absent from dispatch precedence",
-                    origin=spec.origin,
-                    owner_path=spec.declaration.owner_path,
-                    repair_command=spec.declaration.repair_command,
-                )
-            )
-    ordered = sorted(executable, key=lambda spec: spec.detector_tightness or 0)
-    for left, right in zip(ordered, ordered[1:], strict=False):
-        left_position = positions.get(left.provider_wires[0])
-        right_position = positions.get(right.provider_wires[0])
-        if left_position is not None and right_position is not None and left_position > right_position:
-            diagnostics.append(
-                OriginSpecDiagnostic(
-                    code="dispatch_tightness_mismatch",
-                    message=(
-                        f"{left.origin.value}: declared tighter than {right.origin.value} but appears later in dispatch"
-                    ),
-                    origin=left.origin,
-                    owner_path="polylogue/sources/dispatch.py",
-                    repair_command="devtools test tests/unit/sources/test_origin_specs.py",
-                )
-            )
-    return tuple(sorted(diagnostics, key=lambda item: (item.origin.value, item.code)))
 
 
 def validate_stream_parser_parity(stream_record_providers: frozenset[Provider]) -> tuple[OriginSpecDiagnostic, ...]:
@@ -1621,6 +1893,7 @@ __all__ = [
     "OriginSpec",
     "OriginSpecDiagnostic",
     "OriginSpecRegistry",
+    "DetectorBinding",
     "check_dropped_value_vocabularies",
     "origin_specs",
     "artifact_rule_for_path",
@@ -1628,10 +1901,10 @@ __all__ = [
     "schema_observed_leaf_values",
     "undeclared_schema_values",
     "lowering_fingerprint",
+    "detector_registry",
     "materializer_fingerprint",
     "replay_routing_fingerprint",
     "parser_fingerprint_for_origin",
     "validate_assembly_spec_parity",
-    "validate_dispatch_precedence",
     "validate_stream_parser_parity",
 ]

--- a/polylogue/sources/origin_specs.py
+++ b/polylogue/sources/origin_specs.py
@@ -432,9 +432,42 @@ class OriginSpec:
         return _fingerprint_sources(source_paths, namespace=f"parser:{self.origin.value}")
 
 
+def _detector_declaration_fingerprint_payload() -> tuple[dict[str, object], ...]:
+    """Project every runtime detector claim that can change lowering behavior."""
+    return tuple(
+        {
+            "origin": spec.origin.value,
+            "lifecycle": spec.lifecycle,
+            "detector_tightness": spec.detector_tightness,
+            "bindings": tuple(
+                {
+                    "binding_id": binding.binding_id,
+                    "mode": binding.mode.value,
+                    "predicate_path": binding.predicate_path,
+                    "local_rank": binding.local_rank,
+                    "mode_rank": binding.mode_rank,
+                    "evidence_label": binding.evidence_label,
+                    "fixed_provider": binding.fixed_provider.value if binding.fixed_provider is not None else None,
+                    "dynamic_provider_path": binding.dynamic_provider_path,
+                    "dynamic_provider_allowlist": tuple(
+                        provider.value for provider in binding.dynamic_provider_allowlist
+                    ),
+                }
+                for binding in spec.detector_bindings
+            ),
+        }
+        for spec in ORIGIN_SPECS
+        if spec.detector_bindings
+    )
+
+
 def lowering_fingerprint() -> str:
-    """Return the shared lowering, identity, revision, and lineage fingerprint."""
-    return _fingerprint_sources(_LOWERING_FINGERPRINT_PATHS, namespace="lowering")
+    """Return the shared lowering, identity, revision, lineage, and detector fingerprint."""
+    payload = {
+        "source_fingerprint": _fingerprint_sources(_LOWERING_FINGERPRINT_PATHS, namespace="lowering"),
+        "detector_declarations": _detector_declaration_fingerprint_payload(),
+    }
+    return hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
 
 
 def replay_routing_fingerprint() -> str:

--- a/tests/unit/sources/test_dispatch_evidence.py
+++ b/tests/unit/sources/test_dispatch_evidence.py
@@ -11,10 +11,11 @@ implementation.
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 
 import pytest
 
-from polylogue.core.enums import Provider
+from polylogue.core.enums import Origin, Provider
 from polylogue.sources.dispatch import (
     detect_provider,
     detect_provider_evidence,
@@ -73,6 +74,35 @@ def test_detect_provider_evidence_names_the_deciding_rule_for_claude_code() -> N
 
 def test_detect_provider_evidence_reports_no_match_reason() -> None:
     provider, evidence = detect_provider_evidence({"unrelated": "shape"})
+    assert provider is None
+    assert "no detector matched" in evidence
+
+
+def test_origin_spec_binding_is_the_production_detector_authority(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Removing ChatGPT's declared fragment binding removes that real-route match.
+
+    This is deliberately not a test-local dispatcher: the public evidence API
+    must compile the current OriginSpec declarations every time its declaration
+    set changes.  Before F3, OriginSpec had no executable detector bindings and
+    the handwritten dispatch tree continued to identify this payload.
+    """
+    import polylogue.sources.origin_specs as origin_specs
+
+    chatgpt = next(spec for spec in origin_specs.ORIGIN_SPECS if spec.origin is Origin.CHATGPT_EXPORT)
+    without_fragment = replace(
+        chatgpt,
+        detector_bindings=tuple(
+            binding for binding in chatgpt.detector_bindings if binding.binding_id != "chatgpt-record-fragment"
+        ),
+    )
+    monkeypatch.setattr(
+        origin_specs,
+        "ORIGIN_SPECS",
+        tuple(without_fragment if spec is chatgpt else spec for spec in origin_specs.ORIGIN_SPECS),
+    )
+
+    provider, evidence = detect_provider_evidence(_CHATGPT_LIKE_RECORD)
+
     assert provider is None
     assert "no detector matched" in evidence
 

--- a/tests/unit/sources/test_dispatch_evidence.py
+++ b/tests/unit/sources/test_dispatch_evidence.py
@@ -78,8 +78,10 @@ def test_detect_provider_evidence_reports_no_match_reason() -> None:
     assert "no detector matched" in evidence
 
 
-def test_origin_spec_binding_is_the_production_detector_authority(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Removing ChatGPT's declared fragment binding removes that real-route match.
+def test_origin_spec_binding_is_the_production_detector_and_lowering_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Removing ChatGPT's declared fragment binding invalidates the real route.
 
     This is deliberately not a test-local dispatcher: the public evidence API
     must compile the current OriginSpec declarations every time its declaration
@@ -89,6 +91,7 @@ def test_origin_spec_binding_is_the_production_detector_authority(monkeypatch: p
     import polylogue.sources.origin_specs as origin_specs
 
     chatgpt = next(spec for spec in origin_specs.ORIGIN_SPECS if spec.origin is Origin.CHATGPT_EXPORT)
+    before = origin_specs.lowering_fingerprint()
     without_fragment = replace(
         chatgpt,
         detector_bindings=tuple(
@@ -105,6 +108,7 @@ def test_origin_spec_binding_is_the_production_detector_authority(monkeypatch: p
 
     assert provider is None
     assert "no detector matched" in evidence
+    assert origin_specs.lowering_fingerprint() != before
 
 
 def test_detect_provider_from_raw_bytes_evidence_matches_document_detection() -> None:

--- a/tests/unit/sources/test_origin_specs.py
+++ b/tests/unit/sources/test_origin_specs.py
@@ -142,28 +142,6 @@ def test_lowering_fingerprint_changes_when_session_emitter_changes(
     assert before != after
 
 
-def test_lowering_fingerprint_changes_when_detector_registry_changes(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A detector-routing change is a lowering-semantic change, not incidental code."""
-    import polylogue.sources.origin_specs as origin_specs
-
-    source_root = tmp_path / "source-root"
-    source_dir = source_root / "polylogue" / "sources"
-    source_dir.mkdir(parents=True)
-    detector = source_dir / "detection.py"
-    detector.write_text("def detect(payload):\n    return None\n", encoding="utf-8")
-    monkeypatch.setattr(origin_specs, "_SOURCE_ROOT", source_root)
-    monkeypatch.setattr(origin_specs, "_LOWERING_FINGERPRINT_PATHS", ("polylogue/sources/detection.py",))
-    origin_specs._fingerprint_sources_cached.cache_clear()
-
-    before = origin_specs.lowering_fingerprint()
-    detector.write_text("def detect(payload):\n    return payload\n", encoding="utf-8")
-    after = origin_specs.lowering_fingerprint()
-
-    assert before != after
-
-
 def test_production_fingerprints_are_stable_across_a_fresh_interpreter() -> None:
     current_parser = parser_fingerprint_for_origin(Origin.CODEX_SESSION)
     command = (

--- a/tests/unit/sources/test_origin_specs.py
+++ b/tests/unit/sources/test_origin_specs.py
@@ -11,7 +11,8 @@ import pytest
 
 from polylogue.core.enums import Origin, Provider
 from polylogue.sources.assembly import get_assembly_spec
-from polylogue.sources.dispatch import RECORD_DETECTOR_PROVIDER_ORDER, STREAM_RECORD_PROVIDERS
+from polylogue.sources.detection import DetectorBinding, DetectorBindingError, compile_detector_registry
+from polylogue.sources.dispatch import STREAM_RECORD_PROVIDERS
 from polylogue.sources.origin_specs import (
     DROPPED_VALUE_VOCABULARIES,
     ORIGIN_SPEC_REGISTRY,
@@ -20,12 +21,12 @@ from polylogue.sources.origin_specs import (
     OriginSpecRegistry,
     artifact_suffixes_for_provider,
     check_dropped_value_vocabularies,
+    detector_registry,
     lowering_fingerprint,
     parser_fingerprint_for_origin,
     schema_observed_leaf_values,
     undeclared_schema_values,
     validate_assembly_spec_parity,
-    validate_dispatch_precedence,
     validate_stream_parser_parity,
 )
 
@@ -141,6 +142,28 @@ def test_lowering_fingerprint_changes_when_session_emitter_changes(
     assert before != after
 
 
+def test_lowering_fingerprint_changes_when_detector_registry_changes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A detector-routing change is a lowering-semantic change, not incidental code."""
+    import polylogue.sources.origin_specs as origin_specs
+
+    source_root = tmp_path / "source-root"
+    source_dir = source_root / "polylogue" / "sources"
+    source_dir.mkdir(parents=True)
+    detector = source_dir / "detection.py"
+    detector.write_text("def detect(payload):\n    return None\n", encoding="utf-8")
+    monkeypatch.setattr(origin_specs, "_SOURCE_ROOT", source_root)
+    monkeypatch.setattr(origin_specs, "_LOWERING_FINGERPRINT_PATHS", ("polylogue/sources/detection.py",))
+    origin_specs._fingerprint_sources_cached.cache_clear()
+
+    before = origin_specs.lowering_fingerprint()
+    detector.write_text("def detect(payload):\n    return payload\n", encoding="utf-8")
+    after = origin_specs.lowering_fingerprint()
+
+    assert before != after
+
+
 def test_production_fingerprints_are_stable_across_a_fresh_interpreter() -> None:
     current_parser = parser_fingerprint_for_origin(Origin.CODEX_SESSION)
     command = (
@@ -154,20 +177,41 @@ def test_production_fingerprints_are_stable_across_a_fresh_interpreter() -> None
     assert len(lowering_fingerprint()) == 64
 
 
-def test_origin_specs_are_parity_checked_against_current_dispatch_order() -> None:
-    assert validate_dispatch_precedence(RECORD_DETECTOR_PROVIDER_ORDER) == ()
+def test_origin_specs_compile_the_production_detector_registry() -> None:
+    registry = detector_registry()
+
+    assert registry.by_mode
+    assert all(spec.detector_bindings for spec in ORIGIN_SPECS if spec.lifecycle == "executable")
 
 
-def test_origin_spec_reports_source_locatable_missing_dispatch_provider() -> None:
-    diagnostics = validate_dispatch_precedence((Provider.CODEX,))
+def test_detector_registry_rejects_broken_declarations_with_the_binding_id() -> None:
+    codex = next(spec for spec in ORIGIN_SPECS if spec.origin is Origin.CODEX_SESSION)
+    broken = replace(
+        codex,
+        detector_bindings=(
+            replace(codex.detector_bindings[0], predicate_path="polylogue.sources.dispatch:not_a_detector"),
+            *codex.detector_bindings[1:],
+        ),
+    )
+    duplicate = replace(
+        codex,
+        detector_bindings=(
+            *codex.detector_bindings,
+            DetectorBinding(
+                binding_id="codex-record-pydantic",
+                mode=codex.detector_bindings[0].mode,
+                predicate_path=codex.detector_bindings[0].predicate_path,
+                local_rank=99,
+                evidence_label="duplicate",
+                fixed_provider=Provider.CODEX,
+            ),
+        ),
+    )
 
-    assert {item.code for item in diagnostics} == {"missing_dispatch_provider"}
-    assert {item.origin for item in diagnostics} == {
-        spec.origin
-        for spec in ORIGIN_SPECS
-        if spec.lifecycle == "executable" and spec.origin is not Origin.CODEX_SESSION
-    }
-    assert {item.owner_path for item in diagnostics} == {"polylogue/sources/origin_specs.py"}
+    with pytest.raises(DetectorBindingError, match="codex-record-pydantic"):
+        compile_detector_registry(tuple(broken if spec is codex else spec for spec in ORIGIN_SPECS))
+    with pytest.raises(DetectorBindingError, match="duplicate detector binding id"):
+        compile_detector_registry(tuple(duplicate if spec is codex else spec for spec in ORIGIN_SPECS))
 
 
 def test_origin_spec_rejects_missing_fixture_and_noninjective_collision_without_policy() -> None:
@@ -178,6 +222,8 @@ def test_origin_spec_rejects_missing_fixture_and_noninjective_collision_without_
         registry.register(replace(claude, fixture_paths=()))
     with pytest.raises(ValueError, match="collision policy"):
         registry.register(replace(claude, provider_wires=(Provider.CLAUDE_CODE, Provider.DRIVE)))
+    with pytest.raises(ValueError, match="detector binding"):
+        registry.register(replace(claude, detector_bindings=()))
 
 
 def test_origin_spec_rejects_undeclared_coverage() -> None:


### PR DESCRIPTION
## Summary

Compile source-provider detection from the executable `OriginSpec` declarations.

## Problem

`OriginSpec` declared detector tightness but the actual record and sequence detector trees lived independently in `sources.dispatch`. Removing or changing a declaration could not affect production detection, so the declaration could drift from runtime behavior.

## Solution

- Add typed, lazy `DetectorBinding` declarations and a validated compiled registry.
- Bind every executable OriginSpec, including explicit record/sequence precedence and browser-capture's dynamic provider claim.
- Route `detect_provider_evidence` through the registry and remove the handwritten detector trees and legacy precedence projection.
- Fingerprint detector registry code as lowering semantics and regress real-route binding removal, malformed binding diagnostics, stream ordering, evidence labels, and regression fixtures.

No schema, durable storage, ArchiveStore, or payload-declaration changes are included.

## Verification

`devtools test tests/unit/sources/test_origin_specs.py tests/unit/sources/test_dispatch_ordering.py tests/unit/sources/test_dispatch_evidence.py tests/unit/sources/parsers/test_origin_regression_pack.py`

Result: 70 passed (managed focused receipt `20260820T171022Z-focused-test-3453543-e5ad11bf`, 30.38s).

`devtools verify --quick` will run against the published PR head before merge.

## Bead disposition

| Bead | Disposition | Evidence | Residual successor |
| --- | --- | --- | --- |
| polylogue-2qx | Partial: F3 executable detector registry only (AC 1, 3, 6) | focused source regression suite; `60f2d8e14` | polylogue-o21 |

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [
    "polylogue-2qx"
  ],
  "dispositions": [
    {
      "bead_id": "polylogue-2qx",
      "disposition": "partial",
      "evidence": [
        {
          "kind": "test",
          "ref": "devtools test tests/unit/sources/test_origin_specs.py tests/unit/sources/test_dispatch_ordering.py tests/unit/sources/test_dispatch_evidence.py tests/unit/sources/parsers/test_origin_regression_pack.py (70 passed)"
        },
        {
          "kind": "commit",
          "ref": "60f2d8e146547a5a510d51e20aa15270341c8986"
        }
      ],
      "successors": [
        "polylogue-o21"
      ]
    }
  ],
  "mutated_beads": [],
  "scope_digest": "d78791c52c219c4b823e3d7fb63e9fc3c740a001eb6c3148bb6568fa1f6f2ee0",
  "scope_kind": "bead",
  "version": 2
}
-->
