### PR TITLE
fix(devtools): narrow stale testmon binding reclamation

### DIFF
--- a/devtools/testmon_bootstrap.py
+++ b/devtools/testmon_bootstrap.py
@@ -28,6 +28,7 @@ import importlib.metadata
 import json
 import os
 import platform
+import re
 import sqlite3
 import stat
 import subprocess
@@ -1255,9 +1256,9 @@ def _reclaim_stale_native_testmon_bindings(directory_fd: int, name: str) -> None
         entries = os.listdir(directory_fd)
     except OSError as exc:
         raise NativeTestmonRepairError(f"cannot inspect native testmon bindings: {exc}") from exc
-    prefix = f".{name}.bound-"
+    private_name = re.compile(rf"\A\.{re.escape(name)}\.bound-[0-9]+-[0-9a-f]{{32}}\.tmp\Z")
     for entry in entries:
-        if not entry.startswith(prefix) or not entry.endswith(".tmp"):
+        if private_name.fullmatch(entry) is None:
             continue
         try:
             candidate = os.stat(entry, dir_fd=directory_fd, follow_symlinks=False)

--- a/tests/unit/devtools/test_testmon_bootstrap.py
+++ b/tests/unit/devtools/test_testmon_bootstrap.py
@@ -510,6 +510,49 @@ def test_native_inspection_rejects_hardlinked_database_and_sidecars(tmp_path: Pa
     assert outside.read_text(encoding="utf-8") == "external state"
 
 
+@pytest.mark.parametrize("alias_suffix", ("foreign.tmp", "123-not-a-uuid.tmp"))
+def test_source_binding_preserves_foreign_or_malformed_same_inode_alias(
+    tmp_path: Path,
+    alias_suffix: str,
+) -> None:
+    """Reclamation must not delete arbitrary same-inode private-looking names."""
+    source_root = tmp_path / "source"
+    (source_root / "tests").mkdir(parents=True)
+    source_data = _seed_partial_native_graph(
+        source_root,
+        environment_name="owned-environment",
+        fingerprinted="tests/test_recorded.py",
+    )
+    alias = source_data.with_name(f".{source_data.name}.bound-{alias_suffix}")
+    os.link(source_data, alias)
+
+    with pytest.raises(NativeTestmonRepairError, match="child changed while binding"):
+        with native_testmon_source_binding(source_data):
+            pytest.fail("a foreign or malformed alias must reject the source bind")
+
+    assert alias.exists(), "a foreign or malformed alias was reclaimed by broad prefix matching"
+    assert source_data.stat().st_nlink == 2
+
+
+def test_source_binding_reclaims_exactly_shaped_stale_same_inode_alias(tmp_path: Path) -> None:
+    """A crash-left alias produced by this module remains reclaimable."""
+    source_root = tmp_path / "source"
+    (source_root / "tests").mkdir(parents=True)
+    source_data = _seed_partial_native_graph(
+        source_root,
+        environment_name="owned-environment",
+        fingerprinted="tests/test_recorded.py",
+    )
+    alias = source_data.with_name(f".{source_data.name}.bound-123-{'a' * 32}.tmp")
+    os.link(source_data, alias)
+
+    with native_testmon_source_binding(source_data) as binding:
+        assert binding is not None
+
+    assert not alias.exists()
+    assert source_data.stat().st_nlink == 1
+
+
 def test_native_inspection_recovers_sidecars_through_retained_source_descriptor(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Narrow native testmon stale-binding reclamation to the exact filename shape generated by Polylogue, preserving valid crash-left aliases while leaving foreign or malformed same-inode aliases untouched.

## Problem

On the current master before this change, `_reclaim_stale_native_testmon_bindings()` accepted any entry beginning with `.testmondata.bound-` and ending in `.tmp`. The focused reproduction created same-inode aliases named `.testmondata.bound-foreign.tmp` and `.testmondata.bound-123-not-a-uuid.tmp`; current master deleted both aliases before the existing single-link safety check could reject the source.

## Solution

The reclaim filter now requires a numeric PID, a 32-character lowercase hexadecimal token, and the `.tmp` suffix. The focused tests prove that malformed or foreign aliases remain present and cause the existing fail-closed source-bind rejection, while a correctly shaped stale alias is reclaimed.

This PR intentionally excludes the WIP branch's TRUNCATE checkpoint, one-second lock budget, lock API, and descriptor/WAL model. No Beads, main checkout, or other worktrees were changed.

## Verification

- Pre-fix reproduction: `nix develop --command devtools test tests/unit/devtools/test_testmon_bootstrap.py -k source_binding_preserves_foreign_or_malformed_same_inode_alias` produced 2 failures, with both aliases absent after binding.
- Post-fix focused selector: `nix develop --command devtools test tests/unit/devtools/test_testmon_bootstrap.py -k 'source_binding_preserves_foreign_or_malformed_same_inode_alias or source_binding_reclaims_exactly_shaped_stale_same_inode_alias'` produced `3 passed, 55 deselected`.
- Post-rebase focused module: `nix develop --command devtools test tests/unit/devtools/test_testmon_bootstrap.py` produced `58 passed`.
- Commit hook: managed Ruff format check reported `2 files already formatted`.
- No full or complete-corpus test suite was run for this lane.

## Scope disposition

| Scope item | Disposition | Evidence |
| --- | --- | --- |
| Exact stale-binding-name hardening | Satisfied | Regex filter in `_reclaim_stale_native_testmon_bindings` |
| Foreign and malformed same-inode aliases | Satisfied | Parametrized preservation and fail-closed rejection test |
| Correctly shaped stale alias reclamation | Satisfied | Positive reclamation test |
| WIP TRUNCATE checkpoint and WAL changes | Excluded | No checkpoint or WAL code changed |
| WIP one-second lock budget and lock API | Excluded | No lifecycle lock code changed |
| WIP descriptor/WAL model | Excluded | No descriptor model changes imported |
| Beads or unrelated worktrees | Untouched | No task-state or unrelated checkout changes |

## pr-scope

```yaml
base: master
head: feature/fix/testmon-stale-binding-name
commit: 7ec1176b7da01b4707b0c63e5ec7a9401059ef41
changed_files:
  - devtools/testmon_bootstrap.py
  - tests/unit/devtools/test_testmon_bootstrap.py
excluded_wip:
  - TRUNCATE checkpoint
  - one-second lock budget
  - lock API
  - descriptor/WAL model
```
