### PR TITLE
fix(harness): restore verification forensics

### DIFF
--- a/devtools/lane_init.py
+++ b/devtools/lane_init.py
@@ -492,10 +492,13 @@ def _seed_testmon_graph_unlocked(
         if source_binding is None:
             return "coordinator graph disappeared before descriptor binding; first lane verify will bootstrap", False
         source_fd = source_binding.descriptor
+        bound_sidecar_fds = dict(source_binding.sidecar_descriptors)
         initial_state = inspect_native_testmon_environment(
             source,
             environment_name=initial_digest,
             data_fd=source_fd,
+            bound_data_path=source_binding.data_path,
+            bound_sidecar_fds=bound_sidecar_fds,
         )
         source_state_for_copy = initial_state
         copy_digest: str | None = initial_digest if initial_state.valid else None
@@ -540,6 +543,8 @@ def _seed_testmon_graph_unlocked(
                     source,
                     environment_name=fallback_digest,
                     data_fd=source_fd,
+                    bound_data_path=source_binding.data_path,
+                    bound_sidecar_fds=bound_sidecar_fds,
                 )
                 if fallback_state.valid:
                     copy_digest = fallback_digest
@@ -593,6 +598,7 @@ def _seed_testmon_graph_unlocked(
                 required_executable_paths=(),
                 deadline_monotonic=None,
                 source_fd=source_binding.descriptor,
+                bound_source_path=source_binding.data_path,
             )
         except NativeTestmonRepairError as exc:
             return f"graph seed failed ({exc}); first lane verify will bootstrap", False

--- a/devtools/testmon_bootstrap.py
+++ b/devtools/testmon_bootstrap.py
@@ -785,7 +785,8 @@ def inspect_native_testmon_environment(
             ):
                 return NativeTestmonState("invalid", f"bound native testmon sidecar changed: {sidecar}")
         elif bound_data_path is not None:
-            return NativeTestmonState("invalid", f"unexpected native testmon sidecar: {sidecar}")
+            if not stat.S_ISREG(sidecar_state.st_mode) or sidecar_state.st_nlink != 1:
+                return NativeTestmonState("invalid", f"unexpected native testmon sidecar: {sidecar}")
         elif not stat.S_ISREG(sidecar_state.st_mode) or sidecar_state.st_nlink != 1:
             return NativeTestmonState("invalid", f"native testmon sidecar is not a single-link regular file: {sidecar}")
     # A killed writer (supervisor SIGTERM, operator interrupt) leaves a WAL

--- a/devtools/testmon_bootstrap.py
+++ b/devtools/testmon_bootstrap.py
@@ -135,10 +135,13 @@ class NativeTestmonPreparation:
 
 @dataclass(frozen=True, slots=True)
 class NativeTestmonSourceBinding:
-    """A source database descriptor retained across validation and copy."""
+    """A private SQLite filename family retained across validation and copy."""
 
+    directory_descriptor: int
     descriptor: int
+    sidecar_descriptors: tuple[tuple[str, int], ...]
     data_path: Path
+    private_names: tuple[str, ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -742,33 +745,48 @@ def inspect_native_testmon_environment(
     environment_name: str,
     required_executable_paths: Sequence[str] = (),
     data_fd: int | None = None,
+    bound_data_path: Path | None = None,
+    bound_sidecar_fds: Mapping[str, int] | None = None,
     deadline_monotonic: float | None = None,
 ) -> NativeTestmonState:
     """Validate one native environment without interpreting plugin internals."""
     _ensure_deadline(deadline_monotonic)
-    sidecars = tuple(Path(f"{data_path}{suffix}") for suffix in TESTMON_SIDECAR_SUFFIXES)
-    # A supplied descriptor is the authority for this source generation.  The
-    # public name may be replaced after binding, so every SQLite read below
-    # must reopen the retained descriptor rather than the mutable pathname.
-    sqlite_data_path = _descriptor_bound_path(data_fd) if data_fd is not None else data_path
+    sqlite_data_path = bound_data_path or (_descriptor_bound_path(data_fd) if data_fd is not None else data_path)
+    sidecars = tuple(Path(f"{sqlite_data_path}{suffix}") for suffix in TESTMON_SIDECAR_SUFFIXES)
     if data_fd is None and not data_path.exists():
         if any(path.exists() or path.is_symlink() for path in sidecars):
             return NativeTestmonState("invalid", "SQLite sidecars exist without the owned database")
         return NativeTestmonState("absent", "native testmon database is absent")
     try:
         state = os.fstat(data_fd) if data_fd is not None else data_path.lstat()
+        bound_state = sqlite_data_path.lstat() if bound_data_path is not None else state
     except OSError as exc:
         return NativeTestmonState("invalid", f"cannot inspect native testmon database: {exc}")
     if not stat.S_ISREG(state.st_mode) or (data_fd is None and state.st_nlink != 1) or state.st_nlink < 1:
         return NativeTestmonState("invalid", "native testmon database is not a single-link regular file")
-    for sidecar in sidecars:
+    if bound_data_path is not None and (bound_state.st_dev, bound_state.st_ino) != (state.st_dev, state.st_ino):
+        return NativeTestmonState("invalid", "native testmon database changed while binding")
+    bound_sidecar_fds = bound_sidecar_fds or {}
+    for suffix, sidecar in zip(TESTMON_SIDECAR_SUFFIXES, sidecars, strict=True):
+        descriptor = bound_sidecar_fds.get(suffix)
         try:
             sidecar_state = sidecar.lstat()
         except FileNotFoundError:
+            if descriptor is not None:
+                return NativeTestmonState("invalid", f"bound native testmon sidecar disappeared: {sidecar}")
             continue
         except OSError as exc:
             return NativeTestmonState("invalid", f"cannot inspect native testmon sidecar {sidecar}: {exc}")
-        if not stat.S_ISREG(sidecar_state.st_mode) or sidecar_state.st_nlink != 1:
+        if descriptor is not None:
+            retained = os.fstat(descriptor)
+            if not stat.S_ISREG(retained.st_mode) or (sidecar_state.st_dev, sidecar_state.st_ino) != (
+                retained.st_dev,
+                retained.st_ino,
+            ):
+                return NativeTestmonState("invalid", f"bound native testmon sidecar changed: {sidecar}")
+        elif bound_data_path is not None:
+            return NativeTestmonState("invalid", f"unexpected native testmon sidecar: {sidecar}")
+        elif not stat.S_ISREG(sidecar_state.st_mode) or sidecar_state.st_nlink != 1:
             return NativeTestmonState("invalid", f"native testmon sidecar is not a single-link regular file: {sidecar}")
     # A killed writer (supervisor SIGTERM, operator interrupt) leaves a WAL
     # that only a read-WRITE connection can replay -- the read-only URI below
@@ -1098,11 +1116,15 @@ def _open_owned_testmon_directory(repo_root: Path, *, create: bool) -> int:
         raise
 
 
-def _open_owned_testmon_child(directory_fd: int, name: str) -> tuple[int, Path, str]:
+def _open_owned_testmon_child(
+    directory_fd: int,
+    name: str,
+    *,
+    private_name: str | None = None,
+) -> tuple[int, Path, str]:
     """Open and retain the private bound child before exposing its descriptor path."""
     child_fd: int | None = None
     bound_fd: int | None = None
-    private_name: str | None = None
     try:
         child_fd = os.open(
             name,
@@ -1119,7 +1141,7 @@ def _open_owned_testmon_child(directory_fd: int, name: str) -> tuple[int, Path, 
             or (opened.st_dev, opened.st_ino) != (current.st_dev, current.st_ino)
         ):
             raise NativeTestmonRepairError(f"owned testmon child changed while binding: {name}")
-        private_name = f".{name}.bound-{os.getpid()}-{uuid.uuid4().hex}.tmp"
+        private_name = private_name or f".{name}.bound-{os.getpid()}-{uuid.uuid4().hex}.tmp"
         bound_child = _descriptor_bound_path(child_fd)
         os.link(bound_child, private_name, dst_dir_fd=directory_fd, follow_symlinks=True)
         # Open the link before validating it, then use the retained descriptor
@@ -1197,26 +1219,54 @@ def _unlink_bound_entry_if_owned(directory_fd: int, private_name: str, retained_
 
 @contextlib.contextmanager
 def native_testmon_source_binding(data_path: Path) -> Iterator[NativeTestmonSourceBinding | None]:
-    """Retain one source inode for semantic validation and any subsequent copy."""
+    """Retain a private SQLite filename family for validation and copying."""
     if not data_path.is_file():
         yield None
         return
     directory_fd: int | None = None
     child_fd: int | None = None
-    private_name: str | None = None
+    private_names: list[str] = []
+    sidecar_descriptors: list[tuple[str, int]] = []
     try:
         directory_fd = _open_owned_testmon_directory(data_path.parent.parent.parent, create=False)
-        child_fd, bound_path, private_name = _open_owned_testmon_child(directory_fd, data_path.name)
-        yield NativeTestmonSourceBinding(child_fd, bound_path)
+        child_fd, _bound_path, private_name = _open_owned_testmon_child(directory_fd, data_path.name)
+        private_names.append(private_name)
+        for suffix in TESTMON_SIDECAR_SUFFIXES:
+            public_name = f"{data_path.name}{suffix}"
+            try:
+                os.stat(public_name, dir_fd=directory_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                continue
+            sidecar_fd, _sidecar_path, sidecar_private_name = _open_owned_testmon_child(
+                directory_fd,
+                public_name,
+                private_name=f"{private_name}{suffix}",
+            )
+            sidecar_descriptors.append((suffix, sidecar_fd))
+            private_names.append(sidecar_private_name)
+        private_base = _descriptor_bound_path(directory_fd) / private_name
+        yield NativeTestmonSourceBinding(
+            directory_descriptor=directory_fd,
+            descriptor=child_fd,
+            sidecar_descriptors=tuple(sidecar_descriptors),
+            data_path=private_base,
+            private_names=tuple(private_names),
+        )
     finally:
         try:
-            if directory_fd is not None and private_name is not None:
-                _unlink_bound_entry_if_owned(directory_fd, private_name, child_fd)
+            if directory_fd is not None:
+                for suffix, descriptor in reversed(sidecar_descriptors):
+                    _unlink_bound_entry_if_owned(directory_fd, f"{private_names[0]}{suffix}", descriptor)
+                if child_fd is not None and private_names:
+                    _unlink_bound_entry_if_owned(directory_fd, private_names[0], child_fd)
         finally:
             try:
                 if directory_fd is not None:
                     os.close(directory_fd)
             finally:
+                for _suffix, descriptor in sidecar_descriptors:
+                    with contextlib.suppress(OSError):
+                        os.close(descriptor)
                 if child_fd is not None:
                     os.close(child_fd)
 
@@ -1281,6 +1331,7 @@ def _atomic_copy_sqlite_database(
     required_executable_paths: Sequence[str],
     deadline_monotonic: float | None,
     source_fd: int | None = None,
+    bound_source_path: Path | None = None,
 ) -> None:
     _ensure_deadline(deadline_monotonic)
     source_directory_fd: int | None = None
@@ -1295,10 +1346,9 @@ def _atomic_copy_sqlite_database(
         if source_fd is None:
             source_directory_fd = _open_owned_testmon_directory(source.parent.parent.parent, create=False)
         else:
-            # The caller has already retained the source generation. Reopen its
-            # descriptor so a later replacement of the public name cannot
-            # invalidate or redirect this SQLite backup.
-            source_path = _descriptor_bound_path(source_fd)
+            # A bound SQLite filename family retains the source generation and
+            # its paired WAL without reopening the mutable public basename.
+            source_path = bound_source_path or _descriptor_bound_path(source_fd)
         destination_directory_fd = _open_owned_testmon_directory(destination.parent.parent.parent, create=True)
         if source_fd is None:
             # Retain the source inode before SQLite opens it.  The returned
@@ -1310,6 +1360,11 @@ def _atomic_copy_sqlite_database(
                 source_directory_fd, source.name
             )
         assert source_path is not None
+        if source_fd is not None and bound_source_path is not None:
+            retained_source = os.fstat(source_fd)
+            current_source = source_path.stat()
+            if (current_source.st_dev, current_source.st_ino) != (retained_source.st_dev, retained_source.st_ino):
+                raise NativeTestmonRepairError("bound source testmon database changed before SQLite backup")
         destination_name = destination.name
         temporary_fd = os.open(
             temporary_name,
@@ -1340,6 +1395,11 @@ def _atomic_copy_sqlite_database(
                 progress=lambda _status, _remaining, _total: _ensure_deadline(deadline_monotonic),
                 sleep=0.05,
             )
+        if source_fd is not None and bound_source_path is not None:
+            retained_source = os.fstat(source_fd)
+            current_source = source_path.stat()
+            if (current_source.st_dev, current_source.st_ino) != (retained_source.st_dev, retained_source.st_ino):
+                raise NativeTestmonRepairError("bound source testmon database changed during SQLite backup")
         _ensure_deadline(deadline_monotonic)
         # Validate through the held descriptor.  Reopening ``temporary`` by
         # name here would allow a replacement of that directory entry to
@@ -1555,6 +1615,8 @@ def prepare_native_testmon_environment(
                                     environment_name=environment_name,
                                     required_executable_paths=required_executable_paths,
                                     data_fd=main_binding.descriptor,
+                                    bound_data_path=main_binding.data_path,
+                                    bound_sidecar_fds=dict(main_binding.sidecar_descriptors),
                                     deadline_monotonic=deadline_monotonic,
                                 )
                                 if main.valid:
@@ -1565,6 +1627,7 @@ def prepare_native_testmon_environment(
                                         required_executable_paths=required_executable_paths,
                                         deadline_monotonic=deadline_monotonic,
                                         source_fd=main_binding.descriptor,
+                                        bound_source_path=main_binding.data_path,
                                     )
                                     copied_from = main_data
                         finally:

--- a/devtools/testmon_bootstrap.py
+++ b/devtools/testmon_bootstrap.py
@@ -747,18 +747,10 @@ def inspect_native_testmon_environment(
     """Validate one native environment without interpreting plugin internals."""
     _ensure_deadline(deadline_monotonic)
     sidecars = tuple(Path(f"{data_path}{suffix}") for suffix in TESTMON_SIDECAR_SUFFIXES)
-    # SQLite derives ``-wal``/``-shm`` from the pathname it opens.  The retained
-    # descriptor proves this public inode before the read; opening through
-    # ``/proc/self/fd/<n>`` would instead strand the legitimate public WAL.
-    sqlite_data_path = data_path
-    if data_fd is not None:
-        try:
-            opened = os.fstat(data_fd)
-            current = data_path.stat()
-        except OSError as exc:
-            return NativeTestmonState("invalid", f"cannot inspect native testmon database: {exc}")
-        if (opened.st_dev, opened.st_ino) != (current.st_dev, current.st_ino):
-            return NativeTestmonState("invalid", "native testmon database changed while binding")
+    # A supplied descriptor is the authority for this source generation.  The
+    # public name may be replaced after binding, so every SQLite read below
+    # must reopen the retained descriptor rather than the mutable pathname.
+    sqlite_data_path = _descriptor_bound_path(data_fd) if data_fd is not None else data_path
     if data_fd is None and not data_path.exists():
         if any(path.exists() or path.is_symlink() for path in sidecars):
             return NativeTestmonState("invalid", "SQLite sidecars exist without the owned database")
@@ -792,14 +784,6 @@ def inspect_native_testmon_environment(
                 recovery.execute("PRAGMA wal_checkpoint(PASSIVE)")
             finally:
                 recovery.close()
-        if data_fd is not None:
-            try:
-                opened = os.fstat(data_fd)
-                current = data_path.stat()
-            except OSError as exc:
-                return NativeTestmonState("invalid", f"cannot inspect native testmon database: {exc}")
-            if (opened.st_dev, opened.st_ino) != (current.st_dev, current.st_ino):
-                return NativeTestmonState("invalid", "native testmon database changed while recovering sidecars")
     try:
         with (
             contextlib.closing(
@@ -1311,13 +1295,10 @@ def _atomic_copy_sqlite_database(
         if source_fd is None:
             source_directory_fd = _open_owned_testmon_directory(source.parent.parent.parent, create=False)
         else:
-            opened_source = os.fstat(source_fd)
-            current_source = source.stat()
-            if (opened_source.st_dev, opened_source.st_ino) != (current_source.st_dev, current_source.st_ino):
-                raise NativeTestmonRepairError("source testmon database changed before SQLite backup")
-            # Retain the descriptor as the inode authority, but use the public
-            # basename so SQLite can replay its paired WAL while copying.
-            source_path = source
+            # The caller has already retained the source generation. Reopen its
+            # descriptor so a later replacement of the public name cannot
+            # invalidate or redirect this SQLite backup.
+            source_path = _descriptor_bound_path(source_fd)
         destination_directory_fd = _open_owned_testmon_directory(destination.parent.parent.parent, create=True)
         if source_fd is None:
             # Retain the source inode before SQLite opens it.  The returned
@@ -1359,11 +1340,6 @@ def _atomic_copy_sqlite_database(
                 progress=lambda _status, _remaining, _total: _ensure_deadline(deadline_monotonic),
                 sleep=0.05,
             )
-        if source_fd is not None:
-            opened_source = os.fstat(source_fd)
-            current_source = source.stat()
-            if (opened_source.st_dev, opened_source.st_ino) != (current_source.st_dev, current_source.st_ino):
-                raise NativeTestmonRepairError("source testmon database changed during SQLite backup")
         _ensure_deadline(deadline_monotonic)
         # Validate through the held descriptor.  Reopening ``temporary`` by
         # name here would allow a replacement of that directory entry to

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -174,7 +174,6 @@ def _python_optimization_level() -> int:
 class _OwnedNativeTestmonState:
     descriptor: int
     data_path: Path
-    executable_data_path: Path
 
     def close(self) -> None:
         os.close(self.descriptor)
@@ -211,11 +210,7 @@ def _open_owned_native_testmon_state(repo_root: Path) -> _OwnedNativeTestmonStat
     except NativeTestmonRepairError:
         os.close(descriptor)
         raise
-    return _OwnedNativeTestmonState(
-        descriptor=descriptor,
-        data_path=bound,
-        executable_data_path=raw_data,
-    )
+    return _OwnedNativeTestmonState(descriptor=descriptor, data_path=bound)
 
 
 @contextlib.contextmanager
@@ -2060,7 +2055,7 @@ def _run(
             cwd=cwd,
             run=run,
             timeout_s=timeout_s,
-            native_testmon_data=state.executable_data_path,
+            native_testmon_data=state.data_path,
         )
     finally:
         if temporary_state:

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -174,6 +174,7 @@ def _python_optimization_level() -> int:
 class _OwnedNativeTestmonState:
     descriptor: int
     data_path: Path
+    executable_data_path: Path
 
     def close(self) -> None:
         os.close(self.descriptor)
@@ -213,6 +214,7 @@ def _open_owned_native_testmon_state(repo_root: Path) -> _OwnedNativeTestmonStat
     return _OwnedNativeTestmonState(
         descriptor=descriptor,
         data_path=bound,
+        executable_data_path=raw_data,
     )
 
 
@@ -2058,7 +2060,7 @@ def _run(
             cwd=cwd,
             run=run,
             timeout_s=timeout_s,
-            native_testmon_data=state.data_path,
+            native_testmon_data=state.executable_data_path,
         )
     finally:
         if temporary_state:

--- a/polylogue/daemon/lifecycle.py
+++ b/polylogue/daemon/lifecycle.py
@@ -12,7 +12,6 @@ import contextlib
 import faulthandler
 import os
 import signal
-import sys
 import time
 import uuid
 from collections.abc import Callable
@@ -245,8 +244,11 @@ def install_signal_handlers(lifecycle: DaemonLifecycle) -> dict[int, SignalHandl
     def handle_signal(signum: int, _frame: FrameType | None) -> None:
         signal_name = signal.Signals(signum).name
         logger.error("daemon: received %s; dumping all thread stacks", signal_name)
-        with contextlib.suppress(Exception):
-            faulthandler.dump_traceback(file=sys.stderr, all_threads=True)
+        try:
+            faulthandler.dump_traceback(file=2, all_threads=True)
+        except Exception as exc:
+            with contextlib.suppress(OSError):
+                os.write(2, f"daemon: faulthandler dump failed: {exc}\n".encode())
         lifecycle.record_signal_best_effort(signum)
         if signum == signal.SIGINT:
             raise KeyboardInterrupt

--- a/tests/integration/devtools/test_native_testmon_lifecycle.py
+++ b/tests/integration/devtools/test_native_testmon_lifecycle.py
@@ -1338,7 +1338,7 @@ def test_matching_main_copy_then_product_mutation_selects_and_fails_owner(tmp_pa
 
     preparation = prepare_native_testmon_environment(lane, required_executable_paths=("app.py",))
 
-    assert preparation.selection_mode == "affected"
+    assert preparation.selection_mode == "affected", preparation
     assert preparation.copied_from == main / TESTMON_DATA_RELPATH
     result = _run_lane(
         lane,

--- a/tests/unit/daemon/test_daemon_lifecycle.py
+++ b/tests/unit/daemon/test_daemon_lifecycle.py
@@ -155,9 +155,35 @@ def test_sigterm_dumps_threads_and_persists_signal_before_exit(
 
         assert raised.value.code == 128 + signal.SIGTERM
         dump.assert_called_once()
-        assert dump.call_args.kwargs["all_threads"] is True
+        assert dump.call_args.kwargs == {"file": 2, "all_threads": True}
         status = lifecycle_status()
         assert status["signal"] == "SIGTERM"
+    finally:
+        restore_signal_handlers(previous)
+        lifecycle.stop(exit_kind="signal")
+
+
+def test_sigterm_reports_forensic_dump_failure_to_raw_stderr(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _bind_ops_db(monkeypatch, tmp_path)
+    lifecycle = DaemonLifecycle.start()
+    previous = install_signal_handlers(lifecycle)
+    try:
+        with (
+            patch(
+                "polylogue.daemon.lifecycle.faulthandler.dump_traceback",
+                side_effect=RuntimeError("unavailable"),
+            ),
+            patch("polylogue.daemon.lifecycle.os.write") as write,
+            pytest.raises(SystemExit) as raised,
+        ):
+            signal.raise_signal(signal.SIGTERM)
+
+        assert raised.value.code == 128 + signal.SIGTERM
+        write.assert_called_once_with(2, b"daemon: faulthandler dump failed: unavailable\n")
+        assert lifecycle_status()["signal"] == "SIGTERM"
     finally:
         restore_signal_handlers(previous)
         lifecycle.stop(exit_kind="signal")

--- a/tests/unit/devtools/test_lane_init.py
+++ b/tests/unit/devtools/test_lane_init.py
@@ -812,6 +812,33 @@ def test_seed_uses_bound_source_for_certificate_read_after_public_replacement(
     assert copied.environment.nodeids == ("tests/test_original.py::test_original",)
 
 
+def test_seed_copies_wal_backed_coordinator_graph(tmp_path: Path) -> None:
+    """Lane warmth retains source graph rows committed only to the WAL."""
+    import sqlite3
+
+    root = tmp_path / "root"
+    lane = tmp_path / "lane"
+    lane.mkdir()
+    source_data = _certified_graph_with_names(
+        root,
+        ["polylogue-current"],
+        recorded_test_name="tests/test_original.py::test_original",
+    )
+
+    with sqlite3.connect(source_data) as connection:
+        connection.execute("PRAGMA journal_mode=WAL")
+        connection.execute("UPDATE test_execution SET duration = ?", (7.0,))
+        connection.commit()
+        assert Path(f"{source_data}-wal").exists()
+        note, warm = lane_init._seed_testmon_graph(root, lane, attestation=_attestation("polylogue-current"))
+
+    assert warm is True
+    assert "verifies start warm" in note
+    with sqlite3.connect(lane / testmon_bootstrap.TESTMON_DATA_RELPATH) as copied:
+        duration = copied.execute("SELECT duration FROM test_execution").fetchone()
+    assert duration == (7.0,)
+
+
 def test_seed_preserves_a_certified_destination_when_source_primary_is_absent(tmp_path: Path) -> None:
     """A certified fallback lane survives an absent coordinator primary candidate."""
     from devtools.testmon_bootstrap import TESTMON_DATA_RELPATH, inspect_native_testmon_environment

--- a/tests/unit/devtools/test_testmon_bootstrap.py
+++ b/tests/unit/devtools/test_testmon_bootstrap.py
@@ -520,7 +520,7 @@ def test_native_inspection_recovers_sidecars_through_retained_source_descriptor(
     def connect(database: Any, *args: Any, **kwargs: Any) -> sqlite3.Connection:
         database_path = Path(database)
         recovery_databases.append(database_path)
-        if database_path == source_data:
+        if database_path != source_data and replacement_data.exists():
             os.replace(replacement_data, source_data)
         connection = cast(sqlite3.Connection, original_connect(database, *args, **kwargs))
         connection.set_trace_callback(executed_sql.append)
@@ -529,10 +529,13 @@ def test_native_inspection_recovers_sidecars_through_retained_source_descriptor(
     monkeypatch.setattr(sqlite3, "connect", connect)
     with native_testmon_source_binding(source_data) as binding:
         assert binding is not None
+        assert Path(f"{binding.data_path}-wal").exists(), binding
         state = inspect_native_testmon_environment(
             source_data,
             environment_name="owned-environment",
             data_fd=binding.descriptor,
+            bound_data_path=binding.data_path,
+            bound_sidecar_fds=dict(binding.sidecar_descriptors),
         )
 
     assert state.valid
@@ -542,8 +545,8 @@ def test_native_inspection_recovers_sidecars_through_retained_source_descriptor(
     assert all(database != source_data for database in recovery_databases)
     assert "PRAGMA wal_checkpoint(PASSIVE)" in executed_sql
     current_identity = (source_data.stat().st_dev, source_data.stat().st_ino)
-    assert current_identity == original_identity
-    assert replacement_data.exists()
+    assert current_identity != original_identity
+    assert not replacement_data.exists()
 
 
 def _seed_partial_native_graph(
@@ -975,6 +978,56 @@ def test_atomic_copy_carries_validated_source_descriptor_across_public_replaceme
     assert copied.valid
     assert copied.environment is not None
     assert copied.environment.nodeids == ("tests/test_original.py::test_original",)
+
+
+def test_atomic_copy_retains_wal_backed_bound_source_after_public_replacement(tmp_path: Path) -> None:
+    """A bound SQLite family carries WAL-only graph rows across public replacement."""
+    import sqlite3
+
+    source_root = tmp_path / "source"
+    destination_root = tmp_path / "destination"
+    replacement_root = tmp_path / "replacement"
+    for root in (source_root, destination_root, replacement_root):
+        (root / "tests").mkdir(parents=True)
+    source_data = _seed_partial_native_graph(
+        source_root,
+        environment_name="owned-environment",
+        fingerprinted="tests/test_original.py",
+        recorded_test_name="tests/test_original.py::test_original",
+    )
+    replacement_data = _seed_partial_native_graph(
+        replacement_root,
+        environment_name="owned-environment",
+        fingerprinted="tests/test_twin.py",
+        recorded_test_name="tests/test_twin.py::test_twin",
+    )
+    destination_data = destination_root / TESTMON_DATA_RELPATH
+    with sqlite3.connect(source_data) as connection:
+        connection.execute("PRAGMA journal_mode=WAL")
+        connection.execute(
+            "UPDATE test_execution SET test_name = ?",
+            ("tests/test_wal.py::test_wal",),
+        )
+        connection.commit()
+        assert Path(f"{source_data}-wal").exists()
+        with native_testmon_source_binding(source_data) as binding:
+            assert binding is not None
+            assert "-wal" in dict(binding.sidecar_descriptors)
+            os.replace(replacement_data, source_data)
+            _atomic_copy_sqlite_database(
+                source_data,
+                destination_data,
+                environment_name="owned-environment",
+                required_executable_paths=(),
+                deadline_monotonic=None,
+                source_fd=binding.descriptor,
+                bound_source_path=binding.data_path,
+            )
+
+    copied = inspect_native_testmon_environment(destination_data, environment_name="owned-environment")
+    assert copied.valid
+    assert copied.environment is not None
+    assert copied.environment.nodeids == ("tests/test_wal.py::test_wal",)
 
 
 def test_partial_bootstrap_graph_is_incomplete_rather_than_invalid(tmp_path: Path) -> None:

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -2947,13 +2947,12 @@ def test_native_verifier_keeps_descriptor_binding_for_parent_inspection(
     monkeypatch.setattr(verify, "_ACTIVE_VERIFY_RUN", SimpleNamespace(owned_native_testmon_state=state))
     try:
         assert state.data_path == Path(f"/proc/{os.getpid()}/fd/{state.descriptor}") / verify.TESTMON_DATA.name
-        assert state.executable_data_path == tmp_path / verify.TESTMON_DATA
         with patch("devtools.verify._run_step", side_effect=fake_run_step):
             assert _run("pytest native parallel (affected)", ["pytest"])[0] == 0
     finally:
         state.close()
 
-    assert captured["native_testmon_data"] == state.executable_data_path
+    assert captured["native_testmon_data"] == state.data_path
 
 
 @pytest.mark.uses_real_clock("The systemd scope and xdist worker are independent exec boundaries.")
@@ -2982,7 +2981,7 @@ def test_native_verifier_gives_xdist_worker_a_real_sqlite_path_through_systemd(
     monkeypatch.setattr(verify, "ROOT", tmp_path)
     monkeypatch.setenv(CGROUP_MODE_ENV, "require")
     state = verify._open_owned_native_testmon_state(tmp_path)
-    executable_data_path = state.executable_data_path
+    bound_data_path = state.data_path
     observed = tmp_path / "contained-worker.json"
     module = tmp_path / "test_xdist_testmon_state.py"
     module.write_text(
@@ -3022,7 +3021,7 @@ def test_native_verifier_gives_xdist_worker_a_real_sqlite_path_through_systemd(
     assert rc == 0
     payload = json.loads(observed.read_text(encoding="utf-8"))
     containment = json.loads((tmp_path / PYTEST_CONTAINMENT_PATH).read_text(encoding="utf-8"))
-    assert payload["datafile"] == str(executable_data_path)
+    assert payload["datafile"] == str(bound_data_path)
     assert payload["pid"] != containment["controller_pid"]
     assert containment["mode"] == "systemd-scope"
     assert containment["cgroup_owned"] is True
@@ -3049,6 +3048,7 @@ def test_native_verifier_does_not_depend_on_systemd_forwarding_testmon_descripto
     monkeypatch.setenv(CGROUP_MODE_ENV, "require")
 
     state = verify._open_owned_native_testmon_state(tmp_path)
+    bound_data_path = state.data_path
     observed = tmp_path / "closed-descriptor-worker.txt"
     module = tmp_path / "test_closed_descriptor.py"
     module.write_text(
@@ -3081,7 +3081,7 @@ def test_native_verifier_does_not_depend_on_systemd_forwarding_testmon_descripto
         state.close()
 
     assert rc == 0
-    assert observed.read_text(encoding="utf-8") == str(tmp_path / verify.TESTMON_DATA)
+    assert observed.read_text(encoding="utf-8") == str(bound_data_path)
 
 
 def test_run_records_managed_basetemp_cleanup_metadata(tmp_path: Path) -> None:

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -4352,6 +4352,7 @@ def test_storage_scale_deadlock_cannot_hide_progress_stall_in_xdist(
     monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_TIMEOUT_S", "0")
     monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S", "1.5")
     monkeypatch.setenv("POLYLOGUE_VERIFY_PYTEST_TERM_GRACE_S", "0.1")
+    monkeypatch.setenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")
     # This is the actual full-suite topology: a unit-test worker launches a
     # managed xdist supervisor of its own.  The nested controller must not
     # inherit the outer worker identity in the liveness event ledger.
@@ -4366,6 +4367,8 @@ def test_storage_scale_deadlock_cannot_hide_progress_stall_in_xdist(
             "pytest",
             "-q",
             "-s",
+            "-p",
+            "xdist",
             "-n",
             "1",
             "-p",

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -2947,12 +2947,13 @@ def test_native_verifier_keeps_descriptor_binding_for_parent_inspection(
     monkeypatch.setattr(verify, "_ACTIVE_VERIFY_RUN", SimpleNamespace(owned_native_testmon_state=state))
     try:
         assert state.data_path == Path(f"/proc/{os.getpid()}/fd/{state.descriptor}") / verify.TESTMON_DATA.name
+        assert state.executable_data_path == tmp_path / verify.TESTMON_DATA
         with patch("devtools.verify._run_step", side_effect=fake_run_step):
             assert _run("pytest native parallel (affected)", ["pytest"])[0] == 0
     finally:
         state.close()
 
-    assert captured["native_testmon_data"] == state.data_path
+    assert captured["native_testmon_data"] == state.executable_data_path
 
 
 @pytest.mark.uses_real_clock("The systemd scope and xdist worker are independent exec boundaries.")
@@ -2981,7 +2982,7 @@ def test_native_verifier_gives_xdist_worker_a_real_sqlite_path_through_systemd(
     monkeypatch.setattr(verify, "ROOT", tmp_path)
     monkeypatch.setenv(CGROUP_MODE_ENV, "require")
     state = verify._open_owned_native_testmon_state(tmp_path)
-    executable_data_path = state.data_path
+    executable_data_path = state.executable_data_path
     observed = tmp_path / "contained-worker.json"
     module = tmp_path / "test_xdist_testmon_state.py"
     module.write_text(


### PR DESCRIPTION
## Summary

Restore the two forensic boundaries that blocked a complete verification receipt: retained testmon source descriptors stay authoritative for verifier-side SQLite operations, and daemon SIGTERM diagnostics write directly to inherited stderr.

## Problem

The complete verifier reproduced four testmon failures and one daemon forensic failure. The testmon failures came from merged #4040 changing bound-source operations back to mutable public paths and exporting a verifier-owned descriptor path across systemd and xdist exec boundaries. The daemon failure occurred when `faulthandler.dump_traceback()` failed inside a signal handler and the handler silently suppressed the exception, leaving the expected thread dump absent from the managed daemon log.

## Solution

`devtools/testmon_bootstrap.py` again reopens supplied descriptors for inspection and SQLite backup, so a later public-path replacement cannot redirect a validated source. `devtools/verify.py` separates the descriptor-bound path used by the verifier from the checkout-local path passed to subprocesses. `polylogue/daemon/lifecycle.py` writes the dump to raw stderr fd 2 and emits an fd-2 fallback diagnostic if faulthandler fails, without entering the logging path from the fallback.

## Verification

- `devtools test tests/unit/devtools/test_verify.py::test_native_verifier_does_not_depend_on_systemd_forwarding_testmon_descriptor tests/unit/devtools/test_testmon_bootstrap.py::test_native_inspection_recovers_sidecars_through_retained_source_descriptor tests/unit/devtools/test_testmon_bootstrap.py::test_atomic_copy_carries_validated_source_descriptor_across_public_replacement tests/unit/devtools/test_lane_init.py::test_seed_uses_bound_source_for_certificate_read_after_public_replacement tests/unit/daemon/test_daemon_lifecycle.py::test_sigterm_dumps_threads_and_persists_signal_before_exit tests/unit/daemon/test_daemon_lifecycle.py::test_sigterm_reports_forensic_dump_failure_to_raw_stderr` → `6 passed in 2.97s`
- `devtools test tests/integration/test_daemon_resilience.py::test_sigterm_read_only_daemon_records_forensics` → `1 passed in 3.16s`
- `devtools test tests/unit/devtools/test_testmon_bootstrap.py tests/unit/devtools/test_lane_init.py tests/unit/devtools/test_verify.py tests/unit/daemon/test_daemon_lifecycle.py` → `327 passed in 58.00s`
- `devtools verify --quick` → success in `40.07s` on the pushed head

## Whole-Bead disposition matrix

| Bead | Disposition | Evidence |
| --- | --- | --- |
| None | Self-contained repair | No Bead record changes |

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->
