### PR TITLE
test(cli): cover enriched select JSON in PTY

### DIFF
--- a/tests/unit/cli/test_interactive_cli.py
+++ b/tests/unit/cli/test_interactive_cli.py
@@ -193,9 +193,12 @@ def test_select_returns_fzf_choice_in_json_in_a_real_pty(
 
     assert result.exit_code == 0
     assert json.loads(grid_to_text(result.grid).strip()) == {
+        "cwd_display": None,
         "date": "2026-07-11",
         "id": "chatgpt-export:ext-older",
+        "message_count": 1,
         "origin": "chatgpt-export",
+        "repo": None,
         "title": "Interactive picker candidate older",
     }
 


### PR DESCRIPTION
## Summary
- align the real-PTY JSON selector assertion with the current public SelectRow payload
- cover message_count, repo, and cwd_display added by the landed session-context enrichment

## Verification
- 22 focused PTY/select tests passed
- AgentCTL-bound verify_quick job adb5aae3-567d-4e9d-af4d-7a56e5fb300f succeeded at exact head 9a4b2f9