### PR TITLE
feat(daemon): centralize recurring FTS convergence

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -46,9 +46,6 @@ from polylogue.daemon.browser_capture import browser_capture_command
 from polylogue.daemon.fts_startup import (
     ensure_fts_startup_readiness as _ensure_fts_startup_readiness,
 )
-from polylogue.daemon.fts_startup import (
-    ensure_fts_startup_readiness_sync as _ensure_fts_startup_readiness_sync,
-)
 from polylogue.daemon.health import (
     HealthSeverity,
     HealthTier,
@@ -328,9 +325,15 @@ async def _await_parse_stage_writer_admission() -> bool:
     return idle
 
 
-async def _run_startup_fts_readiness(coordinator: DaemonWriteCoordinator) -> None:
-    """Run the real startup FTS writer on an exit-safe coordinator thread."""
-    await coordinator.run_sync("startup.fts_readiness", _ensure_fts_startup_readiness_sync)
+async def _run_startup_fts_readiness(coordinator: DaemonWriteCoordinator) -> object:
+    """Run the single FTS convergence owner before the watcher starts."""
+    from polylogue.daemon.fts_convergence import FtsConvergenceOwner, FtsRunReason
+
+    return await coordinator.run_sync(
+        "startup.fts_convergence",
+        FtsConvergenceOwner(_active_index_db_path()).run_once_sync,
+        reason=FtsRunReason.STARTUP,
+    )
 
 
 async def _run_startup_embedding_lifecycle(coordinator: DaemonWriteCoordinator, archive_root_path: Path) -> Path:
@@ -943,6 +946,7 @@ async def _periodic_convergence_check(
     await _await_catch_up_gate(catch_up_complete, loop_name="convergence debt retry")
     while True:
         await _retry_convergence_debt_once(db)
+        await _run_periodic_fts_convergence_once(db)
         await asyncio.sleep(_CONVERGENCE_DEBT_RETRY_INTERVAL_SECONDS)
 
 
@@ -965,6 +969,23 @@ async def _retry_convergence_debt_once(db: Path) -> None:
         logger.warning("convergence: check failed", exc_info=True)
     except Exception:
         logger.warning("convergence: check failed", exc_info=True)
+
+
+async def _run_periodic_fts_convergence_once(db: Path) -> None:
+    """Run the owner-only archive-wide exact FTS audit when it is due."""
+    from polylogue.daemon.fts_convergence import FtsConvergenceOwner, FtsRunReason
+
+    result = await daemon_write_coordinator().run_sync(
+        "maintenance.fts_convergence",
+        FtsConvergenceOwner(db).run_once_sync,
+        reason=FtsRunReason.PERIODIC,
+    )
+    if bool(getattr(result, "exact", False)):
+        logger.info(
+            "fts convergence: state=%s repaired_surfaces=%d",
+            getattr(result, "state", "unknown"),
+            int(getattr(result, "repaired_surfaces", 0)),
+        )
 
 
 def _bulk_scale_raw_materialization_backlog(counts: RawMaterializationCounts) -> bool:
@@ -2247,7 +2268,14 @@ def _drain_convergence_debt_once(db: Path, *, limit: int = 100) -> int:
         return 0
 
     fts_surfaces = tuple(dict.fromkeys(debt.subject_id for debt in due_debt if debt.subject_type == "fts_surface"))
-    fts_surface_results = _drain_fts_surface_debt(db, fts_surfaces)
+    fts_owner_result: object | None = None
+    if fts_surfaces:
+        from polylogue.daemon.fts_convergence import FtsConvergenceOwner, FtsRunReason
+
+        fts_owner_result = FtsConvergenceOwner(db).run_once_sync(
+            reason=FtsRunReason.DEBT_RETRY,
+            surfaces=fts_surfaces,
+        )
 
     subject_states: dict[tuple[str, str, str], object] = {}
     retryable_debt = tuple(debt for debt in due_debt if debt.subject_type in {"source_path", "session_id"})
@@ -2285,8 +2313,7 @@ def _drain_convergence_debt_once(db: Path, *, limit: int = 100) -> int:
     for debt in due_debt:
         retried += 1
         if debt.subject_type == "fts_surface":
-            result = fts_surface_results.get(debt.subject_id)
-            if bool(getattr(result, "success", result)):
+            if bool(getattr(fts_owner_result, "ready", False)):
                 cursor.clear_convergence_debt(
                     stage=debt.stage,
                     subject_type=debt.subject_type,
@@ -2297,9 +2324,9 @@ def _drain_convergence_debt_once(db: Path, *, limit: int = 100) -> int:
                 stage=debt.stage,
                 subject_type=debt.subject_type,
                 subject_id=debt.subject_id,
-                error="FTS freshness convergence did not converge",
+                error="FTS convergence owner retained outstanding exact-verification debt",
                 materializer_version=debt.materializer_version,
-                deferred=bool(getattr(result, "deferred", False)),
+                deferred=bool(getattr(fts_owner_result, "deferred", False)),
             )
             continue
 
@@ -2355,17 +2382,6 @@ def _drain_convergence_debt_once(db: Path, *, limit: int = 100) -> int:
                 deferred=is_deferred_stage_state(stages_map.get(stage)),
             )
     return retried
-
-
-def _drain_fts_surface_debt(db: Path, surfaces: tuple[str, ...]) -> dict[str, object]:
-    if not surfaces:
-        return {}
-    from polylogue.daemon.convergence_stages import repair_fts_surface_result
-
-    results: dict[str, object] = {}
-    for surface in surfaces:
-        results[surface] = repair_fts_surface_result(db, surface)
-    return results
 
 
 def _debt_retry_due(debt: object, *, now: datetime) -> bool:
@@ -3143,17 +3159,15 @@ async def _run_daemon_services_under_active_writer_lease(
                 periodic_embedding_backlog_check,
                 periodic_embedding_orphan_reconcile_check,
             )
-            from polylogue.daemon.fts_identity_convergence import periodic_fts_identity_drift_recompute
-            from polylogue.daemon.fts_orphan_audit import periodic_fts_orphan_audit
             from polylogue.daemon.judgment_automation import periodic_judgment_automation_sweep
             from polylogue.daemon.secret_scan_sweep import periodic_secret_scan_sweep
 
-            await _run_startup_fts_readiness(write_coordinator)
+            fts_startup = await _run_startup_fts_readiness(write_coordinator)
             if lifecycle_events_enabled:
                 await _emit_daemon_lifecycle_event(
-                    "component_ready",
+                    "component_ready" if bool(getattr(fts_startup, "ready", False)) else "component_degraded",
                     archive_root_path=archive_root_path,
-                    component="fts_startup",
+                    component="fts",
                 )
             await _run_startup_lineage_readiness(write_coordinator)
             if lifecycle_events_enabled:
@@ -3185,8 +3199,6 @@ async def _run_daemon_services_under_active_writer_lease(
                     catch_up_complete=catch_up_complete_gate,
                     archive_root_path=archive_root_path,
                 ),
-                periodic_fts_identity_drift_recompute(catch_up_complete=catch_up_complete_gate),
-                periodic_fts_orphan_audit(catch_up_complete=catch_up_complete_gate),
                 periodic_blob_gc_check(catch_up_complete=catch_up_complete_gate),
                 periodic_blob_publication_reconciliation_check(catch_up_complete=catch_up_complete_gate),
                 periodic_secret_scan_sweep(catch_up_complete=catch_up_complete_gate),

--- a/polylogue/daemon/fts_convergence.py
+++ b/polylogue/daemon/fts_convergence.py
@@ -1,0 +1,145 @@
+"""Single daemon owner for recurring FTS convergence.
+
+Startup recovery, archive-wide exact auditing, and persisted surface-debt
+repair used to be scheduled by separate daemon loops.  This owner is the
+single recurring route; it delegates to the existing transaction-bound FTS
+repair and exact-generation snapshot routines.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from pathlib import Path
+
+from polylogue.logging import get_logger
+
+logger = get_logger(__name__)
+
+FTS_CONVERGENCE_EXACT_INTERVAL = timedelta(hours=24)
+
+
+def _is_transient_sqlite_lock(exc: BaseException) -> bool:
+    import sqlite3
+
+    return isinstance(exc, sqlite3.OperationalError) and any(
+        token in str(exc).lower() for token in ("database is locked", "database table is locked", "database is busy")
+    )
+
+
+class FtsRunReason(StrEnum):
+    STARTUP = "startup"
+    PERIODIC = "periodic"
+    DEBT_RETRY = "debt_retry"
+
+
+class FtsOwnerState(StrEnum):
+    ABSENT = "absent"
+    READY_EXACT = "ready_exact"
+    PENDING = "pending"
+    DEFERRED = "deferred"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True, slots=True)
+class FtsOwnerResult:
+    state: FtsOwnerState
+    exact: bool
+    repaired_surfaces: int = 0
+    detail: str | None = None
+
+    @property
+    def ready(self) -> bool:
+        return self.state is FtsOwnerState.READY_EXACT
+
+    @property
+    def deferred(self) -> bool:
+        return self.state is FtsOwnerState.DEFERRED
+
+
+class FtsConvergenceOwner:
+    """Own every recurring daemon route that may publish FTS readiness."""
+
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = db_path
+
+    def run_once_sync(
+        self,
+        *,
+        reason: FtsRunReason,
+        surfaces: tuple[str, ...] = (),
+    ) -> FtsOwnerResult:
+        if not self._db_path.exists():
+            return FtsOwnerResult(FtsOwnerState.ABSENT, exact=False)
+        try:
+            if reason is FtsRunReason.STARTUP:
+                from polylogue.daemon.fts_startup import ensure_fts_startup_readiness_sync
+
+                ensure_fts_startup_readiness_sync()
+                return self._exact_result()
+            if reason is FtsRunReason.PERIODIC:
+                if not self._exact_due():
+                    return FtsOwnerResult(FtsOwnerState.PENDING, exact=False, detail="exact FTS audit not due")
+                from polylogue.daemon.fts_identity_convergence import run_fts_identity_drift_recompute_once_sync
+                from polylogue.daemon.fts_orphan_audit import run_fts_orphan_audit_once_sync
+
+                audit = run_fts_identity_drift_recompute_once_sync(self._db_path)
+                orphan = run_fts_orphan_audit_once_sync(self._db_path)
+                return FtsOwnerResult(
+                    FtsOwnerState.READY_EXACT if audit.ready else FtsOwnerState.PENDING,
+                    exact=audit.ran,
+                    repaired_surfaces=orphan.orphaned_sessions_found,
+                )
+            return self._repair_debt(surfaces)
+        except Exception as exc:
+            if _is_transient_sqlite_lock(exc):
+                return FtsOwnerResult(FtsOwnerState.DEFERRED, exact=False, detail=str(exc))
+            logger.warning("fts convergence owner failed reason=%s", reason, exc_info=True)
+            return FtsOwnerResult(FtsOwnerState.FAILED, exact=False, detail=f"{type(exc).__name__}: {exc}")
+
+    def _repair_debt(self, surfaces: tuple[str, ...]) -> FtsOwnerResult:
+        from polylogue.daemon.convergence_stages import repair_fts_surface_result
+
+        attempted = tuple(dict.fromkeys(surfaces))
+        if not attempted:
+            return FtsOwnerResult(FtsOwnerState.PENDING, exact=False)
+        results = tuple(repair_fts_surface_result(self._db_path, surface) for surface in attempted)
+        if any(result.deferred for result in results):
+            return FtsOwnerResult(FtsOwnerState.DEFERRED, exact=False, detail="SQLite writer busy")
+        if all(result.success for result in results):
+            return self._exact_result(repaired_surfaces=len(results))
+        return FtsOwnerResult(FtsOwnerState.PENDING, exact=True, repaired_surfaces=len(results))
+
+    def _exact_due(self) -> bool:
+        import sqlite3
+
+        try:
+            with sqlite3.connect(f"file:{self._db_path}?mode=ro", uri=True) as conn:
+                row = conn.execute(
+                    "SELECT exact_checked_at FROM fts_freshness_state WHERE surface = 'messages_fts'"
+                ).fetchone()
+        except sqlite3.Error:
+            return True
+        if row is None or row[0] is None:
+            return True
+        try:
+            return (
+                datetime.now(UTC) - datetime.fromisoformat(str(row[0])).astimezone(UTC)
+                >= FTS_CONVERGENCE_EXACT_INTERVAL
+            )
+        except ValueError:
+            return True
+
+    def _exact_result(self, *, repaired_surfaces: int = 0) -> FtsOwnerResult:
+        from polylogue.daemon.fts_identity_convergence import run_fts_identity_drift_recompute_once_sync
+
+        result = run_fts_identity_drift_recompute_once_sync(self._db_path)
+        return FtsOwnerResult(
+            FtsOwnerState.READY_EXACT if result.ready else FtsOwnerState.PENDING,
+            exact=result.ran,
+            repaired_surfaces=repaired_surfaces,
+        )
+
+
+__all__ = ["FTS_CONVERGENCE_EXACT_INTERVAL", "FtsConvergenceOwner", "FtsOwnerResult", "FtsOwnerState", "FtsRunReason"]

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -433,22 +433,22 @@ def test_drain_convergence_debt_retries_global_messages_fts_surface(
             "UPDATE convergence_debt SET next_retry_at = '1970-01-01T00:00:00+00:00'",
         )
         conn.commit()
-    repairs: list[tuple[Path, str]] = []
+    repairs: list[tuple[Path, tuple[str, ...]]] = []
 
-    def fake_repair_fts_surface(path: Path, surface: str) -> bool:
-        repairs.append((path, surface))
-        return True
+    def fake_owner_run(self: Any, *, reason: object, surfaces: tuple[str, ...]) -> object:
+        repairs.append((self._db_path, surfaces))
+        return SimpleNamespace(ready=True, deferred=False)
 
     monkeypatch.setattr(
-        "polylogue.daemon.convergence_stages.repair_fts_surface_result",
-        fake_repair_fts_surface,
+        "polylogue.daemon.fts_convergence.FtsConvergenceOwner.run_once_sync",
+        fake_owner_run,
     )
 
     retried = daemon_cli._drain_convergence_debt_once(db)
     debt_after = cursor.list_convergence_debt()
 
     assert retried == 1
-    assert repairs == [(db, "messages_fts")]
+    assert repairs == [(db, ("messages_fts",))]
     assert debt_after == []
 
 
@@ -469,22 +469,22 @@ def test_drain_convergence_debt_retries_optional_fts_surface(
         subject_id="session_work_events_fts",
         error="optional FTS startup repair failed",
     )
-    repairs: list[tuple[Path, str]] = []
+    repairs: list[tuple[Path, tuple[str, ...]]] = []
 
-    def fake_repair_fts_surface(path: Path, surface: str) -> bool:
-        repairs.append((path, surface))
-        return True
+    def fake_owner_run(self: Any, *, reason: object, surfaces: tuple[str, ...]) -> object:
+        repairs.append((self._db_path, surfaces))
+        return SimpleNamespace(ready=True, deferred=False)
 
     monkeypatch.setattr(
-        "polylogue.daemon.convergence_stages.repair_fts_surface_result",
-        fake_repair_fts_surface,
+        "polylogue.daemon.fts_convergence.FtsConvergenceOwner.run_once_sync",
+        fake_owner_run,
     )
 
     retried = daemon_cli._drain_convergence_debt_once(db)
     debt_after = cursor.list_convergence_debt()
 
     assert retried == 1
-    assert repairs == [(db, "session_work_events_fts")]
+    assert repairs == [(db, ("session_work_events_fts",))]
     assert debt_after == []
 
 
@@ -1415,7 +1415,7 @@ def test_periodic_raw_materialization_convergence_starts_without_catch_up(
     calls: list[str] = []
 
     async def fake_run_sync(_actor: str, _func: object, *_args: object, **_kwargs: object) -> object:
-        calls.append("drain")
+        calls.append("fts" if _actor == "maintenance.fts_convergence" else "drain")
         raise asyncio.CancelledError
 
     async def exercise() -> None:
@@ -1430,7 +1430,7 @@ def test_periodic_raw_materialization_convergence_starts_without_catch_up(
 
     asyncio.run(exercise())
 
-    assert calls == ["drain"]
+    assert calls == ["drain", "fts"]
 
 
 def test_periodic_raw_materialization_convergence_waits_for_watcher_catch_up(
@@ -1442,7 +1442,7 @@ def test_periodic_raw_materialization_convergence_waits_for_watcher_catch_up(
     calls: list[str] = []
 
     async def fake_run_sync(_actor: str, _func: object, *_args: object, **_kwargs: object) -> object:
-        calls.append("drain")
+        calls.append("fts" if _actor == "maintenance.fts_convergence" else "drain")
         raise asyncio.CancelledError
 
     async def exercise() -> None:
@@ -1463,7 +1463,7 @@ def test_periodic_raw_materialization_convergence_waits_for_watcher_catch_up(
 
     asyncio.run(exercise())
 
-    assert calls == ["drain"]
+    assert calls == ["drain", "fts"]
 
 
 def test_periodic_drive_source_catchup_waits_for_watcher_catch_up(
@@ -2023,7 +2023,7 @@ def test_periodic_convergence_check_waits_for_catch_up_complete(
     drained = asyncio.Event()
 
     async def fake_run_sync(_actor: str, _func: object, *_args: object, **_kwargs: object) -> object:
-        calls.append("drain")
+        calls.append("fts" if _actor == "maintenance.fts_convergence" else "drain")
         drained.set()
         return 0
 
@@ -2047,7 +2047,7 @@ def test_periodic_convergence_check_waits_for_catch_up_complete(
 
     asyncio.run(exercise())
 
-    assert calls == ["drain"]
+    assert calls == ["drain", "fts"]
 
 
 def test_periodic_convergence_check_warns_on_non_lock_failures(tmp_path: Path) -> None:
@@ -4386,8 +4386,9 @@ def test_run_daemon_services_waits_for_fts_startup_before_watcher() -> None:
         def stop(self) -> None:
             events.append("stop")
 
-    def fake_fts_startup() -> None:
+    def fake_fts_owner_run(self: object, *, reason: object, surfaces: tuple[str, ...] = ()) -> object:
         events.append("fts")
+        return SimpleNamespace(ready=True, exact=True, repaired_surfaces=0)
 
     def fake_embedding_lifecycle_startup(_archive_root_path: Path) -> Path:
         events.append("embedding-lifecycle")
@@ -4446,7 +4447,9 @@ def test_run_daemon_services_waits_for_fts_startup_before_watcher() -> None:
         stack.enter_context(
             patch.object(daemon_cli, "_ensure_embedding_lifecycle_startup_sync", fake_embedding_lifecycle_startup)
         )
-        stack.enter_context(patch.object(daemon_cli, "_ensure_fts_startup_readiness_sync", fake_fts_startup))
+        stack.enter_context(
+            patch("polylogue.daemon.fts_convergence.FtsConvergenceOwner.run_once_sync", fake_fts_owner_run)
+        )
         stack.enter_context(patch.object(daemon_cli, "_ensure_lineage_startup_readiness_sync", fake_lineage_startup))
         stack.enter_context(patch.object(daemon_cli, "_reconcile_blob_publications", fake_reconcile_blob_publications))
         stack.enter_context(patch.object(daemon_cli, "_check_schema_version_fast", return_value=ok_schema))
@@ -4541,7 +4544,7 @@ def test_run_daemon_services_waits_for_fts_startup_before_watcher() -> None:
     assert lifecycle_phases[-1] == "shutdown_started"
     assert "shutdown_complete" not in lifecycle_phases
     lifecycle_components = {payload.get("component") for payload in lifecycle_payloads}
-    assert {"embedding_lifecycle_startup", "fts_startup", "lineage_startup", "converger", "watcher"}.issubset(
+    assert {"embedding_lifecycle_startup", "fts", "lineage_startup", "converger", "watcher"}.issubset(
         lifecycle_components
     )
     assert len(watcher_coordinators) == 1


### PR DESCRIPTION
## Summary

Centralize the daemon’s recurring FTS startup, periodic-audit, and surface-debt routes behind one owner.

## Problem

FTS readiness was maintained by independent startup, hourly orphan-audit, daily identity-audit, and debt-retry loops. Those routes duplicated ownership of archive-wide convergence.

## Solution

Add `FtsConvergenceOwner`, route daemon startup and periodic convergence through it, and route all due FTS surface debt through one owner invocation. Existing exact-generation freshness and transaction-bound repair routines remain authoritative.

## Verification

- `devtools test tests/unit/daemon/test_daemon_cli.py::test_drain_convergence_debt_retries_global_messages_fts_surface tests/unit/daemon/test_daemon_cli.py::test_drain_convergence_debt_retries_optional_fts_surface tests/unit/daemon/test_daemon_cli.py::test_periodic_convergence_check_waits_for_catch_up_complete tests/unit/daemon/test_daemon_cli.py::test_run_daemon_services_waits_for_fts_startup_before_watcher`
  - `4 passed in 1.43s`
- `devtools verify --quick`
  - success in 53.9s, receipt `20260823T054347Z-quick-1885136-ee253897`

Ref polylogue-4zyi0.

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->