### PR TITLE
fix(devtools): bootstrap isolated lane environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,14 +15,11 @@ version: 2.1
 #     suite's pre-merge gate remains local `devtools verify` (testmon), same
 #     as the repo's GitHub-era policy where the heavy suite ran post-merge
 #     only.
-#   - lab-policies (scheduled pipeline named "nightly"): the `lab policy *`
-#     checks that stay --lab-only because they scan the whole Beads/backlog
-#     corpus rather than the current diff (bead-graph) or
-#     are otherwise not cheap/deterministic enough for every push
-#     (timestamp-doctrine, insight-honesty). Runs nightly so a policy that fails
-#     continuously is at least visible somewhere, per polylogue-ze5i AC2,
-#     instead of only reachable via a human remembering `devtools verify
-#     --lab`.
+#   - policy-checks (scheduled pipeline named "nightly"): the policy checks
+#     that scan the whole Beads/backlog corpus rather than the current diff
+#     (bead-graph) or are otherwise not cheap/deterministic enough for every
+#     push (timestamp-doctrine, insight-honesty). Runs nightly so a policy that
+#     fails continuously is at least visible somewhere, per polylogue-ze5i AC2.
 #   - full-suite (scheduled pipeline named "nightly"): full coverage suite +
 #     dependency audit on a larger executor.
 #   - release-verify (v* tags): build artifacts and store them.
@@ -107,16 +104,16 @@ jobs:
       # diff, and that must not mask a genuine regression
       # in timestamp-doctrine/insight-honesty going unnoticed.
       - run:
-          name: lab policy timestamp-doctrine
-          command: ~/.local/bin/uv run devtools lab policy timestamp-doctrine
+          name: policy timestamp-doctrine
+          command: ~/.local/bin/uv run devtools verify timestamp-doctrine
           when: always
       - run:
-          name: lab policy insight-honesty
-          command: ~/.local/bin/uv run devtools lab policy insight-honesty
+          name: policy insight-honesty
+          command: ~/.local/bin/uv run devtools verify insight-honesty
           when: always
       - run:
-          name: lab policy bead-graph
-          command: ~/.local/bin/uv run devtools lab policy bead-graph --export .beads/issues.jsonl
+          name: policy bead-graph
+          command: ~/.local/bin/uv run devtools verify bead-graph --export .beads/issues.jsonl
           when: always
 
   full-suite:

--- a/.claude/agents/lane.md
+++ b/.claude/agents/lane.md
@@ -1,7 +1,7 @@
 ---
 name: lane
 description: Worktree-isolated implementation worker for polylogue. Use for any dispatched code/test/PR task that should run in its own git worktree with the standing lane contract already applied — bead work, bug fixes, refactors, sweeps. Dispatch prompts should carry only task content (which bead/files/scope), not the operating rules below.
-model: sonnet
+model: luna
 isolation: worktree
 ---
 
@@ -12,21 +12,29 @@ task-specific instructions accompany the dispatch.
 
 ## Step 0 — self-provision (before ANY other command)
 
-Harness-created worktrees reuse the shared venv, and the checkout guard
-refuses devtools/pytest there. Provision this worktree first, every time:
+Harness-created worktrees inherit the coordinator's `VIRTUAL_ENV` and PATH.
+The checkout guard correctly refuses that foreign environment. Repair the
+shell environment, then provision this worktree first, every time:
 
 ```
+stale_venv="${VIRTUAL_ENV:-}"
+if [ -n "$stale_venv" ]; then
+  PATH="${PATH//"$stale_venv/bin:"/}"
+  export PATH
+fi
+unset VIRTUAL_ENV PYTHONHOME
+direnv allow "$PWD"
+eval "$(direnv export zsh)"
 branch="$(git branch --show-current)"
 [ -n "$branch" ] || { branch="lane/$(basename "$PWD")"; git checkout -b "$branch"; }
 devtools workspace lane-init "$PWD" --branch "$branch"
 export VIRTUAL_ENV="$PWD/.venv"; export PATH="$PWD/.venv/bin:$PATH"
 ```
 
-lane-init adopts an existing worktree (measured 2026-08-19: ~5s with a warm
-uv cache — venv, checkout-guard verification, warm testmon-graph seed,
-ledger registration). If it fails, STOP and report the error — do not run
-devtools/pytest from an unprovisioned worktree, and do not work around the
-guard.
+This makes the lane own its interpreter before `lane-init` invokes devtools.
+If provisioning still fails, STOP and report the error. Do not run
+`devtools`/`pytest` from an unprovisioned worktree, and do not use an
+escape-hatch environment variable to silence the guard.
 
 ## Worktree discipline
 


### PR DESCRIPTION
## Summary

Make isolated implementation lanes establish their own environment before they invoke `devtools`, and repair the scheduled policy job after the retired `devtools lab` route was removed.

## Problem

Harness-created lanes inherited the coordinator checkout's virtual environment. The checkout guard correctly rejected the first `devtools workspace lane-init` invocation, leaving otherwise valid isolated lanes unable to start. Separately, the removed `devtools lab` command remained in three CircleCI scheduled-policy commands, which made the ordinary quick publish gate fail.

## Solution

The lane standing contract now removes the inherited virtual environment from PATH, loads the worktree's `direnv` environment, then invokes `lane-init`. Luna is the default lane model. CircleCI now calls the current `devtools verify` policy routes.

## Verification

- `devtools verify ci-commands` → `CI devtools commands match the live command catalog`
- `devtools verify --quick` → all 12 static steps passed in `42.48s`

## Bead disposition

| Bead | Disposition |
| --- | --- |
| None | Self-contained reliability repair; no Bead state changed. |
