### PR TITLE
feat(agentctl): expose pinned Polylogue operations

### DIFF
--- a/.agentctl/project.toml
+++ b/.agentctl/project.toml
@@ -21,4 +21,4 @@ source_scoped = true
 source_ref = "sinnix://polylogue/archive"
 exec = ["polylogue-agentctl-adapter"]
 timeout_seconds = 300
-documentation = "Bounded Polylogue archive status."
+documentation = "Argument-free, generation-pinned, bounded Polylogue archive status."

--- a/.agentctl/project.toml
+++ b/.agentctl/project.toml
@@ -6,10 +6,33 @@ display_name = "Polylogue"
 root_markers = ["pyproject.toml", "polylogue"]
 
 [environment]
-kind = "plain"
-command = ["env"]
-inherit = ["HOME", "POLYLOGUE_ARCHIVE_ROOT", "XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_STATE_HOME"]
-unset = []
+kind = "nix-develop"
+command = ["nix", "develop", "--accept-flake-config", "--command"]
+inherit = ["HOME", "USER", "LANG", "TERM", "SSH_AUTH_SOCK", "XDG_RUNTIME_DIR", "DBUS_SESSION_BUS_ADDRESS", "POLYLOGUE_ARCHIVE_ROOT", "XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_STATE_HOME"]
+unset = ["PYTHONPATH", "PYTHONHOME", "VIRTUAL_ENV", "_PYTHON_SYSCONFIGDATA_NAME", "_PYTHON_HOST_PLATFORM", "PYTHONPYCACHEPREFIX"]
+
+[operations.verify_affected]
+description = "Run Polylogue's affected-test verification plan"
+exec = ["devtools", "verify"]
+pool = "normal"
+result = "pytest"
+cache = "tree+environment"
+exclusive_keys = ["polylogue:testmon-graph"]
+
+[operations.verify_quick]
+description = "Run Polylogue's static fast verification gates"
+exec = ["devtools", "verify", "--quick"]
+pool = "normal"
+result = "exit"
+cache = "tree+environment"
+
+[operations.verify_all]
+description = "Run Polylogue's explicit complete-corpus verification plan"
+exec = ["devtools", "verify", "--all"]
+pool = "bulk"
+result = "pytest"
+cache = "tree+environment"
+exclusive_keys = ["polylogue:testmon-graph"]
 
 [owner_adapters.polylogue_archive]
 namespace = "polylogue.archive"

--- a/polylogue/agent_integration/agentctl_adapter.py
+++ b/polylogue/agent_integration/agentctl_adapter.py
@@ -8,6 +8,8 @@ import sys
 from collections.abc import Mapping
 from typing import Any
 
+from polylogue.archive.query.execution_control import InterruptibleSQLiteRead
+from polylogue.archive.query.transaction import QueryTransaction, QueryTransactionRequest
 from polylogue.mcp.payloads import MCPArchiveStatsPayload
 from polylogue.storage.archive_identity import ArchiveIdentity, ArchiveLocation
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -117,17 +119,21 @@ def _read_pinned_status(location: ArchiveLocation, identity: ArchiveIdentity) ->
         opened = os.fstat(index_fd)
         if (opened.st_dev, opened.st_ino) != (index.device, index.inode):
             raise AdapterError("OWNER_UNAVAILABLE", "active archive generation changed while opening")
-        archive = ArchiveStore.open_existing(
+        transaction = QueryTransaction(
             location.configured_root,
-            index_path=index.resolved_path,
-            opened_main_fd=index_fd,
+            QueryTransactionRequest(
+                operation="status", arguments={"scope": "archive"}, page_size=1, projection="status"
+            ),
         )
-        try:
-            archive.begin_read_snapshot()
-            return _status_payload(archive)
-        finally:
-            archive.end_read_snapshot()
-            archive.close()
+        return InterruptibleSQLiteRead(transaction.context).run(
+            location.configured_root,
+            _status_payload,
+            store_factory=lambda: ArchiveStore.open_existing(
+                location.configured_root,
+                index_path=index.resolved_path,
+                opened_main_fd=index_fd,
+            ),
+        )
     except AdapterError:
         raise
     except Exception as error:

--- a/polylogue/agent_integration/agentctl_adapter.py
+++ b/polylogue/agent_integration/agentctl_adapter.py
@@ -2,30 +2,47 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
+import os
 import sys
+from collections.abc import Mapping
 from typing import Any
 
-from polylogue.api import Polylogue
-from polylogue.paths import archive_root as resolve_archive_root
+from polylogue.mcp.payloads import MCPArchiveStatsPayload
 from polylogue.storage.archive_identity import ArchiveIdentity, ArchiveLocation
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
 OWNER = "polylogue-archive"
 OPERATION = "polylogue.archive.status"
 SOURCE_REF = "sinnix://polylogue/archive"
 SCHEMA = 1
+INLINE_PAYLOAD_LIMIT_BYTES = 262_144
+
+
+class AdapterError(ValueError):
+    """One stable, protocol-visible failure from the owner adapter."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+def _canonical_json(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
 
 
 def _inline(value: Any) -> dict[str, Any]:
+    if len(_canonical_json(value)) > INLINE_PAYLOAD_LIMIT_BYTES:
+        raise AdapterError("RESOURCE_EXHAUSTED", "archive status exceeds the inline response limit")
     return {"kind": "inline", "value": value}
 
 
 def _response(
-    request: dict[str, Any],
+    request: Mapping[str, Any],
     *,
     payload: Any = None,
-    error: tuple[str, str] | None = None,
+    error: AdapterError | None = None,
     binding: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     result: dict[str, Any] = {
@@ -40,18 +57,39 @@ def _response(
     if error is None:
         result["payload"] = _inline(payload)
     else:
-        code, message = error
         result["error"] = {
             "schema": SCHEMA,
-            "code": code,
-            "message": message,
+            "code": error.code,
+            "message": error.message,
             "details": _inline({}),
         }
     return result
 
 
-def _binding(location: ArchiveLocation) -> dict[str, str]:
-    identity = ArchiveIdentity.resolve_location(location)
+def _validate_request(request: Mapping[str, Any]) -> dict[str, str] | None:
+    if request.get("owner") != OWNER:
+        raise AdapterError("AUTHORITY_MISMATCH", "request owner does not match this adapter")
+    if request.get("operation") != OPERATION:
+        raise AdapterError("AUTHORITY_MISMATCH", "request operation does not match this adapter")
+    arguments = request.get("arguments", {})
+    if not isinstance(arguments, Mapping):
+        raise AdapterError("INVALID_ARGUMENT", "arguments must be an object")
+    if arguments:
+        raise AdapterError("INVALID_ARGUMENT", "polylogue.archive.status does not accept arguments")
+
+    expected = request.get("expected_source_binding")
+    if expected is None:
+        return None
+    if not isinstance(expected, Mapping) or set(expected) != {"source_ref", "generation", "root_digest"}:
+        raise AdapterError("INVALID_ARGUMENT", "expected_source_binding has invalid fields")
+    if not all(isinstance(expected[field], str) for field in expected):
+        raise AdapterError("INVALID_ARGUMENT", "expected_source_binding fields must be strings")
+    if expected["source_ref"] != SOURCE_REF:
+        raise AdapterError("AUTHORITY_MISMATCH", "expected_source_binding names a different source")
+    return dict(expected)
+
+
+def _binding(identity: ArchiveIdentity) -> dict[str, str]:
     return {
         "source_ref": SOURCE_REF,
         "generation": identity.active_generation,
@@ -59,52 +97,70 @@ def _binding(location: ArchiveLocation) -> dict[str, str]:
     }
 
 
-def _read_status(request: dict[str, Any]) -> dict[str, Any]:
-    if request.get("operation") != OPERATION or request.get("owner") != OWNER:
-        raise ValueError("unsupported owner operation")
-    arguments = request.get("arguments", {})
-    if not isinstance(arguments, dict):
-        raise ValueError("arguments must be an object")
-    root = resolve_archive_root()
-    location = ArchiveLocation.resolve(root)
-    binding = _binding(location)
+def _status_payload(archive: ArchiveStore) -> dict[str, Any]:
+    """Use the same archive-stat primitive and status projection as MCP."""
+    stats = MCPArchiveStatsPayload.from_archive_stats(
+        archive.stats(), include_embedded=False, include_db_size=False
+    ).model_dump(mode="json", exclude_none=True)
+    return {"operation": OPERATION, "archive": stats}
 
-    async def read() -> dict[str, Any]:
-        async with Polylogue(archive_root=root) as archive:
-            stats = await archive.stats()
-        return {
-            "operation": OPERATION,
-            "archive": {
-                "session_count": stats.session_count,
-                "message_count": stats.message_count,
-                "word_count": stats.word_count,
-                "origins": stats.origins,
-                "tags": stats.tags,
-                "last_sync": stats.last_sync,
-            },
-            "location": {
-                "configured_root": str(location.configured_root),
-                "active_index": location.active_index.as_dict(),
-                "active_pointer": str(location.active_pointer) if location.active_pointer else None,
-            },
-        }
 
-    payload = asyncio.run(read())
-    # Keep the binding digest independently reproducible from the returned value.
-    json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+def _read_pinned_status(location: ArchiveLocation, identity: ArchiveIdentity) -> dict[str, Any]:
+    index = identity.tier("index")
+    if not index.exists or index.device is None or index.inode is None:
+        raise AdapterError("OWNER_UNAVAILABLE", "active archive index is unavailable")
+    try:
+        index_fd = os.open(index.resolved_path, os.O_RDONLY)
+    except OSError as error:
+        raise AdapterError("OWNER_UNAVAILABLE", "active archive index is unavailable") from error
+    try:
+        opened = os.fstat(index_fd)
+        if (opened.st_dev, opened.st_ino) != (index.device, index.inode):
+            raise AdapterError("OWNER_UNAVAILABLE", "active archive generation changed while opening")
+        archive = ArchiveStore.open_existing(
+            location.configured_root,
+            index_path=index.resolved_path,
+            opened_main_fd=index_fd,
+        )
+        try:
+            archive.begin_read_snapshot()
+            return _status_payload(archive)
+        finally:
+            archive.end_read_snapshot()
+            archive.close()
+    except AdapterError:
+        raise
+    except Exception as error:
+        raise AdapterError("OWNER_UNAVAILABLE", "archive status is unavailable") from error
+    finally:
+        os.close(index_fd)
+
+
+def _read_status(request: Mapping[str, Any]) -> dict[str, Any]:
+    expected_binding = _validate_request(request)
+    from polylogue.paths import archive_root as resolve_archive_root
+
+    location = ArchiveLocation.resolve(resolve_archive_root())
+    identity = ArchiveIdentity.resolve_location(location)
+    binding = _binding(identity)
+    if expected_binding is not None and expected_binding != binding:
+        raise AdapterError("AUTHORITY_MISMATCH", "expected_source_binding does not match the active archive generation")
+    payload = _read_pinned_status(location, identity)
     return _response(request, payload=payload, binding=binding)
 
 
 def main() -> int:
-    raw = sys.stdin.read()
+    request: Mapping[str, Any] = {}
     try:
-        request = json.loads(raw)
-        if not isinstance(request, dict):
-            raise ValueError("request must be an object")
+        decoded = json.loads(sys.stdin.read())
+        if not isinstance(decoded, Mapping):
+            raise AdapterError("INVALID_ARGUMENT", "request must be an object")
+        request = decoded
         response = _read_status(request)
-    except Exception as exc:
-        request = request if "request" in locals() and isinstance(request, dict) else {}
-        response = _response(request, error=("OPERATION_FAILED", str(exc)))
+    except AdapterError as error:
+        response = _response(request, error=error)
+    except Exception:
+        response = _response(request, error=AdapterError("OPERATION_FAILED", "archive status operation failed"))
     sys.stdout.write(json.dumps(response, sort_keys=True, separators=(",", ":")) + "\n")
     return 0
 

--- a/polylogue/archive/query/execution_control.py
+++ b/polylogue/archive/query/execution_control.py
@@ -434,7 +434,14 @@ class InterruptibleSQLiteRead:
             with suppress(Exception):  # pragma: no cover
                 store.interrupt_reads()
 
-    def run(self, archive_root: Path, work: Callable[[ArchiveStore], T], *, read_timeout: float = 5.0) -> T:
+    def run(
+        self,
+        archive_root: Path,
+        work: Callable[[ArchiveStore], T],
+        *,
+        read_timeout: float = 5.0,
+        store_factory: Callable[[], ArchiveStore] | None = None,
+    ) -> T:
         """Execute ``work`` against a dedicated read-only store (worker thread)."""
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
@@ -449,7 +456,11 @@ class InterruptibleSQLiteRead:
             ctx.record_sqlite_progress(progress_opcodes)
             return 1 if ctx.should_abort() else 0
 
-        store = ArchiveStore.open_existing(archive_root, read_timeout=read_timeout)
+        store = (
+            store_factory()
+            if store_factory is not None
+            else ArchiveStore.open_existing(archive_root, read_timeout=read_timeout)
+        )
         with self._store_lock:
             self._store = store
         try:

--- a/tests/unit/agent_integration/test_agentctl_adapter.py
+++ b/tests/unit/agent_integration/test_agentctl_adapter.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import sys
+from collections.abc import Generator
 from pathlib import Path
-from types import SimpleNamespace
+from typing import cast
 from uuid import uuid4
 
 import pytest
 
 from polylogue.agent_integration import agentctl_adapter as adapter
+from polylogue.storage.archive_identity import ArchiveIdentity, ArchiveLocation
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
 
 def _request() -> dict[str, object]:
@@ -22,50 +28,127 @@ def _request() -> dict[str, object]:
     }
 
 
-def test_status_route_preserves_ids_and_returns_one_source_binding(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+@pytest.fixture
+def disposable_archive(tmp_path: Path) -> Generator[Path]:
     root = tmp_path / "archive"
-    root.mkdir()
-    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
+    archive = ArchiveStore(root)
+    archive.close()
+    yield root
 
-    class FakePolylogue:
-        def __init__(self, **kwargs: object) -> None:
-            assert kwargs["archive_root"] == root
 
-        async def __aenter__(self) -> FakePolylogue:
-            return self
+@pytest.fixture
+def adapter_command() -> tuple[str, ...]:
+    installed = Path(sys.executable).with_name("polylogue-agentctl-adapter")
+    if installed.is_file() and os.access(installed, os.X_OK):
+        return (str(installed),)
+    return (sys.executable, "-m", "polylogue.agent_integration.agentctl_adapter")
 
-        async def __aexit__(self, *args: object) -> None:
-            return None
 
-        async def stats(self) -> SimpleNamespace:
-            return SimpleNamespace(
-                session_count=2,
-                message_count=3,
-                word_count=4,
-                origins={"codex-session": 2},
-                tags={},
-                last_sync=None,
-            )
+def _invoke_adapter(command: tuple[str, ...], root: Path, request: dict[str, object]) -> dict[str, object]:
+    environment = os.environ | {"POLYLOGUE_ARCHIVE_ROOT": str(root)}
+    result = subprocess.run(
+        command,
+        input=json.dumps(request),
+        text=True,
+        capture_output=True,
+        env=environment,
+        check=True,
+    )
+    assert result.stderr == ""
+    response = json.loads(result.stdout)
+    assert isinstance(response, dict)
+    return cast(dict[str, object], response)
 
-    monkeypatch.setattr(adapter, "Polylogue", FakePolylogue)
+
+def test_status_rejects_nonempty_arguments_before_archive_access(monkeypatch: pytest.MonkeyPatch) -> None:
     request = _request()
-    response = adapter._read_status(request)
+    request["arguments"] = {"scope": "archive"}
+    monkeypatch.setattr("polylogue.paths.archive_root", pytest.fail)
 
+    with pytest.raises(adapter.AdapterError, match="does not accept arguments") as caught:
+        adapter._read_status(request)
+
+    assert caught.value.code == "INVALID_ARGUMENT"
+
+
+def test_status_pins_payload_and_binding_to_one_archive_generation(disposable_archive: Path) -> None:
+    request = _request()
+    previous = os.environ.get("POLYLOGUE_ARCHIVE_ROOT")
+    os.environ["POLYLOGUE_ARCHIVE_ROOT"] = str(disposable_archive)
+    try:
+        response = adapter._read_status(request)
+    finally:
+        if previous is None:
+            os.environ.pop("POLYLOGUE_ARCHIVE_ROOT", None)
+        else:
+            os.environ["POLYLOGUE_ARCHIVE_ROOT"] = previous
+
+    identity = ArchiveIdentity.resolve_location(ArchiveLocation.resolve(disposable_archive))
     assert response["ok"] is True
     assert response["request_id"] == request["request_id"]
     assert response["correlation_id"] == request["correlation_id"]
-    assert response["owner"] == adapter.OWNER
-    assert len(response["source_bindings"]) == 1
-    binding = response["source_bindings"][0]
-    assert binding["source_ref"] == adapter.SOURCE_REF
-    assert binding["root_digest"].startswith("sha256:")
-    json.dumps(response)
+    assert response["source_bindings"] == [
+        {
+            "source_ref": adapter.SOURCE_REF,
+            "generation": identity.active_generation,
+            "root_digest": f"sha256:{identity.authority_identity_digest}",
+        }
+    ]
+    assert response["payload"] == {
+        "kind": "inline",
+        "value": {
+            "operation": adapter.OPERATION,
+            "archive": {"total_sessions": 0, "total_messages": 0, "origins": {}},
+        },
+    }
 
 
-def test_status_rejects_noncanonical_operation() -> None:
+@pytest.mark.parametrize(
+    ("field", "value", "code"),
+    [
+        ("owner", "wrong-owner", "AUTHORITY_MISMATCH"),
+        ("operation", "polylogue.archive.write", "AUTHORITY_MISMATCH"),
+        ("arguments", {"scope": "archive"}, "INVALID_ARGUMENT"),
+        (
+            "expected_source_binding",
+            {
+                "source_ref": "sinnix://polylogue/other",
+                "generation": "fixture-generation",
+                "root_digest": "sha256:" + "0" * 64,
+            },
+            "AUTHORITY_MISMATCH",
+        ),
+    ],
+)
+def test_production_entrypoint_rejects_owner_contract_boundaries(
+    adapter_command: tuple[str, ...],
+    disposable_archive: Path,
+    field: str,
+    value: object,
+    code: str,
+) -> None:
     request = _request()
-    request["operation"] = "polylogue.archive.write"
-    with pytest.raises(ValueError, match="unsupported owner operation"):
-        adapter._read_status(request)
+    request[field] = value
+
+    response = _invoke_adapter(adapter_command, disposable_archive, request)
+
+    assert response["ok"] is False
+    assert response["request_id"] == request["request_id"]
+    assert response["correlation_id"] == request["correlation_id"]
+    assert response["owner"] == adapter.OWNER
+    assert response["source_bindings"] == []
+    assert response["error"] == {
+        "schema": adapter.SCHEMA,
+        "code": code,
+        "message": {
+            "AUTHORITY_MISMATCH": (
+                "request owner does not match this adapter"
+                if field == "owner"
+                else "request operation does not match this adapter"
+                if field == "operation"
+                else "expected_source_binding names a different source"
+            ),
+            "INVALID_ARGUMENT": "polylogue.archive.status does not accept arguments",
+        }[code],
+        "details": {"kind": "inline", "value": {}},
+    }

--- a/tests/unit/agent_integration/test_agentctl_adapter.py
+++ b/tests/unit/agent_integration/test_agentctl_adapter.py
@@ -103,6 +103,28 @@ def test_status_pins_payload_and_binding_to_one_archive_generation(disposable_ar
     }
 
 
+def test_production_entrypoint_rejects_a_stale_archive_generation(
+    adapter_command: tuple[str, ...], disposable_archive: Path
+) -> None:
+    request = _request()
+    request["expected_source_binding"] = {
+        "source_ref": adapter.SOURCE_REF,
+        "generation": "stale-generation",
+        "root_digest": "sha256:" + "0" * 64,
+    }
+
+    response = _invoke_adapter(adapter_command, disposable_archive, request)
+
+    assert response["ok"] is False
+    assert response["source_bindings"] == []
+    assert response["error"] == {
+        "schema": adapter.SCHEMA,
+        "code": "AUTHORITY_MISMATCH",
+        "message": "expected_source_binding does not match the active archive generation",
+        "details": {"kind": "inline", "value": {}},
+    }
+
+
 @pytest.mark.parametrize(
     ("field", "value", "code"),
     [

--- a/tests/unit/archive/query/test_execution_control.py
+++ b/tests/unit/archive/query/test_execution_control.py
@@ -688,6 +688,24 @@ def test_interrupt_before_first_opcode_never_starts_statement(tmp_path: Path) ->
     assert ctx.receipt.state == "cancelled"
 
 
+def test_reader_accepts_an_already_attested_store_factory(tmp_path: Path) -> None:
+    root = _bootstrap_archive(tmp_path)
+    ctx = QueryExecutionContext.create(query_text="attested-store")
+    opened: list[ArchiveStore] = []
+
+    def factory() -> ArchiveStore:
+        store = ArchiveStore.open_existing(root)
+        opened.append(store)
+        return store
+
+    result = InterruptibleSQLiteRead(ctx).run(root, lambda store: store.stats(), store_factory=factory)
+
+    assert result.total_sessions == 0
+    assert len(opened) == 1
+    assert ctx.receipt.state == "completed"
+    assert ctx.receipt.cleanup_complete is True
+
+
 async def test_api_query_units_routes_through_execution_control(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Expose Polylogue archive status and fixed verification plans through the native AgentCTL project contract.

## Problem

The archive adapter could pair a status payload with a separately observed generation and silently accepted unused arguments. Polylogue was also discoverable through AgentCTL but published no executable project operations, so verification still had to start through project-local host control.

## Solution

Open and identify the active index once, verify its device and inode, then pass that attested store through Polylogue's shared query execution control. The result retains admission, snapshot, SQLite progress guard, 120-second deadline, interruption mapping, and cleanup while returning the bounded MCP archive-status projection with the matching source binding. Wrong owner, operation, arguments, source preconditions, unavailable generations, and oversized inline results return typed protocol errors.

Run declared affected, quick, and complete-corpus verification plans through Polylogue's Nix devshell. The commands remain fixed descriptor operations; callers cannot supply arbitrary argv. Polylogue retains test selection and result semantics while Sinnixd owns the durable job and transient-service lifecycle.

The live archive route returned 23,496 sessions and 4,949,920 messages with generation `dev:61:ino:3789735`. A forged digest was rejected as `AUTHORITY_MISMATCH`, and an undeclared argument was rejected as `INVALID_ARGUMENT`.

## Bead disposition

| Bead | Disposition |
| --- | --- |
| `polylogue-agentctl-adapter` | Partial: the bounded read route is live. Broader caller cutover and deletion evidence remain. |
| `polylogue-agentctl.2` | Partial: fixed affected, quick, and full jobs are declared. Focused selectors, graph promotion, host-control deletion, and live job proof remain. |

## Verification

- `devtools test tests/unit/agent_integration/test_agentctl_adapter.py tests/unit/archive/query/test_execution_control.py`: 34 passed before the added store-factory assertion; the final targeted rerun passed 8 tests.
- `devtools verify --quick`: success in 52.72 seconds, run `20260823T035549Z-quick-1290214-bdf5baf6`.
- Deployed Sinnix owner call: `ok: true` with one canonical source binding.
- Deployed Sinnix stale-binding call: `AUTHORITY_MISMATCH`.
- Deployed descriptor parsing lists `verify_affected`, `verify_quick`, and `verify_all` with fixed commands and result contracts.

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->