### PR TITLE
feat(devtools): emit typed AgentCTL verification receipts

### DIFF
--- a/devtools/agentctl_verification_receipt.py
+++ b/devtools/agentctl_verification_receipt.py
@@ -1,0 +1,190 @@
+"""Bounded public verification results for declared AgentCTL operations."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from typing import Any, Final
+
+AGENTCTL_OPERATION_ENV: Final = "SINNIXD_OPERATION"
+AGENTCTL_CHECKOUT_ID_ENV: Final = "SINNIXD_CHECKOUT_ID"
+AGENTCTL_CHECKOUT_HEAD_ENV: Final = "SINNIXD_CHECKOUT_HEAD"
+AGENTCTL_JOB_ID_ENV: Final = "SINNIXD_JOB_ID"
+SUPPORTED_OPERATIONS: Final = frozenset({"verify_affected", "verify_quick", "verify_all"})
+RECEIPT_SCHEMA_VERSION: Final = 1
+MAX_GATE_OUTCOMES: Final = 16
+MAX_DIAGNOSTIC_PATHS: Final = 16
+MAX_PUBLIC_STRING_LENGTH: Final = 160
+
+
+def agentctl_verification_operation(env: Mapping[str, str] | None = None) -> str | None:
+    """Return the declared verification operation, never a caller-selected name."""
+    operation = (os.environ if env is None else env).get(AGENTCTL_OPERATION_ENV)
+    return operation if operation in SUPPORTED_OPERATIONS else None
+
+
+def agentctl_verification_receipt(
+    payload: Mapping[str, Any], *, env: Mapping[str, str] | None = None
+) -> dict[str, Any] | None:
+    """Project one verifier ledger into the stable AgentCTL result contract.
+
+    The full verifier ledger remains checkout-local forensic evidence. This
+    result intentionally excludes commands, output, exception text, and paths
+    outside the declared repository so AgentCTL can retain and expose it.
+    """
+    values = os.environ if env is None else env
+    operation = agentctl_verification_operation(values)
+    if operation is None:
+        return None
+
+    selection = _mapping(payload.get("testmon_selection"))
+    aggregate = _mapping(payload.get("pytest_aggregate"))
+    missing_paths = _strings(selection.get("missing_executable_paths"))
+    runtime_data_paths = _strings(selection.get("runtime_data_paths"))
+    verification_scope = _string(payload.get("verification_scope"))
+    return {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "kind": "polylogue.verification-result",
+        "operation": operation,
+        "job_id": _string(values.get(AGENTCTL_JOB_ID_ENV)),
+        "run_id": _string(payload.get("run_id")),
+        "workspace": {
+            "checkout_id": _string(values.get(AGENTCTL_CHECKOUT_ID_ENV)),
+            "declared_head": _string(values.get(AGENTCTL_CHECKOUT_HEAD_ENV)),
+            "observed_head": _string(payload.get("git_head")),
+            "final_head": _string(payload.get("final_git_head")),
+            "worktree_fingerprint": _string(payload.get("worktree_fingerprint")),
+            "final_worktree_fingerprint": _string(payload.get("final_worktree_fingerprint")),
+        },
+        "scope": {
+            "verification_scope": verification_scope,
+            "selection_mode": _string(selection.get("selection_mode")),
+            "release_baseline_allowed": _boolean(payload.get("release_baseline_allowed")),
+        },
+        "testmon_environment": {
+            "environment_digest": _string(selection.get("environment_digest")),
+            "graph_content_digest": None,
+            "graph_content_digest_available": False,
+            "state": _string(selection.get("state_status")),
+            "reason": _string(selection.get("state_reason")),
+        },
+        "gate_outcomes": _gate_outcomes(payload.get("steps")),
+        "pytest_outcomes": _pytest_outcomes(aggregate),
+        "diagnostics": {
+            "diagnosis": _string(payload.get("diagnosis")),
+            "checkout_diagnosis": _string(payload.get("checkout_diagnosis")),
+            "selection_widened": _selection_widened(selection),
+            "missing_edges": _bounded_strings(missing_paths),
+            "runtime_data_paths": _bounded_strings(runtime_data_paths),
+        },
+        "semantic_status": _semantic_status(payload, verification_scope),
+        "exit_code": _integer(payload.get("exit_code")),
+    }
+
+
+def _mapping(value: object) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _string(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    return value[:MAX_PUBLIC_STRING_LENGTH]
+
+
+def _integer(value: object) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _boolean(value: object) -> bool | None:
+    return value if isinstance(value, bool) else None
+
+
+def _strings(value: object) -> list[str]:
+    return [item for item in value if isinstance(item, str)] if isinstance(value, list | tuple) else []
+
+
+def _bounded_strings(values: list[str]) -> dict[str, Any]:
+    return {
+        "count": len(values),
+        "items": [_string(value) for value in values[:MAX_DIAGNOSTIC_PATHS]],
+        "truncated": len(values) > MAX_DIAGNOSTIC_PATHS,
+    }
+
+
+def _gate_outcomes(value: object) -> dict[str, Any]:
+    steps = [step for step in value if isinstance(step, Mapping)] if isinstance(value, list) else []
+    gates = [step for step in steps if not str(step.get("name", "")).startswith("pytest")]
+    items = [
+        {
+            "name": _string(step.get("name")),
+            "status": _step_status(step),
+            "exit_code": _integer(step.get("exit")),
+            "diagnosis": _string(step.get("diagnosis")),
+        }
+        for step in gates[:MAX_GATE_OUTCOMES]
+    ]
+    return {"count": len(gates), "items": items, "truncated": len(gates) > MAX_GATE_OUTCOMES}
+
+
+def _step_status(step: Mapping[str, Any]) -> str:
+    if step.get("status") == "running":
+        return "running"
+    return "passed" if step.get("exit") == 0 else "failed"
+
+
+def _pytest_outcomes(aggregate: Mapping[str, Any]) -> dict[str, Any]:
+    outcomes = _mapping(aggregate.get("outcomes"))
+    bounded_outcomes = {
+        key[:MAX_PUBLIC_STRING_LENGTH]: value
+        for key, value in sorted(
+            ((key, value) for key, value in outcomes.items() if isinstance(value, int) and not isinstance(value, bool)),
+            key=lambda item: item[0],
+        )[:MAX_GATE_OUTCOMES]
+    }
+    corpus = _mapping(aggregate.get("corpus"))
+    return {
+        "present": bool(aggregate),
+        "selection_mode": _string(aggregate.get("selection_mode")),
+        "selected_count": _integer(aggregate.get("selected_union_count")),
+        "terminal_count": _integer(aggregate.get("terminal_union_count")),
+        "non_green_count": _integer(aggregate.get("non_green_count")),
+        "terminal_green": _boolean(aggregate.get("terminal_green")),
+        "complete_corpus_covered": _boolean(aggregate.get("complete_corpus_covered")),
+        "corpus_digest": _string(corpus.get("digest")),
+        "outcomes": bounded_outcomes,
+        "outcomes_truncated": len(outcomes) > MAX_GATE_OUTCOMES,
+    }
+
+
+def _selection_widened(selection: Mapping[str, Any]) -> bool:
+    return selection.get("selection_mode") in {"all", "bootstrap"}
+
+
+def _semantic_status(payload: Mapping[str, Any], verification_scope: str | None) -> str:
+    if payload.get("status") == "running":
+        return "running"
+    exit_code = _integer(payload.get("exit_code"))
+    if exit_code == 0:
+        if verification_scope == "release-baseline":
+            return "release-baseline-passed"
+        if verification_scope == "affected":
+            return "affected-passed"
+        if verification_scope == "non-test":
+            return "non-test-passed"
+        return "passed"
+    if exit_code == 130:
+        return "interrupted"
+    return "failed"
+
+
+__all__ = [
+    "AGENTCTL_CHECKOUT_HEAD_ENV",
+    "AGENTCTL_CHECKOUT_ID_ENV",
+    "AGENTCTL_JOB_ID_ENV",
+    "AGENTCTL_OPERATION_ENV",
+    "RECEIPT_SCHEMA_VERSION",
+    "SUPPORTED_OPERATIONS",
+    "agentctl_verification_operation",
+    "agentctl_verification_receipt",
+]

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -42,6 +42,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Final
 
+from devtools.agentctl_verification_receipt import agentctl_verification_receipt
 from devtools.checkout_guard import (
     CheckoutImportMismatchError,
     assert_polylogue_matches_checkout,
@@ -2781,6 +2782,16 @@ def _print_json(result: dict[str, Any]) -> None:
     sys.stdout.write("\n")
 
 
+def _emit_machine_result(result: dict[str, Any], *, use_json: bool) -> None:
+    """Emit the bounded declared-operation result, or the legacy JSON ledger."""
+    agentctl_receipt = agentctl_verification_receipt(result)
+    if agentctl_receipt is not None:
+        json.dump(agentctl_receipt, sys.stdout, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+        sys.stdout.write("\n")
+    elif use_json:
+        _print_json(result)
+
+
 # ── stamp ───────────────────────────────────────────────────────────
 
 
@@ -3159,8 +3170,7 @@ def _finalize_preflight_failure(
     if (recorded_selection := run.testmon_selection) is not None:
         history_entry["testmon_selection"] = recorded_selection
     _save_history(history_entry)
-    if use_json:
-        _print_json(history_entry)
+    _emit_machine_result(history_entry, use_json=use_json)
     sys.stderr.write(f"verify: {message}\n")
     return exit_code
 
@@ -3395,6 +3405,7 @@ def _main(argv: list[str] | None = None) -> int:
             missing_executable_paths=preparation.local_state.missing_executable_paths,
             runtime_data_paths=runtime_data_paths,
             copied_from=str(preparation.copied_from) if preparation.copied_from is not None else None,
+            environment_digest=preparation.environment_name.removeprefix("polylogue-"),
         )
         if preparation.selection_mode == "bootstrap" and not args.all_tests:
             return _finalize_preflight_failure(
@@ -3798,9 +3809,8 @@ def _main(argv: list[str] | None = None) -> int:
         pytest_aggregate=pytest_aggregate,
     )
     history_entry["pytest_aggregate"] = finalized_payload["pytest_aggregate"]
-    if use_json:
-        _print_json(history_entry)
-    elif exit_code == 0:
+    _emit_machine_result(history_entry, use_json=bool(use_json))
+    if not use_json and exit_code == 0:
         flags = _compare_against_last(step_results)
         sys.stderr.write(f"\nverify: all checks passed ({total_duration:.1f}s total)")
         if flags:
@@ -3809,7 +3819,7 @@ def _main(argv: list[str] | None = None) -> int:
                 sys.stderr.write(flag + "\n")
         else:
             sys.stderr.write("\n")
-    else:
+    elif not use_json:
         sys.stderr.write(f"\nverify: FAILED ({total_duration:.1f}s); fix before pushing\n")
 
     _save_history(history_entry)
@@ -3881,8 +3891,7 @@ def _finalize_verify_runner_exception(
     payload["exception_type"] = type(exc).__name__
     payload["error"] = str(exc)
     _save_history(payload)
-    if use_json:
-        _print_json(payload)
+    _emit_machine_result(payload, use_json=use_json)
     sys.stderr.write(f"verify: unexpected runner exception: {exc}\n")
     return exit_code
 

--- a/devtools/verify_runs.py
+++ b/devtools/verify_runs.py
@@ -29,6 +29,7 @@ from typing import Any, Final, ParamSpec, TextIO, TypeVar
 
 import watchfiles
 
+from devtools.agentctl_verification_receipt import agentctl_verification_receipt
 from devtools.cloud_sentinels import CLOUD_SENTINELS, running_in_cloud_sandbox
 from devtools.pytest_supervisor import force_rmtree
 from devtools.testmon_bootstrap import canonical_test_nodeid
@@ -1790,7 +1791,7 @@ class VerifyRun:
         _write_json(self.run_dir / "run.json", self._payload)
         invocation_receipt = os.environ.get(VERIFICATION_RECEIPT_PATH_ENV)
         if invocation_receipt:
-            _write_json(Path(invocation_receipt), self._payload)
+            _write_json(Path(invocation_receipt), agentctl_verification_receipt(self._payload) or self._payload)
         current_path = self.root / CURRENT_RUN_PATH
         if not _current_owner_is_other_live_run(current_path):
             _write_json(current_path, self._payload)
@@ -1820,6 +1821,7 @@ class VerifyRun:
         missing_executable_paths: Sequence[str] = (),
         runtime_data_paths: Sequence[str] = (),
         copied_from: str | None = None,
+        environment_digest: str | None = None,
     ) -> None:
         """Record WHY this run selected the tests it did.
 
@@ -1850,6 +1852,7 @@ class VerifyRun:
             "missing_executable_path_count": len(tuple(missing_executable_paths)),
             "runtime_data_paths": list(runtime_data_paths),
             "copied_from": copied_from,
+            "environment_digest": environment_digest,
         }
         self.write()
 

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -24,6 +24,7 @@ import watchfiles
 
 import devtools.pytest_supervisor as pytest_supervisor
 from devtools import run_tests, verify, verify_runs
+from devtools.agentctl_verification_receipt import agentctl_verification_receipt
 from devtools.checkout_guard import CheckoutImportMismatchError
 from devtools.pytest_supervisor import (
     CGROUP_MODE_ENV,
@@ -4682,6 +4683,172 @@ def test_verify_continues_after_failed_cheap_step(
     assert payload["release_baseline_allowed"] is False
     assert payload["pytest_aggregate"]["selection_mode"] == "none"
     assert json.loads(receipt.read_text())["pytest_aggregate"] == payload["pytest_aggregate"]
+
+
+def test_agentctl_verification_receipt_bounds_public_diagnostics_and_preserves_contract() -> None:
+    receipt = agentctl_verification_receipt(
+        {
+            "run_id": "run-1",
+            "status": "success",
+            "exit_code": 0,
+            "git_head": "observed-head",
+            "final_git_head": "final-head",
+            "worktree_fingerprint": "before",
+            "final_worktree_fingerprint": "after",
+            "verification_scope": "affected",
+            "release_baseline_allowed": False,
+            "testmon_selection": {
+                "selection_mode": "all",
+                "state_status": "incomplete",
+                "state_reason": "changed dependencies require a complete run",
+                "environment_digest": "testmon-environment",
+                "missing_executable_paths": [f"polylogue/module_{index}.py" for index in range(20)],
+                "runtime_data_paths": [f"tests/data_{index}.json" for index in range(20)],
+            },
+            "steps": [
+                {"name": f"gate {index}", "exit": 0, "diagnosis": "passed", "cmd": ["private"]} for index in range(20)
+            ],
+            "pytest_aggregate": {
+                "selection_mode": "all",
+                "selected_union_count": 40,
+                "terminal_union_count": 40,
+                "non_green_count": 0,
+                "terminal_green": True,
+                "complete_corpus_covered": True,
+                "corpus": {"digest": "corpus-digest"},
+                "outcomes": {"passed": 40},
+            },
+        },
+        env={
+            "SINNIXD_OPERATION": "verify_affected",
+            "SINNIXD_JOB_ID": "job-1",
+            "SINNIXD_CHECKOUT_ID": "workspace-1",
+            "SINNIXD_CHECKOUT_HEAD": "declared-head",
+        },
+    )
+
+    assert receipt is not None
+    assert receipt["operation"] == "verify_affected"
+    assert receipt["workspace"] == {
+        "checkout_id": "workspace-1",
+        "declared_head": "declared-head",
+        "observed_head": "observed-head",
+        "final_head": "final-head",
+        "worktree_fingerprint": "before",
+        "final_worktree_fingerprint": "after",
+    }
+    assert receipt["scope"] == {
+        "verification_scope": "affected",
+        "selection_mode": "all",
+        "release_baseline_allowed": False,
+    }
+    assert receipt["testmon_environment"] == {
+        "environment_digest": "testmon-environment",
+        "graph_content_digest": None,
+        "graph_content_digest_available": False,
+        "state": "incomplete",
+        "reason": "changed dependencies require a complete run",
+    }
+    assert receipt["semantic_status"] == "affected-passed"
+    assert receipt["diagnostics"]["selection_widened"] is True
+    assert receipt["diagnostics"]["missing_edges"] == {
+        "count": 20,
+        "items": [f"polylogue/module_{index}.py" for index in range(16)],
+        "truncated": True,
+    }
+    assert receipt["diagnostics"]["runtime_data_paths"]["truncated"] is True
+    assert receipt["gate_outcomes"]["count"] == 20
+    assert len(receipt["gate_outcomes"]["items"]) == 16
+    assert receipt["pytest_outcomes"] == {
+        "present": True,
+        "selection_mode": "all",
+        "selected_count": 40,
+        "terminal_count": 40,
+        "non_green_count": 0,
+        "terminal_green": True,
+        "complete_corpus_covered": True,
+        "corpus_digest": "corpus-digest",
+        "outcomes": {"passed": 40},
+        "outcomes_truncated": False,
+    }
+    assert "cmd" not in json.dumps(receipt)
+
+
+def test_verify_run_writes_typed_agentctl_invocation_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    receipt_path = tmp_path / "receipt.json"
+    monkeypatch.setenv(verify_runs.VERIFICATION_RECEIPT_PATH_ENV, str(receipt_path))
+    monkeypatch.setenv("SINNIXD_OPERATION", "verify_affected")
+    monkeypatch.setenv("SINNIXD_CHECKOUT_ID", "workspace-1")
+    monkeypatch.setenv("SINNIXD_CHECKOUT_HEAD", "declared-head")
+
+    run = VerifyRun(tier="quick", argv=["--quick"], git_head="observed-head", root=tmp_path)
+    run.record_selection(
+        selection_mode="full",
+        state_status="valid",
+        state_reason="the graph is current",
+        environment_digest="testmon-environment",
+    )
+    payload = run.finish(
+        exit_code=0,
+        duration_s=0.1,
+        verification_scope="affected",
+        release_baseline_allowed=False,
+        final_git_head="final-head",
+    )
+
+    persisted = json.loads(receipt_path.read_text())
+    assert persisted["operation"] == "verify_affected"
+    assert persisted["workspace"]["checkout_id"] == "workspace-1"
+    assert persisted["workspace"]["observed_head"] == "observed-head"
+    assert persisted["workspace"]["final_head"] == "final-head"
+    assert persisted["testmon_environment"] == {
+        "environment_digest": "testmon-environment",
+        "graph_content_digest": None,
+        "graph_content_digest_available": False,
+        "state": "valid",
+        "reason": "the graph is current",
+    }
+    assert persisted["semantic_status"] == "affected-passed"
+    assert persisted["exit_code"] == payload["exit_code"]
+
+
+@pytest.mark.parametrize(
+    ("operation", "scope", "expected_status"),
+    [
+        ("verify_affected", "affected", "affected-passed"),
+        ("verify_quick", "non-test", "non-test-passed"),
+        ("verify_all", "release-baseline", "release-baseline-passed"),
+    ],
+)
+def test_verify_emits_typed_agentctl_result_for_every_declared_operation(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    operation: str,
+    scope: str,
+    expected_status: str,
+) -> None:
+    monkeypatch.setenv("SINNIXD_OPERATION", operation)
+    monkeypatch.setenv("SINNIXD_CHECKOUT_ID", "workspace-1")
+    monkeypatch.setenv("SINNIXD_CHECKOUT_HEAD", "declared-head")
+
+    verify._emit_machine_result(
+        {
+            "run_id": "run-1",
+            "status": "success",
+            "exit_code": 0,
+            "verification_scope": scope,
+            "release_baseline_allowed": scope == "release-baseline",
+        },
+        use_json=False,
+    )
+
+    emitted = json.loads(capsys.readouterr().out)
+    assert emitted["operation"] == operation
+    assert emitted["scope"]["verification_scope"] == scope
+    assert emitted["semantic_status"] == expected_status
 
 
 @pytest.mark.parametrize("fingerprints", [("unavailable", "stable"), ("stable", "unavailable")])


### PR DESCRIPTION
## Summary

Adds a schema-v1 public result receipt for Polylogue AgentCTL verification jobs.

## Contract

The receipt binds the declared operation, job and workspace identity, declared and observed Git heads, selected scope, testmon environment digest, gates, pytest aggregate, widening and missing-edge diagnostics, semantic status, and exit code. It explicitly reports graph-content digest as unavailable because the verifier does not expose one. Commands, output, exception text, and artifact paths are excluded and variable-size public fields are bounded.

## Verification

- `mypy devtools/agentctl_verification_receipt.py devtools/verify.py devtools/verify_runs.py`
- `ruff format --check` and `ruff check` for the four changed files
- `devtools test tests/unit/devtools/test_verify.py -k agentctl` with 5 passed
- Required pre-push `devtools verify --quick` with exit code 0

No full test corpus was run.