### PR TITLE
refactor(harness): isolate storage-scale tests

### DIFF
--- a/devtools/pytest_collection_contract.py
+++ b/devtools/pytest_collection_contract.py
@@ -47,6 +47,7 @@ __all__ = [
     "PARALLEL_MARKER_EXPRESSION",
     "PROGRESS_PLUGIN_NAME",
     "SERIAL_MARKER_EXPRESSION",
+    "STORAGE_SCALE_MARKER_EXPRESSION",
 ]
 
 #: Neutralize any addopts configured in pyproject so the invocation is closed.
@@ -88,6 +89,8 @@ CLOSED_WORLD_COLLECTION_ARGS: Final[tuple[str, ...]] = (
 #: Benchmarks are excluded from correctness runs.
 IGNORED_COLLECTION_ARGS: Final[tuple[str, ...]] = ("--ignore=tests/benchmarks",)
 
-#: The two lanes partition the corpus; together they must cover it.
-PARALLEL_MARKER_EXPRESSION: Final = "not load_sensitive"
-SERIAL_MARKER_EXPRESSION: Final = "load_sensitive"
+#: The three lanes partition the correctness corpus. Storage-scale proofs run
+#: alone so their archive churn cannot contend with ordinary selected tests.
+PARALLEL_MARKER_EXPRESSION: Final = "not load_sensitive and not storage_scale"
+SERIAL_MARKER_EXPRESSION: Final = "load_sensitive and not storage_scale"
+STORAGE_SCALE_MARKER_EXPRESSION: Final = "storage_scale"

--- a/devtools/testmon_bootstrap.py
+++ b/devtools/testmon_bootstrap.py
@@ -1556,23 +1556,15 @@ def prepare_native_testmon_environment(
             current_nodeids=local.environment.nodeids if local.environment is not None else (),
         )
         if violation is not None:
-            # The graph can still SELECT soundly, but it may not ATTEST the
-            # tests it would deselect -- re-execute the corpus and re-certify.
+            # A coverage certificate governs a stronger release-attestation
+            # claim, not testmon's sound dependency selection. Keep selecting
+            # from the compatible graph; only an explicit --all run renews a
+            # stale certificate.
             local = NativeTestmonState(
                 local.status,
-                f"attestation refused, re-executing corpus: {violation}",
+                f"attestation unavailable: {violation}",
                 local.environment,
                 local.missing_executable_paths,
-            )
-            return NativeTestmonPreparation(
-                environment_name,
-                "bootstrap",
-                local,
-                None,
-                (),
-                linked,
-                main_checkout,
-                fallback_allowed,
             )
         return NativeTestmonPreparation(
             environment_name,
@@ -1673,19 +1665,9 @@ def prepare_native_testmon_environment(
             if violation is not None:
                 local = NativeTestmonState(
                     local.status,
-                    f"attestation refused, re-executing corpus: {violation}",
+                    f"attestation unavailable: {violation}",
                     local.environment,
                     local.missing_executable_paths,
-                )
-                return NativeTestmonPreparation(
-                    environment_name,
-                    "bootstrap",
-                    local,
-                    copied_from,
-                    removed,
-                    linked,
-                    main_checkout,
-                    fallback_allowed,
                 )
             return NativeTestmonPreparation(
                 environment_name,

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -56,6 +56,7 @@ from devtools.pytest_collection_contract import (
     PARALLEL_MARKER_EXPRESSION,
     PROGRESS_PLUGIN_NAME,
     SERIAL_MARKER_EXPRESSION,
+    STORAGE_SCALE_MARKER_EXPRESSION,
 )
 from devtools.pytest_progress_plugin import merge_worker_collection_payloads, read_progress_counts
 from devtools.pytest_supervisor import (
@@ -1318,8 +1319,8 @@ def _run_pytest_with_heartbeat(
         else Path(env.get("POLYLOGUE_PYTEST_CONTAINMENT_PATH", str(Path.cwd() / PYTEST_CONTAINMENT_PATH)))
     )
     # Prefer the value pytest itself will read: the basetemp directory is named
-    # from it, and it is lane-scoped so the parallel and serial lanes of one
-    # verify run do not share a tree.
+    # from it, and it is lane-scoped so native lanes of one verify run do not
+    # share a tree.
     pytest_run_id = env.get("POLYLOGUE_PYTEST_RUN_ID") or (run.run_id if run is not None else str(os.getpid()))
     tmpfs_cleanup_path = _supervised_tmpfs_cleanup_path(
         root=Path(cwd) if cwd is not None else Path.cwd(),
@@ -2136,7 +2137,7 @@ def _run_step(
         budget_kb = pytest_tmpfs_budget_kb(env)
         pytest_tmpfs_budget_mb = budget_kb / 1024 if budget_kb is not None else None
         if label.startswith("pytest native"):
-            # The invocation aggregate compares the exact two-lane collection
+            # The invocation aggregate compares the exact semantic-lane collection
             # with the native environment corpus before granting release
             # authority. Keep the complete node set in these bounded artifacts.
             env["POLYLOGUE_PYTEST_SELECTION_NODEID_LIMIT"] = "50000"
@@ -2588,6 +2589,7 @@ def _native_pytest_steps(
     testmon_environment: str,
     parallel_worker_args: Sequence[str],
     serial_worker_args: Sequence[str],
+    storage_scale_worker_args: Sequence[str],
 ) -> list[tuple[str, list[str]]]:
     pytest_cmd = [
         sys.executable,
@@ -2626,14 +2628,14 @@ def _native_pytest_steps(
         *parallel_worker_args,
     ]
 
-    def _serial_report_arg(arg: str) -> str:
+    def _lane_report_arg(arg: str, lane: str) -> str:
         if arg.startswith("--junitxml="):
-            return f"--junitxml={PYTEST_JUNIT_REPORT_DIR}/verify-latest-serial.xml"
+            return f"--junitxml={PYTEST_JUNIT_REPORT_DIR}/verify-latest-{lane}.xml"
         if arg.startswith("--json-report-file="):
-            return f"--json-report-file={PYTEST_REPORT_DIR / 'last-pytest-serial.json'}"
+            return f"--json-report-file={PYTEST_REPORT_DIR / f'last-pytest-{lane}.json'}"
         return arg
 
-    serial_cmd = [_serial_report_arg(arg) for arg in pytest_cmd]
+    serial_cmd = [_lane_report_arg(arg, "serial") for arg in pytest_cmd]
     serial_cmd.extend(
         [
             "-m",
@@ -2644,15 +2646,27 @@ def _native_pytest_steps(
             *serial_worker_args,
         ]
     )
+    storage_scale_cmd = [_lane_report_arg(arg, "storage-scale") for arg in pytest_cmd]
+    storage_scale_cmd.extend(
+        [
+            "-m",
+            STORAGE_SCALE_MARKER_EXPRESSION,
+            *native_args,
+            "-p",
+            "no:randomly",
+            *storage_scale_worker_args,
+        ]
+    )
     return [
         (f"pytest native parallel ({testmon_mode})", parallel_cmd),
         (f"pytest native serial ({testmon_mode})", serial_cmd),
+        (f"pytest native storage-scale ({testmon_mode})", storage_scale_cmd),
     ]
 
 
 def _native_pytest_command_is_closed_world(label: str, cmd: Sequence[str]) -> bool:
     """Accept only a command produced by the managed native-lane builder."""
-    match = re.fullmatch(r"pytest native (parallel|serial) \((all|bootstrap|full)\)", label)
+    match = re.fullmatch(r"pytest native (parallel|serial|storage-scale) \((all|bootstrap|full)\)", label)
     if match is None:
         return False
     environment_args = [arg for arg in cmd if arg.startswith("--testmon-env=")]
@@ -2668,6 +2682,7 @@ def _native_pytest_command_is_closed_world(label: str, cmd: Sequence[str]) -> bo
         testmon_environment=environment_args[0].removeprefix("--testmon-env="),
         parallel_worker_args=observed_worker_args,
         serial_worker_args=observed_worker_args,
+        storage_scale_worker_args=observed_worker_args,
     )
     expected = dict(expected_steps).get(label)
     return expected is not None and list(cmd) == expected
@@ -2750,6 +2765,7 @@ def build_verify_steps(
                 testmon_environment=testmon_environment,
                 parallel_worker_args=_pytest_worker_args(),
                 serial_worker_args=_pytest_worker_args(maximum=SERIAL_LANE_MAX_WORKERS),
+                storage_scale_worker_args=_pytest_worker_args(maximum=STORAGE_SCALE_LANE_MAX_WORKERS),
             )
         )
 
@@ -2879,6 +2895,10 @@ def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
 #: failures are starvation of an idle-scheduled containment slice, not a
 #: shortage of cores.
 SERIAL_LANE_MAX_WORKERS: Final = 4
+
+#: Archive-scale proofs materialize large revision chains and must not compete
+#: with the ordinary corpus for filesystem bandwidth or nested subprocesses.
+STORAGE_SCALE_LANE_MAX_WORKERS: Final = 1
 
 
 def _pytest_worker_args(*, maximum: int | None = None) -> list[str]:
@@ -3177,6 +3197,8 @@ def _finalize_preflight_failure(
         "release_baseline_allowed": False,
         "diagnosis": diagnosis,
     }
+    if (recorded_selection := run.testmon_selection) is not None:
+        history_entry["testmon_selection"] = recorded_selection
     _save_history(history_entry)
     if use_json:
         _print_json(history_entry)
@@ -3543,6 +3565,9 @@ def _main(argv: list[str] | None = None) -> int:
             native_graph_touched = True
         elif label.startswith("pytest native serial"):
             step_result["semantic_lane"] = "serial"
+            native_graph_touched = True
+        elif label.startswith("pytest native storage-scale"):
+            step_result["semantic_lane"] = "storage-scale"
             native_graph_touched = True
         step_results.append(step_result)
         if rc == 0:

--- a/devtools/verify_runs.py
+++ b/devtools/verify_runs.py
@@ -1327,7 +1327,7 @@ def aggregate_native_testmon_run(
     invocation_duration_s: float,
     attestation_sound: bool = True,
 ) -> dict[str, Any]:
-    """Build one compact, durable aggregate for the two semantic pytest lanes."""
+    """Build one compact, durable aggregate for the semantic pytest lanes."""
     lanes: list[dict[str, Any]] = []
     selected_union: set[str] = set()
     outcome_by_node: dict[str, str] = {}
@@ -1349,7 +1349,7 @@ def aggregate_native_testmon_run(
     closed_world_collection = True
     for step in steps:
         lane = step.get("semantic_lane")
-        if lane not in {"parallel", "serial"}:
+        if lane not in {"parallel", "serial", "storage-scale"}:
             continue
         step_dir = _safe_step_dir(root, step.get("artifact_dir"))
         selection = _read_json_object(step_dir / "selection.json") if step_dir is not None else None
@@ -1470,9 +1470,10 @@ def aggregate_native_testmon_run(
         and selection_accounted
         and (attestation_sound or corpus_set <= executed_nodes)
         and not duplicate_outcomes
-        and len(lane_names) == 2
+        and len(lane_names) == 3
         and lane_names.count("parallel") == 1
         and lane_names.count("serial") == 1
+        and lane_names.count("storage-scale") == 1
     )
     missing_terminal = (
         tuple(sorted(selected_union - executed_nodes - corpus_set))
@@ -1862,8 +1863,8 @@ class VerifyRun:
 def pytest_step_run_id(run_id: str, step_id: str) -> str:
     """Return the pytest-invocation identity for one step of a verify run.
 
-    A verify run drives more than one pytest invocation — the parallel lane
-    and then the ``load_sensitive`` serial lane — and the basetemp directory
+    A verify run drives multiple pytest invocations: the ordinary parallel
+    lane, the ``load_sensitive`` lane, and the storage-scale lane. The basetemp directory
     is named from this identity. Sharing it across both lanes made them share
     one basetemp: the serial lane's ``TempPathFactory.getbasetemp`` then tried
     to ``rm_rf`` the parallel lane's 20k-test tree and ``mkdir`` it again, and

--- a/tests/integration/devtools/test_native_testmon_lifecycle.py
+++ b/tests/integration/devtools/test_native_testmon_lifecycle.py
@@ -422,7 +422,7 @@ def test_serial_owner():
 
     assert unavailable.returncode == 2, unavailable.stderr
     assert unavailable_payload["diagnosis"] == "native_testmon_graph_unavailable"
-    assert unavailable_payload["testmon_environment"]["selection_mode"] == "bootstrap"
+    assert unavailable_payload["testmon_selection"]["selection_mode"] == "bootstrap"
     assert not [step for step in unavailable_payload["steps"] if step.get("semantic_lane")]
 
     first, bootstrap = _run_production_verify(repo, "--all")
@@ -435,7 +435,7 @@ def test_serial_owner():
     assert aggregate["cleanup"] == {"complete": True}
     assert aggregate["containment"] == {"complete": True}
     lane_steps = [step for step in bootstrap["steps"] if step.get("semantic_lane")]
-    assert [step["semantic_lane"] for step in lane_steps] == ["parallel", "serial"]
+    assert [step["semantic_lane"] for step in lane_steps] == ["parallel", "serial", "storage-scale"]
     environments = {
         arg
         for step in lane_steps
@@ -503,10 +503,11 @@ def test_production_verify_all_grants_release_authority_after_complete_two_lane_
     assert payload["release_baseline_allowed"] is True
     assert payload["worktree_fingerprint"] == payload["final_worktree_fingerprint"]
     lanes = [step for step in payload["steps"] if step.get("semantic_lane")]
-    assert [step["semantic_lane"] for step in lanes] == ["parallel", "serial"]
+    assert [step["semantic_lane"] for step in lanes] == ["parallel", "serial", "storage-scale"]
     assert [step["name"] for step in lanes] == [
         "pytest native parallel (all)",
         "pytest native serial (all)",
+        "pytest native storage-scale (all)",
     ]
     for step in lanes:
         assert "--testmon-noselect" in step["statistics"]["command"]
@@ -530,22 +531,22 @@ def test_production_verify_all_grants_release_authority_after_complete_two_lane_
     assert aggregate["cleanup"] == {"complete": True}
     assert aggregate["containment"] == {"complete": True}
 
-    # A graph that loses recorded rows (an interrupted lane, damaged rows)
-    # shrinks its corpus AND its coverage claim together -- the row set is
-    # blind to its own losses, and testmon's file-level collection skip
-    # would hide the lost test from every later warm run. The certificate
-    # the completed run wrote catches the loss: attestation is refused and
-    # the corpus re-executes and re-certifies.
+    # A graph that loses recorded rows no longer triggers an implicit corpus
+    # replay. The certificate still records that the stronger attest-all-tests
+    # claim is unavailable, while testmon continues to select from the usable
+    # dependency graph. An explicit --all is the only recertification route.
     graph = repo / ".cache" / "testmon" / "testmondata"
     with sqlite3.connect(graph) as connection:
         connection.execute("DELETE FROM test_execution WHERE test_name LIKE '%serial%'")
     warm_completed, warm = _run_production_verify(repo)
 
-    assert warm_completed.returncode == 2, warm_completed.stderr
-    assert warm["diagnosis"] == "native_testmon_graph_unavailable"
-    assert warm["testmon_environment"]["selection_mode"] == "bootstrap"
-    assert "attestation refused" in warm["testmon_selection"]["state_reason"]
-    assert not [step for step in warm["steps"] if step.get("semantic_lane")]
+    assert warm_completed.returncode == 0, warm_completed.stderr
+    assert warm["testmon_environment"]["selection_mode"] == "full"
+    assert "attestation unavailable" in warm["testmon_selection"]["state_reason"]
+    lanes = [step for step in warm["steps"] if step.get("semantic_lane")]
+    assert [step["semantic_lane"] for step in lanes] == ["parallel", "serial", "storage-scale"]
+    assert warm["pytest_aggregate"]["selected_union_count"] == 0
+    assert warm["release_baseline_allowed"] is True
 
 
 def test_release_native_runs_override_a_reduced_hypothesis_profile(tmp_path: Path) -> None:
@@ -665,8 +666,8 @@ def test_production_verify_all_neutralizes_external_pytest_addopts(
     assert aggregate["terminal_union_count"] == 2
     assert aggregate["outcomes"] == {"failed": 2}
     lanes = [step for step in payload["steps"] if step.get("semantic_lane")]
-    assert [step["external_addopts_neutralized"] for step in lanes] == [True, True]
-    assert [step["external_plugins_neutralized"] for step in lanes] == [True, True]
+    assert [step["external_addopts_neutralized"] for step in lanes] == [True, True, True]
+    assert [step["external_plugins_neutralized"] for step in lanes] == [True, True, True]
     assert all("--override-ini=addopts=" in step["statistics"]["command"] for step in lanes)
     assert "parallel body executed" in completed.stderr
     assert "serial body executed" in completed.stderr
@@ -842,8 +843,8 @@ def test_production_affected_verify_neutralizes_execution_suppressing_addopts(
     assert aggregate["terminal_union_count"] == 2
     assert aggregate["outcomes"] == {"failed": 2}
     lanes = [step for step in payload["steps"] if step.get("semantic_lane")]
-    assert [step["external_addopts_neutralized"] for step in lanes] == [True, True]
-    assert [step["closed_world_collection"] for step in lanes] == [True, True]
+    assert [step["external_addopts_neutralized"] for step in lanes] == [True, True, True]
+    assert [step["closed_world_collection"] for step in lanes] == [True, True, True]
     assert "affected parallel body executed" in completed.stderr
     assert "affected serial body executed" in completed.stderr
 
@@ -917,8 +918,8 @@ def test_production_verify_all_owns_complete_test_root_over_configured_testpaths
     assert aggregate["complete_corpus_covered"] is True
     assert aggregate["terminal_green"] is False
     lanes = [step for step in payload["steps"] if step.get("semantic_lane")]
-    assert [step["external_plugins_neutralized"] for step in lanes] == [True, True]
-    assert [step["closed_world_collection"] for step in lanes] == [True, True]
+    assert [step["external_plugins_neutralized"] for step in lanes] == [True, True, True]
+    assert [step["closed_world_collection"] for step in lanes] == [True, True, True]
     assert all(step["statistics"]["command"].count("tests") == 1 for step in lanes)
     assert "outside configured discovery executed" in completed.stderr
 

--- a/tests/unit/devtools/test_pytest_collection_contract.py
+++ b/tests/unit/devtools/test_pytest_collection_contract.py
@@ -22,6 +22,7 @@ from devtools.pytest_collection_contract import (
     PARALLEL_MARKER_EXPRESSION,
     PROGRESS_PLUGIN_NAME,
     SERIAL_MARKER_EXPRESSION,
+    STORAGE_SCALE_MARKER_EXPRESSION,
 )
 from devtools.verify import _native_pytest_steps
 
@@ -32,6 +33,7 @@ def _commands() -> dict[str, list[str]]:
         testmon_environment="env-under-test",
         parallel_worker_args=["-n", "4"],
         serial_worker_args=["--dist=loadgroup", "-n", "2"],
+        storage_scale_worker_args=["--dist=loadgroup", "-n", "1"],
     )
     return dict(steps)
 
@@ -50,7 +52,7 @@ def test_closed_world_collection_args_reach_the_built_command() -> None:
             assert argument in cmd, f"{label} is missing collection arg {argument!r}"
 
 
-def test_the_two_lanes_use_the_declared_marker_expressions() -> None:
+def test_the_semantic_lanes_use_the_declared_marker_expressions() -> None:
     """The lanes partition the corpus; the expressions that split it are digest
     inputs precisely because changing them changes what each lane collects."""
     commands = _commands()
@@ -59,12 +61,16 @@ def test_the_two_lanes_use_the_declared_marker_expressions() -> None:
 
     assert PARALLEL_MARKER_EXPRESSION in markers.values()
     assert SERIAL_MARKER_EXPRESSION in markers.values()
-    assert set(markers.values()) == {PARALLEL_MARKER_EXPRESSION, SERIAL_MARKER_EXPRESSION}, (
-        "a lane is collecting under an expression the digest does not cover"
-    )
+    assert STORAGE_SCALE_MARKER_EXPRESSION in markers.values()
+    assert set(markers.values()) == {
+        PARALLEL_MARKER_EXPRESSION,
+        SERIAL_MARKER_EXPRESSION,
+        STORAGE_SCALE_MARKER_EXPRESSION,
+    }, "a lane is collecting under an expression the digest does not cover"
 
 
-def test_marker_expressions_are_complementary() -> None:
-    """Together the lanes must cover the corpus, or the union silently omits tests."""
-    assert SERIAL_MARKER_EXPRESSION in PARALLEL_MARKER_EXPRESSION
-    assert f"not {SERIAL_MARKER_EXPRESSION}" == PARALLEL_MARKER_EXPRESSION
+def test_marker_expressions_partition_storage_scale_from_ordinary_tests() -> None:
+    """Every storage-scale test has one lane and ordinary tests retain their lanes."""
+    assert "not storage_scale" in PARALLEL_MARKER_EXPRESSION
+    assert "not storage_scale" in SERIAL_MARKER_EXPRESSION
+    assert STORAGE_SCALE_MARKER_EXPRESSION == "storage_scale"

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -43,6 +43,7 @@ from devtools.verify import (
     PYTEST_REPORT_PATH,
     ROOT,
     SERIAL_LANE_MAX_WORKERS,
+    STORAGE_SCALE_LANE_MAX_WORKERS,
     _anchor_verification_paths,
     _native_lane_failure_requires_stop,
     _parse_pytest_test_count,
@@ -131,7 +132,7 @@ def test_quick_verify_omits_pytest() -> None:
         ("full", "--testmon-forceselect"),
     ],
 )
-def test_native_testmon_uses_exactly_two_semantic_lanes(
+def test_native_testmon_partitions_storage_scale_from_semantic_lanes(
     monkeypatch: pytest.MonkeyPatch,
     mode: str,
     selection_flag: str,
@@ -149,16 +150,21 @@ def test_native_testmon_uses_exactly_two_semantic_lanes(
     assert [label for label, _command in pytest_steps] == [
         f"pytest native parallel ({mode})",
         f"pytest native serial ({mode})",
+        f"pytest native storage-scale ({mode})",
     ]
     parallel = pytest_steps[0][1]
     serial = pytest_steps[1][1]
-    assert _pytest_marker_expr(parallel) == "not load_sensitive"
-    assert _pytest_marker_expr(serial) == "load_sensitive"
+    storage_scale = pytest_steps[2][1]
+    assert _pytest_marker_expr(parallel) == "not load_sensitive and not storage_scale"
+    assert _pytest_marker_expr(serial) == "load_sensitive and not storage_scale"
+    assert _pytest_marker_expr(storage_scale) == "storage_scale"
     assert parallel[parallel.index("-n") + 1] == "8"
     # The load_sensitive lane is bounded, not serial: it is capped at
     # SERIAL_LANE_MAX_WORKERS rather than pinned to a single process.
     assert serial[serial.index("-n") + 1] == str(min(8, SERIAL_LANE_MAX_WORKERS))
+    assert storage_scale[storage_scale.index("-n") + 1] == str(STORAGE_SCALE_LANE_MAX_WORKERS)
     assert "--dist=loadgroup" in serial
+    assert "--dist=loadgroup" in storage_scale
     for _label, command in pytest_steps:
         assert "--testmon" in command
         assert "--testmon-env=env-digest" in command
@@ -208,7 +214,7 @@ def test_native_corpus_excludes_only_benchmark_directory() -> None:
 
     complete_command = next(command for label, command in complete_steps if "parallel" in label)
     complete_expr = _pytest_marker_expr(complete_command)
-    assert complete_expr == "not load_sensitive"
+    assert complete_expr == "not load_sensitive and not storage_scale"
     assert "--ignore=tests/benchmarks" in complete_command
     assert "--ignore=tests/integration" not in complete_command
 


### PR DESCRIPTION
## Summary

Separate storage-scale tests from ordinary selected tests and remove the remaining automatic corpus-replay path for a compatible testmon graph.

## Problem

The 804-revision storage proof wrote about 52 GiB during a full run and contended with ordinary tests. A stale coverage certificate also converted an otherwise usable dependency graph into a bootstrap request, despite no automatic full-corpus rebuild being allowed for normal development.

## Solution

`devtools` now uses three semantic pytest lanes: ordinary, load-sensitive, and one-worker storage-scale. The aggregate accounts for all three lanes. A stale certificate remains visible in the selection record, but compatible testmon dependency selection continues; only `devtools verify --all` refreshes a corpus certificate. Preflight rejections now retain testmon-selection metadata.

## Verification

`devtools test tests/integration/devtools/test_native_testmon_lifecycle.py::test_production_plain_verify_owns_bootstrap_warm_selection_and_history tests/integration/devtools/test_native_testmon_lifecycle.py::test_production_verify_all_grants_release_authority_after_complete_two_lane_run tests/integration/devtools/test_native_testmon_lifecycle.py::test_runtime_json_only_mutation_is_recorded_but_not_caught tests/integration/devtools/test_native_testmon_lifecycle.py::test_production_verify_test_runtime_data_mutation_is_recorded_but_not_caught`

`4 passed in 53.18s`

The user-authorized consolidation waiver applies. No full corpus or CI wait was run.

## Scope

Self-contained harness change; no Bead state changed.
