### PR TITLE
fix(devtools): admit ledger-only verify caches

### DIFF
--- a/devtools/checkout_guard.py
+++ b/devtools/checkout_guard.py
@@ -270,7 +270,11 @@ def _cache_artifact(
     if not state_path.exists():
         return None, None
     try:
-        if state_path.is_dir() and not any(state_path.iterdir()):
+        entries = list(state_path.iterdir()) if state_path.is_dir() else []
+        if not entries or all(entry.name == "merge-gate" for entry in entries):
+            # The merge-train ledger is control state, not a derived verification
+            # artifact. A carrier recovery can create it before the first lane
+            # verification writes a checkout-bound run marker.
             return None, None
     except OSError:
         pass

--- a/tests/unit/devtools/test_checkout_guard.py
+++ b/tests/unit/devtools/test_checkout_guard.py
@@ -177,6 +177,24 @@ def test_checkout_environment_fingerprint_accepts_clean_linked_worktree(tmp_path
     assert fingerprint.python_environment_root == root
 
 
+def test_checkout_guard_accepts_a_ledger_only_verify_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = _fake_linked_checkout(tmp_path)
+    ledger = root / ".cache" / "verify" / "merge-gate" / "merge-train-ledger.json"
+    ledger.parent.mkdir(parents=True)
+    ledger.write_text('{"merges": []}\n')
+    package_path = root / "polylogue" / "__init__.py"
+    monkeypatch.setattr("devtools.checkout_guard.resolved_polylogue_path", lambda: package_path)
+
+    fingerprint = assert_polylogue_matches_checkout(
+        root,
+        context="carrier recovery",
+        python_executable=root / ".venv" / "bin" / "python",
+    )
+
+    assert fingerprint.clean
+    assert fingerprint.verify_state_origin is None
+
+
 def test_checkout_guard_leaves_derived_native_testmon_state_for_verify_to_repair(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Allow a carrier-recovery lane to retain merge-train control state before its first managed verification run.

## Problem

PR #4040's recovered disposition batch writes its exact-head merge ledger under `.cache/verify/merge-gate`. The checkout guard treated that ledger-only directory as an unattributed verify cache because it has no `current-run.json` marker, then blocked the graph check and follow-on tracker publication.

## Solution

Classify a cache containing only the `merge-gate` control directory as no verification artifact. A real verification cache still requires its existing checkout-root marker. The regression constructs a linked worktree with a ledger-only cache and proves that the guard admits it.

Whole-Bead disposition: self-contained. This PR changes no Bead record.

## Verification

- `devtools test tests/unit/devtools/test_checkout_guard.py` passed: `16 passed in 1.28s`.
- `devtools verify --quick` passed in `40.05s` as `20260821T005222Z-quick-2204459-4a79ef67`.

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->
