### PR TITLE
refactor(devtools): remove lab command surface

### DIFF
--- a/.agent/CONVENTIONS.md
+++ b/.agent/CONVENTIONS.md
@@ -65,7 +65,7 @@ discovered follow-ups. Run `bd prime` for workflow context.
   `bd dep cycles` clean.
 - No Dolt remote: `.beads/issues.jsonl` in git IS the sync surface; ship
   bead-state deltas in PRs (`chore(beads):`).
-- Graph lint: run `devtools lab policy bead-graph` before shipping bead deltas
+- Graph lint: run `devtools verify bead-graph` before shipping bead deltas
   (cycles, missing acceptance criteria, duplicate `wave:` labels, wave
   inversions). INTENTIONAL DIVERGENCE from sinex: only duplicate `wave:`
   labels are flagged — polylogue does not (yet) enforce exactly-one-area, and

--- a/.agent/README.md
+++ b/.agent/README.md
@@ -16,7 +16,7 @@ repo conventions in [`CONVENTIONS.md`](CONVENTIONS.md).
   cadence (kept deliberately parallel to sinex's; divergences are marked
   intentional).
 - Repo-agent helper scripts live under `devtools/` as proper commands, not in
-  `.agent/` — `devtools lab policy bead-graph` (bead-graph invariant lint; run
+  `.agent/` — `devtools verify bead-graph` (bead-graph invariant lint; run
   before shipping bead-state deltas), `devtools workspace
   bead-reimport-guard`, `devtools workspace delivery-gate-status`, `devtools
   workspace bead-batch-show` (polylogue-kapb: `.agent/scripts/` and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - run: uv run devtools render all --check
       # An index schema bump merged without its lifecycle.py delta declaration
       # downgrades every live generation to a full raw replay (polylogue-9rw0).
-      - run: uv run devtools lab policy schema-versioning
+      - run: uv run devtools verify schema-versioning
       # Surface-to-substrate import ratchet (polylogue-2ciy): the baseline in
       # docs/plans/layering-surface-baseline.json is a fixed inventory of
       # pre-existing violations, exempted so this can be a required check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,7 @@ index additions that can be grouped into one schema bump, and do not call a
 full reingest necessary unless the changed semantics actually require replaying
 source rows.
 
-The policy lint (`devtools lab policy schema-versioning`) validates derived-tier
+The policy lint (`devtools verify schema-versioning`) validates derived-tier
 lifecycle declarations and clone-safe benign-DDL shapes while allowing numbered
 durable-tier SQL migrations. It does not attempt to classify Python helpers by
 their names; ad hoc open-path upgrades remain unsupported because the runtime

--- a/devtools/cli_boundary.py
+++ b/devtools/cli_boundary.py
@@ -1,4 +1,4 @@
-"""Subprocess-backed CLI boundary for lab smoke scenarios."""
+"""Subprocess-backed CLI boundary for archive-smoke scenarios."""
 
 from __future__ import annotations
 
@@ -44,7 +44,7 @@ def invoke_polylogue_cli(
     cwd: Path | None = None,
     timeout: float = 60.0,
 ) -> CliInvocationResult:
-    """Run the real public CLI entrypoint for lab smoke checks."""
+    """Run the real public CLI entrypoint for archive-smoke checks."""
     cli_path = _project_polylogue_cli()
     if cli_path is None:
         return _invoke_python_polylogue_cli(execution, env=env, cwd=cwd or _PROJECT_ROOT, timeout=timeout)

--- a/devtools/click_dispatch.py
+++ b/devtools/click_dispatch.py
@@ -21,14 +21,12 @@ from devtools.command_catalog import (
     COMMAND_SPECS,
     CommandSpec,
     grouped_command_specs,
-    verification_lab_command_specs,
 )
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 
 GROUP_HELP: dict[str, str] = {
     "bench": "Run benchmark, mutation, SLO, and resource-budget commands.",
-    "lab": "Run executable lab evidence, schema, probe, and policy commands.",
     "render": "Render and check generated repository surfaces.",
     "release": "Build, smoke, and validate release/distribution readiness.",
     "verify": "Run the local verification baseline or focused checks. Use --inner-help for baseline flags.",
@@ -37,13 +35,9 @@ GROUP_HELP: dict[str, str] = {
 
 
 def _print_inventory(*, json: bool) -> None:
-    verification_lab = verification_lab_command_specs()
     if json:
         payload = {
             "commands": [spec.to_dict() for spec in COMMAND_SPECS],
-            "surfaces": {
-                "verification_lab": [spec.name for spec in verification_lab],
-            },
             "categories": [
                 {
                     "name": category,
@@ -57,10 +51,6 @@ def _print_inventory(*, json: bool) -> None:
         return
 
     click.echo("Commands:")
-    if verification_lab:
-        click.echo("\n  lab check surface:")
-        for spec in verification_lab:
-            click.echo(f"    {spec.name:<25} {spec.description}")
     for category, specs in grouped_command_specs().items():
         click.echo(f"\n  {category}:")
         for spec in specs:

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -14,7 +14,7 @@ CATEGORY_ORDER: tuple[str, ...] = (
     "core",
     "generated surfaces",
     "release",
-    "verification lab",
+    "verification",
     "verification",
     "benchmarking",
     "workspace",
@@ -265,8 +265,8 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
-        "lab provider completeness",
-        "verification lab",
+        "verify provider-completeness",
+        "verification",
         "Report provider/importer package completeness by origin and capture mode.",
         "devtools.provider_completeness",
         use_when=(
@@ -274,10 +274,10 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
             "before claiming a provider/importer mode is product-ready."
         ),
         examples=(
-            "devtools lab provider completeness",
-            "devtools lab provider completeness --json",
-            "devtools lab provider completeness --origin codex-session --json",
-            "devtools lab provider completeness --check",
+            "devtools verify provider-completeness",
+            "devtools verify provider-completeness --json",
+            "devtools verify provider-completeness --origin codex-session --json",
+            "devtools verify provider-completeness --check",
         ),
     ),
     CommandSpec(
@@ -356,8 +356,8 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
-        "lab snapshot read-surface",
-        "verification lab",
+        "verify read-surface",
+        "verification",
         "Capture and compare archive read-surface snapshots.",
         "devtools.self_verify",
         use_when=(
@@ -365,8 +365,8 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
             "archives against the captured envelope baseline."
         ),
         examples=(
-            "devtools lab snapshot read-surface capture --out .local/self-verify/baseline.json",
-            "devtools lab snapshot read-surface compare .local/self-verify/baseline.json .local/self-verify/candidate.json --json",
+            "devtools verify read-surface capture --out .local/self-verify/baseline.json",
+            "devtools verify read-surface compare .local/self-verify/baseline.json .local/self-verify/candidate.json --json",
         ),
     ),
     CommandSpec(
@@ -1205,8 +1205,8 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
-        "lab policy schema-versioning",
-        "verification lab",
+        "verify schema-versioning",
+        "verification",
         "Verify durable-tier migration and derived-tier rebuild boundaries.",
         "devtools.verify_schema_upgrade_lane",
         use_when=(
@@ -1215,11 +1215,11 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
             "migrations with a backup gate; derived tiers are rebuilt or "
             "blue-green replaced from source evidence."
         ),
-        examples=("devtools lab policy schema-versioning", "devtools lab policy schema-versioning --json"),
+        examples=("devtools verify schema-versioning", "devtools verify schema-versioning --json"),
     ),
     CommandSpec(
-        "lab policy oracle-integrity",
-        "verification lab",
+        "verify oracle-integrity",
+        "verification",
         "Verify tests certify production-reachable code and never read ambient user paths.",
         "devtools.verify_oracle_integrity",
         use_when=(
@@ -1235,13 +1235,13 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
             "deletions derived from grep."
         ),
         examples=(
-            "devtools lab policy oracle-integrity",
-            "devtools lab policy oracle-integrity --ignore-baseline --json",
+            "devtools verify oracle-integrity",
+            "devtools verify oracle-integrity --ignore-baseline --json",
         ),
     ),
     CommandSpec(
-        "lab policy bead-graph",
-        "verification lab",
+        "verify bead-graph",
+        "verification",
         "Validate typed dependency endpoints, closed dependency kinds, parent cardinality, cycles, forcing closures, and registry Bead references.",
         "devtools.verify_bead_graph",
         use_when=(
@@ -1252,14 +1252,14 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
             "checks existing registry Bead references and never makes prose or campaign mirrors authority."
         ),
         examples=(
-            "devtools lab policy bead-graph",
-            "devtools lab policy bead-graph --export .beads/issues.jsonl --json",
-            "devtools lab policy bead-graph --export .beads/issues.jsonl --forcing-root polylogue-818fy --require-resolved --json",
+            "devtools verify bead-graph",
+            "devtools verify bead-graph --export .beads/issues.jsonl --json",
+            "devtools verify bead-graph --export .beads/issues.jsonl --forcing-root polylogue-818fy --require-resolved --json",
         ),
     ),
     CommandSpec(
-        "lab policy timestamp-doctrine",
-        "verification lab",
+        "verify timestamp-doctrine",
+        "verification",
         "Verify durable-tier DDL never stores a timestamp column as TEXT.",
         "devtools.verify_timestamp_doctrine",
         use_when=(
@@ -1269,11 +1269,11 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
             "an explicit additive migration to fix later -- catching it before merge is orders "
             "cheaper than a copy-forward migration after."
         ),
-        examples=("devtools lab policy timestamp-doctrine", "devtools lab policy timestamp-doctrine --json"),
+        examples=("devtools verify timestamp-doctrine", "devtools verify timestamp-doctrine --json"),
     ),
     CommandSpec(
-        "lab policy insight-honesty",
-        "verification lab",
+        "verify insight-honesty",
+        "verification",
         "Verify every registered insight product is rigor-contracted or exempt.",
         "devtools.verify_insight_rigor_honesty",
         use_when=(
@@ -1283,7 +1283,7 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
             "RIGOR_EXEMPT entry used to silently vanish from `polylogue ops insights audit` "
             "instead of showing as uncovered."
         ),
-        examples=("devtools lab policy insight-honesty", "devtools lab policy insight-honesty --json"),
+        examples=("devtools verify insight-honesty", "devtools verify insight-honesty --json"),
     ),
     CommandSpec(
         "release verify-distribution",
@@ -1297,8 +1297,8 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         examples=("devtools release verify-distribution",),
     ),
     CommandSpec(
-        "lab probe cost-reconciliation",
-        "verification lab",
+        "workspace cost-reconciliation",
+        "verification",
         "Reconcile Polylogue token accounting against private provider stores.",
         "devtools.cost_reconciliation_probe",
         use_when=(
@@ -1306,20 +1306,20 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
             "Claude stats-cache.json before publishing cost or usage-analysis claims."
         ),
         examples=(
-            "devtools lab probe cost-reconciliation --json",
-            "devtools lab probe cost-reconciliation --codex-state ~/.codex/state_5.sqlite --json",
-            "devtools lab probe cost-reconciliation --claude-stats-cache ~/.config/claude/stats-cache.json --check",
+            "devtools workspace cost-reconciliation --json",
+            "devtools workspace cost-reconciliation --codex-state ~/.codex/state_5.sqlite --json",
+            "devtools workspace cost-reconciliation --claude-stats-cache ~/.config/claude/stats-cache.json --check",
         ),
     ),
     CommandSpec(
-        "lab probe pipeline",
-        "verification lab",
+        "bench pipeline",
+        "verification",
         "Run typed pipeline probes against synthetic, staged, or archive-subset inputs.",
         "devtools.pipeline_probe",
         use_when="Run real pipeline stages and optionally capture emitted summaries as regression cases.",
         examples=(
-            "devtools lab probe pipeline --provider chatgpt --stage parse",
-            "devtools lab probe pipeline --input-mode archive-subset --capture-regression live-parse-drift",
+            "devtools bench pipeline --provider chatgpt --stage parse",
+            "devtools bench pipeline --input-mode archive-subset --capture-regression live-parse-drift",
         ),
     ),
     CommandSpec(
@@ -1331,66 +1331,55 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         examples=("devtools bench memory --max-rss-mb 1536 -- polylogue --plain analyze",),
     ),
     CommandSpec(
-        "lab run",
-        "verification lab",
+        "verify scenario",
+        "verification",
         "Run a named archive verification scenario.",
         "devtools.lab_scenario",
-        entrypoint="run_main",
-        use_when="Run a scenario such as rebuild-safety through the direct lab command path.",
+        use_when="Run a named archive verification scenario through the direct CLI path.",
         examples=(
-            "devtools lab run rebuild-safety",
-            "devtools lab run rebuild-safety --report-dir .cache/rebuild-safety-report --json",
+            "devtools verify scenario list",
+            "devtools verify scenario run archive-smoke --tier 0",
+            "devtools verify scenario run rebuild-safety --report-dir .cache/rebuild-safety-report --json",
         ),
     ),
     CommandSpec(
-        "lab smoke",
-        "verification lab",
-        "Run direct archive and reader smoke sets.",
-        "devtools.lab_scenario",
-        use_when="Run direct archive and reader smoke sets outside the archive CLI.",
-        examples=(
-            "devtools lab smoke list",
-            "devtools lab smoke run archive-smoke --tier 0",
-        ),
-    ),
-    CommandSpec(
-        "lab schema list",
-        "verification lab",
+        "workspace schema list",
+        "verification",
         "List committed schema packages, versions, and evidence manifests.",
         "devtools.schema_inspect",
         entrypoint="list_main",
         use_when="Inspect committed provider schema package catalogs without presenting them as normal archive usage.",
-        examples=("devtools lab schema list --provider chatgpt --json",),
+        examples=("devtools workspace schema list --provider chatgpt --json",),
     ),
     CommandSpec(
-        "lab schema compare",
-        "verification lab",
+        "workspace schema compare",
+        "verification",
         "Compare two committed schema package versions for a provider.",
         "devtools.schema_inspect",
         entrypoint="compare_main",
         use_when="Review schema package drift between committed versions in the lab surface.",
-        examples=("devtools lab schema compare --provider chatgpt --from v1 --to v2 --markdown",),
+        examples=("devtools workspace schema compare --provider chatgpt --from v1 --to v2 --markdown",),
     ),
     CommandSpec(
-        "lab schema explain",
-        "verification lab",
+        "workspace schema explain",
+        "verification",
         "Explain a committed package element schema with evidence and annotations.",
         "devtools.schema_inspect",
         entrypoint="explain_main",
         use_when="Inspect schema package annotations, semantic roles, and review evidence from the lab surface.",
-        examples=("devtools lab schema explain --provider chatgpt --version latest --verbose",),
+        examples=("devtools workspace schema explain --provider chatgpt --version latest --verbose",),
     ),
     CommandSpec(
-        "lab schema generate",
-        "verification lab",
+        "workspace schema generate",
+        "verification",
         "Generate provider schema packages and optional evidence clusters.",
         "devtools.schema_generate",
         use_when="Refresh provider schema package artifacts from archive observations outside the archive CLI.",
-        examples=("devtools lab schema generate --provider chatgpt --cluster",),
+        examples=("devtools workspace schema generate --provider chatgpt --cluster",),
     ),
     CommandSpec(
-        "lab schema commit",
-        "verification lab",
+        "workspace schema commit",
+        "verification",
         "Persist a real full-corpus schema generation into committed provider packages.",
         "devtools.schema_commit",
         use_when=(
@@ -1398,29 +1387,29 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
             "archive -- 'lab schema generate' only ever previews and never writes committed package files."
         ),
         examples=(
-            "devtools lab schema commit --provider chatgpt --full-corpus --dry-run",
-            "devtools lab schema commit --provider chatgpt --full-corpus",
+            "devtools workspace schema commit --provider chatgpt --full-corpus --dry-run",
+            "devtools workspace schema commit --provider chatgpt --full-corpus",
         ),
     ),
     CommandSpec(
-        "lab schema promote",
-        "verification lab",
+        "workspace schema promote",
+        "verification",
         "Promote a schema evidence cluster into a registered package version.",
         "devtools.schema_promote",
         use_when="Turn reviewed schema evidence clusters into committed provider schema packages.",
-        examples=("devtools lab schema promote --provider chatgpt --cluster chatgpt-message-v2",),
+        examples=("devtools workspace schema promote --provider chatgpt --cluster chatgpt-message-v2",),
     ),
     CommandSpec(
-        "lab schema audit",
-        "verification lab",
+        "verify schema-audit",
+        "verification",
         "Run committed provider schema package quality checks.",
         "devtools.schema_audit",
         use_when="Check committed schema package quality gates without presenting them as normal archive usage.",
-        examples=("devtools lab schema audit --provider chatgpt --json",),
+        examples=("devtools verify schema-audit --provider chatgpt --json",),
     ),
     CommandSpec(
-        "lab schema parser-diff",
-        "verification lab",
+        "workspace schema parser-diff",
+        "verification",
         "List observed provider wire keys that no parser references.",
         "devtools.schema_parser_diff",
         use_when=(
@@ -1429,14 +1418,14 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
             "is name-based, so read the parser before acting on a row."
         ),
         examples=(
-            "devtools lab schema parser-diff",
-            "devtools lab schema parser-diff --provider codex --min-encountered 1000",
-            "devtools lab schema parser-diff --json",
+            "devtools workspace schema parser-diff",
+            "devtools workspace schema parser-diff --provider codex --min-encountered 1000",
+            "devtools workspace schema parser-diff --json",
         ),
     ),
     CommandSpec(
-        "lab schema roundtrip",
-        "verification lab",
+        "verify schema-roundtrip",
+        "verification",
         "Verify committed provider schema packages reload and roundtrip cleanly.",
         "devtools.verify_schema_roundtrip",
         use_when=(
@@ -1444,19 +1433,19 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
             "and every supported element schema must be reachable from the runtime registry."
         ),
         examples=(
-            "devtools lab schema roundtrip --provider chatgpt",
-            "devtools lab schema roundtrip --all --json",
+            "devtools verify schema-roundtrip --provider chatgpt",
+            "devtools verify schema-roundtrip --all --json",
         ),
     ),
     CommandSpec(
-        "lab probe capture-regression",
-        "verification lab",
+        "bench capture-regression",
+        "verification",
         "Capture pipeline-probe summaries as durable local regression cases.",
         "devtools.regression_capture",
         use_when="Turn a live or probe failure JSON summary into a replayable local regression artifact.",
         examples=(
-            "devtools lab probe capture-regression --input probe.json --name parse-drift",
-            "devtools lab probe pipeline --json | devtools lab probe capture-regression --name parse-drift --tag live",
+            "devtools bench capture-regression --input probe.json --name parse-drift",
+            "devtools bench pipeline --json | devtools bench capture-regression --name parse-drift --tag live",
         ),
     ),
     CommandSpec(
@@ -1577,10 +1566,6 @@ def featured_command_specs(commands: Iterable[CommandSpec] = COMMAND_SPECS) -> t
     return tuple(spec for spec in commands if spec.featured)
 
 
-def verification_lab_command_specs(commands: Iterable[CommandSpec] = COMMAND_SPECS) -> tuple[CommandSpec, ...]:
-    return tuple(spec for spec in commands if spec.category == "verification lab")
-
-
 def grouped_command_specs(commands: Iterable[CommandSpec] = COMMAND_SPECS) -> OrderedDict[str, list[CommandSpec]]:
     grouped: OrderedDict[str, list[CommandSpec]] = OrderedDict((category, []) for category in CATEGORY_ORDER)
     for spec in commands:
@@ -1603,5 +1588,4 @@ __all__ = [
     "control_plane_command",
     "featured_command_specs",
     "grouped_command_specs",
-    "verification_lab_command_specs",
 ]

--- a/devtools/lab_scenario.py
+++ b/devtools/lab_scenario.py
@@ -1,4 +1,4 @@
-"""Verification-lab direct smoke runner."""
+"""Executable repository verification scenarios."""
 
 from __future__ import annotations
 
@@ -90,7 +90,7 @@ _ARCHIVE_SMOKE_CHECKS: tuple[ArchiveSmokeCheck, ...] = (
 
 
 class ArchiveSmokeResult:
-    """Direct result wrapper for the archive-smoke lab smoke."""
+    """Direct result wrapper for the archive-smoke scenario."""
 
     def __init__(
         self,
@@ -197,7 +197,7 @@ class RebuildSafetyResult:
 
 
 def get_archive_smoke_checks() -> tuple[ArchiveSmokeCheck, ...]:
-    """Return direct CLI checks for the archive-smoke lab smoke."""
+    """Return direct CLI checks for the archive-smoke scenario."""
     return _ARCHIVE_SMOKE_CHECKS
 
 
@@ -224,9 +224,6 @@ def _build_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="action", required=True)
     run_parser = subparsers.add_parser("run", help="Run a named smoke set.")
     run_parser.add_argument("scenario", choices=_SCENARIO_NAMES, help="Smoke set to run.")
-    run_parser.add_argument(
-        "--live", action="store_true", help="Run against the active archive instead of a seeded workspace."
-    )
     run_parser.add_argument("--tier", type=int, default=None, help="Only run smoke checks at this tier.")
     run_parser.add_argument("--report-dir", type=Path, default=None, help="Directory for scenario artifacts.")
     run_parser.add_argument("--json", action="store_true", help="Emit a machine-readable scenario payload.")
@@ -343,7 +340,6 @@ def _format_scenario_summary(result: _ScenarioResult) -> str:
 
 def run_archive_smoke(
     *,
-    live: bool,
     tier: int | None,
     report_dir: Path | None,
     verbose: bool,
@@ -362,7 +358,7 @@ def run_archive_smoke(
         fail_fast=fail_fast,
         progress_stream=sys.stderr if as_json else sys.stdout,
     )
-    _write_archive_smoke_report(report_dir, check_results=check_results, live=live, tier=tier)
+    _write_archive_smoke_report(report_dir, check_results=check_results, tier=tier)
     return ArchiveSmokeResult(
         check_results=check_results,
         report_dir=report_dir,
@@ -370,7 +366,7 @@ def run_archive_smoke(
 
 
 def _scenario_payload(result: _ScenarioResult) -> dict[str, object]:
-    """Return the direct lab smoke payload without report wrapping."""
+    """Return the direct archive-smoke payload without report wrapping."""
     stage_statuses = result.stage_statuses()
     failed_stages = result.failed_stages()
     payload: dict[str, object] = {
@@ -446,7 +442,6 @@ def _write_archive_smoke_report(
     report_dir: Path | None,
     *,
     check_results: list[ArchiveSmokeCheckResult],
-    live: bool,
     tier: int | None,
 ) -> None:
     if report_dir is None:
@@ -454,7 +449,6 @@ def _write_archive_smoke_report(
     report_dir.mkdir(parents=True, exist_ok=True)
     payload = {
         "scenario": "archive-smoke",
-        "live": live,
         "tier": tier,
         "checks": [
             {
@@ -486,7 +480,6 @@ def main(argv: list[str] | None = None) -> int:
         result = RebuildSafetyResult(report_dir=args.report_dir)
     else:
         result = run_archive_smoke(
-            live=bool(args.live),
             tier=args.tier,
             report_dir=args.report_dir,
             verbose=bool(args.verbose),
@@ -501,7 +494,7 @@ def main(argv: list[str] | None = None) -> int:
 
 
 def run_main(argv: list[str] | None = None) -> int:
-    """Run a named lab scenario through the advertised ``devtools lab run`` route."""
+    """Run a named scenario through the historical direct route."""
     return main(["run", *(argv or [])])
 
 

--- a/devtools/pre_push_gate.py
+++ b/devtools/pre_push_gate.py
@@ -98,7 +98,7 @@ def run_gate(updates: list[PushUpdate], *, cwd: Path) -> str:
     if is_beads_only(paths):
         print("pre-push: Beads-only diff; checking the structured dependency graph.", file=sys.stderr)
         _run(
-            [sys.executable, "-m", *control_plane_argv("lab policy bead-graph", "--export", ".beads/issues.jsonl")],
+            [sys.executable, "-m", *control_plane_argv("verify bead-graph", "--export", ".beads/issues.jsonl")],
             cwd=cwd,
         )
         return "beads"

--- a/devtools/regression_capture.py
+++ b/devtools/regression_capture.py
@@ -24,14 +24,14 @@ def _read_input(input_path: Path | None) -> str:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Capture a devtools lab probe pipeline JSON summary as a durable regression case.",
+        description="Capture a devtools bench pipeline JSON summary as a durable regression case.",
     )
     parser.add_argument(
         "--input",
         "-i",
         type=Path,
         default=None,
-        help="Lab probe pipeline JSON summary path. Reads stdin when omitted or set to '-'.",
+        help="Pipeline benchmark JSON summary path. Reads stdin when omitted or set to '-'.",
     )
     parser.add_argument("--name", required=True, help="Human-readable regression case name.")
     parser.add_argument(

--- a/devtools/regression_cases.py
+++ b/devtools/regression_cases.py
@@ -82,16 +82,16 @@ class RegressionCase:
         created_at: str | None = None,
         capture_keys: tuple[str, ...] = DEFAULT_CAPTURE_KEYS,
     ) -> RegressionCase:
-        """Create a regression case from a ``devtools lab probe pipeline`` summary."""
+        """Create a regression case from a ``devtools bench pipeline`` summary."""
         if "probe" not in summary or "result" not in summary:
-            raise ValueError("lab probe pipeline regression cases require `probe` and `result` summary keys")
+            raise ValueError("bench pipeline regression cases require `probe` and `result` summary keys")
         selected = _selected_summary(summary, capture_keys)
         provenance = require_json_document(summary.get("provenance", {}), context="probe provenance")
         case_id = f"{_slug(name)}-{_stable_digest(selected)}"
         return cls(
             case_id=case_id,
             name=name,
-            source="lab probe pipeline",
+            source="bench pipeline",
             created_at=created_at or _utc_now(),
             summary=selected,
             provenance=provenance,

--- a/devtools/render_devtools_reference.py
+++ b/devtools/render_devtools_reference.py
@@ -11,7 +11,6 @@ from devtools.command_catalog import (
     control_plane_command,
     featured_command_specs,
     grouped_command_specs,
-    verification_lab_command_specs,
 )
 from devtools.render_support import write_if_changed
 
@@ -19,9 +18,8 @@ MARKER = "devtools-command-catalog"
 
 
 def _render_table(category: str, commands: list[CommandSpec]) -> list[str]:
-    display_category = "Lab Checks" if category == "verification lab" else category.title()
     lines = [
-        f"### {display_category}",
+        f"### {category.title()}",
         "",
         "| Command | Description |",
         "| --- | --- |",
@@ -47,28 +45,9 @@ def _render_featured_commands(commands: tuple[CommandSpec, ...]) -> list[str]:
     return lines
 
 
-def _render_verification_lab_surface(commands: tuple[CommandSpec, ...]) -> list[str]:
-    if not commands:
-        return []
-    lines = [
-        "## Executable Lab Checks",
-        "",
-        "These commands are thin wrappers around concrete schema, provider, pipeline, smoke, and lane checks.",
-        "They are not a proof ledger or end-user archive workflow.",
-        "",
-        "| Command | Role |",
-        "| --- | --- |",
-    ]
-    for spec in commands:
-        lines.append(f"| `{spec.invocation}` | {spec.use_when or spec.description} |")
-    lines.append("")
-    return lines
-
-
 def build_command_catalog() -> str:
     groups = grouped_command_specs()
     featured = featured_command_specs()
-    verification_lab = verification_lab_command_specs()
     lines = [
         "<!-- BEGIN GENERATED: devtools-command-catalog -->",
         "## Command Catalog",
@@ -84,7 +63,6 @@ def build_command_catalog() -> str:
         "```",
         "",
     ]
-    lines.extend(_render_verification_lab_surface(verification_lab))
     if featured:
         lines.extend(_render_featured_commands(featured))
     for category, commands in groups.items():

--- a/devtools/schema_commit.py
+++ b/devtools/schema_commit.py
@@ -1,6 +1,6 @@
 """Commit a real full-corpus schema generation into committed packages.
 
-``devtools lab schema generate`` only ever produces a preview
+``devtools workspace schema generate`` only ever produces a preview
 ``GenerationResult`` -- it never writes to ``polylogue/schemas/providers/``.
 This command is the actual persisting entry point (polylogue-k45pq):
 it calls ``generate_all_schemas`` for real via

--- a/devtools/schema_generate.py
+++ b/devtools/schema_generate.py
@@ -3,7 +3,7 @@
 This command previews a schema generation only -- it never writes to
 ``polylogue/schemas/providers/``. To actually persist a full-corpus
 generation into the committed package files, use
-``devtools lab schema commit`` (``devtools/schema_commit.py``).
+``devtools workspace schema commit`` (``devtools/schema_commit.py``).
 """
 
 from __future__ import annotations

--- a/devtools/schema_inspect.py
+++ b/devtools/schema_inspect.py
@@ -1,4 +1,4 @@
-"""Inspect committed schema packages from the devtools lab surface."""
+"""Inspect committed schema packages from the devtools workspace surface."""
 
 from __future__ import annotations
 

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -2571,7 +2571,7 @@ def _subprocess_env(*, native_testmon_data: Path | None = None) -> dict[str, str
 
 
 def _stop_after_failed_step(label: str) -> bool:
-    return label in {"lab smoke", "bench slo"}
+    return label in {"verify scenario", "bench slo"}
 
 
 def _native_lane_failure_requires_stop(step: Mapping[str, Any]) -> bool:
@@ -2694,14 +2694,14 @@ def build_verify_steps(
                 ("verify layering", _devtools_cmd("verify layering")),
                 ("verify ci-commands", _devtools_cmd("verify ci-commands")),
                 ("verify doc-commands", _devtools_cmd("verify doc-commands")),
-                ("lab schema roundtrip", _devtools_cmd("lab schema roundtrip", "--all")),
+                ("verify schema-roundtrip", _devtools_cmd("verify schema-roundtrip", "--all")),
                 # Static, archive-independent, sub-second: an index bump that
                 # lands without its lifecycle.py delta declaration silently
                 # downgrades every existing generation to a full raw replay
                 # (polylogue-9rw0). Gated here, not behind --lab, because the
                 # failure surfaces as an unqueryable live archive rather than
                 # as a test failure.
-                ("lab policy schema-versioning", _devtools_cmd("lab policy schema-versioning")),
+                ("verify schema-versioning", _devtools_cmd("verify schema-versioning")),
                 # Static, seconds-scale, archive-independent. A test whose
                 # entire target set is production-unreachable stays green
                 # forever regardless of live behaviour, and a test that reads
@@ -2710,7 +2710,7 @@ def build_verify_steps(
                 # gate has to live here rather than in the suite it audits.
                 # Ratcheted against docs/plans/oracle-integrity-baseline.json:
                 # pre-existing findings are exempt, new ones fail.
-                ("lab policy oracle-integrity", _devtools_cmd("lab policy oracle-integrity")),
+                ("verify oracle-integrity", _devtools_cmd("verify oracle-integrity")),
                 # Publication gate. Committed provider schema packages are
                 # public artifacts; this blocks local provenance
                 # (bundle_scopes/representative_paths) and scans for secrets.
@@ -2754,11 +2754,11 @@ def build_verify_steps(
         )
 
     if lab:
-        steps.append(("lab smoke", _devtools_cmd("lab smoke", "run", "archive-smoke", "--tier", "0")))
+        steps.append(("verify scenario", _devtools_cmd("verify scenario", "run", "archive-smoke", "--tier", "0")))
         steps.append(("bench slo", _devtools_cmd("bench slo", "--include-lab")))
-        steps.append(("lab policy timestamp-doctrine", _devtools_cmd("lab policy timestamp-doctrine")))
-        steps.append(("lab policy insight-honesty", _devtools_cmd("lab policy insight-honesty")))
-        steps.append(("lab policy bead-graph", _devtools_cmd("lab policy bead-graph")))
+        steps.append(("verify timestamp-doctrine", _devtools_cmd("verify timestamp-doctrine")))
+        steps.append(("verify insight-honesty", _devtools_cmd("verify insight-honesty")))
+        steps.append(("verify bead-graph", _devtools_cmd("verify bead-graph")))
     return steps
 
 

--- a/devtools/verify_oracle_integrity.py
+++ b/devtools/verify_oracle_integrity.py
@@ -78,7 +78,7 @@ def main(argv: list[str] | None = None) -> int:
                 "adoptable today. Each entry is a WS-F deletion-sweep worklist item, not an "
                 "endorsement. Removing entries is the goal."
             ),
-            "generated_by": "devtools lab policy oracle-integrity --write-baseline",
+            "generated_by": "devtools verify oracle-integrity --write-baseline",
             "entries": entries,
         }
         target = root / BASELINE_PATH

--- a/devtools/visual_vhs.py
+++ b/devtools/visual_vhs.py
@@ -118,7 +118,7 @@ DEFAULT_TAPE_SPECS: tuple[VHSTapeSpec, ...] = (
             # itself -- otherwise Wait+Screen matches the terminal's own
             # echo of the not-yet-executed command instantly.
             "Hide",
-            "Type \"devtools lab smoke run reader-visual-smoke --json --report-dir reader-evidence-tour >/dev/null 2>&1 && printf 'REA''DY\\n'\"",
+            "Type \"devtools verify scenario run reader-visual-smoke --json --report-dir reader-evidence-tour >/dev/null 2>&1 && printf 'REA''DY\\n'\"",
             "Enter",
             "Wait+Screen@150s /READY/",
             'Type "clear"',

--- a/docs/architecture-spine.md
+++ b/docs/architecture-spine.md
@@ -40,6 +40,10 @@ Load-bearing policy files are parsed and enforced by the gate that owns their se
 
 ## Major Decisions
 
+### Command ownership and verification planes (polylogue-60gzo)
+
+`ARCHIVE_VERIFICATION_CHECKS` is the sole authority for permanent archive invariants. Its typed metadata binds each invariant to fixture and red-twin coverage for code correctness and to daemon or promotion execution for production health. A command is not a second predicate authority: `verify` exposes deterministic repository checks, `bench` owns bounded experiments, and `workspace` owns operator workflows. The removed `lab` namespace had mixed those meanings and made archive-poking commands look like correctness gates. Temporary snapshot and drift workflows remain explicitly named workspace routes until their production or fixture replacements are wired.
+
 ### Schema versioning: two regimes keyed by tier durability
 - **Chosen**: per-tier version constants are the authority; mismatch is rejected.
   Two evolution regimes (see `docs/internals.md` § Schema Versioning Model):
@@ -54,7 +58,7 @@ Load-bearing policy files are parsed and enforced by the gate that owns their se
 - **Rejected**: a *single* fresh-first-only policy that forces re-ingest for any
   durable-tier change (loses irreplaceable `user.db` assertions); and full
   Alembic-style forward/reverse upgrade chains for derived tiers (unnecessary —
-  they rebuild). The `devtools lab policy schema-versioning` lint enforces the
+  they rebuild). The `devtools verify schema-versioning` lint enforces the
   boundary through numbered durable migration slots, declared derived lifecycle
   deltas, and clone-safe SQL shapes rather than helper-name pattern matching.
 - **Constraint**: Archive SQLite file set, WAL mode. Durable-tier migration

--- a/docs/code-navigation.md
+++ b/docs/code-navigation.md
@@ -194,7 +194,7 @@ registry or declaration, not the rendered output.
 | --- | --- |
 | Documentation navigation | `devtools render docs-surface --check` |
 | Package/import boundary | `devtools verify layering` |
-| Durable or derived schema | `devtools lab policy schema-versioning` plus the owning migration/rebuild tests |
+| Durable or derived schema | `devtools verify schema-versioning` plus the owning migration/rebuild tests |
 | CLI/API/MCP contract | owning focused tests plus generated reference checks |
 | Archive invariant or maintenance route | red-twin test, real command dispatch, and receipt validation |
 | Parser or identity semantics | provider fixture, eager/streaming/replay equivalence, and content-hash/fingerprint tests |

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -32,7 +32,7 @@ parallel dispatch. Validate branch-local dependency records without importing
 an aging worktree into the shared Beads database:
 
 ```bash
-devtools lab policy bead-graph --export .beads/issues.jsonl --json
+devtools verify bead-graph --export .beads/issues.jsonl --json
 ```
 
 <!-- BEGIN GENERATED: devtools-command-catalog -->
@@ -47,35 +47,6 @@ devtools --list-commands --json
 devtools status
 devtools status --json
 ```
-
-## Executable Lab Checks
-
-These commands are thin wrappers around concrete schema, provider, pipeline, smoke, and lane checks.
-They are not a proof ledger or end-user archive workflow.
-
-| Command | Role |
-| --- | --- |
-| `devtools lab provider completeness` | Inspect detector, parser, fixture, schema, docs, ImportExplain, and caveat coverage before claiming a provider/importer mode is product-ready. |
-| `devtools lab snapshot read-surface` | Freeze archive read-surface behavior before archive work, then compare candidate archives against the captured envelope baseline. |
-| `devtools lab policy schema-versioning` | Enforce the policy boundary documented in docs/internals.md § 'Schema Versioning Model'. Durable tiers use explicit additive migrations with a backup gate; derived tiers are rebuilt or blue-green replaced from source evidence. |
-| `devtools lab policy oracle-integrity` | Before a deletion sweep, and as a standing gate. Catches the two ways a green test can certify nothing: its entire target set is unreachable from any production entrypoint (dead-engine suites), or it reads a real ~/.codex / ~/.claude / /realm path instead of a fixture. Reachability seeds four root classes import edges miss -- Click lazy commands, `python -m` entrypoints, ancestor packages, and literal-container registries -- resolves facade re-exports per symbol, and flags module-level Path.home()/expanduser constants in polylogue/** that capture an ambient location at import time, because import edges alone under-report and this repo has four recorded wrong deletions derived from grep. |
-| `devtools lab policy bead-graph` | Run before shipping a bead-state delta. With no source option it checks live `bd` state; `--export .beads/issues.jsonl` validates the branch snapshot without importing it into the shared database. `--forcing-root` reports a digest-bound transitive blocks closure; `--require-resolved` is for an operation boundary that requires no open blockers. The gate checks existing registry Bead references and never makes prose or campaign mirrors authority. |
-| `devtools lab policy timestamp-doctrine` | Enforce the time doctrine (UTC epoch-ms canon, docs/internals.md) at DDL-review time (cpf.1): a TEXT timestamp in source.db/user.db re-introduces tz-unknown ambiguity and lexicographic-vs-temporal sort divergence, and durable tiers need an explicit additive migration to fix later -- catching it before merge is orders cheaper than a copy-forward migration after. |
-| `devtools lab policy insight-honesty` | Enforce that polylogue.insights.registry.INSIGHT_REGISTRY and polylogue.insights.rigor's contract matrix/exemption list never drift apart (9e5.28) -- a registered product with neither a RigorContract nor a RIGOR_EXEMPT entry used to silently vanish from `polylogue ops insights audit` instead of showing as uncovered. |
-| `devtools lab probe cost-reconciliation` | Validate archive token accounting against optional local Codex state_5.sqlite and Claude stats-cache.json before publishing cost or usage-analysis claims. |
-| `devtools lab probe pipeline` | Run real pipeline stages and optionally capture emitted summaries as regression cases. |
-| `devtools lab run` | Run a scenario such as rebuild-safety through the direct lab command path. |
-| `devtools lab smoke` | Run direct archive and reader smoke sets outside the archive CLI. |
-| `devtools lab schema list` | Inspect committed provider schema package catalogs without presenting them as normal archive usage. |
-| `devtools lab schema compare` | Review schema package drift between committed versions in the lab surface. |
-| `devtools lab schema explain` | Inspect schema package annotations, semantic roles, and review evidence from the lab surface. |
-| `devtools lab schema generate` | Refresh provider schema package artifacts from archive observations outside the archive CLI. |
-| `devtools lab schema commit` | Actually regenerate and write `polylogue/schemas/providers/<provider>/versions/...` from the live archive -- 'lab schema generate' only ever previews and never writes committed package files. |
-| `devtools lab schema promote` | Turn reviewed schema evidence clusters into committed provider schema packages. |
-| `devtools lab schema audit` | Check committed schema package quality gates without presenting them as normal archive usage. |
-| `devtools lab schema parser-diff` | Scope a parser batch by evidence before a rebuild: ranks every schema key nothing reads by how many records actually carry it. Output is a triage queue, not a verdict -- parser-side matching is name-based, so read the parser before acting on a row. |
-| `devtools lab schema roundtrip` | Close the schema inference-validation loop: package manifests must roundtrip through typed models, and every supported element schema must be reachable from the runtime registry. |
-| `devtools lab probe capture-regression` | Turn a live or probe failure JSON summary into a replayable local regression artifact. |
 
 ## Core Loop
 
@@ -125,46 +96,40 @@ These are the commands worth remembering during normal repo work:
 | `devtools release build-package` | Build the default Nix package with the out-link under .local/result. |
 | `devtools release verify-distribution` | Verify wheel/sdist installed artifacts expose only supported runtime entrypoints. |
 
-### Lab Checks
-
-| Command | Description |
-| --- | --- |
-| `devtools lab policy bead-graph` | Validate typed dependency endpoints, closed dependency kinds, parent cardinality, cycles, forcing closures, and registry Bead references. |
-| `devtools lab policy insight-honesty` | Verify every registered insight product is rigor-contracted or exempt. |
-| `devtools lab policy oracle-integrity` | Verify tests certify production-reachable code and never read ambient user paths. |
-| `devtools lab policy schema-versioning` | Verify durable-tier migration and derived-tier rebuild boundaries. |
-| `devtools lab policy timestamp-doctrine` | Verify durable-tier DDL never stores a timestamp column as TEXT. |
-| `devtools lab probe capture-regression` | Capture pipeline-probe summaries as durable local regression cases. |
-| `devtools lab probe cost-reconciliation` | Reconcile Polylogue token accounting against private provider stores. |
-| `devtools lab probe pipeline` | Run typed pipeline probes against synthetic, staged, or archive-subset inputs. |
-| `devtools lab provider completeness` | Report provider/importer package completeness by origin and capture mode. |
-| `devtools lab run` | Run a named archive verification scenario. |
-| `devtools lab schema audit` | Run committed provider schema package quality checks. |
-| `devtools lab schema commit` | Persist a real full-corpus schema generation into committed provider packages. |
-| `devtools lab schema compare` | Compare two committed schema package versions for a provider. |
-| `devtools lab schema explain` | Explain a committed package element schema with evidence and annotations. |
-| `devtools lab schema generate` | Generate provider schema packages and optional evidence clusters. |
-| `devtools lab schema list` | List committed schema packages, versions, and evidence manifests. |
-| `devtools lab schema parser-diff` | List observed provider wire keys that no parser references. |
-| `devtools lab schema promote` | Promote a schema evidence cluster into a registered package version. |
-| `devtools lab schema roundtrip` | Verify committed provider schema packages reload and roundtrip cleanly. |
-| `devtools lab smoke` | Run direct archive and reader smoke sets. |
-| `devtools lab snapshot read-surface` | Capture and compare archive read-surface snapshots. |
-
 ### Verification
 
 | Command | Description |
 | --- | --- |
+| `devtools bench capture-regression` | Capture pipeline-probe summaries as durable local regression cases. |
+| `devtools bench pipeline` | Run typed pipeline probes against synthetic, staged, or archive-subset inputs. |
 | `devtools test` | Run a focused pytest selection through the managed harness. |
 | `devtools verify` | Run the local verification baseline before pushing or creating a PR, including the required committed-schema privacy registry check. |
 | `devtools verify agent-integration` | Verify manual compilation, parser examples, continuation, native delivery, packaging, and live cutover signatures. |
+| `devtools verify bead-graph` | Validate typed dependency endpoints, closed dependency kinds, parent cardinality, cycles, forcing closures, and registry Bead references. |
 | `devtools verify ci-commands` | Validate devtools invocations in structured CI run fields. |
 | `devtools verify corpus-fidelity` | Run the production corpus-fidelity acceptance gate against an archive root. |
 | `devtools verify coverage` | Run pytest with the repository coverage floor from pyproject.toml. |
 | `devtools verify doc-commands` | Validate executable documentation examples against live command inventories. |
+| `devtools verify insight-honesty` | Verify every registered insight product is rigor-contracted or exempt. |
 | `devtools verify layering` | Check inter-package imports against declared layering rules from docs/plans/layering.yaml. |
 | `devtools verify mutation-freshness` | Verify executable mutation campaigns meet the selected freshness and kill-rate thresholds. |
+| `devtools verify oracle-integrity` | Verify tests certify production-reachable code and never read ambient user paths. |
+| `devtools verify provider-completeness` | Report provider/importer package completeness by origin and capture mode. |
+| `devtools verify read-surface` | Capture and compare archive read-surface snapshots. |
+| `devtools verify scenario` | Run a named archive verification scenario. |
+| `devtools verify schema-audit` | Run committed provider schema package quality checks. |
 | `devtools verify schema-inference-gate` | Run the read-only schema-inference prerequisite and persist a PASS/FAIL receipt. |
+| `devtools verify schema-roundtrip` | Verify committed provider schema packages reload and roundtrip cleanly. |
+| `devtools verify schema-versioning` | Verify durable-tier migration and derived-tier rebuild boundaries. |
+| `devtools verify timestamp-doctrine` | Verify durable-tier DDL never stores a timestamp column as TEXT. |
+| `devtools workspace cost-reconciliation` | Reconcile Polylogue token accounting against private provider stores. |
+| `devtools workspace schema commit` | Persist a real full-corpus schema generation into committed provider packages. |
+| `devtools workspace schema compare` | Compare two committed schema package versions for a provider. |
+| `devtools workspace schema explain` | Explain a committed package element schema with evidence and annotations. |
+| `devtools workspace schema generate` | Generate provider schema packages and optional evidence clusters. |
+| `devtools workspace schema list` | List committed schema packages, versions, and evidence manifests. |
+| `devtools workspace schema parser-diff` | List observed provider wire keys that no parser references. |
+| `devtools workspace schema promote` | Promote a schema evidence cluster into a registered package version. |
 
 ### Benchmarking
 
@@ -267,8 +232,8 @@ When changing semantics, validation, or surfaces:
 ```bash
 devtools verify
 devtools test tests/unit/path/to/test_file.py
-devtools lab smoke run archive-smoke --tier 0
-devtools lab smoke run reader-visual-smoke
+devtools verify scenario run archive-smoke --tier 0
+devtools verify scenario run reader-visual-smoke
 devtools bench memory --max-rss-mb 1536 -- polylogue --plain analyze
 ```
 

--- a/docs/examples/visual-tapes/reader-evidence-tour.tape
+++ b/docs/examples/visual-tapes/reader-evidence-tour.tape
@@ -11,7 +11,7 @@ Set Height 680
 Set Padding 20
 
 Hide
-Type "devtools lab smoke run reader-visual-smoke --json --report-dir reader-evidence-tour >/dev/null 2>&1 && printf 'REA''DY\n'"
+Type "devtools verify scenario run reader-visual-smoke --json --report-dir reader-evidence-tour >/dev/null 2>&1 && printf 'REA''DY\n'"
 Enter
 Wait+Screen@150s /READY/
 Type "clear"

--- a/docs/generate.md
+++ b/docs/generate.md
@@ -8,7 +8,7 @@ For users, the supported entrypoint is `polylogue import --demo`: it generates
 the approved deterministic fixture world and schedules it through the same
 daemon-backed import path as ordinary source imports. For tests and repository behavior checks, the same generator is available
 through `polylogue.scenarios`, shared fixtures, `polylogue demo seed`, and the
-thin `devtools lab smoke` wrapper.
+thin `devtools verify scenario` wrapper.
 
 ## Quick Start
 
@@ -38,7 +38,7 @@ polylogue demo verify --root "$POLYLOGUE_ARCHIVE_ROOT" --require-overlays --form
 polylogue demo script --shell bash
 
 # Repository behavior checks
-devtools lab smoke run archive-smoke --tier 0
+devtools verify scenario run archive-smoke --tier 0
 devtools test tests/unit/cli/test_demo_command.py tests/unit/demo/test_demo_seed_verify.py tests/visual
 ```
 

--- a/docs/insights-rigor-matrix.md
+++ b/docs/insights-rigor-matrix.md
@@ -303,7 +303,7 @@ API.
 Every insight product registered in
 `polylogue/insights/registry.py:INSIGHT_REGISTRY` must appear above or in
 `polylogue/insights/rigor.py:RIGOR_EXEMPT` with an inline justification
-(genuinely non-number-bearing products only). `devtools lab policy
+(genuinely non-number-bearing products only). `devtools verify
 insight-honesty` enforces this statically; the audit runner reports an
 uncovered product's `coverage_status` as `"uncovered"` rather than
 silently omitting it (9e5.28).

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -173,7 +173,7 @@ Polylogue has two schema-evolution regimes, keyed by tier durability.
   (e.g. dropping a zero-consumer table, adding an index/table nothing reads
   yet) — not a general escape hatch. `INDEX_SCHEMA_VERSION` stays reserved for
   semantic changes: consumer-visible column/behavior changes or
-  reparse-required content. `devtools lab policy schema-versioning` validates
+  reparse-required content. `devtools verify schema-versioning` validates
   every registry entry against the allowed idempotent-DDL shapes and rejects
   anything else (ALTER/INSERT/UPDATE/DELETE, or a `CREATE`/`DROP` missing its
   `IF NOT EXISTS`/`IF EXISTS` guard). First application: dropped the
@@ -191,7 +191,7 @@ Polylogue has two schema-evolution regimes, keyed by tier durability.
   metadata-only, index-only, additive-derived, additive-durable, or
   semantic-reparse-required. Same-tier schema changes from ready Beads should be
   batched before a live rebuild so the active archive is not reset repeatedly.
-- `devtools lab policy schema-versioning` enforces the boundary: durable SQL
+- `devtools verify schema-versioning` enforces the boundary: durable SQL
   migrations are allowed only under the numbered migration resource roots, while
   derived changes must use declared lifecycle deltas and clone-validated
   fast-forward plans or rebuild. The gate validates those structured carriers
@@ -659,12 +659,12 @@ Polylogue has two schema-evolution regimes, keyed by tier durability.
   rows move out of authored-user accounting while provider-role counts remain
   available.
 - Provider schemas (the parsing/validation surface, distinct from the
-  storage schema) are still regenerated fresh. `devtools lab schema generate`
+  storage schema) are still regenerated fresh. `devtools workspace schema generate`
   only previews a generation (it never writes committed package files);
-  `devtools lab schema commit --full-corpus` is the entry point that actually
+  `devtools workspace schema commit --full-corpus` is the entry point that actually
   persists a full-corpus regeneration into
   `polylogue/schemas/providers/<provider>/versions/...`, and
-  `devtools lab schema promote` promotes a single reviewed evidence cluster
+  `devtools workspace schema promote` promotes a single reviewed evidence cluster
   (from `generate --cluster`) into a registered package version -- a
   narrower, single-version operation `commit` does not replace.
 
@@ -690,7 +690,7 @@ copy-forward design and explicit operator consent, never a routine migration.
 `ALTER TABLE ... ADD COLUMN` bootstrap helpers in
 `storage/sqlite/archive_tiers/bootstrap.py`
 (ingest-cursor runtime fields, cursor-lag rollups). The
-`devtools lab policy schema-versioning` lint enforces the whole boundary:
+`devtools verify schema-versioning` lint enforces the whole boundary:
 numbered durable-tier migrations are allowed; derived-tier lifecycle deltas and
 same-version DDL are validated structurally. Ad hoc open-path upgrades are not a
 supported runtime route, but the lint does not pretend to detect them from

--- a/docs/plans/content-identity-lineage-design.md
+++ b/docs/plans/content-identity-lineage-design.md
@@ -510,7 +510,7 @@ Existing authorization in `polylogue-a7xr.25` covers inclusion of the event tran
 
 ## 12. Luna implementation packets
 
-All lanes work from isolated worktrees. They do not edit Beads. Each lane commits after its focused production-route check passes, then runs `devtools verify --quick` before handoff. The coordinator rebases at the stated points, runs `devtools verify` once for the affected merge state, and runs `devtools verify --all` plus `devtools lab policy schema-versioning` and `devtools render all --check` at the terminal merge-train boundary. Tests below are selectors, not permission to run whole unit directories.
+All lanes work from isolated worktrees. They do not edit Beads. Each lane commits after its focused production-route check passes, then runs `devtools verify --quick` before handoff. The coordinator rebases at the stated points, runs `devtools verify` once for the affected merge state, and runs `devtools verify --all` plus `devtools verify schema-versioning` and `devtools render all --check` at the terminal merge-train boundary. Tests below are selectors, not permission to run whole unit directories.
 
 ### Packet A: OriginSpec, title authority, and hash v2
 
@@ -604,7 +604,7 @@ All lanes work from isolated worktrees. They do not edit Beads. Each lane commit
 
 **Implement:** census first. Stop after the report if any durable archive contains Beads rows or operator consent is absent. After authorization, preserve work evidence, narrow durable checks by copy-forward, delete normalized-session admission, and regenerate public surfaces.
 
-**Verification:** exact pre/post row and raw-byte counts; work-evidence preservation query when rows exist; durable backup restore rehearsal; focused parser deletion fallout, origin-spec conformance, `devtools lab policy schema-versioning`, and render check.
+**Verification:** exact pre/post row and raw-byte counts; work-evidence preservation query when rows exist; durable backup restore rehearsal; focused parser deletion fallout, origin-spec conformance, `devtools verify schema-versioning`, and render check.
 
 **Anti-vacuity:** before removal a representative `interactions.jsonl` routes to the Beads parser; after removal it is rejected as a session source while its intended work-effect path remains queryable. Restoring the pre-migration backup must recover every raw byte.
 

--- a/docs/plans/layering-surface-baseline.json
+++ b/docs/plans/layering-surface-baseline.json
@@ -5,11 +5,6 @@
     "import": "devtools.checkout_guard"
   },
   {
-    "target": "polylogue",
-    "file": "polylogue/scenarios/execution.py",
-    "import": "devtools.command_catalog"
-  },
-  {
     "target": "polylogue/api",
     "file": "polylogue/api/__init__.py",
     "import": "polylogue.storage.embeddings.materialization"

--- a/docs/plans/layering.yaml
+++ b/docs/plans/layering.yaml
@@ -201,9 +201,8 @@ rules:
       the devtools command catalog; that entry and archive_space_report's were
       pruned from the baseline once both modules relocated into
       polylogue/operations/ (WS-C tranche 3). The two remaining importers
-      (click_app.py's checkout_guard safety check, scenarios/execution.py's
-      command_catalog reference, tracked as the tranche-2 60gzo scenario-
-      layering item) are an audited allowlist, not an accepted pattern: new
+      (click_app.py's checkout_guard safety check) is an audited allowlist,
+      not an accepted pattern: new
       ones fail, and the right fix for an entry is to move the code into
       polylogue/ where its caller lives.
     disallow:

--- a/docs/plans/oracle-integrity-baseline.json
+++ b/docs/plans/oracle-integrity-baseline.json
@@ -204,7 +204,7 @@
       "path": "polylogue/schemas/observation_models.py"
     }
   ],
-  "generated_by": "devtools lab policy oracle-integrity --write-baseline",
+  "generated_by": "devtools verify oracle-integrity --write-baseline",
   "purpose": "Pre-existing oracle-integrity findings, exempted as a ratchet so the gate is adoptable today. Each entry is a WS-F deletion-sweep worklist item, not an endorsement. Removing entries is the goal.",
   "schema_version": 1
 }

--- a/docs/provider-completeness.md
+++ b/docs/provider-completeness.md
@@ -4,14 +4,14 @@ Polylogue import support is larger than a parser function. A provider/capture
 mode is product-ready only when the detector, parser, fixtures, schema/docs,
 query/read coverage, ImportExplain, and caveat surfaces are all visible.
 
-`devtools lab provider completeness` renders that readiness map from the current
+`devtools verify provider-completeness` renders that readiness map from the current
 tree:
 
 ```bash
-devtools lab provider completeness
-devtools lab provider completeness --json
-devtools lab provider completeness --origin codex-session --json
-devtools lab provider completeness --check
+devtools verify provider-completeness
+devtools verify provider-completeness --json
+devtools verify provider-completeness --origin codex-session --json
+devtools verify provider-completeness --check
 ```
 
 Rows are keyed by public `origin` plus `capture_mode`. `provider_wire` is
@@ -68,8 +68,8 @@ When adding a provider/importer:
 6. Run:
 
 ```bash
-devtools lab provider completeness --json
-devtools lab provider completeness --check
+devtools verify provider-completeness --json
+devtools verify provider-completeness --check
 devtools render all --check
 ```
 

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -88,7 +88,7 @@ pipeline.
 3. **Register the detector** in `polylogue/sources/dispatch.py` at the
    appropriate priority level
 4. **Add a provider schema bundle** under `polylogue/schemas/providers/`
-   (run `devtools lab schema generate` to preview, `devtools lab schema commit`
+   (run `devtools workspace schema generate` to preview, `devtools workspace schema commit`
    to actually write the committed package files)
 5. **Update schema inference** if the new provider introduces novel content
    block types or message structures

--- a/docs/schema-annotations.md
+++ b/docs/schema-annotations.md
@@ -7,12 +7,12 @@ role of each JSON path (e.g., `message_role`, `session_title`,
 
 ## Review process
 
-1. Run schema inference: `devtools lab schema generate <provider>`
+1. Run schema inference: `devtools workspace schema generate <provider>`
 2. Review generated annotations for correctness
 3. Create or update `pins.json` in the provider directory to reject
    known-wrong annotations (see `claude-code/pins.json` for format)
 4. Re-run inference — `select_best_roles()` will respect pin overrides
-5. Promote reviewed annotations: `devtools lab schema promote <provider>`
+5. Promote reviewed annotations: `devtools workspace schema promote <provider>`
 6. Verify: `python devtools/verify_schema_annotations.py`
 
 ## Verification

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -307,7 +307,7 @@ polylogue ops doctor                     # schema health + referential integrity
 polylogue ops doctor --schemas           # provider-schema conformance over raw records
 ```
 
-The `devtools lab schema roundtrip` command verifies committed provider
+The `devtools verify schema-roundtrip` command verifies committed provider
 schema packages reload and roundtrip cleanly through typed models.
 
 ---

--- a/docs/visual-evidence.md
+++ b/docs/visual-evidence.md
@@ -23,7 +23,7 @@ verification authority.
 Representative media has to be evidence, not decoration. Public evidence must
 point to commands that run against synthetic fixtures or an explicitly local
 operator profile and produce a named artifact: the DOM smoke lane below,
-`devtools lab smoke run reader-visual-smoke`,
+`devtools verify scenario run reader-visual-smoke`,
 `devtools workspace dev-loop --tui-plan`,
 `devtools workspace dev-loop --browser-provider-smoke`, or
 `devtools workspace deployment-smoke --browser`. Screenshots, screencasts, and
@@ -69,7 +69,7 @@ From the devshell:
 ```bash
 uv run devtools test tests/unit/daemon/test_web_reader.py
 uv run devtools test tests/visual
-uv run devtools lab smoke run reader-visual-smoke --json --report-dir .local/visual/reader-smoke
+uv run devtools verify scenario run reader-visual-smoke --json --report-dir .local/visual/reader-smoke
 ```
 
 The first command owns the fast endpoint and envelope contracts. The second
@@ -87,7 +87,7 @@ id, fixture id, route, and structural checks asserted by that test.
 Both suites are part of the standard correctness corpus. There is no
 browser binary or Playwright dependency in these fast lanes: they use Python's
 standard `http.server`, `urllib.request`, and `html.parser` against the real
-`DaemonAPIHTTPServer`. The `devtools lab smoke` command is the
+`DaemonAPIHTTPServer`. The `devtools verify scenario` command is the
 operator-facing wrapper for the visual/DOM lane.
 
 ## Artifact inventory

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -1845,7 +1845,7 @@ def _render_schema_drift_status(env: AppEnv, drift: dict[str, Any]) -> None:
             f"    [{color}]origin {origin}: {risky_rate:.0%} of {total} records since {since_date} "
             f"carry unseen shapes[/{color}]{example_text}"
         )
-    env.ui.console.print("    next action: devtools lab schema generate/promote (detection only)")
+    env.ui.console.print("    next action: devtools workspace schema generate/promote (detection only)")
 
 
 def _render_raw_replay_backlog(env: AppEnv, backlog: dict[str, Any]) -> None:

--- a/polylogue/daemon/health.py
+++ b/polylogue/daemon/health.py
@@ -973,7 +973,7 @@ def _check_schema_drift_medium() -> HealthAlert:
     benign/risky-rate thresholds
     (:mod:`polylogue.cli.commands.status`), so the daemon health surface
     and the CLI status line never disagree about severity. Follow-up
-    action always points at ``devtools lab schema generate/promote`` --
+    action always points at ``devtools workspace schema generate/promote`` --
     this check only detects drift, it never repairs a schema package.
     """
     now = datetime.now(UTC).isoformat()
@@ -1005,10 +1005,10 @@ def _check_schema_drift_medium() -> HealthAlert:
                 worst_detail = f"{origin}: {rate:.0%} of {total} records carry unseen shapes"
         if worst == "error":
             severity = HealthSeverity.ERROR
-            message = f"format drift: {worst_detail} — devtools lab schema generate/promote"
+            message = f"format drift: {worst_detail}: devtools workspace schema generate/promote"
         elif worst == "warning":
             severity = HealthSeverity.WARNING
-            message = f"format drift: {worst_detail} — devtools lab schema generate/promote"
+            message = f"format drift: {worst_detail}: devtools workspace schema generate/promote"
         else:
             severity = HealthSeverity.OK
             message = "no risky format drift"

--- a/polylogue/insights/rigor.py
+++ b/polylogue/insights/rigor.py
@@ -894,7 +894,7 @@ _RIGOR_MATRIX: tuple[RigorContract, ...] = (
 #: because they carry no number-bearing/quantitative fields at all (37t.15
 #: sibling, 9e5.28). Every entry needs an inline justification string; a
 #: number-bearing product belongs in ``_RIGOR_MATRIX`` above, not here --
-#: ``devtools lab policy insight-honesty`` fails on any registered insight
+#: ``devtools verify insight-honesty`` fails on any registered insight
 #: that is in neither set.
 RIGOR_EXEMPT: dict[str, str] = {}
 

--- a/polylogue/scenarios/execution.py
+++ b/polylogue/scenarios/execution.py
@@ -19,6 +19,12 @@ from .corpus import CorpusRequest, CorpusSourceKind
 from .metadata import ScenarioMetadata
 
 
+def _devtools_argv(subcommand: str, *argv: str) -> tuple[str, ...]:
+    """Render a control-plane invocation without importing devtools policy."""
+
+    return ("devtools", *subcommand.split(), *argv)
+
+
 class ExecutionKind(str, Enum):
     """Authored execution substrate for scenario-bearing catalogs."""
 
@@ -282,31 +288,23 @@ class ExecutionSpec:
         if self.kind is ExecutionKind.PIPELINE_PROBE:
             if self.pipeline_probe is None:
                 return None
-            from devtools.command_catalog import control_plane_argv
-
-            return tuple(control_plane_argv("lab probe pipeline", *self.pipeline_probe.to_argv()))
+            return _devtools_argv("bench pipeline", *self.pipeline_probe.to_argv())
         if self.kind is ExecutionKind.POLYLOGUE:
             return ("polylogue", "--plain", *self.argv)
         if self.kind is ExecutionKind.DEVTOOLS:
-            from devtools.command_catalog import control_plane_argv
-
-            return tuple(control_plane_argv(self.subcommand, *self.argv))
+            return _devtools_argv(self.subcommand, *self.argv)
         if self.kind is ExecutionKind.MEMORY_BUDGET:
             if self.wrapped is None or self.max_rss_mb <= 0:
                 return None
             wrapped_command = self.wrapped.command
             if wrapped_command is None:
                 return None
-            from devtools.command_catalog import control_plane_argv
-
-            return tuple(
-                control_plane_argv(
-                    "bench memory",
-                    "--max-rss-mb",
-                    str(self.max_rss_mb),
-                    "--",
-                    *wrapped_command,
-                )
+            return _devtools_argv(
+                "bench memory",
+                "--max-rss-mb",
+                str(self.max_rss_mb),
+                "--",
+                *wrapped_command,
             )
         if self.kind is ExecutionKind.PYTEST:
             return ("pytest", *self.argv)
@@ -323,11 +321,7 @@ class ExecutionSpec:
             wrapped_display = self.wrapped.display_command or self.wrapped.command
             if wrapped_display is None:
                 return command
-            from devtools.command_catalog import control_plane_argv
-
-            return tuple(
-                control_plane_argv("bench memory", "--max-rss-mb", str(self.max_rss_mb), "--", *wrapped_display)
-            )
+            return _devtools_argv("bench memory", "--max-rss-mb", str(self.max_rss_mb), "--", *wrapped_display)
         return command
 
     @property

--- a/polylogue/schemas/operator/commit.py
+++ b/polylogue/schemas/operator/commit.py
@@ -1,6 +1,6 @@
 """Commit a real full-corpus schema generation into registered packages.
 
-``generate_provider_schema``/``infer_schema`` (what ``devtools lab schema
+``generate_provider_schema``/``infer_schema`` (what ``devtools workspace schema
 generate`` calls) only ever return a ``GenerationResult`` -- they never call
 ``persist_generated_provider_bundle``, the function that actually writes
 ``polylogue/schemas/providers/<provider>/versions/...`` via

--- a/polylogue/schemas/operator/models.py
+++ b/polylogue/schemas/operator/models.py
@@ -356,7 +356,7 @@ class SchemaCommitRequest:
     ``privacy_config`` takes the same ``JSONDocument | None`` payload shape as
     ``SchemaInferRequest.privacy_config`` (converted internally via
     ``privacy_config_from_payload``), so CLI callers can build it the same way
-    ``devtools lab schema generate`` already does.
+    ``devtools workspace schema generate`` already does.
     """
 
     provider: str

--- a/polylogue/storage/sqlite/archive_tiers/index.py
+++ b/polylogue/storage/sqlite/archive_tiers/index.py
@@ -51,7 +51,7 @@ from polylogue.storage.sqlite.delegation_facts import delegation_facts_insert_sq
 # routes to `polylogue ops reset --index && polylogued run`.
 #
 # A bump without a declaration is a policy violation, not a free rebuild:
-# `devtools lab policy schema-versioning` fails, and the archive silently
+# `devtools verify schema-versioning` fails, and the archive silently
 # falls back to full raw replay. See polylogue-9rw0 / polylogue-b5l.
 #
 # polylogue-o4j2: v47 adds sessions.pending_drafts_json -- aistudio-drive's

--- a/polylogue/storage/sqlite/archive_tiers/index_convergence.py
+++ b/polylogue/storage/sqlite/archive_tiers/index_convergence.py
@@ -12,7 +12,7 @@ The ops tier already proved this pattern (``bootstrap.py``'s
 same-version open, zero bumps ever). This module extends the regime to the
 index tier with a narrow, explicitly registered statement list rather than a
 blanket DDL re-exec, so each entry can be policy-checked
-(``devtools lab policy schema-versioning``) for the three properties that make
+(``devtools verify schema-versioning``) for the three properties that make
 it safe to apply on every open of an already-populated, same-version archive:
 
 - **Idempotent**: ``CREATE TABLE IF NOT EXISTS`` / ``CREATE INDEX IF NOT
@@ -56,7 +56,7 @@ import aiosqlite
 class BenignDDLEntry:
     """One registered idempotent, data-non-transforming DDL statement.
 
-    ``devtools lab policy schema-versioning`` validates every registry entry's
+    ``devtools verify schema-versioning`` validates every registry entry's
     ``sql`` against the allowed idempotent-DDL shapes; see
     ``devtools/verify_schema_upgrade_lane.py``.
     """

--- a/tests/integration/test_schema_operator_workflow.py
+++ b/tests/integration/test_schema_operator_workflow.py
@@ -557,7 +557,7 @@ class TestSchemaExplainCommand:
 
 
 # =============================================================================
-# devtools lab schema promote (end-to-end with clustering)
+# devtools workspace schema promote (end-to-end with clustering)
 # =============================================================================
 
 

--- a/tests/unit/cli/test_schema_drift_status.py
+++ b/tests/unit/cli/test_schema_drift_status.py
@@ -113,7 +113,7 @@ def test_render_schema_drift_status_prints_percent_and_examples() -> None:
     assert "20 records" in output
     assert "carry unseen shapes" in output
     assert "raw-a" in output
-    assert "devtools lab schema generate/promote" in output
+    assert "devtools workspace schema generate/promote" in output
 
 
 def test_render_schema_drift_status_stays_quiet_when_all_origins_ok() -> None:

--- a/tests/unit/daemon/test_schema_drift_health_check.py
+++ b/tests/unit/daemon/test_schema_drift_health_check.py
@@ -77,7 +77,7 @@ def test_schema_drift_warning_when_one_origin_crosses_warn_threshold(
     alert = _check_schema_drift_medium()
     assert alert.severity == HealthSeverity.WARNING
     assert "claude-code-session" in alert.message
-    assert "devtools lab schema generate/promote" in alert.message
+    assert "devtools workspace schema generate/promote" in alert.message
     assert alert.consecutive_failures == 1
 
 

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -8,7 +8,7 @@ any regression in the daemon's contract surface fails here loudly.
 
 This is the documented reader visual smoke lane (see
 ``docs/visual-evidence.md``). The lane runs as part of the standard
-unit suite and ``devtools verify``; a separate ``devtools lab smoke``
+unit suite and ``devtools verify``; a separate ``devtools verify scenario``
 entrypoint can be added later if Playwright-based screenshot evidence
 is bolted on.
 

--- a/tests/unit/devtools/test_command_catalog.py
+++ b/tests/unit/devtools/test_command_catalog.py
@@ -9,7 +9,6 @@ from devtools.command_catalog import (
     control_plane_command,
     featured_command_specs,
     grouped_command_specs,
-    verification_lab_command_specs,
 )
 
 
@@ -18,10 +17,10 @@ def test_control_plane_helpers_render_consistent_invocations() -> None:
     assert control_plane_argv("status", "--json") == ("devtools", "status", "--json")
     assert control_plane_command("render all", "--check") == "devtools render all --check"
     assert control_plane_argv("render all", "--check") == ("devtools", "render", "all", "--check")
-    assert control_plane_command("lab schema roundtrip", "--all") == "devtools lab schema roundtrip --all"
-    assert control_plane_argv("lab schema roundtrip", "--all") == ("devtools", "lab", "schema", "roundtrip", "--all")
+    assert control_plane_command("verify schema-roundtrip", "--all") == "devtools verify schema-roundtrip --all"
+    assert control_plane_argv("verify schema-roundtrip", "--all") == ("devtools", "verify", "schema-roundtrip", "--all")
     assert command_name_from_tokens(["render", "all", "--check"]) == "render all"
-    assert command_name_from_tokens(["lab", "schema", "roundtrip", "--all"]) == "lab schema roundtrip"
+    assert command_name_from_tokens(["verify", "schema-roundtrip", "--all"]) == "verify schema-roundtrip"
 
 
 def test_command_specs_have_unique_names_and_known_categories() -> None:
@@ -46,21 +45,12 @@ def test_featured_command_specs_are_actionable() -> None:
         assert spec.to_dict()["argv"] == list(spec.argv)
 
 
-def test_verification_lab_surface_is_explicit_and_implemented() -> None:
-    specs = verification_lab_command_specs()
-
-    assert specs == tuple(spec for spec in COMMAND_SPECS if spec.category == "verification lab")
-    assert {spec.category for spec in specs} == {"verification lab"}
-    assert len({(spec.module, spec.entrypoint) for spec in specs}) == len(specs)
-
-    for spec in specs:
-        assert spec.module.startswith("devtools.")
-        assert spec.use_when
-        assert spec.examples
-        assert callable(spec.resolve_main())
+def test_catalog_uses_command_ownership_categories() -> None:
+    assert "verification lab" not in {spec.category for spec in COMMAND_SPECS}
+    assert {"verify schema-roundtrip", "bench pipeline", "workspace schema commit"} <= set(COMMANDS)
 
 
 def test_bead_graph_catalog_exposes_json_report() -> None:
-    graph = COMMANDS["lab policy bead-graph"]
+    graph = COMMANDS["verify bead-graph"]
 
     assert any("--json" in example for example in graph.examples)

--- a/tests/unit/devtools/test_devtools_main.py
+++ b/tests/unit/devtools/test_devtools_main.py
@@ -6,21 +6,19 @@ from types import ModuleType
 import pytest
 
 import devtools.__main__ as devtools_main
-from devtools.command_catalog import COMMAND_SPECS, COMMANDS, CommandSpec, verification_lab_command_specs
+from devtools.command_catalog import COMMAND_SPECS, COMMANDS, CommandSpec
 
 
 def test_list_commands_json_includes_generated_surface(capsys: pytest.CaptureFixture[str]) -> None:
     assert devtools_main.main(["--list-commands", "--json"]) == 0
     payload = json.loads(capsys.readouterr().out)
     commands = {entry["name"] for entry in payload["commands"]}
-    assert payload["surfaces"]["verification_lab"] == [spec.name for spec in verification_lab_command_specs()]
     assert commands == {spec.name for spec in COMMAND_SPECS}
 
 
 def test_list_commands_human_output(capsys: pytest.CaptureFixture[str]) -> None:
     assert devtools_main.main(["--list-commands"]) == 0
     captured = capsys.readouterr()
-    assert "lab check surface:" in captured.out
     assert "generated surfaces:" in captured.out
     for spec in COMMAND_SPECS:
         assert spec.name in captured.out

--- a/tests/unit/devtools/test_execution_specs.py
+++ b/tests/unit/devtools/test_execution_specs.py
@@ -50,8 +50,7 @@ def test_pipeline_probe_execution_renders_control_plane_command() -> None:
     assert execution.kind is ExecutionKind.PIPELINE_PROBE
     assert execution.command == (
         "devtools",
-        "lab",
-        "probe",
+        "bench",
         "pipeline",
         "--provider",
         "chatgpt",
@@ -96,7 +95,7 @@ def test_memory_budget_execution_wraps_structured_execution() -> None:
 
 
 def test_execution_spec_round_trips_payload() -> None:
-    execution = devtools_execution("lab smoke", "run", "archive-smoke", "--tier", "0")
+    execution = devtools_execution("verify scenario", "run", "archive-smoke", "--tier", "0")
 
     restored = type(execution).from_payload(execution.to_payload())
 

--- a/tests/unit/devtools/test_lab_scenario.py
+++ b/tests/unit/devtools/test_lab_scenario.py
@@ -1,4 +1,4 @@
-"""Tests for the executable lab smoke command surface."""
+"""Tests for executable verification scenarios."""
 
 from __future__ import annotations
 
@@ -79,6 +79,15 @@ def test_main_prints_direct_stage_summary(capsys: pytest.CaptureFixture[str]) ->
     assert "Smoke stages:" in out
     assert "cli: ok" in out
     assert "Failed stages: none" in out
+
+
+def test_main_rejects_removed_live_archive_flag() -> None:
+    from devtools.lab_scenario import main
+
+    with pytest.raises(SystemExit) as raised:
+        main(["run", "archive-smoke", "--live"])
+
+    assert raised.value.code == 2
 
 
 def test_main_json_reports_direct_scenario_payload(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/unit/devtools/test_pipeline_probe.py
+++ b/tests/unit/devtools/test_pipeline_probe.py
@@ -241,7 +241,7 @@ def _seed_archive_source_payload(provider: str, seed: int) -> bytes:
             messages_max=3,
             seed=seed,
             origin="generated.test-pipeline-probe",
-            tags=("synthetic", "test", "lab probe pipeline"),
+            tags=("synthetic", "test", "bench pipeline"),
         )
     )[0]
 
@@ -732,7 +732,7 @@ async def test_run_probe_can_sample_archive_file_set_subset(tmp_path: Path) -> N
                 messages_max=3,
                 seed=301,
                 origin="generated.test-pipeline-probe-archive",
-                tags=("synthetic", "test", "lab probe pipeline"),
+                tags=("synthetic", "test", "bench pipeline"),
             )
         )[0]
     )

--- a/tests/unit/devtools/test_pre_push_hook.py
+++ b/tests/unit/devtools/test_pre_push_hook.py
@@ -117,7 +117,7 @@ def test_beads_only_gate_uses_structural_bead_graph_command(git_repo: Path, monk
     assert pre_push_gate.run_gate([update], cwd=git_repo) == "beads"
     assert len(commands) == 1
     assert commands[0][:3] == [sys.executable, "-m", "devtools"]
-    assert command_name_from_tokens(commands[0][3:]) == "lab policy bead-graph"
+    assert command_name_from_tokens(commands[0][3:]) == "verify bead-graph"
     assert commands[0][-2:] == ["--export", ".beads/issues.jsonl"]
 
 

--- a/tests/unit/devtools/test_regression_capture.py
+++ b/tests/unit/devtools/test_regression_capture.py
@@ -50,7 +50,7 @@ def test_regression_capture_writes_probe_case(tmp_path: Path, capsys: pytest.Cap
     case = RegressionCase.read(output_path)
     assert output_path.parent == output_dir
     assert case.name == "Parse Drift"
-    assert case.source == "lab probe pipeline"
+    assert case.source == "bench pipeline"
     assert case.tags == ("live",)
     assert case.notes == ("captured from probe",)
     assert case.summary["result"] == {"ok": False, "error": "parse drift"}
@@ -77,6 +77,6 @@ def test_regression_capture_json_output_includes_path(tmp_path: Path, capsys: py
     )
 
     payload = json.loads(capsys.readouterr().out)
-    assert payload["source"] == "lab probe pipeline"
+    assert payload["source"] == "bench pipeline"
     assert Path(payload["path"]).exists()
     assert payload["summary"]["db_stats"] == {"sessions": 0, "raw_sessions": 1}

--- a/tests/unit/devtools/test_render_devtools_reference.py
+++ b/tests/unit/devtools/test_render_devtools_reference.py
@@ -8,7 +8,6 @@ from devtools.command_catalog import (
     control_plane_command,
     featured_command_specs,
     grouped_command_specs,
-    verification_lab_command_specs,
 )
 from devtools.render_support import write_if_changed
 
@@ -26,8 +25,6 @@ def test_build_command_catalog_includes_discovery_and_commands() -> None:
         control_plane_command("status", "--json"),
     ):
         assert command in rendered
-    for spec in verification_lab_command_specs():
-        assert f"| `{spec.invocation}` | {spec.use_when or spec.description} |" in rendered
     for spec in featured_command_specs():
         assert f"- `{spec.invocation}`: {spec.use_when or spec.description}" in rendered
     for specs in grouped_command_specs().values():

--- a/tests/unit/devtools/test_schema_commit_command.py
+++ b/tests/unit/devtools/test_schema_commit_command.py
@@ -1,4 +1,4 @@
-"""``devtools lab schema commit`` -- the real, persisting schema-commit CLI.
+"""``devtools workspace schema commit`` is the real, persisting schema-commit CLI.
 
 Unit-level plumbing tests: the request built from CLI args, and rendering of
 the ``SchemaCommitResult``. The commit path's actual file-writing behavior is

--- a/tests/unit/devtools/test_visual_vhs.py
+++ b/tests/unit/devtools/test_visual_vhs.py
@@ -214,7 +214,7 @@ class TestDefaultTapeContent:
 
         tape = generate_tape(spec)
 
-        assert "devtools lab smoke run reader-visual-smoke" in tape
+        assert "devtools verify scenario run reader-visual-smoke" in tape
         assert "reader-visual-smoke.json" in tape
 
     def test_browser_capture_tour_uses_deterministic_live_follow(self) -> None:

--- a/tests/unit/scenarios/test_runtime.py
+++ b/tests/unit/scenarios/test_runtime.py
@@ -83,15 +83,14 @@ def test_run_execution_dispatches_devtools_through_the_checkout_module(monkeypat
 
     monkeypatch.setattr("polylogue.scenarios.runtime.subprocess.run", fake_run)
 
-    result = run_execution(devtools_execution("lab smoke", "run", "storage-correctness", "--json"), capture_output=True)
+    result = run_execution(devtools_execution("verify scenario", "storage-correctness", "--json"), capture_output=True)
 
     assert captured_command == [
         sys.executable,
         "-m",
         "devtools",
-        "lab",
-        "smoke",
-        "run",
+        "verify",
+        "scenario",
         "storage-correctness",
         "--json",
     ]

--- a/tests/unit/schemas/test_operator_commit.py
+++ b/tests/unit/schemas/test_operator_commit.py
@@ -1,6 +1,6 @@
 """``commit_provider_schema`` -- the real, persisting full-corpus commit path.
 
-``devtools lab schema generate`` (``generate_provider_schema``/``infer_schema``)
+``devtools workspace schema generate`` (``generate_provider_schema``/``infer_schema``)
 never writes to ``polylogue/schemas/providers/`` -- only
 ``generate_all_schemas`` does, and it had zero CLI wiring before
 ``polylogue.schemas.operator.commit`` (polylogue-k45pq). These tests prove the

--- a/tests/unit/sources/test_parsers_codex.py
+++ b/tests/unit/sources/test_parsers_codex.py
@@ -1839,7 +1839,7 @@ class TestEdgeCases:
 
 
 class TestUnreadFieldTriage:
-    """Fields identified by `devtools lab schema parser-diff --provider codex`
+    """Fields identified by `devtools workspace schema parser-diff --provider codex`
     that were previously parsed by name but silently dropped in value."""
 
     def test_turn_context_captures_truncation_policy_and_output_schema(self) -> None:


### PR DESCRIPTION
## Summary

Removes the separate devtools lab command group and stale catalog/docs references while retaining archive-smoke behavior through the normal command surface.

## Problem

The devtools command surface accumulated a parallel lab namespace and compatibility references that made the tool harder to discover and maintain.

## Solution

Removes the lab dispatch group and updates command ownership, references, scenarios, and tests to use the retained surfaces.

## Verification

The operator explicitly waived the normal verification gate and CI wait for this consolidation pass.