### PR TITLE
fix(devtools): bound optional testmon source reuse (#4082)

### DIFF
--- a/devtools/testmon_bootstrap.py
+++ b/devtools/testmon_bootstrap.py
@@ -1272,14 +1272,18 @@ def _reclaim_stale_native_testmon_bindings(directory_fd: int, name: str) -> None
 @contextlib.contextmanager
 def native_testmon_source_binding(data_path: Path) -> Iterator[NativeTestmonSourceBinding | None]:
     """Retain a private SQLite filename family for validation and copying."""
-    if not data_path.is_file():
-        yield None
-        return
     directory_fd: int | None = None
     child_fd: int | None = None
     private_names: list[str] = []
     sidecar_descriptors: list[tuple[str, int]] = []
     try:
+        try:
+            present = data_path.is_file()
+        except OSError as exc:
+            raise NativeTestmonRepairError(f"cannot inspect native testmon source {data_path}: {exc}") from exc
+        if not present:
+            yield None
+            return
         directory_fd = _open_owned_testmon_directory(data_path.parent.parent.parent, create=False)
         _reclaim_stale_native_testmon_bindings(directory_fd, data_path.name)
         child_fd, _bound_path, private_name = _open_owned_testmon_child(directory_fd, data_path.name)
@@ -1305,6 +1309,10 @@ def native_testmon_source_binding(data_path: Path) -> Iterator[NativeTestmonSour
             data_path=private_base,
             private_names=tuple(private_names),
         )
+    except NativeTestmonRepairError:
+        raise
+    except OSError as exc:
+        raise NativeTestmonRepairError(f"cannot bind native testmon source {data_path}: {exc}") from exc
     finally:
         try:
             if directory_fd is not None:
@@ -1546,7 +1554,7 @@ def prepare_native_testmon_environment(
     pytest_profile: str = "default",
     pytest_environment: Mapping[str, str | None] | None = None,
     deadline_monotonic: float | None = None,
-    source_lock_factory: Callable[[], contextlib.AbstractContextManager[bool]] | None = None,
+    source_lock_factory: Callable[[Path], contextlib.AbstractContextManager[bool]] | None = None,
 ) -> NativeTestmonPreparation:
     """Repair derived local state and optionally reuse a matching main graph."""
     root = repo_root.resolve()
@@ -1625,7 +1633,9 @@ def prepare_native_testmon_environment(
     _ensure_deadline(deadline_monotonic)
     copied_from: Path | None = None
     if main_checkout is not None and main_checkout != root and not missing_checkout_paths:
-        source_lock = source_lock_factory() if source_lock_factory is not None else contextlib.nullcontext(True)
+        source_lock = (
+            source_lock_factory(main_checkout) if source_lock_factory is not None else contextlib.nullcontext(True)
+        )
         main = NativeTestmonState("absent", "optional main native testmon state unavailable")
         with _optional_native_testmon_source_lock(source_lock) as source_available:
             if source_available:

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -83,7 +83,6 @@ from devtools.testmon_bootstrap import (
     _descriptor_bound_path,
     classify_native_testmon_changes,
     inspect_native_testmon_environment,
-    linked_worktree_info,
     native_testmon_lifecycle_lock,
     prepare_native_testmon_environment,
     remove_invalid_native_testmon_state,
@@ -230,20 +229,16 @@ def _native_testmon_lifecycle_lock(
 
 @contextlib.contextmanager
 def _native_testmon_source_lifecycle_lock(
-    repo_root: Path,
     *,
+    main_checkout: Path,
     timeout_s: float = NATIVE_TESTMON_LIFECYCLE_LOCK_TIMEOUT_S,
 ) -> Iterator[bool]:
-    """Protect linked-worktree source preparation without extending the lane lock."""
-    linked_info = linked_worktree_info(repo_root)
-    if linked_info is None or not linked_info[0]:
-        yield True
-        return
+    """Protect an already-resolved linked-worktree source preparation."""
     try:
         # The caller already holds the lane-local lock. The launcher acquires its
         # linked-worktree locks in this same lane-then-common order, so waiting
         # for the common source lock cannot form an inverse lock cycle.
-        with native_testmon_lifecycle_lock(linked_info[1], timeout_s=timeout_s, waiter_label="verify-source"):
+        with native_testmon_lifecycle_lock(main_checkout, timeout_s=timeout_s, waiter_label="verify-source"):
             yield True
     except NativeTestmonLifecycleLockTimeoutError as exc:
         del exc
@@ -353,7 +348,7 @@ DEFAULT_PYTEST_TIMEOUT_S = 45 * 60.0
 DEFAULT_PYTEST_STALL_TIMEOUT_S = 10 * 60.0
 DEFAULT_PYTEST_TERM_GRACE_S = 5.0
 DEFAULT_PYTEST_RESOURCE_INTERVAL_S = 2.0
-DEFAULT_TESTMON_SOURCE_LOCK_TIMEOUT_S = NATIVE_TESTMON_LIFECYCLE_LOCK_TIMEOUT_S
+DEFAULT_TESTMON_SOURCE_LOCK_TIMEOUT_S = 1.0
 
 
 def _is_productive_test_progress_event(event: Mapping[str, Any]) -> bool:
@@ -3321,9 +3316,9 @@ def _main(argv: list[str] | None = None) -> int:
             )
             runtime_data_paths = change_impact.runtime_data_paths
 
-            def source_lock_factory() -> contextlib.AbstractContextManager[bool]:
+            def source_lock_factory(main_checkout: Path) -> contextlib.AbstractContextManager[bool]:
                 return _native_testmon_source_lifecycle_lock(
-                    ROOT,
+                    main_checkout=main_checkout,
                     timeout_s=_native_testmon_source_lock_timeout_s(),
                 )
 

--- a/tests/unit/devtools/test_testmon_bootstrap.py
+++ b/tests/unit/devtools/test_testmon_bootstrap.py
@@ -1273,8 +1273,44 @@ def test_optional_main_invalid_parent_falls_back_to_lane_local_bootstrap(
 
     preparation = prepare_native_testmon_environment(
         lane,
-        source_lock_factory=lambda: contextlib.nullcontext(True),
+        source_lock_factory=lambda _main_checkout: contextlib.nullcontext(True),
     )
+
+    assert preparation.selection_mode == "bootstrap"
+    assert preparation.copied_from is None
+    assert preparation.local_state.status == "absent"
+    assert preparation.fallback_allowed is True
+
+
+def test_optional_main_binding_open_error_falls_back_to_lane_local_bootstrap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An optional source-open race is typed so bootstrap can fall back."""
+    lane = tmp_path / "lane"
+    main = tmp_path / "main"
+    lane.mkdir()
+    (main / "tests").mkdir(parents=True)
+    _seed_partial_native_graph(
+        main,
+        environment_name="lane-environment",
+        fingerprinted="tests/test_recorded.py",
+    )
+
+    monkeypatch.setattr(testmon_bootstrap, "testmon_environment_digest", lambda *_args, **_kwargs: "lane-environment")
+    monkeypatch.setattr(
+        testmon_bootstrap,
+        "linked_worktree_info",
+        lambda checkout, **_kwargs: (True, main) if checkout.resolve() == lane.resolve() else None,
+    )
+
+    def binding_open_race(_parent: Path, *, create: bool) -> int:
+        assert create is False
+        raise OSError("source directory replaced during bind")
+
+    monkeypatch.setattr(testmon_bootstrap, "_open_owned_testmon_directory", binding_open_race)
+
+    preparation = prepare_native_testmon_environment(lane)
 
     assert preparation.selection_mode == "bootstrap"
     assert preparation.copied_from is None

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -23,7 +23,7 @@ import pytest
 import watchfiles
 
 import devtools.pytest_supervisor as pytest_supervisor
-from devtools import run_tests, verify, verify_runs
+from devtools import run_tests, testmon_bootstrap, verify, verify_runs
 from devtools.agentctl_verification_receipt import agentctl_verification_receipt
 from devtools.checkout_guard import CheckoutImportMismatchError
 from devtools.pytest_supervisor import (
@@ -3425,28 +3425,20 @@ def test_native_testmon_lifecycle_lock_serializes_checkout_state(tmp_path: Path)
 @pytest.mark.uses_real_clock("coordinates linked-worktree source lifecycle locks")
 def test_linked_source_preparation_lifecycle_lock_includes_main_checkout(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     main = tmp_path / "main"
-    lane = tmp_path / "lane"
     main.mkdir()
-    lane.mkdir()
-
-    def linked_info(root: Path, **_kwargs: object) -> tuple[bool, Path] | None:
-        return (True, main) if root.resolve() == lane.resolve() else (False, main)
-
-    monkeypatch.setattr(verify, "linked_worktree_info", linked_info)
     holder_entered = threading.Event()
     release_holder = threading.Event()
     contender_entered = threading.Event()
 
     def hold_source_lock() -> None:
-        with verify._native_testmon_source_lifecycle_lock(lane):
+        with verify._native_testmon_source_lifecycle_lock(main_checkout=main):
             holder_entered.set()
             assert release_holder.wait(timeout=2)
 
     def contend_for_source_lock() -> None:
-        with verify._native_testmon_source_lifecycle_lock(lane):
+        with verify._native_testmon_source_lifecycle_lock(main_checkout=main):
             contender_entered.set()
 
     with ThreadPoolExecutor(max_workers=2) as pool:
@@ -3461,21 +3453,38 @@ def test_linked_source_preparation_lifecycle_lock_includes_main_checkout(
     assert contender_entered.is_set()
 
 
-@pytest.mark.uses_real_clock("proves a busy optional main source degrades to local preparation")
-def test_busy_optional_main_source_lock_is_unavailable(
+def test_source_lock_uses_precomputed_main_checkout_without_a_second_probe(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """An indeterminate later worktree probe cannot turn uncertainty into access."""
     main = tmp_path / "main"
-    lane = tmp_path / "lane"
     main.mkdir()
-    lane.mkdir()
-
     monkeypatch.setattr(
         verify,
         "linked_worktree_info",
-        lambda root, **_kwargs: (True, main) if root.resolve() == lane.resolve() else None,
+        lambda *_args, **_kwargs: pytest.fail("unexpected probe"),
+        raising=False,
     )
+
+    with verify._native_testmon_source_lifecycle_lock(main_checkout=main) as source_available:
+        assert source_available is True
+
+
+def test_optional_source_lock_default_is_a_short_cache_miss_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Optional warm reuse must not inherit the full lifecycle-lock wait."""
+    monkeypatch.delenv(verify.TESTMON_SOURCE_LOCK_TIMEOUT_ENV, raising=False)
+
+    assert verify._native_testmon_source_lock_timeout_s() == 1.0
+    assert verify._native_testmon_source_lock_timeout_s() < testmon_bootstrap.NATIVE_TESTMON_LIFECYCLE_LOCK_TIMEOUT_S
+
+
+@pytest.mark.uses_real_clock("proves a busy optional main source degrades to local preparation")
+def test_busy_optional_main_source_lock_is_unavailable(
+    tmp_path: Path,
+) -> None:
+    main = tmp_path / "main"
+    main.mkdir()
     holder_entered = threading.Event()
     release_holder = threading.Event()
 
@@ -3487,7 +3496,7 @@ def test_busy_optional_main_source_lock_is_unavailable(
     with ThreadPoolExecutor(max_workers=1) as pool:
         holder = pool.submit(hold_main_lock)
         assert holder_entered.wait(timeout=2)
-        with verify._native_testmon_source_lifecycle_lock(lane, timeout_s=0.01) as source_available:
+        with verify._native_testmon_source_lifecycle_lock(main_checkout=main, timeout_s=0.01) as source_available:
             assert source_available is False
         release_holder.set()
         holder.result(timeout=2)
@@ -3506,7 +3515,7 @@ def test_busy_main_source_wait_has_bounded_liveness(
     lane.mkdir()
 
     monkeypatch.setattr(
-        verify,
+        testmon_bootstrap,
         "linked_worktree_info",
         lambda root, **_kwargs: (True, main) if root.resolve() == lane.resolve() else None,
     )
@@ -3527,8 +3536,8 @@ def test_busy_main_source_wait_has_bounded_liveness(
         started = time.monotonic()
         preparation = prepare_native_testmon_environment(
             lane,
-            source_lock_factory=lambda: verify._native_testmon_source_lifecycle_lock(
-                lane,
+            source_lock_factory=lambda main_checkout: verify._native_testmon_source_lifecycle_lock(
+                main_checkout=main_checkout,
                 timeout_s=verify._native_testmon_source_lock_timeout_s(),
             ),
         )
@@ -3545,7 +3554,6 @@ def test_busy_main_source_wait_has_bounded_liveness(
 @pytest.mark.uses_real_clock("proves common source lock ends before linked verify lifecycle ends")
 def test_unrelated_linked_lane_proceeds_after_source_preparation(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     main = tmp_path / "main"
     lane_a = tmp_path / "lane-a"
@@ -3554,10 +3562,6 @@ def test_unrelated_linked_lane_proceeds_after_source_preparation(
     lane_a.mkdir()
     lane_b.mkdir()
 
-    def linked_info(root: Path, **_kwargs: object) -> tuple[bool, Path] | None:
-        return (True, main) if root.resolve() in {lane_a.resolve(), lane_b.resolve()} else (False, main)
-
-    monkeypatch.setattr(verify, "linked_worktree_info", linked_info)
     source_started = threading.Event()
     release_source = threading.Event()
     post_source_started = threading.Event()
@@ -3566,7 +3570,7 @@ def test_unrelated_linked_lane_proceeds_after_source_preparation(
 
     def run_lane_a() -> None:
         with verify._native_testmon_lifecycle_lock(lane_a):
-            with verify._native_testmon_source_lifecycle_lock(lane_a):
+            with verify._native_testmon_source_lifecycle_lock(main_checkout=main):
                 source_started.set()
                 assert release_source.wait(timeout=2)
             post_source_started.set()
@@ -3574,7 +3578,7 @@ def test_unrelated_linked_lane_proceeds_after_source_preparation(
 
     def run_lane_b() -> None:
         with verify._native_testmon_lifecycle_lock(lane_b):
-            with verify._native_testmon_source_lifecycle_lock(lane_b):
+            with verify._native_testmon_source_lifecycle_lock(main_checkout=main):
                 lane_b_entered.set()
 
     with ThreadPoolExecutor(max_workers=2) as pool:


### PR DESCRIPTION
## Summary

- normalize optional Testmon source binding/open races to `NativeTestmonRepairError`
- bind the source lock to the already-resolved main checkout instead of probing worktree identity twice
- cap optional main-checkout lock acquisition at one second so local fallback remains bounded

## Verification

- focused lifecycle regressions cover typed fallback, probe elimination, contention, and the default lock budget
- `devtools verify --quick`

This intentionally excludes the obsolete descriptor/WAL/TRUNCATE and workspace-lifecycle implementation from the historical WIP branch.