### PR TITLE
refactor(agentctl): delegate verifier lifecycle ownership

### DIFF
--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -99,6 +99,7 @@ from devtools.verify_runs import (
     PYTEST_CANONICAL_REPORT_NAME,
     PYTEST_EXPLICIT_BASETEMP_ENV,
     VERIFY_HISTORY_PATH,
+    AgentctlDeclaredJobBinding,
     CheckoutMutationMonitor,
     CheckoutMutationObservation,
     PytestResourceError,
@@ -106,6 +107,7 @@ from devtools.verify_runs import (
     ResourceSampler,
     VerifyRun,
     adaptive_pytest_worker_count,
+    agentctl_declared_job_binding,
     aggregate_native_testmon_run,
     append_verify_history,
     apply_managed_pytest_runtime_policy,
@@ -142,6 +144,11 @@ from polylogue.scenarios.workload import (
 )
 
 ROOT = Path(__file__).resolve().parents[1]
+_AGENTCTL_OPERATION_ARGV: Final = {
+    "verify_affected": (),
+    "verify_quick": ("--quick",),
+    "verify_all": ("--all",),
+}
 _PYTEST_CLEAR_CONFIGURED_ADDOPTS = CLEAR_CONFIGURED_ADDOPTS
 # Collection-affecting values live in devtools/pytest_collection_contract.py and
 # are re-exported here under their historical names. That module -- not this
@@ -248,6 +255,13 @@ def _native_testmon_source_lifecycle_lock(
 def _native_testmon_source_lock_timeout_s() -> float:
     """Return the bounded wait used only while consulting a linked source."""
     return _float_env(TESTMON_SOURCE_LOCK_TIMEOUT_ENV, DEFAULT_TESTMON_SOURCE_LOCK_TIMEOUT_S)
+
+
+def _agentctl_lifecycle_free_binding(raw_argv: Sequence[str]) -> AgentctlDeclaredJobBinding | None:
+    binding = agentctl_declared_job_binding(ROOT)
+    if binding is None or tuple(raw_argv) != _AGENTCTL_OPERATION_ARGV[binding.operation]:
+        return None
+    return binding
 
 
 def _anchor_verification_paths() -> None:
@@ -666,6 +680,7 @@ def _pytest_workload_receipt(
     basetemp_cleanup: Path | None,
     concurrency: int,
     timeout_s: float,
+    lifecycle_authority: str = "devtools",
 ) -> dict[str, Any]:
     """Adapt managed-pytest accounting to the shared workload receipt."""
     input_digest = hashlib.sha256(
@@ -808,7 +823,11 @@ def _pytest_workload_receipt(
         cancellation_requested=termination_reason is not None,
         cleanup_complete=True if basetemp_cleanup is not None else None,
         notes=(
-            "Managed pytest process-tree sampler adapter.",
+            (
+                "AgentCTL owns process-tree lifecycle; local sampler evidence is unavailable."
+                if lifecycle_authority == "agentctl"
+                else "Managed pytest process-tree sampler adapter."
+            ),
             (
                 f"Logical basetemp peak retained as diagnostic evidence: {logical_basetemp_kb * 1024} bytes."
                 if isinstance(logical_basetemp_kb, int)
@@ -2002,6 +2021,7 @@ def _run_step(
     sys.stderr.flush()
     is_pytest = label.startswith("pytest")
     managed_native_lane = label.startswith("pytest native")
+    agentctl_lifecycle_free = bool(_ACTIVE_VERIFY_RUN is not None and _ACTIVE_VERIFY_RUN.agentctl_binding is not None)
     closed_world_command = _native_pytest_command_is_closed_world(label, cmd)
     # ``bench slo`` starts pytest-benchmark itself, so it needs the same
     # bounded temp policy and run marker as a direct pytest step.
@@ -2112,15 +2132,18 @@ def _run_step(
     if is_pytest:
         try:
             try:
-                result = _run_pytest_with_heartbeat(
-                    cmd,
-                    cwd=cwd,
-                    env=env,
-                    t0=t0,
-                    run=run,
-                    artifacts=artifacts,
-                    timeout_override_s=timeout_s,
-                )
+                if agentctl_lifecycle_free:
+                    result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, env=env)
+                else:
+                    result = _run_pytest_with_heartbeat(
+                        cmd,
+                        cwd=cwd,
+                        env=env,
+                        t0=t0,
+                        run=run,
+                        artifacts=artifacts,
+                        timeout_override_s=timeout_s,
+                    )
             except PytestContainmentError as exc:
                 pytest_containment_quiescent = False
                 containment_error = str(exc)
@@ -2163,11 +2186,15 @@ def _run_step(
         metadata["external_addopts_neutralized"] = external_addopts_neutralized
         metadata["external_plugins_neutralized"] = external_plugins_neutralized
         metadata["closed_world_collection"] = closed_world_collection
-        metadata["heartbeat_s"] = _pytest_heartbeat_interval()
-        metadata["timeout_s"] = _pytest_timeout_s() if timeout_s is None else timeout_s
-        metadata["stall_timeout_s"] = _pytest_stall_timeout_s()
-        metadata["term_grace_s"] = _pytest_term_grace_s()
-        metadata["resource_interval_s"] = _pytest_resource_interval_s()
+        if agentctl_lifecycle_free:
+            metadata["lifecycle_authority"] = "agentctl"
+        metadata["heartbeat_s"] = None if agentctl_lifecycle_free else _pytest_heartbeat_interval()
+        metadata["timeout_s"] = (
+            None if agentctl_lifecycle_free else (_pytest_timeout_s() if timeout_s is None else timeout_s)
+        )
+        metadata["stall_timeout_s"] = None if agentctl_lifecycle_free else _pytest_stall_timeout_s()
+        metadata["term_grace_s"] = None if agentctl_lifecycle_free else _pytest_term_grace_s()
+        metadata["resource_interval_s"] = None if agentctl_lifecycle_free else _pytest_resource_interval_s()
         metadata["pytest_tmpfs"] = pytest_tmpfs
         metadata["pytest_tmpfs_budget_mb"] = pytest_tmpfs_budget_mb
         metadata["pytest_runtime_policy"] = runtime_policy.to_dict() if runtime_policy is not None else None
@@ -2177,9 +2204,9 @@ def _run_step(
         metadata["selection_path"] = str(PYTEST_SELECTION_PATH)
         metadata["summary_path"] = str(PYTEST_SUMMARY_PATH)
         metadata["output_path"] = str(PYTEST_OUTPUT_PATH)
-        metadata["resources_path"] = str(CURRENT_RESOURCES_PATH)
-        metadata["postmortem_path"] = str(CURRENT_POSTMORTEM_PATH)
-        metadata["containment_path"] = str(PYTEST_CONTAINMENT_PATH)
+        metadata["resources_path"] = None if agentctl_lifecycle_free else str(CURRENT_RESOURCES_PATH)
+        metadata["postmortem_path"] = None if agentctl_lifecycle_free else str(CURRENT_POSTMORTEM_PATH)
+        metadata["containment_path"] = None if agentctl_lifecycle_free else str(PYTEST_CONTAINMENT_PATH)
         metadata["basetemp_cleanup"] = str(basetemp_cleanup) if basetemp_cleanup is not None else None
         metadata["basetemp_swept"] = [str(path) for path in swept]
         junit_paths = [
@@ -2401,7 +2428,8 @@ def _run_step(
             tmpfs_budget_mb=pytest_tmpfs_budget_mb,
             basetemp_cleanup=basetemp_cleanup,
             concurrency=max(1, pytest_concurrency),
-            timeout_s=_pytest_timeout_s() if timeout_s is None else timeout_s,
+            timeout_s=(0 if agentctl_lifecycle_free else _pytest_timeout_s() if timeout_s is None else timeout_s),
+            lifecycle_authority="agentctl" if agentctl_lifecycle_free else "devtools",
         )
         metadata["workload_receipt"] = workload_receipt
         if artifacts is not None:
@@ -2941,6 +2969,7 @@ class _ActiveVerifyRun:
     started_at: float
     verification_scope: VerificationScope
     head: str | None
+    agentctl_binding: AgentctlDeclaredJobBinding | None = None
     mutation_monitor: CheckoutMutationMonitor | None = None
     initial_worktree_fingerprint: str | None = None
     owned_native_testmon_state: _OwnedNativeTestmonState | None = None
@@ -3098,16 +3127,21 @@ def _finalize_preflight_failure(
     initial_worktree_fingerprint: str | None = None,
 ) -> int:
     """Persist one normalized failed invocation before pytest can start."""
+    externally_bound = bool(_ACTIVE_VERIFY_RUN is not None and _ACTIVE_VERIFY_RUN.agentctl_binding is not None)
     final_head = _git_head()
     try:
-        final_worktree_fingerprint = worktree_fingerprint(ROOT) if mutation_monitor is not None else "unavailable"
+        final_worktree_fingerprint = (
+            worktree_fingerprint(ROOT) if mutation_monitor is not None or externally_bound else "unavailable"
+        )
     except Exception:
         final_worktree_fingerprint = "unavailable"
     mutation_observation = (
         _finish_active_checkout_mutation_monitor(mutation_monitor) if mutation_monitor is not None else None
     )
+    if externally_bound:
+        mutation_observation = CheckoutMutationObservation(changed=False, unavailable=False)
     checkout_diagnosis: str | None = None
-    if mutation_monitor is None:
+    if mutation_monitor is None and not externally_bound:
         checkout_diagnosis = "preflight_failed_before_checkout_monitor"
     elif (
         head is None
@@ -3170,7 +3204,11 @@ def _finalize_preflight_failure(
     return exit_code
 
 
-def _main(argv: list[str] | None = None) -> int:
+def _main(
+    argv: list[str] | None = None,
+    *,
+    agentctl_binding: AgentctlDeclaredJobBinding | None = None,
+) -> int:
     global _ACTIVE_VERIFY_RUN
     started_at = time.monotonic()
     parser = argparse.ArgumentParser(description="Run the local verification baseline.")
@@ -3228,6 +3266,7 @@ def _main(argv: list[str] | None = None) -> int:
         started_at=started_at,
         verification_scope=planned_scope,
         head=head,
+        agentctl_binding=agentctl_binding,
     )
 
     optimization_level = _python_optimization_level()
@@ -3269,12 +3308,16 @@ def _main(argv: list[str] | None = None) -> int:
     )
     sys.stderr.write(f"verify: polylogue package → {polylogue_import_path}\n")
 
-    mutation_monitor = CheckoutMutationMonitor(ROOT)
-    _start_active_checkout_mutation_monitor(mutation_monitor)
-    checkout_fingerprint = worktree_fingerprint(ROOT)
-    _finish_active_checkout_mutation_monitor(mutation_monitor)
-    mutation_monitor = CheckoutMutationMonitor(ROOT)
-    _start_active_checkout_mutation_monitor(mutation_monitor)
+    mutation_monitor: CheckoutMutationMonitor | None = None
+    if agentctl_binding is not None:
+        checkout_fingerprint = worktree_fingerprint(ROOT)
+    else:
+        mutation_monitor = CheckoutMutationMonitor(ROOT)
+        _start_active_checkout_mutation_monitor(mutation_monitor)
+        checkout_fingerprint = worktree_fingerprint(ROOT)
+        _finish_active_checkout_mutation_monitor(mutation_monitor)
+        mutation_monitor = CheckoutMutationMonitor(ROOT)
+        _start_active_checkout_mutation_monitor(mutation_monitor)
     assert _ACTIVE_VERIFY_RUN is not None
     _ACTIVE_VERIFY_RUN.initial_worktree_fingerprint = checkout_fingerprint
     verify_run.update_checkout_provenance(worktree_fingerprint=checkout_fingerprint)
@@ -3504,9 +3547,12 @@ def _main(argv: list[str] | None = None) -> int:
     # of their own read path. Retain that interval's observation: a tracked
     # file can be edited and restored while the graph is prepared, which makes
     # any resulting selection unsuitable as exact-head authority.
-    preparation_mutation_observation = _finish_active_checkout_mutation_monitor(mutation_monitor)
-    mutation_monitor = CheckoutMutationMonitor(ROOT)
-    _start_active_checkout_mutation_monitor(mutation_monitor)
+    if mutation_monitor is None:
+        preparation_mutation_observation = CheckoutMutationObservation(changed=False, unavailable=False)
+    else:
+        preparation_mutation_observation = _finish_active_checkout_mutation_monitor(mutation_monitor)
+        mutation_monitor = CheckoutMutationMonitor(ROOT)
+        _start_active_checkout_mutation_monitor(mutation_monitor)
     step_results: list[dict[str, Any]] = []
     exit_code = 0
     native_graph_touched = False
@@ -3535,10 +3581,13 @@ def _main(argv: list[str] | None = None) -> int:
         if label.startswith("pytest") or rc == 130 or _stop_after_failed_step(label):
             break
 
-    assert mutation_monitor is not None
     final_head = _git_head()
     final_checkout_fingerprint = worktree_fingerprint(ROOT)
-    mutation_observation = _finish_active_checkout_mutation_monitor(mutation_monitor)
+    mutation_observation = (
+        _finish_active_checkout_mutation_monitor(mutation_monitor)
+        if mutation_monitor is not None
+        else CheckoutMutationObservation(changed=False, unavailable=False)
+    )
     checkout_stable = True
     checkout_fingerprint_unavailable = (
         head is None
@@ -3849,6 +3898,8 @@ def _finalize_verify_runner_exception(
             mutation_observation = _finish_active_checkout_mutation_monitor(active.mutation_monitor)
         except Exception:
             mutation_observation = None
+    elif active.agentctl_binding is not None:
+        mutation_observation = CheckoutMutationObservation(changed=False, unavailable=False)
     _close_active_native_testmon_state()
     run.finish_interrupted_steps(
         exit_code=exit_code,
@@ -4009,7 +4060,8 @@ def main(argv: list[str] | None = None) -> int:
     global _ACTIVE_VERIFY_RUN
     _ACTIVE_VERIFY_RUN = None
     raw_argv = list(sys.argv[1:] if argv is None else argv)
-    if _should_isolate(raw_argv):
+    agentctl_binding = _agentctl_lifecycle_free_binding(raw_argv)
+    if agentctl_binding is None and _should_isolate(raw_argv):
         return _reexec_isolated(raw_argv)
     native_pytest_enabled = not any(flag in raw_argv for flag in ("--quick", "--commit", "--plan"))
     if os.environ.get("PYTEST_CURRENT_TEST"):
@@ -4032,7 +4084,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         with _terminate_as_interrupt(), lock:
             try:
-                return _main(argv)
+                return _main(argv, agentctl_binding=agentctl_binding)
             except KeyboardInterrupt as exc:
                 if _ACTIVE_VERIFY_RUN is None:
                     raise

--- a/devtools/verify_runs.py
+++ b/devtools/verify_runs.py
@@ -29,7 +29,11 @@ from typing import Any, Final, ParamSpec, TextIO, TypeVar
 
 import watchfiles
 
-from devtools.agentctl_verification_receipt import agentctl_verification_receipt
+from devtools.agentctl_verification_receipt import (
+    SUPPORTED_OPERATIONS,
+    agentctl_verification_operation,
+    agentctl_verification_receipt,
+)
 from devtools.cloud_sentinels import CLOUD_SENTINELS, running_in_cloud_sandbox
 from devtools.pytest_supervisor import force_rmtree
 from devtools.testmon_bootstrap import canonical_test_nodeid
@@ -96,6 +100,87 @@ PYTEST_CGROUP_OVERHEAD_FLOOR_KB = max(
 
 class PytestResourceError(RuntimeError):
     """Raised when the host cannot safely start a managed pytest run."""
+
+
+@dataclass(frozen=True)
+class AgentctlDeclaredJobBinding:
+    """Validated outer lifecycle and exact-checkout authority for verification."""
+
+    operation: str
+    job_id: str
+    checkout_id: str
+    checkout_head: str
+
+
+def agentctl_declared_job_binding(
+    root: Path,
+    *,
+    env: Mapping[str, str] | None = None,
+    cgroup_text: str | None = None,
+    current_head: str | None = None,
+    git_common_dir: Path | None = None,
+) -> AgentctlDeclaredJobBinding | None:
+    """Prove that this process is the exact checkout-bound declared job."""
+    values = os.environ if env is None else env
+    operation = agentctl_verification_operation(values)
+    if operation not in SUPPORTED_OPERATIONS or values.get("SINNIXD_PROJECT_ID") != "polylogue":
+        return None
+
+    job_id = values.get("SINNIXD_JOB_ID", "")
+    correlation_id = values.get("SINNIXD_CORRELATION_ID", "")
+    try:
+        if str(uuid.UUID(job_id)) != job_id or str(uuid.UUID(correlation_id)) != correlation_id:
+            return None
+    except (ValueError, AttributeError):
+        return None
+
+    declared_head = values.get("SINNIXD_CHECKOUT_HEAD", "")
+    if not re.fullmatch(r"[0-9a-f]{40}", declared_head):
+        return None
+    observed_head = current_head if current_head is not None else git_head(root)
+    if observed_head != declared_head:
+        return None
+
+    resolved_root = root.resolve()
+    common_dir = git_common_dir
+    if common_dir is None:
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+                cwd=resolved_root,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+            common_dir = Path(result.stdout.strip())
+        except (OSError, subprocess.SubprocessError):
+            return None
+    common_dir = common_dir.resolve()
+    project_root = common_dir.parent if common_dir.name == ".git" else None
+    expected_checkout_id = (
+        "default"
+        if project_root == resolved_root
+        else "worktree-" + hashlib.sha256(str(resolved_root).encode()).hexdigest()[:16]
+    )
+    checkout_id = values.get("SINNIXD_CHECKOUT_ID", "")
+    if checkout_id != expected_checkout_id:
+        return None
+
+    if cgroup_text is None:
+        try:
+            cgroup_text = Path("/proc/self/cgroup").read_text()
+        except OSError:
+            return None
+    unit = f"sinnixd-job-{job_id}.service"
+    if not any(unit == component for line in cgroup_text.splitlines() for component in line.split("/")):
+        return None
+    return AgentctlDeclaredJobBinding(
+        operation=operation,
+        job_id=job_id,
+        checkout_id=checkout_id,
+        checkout_head=declared_head,
+    )
 
 
 def _trailing_history_record(descriptor: int, *, end: int) -> tuple[int, bytes]:

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import fcntl
+import hashlib
 import itertools
 import json
 import os
@@ -60,6 +61,7 @@ from devtools.verify import (
     main,
 )
 from devtools.verify_runs import (
+    AgentctlDeclaredJobBinding,
     CheckoutMutationMonitor,
     CheckoutMutationObservation,
     PytestResourceError,
@@ -68,6 +70,7 @@ from devtools.verify_runs import (
     VerifyRun,
     adaptive_pytest_runtime_policy,
     adaptive_pytest_worker_count,
+    agentctl_declared_job_binding,
     aggregate_native_testmon_run,
     aggregate_pytest_statistics,
     append_verify_history,
@@ -4687,6 +4690,186 @@ def test_verify_continues_after_failed_cheap_step(
     assert payload["release_baseline_allowed"] is False
     assert payload["pytest_aggregate"]["selection_mode"] == "none"
     assert json.loads(receipt.read_text())["pytest_aggregate"] == payload["pytest_aggregate"]
+
+
+def test_agentctl_declared_job_binding_requires_outer_job_and_exact_checkout(tmp_path: Path) -> None:
+    root = (tmp_path / "worktree").resolve()
+    common_dir = (tmp_path / "project" / ".git").resolve()
+    head = "a" * 40
+    job_id = "11111111-1111-1111-1111-111111111111"
+    checkout_id = "worktree-" + hashlib.sha256(str(root).encode()).hexdigest()[:16]
+    environment = {
+        "SINNIXD_OPERATION": "verify_affected",
+        "SINNIXD_JOB_ID": job_id,
+        "SINNIXD_CORRELATION_ID": "22222222-2222-2222-2222-222222222222",
+        "SINNIXD_PROJECT_ID": "polylogue",
+        "SINNIXD_CHECKOUT_ID": checkout_id,
+        "SINNIXD_CHECKOUT_HEAD": head,
+    }
+    cgroup = f"0::/user.slice/agent.slice/sinnixd-job-{job_id}.service\n"
+
+    binding = agentctl_declared_job_binding(
+        root,
+        env=environment,
+        cgroup_text=cgroup,
+        current_head=head,
+        git_common_dir=common_dir,
+    )
+
+    assert binding == AgentctlDeclaredJobBinding(
+        operation="verify_affected",
+        job_id=job_id,
+        checkout_id=checkout_id,
+        checkout_head=head,
+    )
+    assert (
+        agentctl_declared_job_binding(
+            root,
+            env={"SINNIXD_OPERATION": "verify_affected"},
+            cgroup_text=cgroup,
+            current_head=head,
+            git_common_dir=common_dir,
+        )
+        is None
+    )
+    assert (
+        agentctl_declared_job_binding(
+            root,
+            env=environment,
+            cgroup_text="0::/user.slice/agent.slice/not-the-declared-job.service\n",
+            current_head=head,
+            git_common_dir=common_dir,
+        )
+        is None
+    )
+    assert (
+        agentctl_declared_job_binding(
+            root,
+            env={**environment, "SINNIXD_CHECKOUT_HEAD": "b" * 40},
+            cgroup_text=cgroup,
+            current_head=head,
+            git_common_dir=common_dir,
+        )
+        is None
+    )
+    assert (
+        agentctl_declared_job_binding(
+            root,
+            env={**environment, "SINNIXD_CHECKOUT_ID": "default"},
+            cgroup_text=cgroup,
+            current_head=head,
+            git_common_dir=common_dir,
+        )
+        is None
+    )
+
+
+def test_agentctl_descriptor_argv_is_part_of_lifecycle_free_proof() -> None:
+    binding = AgentctlDeclaredJobBinding(
+        operation="verify_quick",
+        job_id="11111111-1111-1111-1111-111111111111",
+        checkout_id="default",
+        checkout_head="a" * 40,
+    )
+    with patch("devtools.verify.agentctl_declared_job_binding", return_value=binding):
+        assert verify._agentctl_lifecycle_free_binding(["--quick"]) == binding
+        assert verify._agentctl_lifecycle_free_binding([]) is None
+        assert verify._agentctl_lifecycle_free_binding(["--quick", "--json"]) is None
+
+
+def test_declared_agentctl_pytest_bypasses_inner_lifecycle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    binding = AgentctlDeclaredJobBinding(
+        operation="verify_affected",
+        job_id="11111111-1111-1111-1111-111111111111",
+        checkout_id="default",
+        checkout_head="a" * 40,
+    )
+    previous = verify._ACTIVE_VERIFY_RUN
+    verify._ACTIVE_VERIFY_RUN = cast(Any, SimpleNamespace(agentctl_binding=binding))
+    completed = subprocess.CompletedProcess(args=["pytest"], returncode=0, stdout="1 passed\n", stderr="")
+    policy = SimpleNamespace(to_dict=lambda: {"workers": 1})
+    try:
+        with (
+            patch("devtools.verify._subprocess_env", return_value={}),
+            patch("devtools.verify._pytest_command_concurrency", return_value=1),
+            patch("devtools.verify.sweep_stale_managed_basetemps", return_value=[]),
+            patch("devtools.verify.apply_managed_pytest_runtime_policy", return_value=({}, policy)),
+            patch("devtools.verify.cleanup_managed_pytest_basetemp", return_value=tmp_path / "cleaned"),
+            patch("devtools.verify._run_pytest_with_heartbeat", side_effect=AssertionError("inner lifecycle used")),
+            patch("devtools.verify.subprocess.run", return_value=completed) as direct_run,
+            patch("devtools.verify._read_pytest_report", return_value=None),
+            patch("devtools.verify._read_json_artifact", return_value=None),
+            patch("devtools.verify._persist_pytest_output"),
+            patch("devtools.verify._pytest_workload_receipt", return_value={}),
+        ):
+            rc, _elapsed, metadata = verify._run_step("pytest native parallel (affected)", ["pytest"])
+    finally:
+        verify._ACTIVE_VERIFY_RUN = previous
+
+    assert rc == 0
+    direct_run.assert_called_once()
+    assert "timeout" not in direct_run.call_args.kwargs
+    assert metadata["lifecycle_authority"] == "agentctl"
+    assert metadata["heartbeat_s"] is None
+    assert metadata["stall_timeout_s"] is None
+    assert metadata["resource_interval_s"] is None
+    assert metadata["containment_path"] is None
+
+
+def test_incomplete_agentctl_environment_retains_inner_lifecycle(tmp_path: Path) -> None:
+    previous = verify._ACTIVE_VERIFY_RUN
+    verify._ACTIVE_VERIFY_RUN = cast(Any, SimpleNamespace(agentctl_binding=None))
+    completed = subprocess.CompletedProcess(args=["pytest"], returncode=0, stdout="1 passed\n", stderr="")
+    policy = SimpleNamespace(to_dict=lambda: {"workers": 1})
+    try:
+        with (
+            patch("devtools.verify._subprocess_env", return_value={}),
+            patch("devtools.verify._pytest_command_concurrency", return_value=1),
+            patch("devtools.verify.sweep_stale_managed_basetemps", return_value=[]),
+            patch("devtools.verify.apply_managed_pytest_runtime_policy", return_value=({}, policy)),
+            patch("devtools.verify.cleanup_managed_pytest_basetemp", return_value=tmp_path / "cleaned"),
+            patch("devtools.verify._run_pytest_with_heartbeat", return_value=completed) as supervised_run,
+            patch("devtools.verify._read_pytest_report", return_value=None),
+            patch("devtools.verify._read_json_artifact", return_value=None),
+            patch("devtools.verify._persist_pytest_output"),
+            patch("devtools.verify._pytest_workload_receipt", return_value={}),
+        ):
+            rc, _elapsed, metadata = verify._run_step("pytest native parallel (affected)", ["pytest"])
+    finally:
+        verify._ACTIVE_VERIFY_RUN = previous
+
+    assert rc == 0
+    supervised_run.assert_called_once()
+    assert "lifecycle_authority" not in metadata
+    assert metadata["heartbeat_s"] == verify._pytest_heartbeat_interval()
+    assert metadata["containment_path"] == str(PYTEST_CONTAINMENT_PATH)
+
+
+def test_declared_agentctl_quick_route_skips_snapshot_and_mutation_monitor() -> None:
+    binding = AgentctlDeclaredJobBinding(
+        operation="verify_quick",
+        job_id="11111111-1111-1111-1111-111111111111",
+        checkout_id="default",
+        checkout_head="a" * 40,
+    )
+    fingerprint = SimpleNamespace(polylogue_import_path=ROOT / "polylogue", as_dict=lambda: {})
+    with (
+        patch("devtools.verify._agentctl_lifecycle_free_binding", return_value=binding),
+        patch("devtools.verify._should_isolate", side_effect=AssertionError("snapshot decision used")),
+        patch("devtools.verify.CheckoutMutationMonitor", side_effect=AssertionError("mutation monitor used")),
+        patch("devtools.verify.assert_polylogue_matches_checkout", return_value=fingerprint),
+        patch("devtools.verify._run", return_value=(0, 0.01, {})),
+        patch("devtools.verify._git_head", return_value="a" * 40),
+        patch("devtools.verify.worktree_fingerprint", return_value="stable"),
+        patch("devtools.verify._save_history"),
+        patch("devtools.verify._stamp_head"),
+    ):
+        rc = main(["--quick"])
+
+    assert rc == 0
 
 
 def test_agentctl_verification_receipt_bounds_public_diagnostics_and_preserves_contract() -> None:


### PR DESCRIPTION
## Summary

- recognize only a fully attested Sinnixd declared-operation environment as AgentCTL-owned
- bypass Polylogue snapshot re-exec, checkout mutation monitoring, inner process/systemd supervision, timeout/stall termination, subreaper handling, and resource sampling on that route
- retain all existing lifecycle safeguards for direct devtools, CI, hooks, and incomplete/spoofed environments

## Verification

- `devtools test tests/unit/devtools/test_verify.py -k agentctl`: 10 passed, 231 deselected
- required pre-push `devtools verify --quick`: all 12 gates passed in 53.31s

## Cleanup leverage

This establishes the route split needed to migrate AgentCTL verification off Polylogue host-control machinery. It does not yet delete globally shared legacy implementations because direct `devtools verify`, `devtools test`, CI/hooks, `run_tests.py`, and `verify_slos.py` still consume them.