### PR TITLE
fix(fts): clear settled startup readiness debt

### DIFF
--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -2407,13 +2407,9 @@ def _archive_insights_execute_ids(
 def _clear_messages_fts_surface_debt(archive_root: Path) -> None:
     """Clear startup FTS debt only after an exact settled snapshot is ready."""
     try:
-        from polylogue.sources.live.cursor import CursorStore
+        from polylogue.daemon.fts_startup import clear_messages_fts_surface_debt
 
-        CursorStore(archive_root / "index.db").clear_convergence_debt(
-            stage="fts",
-            subject_type="fts_surface",
-            subject_id="messages_fts",
-        )
+        clear_messages_fts_surface_debt(archive_root / "index.db")
     except Exception:
         logger.warning("fts: failed to clear ready messages_fts surface debt", exc_info=True)
 

--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -1403,7 +1403,7 @@ def _mark_message_fts_ready_after_targeted_repair(conn: sqlite3.Connection) -> N
     )
 
 
-def _record_fts_freshness_after_insights(conn: sqlite3.Connection) -> None:
+def _record_fts_freshness_after_insights(conn: sqlite3.Connection) -> bool:
     """Publish exact FTS readiness after insight rows have changed.
 
     The insights materializer writes ``session_work_events`` after the message
@@ -1416,7 +1416,9 @@ def _record_fts_freshness_after_insights(conn: sqlite3.Connection) -> None:
     from polylogue.storage.fts.freshness import record_fts_invariant_snapshot_sync
     from polylogue.storage.fts.fts_lifecycle import fts_invariant_snapshot_sync
 
-    record_fts_invariant_snapshot_sync(conn, fts_invariant_snapshot_sync(conn))
+    snapshot = fts_invariant_snapshot_sync(conn)
+    record_fts_invariant_snapshot_sync(conn, snapshot)
+    return bool(snapshot.messages.ready)
 
 
 def _session_ids_missing_profiles(conn: sqlite3.Connection) -> list[str]:
@@ -2385,8 +2387,10 @@ def _archive_insights_execute_ids(
     )
     # The rebuild commits its own rows. Publish and commit the final exact FTS
     # state in the same production stage before reporting success.
-    _record_fts_freshness_after_insights(conn)
+    message_fts_ready = _record_fts_freshness_after_insights(conn)
     conn.commit()
+    if message_fts_ready and archive_root is not None:
+        _clear_messages_fts_surface_debt(archive_root)
     remaining = _archive_stale_session_profile_ids(conn, list(session_ids))
     logger.info(
         "insights: archive refreshed sessions=%d profiles=%d work_events=%d phases=%d threads=%d remaining=%d",
@@ -2398,6 +2402,20 @@ def _archive_insights_execute_ids(
         len(remaining),
     )
     return StageExecutionResult(success=not hot_ids and not remaining, stage_timings_s=stage_timings_s)
+
+
+def _clear_messages_fts_surface_debt(archive_root: Path) -> None:
+    """Clear startup FTS debt only after an exact settled snapshot is ready."""
+    try:
+        from polylogue.sources.live.cursor import CursorStore
+
+        CursorStore(archive_root / "index.db").clear_convergence_debt(
+            stage="fts",
+            subject_type="fts_surface",
+            subject_id="messages_fts",
+        )
+    except Exception:
+        logger.warning("fts: failed to clear ready messages_fts surface debt", exc_info=True)
 
 
 __all__ = [

--- a/polylogue/daemon/fts_startup.py
+++ b/polylogue/daemon/fts_startup.py
@@ -268,6 +268,17 @@ def _record_message_fts_surface_debt(db_path: Path | None, error: str) -> None:
     _record_fts_surface_debt(db_path, "messages_fts", error)
 
 
+def clear_messages_fts_surface_debt(db_path: Path) -> None:
+    """Clear settled message-FTS startup debt through its owning daemon adapter."""
+    from polylogue.sources.live.cursor import CursorStore
+
+    CursorStore(db_path).clear_convergence_debt(
+        stage="fts",
+        subject_type="fts_surface",
+        subject_id="messages_fts",
+    )
+
+
 def _record_fts_surface_debt(db_path: Path | None, surface: str, error: str) -> None:
     if db_path is None:
         return
@@ -472,6 +483,7 @@ def ensure_fts_startup_readiness_sync() -> None:
 
 __all__ = [
     "active_fts_triggers_sync",
+    "clear_messages_fts_surface_debt",
     "ensure_fts_startup_readiness",
     "ensure_fts_startup_readiness_sync",
     "missing_fts_triggers_sync",

--- a/polylogue/storage/index.py
+++ b/polylogue/storage/index.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import sqlite3
 from collections.abc import Sequence
 
+from polylogue.storage.fts.freshness import record_fts_invariant_snapshot_sync
 from polylogue.storage.fts.fts_lifecycle import (
     _chunked as _chunked,
 )
 from polylogue.storage.fts.fts_lifecycle import (
     ensure_fts_index_sync,
     fts_index_status_sync,
+    fts_invariant_snapshot_sync,
     rebuild_fts_index_sync,
     repair_fts_index_sync,
 )
@@ -39,6 +41,7 @@ def update_index_for_sessions(session_ids: Sequence[str], conn: sqlite3.Connecti
 
     def _do(db_conn: sqlite3.Connection) -> None:
         repair_fts_index_sync(db_conn, session_ids)
+        record_fts_invariant_snapshot_sync(db_conn, fts_invariant_snapshot_sync(db_conn))
         db_conn.commit()
         if changed:
             invalidate_search_cache()


### PR DESCRIPTION
## Summary

- publish an exact FTS snapshot after synchronous session indexing so immediate search can use the repaired index
- clear startup-created `messages_fts` surface debt only after the archive insights stage commits an exact ready snapshot
- keep convergence stages behind the daemon FTS-startup adapter rather than importing the live cursor layer directly

## Problem

The controlled current-master full run found both immediate search failures after `update_index_for_sessions` and unresolved `fts_surface/messages_fts` debt after a successful daemon convergence pass. Startup recorded the surface debt when the ledger was stale, but no later settled path cleared it.

## Solution

The explicit synchronous indexing route now publishes a transaction-bound exact FTS snapshot. The archive insights route clears the startup debt only when that same exact snapshot reports message FTS ready. The daemon startup module owns the cursor adapter, preserving layering.

## Verification

- `direnv exec . devtools test tests/integration/test_daemon_convergence_evidence.py tests/unit/storage/test_index.py tests/integration/test_workflows.py`
- `21 passed in 26.64s`
- `direnv exec . devtools verify --quick`
- `quick run success (exit 0) in 52.3s`