### PR TITLE
fix(embeddings): recover lifecycle at daemon startup

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -3079,6 +3079,19 @@ async def _run_daemon_services_under_active_writer_lease(
                     },
                 )
 
+        # Embedding reads are exposed by the API, so recover the active
+        # generation before publishing either HTTP socket.  Otherwise an
+        # immediate similarity request can recreate legacy WAL sidecars after
+        # the lifecycle checkpoint and turn a clean restart into a failure.
+        if not watcher_blocked:
+            await _run_startup_embedding_lifecycle(write_coordinator, archive_root_path)
+            if lifecycle_events_enabled:
+                await _emit_daemon_lifecycle_event(
+                    "component_ready",
+                    archive_root_path=archive_root_path,
+                    component="embedding_lifecycle_startup",
+                )
+
         if enable_api:
             from polylogue.daemon.http import (
                 DaemonAPIHandler,
@@ -3135,13 +3148,6 @@ async def _run_daemon_services_under_active_writer_lease(
             from polylogue.daemon.judgment_automation import periodic_judgment_automation_sweep
             from polylogue.daemon.secret_scan_sweep import periodic_secret_scan_sweep
 
-            await _run_startup_embedding_lifecycle(write_coordinator, archive_root_path)
-            if lifecycle_events_enabled:
-                await _emit_daemon_lifecycle_event(
-                    "component_ready",
-                    archive_root_path=archive_root_path,
-                    component="embedding_lifecycle_startup",
-                )
             await _run_startup_fts_readiness(write_coordinator)
             if lifecycle_events_enabled:
                 await _emit_daemon_lifecycle_event(

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -68,6 +68,9 @@ from polylogue.daemon.write_coordinator import (
     daemon_write_coordinator,
 )
 from polylogue.logging import configure_logging, get_logger
+from polylogue.operations.embedding_lifecycle import (
+    ensure_embedding_lifecycle_startup as _ensure_embedding_lifecycle_startup_sync,
+)
 from polylogue.product.raw_authority import (
     RAW_MATERIALIZATION_ORDINARY_BLOB_LIMIT_BYTES,
     RAW_MATERIALIZATION_WHALE_BLOB_LIMIT_BYTES,
@@ -328,6 +331,15 @@ async def _await_parse_stage_writer_admission() -> bool:
 async def _run_startup_fts_readiness(coordinator: DaemonWriteCoordinator) -> None:
     """Run the real startup FTS writer on an exit-safe coordinator thread."""
     await coordinator.run_sync("startup.fts_readiness", _ensure_fts_startup_readiness_sync)
+
+
+async def _run_startup_embedding_lifecycle(coordinator: DaemonWriteCoordinator, archive_root_path: Path) -> Path:
+    """Run embedding lifecycle recovery before any embedding maintenance starts."""
+    return await coordinator.run_sync(
+        "startup.embedding_lifecycle",
+        _ensure_embedding_lifecycle_startup_sync,
+        archive_root_path,
+    )
 
 
 async def _run_startup_lineage_readiness(coordinator: DaemonWriteCoordinator) -> int:
@@ -3123,6 +3135,13 @@ async def _run_daemon_services_under_active_writer_lease(
             from polylogue.daemon.judgment_automation import periodic_judgment_automation_sweep
             from polylogue.daemon.secret_scan_sweep import periodic_secret_scan_sweep
 
+            await _run_startup_embedding_lifecycle(write_coordinator, archive_root_path)
+            if lifecycle_events_enabled:
+                await _emit_daemon_lifecycle_event(
+                    "component_ready",
+                    archive_root_path=archive_root_path,
+                    component="embedding_lifecycle_startup",
+                )
             await _run_startup_fts_readiness(write_coordinator)
             if lifecycle_events_enabled:
                 await _emit_daemon_lifecycle_event(

--- a/polylogue/operations/embedding_lifecycle.py
+++ b/polylogue/operations/embedding_lifecycle.py
@@ -1,0 +1,12 @@
+"""Operation boundary for embedding generation lifecycle recovery."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def ensure_embedding_lifecycle_startup(archive_root_path: Path) -> Path:
+    """Adopt or recover the archive-owned embedding generation pointer."""
+    from polylogue.storage.embeddings.generations import ensure_embedding_lifecycle
+
+    return ensure_embedding_lifecycle(archive_root_path)

--- a/polylogue/storage/embeddings/generations.py
+++ b/polylogue/storage/embeddings/generations.py
@@ -188,6 +188,37 @@ class EmbeddingGenerationStore:
         except (OSError, sqlite3.Error, TypeError, ValueError) as exc:
             raise EmbeddingGenerationError(f"malformed embedding database: {path}") from exc
 
+    def prepare_legacy_active_database(self) -> None:
+        """Checkpoint a pre-lifecycle active database before copying it.
+
+        The lifecycle never copies bytes accompanied by SQLite sidecars.  The
+        daemon owns the archive writer when this route runs, so ask SQLite to
+        complete a truncate checkpoint and reject the handoff if any sidecar
+        remains.  In particular, do not unlink a WAL or SHM file ourselves:
+        SQLite remains the authority for recovery and lock safety.
+        """
+        if self.active_path.is_symlink() or not self.active_path.exists():
+            return
+        if not _regular_file(self.active_path):
+            raise EmbeddingGenerationError("embedding active path is not a regular file")
+        try:
+            with sqlite3.connect(self.active_path, timeout=30.0) as conn:
+                row = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+        except (OSError, sqlite3.Error) as exc:
+            raise EmbeddingGenerationError("could not checkpoint legacy embedding database") from exc
+        if row is None or int(row[0] or 0) != 0:
+            raise EmbeddingGenerationError("legacy embedding database checkpoint is blocked")
+        sidecars = tuple(
+            path
+            for path in (
+                self.active_path.with_name(self.active_path.name + "-wal"),
+                self.active_path.with_name(self.active_path.name + "-shm"),
+            )
+            if path.exists()
+        )
+        if sidecars:
+            raise EmbeddingGenerationError("legacy embedding database retains SQLite sidecars after checkpoint")
+
     def _read_generation(self, path: Path) -> EmbeddingGeneration:
         try:
             if path.is_symlink() or path.name != "generation.json" or not _regular_file(path):
@@ -558,6 +589,7 @@ class EmbeddingGenerationStore:
 def ensure_embedding_lifecycle(archive_root: str | Path, *, active_path: str | Path | None = None) -> Path:
     """Actual daemon/CLI entrypoint for recovery, legacy adoption, and collection."""
     store = EmbeddingGenerationStore(archive_root, active_path=active_path)
+    store.prepare_legacy_active_database()
     store.recover_interrupted()
     path = store.ensure_active()
     store.collect()

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -4389,6 +4389,10 @@ def test_run_daemon_services_waits_for_fts_startup_before_watcher() -> None:
     def fake_fts_startup() -> None:
         events.append("fts")
 
+    def fake_embedding_lifecycle_startup(_archive_root_path: Path) -> Path:
+        events.append("embedding-lifecycle")
+        return Path("/tmp/polylogue-test-archive/embeddings.db")
+
     def fake_lineage_startup() -> int:
         events.append("lineage")
         return 0
@@ -4434,6 +4438,9 @@ def test_run_daemon_services_waits_for_fts_startup_before_watcher() -> None:
     with contextlib.ExitStack() as stack:
         stack.enter_context(patch.object(daemon_cli, "Polylogue", FakePolylogue))
         stack.enter_context(patch.object(daemon_cli, "LiveWatcher", FakeWatcher))
+        stack.enter_context(
+            patch.object(daemon_cli, "_ensure_embedding_lifecycle_startup_sync", fake_embedding_lifecycle_startup)
+        )
         stack.enter_context(patch.object(daemon_cli, "_ensure_fts_startup_readiness_sync", fake_fts_startup))
         stack.enter_context(patch.object(daemon_cli, "_ensure_lineage_startup_readiness_sync", fake_lineage_startup))
         stack.enter_context(patch.object(daemon_cli, "_reconcile_blob_publications", fake_reconcile_blob_publications))
@@ -4508,6 +4515,7 @@ def test_run_daemon_services_waits_for_fts_startup_before_watcher() -> None:
         )
 
     assert "watcher" in events
+    assert events.index("embedding-lifecycle") < events.index("fts") < events.index("watcher")
     assert events.index("fts") < events.index("watcher")
     assert events.index("fts") < events.index("lineage") < events.index("watcher")
     assert events.index("lineage") < events.index("blob-publications") < events.index("watcher")
@@ -4527,7 +4535,9 @@ def test_run_daemon_services_waits_for_fts_startup_before_watcher() -> None:
     assert lifecycle_phases[-1] == "shutdown_started"
     assert "shutdown_complete" not in lifecycle_phases
     lifecycle_components = {payload.get("component") for payload in lifecycle_payloads}
-    assert {"fts_startup", "lineage_startup", "converger", "watcher"}.issubset(lifecycle_components)
+    assert {"embedding_lifecycle_startup", "fts_startup", "lineage_startup", "converger", "watcher"}.issubset(
+        lifecycle_components
+    )
     assert len(watcher_coordinators) == 1
     bridge = api_server_factory.call_args.kwargs["write_bridge"]
     assert bridge._coordinator is watcher_coordinators[0]
@@ -4720,7 +4730,7 @@ def test_daemon_shutdown_marks_interrupted_attempts_only_without_signal(
     async def noop() -> None:
         return None
 
-    def noop_sync() -> None:
+    def noop_sync(*_args: object) -> None:
         return None
 
     async def no_drive_changes() -> int:
@@ -4764,6 +4774,7 @@ def test_daemon_shutdown_marks_interrupted_attempts_only_without_signal(
 
     with (
         patch.object(daemon_cli, "make_server", return_value=browser_server),
+        patch.object(daemon_cli, "_ensure_embedding_lifecycle_startup_sync", noop_sync),
         patch.object(daemon_cli, "_ensure_fts_startup_readiness_sync", noop_sync),
         patch.object(daemon_cli, "_ensure_lineage_startup_readiness_sync", noop_sync),
         patch.object(daemon_cli, "_reconcile_blob_publications", noop),

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -4429,7 +4429,12 @@ def test_run_daemon_services_waits_for_fts_startup_before_watcher() -> None:
             return None
 
     api_server = FakeAPIServer()
-    api_server_factory = Mock(return_value=api_server)
+
+    def make_api_server(*_args: object, **_kwargs: object) -> FakeAPIServer:
+        events.append("api-bind")
+        return api_server
+
+    api_server_factory = Mock(side_effect=make_api_server)
 
     def fake_emit_daemon_event(kind: str, **kwargs: object) -> None:
         assert kind == "daemon.lifecycle"
@@ -4515,6 +4520,7 @@ def test_run_daemon_services_waits_for_fts_startup_before_watcher() -> None:
         )
 
     assert "watcher" in events
+    assert events.index("embedding-lifecycle") < events.index("api-bind")
     assert events.index("embedding-lifecycle") < events.index("fts") < events.index("watcher")
     assert events.index("fts") < events.index("watcher")
     assert events.index("fts") < events.index("lineage") < events.index("watcher")

--- a/tests/unit/storage/test_embedding_generations.py
+++ b/tests/unit/storage/test_embedding_generations.py
@@ -158,6 +158,23 @@ def test_legacy_adoption_runs_on_ensure_route(tmp_path: Path) -> None:
     assert json.loads(metadata[0].read_text(encoding="utf-8"))["state"] == "active"
 
 
+def test_legacy_adoption_rejects_sidecars_that_sqlite_cannot_clear(tmp_path: Path) -> None:
+    active = tmp_path / "embeddings.db"
+    _sqlite(active, "legacy")
+    writer = sqlite3.connect(active)
+    try:
+        writer.execute("PRAGMA journal_mode=WAL")
+        writer.execute("INSERT INTO values_ VALUES ('wal')")
+        writer.commit()
+        assert active.with_name("embeddings.db-wal").exists()
+        with pytest.raises(EmbeddingGenerationError, match="retains SQLite sidecars"):
+            ensure_embedding_lifecycle(tmp_path)
+    finally:
+        writer.close()
+    assert active.is_file()
+    assert not active.is_symlink()
+
+
 def test_lifecycle_entrypoint_enters_collector(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[str] = []
     original = EmbeddingGenerationStore.collect


### PR DESCRIPTION
## Summary

Recover the embedding generation lifecycle under the daemon writer before FTS, lineage, and live watcher work begin.

## Problem

The retention state machine existed, but daemon startup never invoked it. A pre-lifecycle embeddings database therefore remained an unmanaged regular file, and copying one with SQLite sidecars would be unsafe.

## Solution

Add an operations-layer lifecycle entrypoint, run it through the daemon write coordinator at startup, emit its readiness event, and require SQLite to clear legacy sidecars through a truncate checkpoint before adoption. Residual sidecars fail closed; the code never deletes them directly.

## Verification

- `nix develop --command devtools test tests/unit/storage/test_embedding_generations.py tests/unit/daemon/test_daemon_cli.py::test_run_daemon_services_waits_for_fts_startup_before_watcher tests/unit/daemon/test_daemon_cli.py::test_daemon_shutdown_marks_interrupted_attempts_only_without_signal`
  - `19 passed in 2.43s`
- `nix develop --command devtools verify --quick`
  - all 12 quick-gate steps succeeded

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->