### PR TITLE
fix(maintenance): validate operation IDs before CLI setup

### DIFF
--- a/polylogue/cli/commands/maintenance/_rebuild_index_status.py
+++ b/polylogue/cli/commands/maintenance/_rebuild_index_status.py
@@ -49,15 +49,16 @@ def rebuild_index_status_command(
     output_format: str,
 ) -> None:
     """Report consolidated raw-replay rebuild status. Read-only."""
-    from polylogue.maintenance.rebuild_index import rebuild_status
-
-    configure_logging()
-    root = archive_root()
     if operation_id is not None:
         try:
             operation_id = validate_operation_id(operation_id)
         except ValueError as exc:
             raise click.BadParameter(str(exc), param_hint="--operation-id") from exc
+
+    from polylogue.maintenance.rebuild_index import rebuild_status
+
+    configure_logging()
+    root = archive_root()
     status = rebuild_status(root, operation_id=operation_id, include_daemon_bulk_rebuild=not no_daemon_fallback)
 
     if output_format == "json":

--- a/polylogue/cli/commands/maintenance/_status.py
+++ b/polylogue/cli/commands/maintenance/_status.py
@@ -58,6 +58,12 @@ def status_command(
     that the CLI ``plan``/``run`` commands, daemon HTTP, and MCP tools
     return.
     """
+    if operation_id is not None:
+        try:
+            operation_id = validate_operation_id(operation_id)
+        except ValueError as exc:
+            raise click.BadParameter(str(exc), param_hint="--operation-id") from exc
+
     from polylogue.maintenance.envelope import envelope_from_operation
     from polylogue.maintenance.registry import MaintenanceOperationRegistry
 
@@ -68,12 +74,6 @@ def status_command(
         sources=[],
     )
     registry = MaintenanceOperationRegistry(config=config)
-
-    if operation_id is not None:
-        try:
-            operation_id = validate_operation_id(operation_id)
-        except ValueError as exc:
-            raise click.BadParameter(str(exc), param_hint="--operation-id") from exc
 
     if operation_id is not None:
         record = registry.get_operation(operation_id)

--- a/tests/unit/cli/test_maintenance_operation_id_boundaries.py
+++ b/tests/unit/cli/test_maintenance_operation_id_boundaries.py
@@ -12,7 +12,7 @@ from polylogue.cli.commands.maintenance import _rebuild_index_status as rebuild_
 from polylogue.cli.commands.maintenance import _status as status_module
 from polylogue.cli.shared.types import AppEnv
 
-INVALID_OPERATION_ID = "../escape"
+INVALID_OPERATION_ID = "../not-an-opaque-id"
 
 
 def test_status_rejects_invalid_operation_id_before_registry_lookup(
@@ -33,7 +33,7 @@ def test_status_rejects_invalid_operation_id_before_registry_lookup(
     )
 
     assert result.exit_code != 0
-    assert result.exception is not None
+    assert "operation_id must not contain path separators" in result.output
 
 
 def test_rebuild_index_status_rejects_invalid_operation_id_before_status_lookup(
@@ -53,7 +53,7 @@ def test_rebuild_index_status_rejects_invalid_operation_id_before_status_lookup(
     )
 
     assert result.exit_code != 0
-    assert result.exception is not None
+    assert "operation_id must not contain path separators" in result.output
 
 
 def test_raw_authority_recovery_rejects_invalid_operation_id_before_recovery(
@@ -66,8 +66,9 @@ def test_raw_authority_recovery_rejects_invalid_operation_id_before_recovery(
     monkeypatch.setattr(raw_module, "resume_raw_authority_recovery", fail_recovery)
     result = CliRunner().invoke(
         raw_module.raw_authority_recovery_command,
-        ["--operation", "reset", "--operation-id", INVALID_OPERATION_ID],
+        ["--operation", "reset_raw_authority_census", "--operation-id", INVALID_OPERATION_ID],
+        obj=AppEnv(),
     )
 
     assert result.exit_code != 0
-    assert result.exception is not None
+    assert "operation_id must not contain path separators" in result.output


### PR DESCRIPTION
## Summary
Move maintenance operation-ID validation ahead of downstream command setup and strengthen the direct Click boundary proofs for status, rebuild-index-status, and raw-authority recovery.

## Problem
Current master already validates operation IDs, but the status and rebuild-index-status commands did so only after importing and constructing downstream state. That left the fail-closed boundary later than the maintenance contract and made the tests verify only that an exception occurred, without checking the user-facing rejection.

## Solution
Validate supplied IDs before downstream imports, logging, archive-root resolution, registry construction, or status execution while preserving the existing Click BadParameter error surface. The three direct Click tests now assert the validator message, use the current raw-authority operation name, and fail if the downstream registry, status, or recovery route is entered.

## Verification
- `direnv exec . devtools test tests/unit/cli/test_maintenance_operation_id_boundaries.py tests/unit/maintenance/test_operation_ids.py`: 19 passed in 2.93s.
- `direnv exec . devtools verify --quick`: all 12 steps passed, run `20260823T065004Z-quick-2428764-b6910519`.
- Pre-push `devtools verify --quick`: all 12 steps passed at exact head `4b55d443f`, run `20260823T070548Z-quick-2483394-6f828f23`.
- `git diff --check origin/master...HEAD`: clean.

Anti-vacuity: each regression enters the production Click command. The test replaces only the downstream registry lookup, rebuild status lookup, or recovery function with a failing sentinel, then requires the real validator error text. Removing or moving the validation after that downstream call makes the test fail.

## Bead disposition matrix

| Assigned Bead | Whole-Bead disposition | Evidence refs | Named successor for residual work |
| --- | --- | --- | --- |
| n/a | self-contained | `bd show --readonly polylogue-dixog` confirms the source Bead was already closed; current master commits `1c8366175`, `d4e9bc26d`, and `36b85a498`; this PR's 19-test route run | n/a |

No Bead records are assigned or mutated by this PR. The authoritative `polylogue-dixog` scope was already satisfied on master; the local lane commit was audited as still-valid boundary hardening and adapted onto current master without changing the existing option-error contract.

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": [],
  "dispositions": [],
  "mutated_beads": [],
  "scope_digest": "79a7984a9ec80a157c96dc8d28561159c642c15de3793837eff751fa7eac34a1",
  "scope_kind": "self_contained",
  "version": 2
}
-->

## Risks and Follow-ups
No live archive mutation was performed. This change only changes validation ordering and test assertions; valid IDs, omitted IDs, and Click's invalid-parameter classification remain unchanged.
