### PR TITLE
refactor(devtools): reduce lane provisioning to its invariant

### DIFF
--- a/.claude/agents/lane.md
+++ b/.claude/agents/lane.md
@@ -13,14 +13,13 @@ task-specific instructions accompany the dispatch.
 ## Step 0 — self-provision (before ANY other command)
 
 `devtools workspace lane-init` is the automatic environment bootstrap. It
-accepts the harness's inherited environment only for this exact command, then
-provisions and proves the worktree-local interpreter before any ordinary
-command can run. Invoke it first, every time:
+accepts the harness's inherited environment only for this exact command,
+derives the already-checked-out lane branch, then provisions and proves the
+worktree-local interpreter before any ordinary command can run. Invoke it
+first, every time:
 
 ```
-branch="$(git branch --show-current)"
-[ -n "$branch" ] || { branch="lane/$(basename "$PWD")"; git checkout -b "$branch"; }
-devtools workspace lane-init "$PWD" --branch "$branch"
+python -m devtools workspace lane-init "$PWD"
 ```
 
 If provisioning fails, STOP and report the error. Do not repair shell state by
@@ -115,54 +114,11 @@ by construction.
   testmon, in a file you never touched), say so explicitly rather than
   silently working around it or claiming it as fixed.
 
-## PR shape
+## Delivery
 
-Open a PR (branch off `master`, conventional commit-style subject,
-`feature/<category>/<desc>` branch name) with a body containing:
-
-- **Summary** — one paragraph.
-- **Problem** — what evidence/observation motivated this (not "was asked").
-- **Solution** — modules touched, non-obvious decisions, alternatives
-  rejected if there was a real fork.
-- **Verification** — the exact commands you ran and the output line that
-  matters, not "tests pass".
-- **Bead disposition matrix** — one whole-Bead disposition per assigned ID,
-  typed evidence refs, and an existing open successor for every residual
-  outcome.
-
-Before publishing the PR as non-draft, render the versioned embedded carrier
-with `devtools workspace pr-scope render --input <scope.json>`, put that exact
-comment beside the human matrix, and validate the published PR with
-`devtools workspace pr-scope check --pr <N>`. Never infer a disposition from
-Bead acceptance prose or invent a successor ID. The v2 body is stable intent;
-use `devtools workspace pr-scope sync --pr <N>` to inspect the current
-head-bound attestation rather than rewriting the body after every commit.
-
-Reference any bead with neutral wording only (`Ref polylogue-xxxx` /
-`Ref #N`). **Never use GitHub resolver keywords** (closes/fixes/resolves)
-next to an issue number unless the dispatch prompt explicitly told you to
-close that exact issue from this exact PR.
-
-**Never merge the PR.** Leave it open for the coordinator to review and
-merge. Do not self-merge even if checks are green.
-
-## Record your own merge-gate receipt
-
-Immediately after opening the PR, while your worktree is still checked out at
-the exact commit you just pushed, run:
-
-```
-devtools workspace merge-gate record <PR-number> --command "<the focused devtools test command you already ran>"
-```
-
-This is not extra work — it re-runs the same focused test command you already
-verified passes, but ties a receipt to the exact head SHA so the coordinator
-doesn't have to re-check-out your branch and re-run your tests from scratch
-before merging. Do this even though you're not the one merging; the receipt
-is what makes the coordinator's merge fast instead of redundant. If the PR
-gets a real code review comment later and you push a fix commit, there is no
-need to re-record — the coordinator (or a future you) records again at
-whatever the final head ends up being.
+- Commit every completed logical chunk with an accurate conventional subject.
+- Do **not** open an individual PR, create a scope carrier, record a merge-gate receipt, or merge to `master` unless the dispatch explicitly assigns you exclusive ownership of a batch branch. The normal delivery unit is a committed lane branch, which the integration queue assimilates into the shared batch.
+- Reference any assigned Bead with neutral wording only (`Ref polylogue-xxxx` / `Ref #N`). Never use GitHub resolver keywords beside an issue number unless the dispatch explicitly assigns that state transition.
 
 ## Final report
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -378,78 +378,15 @@ Batch changes before verification. Classify unrelated selected failures instead 
 
 Classify every schema change first: durable tier means additive numbered migration plus verified backup manifest; derived tier means canonical DDL plus declared lifecycle delta. Semantic parser changes require `polylogue ops maintenance rebuild-index`; do not add an ad hoc third upgrade path.
 
-### Multi-lane / merge-train tooling — use these, don't reinvent the discipline by hand
+### Parallel lane workflow
 
-Discoverable-only tooling is inert tooling: a command that exists but isn't
-named here is invisible to the next session unless it happens to remember it
-from transcript, so it doesn't get used and the failure mode it exists to
-prevent recurs. These four are load-bearing steps in the fanout/merge-train
-workflow, not optional conveniences — use them at the point named, every time:
+Use tools to eliminate repeated manual steps, not to prove a local ceremony happened. The normal delivery unit is one coherent integration branch, not one PR per implementation lane.
 
-- **When provisioning any lane worktree (spawn time, before dispatch)**:
-  `devtools workspace lane-init <path> --branch <branch> [--beads ids]` —
-  creates worktree+branch, provisions the lane's OWN venv (`uv sync --extra
-  dev`; this expands to the documented `dev-common` + `speed` dependency set;
-  a shared-venv worktree cannot run devtools/pytest at all), guard-verifies
-  imports resolve inside the lane, runs verify-worktree, registers the lane in
-  `.cache/fanout/lanes.jsonl`,
-  and prints the per-lane `POLYLOGUE_PYTEST_WORKERS` budget for the planned
-  concurrency. At 16 lanes this is the difference between lanes that verify
-  and lanes that idle on guard refusals.
-- **Before claiming a batch of ready beads**: `devtools workspace bead-cluster`
-  — footprint/overlap/contention clustering so overlapping-file beads land on
-  one branch instead of colliding across parallel lanes.
-- **When dispatching a worktree-isolated lane**: give the worker the current
-  Bead acceptance criteria, verified file ownership, relevant prior commits,
-  concrete non-goals, and exact verification commands directly. Do not insert
-  a generated Markdown packet between the current evidence and the worker.
-- **Before opening a non-draft PR for a Bead lane**: render the versioned
-  carrier with `devtools workspace pr-scope render --input <scope.json>`, put
-  it in the PR body beside the human whole-Bead disposition matrix, then run
-  `devtools workspace pr-scope check --pr <PR>`. The v2 carrier is stable PR
-  intent: scope kind, assigned and mutated Beads, typed dispositions, evidence
-  refs, and open successors for residual work. It never parses acceptance
-  prose. `devtools workspace pr-scope sync --pr <PR>` reports the current
-  head-bound attestation, including canonical Bead state, without editing the
-  PR body after every commit. `mutated_beads` must name every Bead record this
-  PR changes. A self-contained PR uses the typed `self_contained` scope with
-  empty Bead lists.
-  CircleCI uses `pr-scope check-ci`, resolves PR metadata through public GitHub
-  REST when `CIRCLE_PULL_REQUEST` is absent, and executes the validator from
-  the PR base revision so candidate code cannot weaken validation once that job
-  runs. This is advisory defense-in-depth, not a protected merge authority:
-  this user-owned repository has no required-workflow ruleset, and PR-controlled
-  CI configuration can omit the job. The local merge wrapper is likewise an
-  operational convention, not a security boundary. Do not describe either
-  path as unspoofable or repository-enforced.
-- **Immediately after spawning a worktree-isolated lane, not after it reports
-  back**: `devtools workspace verify-worktree <path> --expect-branch
-  <branch>` — confirms the worktree is real and isolated before the lane has
-  had a chance to run anything. Waiting until the lane reports is too late:
-  the 2026-08-01 incident this check exists for was a silent worktree-escape
-  where ~1700 lines of half-finished output had already landed directly in
-  the coordinator's live tree by the time the lane reported back.
-- **To squash-merge any PR**: use `devtools workspace merge <PR>` instead of
-  a bare `gh pr merge --squash` — it wraps `merge-gate record`/`check` at the
-  actual merge boundary instead of leaving them a step a coordinator must
-  remember. It validates the current non-draft PR's structured scope carrier,
-  then auto-records a receipt if none is fresh for the current head
-  sha (running `--command`, default `devtools verify`), BLOCKs the merge on
-  any `merge-gate check` failure (no fresh receipt, stale receipt, nonzero
-  exit, a changed head-bound scope attestation, an unresolved GitHub review thread, or a changes-requested review), strips a
-  doubled `(#N) (#N)` squash-subject suffix, then runs the actual
-  `gh pr merge --squash`, then records the exact-head scope attestation in the merge ledger. Carrier dispositions are whole-Bead scope declarations, not Beads lifecycle commands: this wrapper never invokes `bd`, mutates Dolt, exports `.beads/issues.jsonl`, or pushes `master`. After a merged PR, run `devtools workspace carrier-dispositions <PR> --base-export <follow-on>/.beads/issues.jsonl --output <follow-on>/.beads/issues.jsonl`: it validates the merged PR/head/attestation and live successor/registry state, applies one guarded `bd batch`, and writes a scoped export plus receipt for a normal follow-on PR. The follow-on uses the typed `carrier_disposition` scope, which binds its changed Beads and copied dispositions to the committed receipt and revalidates the source PR's exact merged carrier. An unledgered external merge may use the explicit `carrier-dispositions recover <PR>` form. It validates the immutable head against the squash parent, records distinct post-merge recovery provenance, and does not retroactively claim pre-merge gate admission. A terminal verify failure does not erase the post-merge ledger reconciliation. `--dry-run` runs every check without merging;
-  `--with-verify` immediately runs and records the merge-train's terminal
-  verify after merging. `devtools workspace merge train-status`
-  reports (exit 1) any PRs merged since the last recorded terminal verify.
-  The terminal step records itself: any plain `devtools verify` that earns
-  release-baseline authority at origin/master writes the ledger entry — no
-  separate record command exists. The lower-level
-  `devtools workspace merge-gate record/check` commands still exist for
-  ad hoc receipt inspection, but the merge action itself should go through
-  `workspace merge`.
-If you build a new tool in this family, add it here in the same sentence —
-a tool without a line in this file is a tool the next session won't use.
+- **Lane bootstrap:** a harness-created lane runs `python -m devtools workspace lane-init "$PWD"` first. The command derives an existing lane branch, provisions and guard-verifies its local venv, and verifies Git isolation. Later `devtools` commands route through that local interpreter automatically. Do not export or repair interpreter variables by hand.
+- **Lane work:** give each lane concrete ownership and focused verification. A lane commits each completed logical chunk and reports its commit plus focused test result. It does not open an individual PR, render a carrier, or run a merge-gate receipt ritual unless it owns an explicitly assigned batch branch.
+- **Integration:** assimilate disjoint lane commits into the current batch branch. Resolve only actual Git, generated-surface, schema-slot, or test-environment conflicts. Use `devtools workspace bead-cluster` as advisory planning, then check actual changed paths before integration. Do not serialize independent implementation behind a coordinator PR queue.
+- **Verification:** lanes run exact focused `devtools test` selectors. Plain `devtools verify` runs the compatible selected testmon set or refuses; it never promotes an unavailable graph into a complete corpus. `devtools verify --all` is an explicit end-of-wave or operator-directed checkpoint.
+- **Publication:** open one PR for a coherent batch. Keep merge automation only where it removes real manual mistakes; do not make receipts, carrier updates, or a complete corpus a per-lane admission requirement. The lane runtime and merge surface are being reduced toward derived Git/job state and batch integration.
 
 ### Coordinator dispatch: no poll loops
 

--- a/devtools/click_dispatch.py
+++ b/devtools/click_dispatch.py
@@ -10,13 +10,19 @@ Generates Click commands from the CommandSpec catalog and preserves:
 from __future__ import annotations
 
 import json as json_mod
+import os
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
 
 import click
 
-from devtools.checkout_guard import CheckoutImportMismatchError, assert_polylogue_matches_checkout
+from devtools.checkout_guard import (
+    CheckoutImportMismatchError,
+    assert_polylogue_matches_checkout,
+    find_git_worktree_root,
+)
 from devtools.command_catalog import (
     COMMAND_SPECS,
     CommandSpec,
@@ -270,10 +276,47 @@ def _is_lane_init_bootstrap(argv: list[str]) -> bool:
     return normalized[:2] == ["workspace", "lane-init"]
 
 
+def _run_from_invoking_lane(argv: list[str]) -> int | None:
+    """Re-exec from an invoking lane's source and interpreter when possible.
+
+    Console scripts installed in the coordinator's editable venv resolve their
+    own modules from that coordinator. A linked worktree is the authority for
+    its source and, after bootstrap, its interpreter. Detecting that boundary
+    here removes the exported-VIRTUAL_ENV ritual from every worker command.
+    """
+    worktree = find_git_worktree_root(Path.cwd())
+    if worktree is None:
+        return None
+    lane_python = worktree / ".venv" / "bin" / "python"
+    if lane_python.is_file() and Path(sys.executable).absolute() != lane_python.absolute():
+        from devtools.lane_init import lane_command_env
+
+        return subprocess.run(
+            [str(lane_python), "-m", "devtools", *argv],
+            cwd=worktree,
+            env=lane_command_env(worktree),
+            check=False,
+        ).returncode
+    if worktree != _REPO_ROOT and _is_lane_init_bootstrap(argv):
+        # No lane interpreter exists yet. Re-enter with ``-m`` from the
+        # worktree so module resolution uses its source before the bootstrap
+        # provenance check allows the one exception to the ordinary guard.
+        return subprocess.run(
+            [sys.executable, "-m", "devtools", *argv],
+            cwd=worktree,
+            env=os.environ.copy(),
+            check=False,
+        ).returncode
+    return None
+
+
 def main(argv: list[str] | None = None) -> int:
     """Entry point for programmatic use of the Click-based devtools CLI."""
 
     command_argv = list(argv or [])
+    lane_exit_code = _run_from_invoking_lane(command_argv)
+    if lane_exit_code is not None:
+        return lane_exit_code
     if not _is_lane_init_bootstrap(command_argv):
         try:
             assert_polylogue_matches_checkout(_REPO_ROOT, context="devtools")

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -425,19 +425,18 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
     CommandSpec(
         "workspace lane-init",
         "workspace",
-        "Provision a fanout lane worktree: branch, isolated venv, guard check, ledger record.",
+        "Provision a lane worktree with an isolated, guard-verified interpreter.",
         "devtools.lane_init",
         use_when=(
-            "Before dispatching a lane in a high-concurrency fanout: creates the worktree/branch "
-            "if missing, provisions its OWN venv via uv sync (a shared-venv worktree cannot run "
-            "devtools/pytest -- checkout guard), proves import polylogue resolves inside the lane, "
-            "runs verify-worktree, appends the lane to .cache/fanout/lanes.jsonl (resumable fanout "
-            "state, polylogue-in94), and prints the per-lane POLYLOGUE_PYTEST_WORKERS budget for "
-            "the planned concurrency."
+            "Before a lane runs repository tooling: creates the worktree/branch if missing, provisions "
+            "its own venv via uv sync, proves import polylogue resolves inside the lane, and runs "
+            "verify-worktree. Existing lanes derive their checked-out branch automatically. Selected "
+            "verification owns shared testmon graph reuse; devtools routes later lane commands through "
+            "the local interpreter without shell exports."
         ),
         examples=(
-            "devtools workspace lane-init /realm/worktrees/lane-cursors --branch feature/sources/cursor-catchup --beads polylogue-2qrx,polylogue-ix5r",
-            "devtools workspace lane-init /realm/worktrees/lane-x --branch feature/x --expected-lanes 16 --json",
+            'python -m devtools workspace lane-init "$PWD"',
+            "devtools workspace lane-init /realm/worktrees/lane-cursors --branch feature/sources/cursor-catchup",
         ),
     ),
     CommandSpec(

--- a/devtools/lane_init.py
+++ b/devtools/lane_init.py
@@ -1,139 +1,38 @@
-"""lane-init: provision a fanout lane worktree that can actually verify itself.
+"""Provision an isolated worktree that executes repository tooling correctly.
 
-High-concurrency fanouts (16+ parallel lanes) have one hard prerequisite this
-command owns end to end: every lane worktree needs its OWN virtualenv, because
-a worktree reusing the main checkout's venv resolves ``import polylogue`` to
-the main checkout (editable-install ``.pth``), and ``devtools verify``/pytest
-correctly refuse to run there (checkout guard, exit 125). Until now the fix
-was a manual multi-minute ``nix develop`` per worktree or skipping lane-side
-verification entirely -- the 2026-08-03 fanout evidence shows neither scales.
-
-One invocation, from the coordinator's checkout:
-
-  1. Creates the worktree + branch if missing (from ``--base``, default
-     ``origin/master``); reuses them if already present.
-  2. Provisions an isolated venv via ``uv sync`` (``--frozen`` when
-     ``uv.lock`` exists), pinned to the coordinator's own interpreter and
-     verified to have actually been built from it. With a warm uv cache this
-     is seconds, not minutes.
-  3. Proves the guard invariant: the lane venv's ``import polylogue`` must
-     resolve inside the lane worktree, else exit non-zero loudly.
-  4. Runs the standard ``verify-worktree`` checks (linked, distinct,
-     expected branch).
-  5. Seeds the coordinator's testmon graph and reports whether it actually
-     covers this lane's environment digest -- a lane whose first verify will
-     bootstrap says so instead of claiming warmth.
-  6. Appends a lane record to the coordinator-side ledger
-     ``.cache/fanout/lanes.jsonl`` (append-only JSONL: lane name, worktree,
-     branch, base sha, bead ids, venv state, timestamp) -- the resumable
-     fanout state polylogue-in94 asks for, seeded here so dispatch/recovery
-     tooling has one place to look.
-  7. Prints the recommended per-lane resource env for the requested
-     concurrency (``POLYLOGUE_PYTEST_WORKERS``) so 16 lanes do not
-     oversubscribe the host by default.
+The command creates or adopts a lane, gives it its own venv pinned to the
+coordinator interpreter, proves the checkout import invariant, and verifies
+that Git recognizes the expected linked worktree. It does not carry testmon
+state, create a lane ledger, or configure an agent shell: selected verification
+owns graph reuse, and the devtools entry point routes later commands through
+the lane interpreter automatically.
 
 Usage:
-    devtools workspace lane-init /realm/worktrees/lane-cursors \\
-        --branch feature/sources/cursor-catchup --beads polylogue-2qrx,polylogue-ix5r
-    devtools workspace lane-init /realm/worktrees/lane-x --branch feature/x --no-venv
+    devtools workspace lane-init /realm/worktrees/lane-cursors --branch feature/sources/cursor-catchup
+    devtools workspace lane-init "$PWD"
 """
 
 from __future__ import annotations
 
 import argparse
-import json
 import os
-import shlex
 import subprocess
 import sys
 from collections.abc import Sequence
-from dataclasses import dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 
 from devtools import repo_root
-
-LEDGER_RELPATH = Path(".cache/fanout/lanes.jsonl")
-
-
-@dataclass(frozen=True, slots=True)
-class LaneEnvironmentAttestation:
-    """The exact native-testmon inputs and candidate environments verify may use."""
-
-    pytest_profile: str
-    pytest_environment: tuple[tuple[str, str | None], ...]
-    digests: tuple[str, ...]
-
-    @property
-    def environment(self) -> dict[str, str | None]:
-        return dict(self.pytest_environment)
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("worktree", help="lane worktree path (created if missing)")
-    parser.add_argument("--branch", required=True, help="lane branch (created from --base if missing)")
+    parser.add_argument(
+        "--branch",
+        help="lane branch (derived from an existing worktree; required when creating one)",
+    )
     parser.add_argument("--base", default="origin/master", help="base ref for a new branch (default: origin/master)")
-    parser.add_argument("--beads", default="", help="comma-separated bead ids this lane owns")
-    parser.add_argument(
-        "--no-venv", action="store_true", help="skip venv provisioning (lane will NOT be able to run devtools/pytest)"
-    )
-    parser.add_argument(
-        "--expected-lanes",
-        type=int,
-        default=16,
-        help="planned concurrent lane count, sizes the per-lane worker hint (default: 16)",
-    )
-    parser.add_argument("--json", action="store_true", dest="as_json", help="emit the lane record as JSON on stdout")
     return parser
-
-
-def recommended_workers(expected_lanes: int, cpu_count: int | None = None) -> int:
-    """Per-lane pytest worker budget: fair CPU share, floor 1, cap 4."""
-    cpus = cpu_count if cpu_count is not None else (os.cpu_count() or 8)
-    if expected_lanes < 1:
-        expected_lanes = 1
-    return max(1, min(4, cpus // expected_lanes))
-
-
-def lane_record(
-    *,
-    worktree: Path,
-    branch: str,
-    base_sha: str,
-    beads: Sequence[str],
-    venv: bool,
-    workers: int,
-) -> dict[str, object]:
-    return {
-        "lane": worktree.name,
-        "worktree": str(worktree),
-        "branch": branch,
-        "base_sha": base_sha,
-        "beads": list(beads),
-        "venv": venv,
-        "pytest_workers": workers,
-        "status": "provisioned",
-        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
-    }
-
-
-def coordinator_root(start: Path) -> Path:
-    """Resolve the MAIN checkout root (ledger home) even when run from a linked worktree."""
-    probe = _run(["git", "-C", str(start), "rev-parse", "--path-format=absolute", "--git-common-dir"])
-    if probe.returncode == 0:
-        common = Path(probe.stdout.strip())
-        if common.name == ".git":
-            return common.parent
-    return start
-
-
-def append_ledger(root: Path, record: dict[str, object]) -> Path:
-    path = root / LEDGER_RELPATH
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as fh:
-        fh.write(json.dumps(record, ensure_ascii=False) + "\n")
-    return path
 
 
 def _run(
@@ -165,6 +64,13 @@ def _ensure_worktree(root: Path, worktree: Path, branch: str, base: str) -> str 
     return None
 
 
+def _checked_out_branch(worktree: Path) -> str | None:
+    """Return an existing worktree's branch, never guessing detached state."""
+    probe = _run(["git", "-C", str(worktree), "branch", "--show-current"])
+    branch = probe.stdout.strip() if probe.returncode == 0 else ""
+    return branch or None
+
+
 def _base_executable_of(python: Path) -> Path | None:
     """Resolve the real interpreter behind a venv's ``python`` shim.
 
@@ -192,10 +98,6 @@ def coordinator_base_interpreter(root: Path) -> Path | None:
        from ``sysconfig``, so ``tests/conftest.py`` fails to import and EVERY
        ``devtools test`` invocation in the lane dies during collection. The
        lane looks provisioned and cannot run a single test.
-    2. The interpreter is an input to the testmon environment digest, so a
-       divergent one guarantees the lane's seeded graph can never match and
-       its first verify pays a full bootstrap (~9.5x a warm run).
-
     Derived from the coordinator's venv rather than hardcoded: the store path
     changes on every nixpkgs bump, and a pinned literal would rot silently
     into the same class of mismatch it exists to prevent.
@@ -274,7 +176,7 @@ def _bootstrap_source_error(root: Path) -> str | None:
     )
 
 
-def _lane_env(worktree: Path) -> dict[str, str]:
+def lane_subprocess_env(worktree: Path) -> dict[str, str]:
     """Return an environment that cannot inherit another checkout's Python."""
     env = os.environ.copy()
     inherited_venv = env.get("VIRTUAL_ENV")
@@ -299,6 +201,16 @@ def _lane_env(worktree: Path) -> dict[str, str]:
     return env
 
 
+def lane_command_env(worktree: Path) -> dict[str, str]:
+    """Return the activated, sanitized environment for an existing lane."""
+    env = lane_subprocess_env(worktree)
+    venv = worktree / ".venv"
+    venv_bin = str(venv / "bin")
+    env["VIRTUAL_ENV"] = str(venv)
+    env["PATH"] = os.pathsep.join((venv_bin, env.get("PATH", "")))
+    return env
+
+
 def _provision_venv(worktree: Path, interpreter: Path | None = None) -> str | None:
     # ``dev`` is the canonical devshell selector in flake.nix; it expands to
     # the same dev-common+speed surface while keeping lane provisioning on the
@@ -310,7 +222,7 @@ def _provision_venv(worktree: Path, interpreter: Path | None = None) -> str | No
         cmd.extend(["--python", str(interpreter)])
     if (worktree / "uv.lock").exists():
         cmd.append("--frozen")
-    result = _run(cmd, cwd=worktree, env=_lane_env(worktree))
+    result = _run(cmd, cwd=worktree, env=lane_subprocess_env(worktree))
     if result.returncode != 0:
         return f"uv sync failed: {result.stderr.strip()[-800:]}"
     return None
@@ -334,355 +246,11 @@ def _guard_check(worktree: Path) -> str | None:
             ),
         ],
         cwd=worktree,
-        env=_lane_env(worktree),
+        env=lane_subprocess_env(worktree),
     )
     if result.returncode != 0:
         return f"lane checkout guard failed: {result.stderr.strip()[-800:]}"
     return None
-
-
-def lane_environment_digest(worktree: Path) -> str | None:
-    """The initial verify environment name this lane's interpreter computes."""
-    attestation = lane_environment_attestation(worktree)
-    return attestation.digests[0] if attestation is not None and attestation.digests else None
-
-
-def lane_environment_attestation(worktree: Path) -> LaneEnvironmentAttestation | None:
-    """Compute the same digest candidates as verify, using the lane interpreter.
-
-    Verify first prepares the normalized ambient environment. If that candidate
-    bootstraps with a non-default Hypothesis profile, it explicitly retries
-    with ``HYPOTHESIS_PROFILE=default``. Lane seeding must accept either
-    candidate, but only after validating the graph and its completion
-    certificate; otherwise a seed can claim warmth for a graph verify will not
-    attest.
-    """
-    python = worktree / ".venv" / "bin" / "python"
-    if not python.exists():
-        return None
-    probe = _run(
-        [
-            str(python),
-            "-c",
-            (
-                "import json; "
-                "from pathlib import Path; "
-                "from devtools.testmon_bootstrap import testmon_environment_digest; "
-                "from devtools.verify import _native_pytest_environment_candidates, _pytest_profile; "
-                "profile = _pytest_profile(); "
-                "candidates = _native_pytest_environment_candidates(); "
-                "digests = [testmon_environment_digest(Path.cwd(), pytest_profile=profile, "
-                "pytest_environment=environment) for environment in candidates]; "
-                "print(json.dumps({'pytest_profile': profile, 'pytest_environment': candidates[0], "
-                "'digests': list(dict.fromkeys(digests))}, sort_keys=True))"
-            ),
-        ],
-        cwd=worktree,
-        env=_lane_env(worktree),
-    )
-    if probe.returncode != 0:
-        return None
-    try:
-        payload = json.loads(probe.stdout)
-    except (json.JSONDecodeError, TypeError):
-        return None
-    if not isinstance(payload, dict):
-        return None
-    profile = payload.get("pytest_profile")
-    raw_environment = payload.get("pytest_environment")
-    raw_digests = payload.get("digests")
-    if not isinstance(profile, str) or not isinstance(raw_environment, dict) or not isinstance(raw_digests, list):
-        return None
-    expected_keys = {"HYPOTHESIS_PROFILE", "POLYLOGUE_CI"}
-    if set(raw_environment) != expected_keys:
-        return None
-    environment: list[tuple[str, str | None]] = []
-    for key in ("HYPOTHESIS_PROFILE", "POLYLOGUE_CI"):
-        value = raw_environment[key]
-        if value is not None and not isinstance(value, str):
-            return None
-        environment.append((key, value))
-    digests = tuple(value for value in raw_digests if isinstance(value, str) and value)
-    if not digests or len(digests) != len(raw_digests):
-        return None
-    return LaneEnvironmentAttestation(profile, tuple(environment), tuple(dict.fromkeys(digests)))
-
-
-def _seed_testmon_graph(
-    root: Path,
-    worktree: Path,
-    *,
-    attestation: LaneEnvironmentAttestation | None = None,
-) -> tuple[str, bool]:
-    """Seed a lane while serializing source and destination testmon state."""
-    if not root.exists():
-        return "no coordinator graph to seed (first lane verify will bootstrap)", False
-    from devtools.testmon_bootstrap import (
-        NativeTestmonRepairError,
-        _validate_owned_state_parents,
-        native_testmon_lifecycle_lock,
-    )
-
-    try:
-        _validate_owned_state_parents(root)
-        _validate_owned_state_parents(worktree)
-    except NativeTestmonRepairError as exc:
-        return f"graph seed refused unsafe owned testmon path ({exc}); first lane verify will bootstrap", False
-
-    try:
-        # Verify holds the lane lock while it briefly acquires the common
-        # source lock. Match that order here so a concurrent seed cannot hold
-        # the common lock while waiting for this lane.
-        with (
-            native_testmon_lifecycle_lock(worktree, waiter_label="lane-init"),
-            native_testmon_lifecycle_lock(root, waiter_label="lane-init"),
-        ):
-            return _seed_testmon_graph_unlocked(root, worktree, attestation=attestation)
-    except NativeTestmonRepairError as exc:
-        return f"graph seed refused unsafe owned testmon path ({exc}); first lane verify will bootstrap", False
-
-
-def _seed_testmon_graph_unlocked(
-    root: Path,
-    worktree: Path,
-    *,
-    attestation: LaneEnvironmentAttestation | None = None,
-) -> tuple[str, bool]:
-    """Copy the coordinator's testmon graph into a lane, and say whether it helps.
-
-    Returns ``(note, warm)``. ``warm`` is True only when the copied graph
-    actually contains an environment matching the digest THIS LANE computes --
-    which is the only thing that makes a lane's first verify an
-    affected-selection run instead of a complete-corpus bootstrap.
-
-    This used to report "seeded from main checkout (lane verifies start warm)"
-    whenever the file copy succeeded, which is a claim about the wrong fact. A
-    graph is useless to a lane unless it carries that lane's environment, and
-    a copy can succeed while carrying none: the digest is invalidated by an
-    interpreter change, a dependency bump, or an edit to ``tests/**/conftest.py``
-    or ``devtools/pytest*.py``, so after any of those the coordinator's own
-    graph goes stale for the coordinator too. Advertising warmth there sends a
-    lane into a ~45-minute bootstrap it was told to expect in seconds
-    (polylogue-l218h).
-
-    A cold seed is reported, not fatal. A stale graph is the NORMAL state
-    right after a dependency bump or conftest edit, and refusing to provision
-    would break every lane for an expected condition; the honest note plus the
-    ``testmon_warm`` field in the ledger record is what lets a coordinator
-    decide to bootstrap once centrally instead of per lane.
-    """
-    from devtools.testmon_bootstrap import (
-        TESTMON_DATA_RELPATH,
-        NativeTestmonRepairError,
-        _atomic_copy_sqlite_database,
-        _validate_owned_state_parents,
-        certified_attestation_violation,
-        inspect_native_testmon_environment,
-        native_testmon_fallback_allowed,
-        native_testmon_source_binding,
-        read_certified_corpus,
-        validate_native_testmon_state_ownership,
-    )
-
-    source = root / TESTMON_DATA_RELPATH
-    if not source.is_file():
-        return "no coordinator graph to seed (first lane verify will bootstrap)", False
-    destination = worktree / TESTMON_DATA_RELPATH
-    try:
-        _validate_owned_state_parents(root)
-        _validate_owned_state_parents(worktree)
-        validate_native_testmon_state_ownership(root)
-        validate_native_testmon_state_ownership(worktree)
-    except NativeTestmonRepairError as exc:
-        return f"graph seed refused unsafe owned testmon path ({exc}); first lane verify will bootstrap", False
-
-    if attestation is None:
-        attestation = lane_environment_attestation(worktree)
-    if attestation is None:
-        return ("seeded graph but could not compute verify's normalized digest inputs; warmth unverified"), False
-
-    initial_digest = attestation.digests[0]
-    destination_states = tuple(
-        (
-            digest,
-            inspect_native_testmon_environment(destination, environment_name=digest),
-        )
-        for digest in attestation.digests
-    )
-    destination_initial_state = destination_states[0][1]
-    with native_testmon_source_binding(source) as source_binding:
-        if source_binding is None:
-            return "coordinator graph disappeared before descriptor binding; first lane verify will bootstrap", False
-        source_fd = source_binding.descriptor
-        bound_sidecar_fds = dict(source_binding.sidecar_descriptors)
-        initial_state = inspect_native_testmon_environment(
-            source,
-            environment_name=initial_digest,
-            data_fd=source_fd,
-            bound_data_path=source_binding.data_path,
-            bound_sidecar_fds=bound_sidecar_fds,
-        )
-        source_state_for_copy = initial_state
-        copy_digest: str | None = initial_digest if initial_state.valid else None
-        if destination_initial_state.valid and destination_initial_state.environment is not None:
-            destination_violation = certified_attestation_violation(
-                worktree,
-                environment_name=initial_digest,
-                current_nodeids=destination_initial_state.environment.nodeids,
-            )
-            if destination_violation is None:
-                return (
-                    f"preserved certified lane environment ({initial_digest[:24]}...); verifies start warm",
-                    True,
-                )
-
-        fallback_allowed = native_testmon_fallback_allowed(destination_initial_state, initial_state)
-        if fallback_allowed:
-            for candidate_digest, destination_state in destination_states[1:]:
-                if destination_state.valid and destination_state.environment is not None:
-                    destination_violation = certified_attestation_violation(
-                        worktree,
-                        environment_name=candidate_digest,
-                        current_nodeids=destination_state.environment.nodeids,
-                    )
-                    if destination_violation is None:
-                        return (
-                            f"preserved certified lane environment ({candidate_digest[:24]}...); verifies start warm",
-                            True,
-                        )
-
-        if copy_digest is None and len(attestation.digests) > 1:
-            if not fallback_allowed:
-                return (
-                    "seeded graph's initial verify environment is invalid and not attestable; "
-                    "refusing the default-profile fallback; "
-                    "first lane verify will bootstrap",
-                    False,
-                )
-            if initial_state.status in {"absent", "incomplete"}:
-                fallback_digest = attestation.digests[1]
-                fallback_state = inspect_native_testmon_environment(
-                    source,
-                    environment_name=fallback_digest,
-                    data_fd=source_fd,
-                    bound_data_path=source_binding.data_path,
-                    bound_sidecar_fds=bound_sidecar_fds,
-                )
-                if fallback_state.valid:
-                    copy_digest = fallback_digest
-                    source_state_for_copy = fallback_state
-        if copy_digest is None and initial_state.status == "invalid":
-            # Structural inspection cannot expose node ids when the source
-            # certificate table has gone missing.  It is still important to
-            # preserve that more specific fail-closed reason: no graph may be
-            # published from a source with no completed-corpus certificate.
-            if read_certified_corpus(source_binding.data_path, initial_digest) is None:
-                return (
-                    "coordinator graph is not certified for the selected environment "
-                    "(no completed covered run has certified this environment's corpus); "
-                    "first lane verify will bootstrap",
-                    False,
-                )
-            return (
-                "seeded graph's initial verify environment is invalid and not attestable; first lane verify will bootstrap",
-                False,
-            )
-        if copy_digest is None:
-            return (
-                "seeded graph is not attestable for verify's environment candidates; "
-                "no valid candidate; first lane verify will bootstrap",
-                False,
-            )
-
-        if not source_state_for_copy.valid or source_state_for_copy.environment is None:
-            return (
-                "coordinator graph is not attestable for the selected environment; first lane verify will bootstrap",
-                False,
-            )
-        source_violation = certified_attestation_violation(
-            root,
-            environment_name=copy_digest,
-            current_nodeids=source_state_for_copy.environment.nodeids,
-            certificate_data_path=source_binding.data_path,
-        )
-        if source_violation is not None:
-            return (
-                f"coordinator graph is not certified for the selected environment ({source_violation}); "
-                "first lane verify will bootstrap",
-                False,
-            )
-
-        try:
-            _atomic_copy_sqlite_database(
-                source,
-                destination,
-                environment_name=copy_digest,
-                required_executable_paths=(),
-                deadline_monotonic=None,
-                source_fd=source_binding.descriptor,
-                bound_source_path=source_binding.data_path,
-            )
-        except NativeTestmonRepairError as exc:
-            return f"graph seed failed ({exc}); first lane verify will bootstrap", False
-
-        failures: list[str] = []
-        for digest in attestation.digests:
-            state = inspect_native_testmon_environment(destination, environment_name=digest)
-            if not state.valid or state.environment is None:
-                failures.append(f"{digest[:24]}...: {state.reason}")
-                continue
-            violation = certified_attestation_violation(
-                worktree,
-                environment_name=digest,
-                current_nodeids=state.environment.nodeids,
-            )
-            if violation is not None:
-                failures.append(f"{digest[:24]}...: {violation}")
-                continue
-            suffix = " (verify default-profile fallback)" if digest != attestation.digests[0] else ""
-            return f"seeded and certified this lane environment ({digest[:24]}...){suffix}; verifies start warm", True
-    detail = "; ".join(failures) if failures else "no candidate environment"
-    return (
-        f"seeded graph is not attestable for verify's environment candidates ({detail}); first lane verify will bootstrap",
-        False,
-    )
-
-
-def dispatch_env_lines(
-    worktree: Path,
-    *,
-    attestation: LaneEnvironmentAttestation | None = None,
-) -> tuple[str, ...]:
-    """Environment a dispatched agent must apply before running lane tooling.
-
-    ``_lane_env`` only sanitises the subprocesses lane-init itself spawns. An
-    agent that later opens this worktree inherits the operator's or harness's
-    environment untouched, so the same interpreter-describing variables that
-    would have broken provisioning break its very first ``devtools test``
-    instead. Printing the remedy next to the worker budget is the only place a
-    dispatcher reliably reads.
-    """
-    lines = [f"export VIRTUAL_ENV={worktree / '.venv'}", 'export PATH="$VIRTUAL_ENV/bin:$PATH"']
-    lines.extend(f"unset {key}" for key in _LANE_ENV_UNSETS if key != "VIRTUAL_ENV")
-    lines.append(f"export UV_PROJECT_ENVIRONMENT={worktree / '.venv'}")
-    if attestation is None:
-        attestation = lane_environment_attestation(worktree)
-    if attestation is None:
-        lines.append("echo 'lane-init: cannot compute normalized testmon digest inputs; do not run verify' >&2")
-        lines.append("false")
-    else:
-        for key, value in attestation.pytest_environment:
-            if value is None:
-                lines.append(f"unset {key}")
-            else:
-                lines.append(f"export {key}={shlex.quote(value)}")
-        lines.append(f"# testmon pytest profile: {shlex.quote(attestation.pytest_profile)}")
-        if len(attestation.digests) > 1:
-            lines.append("# testmon fallback: HYPOTHESIS_PROFILE=default after a non-default bootstrap")
-    # gh / pr-scope reach GitHub over TLS; a devshell without this resolves no
-    # CA bundle and every API call fails with a certificate error.
-    lines.append("export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt")
-    return tuple(lines)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -692,86 +260,61 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"lane-init: {error}", file=sys.stderr)
         return 125
     worktree = Path(args.worktree).resolve()
-    beads = [b.strip() for b in args.beads.split(",") if b.strip()]
+    branch = args.branch
+    if branch is None:
+        branch = _checked_out_branch(worktree) if worktree.exists() else None
+        if branch is None:
+            print(
+                "lane-init: --branch is required when creating a worktree or initializing a detached checkout",
+                file=sys.stderr,
+            )
+            return 2
 
-    error = _ensure_worktree(root, worktree, args.branch, args.base)
+    error = _ensure_worktree(root, worktree, branch, args.base)
     if error:
         print(f"lane-init: {error}", file=sys.stderr)
         return 1
 
-    interpreter = None if args.no_venv else coordinator_base_interpreter(root)
-    if not args.no_venv:
-        error = _provision_venv(worktree, interpreter)
+    interpreter = coordinator_base_interpreter(root)
+    error = _provision_venv(worktree, interpreter)
+    if error:
+        print(f"lane-init: {error}", file=sys.stderr)
+        return 1
+    if interpreter is not None:
+        error = _interpreter_guard(worktree, interpreter)
         if error:
             print(f"lane-init: {error}", file=sys.stderr)
             return 1
-        if interpreter is not None:
-            error = _interpreter_guard(worktree, interpreter)
-            if error:
-                print(f"lane-init: {error}", file=sys.stderr)
-                return 1
-        error = _guard_check(worktree)
-        if error:
-            print(f"lane-init: {error}", file=sys.stderr)
-            return 1
+    error = _guard_check(worktree)
+    if error:
+        print(f"lane-init: {error}", file=sys.stderr)
+        return 1
 
-    verify_python = worktree / ".venv" / "bin" / "python" if not args.no_venv else Path(sys.executable)
     verify = _run(
         [
-            str(verify_python),
+            str(worktree / ".venv" / "bin" / "python"),
             "-m",
             "devtools",
             "workspace",
             "verify-worktree",
             str(worktree),
             "--expect-branch",
-            args.branch,
+            branch,
         ],
-        cwd=worktree if not args.no_venv else root,
-        env=_lane_env(worktree) if not args.no_venv else None,
+        cwd=worktree,
+        env=lane_subprocess_env(worktree),
     )
     if verify.returncode != 0:
         sys.stderr.write(verify.stdout + verify.stderr)
         print("lane-init: verify-worktree failed", file=sys.stderr)
         return 1
 
-    attestation = lane_environment_attestation(worktree) if not args.no_venv else None
-    graph_note, graph_warm = _seed_testmon_graph(root, worktree, attestation=attestation)
     base_sha = _run(["git", "-C", str(worktree), "rev-parse", "--short=9", "HEAD"]).stdout.strip()
-    workers = recommended_workers(args.expected_lanes)
-    record = lane_record(
-        worktree=worktree,
-        branch=args.branch,
-        base_sha=base_sha,
-        beads=beads,
-        venv=not args.no_venv,
-        workers=workers,
-    )
-    record["testmon_graph"] = graph_note
-    record["testmon_warm"] = graph_warm
-    record["interpreter"] = str(interpreter) if interpreter is not None else None
-    record["dispatch_env"] = list(dispatch_env_lines(worktree, attestation=attestation))
-    ledger_path = append_ledger(coordinator_root(root), record)
-
-    if args.as_json:
-        print(json.dumps(record, ensure_ascii=False, indent=2))
-    else:
-        print(f"lane ready: {worktree}")
-        print(f"  branch: {args.branch} @ {base_sha}")
-        print(
-            f"  venv: {'provisioned (guard-verified)' if not args.no_venv else 'SKIPPED -- lane cannot run devtools/pytest'}"
-        )
-        if interpreter is not None:
-            print(f"  interpreter: {interpreter} (verified)")
-        print(f"  testmon graph: {graph_note}")
-        if not graph_warm and not args.no_venv:
-            print("  NOTE: this lane's first devtools verify will be a complete-corpus bootstrap.")
-        if beads:
-            print(f"  beads: {', '.join(beads)}")
-        print(f"  ledger: {ledger_path}")
-        print(f"  dispatch env: POLYLOGUE_PYTEST_WORKERS={workers}  (for {args.expected_lanes} concurrent lanes)")
-        for line in dispatch_env_lines(worktree, attestation=attestation):
-            print(f"    {line}")
+    print(f"lane ready: {worktree}")
+    print(f"  branch: {branch} @ {base_sha}")
+    print("  venv: provisioned (guard-verified)")
+    if interpreter is not None:
+        print(f"  interpreter: {interpreter} (verified)")
     return 0
 
 

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -166,7 +166,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools workspace dev-loop` | Preflight branch-local daemon, web-shell, and browser-capture development loops. |
 | `devtools workspace failure-context` | Join testmon, git history, and fixtures for a pytest failure ID into a JSON envelope. |
 | `devtools workspace index-fast-forward` | Plan and prove a declared index fast-forward against retained raw replay. |
-| `devtools workspace lane-init` | Provision a fanout lane worktree: branch, isolated venv, guard check, ledger record. |
+| `devtools workspace lane-init` | Provision a lane worktree with an isolated, guard-verified interpreter. |
 | `devtools workspace lineage-validation` | Validate lineage-count evidence before citing archive counts externally. |
 | `devtools workspace merge` | Merge boundary wrapper: refuses `gh pr merge` without a fresh exact-head receipt, then records the carrier attestation in the merge ledger. |
 | `devtools workspace merge-gate` | Structural pre-merge safety check: fresh local verification + resolved review threads. |

--- a/tests/unit/devtools/test_lane_init.py
+++ b/tests/unit/devtools/test_lane_init.py
@@ -1,19 +1,16 @@
 from __future__ import annotations
 
-import json
 import os
 import shutil
 import subprocess
 import sys
-import threading
 from collections.abc import Sequence
-from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from subprocess import CompletedProcess
 
 import pytest
 
-from devtools import lane_init, testmon_bootstrap, verify
+from devtools import lane_init
 
 
 def _write_minimal_uv_project(root: Path) -> None:
@@ -37,33 +34,6 @@ build-backend = "setuptools.build_meta"
 """,
         encoding="utf-8",
     )
-
-
-def test_recommended_workers_fair_share_floor_and_cap() -> None:
-    assert lane_init.recommended_workers(16, cpu_count=24) == 1
-    assert lane_init.recommended_workers(8, cpu_count=24) == 3
-    assert lane_init.recommended_workers(2, cpu_count=24) == 4  # capped
-    assert lane_init.recommended_workers(0, cpu_count=24) == 4  # clamped lanes
-    assert lane_init.recommended_workers(64, cpu_count=24) == 1  # floor
-
-
-def test_lane_record_shape_and_ledger_append(tmp_path: Path) -> None:
-    record = lane_init.lane_record(
-        worktree=tmp_path / "lane-x",
-        branch="feature/x",
-        base_sha="abc123def",
-        beads=["polylogue-aaa", "polylogue-bbb"],
-        venv=True,
-        workers=2,
-    )
-    assert record["lane"] == "lane-x"
-    assert record["status"] == "provisioned"
-    assert record["beads"] == ["polylogue-aaa", "polylogue-bbb"]
-    path = lane_init.append_ledger(tmp_path, record)
-    lane_init.append_ledger(tmp_path, record)
-    assert path == tmp_path / lane_init.LEDGER_RELPATH
-    lines = [json.loads(line) for line in path.read_text().splitlines()]
-    assert len(lines) == 2 and lines[0]["branch"] == "feature/x"
 
 
 def test_guard_check_rejects_a_true_foreign_environment(tmp_path: Path) -> None:
@@ -139,7 +109,7 @@ def test_lane_env_removes_the_inherited_venv_bin_from_path(tmp_path: Path, monke
     monkeypatch.setenv("VIRTUAL_ENV", str(coordinator / ".venv"))
     monkeypatch.setenv("PATH", os.pathsep.join((str(foreign_bin), str(retained_bin), str(foreign_bin))))
 
-    env = lane_init._lane_env(lane)
+    env = lane_init.lane_subprocess_env(lane)
 
     assert env["PATH"] == str(retained_bin)
     assert "VIRTUAL_ENV" not in env
@@ -157,6 +127,19 @@ def test_main_refuses_foreign_lane_init_implementation_before_writing(
 
     assert lane_init.main([str(root / "child"), "--branch", "feature/test/lane"]) == 125
     assert "implementation belongs to a different checkout" in capsys.readouterr().err
+
+
+def test_main_requires_branch_only_when_it_must_create_a_worktree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    monkeypatch.setattr(lane_init, "repo_root", lambda: root)
+    monkeypatch.setattr(lane_init, "_implementation_root", lambda: root)
+    monkeypatch.setattr(lane_init, "_ensure_worktree", lambda *_args: pytest.fail("must not create a worktree"))
+
+    assert lane_init.main([str(root / "missing-lane")]) == 2
+    assert "--branch is required when creating a worktree" in capsys.readouterr().err
 
 
 def test_provision_venv_ignores_inherited_uv_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -178,8 +161,8 @@ def test_main_provisions_and_verifies_a_real_lane_from_a_poisoned_coordinator(tm
     The outer process also names that coordinator in every Python and uv
     routing variable. A successful run therefore proves that lane-init creates
     the linked worktree, provisions its venv, runs the shared checkout guard,
-    invokes verify-worktree through the lane interpreter, and appends its
-    ledger without using coordinator code or environment state.
+    invokes verify-worktree through the lane interpreter without using
+    coordinator code or environment state.
 
     Mutation proof: restoring the former coordinator interpreter/environment
     route executes the coordinator canary and makes lane-init fail. Removing
@@ -232,12 +215,6 @@ def test_main_provisions_and_verifies_a_real_lane_from_a_poisoned_coordinator(tm
     assert (lane / ".git").is_file()
     lane_python = lane / ".venv" / "bin" / "python"
     assert lane_python.is_file()
-
-    ledger = coordinator / lane_init.LEDGER_RELPATH
-    record = json.loads(ledger.read_text(encoding="utf-8").splitlines()[-1])
-    assert record["worktree"] == str(lane)
-    assert record["branch"] == "feature/test/real-lane"
-    assert record["venv"] is True
 
     foreign_guard = subprocess.run(
         [
@@ -302,8 +279,6 @@ def test_public_lane_init_bootstraps_an_existing_lane_with_inherited_coordinator
             "workspace",
             "lane-init",
             str(lane),
-            "--branch",
-            branch,
         ],
         cwd=lane,
         env=poisoned_env,
@@ -315,129 +290,23 @@ def test_public_lane_init_bootstraps_an_existing_lane_with_inherited_coordinator
     assert "lane ready:" in result.stdout
     assert (lane / ".venv" / "bin" / "python").is_file()
 
-
-def test_lane_warm_claim_is_revalidated_after_distribution_drift(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The real lane boundary refuses a graph after its distribution set drifts.
-
-    The lane is provisioned and attested through its own interpreter, then
-    ``lane_init.main`` seeds it from a certified coordinator graph.  A second
-    lane-interpreter subprocess adds an installed distribution after that warm
-    claim.  Verifier preparation must recompute the lane digest and go cold;
-    a coordinator-process preparation or mocked attestation would miss this.
-    """
-
-    coordinator = tmp_path / "coordinator"
-    lane = tmp_path / "lane"
-    project_root = Path(__file__).resolve().parents[3]
-    subprocess.run(
-        ["git", "clone", "--shared", str(project_root), str(coordinator)],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    monkeypatch.setenv("HYPOTHESIS_PROFILE", "default")
-    monkeypatch.delenv("POLYLOGUE_CI", raising=False)
-    branch = "feature/test/seeded-verifier"
-    assert lane_init._ensure_worktree(coordinator, lane, branch, "HEAD") is None
-    coordinator_python = Path(sys.executable)
-    coordinator_interpreter = lane_init.coordinator_base_interpreter(coordinator)
-    assert coordinator_interpreter is not None
-    assert lane_init._provision_venv(lane, coordinator_interpreter) is None
-    attestation = lane_init.lane_environment_attestation(lane)
-    assert attestation is not None
-    _certified_graph_with_names(coordinator, attestation.digests)
-
-    poisoned_env = os.environ | {
-        "VIRTUAL_ENV": str(coordinator / ".venv"),
-        "PYTHONPATH": str(coordinator),
-        "UV_PROJECT": str(coordinator),
-        "UV_WORKING_DIR": str(coordinator),
-    }
-    main_driver = "from devtools.lane_init import main; import sys; raise SystemExit(main(sys.argv[1:]))"
-    main_result = subprocess.run(
+    rerouted = subprocess.run(
         [
             str(coordinator_python),
-            "-c",
-            main_driver,
+            "-m",
+            "devtools",
+            "workspace",
+            "verify-worktree",
             str(lane),
-            "--branch",
+            "--expect-branch",
             branch,
-            "--base",
-            "HEAD",
-            "--json",
         ],
-        cwd=coordinator,
+        cwd=lane,
         env=poisoned_env,
         capture_output=True,
         text=True,
     )
-    assert main_result.returncode == 0, main_result.stdout + main_result.stderr
-
-    record = json.loads((coordinator / lane_init.LEDGER_RELPATH).read_text(encoding="utf-8").splitlines()[-1])
-    assert record["testmon_warm"] is True
-    lane_python = lane / ".venv" / "bin" / "python"
-    assert lane_python.is_file()
-    drift_driver = (
-        "from pathlib import Path; "
-        "import sysconfig; "
-        "root = Path(sysconfig.get_paths()['purelib']) / 'polylogue_lane_drift-0.0.0.dist-info'; "
-        "root.mkdir(); "
-        "(root / 'METADATA').write_text('Metadata-Version: 2.1\\nName: polylogue-lane-drift\\nVersion: 0.0.0\\n')"
-    )
-    drift_result = subprocess.run(
-        [str(lane_python), "-P", "-c", drift_driver],
-        cwd=lane,
-        env=lane_init._lane_env(lane),
-        capture_output=True,
-        text=True,
-    )
-    assert drift_result.returncode == 0, drift_result.stdout + drift_result.stderr
-    drift_attestation_driver = (
-        "import json; "
-        "from pathlib import Path; "
-        "from devtools.lane_init import lane_environment_attestation; "
-        "attestation = lane_environment_attestation(Path.cwd()); "
-        "assert attestation is not None; "
-        "print(json.dumps({'digests': list(attestation.digests)}))"
-    )
-    drift_attestation_result = subprocess.run(
-        [str(lane_python), "-P", "-c", drift_attestation_driver],
-        cwd=lane,
-        env=lane_init._lane_env(lane),
-        capture_output=True,
-        text=True,
-    )
-    assert drift_attestation_result.returncode == 0, drift_attestation_result.stdout + drift_attestation_result.stderr
-    drift_attestation = json.loads(drift_attestation_result.stdout)
-    assert drift_attestation["digests"][0] != attestation.digests[0]
-    preparation_driver = (
-        "import json; "
-        "from pathlib import Path; "
-        "from devtools.testmon_bootstrap import prepare_native_testmon_environment; "
-        "preparation = prepare_native_testmon_environment("
-        "Path.cwd(), pytest_profile='correctness=complete', "
-        "pytest_environment={'HYPOTHESIS_PROFILE': 'default', 'POLYLOGUE_CI': None}); "
-        "print(json.dumps({'environment_name': preparation.environment_name, "
-        "'selection_mode': preparation.selection_mode, "
-        "'local_status': preparation.local_state.status, "
-        "'copied_from': preparation.copied_from is not None}))"
-    )
-    preparation_result = subprocess.run(
-        [str(lane_python), "-P", "-c", preparation_driver],
-        cwd=lane,
-        env=lane_init._lane_env(lane),
-        capture_output=True,
-        text=True,
-    )
-    assert preparation_result.returncode == 0, preparation_result.stdout + preparation_result.stderr
-    preparation = json.loads(preparation_result.stdout)
-    assert preparation["environment_name"] == drift_attestation["digests"][0]
-    assert preparation["selection_mode"] == "bootstrap"
-    assert preparation["local_status"] in {"absent", "invalid"}
-    assert preparation["copied_from"] is False
+    assert rerouted.returncode == 0, rerouted.stdout + rerouted.stderr
 
 
 # ---------------------------------------------------------------------------
@@ -529,86 +398,6 @@ def test_provision_venv_uses_the_canonical_devshell_extra(tmp_path: Path, monkey
     assert command[4:] == []
 
 
-def test_lane_environment_digest_uses_the_verify_digest_contract(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    lane = tmp_path / "lane"
-    python = lane / ".venv" / "bin" / "python"
-    python.parent.mkdir(parents=True)
-    python.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
-    python.chmod(0o755)
-    captured: dict[str, object] = {}
-
-    def fake_run(
-        cmd: Sequence[str],
-        *,
-        cwd: Path | None = None,
-        env: dict[str, str] | None = None,
-    ) -> CompletedProcess[str]:
-        captured["cmd"] = list(cmd)
-        return CompletedProcess(
-            cmd,
-            0,
-            json.dumps(
-                {
-                    "pytest_profile": "correctness=complete",
-                    "pytest_environment": {"HYPOTHESIS_PROFILE": "default", "POLYLOGUE_CI": None},
-                    "digests": ["polylogue-current"],
-                }
-            )
-            + "\n",
-            "",
-        )
-
-    monkeypatch.setattr(lane_init, "_run", fake_run)
-
-    assert lane_init.lane_environment_digest(lane) == "polylogue-current"
-    command = captured["cmd"]
-    assert isinstance(command, list)
-    probe = command[-1]
-    assert isinstance(probe, str)
-    assert "_native_pytest_environment_candidates" in probe
-    assert "initial.get('HYPOTHESIS_PROFILE')" not in probe
-
-
-def test_lane_environment_attestation_includes_verify_default_fallback(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    lane = tmp_path / "lane"
-    python = lane / ".venv" / "bin" / "python"
-    python.parent.mkdir(parents=True)
-    python.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
-    python.chmod(0o755)
-
-    def fake_run(
-        cmd: Sequence[str],
-        *,
-        cwd: Path | None = None,
-        env: dict[str, str] | None = None,
-    ) -> CompletedProcess[str]:
-        return CompletedProcess(
-            cmd,
-            0,
-            json.dumps(
-                {
-                    "pytest_profile": "correctness=complete",
-                    "pytest_environment": {"HYPOTHESIS_PROFILE": "ci", "POLYLOGUE_CI": "1"},
-                    "digests": ["polylogue-initial", "polylogue-default"],
-                }
-            ),
-            "",
-        )
-
-    monkeypatch.setattr(lane_init, "_run", fake_run)
-    attestation = lane_init.lane_environment_attestation(lane)
-
-    assert attestation is not None
-    assert attestation.digests == ("polylogue-initial", "polylogue-default")
-    assert attestation.environment == {"HYPOTHESIS_PROFILE": "ci", "POLYLOGUE_CI": "1"}
-
-
 def test_verify_candidate_helper_preserves_deliberate_profile_and_ci(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -682,588 +471,6 @@ def test_coordinator_base_interpreter_falls_back_to_the_running_interpreter(tmp_
 
 
 # ---------------------------------------------------------------------------
-# Graph seeding reports warmth honestly (polylogue-l218h)
-# ---------------------------------------------------------------------------
-
-
-def _graph_with(path: Path, environments: Sequence[str]) -> Path:
-    import sqlite3
-
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with sqlite3.connect(path) as conn:
-        conn.execute("CREATE TABLE environment (environment_name TEXT)")
-        conn.executemany("INSERT INTO environment VALUES (?)", [(name,) for name in environments])
-    return path
-
-
-def _certified_graph_with(path: Path, environment_name: str) -> Path:
-    return _certified_graph_with_names(path, [environment_name])
-
-
-def _certified_graph_with_names(
-    path: Path,
-    environment_names: Sequence[str],
-    recorded_test_name: str = "tests/test_recorded.py::test_recorded",
-) -> Path:
-    import testmon.db
-
-    from devtools.testmon_bootstrap import TESTMON_DATA_RELPATH, write_certified_corpus
-
-    data = path / TESTMON_DATA_RELPATH
-    data.parent.mkdir(parents=True, exist_ok=True)
-    recorded_test_path = recorded_test_name.split("::", 1)[0]
-    (path / recorded_test_path).parent.mkdir(parents=True, exist_ok=True)
-    (path / recorded_test_path).write_text("def test_recorded(): pass\n", encoding="utf-8")
-    db = testmon.db.DB(str(data))
-    try:
-        con = db.con
-        fingerprint_id = con.execute(
-            "INSERT INTO file_fp (filename, method_checksums, mtime, fsha) VALUES (?, ?, ?, ?)",
-            (recorded_test_path, b"", 0.0, ""),
-        ).lastrowid
-        for index, environment_name in enumerate(environment_names):
-            environment_id = con.execute(
-                "INSERT INTO environment (environment_name, system_packages, python_version) VALUES (?, ?, ?)",
-                (environment_name, f"packages-{index}", "3.14"),
-            ).lastrowid
-            execution_id = con.execute(
-                "INSERT INTO test_execution (environment_id, test_name, duration, failed, forced) VALUES (?, ?, ?, ?, ?)",
-                (environment_id, recorded_test_name, 0.01, 0, 0),
-            ).lastrowid
-            con.execute(
-                "INSERT INTO test_execution_file_fp (test_execution_id, fingerprint_id) VALUES (?, ?)",
-                (execution_id, fingerprint_id),
-            )
-        con.commit()
-    finally:
-        db.con.close()
-
-    for environment_name in set(environment_names):
-        assert write_certified_corpus(path, environment_name, [recorded_test_name])
-    return data
-
-
-def _attestation(*digests: str, profile: str = "correctness=complete") -> lane_init.LaneEnvironmentAttestation:
-    return lane_init.LaneEnvironmentAttestation(
-        profile,
-        (("HYPOTHESIS_PROFILE", "default"), ("POLYLOGUE_CI", None)),
-        digests,
-    )
-
-
-def test_seed_reports_cold_when_the_graph_lacks_this_lanes_environment(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """RED TWIN: a stale seed must NOT advertise warmth.
-
-    This is the exact 2026-08-19 shape: the copy succeeds and the graph is
-    perfectly valid, but it holds only environments from before a dependency
-    bump / conftest edit, so the lane's first verify is a complete-corpus
-    bootstrap. Restoring the unconditional
-    ``"seeded from main checkout (lane verifies start warm)"`` return makes
-    this fail, because ``warm`` comes back True and the note claims warmth for
-    a graph that cannot deliver it.
-    """
-    root = tmp_path / "root"
-    lane = tmp_path / "lane"
-    lane.mkdir()
-    _certified_graph_with(root, "polylogue-stale")
-
-    note, warm = lane_init._seed_testmon_graph(root, lane, attestation=_attestation("polylogue-current"))
-
-    assert warm is False
-    assert "not attestable" in note
-    assert "bootstrap" in note
-
-
-def test_seed_reports_warm_only_on_a_real_environment_match(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    root = tmp_path / "root"
-    lane = tmp_path / "lane"
-    lane.mkdir()
-    _certified_graph_with(root, "polylogue-current")
-
-    note, warm = lane_init._seed_testmon_graph(root, lane, attestation=_attestation("polylogue-current"))
-
-    assert warm is True
-    assert "verifies start warm" in note
-
-
-def test_seed_preserves_a_certified_destination_when_source_is_uncertified(tmp_path: Path) -> None:
-    """Rerunning lane-init cannot replace a certified lane with stale source state."""
-    import sqlite3
-
-    from devtools.testmon_bootstrap import TESTMON_DATA_RELPATH, inspect_native_testmon_environment
-
-    root = tmp_path / "root"
-    lane = tmp_path / "lane"
-    _certified_graph_with(root, "polylogue-current")
-    _certified_graph_with_names(lane, ["polylogue-current", "lane-only"])
-    with sqlite3.connect(root / TESTMON_DATA_RELPATH) as connection:
-        connection.execute("DROP TABLE polylogue_certified_corpus")
-        connection.commit()
-
-    note, warm = lane_init._seed_testmon_graph(root, lane, attestation=_attestation("polylogue-current"))
-
-    assert warm is True
-    assert "preserved certified lane environment" in note
-    assert inspect_native_testmon_environment(lane / TESTMON_DATA_RELPATH, environment_name="lane-only").valid
-
-
-def test_seed_rejects_an_uncertified_source_before_publication(tmp_path: Path) -> None:
-    """A structurally valid coordinator graph needs a certificate before copy."""
-    import sqlite3
-
-    from devtools.testmon_bootstrap import TESTMON_DATA_RELPATH
-
-    root = tmp_path / "root"
-    lane = tmp_path / "lane"
-    lane.mkdir()
-    _certified_graph_with(root, "polylogue-current")
-    with sqlite3.connect(root / TESTMON_DATA_RELPATH) as connection:
-        connection.execute("DROP TABLE polylogue_certified_corpus")
-        connection.commit()
-
-    note, warm = lane_init._seed_testmon_graph(root, lane, attestation=_attestation("polylogue-current"))
-
-    assert warm is False
-    assert "not certified" in note
-    assert "no completed covered run has certified this environment's corpus" in note
-    assert not (lane / TESTMON_DATA_RELPATH).exists()
-
-
-def test_seed_uses_bound_source_for_certificate_read_after_public_replacement(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A replacement immediately before source attestation cannot redirect the certificate read."""
-    root = tmp_path / "root"
-    lane = tmp_path / "lane"
-    lane.mkdir()
-    source_data = _certified_graph_with_names(
-        root,
-        ["polylogue-current"],
-        recorded_test_name="tests/test_original.py::test_original",
-    )
-    replacement_root = tmp_path / "replacement"
-    replacement_data = _certified_graph_with_names(
-        replacement_root,
-        ["polylogue-current"],
-        recorded_test_name="tests/test_replacement.py::test_replacement",
-    )
-
-    original_violation = testmon_bootstrap.certified_attestation_violation
-    swapped = False
-
-    def replace_before_certificate_read(
-        repo_root: Path,
-        *,
-        environment_name: str,
-        current_nodeids: Sequence[str],
-        certificate_data_path: Path | None = None,
-    ) -> str | None:
-        nonlocal swapped
-        if repo_root.resolve() == root.resolve() and certificate_data_path is not None and not swapped:
-            swapped = True
-            os.replace(replacement_data, source_data)
-        return original_violation(
-            repo_root,
-            environment_name=environment_name,
-            current_nodeids=current_nodeids,
-            certificate_data_path=certificate_data_path,
-        )
-
-    monkeypatch.setattr(testmon_bootstrap, "certified_attestation_violation", replace_before_certificate_read)
-
-    note, warm = lane_init._seed_testmon_graph(root, lane, attestation=_attestation("polylogue-current"))
-
-    assert swapped
-    assert warm is True
-    assert "verifies start warm" in note
-    copied = testmon_bootstrap.inspect_native_testmon_environment(
-        lane / testmon_bootstrap.TESTMON_DATA_RELPATH,
-        environment_name="polylogue-current",
-    )
-    assert copied.valid
-    assert copied.environment is not None
-    assert copied.environment.nodeids == ("tests/test_original.py::test_original",)
-
-
-def test_seed_copies_wal_backed_coordinator_graph(tmp_path: Path) -> None:
-    """Lane warmth retains source graph rows committed only to the WAL."""
-    import sqlite3
-
-    root = tmp_path / "root"
-    lane = tmp_path / "lane"
-    lane.mkdir()
-    source_data = _certified_graph_with_names(
-        root,
-        ["polylogue-current"],
-        recorded_test_name="tests/test_original.py::test_original",
-    )
-
-    with sqlite3.connect(source_data) as connection:
-        connection.execute("PRAGMA journal_mode=WAL")
-        connection.execute("UPDATE test_execution SET duration = ?", (7.0,))
-        connection.commit()
-        assert Path(f"{source_data}-wal").exists()
-        note, warm = lane_init._seed_testmon_graph(root, lane, attestation=_attestation("polylogue-current"))
-
-    assert warm is True
-    assert "verifies start warm" in note
-    with sqlite3.connect(lane / testmon_bootstrap.TESTMON_DATA_RELPATH) as copied:
-        duration = copied.execute("SELECT duration FROM test_execution").fetchone()
-    assert duration == (7.0,)
-
-
-def test_seed_preserves_a_certified_destination_when_source_primary_is_absent(tmp_path: Path) -> None:
-    """A certified fallback lane survives an absent coordinator primary candidate."""
-    from devtools.testmon_bootstrap import TESTMON_DATA_RELPATH, inspect_native_testmon_environment
-
-    root = tmp_path / "root"
-    lane = tmp_path / "lane"
-    _certified_graph_with(root, "unrelated-environment")
-    _certified_graph_with(lane, "fallback-environment")
-
-    note, warm = lane_init._seed_testmon_graph(
-        root,
-        lane,
-        attestation=_attestation("primary-environment", "fallback-environment"),
-    )
-
-    assert warm is True
-    assert "preserved certified lane environment" in note
-    assert inspect_native_testmon_environment(
-        lane / TESTMON_DATA_RELPATH,
-        environment_name="fallback-environment",
-    ).valid
-
-
-def test_seed_does_not_preserve_a_fallback_when_destination_primary_is_invalid(tmp_path: Path) -> None:
-    """An invalid primary blocks the fallback the verifier would reject."""
-    from devtools.testmon_bootstrap import TESTMON_DATA_RELPATH, inspect_native_testmon_environment
-
-    root = tmp_path / "root"
-    lane = tmp_path / "lane"
-    _certified_graph_with(root, "unrelated-environment")
-    _certified_graph_with_names(lane, ["primary-environment", "primary-environment", "fallback-environment"])
-
-    note, warm = lane_init._seed_testmon_graph(
-        root,
-        lane,
-        attestation=_attestation("primary-environment", "fallback-environment"),
-    )
-
-    assert warm is False
-    assert "initial verify environment is invalid" in note
-    assert inspect_native_testmon_environment(
-        lane / TESTMON_DATA_RELPATH,
-        environment_name="fallback-environment",
-    ).valid
-
-
-@pytest.mark.uses_real_clock("coordinates lane publication with verifier preparation")
-def test_seed_serializes_with_verifier_publication_and_preserves_later_write(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A verifier write cannot be overwritten by a concurrent lane seed."""
-    root = tmp_path / "root"
-    lane = tmp_path / "lane"
-    verifier_source = tmp_path / "verifier-source"
-    lane.mkdir()
-    _certified_graph_with(root, "lane-environment")
-    _certified_graph_with(verifier_source, "verifier-environment")
-
-    original_copy = testmon_bootstrap._atomic_copy_sqlite_database
-    publication_started = threading.Event()
-    release_publication = threading.Event()
-    verifier_started = threading.Event()
-    verifier_finished = threading.Event()
-    first_publication = True
-    publication_state_lock = threading.Lock()
-
-    def block_lane_publication(*args: object, **kwargs: object) -> None:
-        nonlocal first_publication
-        with publication_state_lock:
-            is_lane_publication = first_publication
-            first_publication = False
-        if is_lane_publication:
-            publication_started.set()
-            assert release_publication.wait(timeout=2)
-        original_copy(*args, **kwargs)  # type: ignore[arg-type]
-
-    monkeypatch.setattr(testmon_bootstrap, "_atomic_copy_sqlite_database", block_lane_publication)
-    monkeypatch.setattr(
-        testmon_bootstrap,
-        "testmon_environment_digest",
-        lambda checkout, **_kwargs: (
-            "verifier-environment" if checkout.resolve() == lane.resolve() else "lane-environment"
-        ),
-    )
-    monkeypatch.setattr(
-        testmon_bootstrap,
-        "linked_worktree_info",
-        lambda checkout, **_kwargs: (True, verifier_source) if checkout.resolve() == lane.resolve() else None,
-    )
-    monkeypatch.setattr(
-        verify,
-        "linked_worktree_info",
-        lambda checkout, **_kwargs: (True, verifier_source) if checkout.resolve() == lane.resolve() else None,
-    )
-
-    def verifier_prepare() -> testmon_bootstrap.NativeTestmonPreparation:
-        verifier_started.set()
-        try:
-            with verify._native_testmon_lifecycle_lock(lane):
-                return testmon_bootstrap.prepare_native_testmon_environment(lane)
-        finally:
-            verifier_finished.set()
-
-    with ThreadPoolExecutor(max_workers=2) as pool:
-        lane_future = pool.submit(
-            lane_init._seed_testmon_graph,
-            root,
-            lane,
-            attestation=_attestation("lane-environment"),
-        )
-        assert publication_started.wait(timeout=2)
-        verifier_future = pool.submit(verifier_prepare)
-        assert verifier_started.wait(timeout=2)
-        assert not verifier_finished.wait(timeout=0.05)
-        release_publication.set()
-        note, warm = lane_future.result(timeout=2)
-        preparation = verifier_future.result(timeout=2)
-
-    assert warm is True
-    assert "verifies start warm" in note
-    assert preparation.selection_mode == "affected"
-    final_state = testmon_bootstrap.inspect_native_testmon_environment(
-        lane / testmon_bootstrap.TESTMON_DATA_RELPATH,
-        environment_name="verifier-environment",
-    )
-    assert final_state.valid
-
-
-def test_seeded_primary_copy_stays_warm_when_lane_primary_state_is_invalid(tmp_path: Path) -> None:
-    """Lane seeding and verifier preparation agree on a safe primary reuse."""
-    from devtools.testmon_bootstrap import prepare_native_testmon_environment, testmon_environment_digest
-
-    root = tmp_path / "root"
-    lane = tmp_path / "lane"
-    lane.mkdir()
-    digest_inputs = {"HYPOTHESIS_PROFILE": "default", "POLYLOGUE_CI": None}
-    primary = testmon_environment_digest(
-        root,
-        pytest_profile="correctness=complete",
-        pytest_environment=digest_inputs,
-    )
-    _certified_graph_with(root, primary)
-    _certified_graph_with_names(lane, [primary, primary])
-
-    note, warm = lane_init._seed_testmon_graph(root, lane, attestation=_attestation(primary))
-
-    assert warm is True
-    assert "verifies start warm" in note
-    preparation = prepare_native_testmon_environment(
-        lane,
-        pytest_profile="correctness=complete",
-        pytest_environment=digest_inputs,
-    )
-    assert preparation.environment_name == primary
-    assert preparation.selection_mode == "affected"
-    assert preparation.copied_from is None
-
-
-def test_seed_accepts_verify_default_profile_fallback_when_certified(
-    tmp_path: Path,
-) -> None:
-    root = tmp_path / "root"
-    lane = tmp_path / "lane"
-    lane.mkdir()
-    _certified_graph_with(root, "polylogue-default")
-    attestation = _attestation("polylogue-initial", "polylogue-default", profile="ci")
-
-    note, warm = lane_init._seed_testmon_graph(root, lane, attestation=attestation)
-
-    assert warm is True
-    assert "verify default-profile fallback" in note
-
-
-def test_seed_rejects_certified_fallback_after_an_invalid_initial_environment(
-    tmp_path: Path,
-) -> None:
-    from devtools.testmon_bootstrap import TESTMON_DATA_RELPATH
-
-    root = tmp_path / "root"
-    lane = tmp_path / "lane"
-    _certified_graph_with(root, "polylogue-default")
-    _certified_graph_with_names(lane, ["polylogue-initial", "polylogue-initial"])
-
-    note, warm = lane_init._seed_testmon_graph(
-        root,
-        lane,
-        attestation=_attestation("polylogue-initial", "polylogue-default", profile="ci"),
-    )
-
-    assert warm is False
-    assert "initial verify environment is invalid" in note
-    assert "refusing the default-profile fallback" in note
-    assert (lane / TESTMON_DATA_RELPATH).is_file()
-
-
-def test_seed_then_verifier_stays_cold_after_invalid_initial_with_valid_default(tmp_path: Path) -> None:
-    """An invalid primary must not authorize a different profile's graph."""
-    from devtools.testmon_bootstrap import prepare_native_testmon_environment, testmon_environment_digest
-
-    root = tmp_path / "root"
-    lane = tmp_path / "lane"
-    lane.mkdir()
-    initial_inputs = {"HYPOTHESIS_PROFILE": "ci", "POLYLOGUE_CI": "1"}
-    initial = testmon_environment_digest(
-        root,
-        pytest_profile="correctness=complete",
-        pytest_environment=initial_inputs,
-    )
-    default = testmon_environment_digest(
-        root,
-        pytest_profile="correctness=complete",
-        pytest_environment={"HYPOTHESIS_PROFILE": "default", "POLYLOGUE_CI": "1"},
-    )
-    _certified_graph_with(root, default)
-    _certified_graph_with_names(lane, [initial, initial])
-
-    note, warm = lane_init._seed_testmon_graph(
-        root,
-        lane,
-        attestation=_attestation(initial, default),
-    )
-
-    assert warm is False
-    assert "refusing the default-profile fallback" in note
-    preparation = prepare_native_testmon_environment(
-        lane,
-        pytest_profile="correctness=complete",
-        pytest_environment=initial_inputs,
-    )
-    assert preparation.environment_name == initial
-    assert preparation.selection_mode == "bootstrap"
-    assert preparation.copied_from is None
-
-
-def test_seed_reports_cold_for_an_empty_or_absent_graph(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    from devtools.testmon_bootstrap import TESTMON_DATA_RELPATH
-
-    root = tmp_path / "root"
-    lane = tmp_path / "lane"
-    lane.mkdir()
-
-    note, warm = lane_init._seed_testmon_graph(root, lane)
-    assert warm is False
-    assert "no coordinator graph" in note
-
-    _graph_with(root / TESTMON_DATA_RELPATH, [])
-    note, warm = lane_init._seed_testmon_graph(root, lane, attestation=_attestation("polylogue-current"))
-    assert warm is False
-    assert "not certified" in note
-    assert "no completed covered run has certified" in note
-
-
-def test_seed_reports_cold_when_the_lane_digest_cannot_be_computed(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """An unverifiable lane must never be reported as warm."""
-    root = tmp_path / "root"
-    lane = tmp_path / "lane"
-    lane.mkdir()
-    _certified_graph_with(root, "polylogue-something")
-    note, warm = lane_init._seed_testmon_graph(root, lane)
-
-    assert warm is False
-    assert "normalized digest inputs" in note
-
-
-def test_seed_rejects_a_minimal_fake_graph_even_with_a_matching_environment(
-    tmp_path: Path,
-) -> None:
-    root = tmp_path / "root"
-    lane = tmp_path / "lane"
-    lane.mkdir()
-    from devtools.testmon_bootstrap import TESTMON_DATA_RELPATH
-
-    _graph_with(root / TESTMON_DATA_RELPATH, ["polylogue-current"])
-
-    note, warm = lane_init._seed_testmon_graph(root, lane, attestation=_attestation("polylogue-current"))
-
-    assert warm is False
-    assert "not certified" in note
-    assert "no completed covered run has certified" in note
-
-
-def test_distribution_mutation_makes_a_seeded_graph_unattestable(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A changed installed distribution cannot inherit a warm graph claim."""
-    from devtools import testmon_bootstrap
-    from devtools.testmon_bootstrap import testmon_environment_digest
-
-    root = tmp_path / "root"
-    lane = tmp_path / "lane"
-    lane.mkdir()
-    digest_inputs = {"HYPOTHESIS_PROFILE": "default", "POLYLOGUE_CI": None}
-    recorded = testmon_environment_digest(
-        root,
-        pytest_profile="correctness=complete",
-        pytest_environment=digest_inputs,
-    )
-    _certified_graph_with(root, recorded)
-
-    monkeypatch.setattr(testmon_bootstrap, "_installed_distributions", lambda: (("pytest", "mutated"),))
-    unattestable = testmon_environment_digest(
-        root,
-        pytest_profile="correctness=complete",
-        pytest_environment=digest_inputs,
-    )
-    assert unattestable != recorded
-    note, warm = lane_init._seed_testmon_graph(root, lane, attestation=_attestation(unattestable))
-
-    assert warm is False
-    assert "not attestable" in note
-    assert "bootstrap" in note
-
-
-@pytest.mark.parametrize("symlinked_parent", [".cache", ".cache/testmon"])
-def test_seed_refuses_symlinked_cache_before_touching_external_sentinel(
-    tmp_path: Path,
-    symlinked_parent: str,
-) -> None:
-    from devtools.testmon_bootstrap import TESTMON_DATA_RELPATH
-
-    root = tmp_path / "root"
-    lane = tmp_path / "lane"
-    _certified_graph_with(root, "polylogue-current")
-    external = tmp_path / "external"
-    sentinel = external / "sentinel"
-    sentinel.parent.mkdir(parents=True)
-    sentinel.write_text("do not touch", encoding="utf-8")
-    parent = lane / symlinked_parent
-    parent.parent.mkdir(parents=True, exist_ok=True)
-    parent.symlink_to(external, target_is_directory=True)
-
-    note, warm = lane_init._seed_testmon_graph(root, lane, attestation=_attestation("polylogue-current"))
-
-    assert warm is False
-    assert "unsafe owned testmon path" in note
-    assert sentinel.read_text(encoding="utf-8") == "do not touch"
-    assert not (external / TESTMON_DATA_RELPATH.name).exists()
-
-
-# ---------------------------------------------------------------------------
 # Interpreter-describing environment must not reach a lane (polylogue-l218h)
 # ---------------------------------------------------------------------------
 
@@ -1283,63 +490,26 @@ def test_lane_env_scrubs_interpreter_describing_variables(tmp_path: Path, monkey
     monkeypatch.setenv("_PYTHON_HOST_PLATFORM", "linux-x86_64")
     monkeypatch.setenv("PYTHONPYCACHEPREFIX", "/coordinator/.cache/pycache")
 
-    env = lane_init._lane_env(tmp_path / "lane")
+    env = lane_init.lane_subprocess_env(tmp_path / "lane")
 
     assert "_PYTHON_SYSCONFIGDATA_NAME" not in env
     assert "_PYTHON_HOST_PLATFORM" not in env
     assert "PYTHONPYCACHEPREFIX" not in env
 
 
-def test_dispatch_env_lines_carry_the_unsets_and_the_ca_bundle(tmp_path: Path) -> None:
-    """The lane's own venv, the fatal unsets, and the CA bundle gh/pr-scope need.
-
-    ``_lane_env`` only sanitises lane-init's OWN subprocesses; an agent that
-    opens the worktree later inherits the harness environment untouched, so
-    the remedy has to be printed where a dispatcher reads it.
-    """
-    lane = tmp_path / "lane"
-    lines = lane_init.dispatch_env_lines(lane, attestation=_attestation())
-    joined = "\n".join(lines)
-
-    assert f"export VIRTUAL_ENV={lane / '.venv'}" in lines
-    for key in lane_init._INTERPRETER_DESCRIBING_ENV:
-        assert f"unset {key}" in lines
-    assert "export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt" in lines
-    assert "$VIRTUAL_ENV/bin:$PATH" in joined
-
-
-def test_dispatch_env_lines_bind_normalized_testmon_inputs(tmp_path: Path) -> None:
-    lines = lane_init.dispatch_env_lines(
-        tmp_path / "lane",
-        attestation=_attestation("polylogue-initial", "polylogue-default", profile="correctness=complete"),
-    )
-
-    assert "export HYPOTHESIS_PROFILE=default" in lines
-    assert "unset POLYLOGUE_CI" in lines
-    assert "# testmon pytest profile: correctness=complete" in lines
-    assert "# testmon fallback: HYPOTHESIS_PROFILE=default after a non-default bootstrap" in lines
-
-
-def test_dispatch_env_lines_match_lane_env_sanitization(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_lane_command_env_activates_only_the_sanitized_lane(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     lane = tmp_path / "lane"
     for key in lane_init._LANE_ENV_UNSETS:
-        monkeypatch.setenv(key, f"inherited-{key}")
-    attestation = lane_init.LaneEnvironmentAttestation(
-        "correctness=complete",
-        (("HYPOTHESIS_PROFILE", "ci"), ("POLYLOGUE_CI", "1")),
-        ("polylogue-initial", "polylogue-default"),
-    )
+        if key != "VIRTUAL_ENV":
+            monkeypatch.setenv(key, f"inherited-{key}")
+    monkeypatch.setenv("VIRTUAL_ENV", "/coordinator/.venv")
+    monkeypatch.setenv("PATH", "/coordinator/.venv/bin:/usr/bin")
 
-    sanitized = lane_init._lane_env(lane)
-    lines = lane_init.dispatch_env_lines(lane, attestation=attestation)
+    env = lane_init.lane_command_env(lane)
 
+    assert env["VIRTUAL_ENV"] == str(lane / ".venv")
+    assert env["PATH"].split(os.pathsep)[0] == str(lane / ".venv" / "bin")
+    assert "/coordinator/.venv/bin" not in env["PATH"].split(os.pathsep)
     for key in ("PYTHONHOME", "PYTHONPATH", "UV_PROJECT", "UV_WORKING_DIR", *lane_init._INTERPRETER_DESCRIBING_ENV):
-        assert key not in sanitized
-        assert f"unset {key}" in lines
-    assert sanitized["UV_PROJECT_ENVIRONMENT"] == str(lane / ".venv")
-    assert f"export UV_PROJECT_ENVIRONMENT={lane / '.venv'}" in lines
-    assert "export HYPOTHESIS_PROFILE=ci" in lines
-    assert "export POLYLOGUE_CI=1" in lines
+        assert key not in env
+    assert env["UV_PROJECT_ENVIRONMENT"] == str(lane / ".venv")


### PR DESCRIPTION
## Summary

Reduce lane provisioning to the operations that establish a correct isolated checkout, and make later devtools commands select that checkout’s interpreter automatically.

## Problem

`lane-init` had become a per-worktree control plane: it copied and certified testmon state, transported SQLite sidecars, wrote a fanout ledger, emitted worker-budget and shell-export instructions, and waited on lifecycle locks. These layers delayed every lane while still requiring agents to repair their environment and open individual PRs.

## Solution

The command now creates or adopts a worktree, provisions an exact local venv, proves the checkout import invariant, and verifies Git isolation. Existing lanes derive their branch. The dispatcher re-enters an invoking linked worktree under its own venv, so the lane contract uses one simple bootstrap invocation and returns commits to a batch branch. Selected verification retains responsibility for compatible testmon reuse; no per-lane graph transport remains.

## Verification

`devtools test tests/unit/devtools/test_checkout_guard.py tests/unit/devtools/test_lane_init.py` completed with `39 passed in 6.29s`. The remaining process-boundary tests prove public bootstrap with a poisoned coordinator environment, automatic rerouting of a later command into the lane venv, and refusal of foreign source implementations. `devtools verify --quick` completed successfully in `52.38s`.

| Bead | Disposition | Evidence |
| --- | --- | --- |
| None | Self-contained | Focused lane runtime and checkout-guard tests |

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->
