### PR TITLE
fix(storage): complete artifact cache restoration

### DIFF
--- a/polylogue/core/sqlite_locking.py
+++ b/polylogue/core/sqlite_locking.py
@@ -1,0 +1,37 @@
+"""SQLite contention classification shared by runtime layers."""
+
+from __future__ import annotations
+
+import sqlite3
+
+_SQLITE_PRIMARY_RESULT_CODE_MASK = 0xFF
+_TRANSIENT_SQLITE_LOCK_CODES = frozenset({sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED})
+_TRANSIENT_SQLITE_LOCK_NAMES = frozenset({"SQLITE_BUSY", "SQLITE_LOCKED", "SQLITE_LOCKED_SHAREDCACHE"})
+
+
+def is_transient_sqlite_lock(exc: BaseException) -> bool:
+    """Return whether SQLite reported retryable BUSY or LOCKED contention.
+
+    Extended result codes such as ``SQLITE_LOCKED_SHAREDCACHE`` retain the
+    ``SQLITE_LOCKED`` primary code in their low byte.  Prefer SQLite's typed
+    result metadata over message text so corruption or I/O failures that happen
+    to mention a lock are never mistaken for safe retryable contention.
+    """
+    if not isinstance(exc, sqlite3.Error):
+        return False
+    error_code = getattr(exc, "sqlite_errorcode", None)
+    if isinstance(error_code, int):
+        return error_code & _SQLITE_PRIMARY_RESULT_CODE_MASK in _TRANSIENT_SQLITE_LOCK_CODES
+    error_name = getattr(exc, "sqlite_errorname", None)
+    if isinstance(error_name, str):
+        return error_name in _TRANSIENT_SQLITE_LOCK_NAMES
+    message = str(exc).lower()
+    return (
+        "database is locked" in message
+        or "database table is locked" in message
+        or "database schema is locked" in message
+        or "database is busy" in message
+    )
+
+
+__all__ = ["is_transient_sqlite_lock"]

--- a/polylogue/sources/live/sqlite_locking.py
+++ b/polylogue/sources/live/sqlite_locking.py
@@ -6,17 +6,12 @@ import sqlite3
 import time
 from collections.abc import Callable
 
+from polylogue.core.sqlite_locking import is_transient_sqlite_lock
 from polylogue.logging import get_logger
 
 logger = get_logger(__name__)
 
 _SQLITE_LOCK_RETRY_DELAYS_S: tuple[float, ...] = (0.05, 0.2, 0.5)
-
-
-def is_transient_sqlite_lock(exc: sqlite3.OperationalError) -> bool:
-    """Return true for SQLite lock/busy errors worth treating as transient."""
-    message = str(exc).lower()
-    return "database is locked" in message or "database table is locked" in message or "database is busy" in message
 
 
 def best_effort_cursor_write(label: str, write: Callable[[], None]) -> bool:

--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from polylogue.core.enums import Origin
 from polylogue.core.sources import provider_from_origin
+from polylogue.core.sqlite_locking import is_transient_sqlite_lock
 from polylogue.logging import get_logger
 from polylogue.sources.hooks import drain_hook_event_spool, hook_spool_root, pending_hook_spool_dir
 from polylogue.sources.live.acquisition_log import log_unclaimed_file
@@ -426,7 +427,7 @@ class LiveWatcher:
                 if roots:
                     await self._catch_up(roots)
             except sqlite3.OperationalError as exc:
-                if not _is_database_locked(exc):
+                if not is_transient_sqlite_lock(exc):
                     raise
                 logger.warning("live.watcher: archive busy during periodic catch-up; will retry")
             # A periodic pass is deliberately a low-duty-cycle safety net.
@@ -487,7 +488,7 @@ class LiveWatcher:
                 # tier contention.  A just-created shard must get the same
                 # treatment instead of letting this narrow event-ordering
                 # recovery task die before its envelope is acknowledged.
-                if not _is_database_locked(exc):
+                if not is_transient_sqlite_lock(exc):
                     raise
                 logger.warning("live.watcher: archive busy while draining new hook shard; will retry")
             except OSError:
@@ -976,7 +977,7 @@ class LiveWatcher:
                 self._pending_paths.update(paths)
             return True
         except sqlite3.OperationalError as exc:
-            if not _is_database_locked(exc):
+            if not is_transient_sqlite_lock(exc):
                 raise
             logger.warning("live.watcher: archive busy; requeueing %d changed file(s)", len(paths))
             async with self._batch_lock:
@@ -1908,17 +1909,6 @@ def _cursor_db_path(polylogue: Polylogue) -> Path:
     if isinstance(db_path, Path):
         return db_path
     return Path(polylogue.archive_root) / "ops.db"
-
-
-def _is_database_locked(exc: sqlite3.OperationalError) -> bool:
-    error_code = getattr(exc, "sqlite_errorcode", None)
-    if error_code in {sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED}:
-        return True
-    message = str(exc).lower()
-    return any(
-        locked_message in message
-        for locked_message in ("database is locked", "database table is locked", "database schema is locked")
-    )
 
 
 def _cursor_age_exceeds(cursor: CursorRecord, min_age_s: float) -> bool:

--- a/polylogue/storage/sqlite/archive_tiers/bootstrap.py
+++ b/polylogue/storage/sqlite/archive_tiers/bootstrap.py
@@ -102,9 +102,9 @@ def archive_tier_spec(tier: ArchiveTier) -> ArchiveTierSpec:
 # faithful prototype for every later one in the same process, and SQLite's own
 # backup API restores it as a page copy instead of re-parsing.
 #
-# Embeddings is deliberately excluded: its DDL creates ``vec0`` virtual tables
-# that require the sqlite-vec extension to be loaded on the connection doing the
-# creating, so a page copy would silently skip that requirement.
+# Embeddings requires sqlite-vec to be loaded on the target connection before
+# a cached page copy is restored.  The restore path performs that readiness
+# step, so its empty vec0 schema is cacheable like every other tier.
 _TIER_PROTOTYPE_LOCK = threading.Lock()
 #: Per-process tally of how each tier initialization resolved, keyed
 #: ``(tier, outcome)``. Three outcomes, because they have three different
@@ -112,8 +112,7 @@ _TIER_PROTOTYPE_LOCK = threading.Lock()
 #:
 #: * ``prototype_hit``  -- restored by page copy from this process's cache.
 #: * ``ddl_fresh``      -- verifiably-empty database, real DDL executed. Paid
-#:   once per tier per process for cacheable tiers; once per archive for
-#:   EMBEDDINGS, which is excluded from the cache.
+#:   once per tier/DDL identity per process for cacheable tiers.
 #: * ``ddl_reapply``    -- NON-empty database, whole-tier DDL re-executed for
 #:   its ``IF NOT EXISTS`` idempotence and the same-version convergence steps
 #:   that follow it. Every one of these is a fully redundant executescript
@@ -129,7 +128,7 @@ _TIER_INIT_COUNTS_LOCK = threading.Lock()
 
 _TIER_PROTOTYPES: dict[tuple[str, int, str], Path] = {}
 _TIER_PROTOTYPE_DIR: Path | None = None
-_PROTOTYPE_CACHEABLE_TIERS = frozenset(ArchiveTier) - {ArchiveTier.EMBEDDINGS}
+_PROTOTYPE_CACHEABLE_TIERS = frozenset(ArchiveTier)
 
 
 def _record_tier_init(tier: ArchiveTier, outcome: str) -> None:
@@ -173,6 +172,10 @@ def _restore_tier_prototype(conn: sqlite3.Connection, tier: ArchiveTier, require
     if prototype is None or not prototype.is_file():
         return False
     try:
+        if tier is ArchiveTier.EMBEDDINGS:
+            loaded, _error = try_load_sqlite_vec(conn)
+            if not loaded:
+                return False
         with contextlib.closing(sqlite3.connect(prototype)) as source:
             source.backup(conn)
         stored = int(conn.execute("PRAGMA user_version").fetchone()[0])
@@ -229,6 +232,7 @@ def initialize_archive_tier(conn: sqlite3.Connection, tier: ArchiveTier) -> None
         if object_count == 0:
             if _restore_tier_prototype(conn, tier, spec.version):
                 conn.execute("PRAGMA foreign_keys = ON")
+                _apply_archive_tier_convergence(conn, tier, spec)
                 _record_tier_init(tier, "prototype_hit")
                 return
             _initialize_archive_tier_ddl(conn, tier)
@@ -238,9 +242,9 @@ def initialize_archive_tier(conn: sqlite3.Connection, tier: ArchiveTier) -> None
         _initialize_archive_tier_ddl(conn, tier)
         _record_tier_init(tier, "ddl_reapply")
         return
-    # EMBEDDINGS: never prototype-cached, so classify it the same way rather
-    # than lumping every call together. One COUNT over ``sqlite_master`` on a
-    # database this call is about to run a whole schema against.
+    # Explicit escape hatch for a future tier that cannot safely be restored
+    # from a page-copy prototype (for example, an extension with connection-
+    # local state that cannot be prepared before backup restoration).
     empty = int(conn.execute("SELECT COUNT(*) FROM sqlite_master").fetchone()[0]) == 0
     _initialize_archive_tier_ddl(conn, tier)
     _record_tier_init(tier, "ddl_fresh" if empty else "ddl_reapply")
@@ -255,6 +259,19 @@ def _initialize_archive_tier_ddl(conn: sqlite3.Connection, tier: ArchiveTier) ->
         if not loaded:
             raise RuntimeError("archive embeddings initialization requires sqlite-vec") from error
     conn.executescript(spec.ddl)
+    _apply_archive_tier_convergence(conn, tier, spec)
+
+
+def _apply_archive_tier_convergence(
+    conn: sqlite3.Connection,
+    tier: ArchiveTier,
+    spec: ArchiveTierSpec,
+) -> None:
+    """Replay same-version convergence after either DDL or page-copy restore.
+
+    Prototypes accelerate canonical DDL; they are not a second schema
+    authority.  Any idempotent same-version repair must run on cache hits too.
+    """
     if tier is ArchiveTier.OPS:
         from polylogue.storage.sqlite.archive_tiers.ops_write import (
             ensure_embedding_catchup_run_outcome_columns,

--- a/tests/infra/workload_artifacts.py
+++ b/tests/infra/workload_artifacts.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from polylogue.config import Config, Source
+from polylogue.core.sqlite_locking import is_transient_sqlite_lock
 from polylogue.pipeline.services.archive_ingest import parse_sources_archive
 from polylogue.scenarios import CorpusSpec
 from polylogue.scenarios.workload import (
@@ -377,7 +378,7 @@ def _journal_mode_delete_with_retry(conn: sqlite3.Connection, *, name: str) -> N
         try:
             mode = conn.execute("PRAGMA journal_mode=DELETE").fetchone()
         except sqlite3.OperationalError as exc:
-            if "locked" not in str(exc).lower() or time.monotonic() >= deadline:
+            if not is_transient_sqlite_lock(exc) or time.monotonic() >= deadline:
                 raise
             gc.collect()
             time.sleep(min(0.05 * attempt, 0.5))
@@ -528,11 +529,11 @@ def _validate_artifact(root: Path, key: SeededArchiveKey) -> SeededArchiveArtifa
         _sqlite_integrity(root)
         _validate_facts(root, manifest.facts)
         _validate_frontier_convergence(root)
-    except sqlite3.OperationalError as exc:
-        if "locked" in str(exc).lower() or "busy" in str(exc).lower():
+    except sqlite3.Error as exc:
+        if is_transient_sqlite_lock(exc):
             raise _ArtifactValidationContentionError(f"published artifact validation is contended: {root}") from exc
         return None
-    except (OSError, RuntimeError, TypeError, ValueError, json.JSONDecodeError, sqlite3.Error):
+    except (OSError, RuntimeError, TypeError, ValueError, json.JSONDecodeError):
         return None
     return SeededArchiveArtifact(root=root, manifest=manifest)
 
@@ -689,7 +690,7 @@ def build_seeded_archive(
                 # makes many workers rebuild artifacts at once and a setup ERROR
                 # here fails the whole consuming test.
                 _remove_tree(staging)
-                if "locked" not in str(exc).lower() or attempt == _BUILD_LOCK_ATTEMPTS:
+                if not is_transient_sqlite_lock(exc) or attempt == _BUILD_LOCK_ATTEMPTS:
                     raise
                 gc.collect()
                 time.sleep(min(0.25 * attempt, 2.0))

--- a/tests/unit/infra/test_workload_artifacts.py
+++ b/tests/unit/infra/test_workload_artifacts.py
@@ -16,6 +16,7 @@ from typing import Any
 
 import pytest
 
+from polylogue.core.sqlite_locking import is_transient_sqlite_lock
 from polylogue.storage.archive_readiness import raw_materialization_readiness_snapshot, raw_materialization_ready
 from polylogue.storage.sqlite.archive_tiers import ARCHIVE_DDL_BY_TIER
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -673,3 +674,80 @@ def test_build_gives_up_on_a_persistent_lock(tmp_path: Path, monkeypatch: pytest
 
     assert attempts == artifacts._BUILD_LOCK_ATTEMPTS
     assert not list((tmp_path / "cache" / ".staging").iterdir())
+
+
+@pytest.mark.parametrize(
+    ("error_code", "error_name", "message"),
+    (
+        (sqlite3.SQLITE_LOCKED | (1 << 8), None, "opaque SQLite error"),
+        (None, "SQLITE_LOCKED_SHAREDCACHE", "opaque SQLite error"),
+        (None, None, "database table is locked: sqlite_master"),
+        (sqlite3.SQLITE_BUSY, "SQLITE_BUSY", "database is busy"),
+    ),
+)
+def test_transient_sqlite_lock_recognizes_shared_cache_variants(
+    error_code: int | None,
+    error_name: str | None,
+    message: str,
+) -> None:
+    exc = sqlite3.OperationalError(message)
+    if error_code is not None:
+        exc.sqlite_errorcode = error_code
+    if error_name is not None:
+        exc.sqlite_errorname = error_name
+
+    assert is_transient_sqlite_lock(exc)
+
+
+@pytest.mark.parametrize(
+    ("error_code", "message"),
+    (
+        (sqlite3.SQLITE_CORRUPT, "database disk image is malformed"),
+        (sqlite3.SQLITE_CORRUPT, "database is locked while reading a corrupt page"),
+        (sqlite3.SQLITE_IOERR, "disk I/O error"),
+        (None, "no such table: sqlite_master"),
+    ),
+)
+def test_transient_sqlite_lock_rejects_non_contention_errors(
+    error_code: int | None,
+    message: str,
+) -> None:
+    exc = sqlite3.OperationalError(message)
+    if error_code is not None:
+        exc.sqlite_errorcode = error_code
+
+    assert not is_transient_sqlite_lock(exc)
+
+
+def test_contention_during_cache_validation_reuses_published_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient validation lock must not turn valid bytes into a rebuild."""
+    import tests.infra.workload_artifacts as artifacts
+
+    cache_root = tmp_path / "cache"
+    artifacts._VALIDATED_ARTIFACTS.clear()
+    published = build_seeded_archive(cache_root=cache_root)
+    artifacts._VALIDATED_ARTIFACTS.clear()
+    real_validate = artifacts._validate_artifact
+    attempts = 0
+
+    def contend_once(root: Path, key: Any) -> Any:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            cause = sqlite3.OperationalError("database table is locked: sqlite_master")
+            raise artifacts._ArtifactValidationContentionError from cause
+        return real_validate(root, key)
+
+    def forbid_republish(path: Path) -> None:
+        raise AssertionError(f"valid artifact was republished: {path}")
+
+    monkeypatch.setattr(artifacts, "_validate_artifact", contend_once)
+    monkeypatch.setattr(artifacts, "_remove_tree", forbid_republish)
+    reused = build_seeded_archive(cache_root=cache_root)
+
+    assert attempts >= 2
+    assert reused.root == published.root
+    assert reused.manifest.manifest_id == published.manifest.manifest_id

--- a/tests/unit/storage/test_archive_tier_init.py
+++ b/tests/unit/storage/test_archive_tier_init.py
@@ -140,6 +140,42 @@ def test_tier_prototype_key_includes_rendered_ddl(tmp_path: Path, monkeypatch: p
         bootstrap._TIER_PROTOTYPES.clear()
 
 
+def test_cached_index_prototype_replays_same_version_convergence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A page-copy hit must still apply newly registered benign DDL."""
+    from polylogue.storage.sqlite.archive_tiers import bootstrap, index_convergence
+
+    bootstrap.reset_archive_tier_init_counts()
+    bootstrap._TIER_PROTOTYPES.clear()
+    try:
+        with sqlite3.connect(tmp_path / "first.db") as first:
+            bootstrap.initialize_archive_tier(first, ArchiveTier.INDEX)
+
+        entry = index_convergence.BenignDDLEntry(
+            name="cached_prototype_test_table",
+            sql="CREATE TABLE IF NOT EXISTS cached_prototype_test_table (id TEXT PRIMARY KEY) STRICT",
+            reason="test-only same-version additive convergence",
+        )
+        monkeypatch.setattr(
+            index_convergence,
+            "INDEX_BENIGN_DDL_REGISTRY",
+            (*index_convergence.INDEX_BENIGN_DDL_REGISTRY, entry),
+        )
+        with sqlite3.connect(tmp_path / "second.db") as second:
+            bootstrap.initialize_archive_tier(second, ArchiveTier.INDEX)
+            assert second.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'cached_prototype_test_table'"
+            ).fetchone() == (1,)
+    finally:
+        bootstrap._TIER_PROTOTYPES.clear()
+
+    counts = bootstrap.archive_tier_init_counts()
+    assert counts["index.ddl_fresh"] == 1
+    assert counts["index.prototype_hit"] == 1
+
+
 def test_tier_init_counts_expose_the_ops_only_whole_schema_reapply(tmp_path: Path) -> None:
     """Only ops.db re-executes its WHOLE schema on a same-version open.
 
@@ -167,24 +203,42 @@ def test_tier_init_counts_expose_the_ops_only_whole_schema_reapply(tmp_path: Pat
     assert "index.ddl_reapply" not in counts
 
 
-def test_tier_init_counts_classify_the_uncached_embeddings_tier(tmp_path: Path) -> None:
-    """EMBEDDINGS is excluded from the prototype cache, so a fresh archive pays DDL.
-
-    Each new archive gets a real DDL execution rather than a page copy; a
-    same-version reopen returns without work, like every tier except OPS.
-    """
+def test_embeddings_prototype_restore_keeps_sqlite_vec_ready(tmp_path: Path) -> None:
+    """A cached embeddings prototype restores an operational vec0 schema."""
     from polylogue.storage.sqlite.archive_tiers import bootstrap
+    from polylogue.storage.sqlite.sqlite_vec_extension import try_load_sqlite_vec
 
     bootstrap.reset_archive_tier_init_counts()
+    bootstrap._TIER_PROTOTYPES.clear()
+    try:
+        first_path = tmp_path / "e1.db"
+        second_path = tmp_path / "e2.db"
+        first = sqlite3.connect(first_path)
+        try:
+            loaded, error = try_load_sqlite_vec(first)
+            if not loaded:
+                pytest.skip(f"sqlite-vec extension is unavailable: {error}")
+            bootstrap.initialize_archive_tier(first, ArchiveTier.EMBEDDINGS)
+        finally:
+            first.close()
 
-    bootstrap.initialize_archive_database(tmp_path / "e1.db", ArchiveTier.EMBEDDINGS)
-    bootstrap.initialize_archive_database(tmp_path / "e2.db", ArchiveTier.EMBEDDINGS)
-    bootstrap.initialize_archive_database(tmp_path / "e1.db", ArchiveTier.EMBEDDINGS)
+        second = sqlite3.connect(second_path)
+        try:
+            bootstrap.initialize_archive_tier(second, ArchiveTier.EMBEDDINGS)
+            table = second.execute(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'message_embeddings'"
+            ).fetchone()
+            assert table is not None
+            assert "vec0" in str(table[0])
+            assert second.execute("SELECT COUNT(*) FROM message_embeddings").fetchone() == (0,)
+        finally:
+            second.close()
+    finally:
+        bootstrap._TIER_PROTOTYPES.clear()
 
     counts = bootstrap.archive_tier_init_counts()
-
-    assert counts["embeddings.ddl_fresh"] == 2
-    assert not any(key.startswith("embeddings.prototype_hit") for key in counts)
+    assert counts["embeddings.ddl_fresh"] == 1
+    assert counts["embeddings.prototype_hit"] == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Make archive-tier prototype restores complete the same convergence work as fresh DDL initialization, cache embeddings prototypes safely, and classify SQLite contention from SQLite result metadata.

## Problem

A cached tier restore bypassed same-version convergence. Embeddings could not use the prototype fast path even though the target connection can prepare `sqlite-vec` before restore. Artifact validation and retry paths also inferred SQLite lock contention from exception prose, so a valid shared-cache artifact could be unnecessarily discarded and republished.

## Solution

Prototype hits now replay canonical convergence. The embeddings restore path loads `sqlite-vec` before copying a prepared prototype, while retaining the DDL fallback for a future non-cacheable tier. A shared typed SQLite contention helper recognizes primary and extended SQLite lock result codes, including `SQLITE_LOCKED_SHAREDCACHE`, and replaces duplicated message matching in artifact and live-watcher paths.

## Verification

- `devtools test tests/unit/storage/test_archive_tier_init.py` → `11 passed`
- `devtools test tests/unit/infra/test_workload_artifacts.py` → `33 passed`
- `devtools test tests/unit/sources/test_live_watcher_locking.py` → `8 passed`
- focused `ruff format --check` and `ruff check` → passed

The operator-authorized consolidation waiver applies. No full verification, CI wait, or live archive action was run.

## Bead disposition

| Bead | Disposition |
| --- | --- |
| None | Self-contained storage correctness repair; no Bead state changed. |
