### PR TITLE
fix(devtools): bootstrap lane environments automatically

### DIFF
--- a/.claude/agents/lane.md
+++ b/.claude/agents/lane.md
@@ -12,28 +12,19 @@ task-specific instructions accompany the dispatch.
 
 ## Step 0 — self-provision (before ANY other command)
 
-Harness-created worktrees inherit the coordinator's `VIRTUAL_ENV` and PATH.
-The checkout guard correctly refuses that foreign environment. Repair the
-shell environment, then provision this worktree first, every time:
+`devtools workspace lane-init` is the automatic environment bootstrap. It
+accepts the harness's inherited environment only for this exact command, then
+provisions and proves the worktree-local interpreter before any ordinary
+command can run. Invoke it first, every time:
 
 ```
-stale_venv="${VIRTUAL_ENV:-}"
-if [ -n "$stale_venv" ]; then
-  PATH="${PATH//"$stale_venv/bin:"/}"
-  export PATH
-fi
-unset VIRTUAL_ENV PYTHONHOME
-direnv allow "$PWD"
-eval "$(direnv export zsh)"
 branch="$(git branch --show-current)"
 [ -n "$branch" ] || { branch="lane/$(basename "$PWD")"; git checkout -b "$branch"; }
 devtools workspace lane-init "$PWD" --branch "$branch"
-export VIRTUAL_ENV="$PWD/.venv"; export PATH="$PWD/.venv/bin:$PATH"
 ```
 
-This makes the lane own its interpreter before `lane-init` invokes devtools.
-If provisioning still fails, STOP and report the error. Do not run
-`devtools`/`pytest` from an unprovisioned worktree, and do not use an
+If provisioning fails, STOP and report the error. Do not repair shell state by
+hand, run `devtools`/`pytest` from an unprovisioned worktree, or use an
 escape-hatch environment variable to silence the guard.
 
 ## Worktree discipline

--- a/devtools/click_dispatch.py
+++ b/devtools/click_dispatch.py
@@ -257,13 +257,28 @@ def _dispatch(argv: list[str]) -> int:
         return code if isinstance(code, int) else 0
 
 
+def _is_lane_init_bootstrap(argv: list[str]) -> bool:
+    """Return whether ``argv`` names the sole self-provisioning command.
+
+    A harness-created worktree may inherit the coordinator's environment, so
+    it cannot pass the ordinary import guard until its first lane-init has
+    built a local venv. Every other command remains guarded before dispatch.
+    """
+    normalized = list(argv)
+    if normalized[:1] == ["--json"]:
+        normalized.pop(0)
+    return normalized[:2] == ["workspace", "lane-init"]
+
+
 def main(argv: list[str] | None = None) -> int:
     """Entry point for programmatic use of the Click-based devtools CLI."""
 
-    try:
-        assert_polylogue_matches_checkout(_REPO_ROOT, context="devtools")
-    except CheckoutImportMismatchError as exc:
-        sys.stderr.write(f"{exc}\n")
-        return 125
+    command_argv = list(argv or [])
+    if not _is_lane_init_bootstrap(command_argv):
+        try:
+            assert_polylogue_matches_checkout(_REPO_ROOT, context="devtools")
+        except CheckoutImportMismatchError as exc:
+            sys.stderr.write(f"{exc}\n")
+            return 125
 
-    return _dispatch(list(argv or []))
+    return _dispatch(command_argv)

--- a/devtools/lane_init.py
+++ b/devtools/lane_init.py
@@ -257,9 +257,31 @@ _LANE_ENV_UNSETS = (
 )
 
 
+def _implementation_root() -> Path:
+    """Return the checkout containing the lane-init implementation."""
+    return Path(__file__).resolve().parents[1]
+
+
+def _bootstrap_source_error(root: Path) -> str | None:
+    """Refuse bootstrap if this command was imported from another checkout."""
+    implementation_root = _implementation_root()
+    if implementation_root == root.resolve():
+        return None
+    return (
+        "lane-init implementation belongs to a different checkout:\n"
+        f"  invoking checkout: {root.resolve()}\n"
+        f"  implementation:    {implementation_root}"
+    )
+
+
 def _lane_env(worktree: Path) -> dict[str, str]:
     """Return an environment that cannot inherit another checkout's Python."""
     env = os.environ.copy()
+    inherited_venv = env.get("VIRTUAL_ENV")
+    if inherited_venv:
+        inherited_bin = str(Path(inherited_venv) / "bin")
+        path_entries = env.get("PATH", "").split(os.pathsep)
+        env["PATH"] = os.pathsep.join(entry for entry in path_entries if entry != inherited_bin)
     for key in _LANE_ENV_UNSETS:
         env.pop(key, None)
     # Not merely hygiene: these describe a specific interpreter BUILD, so
@@ -666,6 +688,9 @@ def dispatch_env_lines(
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     root = repo_root()
+    if error := _bootstrap_source_error(root):
+        print(f"lane-init: {error}", file=sys.stderr)
+        return 125
     worktree = Path(args.worktree).resolve()
     beads = [b.strip() for b in args.beads.split(",") if b.strip()]
 

--- a/tests/unit/devtools/test_checkout_guard.py
+++ b/tests/unit/devtools/test_checkout_guard.py
@@ -149,8 +149,12 @@ def test_click_dispatch_allows_only_lane_init_to_bootstrap_foreign_environment(
     def _boom(*_args: object, **_kwargs: object) -> None:
         raise AssertionError("ordinary checkout guard must not run for lane-init")
 
+    def _dispatch(command_argv: list[str]) -> int:
+        dispatched.append(command_argv)
+        return 23
+
     monkeypatch.setattr(click_dispatch, "assert_polylogue_matches_checkout", _boom)
-    monkeypatch.setattr(click_dispatch, "_dispatch", lambda command_argv: dispatched.append(command_argv) or 23)
+    monkeypatch.setattr(click_dispatch, "_dispatch", _dispatch)
 
     assert click_dispatch.main(argv) == 23
     assert dispatched == [argv]

--- a/tests/unit/devtools/test_checkout_guard.py
+++ b/tests/unit/devtools/test_checkout_guard.py
@@ -133,6 +133,50 @@ def test_click_dispatch_main_refuses_on_checkout_mismatch(
     assert captured.out == ""
 
 
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["workspace", "lane-init", "/worktree", "--branch", "feature/test/lane"],
+        ["--json", "workspace", "lane-init", "/worktree", "--branch", "feature/test/lane"],
+    ],
+)
+def test_click_dispatch_allows_only_lane_init_to_bootstrap_foreign_environment(
+    argv: list[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The one self-healing command reaches lane-init before import validation."""
+    dispatched: list[list[str]] = []
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("ordinary checkout guard must not run for lane-init")
+
+    monkeypatch.setattr(click_dispatch, "assert_polylogue_matches_checkout", _boom)
+    monkeypatch.setattr(click_dispatch, "_dispatch", lambda command_argv: dispatched.append(command_argv) or 23)
+
+    assert click_dispatch.main(argv) == 23
+    assert dispatched == [argv]
+
+
+def test_click_dispatch_keeps_workspace_non_bootstrap_commands_guarded(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    dispatched = False
+
+    def _boom(repo_root: Path, *, context: str) -> None:
+        raise CheckoutImportMismatchError(f"{context}: foreign environment at {repo_root}")
+
+    def _dispatch(_argv: list[str]) -> int:
+        nonlocal dispatched
+        dispatched = True
+        return 0
+
+    monkeypatch.setattr(click_dispatch, "assert_polylogue_matches_checkout", _boom)
+    monkeypatch.setattr(click_dispatch, "_dispatch", _dispatch)
+
+    assert click_dispatch.main(["workspace", "verify-worktree", "/worktree"]) == 125
+    assert dispatched is False
+    assert "foreign environment" in capsys.readouterr().err
+
+
 def test_run_tests_main_refuses_on_checkout_mismatch(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/unit/devtools/test_lane_init.py
+++ b/tests/unit/devtools/test_lane_init.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 import threading
@@ -130,6 +131,34 @@ def test_provision_venv_forces_the_lane_environment(tmp_path: Path, monkeypatch:
     assert env["UV_PROJECT_ENVIRONMENT"] == str(lane / ".venv")
 
 
+def test_lane_env_removes_the_inherited_venv_bin_from_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    coordinator = tmp_path / "coordinator"
+    lane = tmp_path / "lane"
+    foreign_bin = coordinator / ".venv" / "bin"
+    retained_bin = tmp_path / "tools"
+    monkeypatch.setenv("VIRTUAL_ENV", str(coordinator / ".venv"))
+    monkeypatch.setenv("PATH", os.pathsep.join((str(foreign_bin), str(retained_bin), str(foreign_bin))))
+
+    env = lane_init._lane_env(lane)
+
+    assert env["PATH"] == str(retained_bin)
+    assert "VIRTUAL_ENV" not in env
+    assert env["UV_PROJECT_ENVIRONMENT"] == str(lane / ".venv")
+
+
+def test_main_refuses_foreign_lane_init_implementation_before_writing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "lane"
+    root.mkdir()
+    monkeypatch.setattr(lane_init, "repo_root", lambda: root)
+    monkeypatch.setattr(lane_init, "_implementation_root", lambda: tmp_path / "other-checkout")
+    monkeypatch.setattr(lane_init, "_ensure_worktree", lambda *_args: pytest.fail("must not create a worktree"))
+
+    assert lane_init.main([str(root / "child"), "--branch", "feature/test/lane"]) == 125
+    assert "implementation belongs to a different checkout" in capsys.readouterr().err
+
+
 def test_provision_venv_ignores_inherited_uv_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A coordinator's UV_PROJECT must not install its editable source in a lane venv."""
     coordinator = tmp_path / "coordinator"
@@ -234,6 +263,57 @@ def test_main_provisions_and_verifies_a_real_lane_from_a_poisoned_coordinator(tm
     assert foreign_guard.returncode == 125
     assert "resolved OUTSIDE this checkout" in foreign_guard.stderr
     assert "give this checkout its own venv" in foreign_guard.stderr
+
+
+def test_public_lane_init_bootstraps_an_existing_lane_with_inherited_coordinator_venv(tmp_path: Path) -> None:
+    """The public devtools command self-heals the one allowed foreign environment."""
+    coordinator = tmp_path / "main"
+    lane = tmp_path / "lane"
+    project_root = Path(__file__).resolve().parents[3]
+    subprocess.run(
+        ["git", "clone", "--shared", str(project_root), str(coordinator)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    coordinator_python = coordinator / ".venv" / "bin" / "python"
+    coordinator_python.parent.mkdir(parents=True)
+    coordinator_python.write_text(
+        f'#!/bin/sh\nexec {sys.executable!s} "$@"\n',
+        encoding="utf-8",
+    )
+    coordinator_python.chmod(0o755)
+    branch = "feature/test/public-lane-bootstrap"
+    assert lane_init._ensure_worktree(coordinator, lane, branch, "HEAD") is None
+    for relative_path in ("devtools/click_dispatch.py", "devtools/lane_init.py"):
+        shutil.copy2(project_root / relative_path, lane / relative_path)
+
+    poisoned_env = os.environ | {
+        "VIRTUAL_ENV": str(coordinator / ".venv"),
+        "PYTHONPATH": str(coordinator),
+        "UV_PROJECT": str(coordinator),
+        "UV_WORKING_DIR": str(coordinator),
+    }
+    result = subprocess.run(
+        [
+            str(coordinator_python),
+            "-m",
+            "devtools",
+            "workspace",
+            "lane-init",
+            str(lane),
+            "--branch",
+            branch,
+        ],
+        cwd=lane,
+        env=poisoned_env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "lane ready:" in result.stdout
+    assert (lane / ".venv" / "bin" / "python").is_file()
 
 
 def test_lane_warm_claim_is_revalidated_after_distribution_drift(


### PR DESCRIPTION
## Summary

Make `devtools workspace lane-init` the one self-healing entry point for an isolated worktree that inherited its coordinator's Python environment.

## Problem

Harness-created worktrees begin with the coordinator environment. The checkout guard correctly rejects that environment, but the pre-dispatch rejection previously prevented the lane bootstrap command from creating the local venv that would make every later command safe. The workaround was an error-prone shell ritual in every agent instruction.

## Solution

`devtools` now exempts only the exact `workspace lane-init` path from its ordinary pre-dispatch guard. `lane-init` then proves that its implementation was loaded from the invoking checkout before it creates a worktree or writes state, strips the inherited venv's `bin` directory from child `PATH`, and preserves the ordinary fail-closed guard for every other command. The lane contract no longer contains manual environment repair.

## Verification

`devtools test tests/unit/devtools/test_checkout_guard.py tests/unit/devtools/test_lane_init.py` completed with `64 passed in 76.41s`. The public process-boundary test runs `python -m devtools workspace lane-init` from a linked lane with coordinator `VIRTUAL_ENV`, `PYTHONPATH`, and uv routing variables inherited, then proves it creates the lane venv. `devtools verify --quick` completed successfully in `41.4s`, including mypy, render, layering, command, schema, and oracle checks.

| Bead | Disposition | Evidence |
| --- | --- | --- |
| None | Self-contained | Focused devtools regression coverage |

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->
