### PR TITLE
fix(devtools): route all-mode pytest to scratch

### DIFF
--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -2893,7 +2893,7 @@ def _pytest_uses_full_suite_basetemp(label: str) -> bool:
     so it is NOT full-suite-shaped by label alone; selection_may_run_broadly
     covers the non-valid-graph cases at the placement decision.
     """
-    return label.startswith("pytest native") and "(bootstrap)" in label
+    return label.startswith("pytest native") and ("(bootstrap)" in label or "(all)" in label)
 
 
 def _changed_paths(base_commit: str, head_commit: str) -> set[str]:

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -3767,6 +3767,10 @@ def test_run_receipt_uses_capped_pytest_command_concurrency() -> None:
         # bootstrap lane is full-suite-shaped by label alone.
         ("pytest native parallel (full)", False),
         ("pytest native serial (full)", False),
+        # ``--all`` executes the complete corpus even when the testmon graph
+        # is valid; unlike affected ``(full)`` mode, it cannot be narrow.
+        ("pytest native parallel (all)", True),
+        ("pytest native serial (all)", True),
         ("pytest native parallel (bootstrap)", True),
         ("pytest native serial (bootstrap)", True),
     ],


### PR DESCRIPTION
## Summary
- classify complete-corpus `(all)` pytest lanes as full-suite basetemp consumers
- preserve narrow affected `(full)` lanes on bounded tmpfs
- route all-mode to managed NVMe scratch without reducing workers or coverage

## Evidence harness

| Scenario | Before | After |
|---|---:|---:|
| `pytest native parallel (all)` full-suite flag | false | true |
| `pytest native serial (all)` full-suite flag | false | true |
| valid affected `(full)` | false | false |
| focused placement | tmpfs | tmpfs |

The merged-master run was killed at 2087.1 MiB against a 2048 MiB tmpfs cap after 1,772/20,549 outcomes; the source documents a prior 2108 MiB incident. Explicit tmpfs, worker-count, and supervisor-cap machinery were not changed because the semantic lane misclassification alone reproduced the failure.

## Verification
- reproduction before fix: 2 failed, 5 passed (both all-mode cases)
- targeted after fix: 9 passed
- full module: changed 6 failed / 223 passed; untouched master 6 failed / 221 passed, identical inherited failures
- AgentCTL bound `verify_quick` job `438977cf-055d-4069-b935-aa12996b9c64` at exact head `73c1692d6`: succeeded