### PR TITLE
fix(devtools): add pinned campaign genesis

### DIFF
--- a/devtools/campaign_genesis/reindex-2026.json
+++ b/devtools/campaign_genesis/reindex-2026.json
@@ -1,0 +1,19 @@
+{
+  "schema": "polylogue.campaign-genesis/v1",
+  "campaign_id": "reindex-2026",
+  "input_snapshot": {
+    "revision": "1a6bce13ff0ed9aaa5de6cb6d992968145d44c64",
+    "path": ".beads/issues.jsonl",
+    "sha256": "12f6be2b3470c3d5a1b48db1a406203b9afa3922fbed209e1ca1a98182ba4093"
+  },
+  "migration_snapshot": {
+    "revision": "317b59f41f938884d289d48737cfe87ec00bd769",
+    "path": ".beads/issues.jsonl",
+    "sha256": "1f4ad936d690de3bbda854cd737741eb92de631167c82294fe661f536045f64b"
+  },
+  "formula_snapshot": {
+    "revision": "d250e578bf7353519f667a96fafd7ea7d43f8e0b",
+    "path": ".beads/formulas/mol-polylogue-thematic-batch.formula.json",
+    "sha256": "465a7032fa2c1c2f450cd58f96cee7e32dab2751b553590056e54b4bd7cff2b2"
+  }
+}

--- a/devtools/snapshot_run.py
+++ b/devtools/snapshot_run.py
@@ -55,6 +55,9 @@ __all__ = [
 #: are either not code under test (`.venv`), or state that must outlive the
 #: run (`.cache` carries the testmon graph and the receipts the caller reads).
 _LIVE_BINDS: tuple[str, ...] = (".venv", ".cache", ".git")
+# `/realm/tmp` is deliberately an immutable directory index. Ephemeral files
+# belong in its managed, sticky work area instead.
+SNAPSHOT_ROOT = Path("/realm/tmp/work")
 
 
 class SnapshotUnavailableError(RuntimeError):
@@ -82,7 +85,11 @@ def materialize_snapshot(root: Path, destination: Path | None = None) -> Path:
     means a newly written test still runs; ignored means build output and caches
     stay out, which is what keeps the copy cheap.
     """
-    target = destination or Path(tempfile.mkdtemp(prefix="polylogue-snapshot-", dir="/realm/tmp"))
+    if destination is None:
+        SNAPSHOT_ROOT.mkdir(parents=True, exist_ok=True)
+        target = Path(tempfile.mkdtemp(prefix="polylogue-snapshot-", dir=SNAPSHOT_ROOT))
+    else:
+        target = destination
     target.mkdir(parents=True, exist_ok=True)
     listings = (
         ["git", "ls-files", "-z"],

--- a/tests/unit/devtools/test_snapshot_run.py
+++ b/tests/unit/devtools/test_snapshot_run.py
@@ -69,6 +69,19 @@ def test_snapshot_captures_tracked_and_untracked_but_not_ignored(sample_repo: Pa
     assert not (snapshot / "ignored.log").exists(), "ignored files must stay out of the snapshot"
 
 
+def test_snapshot_default_uses_managed_work_root(
+    sample_repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Implicit snapshots use the writable managed work area, not its index."""
+    from devtools import snapshot_run
+
+    monkeypatch.setattr(snapshot_run, "SNAPSHOT_ROOT", tmp_path / "work")
+
+    snapshot = materialize_snapshot(sample_repo)
+
+    assert snapshot.parent == tmp_path / "work"
+
+
 def test_snapshot_captures_uncommitted_edits_to_tracked_files(sample_repo: Path, tmp_path: Path) -> None:
     """Working-tree content, not HEAD content: the run tests what you have."""
     (sample_repo / "pkg" / "mod.py").write_text("VALUE = 'edited'\n", encoding="utf-8")


### PR DESCRIPTION
## Summary

Adds the immutable campaign genesis artifact and restores the managed temporary root required by snapshot-isolated verification.

## Problem

PR #4069 added `CAMPAIGN_GENESIS_PATH` and unconditionally loads `devtools/campaign_genesis/reindex-2026.json`, but the required JSON artifact was left untracked in its originating worktree and was absent from `master`. In addition, the guarded `devtools verify --quick` path attempted to create its isolated snapshot under `/realm/tmp`, the deliberately immutable directory index, so the repository pre-push hook could not complete.

## Solution

Adds the pinned reindex-2026 input, migration, and formula snapshot digests at the path the validator owns. Snapshot isolation now uses `/realm/tmp/work`, the managed writable work area, with a regression test for the implicit destination.

## Verification

`direnv exec . devtools test tests/unit/devtools/test_snapshot_run.py tests/unit/devtools/test_verify_bead_graph.py`

Result: `40 passed in 7.94s` (`ok (10.1s)`).

The guarded push also completed using the repaired snapshot path.

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->