### PR TITLE
fix(archive): admit reads before worker submission

### DIFF
--- a/polylogue/archive/query/execution_control.py
+++ b/polylogue/archive/query/execution_control.py
@@ -34,8 +34,8 @@ import threading
 import time
 import uuid
 from collections import deque
-from collections.abc import Callable, Iterator
-from contextlib import contextmanager, suppress
+from collections.abc import AsyncIterator, Callable, Iterator
+from contextlib import asynccontextmanager, contextmanager, suppress
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, TypeVar
@@ -350,6 +350,49 @@ class QueryAdmissionController:
             self._in_flight -= weight
             self._cond.notify_all()
 
+    async def _admit_async(self, ctx: QueryExecutionContext) -> int:
+        """Admit without occupying a storage worker while queued.
+
+        The controller remains the sole owner of class-aware queueing and
+        weights. Async callers re-check the thread-safe state at a short
+        cadence so a queued scan cannot consume a bounded archive-read worker
+        before its class is eligible to run.
+        """
+        weight = self.clamped_weight(ctx)
+        started = time.monotonic()
+        queued = False
+        try:
+            while True:
+                with self._cond:
+                    if not queued:
+                        self._queues[ctx.workload_class].append(ctx.call_id)
+                        ctx.receipt.queue_position = len(self._queues[ctx.workload_class]) - 1
+                        queued = True
+                    if self._may_admit_locked(ctx, weight):
+                        self._queues[ctx.workload_class].popleft()
+                        self._in_flight += weight
+                        ctx.receipt.queued_s = time.monotonic() - started
+                        ctx.receipt.state = "admitted"
+                        self._cond.notify_all()
+                        return weight
+                    if ctx.should_abort():
+                        raise _abort_error(ctx)
+                await asyncio.sleep(0.01)
+        except BaseException:
+            with self._cond:
+                self._remove_queued_locked(ctx)
+                self._cond.notify_all()
+            raise
+
+    @asynccontextmanager
+    async def admit_async(self, ctx: QueryExecutionContext) -> AsyncIterator[None]:
+        """Async admission that reserves capacity before worker submission."""
+        weight = await self._admit_async(ctx)
+        try:
+            yield
+        finally:
+            self._release(ctx, weight)
+
     @contextmanager
     def admit_blocking(self, ctx: QueryExecutionContext) -> Iterator[None]:
         """Synchronous admission for threaded callers (daemon HTTP handlers)."""
@@ -574,10 +617,19 @@ async def execute_archive_read(
     reader = InterruptibleSQLiteRead(ctx)
 
     def _admitted_run() -> T:
-        with admission.admit_blocking(ctx):
-            return reader.run(archive_root, work, read_timeout=read_timeout)
+        return reader.run(archive_root, work, read_timeout=read_timeout)
 
-    worker = asyncio.create_task(asyncio.to_thread(_admitted_run))
+    from polylogue.storage.sqlite.async_adapter import default_archive_read_async_adapter
+
+    async def _admitted_submission() -> T:
+        # Keep the lease inside the shielded task. A client disconnect may
+        # stop awaiting this coroutine after its bounded drain, but capacity
+        # must remain held until the owned SQLite worker has actually cleaned
+        # up and returned.
+        async with admission.admit_async(ctx):
+            return await default_archive_read_async_adapter().run(_admitted_run)
+
+    worker = asyncio.create_task(_admitted_submission())
     try:
         result = await asyncio.shield(worker)
     except asyncio.CancelledError:
@@ -588,7 +640,10 @@ async def execute_archive_read(
             # but Python-side post-processing is uninterruptible — do not
             # wait on it forever. An undrained worker keeps running in the
             # background and still performs its own cleanup on exit.
-            await asyncio.wait_for(worker, timeout=DISCONNECT_DRAIN_TIMEOUT_S)
+            # Timeout ends the caller's drain wait, never the lease-owning
+            # runner: the underlying executor operation may still be cleaning
+            # up and must retain admission until it returns.
+            await asyncio.wait_for(asyncio.shield(worker), timeout=DISCONNECT_DRAIN_TIMEOUT_S)
         except (QueryCancelledError, QueryTimeoutError, QueryWorkBudgetExceededError, asyncio.CancelledError):
             pass
         except TimeoutError:

--- a/polylogue/storage/sqlite/async_adapter.py
+++ b/polylogue/storage/sqlite/async_adapter.py
@@ -1,0 +1,69 @@
+"""Storage-owned async adapter for synchronous archive read operations."""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from contextvars import Context, copy_context
+from threading import Lock
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+class ArchiveReadAsyncAdapter:
+    """Run synchronous archive reads on storage-owned worker threads.
+
+    Admission, cancellation, snapshots, and SQLite interruption stay in the
+    caller's production read controller. This adapter owns only worker
+    selection and context propagation, keeping the async boundary out of the
+    default executor shared with unrelated application work.
+    """
+
+    def __init__(self, *, max_workers: int = 4) -> None:
+        if max_workers < 1:
+            raise ValueError("max_workers must be >= 1")
+        self._executor = ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="polylogue-archive-read")
+        self._closed = False
+        self._lock = Lock()
+
+    async def run(self, operation: Callable[[], T]) -> T:
+        """Await one already-admitted bounded submission with context vars.
+
+        The read controller performs workload-class admission before this
+        adapter receives work. This executor therefore contains only active
+        reads, never scans blocked before admission.
+        """
+        context = copy_context()
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("archive read adapter is closed")
+            executor = self._executor
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(executor, _run_in_context, context, operation)
+
+    def close(self) -> None:
+        """Drain worker threads and reject subsequent submissions."""
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+        self._executor.shutdown(wait=True, cancel_futures=True)
+
+
+def _run_in_context(context: Context, operation: Callable[[], T]) -> T:
+    return context.run(operation)
+
+
+_default_adapter = ArchiveReadAsyncAdapter()
+atexit.register(_default_adapter.close)
+
+
+def default_archive_read_async_adapter() -> ArchiveReadAsyncAdapter:
+    """Return the process-owned adapter shared by archive read transactions."""
+    return _default_adapter
+
+
+__all__ = ["ArchiveReadAsyncAdapter", "default_archive_read_async_adapter"]

--- a/tests/unit/archive/query/test_execution_control.py
+++ b/tests/unit/archive/query/test_execution_control.py
@@ -174,6 +174,119 @@ async def test_cheap_read_completes_while_expensive_read_runs(tmp_path: Path) ->
         await slow
 
 
+async def test_interactive_read_starts_while_scan_submission_is_saturated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Admission waits must not consume storage adapter workers."""
+    from polylogue.storage.sqlite import async_adapter
+    from polylogue.storage.sqlite.async_adapter import ArchiveReadAsyncAdapter
+
+    root = _bootstrap_archive(tmp_path)
+    adapter = ArchiveReadAsyncAdapter(max_workers=2)
+    monkeypatch.setattr(async_adapter, "default_archive_read_async_adapter", lambda: adapter)
+    controller = QueryAdmissionController(capacity=2, reserved_interactive=1)
+    release_scans = threading.Event()
+    first_scan_started = threading.Event()
+    interactive_started = threading.Event()
+
+    def blocking_scan(store: ArchiveStore) -> int:
+        first_scan_started.set()
+        assert release_scans.wait(timeout=5)
+        return _cheap_work(store)
+
+    def interactive_work(store: ArchiveStore) -> int:
+        interactive_started.set()
+        return _cheap_work(store)
+
+    second_scan: asyncio.Task[int] | None = None
+    interactive: asyncio.Task[int] | None = None
+    first_scan = asyncio.create_task(
+        execute_archive_read(
+            root,
+            blocking_scan,
+            ctx=QueryExecutionContext.create(query_text="scan-1", workload_class="scan", timeout_s=5.0),
+            controller=controller,
+        )
+    )
+    try:
+        assert await asyncio.to_thread(first_scan_started.wait, 2)
+        second_scan_ctx = QueryExecutionContext.create(query_text="scan-2", workload_class="scan", timeout_s=5.0)
+        second_scan = asyncio.create_task(
+            execute_archive_read(root, blocking_scan, ctx=second_scan_ctx, controller=controller)
+        )
+        deadline = time.monotonic() + 2
+        while controller.queue_position(second_scan_ctx) is None and time.monotonic() < deadline:
+            await asyncio.sleep(0.005)
+        assert controller.queue_position(second_scan_ctx) == 0
+        interactive = asyncio.create_task(
+            execute_archive_read(
+                root,
+                interactive_work,
+                ctx=QueryExecutionContext.create(query_text="interactive", timeout_s=5.0),
+                controller=controller,
+            )
+        )
+        assert await asyncio.to_thread(interactive_started.wait, 1)
+    finally:
+        release_scans.set()
+        await asyncio.gather(
+            first_scan,
+            *(task for task in (second_scan, interactive) if task is not None),
+            return_exceptions=True,
+        )
+        adapter.close()
+    assert controller.in_flight_weight == 0
+
+
+async def test_cancelled_pre_admission_scan_never_reaches_archive_worker(tmp_path: Path) -> None:
+    """Cancellation removes a queued read before storage submission."""
+    root = _bootstrap_archive(tmp_path)
+    controller = QueryAdmissionController(capacity=1, reserved_interactive=0)
+    release_first_scan = threading.Event()
+    first_scan_started = threading.Event()
+    cancelled_scan_started = threading.Event()
+
+    def blocking_scan(store: ArchiveStore) -> int:
+        first_scan_started.set()
+        assert release_first_scan.wait(timeout=5)
+        return _cheap_work(store)
+
+    def cancelled_scan(store: ArchiveStore) -> int:
+        cancelled_scan_started.set()
+        return _cheap_work(store)
+
+    first_scan = asyncio.create_task(
+        execute_archive_read(
+            root,
+            blocking_scan,
+            ctx=QueryExecutionContext.create(query_text="scan-holder", workload_class="scan", timeout_s=5.0),
+            controller=controller,
+        )
+    )
+    queued_scan: asyncio.Task[int] | None = None
+    try:
+        assert await asyncio.to_thread(first_scan_started.wait, 2)
+        queued_ctx = QueryExecutionContext.create(query_text="cancelled-scan", workload_class="scan", timeout_s=5.0)
+        queued_scan = asyncio.create_task(
+            execute_archive_read(root, cancelled_scan, ctx=queued_ctx, controller=controller)
+        )
+        deadline = time.monotonic() + 2
+        while controller.queue_position(queued_ctx) is None and time.monotonic() < deadline:
+            await asyncio.sleep(0.005)
+        assert controller.queue_position(queued_ctx) == 0
+
+        queued_scan.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await queued_scan
+        assert controller.queue_position(queued_ctx) is None
+    finally:
+        release_first_scan.set()
+        await asyncio.gather(first_scan, *(task for task in (queued_scan,) if task is not None), return_exceptions=True)
+
+    assert cancelled_scan_started.is_set() is False
+    assert controller.in_flight_weight == 0
+
+
 def test_admission_fifo_within_class(tmp_path: Path) -> None:
     controller = QueryAdmissionController(capacity=1, reserved_interactive=0)
     holder = QueryExecutionContext.create(query_text="hold", timeout_s=None)


### PR DESCRIPTION
## Summary

Move archive-read admission ahead of worker submission so queued scans cannot consume workers needed by interactive reads.

## Problem

`execute_archive_read()` submitted a blocking admission wait through the shared default executor. A scan queued behind the admission controller could therefore occupy executor capacity before it was eligible to run, delaying unrelated admitted work.

## Solution

Add a small storage-owned async adapter for already-admitted archive reads. `execute_archive_read()` now waits asynchronously for admission, submits only admitted SQLite work, preserves the lease through bounded cancellation cleanup, and propagates context into the bounded worker executor. The change deliberately excludes the pilot branch's redundant read-SQL extraction.

## Verification

- `devtools test tests/unit/archive/query/test_execution_control.py -k 'interactive_read_starts_while_scan_submission_is_saturated or cancelled_pre_admission_scan_never_reaches_archive_worker'` → `2 passed`
- `devtools test tests/unit/archive/query/test_execution_control.py` → `25 passed`

The operator-authorized consolidation waiver applies. No full verification or CI wait was run.

## Bead disposition

| Bead | Disposition |
| --- | --- |
| None | Self-contained change; no Bead state changed. |
