### PR TITLE
chore(agentctl): declare workspace verifiers

### DIFF
--- a/.agentctl/project.toml
+++ b/.agentctl/project.toml
@@ -22,7 +22,11 @@ verification_operations = ["verify_affected", "verify_quick", "verify_all"]
 [conflicts]
 exact_files = ["pyproject.toml", "uv.lock"]
 generated_surfaces = ["docs/reference/schema-support-matrix.md"]
-semantic_slots = ["archive-schema", "command-catalog", "verification-graph"]
+
+[conflicts.semantic_slots]
+archive-schema = ["polylogue/storage/schema.py", "polylogue/storage/sqlite/migrations/*.py"]
+command-catalog = ["devtools/command_catalog.py", "docs/devtools.md"]
+verification-graph = ["devtools/verify.py", "pyproject.toml"]
 
 [operations.verify_affected]
 description = "Run Polylogue's affected-test verification plan"

--- a/.agentctl/project.toml
+++ b/.agentctl/project.toml
@@ -17,6 +17,7 @@ root = "/realm/worktrees"
 default_base = "origin/master"
 identity_check = ["git", "diff", "--quiet", "--", "pyproject.toml", "uv.lock"]
 checkpoint_untracked = true
+verification_operations = ["verify_affected", "verify_quick", "verify_all"]
 
 [conflicts]
 exact_files = ["pyproject.toml", "uv.lock"]


### PR DESCRIPTION
Declare the Polylogue operations that may supply exact-head publication evidence to AgentCTL.

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->
