### PR TITLE
fix(canary): align fixture receipts with current contracts

### DIFF
--- a/polylogue/maintenance/reindex_canary.py
+++ b/polylogue/maintenance/reindex_canary.py
@@ -1717,7 +1717,7 @@ def _validate_rebuild_receipt(
     generation = receipt.get("generation")
     source_evidence_after = receipt.get("source_evidence_after")
     if (
-        receipt.get("receipt_schema_version") != 4
+        receipt.get("receipt_schema_version") != 5
         or not isinstance(archive_root, str)
         or not archive_root
         or not requested_raw_ids

--- a/tests/infra/archive_templates.py
+++ b/tests/infra/archive_templates.py
@@ -65,6 +65,15 @@ def finalize_archive_template(root: Path) -> None:
     _freeze_archive_template(root)
 
 
+def _remove_partial_clone(destination: Path) -> None:
+    """Thaw a failed reflink attempt before replacing it with a full copy."""
+    for path in sorted(destination.rglob("*"), reverse=True):
+        if not path.is_symlink():
+            path.chmod(path.stat().st_mode | stat.S_IWUSR)
+    destination.chmod(destination.stat().st_mode | stat.S_IWUSR)
+    shutil.rmtree(destination)
+
+
 def clone_archive_template(template: Path, destination: Path) -> None:
     """Clone an immutable archive into a private writable destination."""
     destination.mkdir(parents=True, exist_ok=True)
@@ -82,10 +91,9 @@ def clone_archive_template(template: Path, destination: Path) -> None:
             timeout=10,
         )
     except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
-        # ``destination`` already exists from the fast-path setup.  Reusing it
-        # makes copytree try to overwrite read-only template files before the
-        # thaw loop runs, which fails on a legitimate no-CoW filesystem.
-        shutil.rmtree(destination)
+        # A failed ``cp`` can have already copied immutable directories. Thaw
+        # that partial tree before replacing it on a filesystem without CoW.
+        _remove_partial_clone(destination)
         shutil.copytree(template, destination, symlinks=True)
     for path in destination.rglob("*"):
         if path.is_symlink():

--- a/tests/unit/cli/test_reindex_canary_cli.py
+++ b/tests/unit/cli/test_reindex_canary_cli.py
@@ -302,6 +302,9 @@ def _write_real_unreviewed_canary_report(
     monkeypatch.setattr("polylogue.config.resolve_archive_root", lambda: live_root)
     with sqlite3.connect(canary_root / "index.db") as connection:
         connection.execute("UPDATE sessions SET title_ref = NULL, title_confidence = NULL")
+        # Model the v43 -> v44 targeted title backfill: the old index shape
+        # lacks authored title values and the rebuilt candidate restores them.
+        connection.execute("PRAGMA user_version = 43")
 
     receipt_path = _schema_receipt_path(canary_root)
     observed_result = run_reindex_canary(
@@ -322,10 +325,10 @@ def _write_real_unreviewed_canary_report(
                         "operation": difference.operation.value,
                         "identity": dict(difference.identity),
                         "changed_columns": list(difference.changed_columns),
-                        "classification": "unexpected",
-                        "reference": "successor:polylogue-ox2iz",
-                        "authority": {"kind": "successor", "id": "polylogue-ox2iz"},
-                        "rationale": "reviewed real canary difference",
+                        "classification": "expected",
+                        "reference": "delta:44",
+                        "authority": {"kind": "delta", "id": "44"},
+                        "rationale": "reviewed v44 title-reprocess difference",
                     }
                     for difference in observed_result.comparison.differences
                 ]
@@ -371,10 +374,10 @@ def _write_review_manifest(path: Path, differences: list[dict[str, object]]) -> 
                 "reviews": [
                     {
                         **difference,
-                        "classification": "unexpected",
-                        "reference": "successor:polylogue-ox2iz",
-                        "authority": {"kind": "successor", "id": "polylogue-ox2iz"},
-                        "rationale": "reviewed real canary difference",
+                        "classification": "expected",
+                        "reference": "delta:44",
+                        "authority": {"kind": "delta", "id": "44"},
+                        "rationale": "reviewed v44 title-reprocess difference",
                     }
                     for difference in differences
                 ]
@@ -880,10 +883,10 @@ def test_cli_rejects_membership_and_logical_key_expansion_drift(
     _write_review_manifest(review_path, [difference.to_dict() for difference in observed_result.comparison.differences])
     review_payload = json.loads(review_path.read_text(encoding="utf-8"))
     for review in review_payload["reviews"]:
-        review["classification"] = "expected"
-        review["reference"] = "delta:44"
-        review["authority"] = {"kind": "delta", "id": "44"}
-        review["rationale"] = "reviewed v44 title-reprocess difference"
+        review["classification"] = "unexpected"
+        review["reference"] = "successor:polylogue-ox2iz"
+        review["authority"] = {"kind": "successor", "id": "polylogue-ox2iz"}
+        review["rationale"] = "reviewed real canary difference"
     review_path.write_text(json.dumps(review_payload), encoding="utf-8")
     generated = CliRunner().invoke(
         cli,
@@ -1171,7 +1174,7 @@ def _run_result(index_path: Path, *, differences: tuple[object, ...] = ()) -> Ca
         selection=selection,
         comparison=comparison,
         rebuild_receipt={
-            "receipt_schema_version": 4,
+            "receipt_schema_version": 5,
             "archive_root": str(index_path.parent),
             "selected_raw_count": len(selection.selected_raw_ids),
             "status": "replayed",
@@ -1227,7 +1230,7 @@ def _nonempty_run_result(index_path: Path) -> CanaryRunResult:
         selection=result.selection,
         comparison=result.comparison,
         rebuild_receipt={
-            "receipt_schema_version": 4,
+            "receipt_schema_version": 5,
             "archive_root": str(index_path.parent),
             "selected_raw_count": 1,
             "status": "replayed",

--- a/tests/unit/infra/test_archive_templates.py
+++ b/tests/unit/infra/test_archive_templates.py
@@ -144,3 +144,32 @@ def test_clone_requests_reflink_before_copy_fallback(monkeypatch: pytest.MonkeyP
     assert calls == [["cp", "-a", "--reflink=always", f"{template}/.", str(destination)]]
     assert (destination / "index.db").read_bytes() == b"snapshot"
     assert (destination / "index.db").stat().st_mode & stat.S_IWUSR
+
+
+def test_clone_fallback_replaces_a_read_only_partial_reflink_copy(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A failed reflink may leave immutable directories that the fallback replaces."""
+    template = tmp_path / "template"
+    destination = tmp_path / "clone"
+    template.mkdir()
+    source = template / "source.db"
+    with contextlib.closing(sqlite3.connect(source)) as connection, connection:
+        connection.execute("CREATE TABLE entries (value TEXT)")
+        connection.execute("INSERT INTO entries VALUES ('complete-template')")
+    finalize_archive_template(template)
+
+    def partial_reflink(argv: list[str], **_kwargs: object) -> None:
+        partial = destination / "nested" / "partial.db"
+        partial.parent.mkdir(parents=True)
+        partial.write_bytes(b"incomplete")
+        for path in (partial, partial.parent, destination):
+            path.chmod(path.stat().st_mode & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH))
+        raise subprocess.CalledProcessError(1, argv)
+
+    monkeypatch.setattr(subprocess, "run", partial_reflink)
+    clone_archive_template(template, destination)
+
+    with contextlib.closing(sqlite3.connect(destination / "source.db")) as connection:
+        assert connection.execute("SELECT value FROM entries").fetchall() == [("complete-template",)]
+    assert not destination.joinpath("nested", "partial.db").exists()

--- a/tests/unit/maintenance/test_reindex_canary.py
+++ b/tests/unit/maintenance/test_reindex_canary.py
@@ -274,7 +274,7 @@ def _rebuild_receipt(selection: CanarySelection, comparison: CanaryDiffReport) -
         "source_snapshot": "snapshot",
     }
     return {
-        "receipt_schema_version": 4,
+        "receipt_schema_version": 5,
         "archive_root": str(comparison.candidate_index.parent),
         "selected_raw_count": len(selection.selected_raw_ids),
         "status": "replayed",
@@ -1400,7 +1400,7 @@ def test_run_reindex_canary_accepts_split_root_active_pointer_through_real_valid
     assert isinstance(owner_id, str) and owner_id
     assert isinstance(source_snapshot, str) and source_snapshot
     assert source_snapshot == evidence_before == rebuild_source_evidence_snapshot(root)
-    assert receipt["receipt_schema_version"] == 4
+    assert receipt["receipt_schema_version"] == 5
     assert receipt["source_evidence_after"] == rebuild_source_evidence_snapshot(root)
     canary_acceptance = receipt["canary_acceptance"]
     assert isinstance(canary_acceptance, dict)


### PR DESCRIPTION
## Summary

Align reusable archive-template fallback and reindex-canary fixtures with current runtime contracts.

## Problem

The complete corpus exposed two coupled fixture drifts: a failed reflink left immutable partial trees that fallback copying could not remove, and canary fixtures still asserted rebuild receipt schema v4 after production emitted v5.

## Solution

Thaw partial clone trees before fallback copying; model the real v43-to-v44 title-backfill boundary in approval fixtures; update receipt-version contract coverage.

## Verification

- `direnv exec . devtools test tests/unit/infra/test_archive_templates.py tests/unit/cli/test_reindex_canary_cli.py tests/unit/maintenance/test_reindex_canary.py` — `119 passed in 102.67s`
- `direnv exec . devtools verify --quick` — success
