### PR TITLE
feat(agentctl): expose quick verification receipt

### DIFF
--- a/.agentctl/project.toml
+++ b/.agentctl/project.toml
@@ -40,7 +40,7 @@ exclusive_keys = ["polylogue:testmon-graph"]
 description = "Run Polylogue's static fast verification gates"
 exec = ["devtools", "verify", "--quick"]
 pool = "normal"
-result = "exit"
+result = "pytest"
 cache = "tree+environment"
 
 [operations.verify_all]


### PR DESCRIPTION
## Summary

Declare `verify_quick` as a typed pytest result so Sinnixd captures its bounded Polylogue verification receipt through `agentctl job result`, consistently with affected and full verification.

## Verification

- required pre-push `devtools verify --quick`: passed in 94.57s
- all 12 quick gates passed at exact head `5d4adabd8`