### PR TITLE
test(schema): use workspace inspection commands

### DIFF
--- a/tests/integration/test_schema_operator_workflow.py
+++ b/tests/integration/test_schema_operator_workflow.py
@@ -177,7 +177,7 @@ def _patch_registry(registry: SchemaRegistry) -> AbstractContextManager[object]:
 class TestSchemaListCommand:
     def test_list_all_providers_json(self, runner: CliRunner, seeded_registry: SchemaRegistry) -> None:
         with _patch_registry(seeded_registry):
-            result = _invoke_devtools(["lab", "schema", "list", "--format", "json"])
+            result = _invoke_devtools(["workspace", "schema", "list", "--format", "json"])
 
         assert result.exit_code == 0, f"CLI failed: {result.output}"
         outer = _extract_json(result.output)
@@ -195,7 +195,9 @@ class TestSchemaListCommand:
 
     def test_list_specific_provider_json(self, runner: CliRunner, seeded_registry: SchemaRegistry) -> None:
         with _patch_registry(seeded_registry):
-            result = _invoke_devtools(["lab", "schema", "list", "--provider", "test-provider", "--format", "json"])
+            result = _invoke_devtools(
+                ["workspace", "schema", "list", "--provider", "test-provider", "--format", "json"]
+            )
 
         assert result.exit_code == 0, f"CLI failed: {result.output}"
         outer = _extract_json(result.output)
@@ -213,7 +215,7 @@ class TestSchemaListCommand:
 
     def test_list_specific_provider_text(self, runner: CliRunner, seeded_registry: SchemaRegistry) -> None:
         with _patch_registry(seeded_registry):
-            result = _invoke_devtools(["lab", "schema", "list", "--provider", "test-provider"])
+            result = _invoke_devtools(["workspace", "schema", "list", "--provider", "test-provider"])
 
         assert result.exit_code == 0, f"CLI failed: {result.output}"
         assert "test-provider" in result.output
@@ -224,7 +226,7 @@ class TestSchemaListCommand:
 
     def test_list_unknown_provider(self, runner: CliRunner, seeded_registry: SchemaRegistry) -> None:
         with _patch_registry(seeded_registry):
-            result = _invoke_devtools(["lab", "schema", "list", "--provider", "nonexistent"])
+            result = _invoke_devtools(["workspace", "schema", "list", "--provider", "nonexistent"])
 
         assert result.exit_code == 0  # not an error, just "no schemas found"
         assert "No schemas found" in result.output or "nonexistent" in result.output
@@ -263,7 +265,7 @@ class TestSchemaCompareCommand:
         with _patch_registry(seeded_registry):
             result = _invoke_devtools(
                 [
-                    "lab",
+                    "workspace",
                     "schema",
                     "compare",
                     "--provider",
@@ -292,7 +294,7 @@ class TestSchemaCompareCommand:
         with _patch_registry(seeded_registry):
             result = _invoke_devtools(
                 [
-                    "lab",
+                    "workspace",
                     "schema",
                     "compare",
                     "--provider",
@@ -318,7 +320,7 @@ class TestSchemaCompareCommand:
         with _patch_registry(seeded_registry):
             result = _invoke_devtools(
                 [
-                    "lab",
+                    "workspace",
                     "schema",
                     "compare",
                     "--provider",
@@ -341,7 +343,7 @@ class TestSchemaCompareCommand:
     def test_compare_text_output(self, runner: CliRunner, seeded_registry: SchemaRegistry) -> None:
         with _patch_registry(seeded_registry):
             result = _invoke_devtools(
-                ["lab", "schema", "compare", "--provider", "test-provider", "--from", "v1", "--to", "v2"],
+                ["workspace", "schema", "compare", "--provider", "test-provider", "--from", "v1", "--to", "v2"],
             )
 
         assert result.exit_code == 0, f"CLI failed: {result.output}"
@@ -352,7 +354,7 @@ class TestSchemaCompareCommand:
         with _patch_registry(seeded_registry):
             result = _invoke_devtools(
                 [
-                    "lab",
+                    "workspace",
                     "schema",
                     "compare",
                     "--provider",
@@ -384,7 +386,7 @@ class TestSchemaCompareCommand:
         with _patch_registry(registry):
             result = _invoke_devtools(
                 [
-                    "lab",
+                    "workspace",
                     "schema",
                     "compare",
                     "--provider",
@@ -435,7 +437,7 @@ class TestSchemaCompareCommand:
         with _patch_registry(registry):
             result = _invoke_devtools(
                 [
-                    "lab",
+                    "workspace",
                     "schema",
                     "compare",
                     "--provider",
@@ -462,7 +464,7 @@ class TestSchemaCompareCommand:
     def test_compare_nonexistent_version_fails(self, runner: CliRunner, seeded_registry: SchemaRegistry) -> None:
         with _patch_registry(seeded_registry):
             result = _invoke_devtools(
-                ["lab", "schema", "compare", "--provider", "test-provider", "--from", "v1", "--to", "v99"],
+                ["workspace", "schema", "compare", "--provider", "test-provider", "--from", "v1", "--to", "v99"],
             )
 
         assert result.exit_code != 0
@@ -476,7 +478,9 @@ class TestSchemaCompareCommand:
 class TestSchemaExplainCommand:
     def test_explain_json_output(self, runner: CliRunner, seeded_registry: SchemaRegistry) -> None:
         with _patch_registry(seeded_registry):
-            result = _invoke_devtools(["lab", "schema", "explain", "--provider", "test-provider", "--format", "json"])
+            result = _invoke_devtools(
+                ["workspace", "schema", "explain", "--provider", "test-provider", "--format", "json"]
+            )
 
         assert result.exit_code == 0, f"CLI failed: {result.output}"
         outer = _extract_json(result.output)
@@ -490,7 +494,7 @@ class TestSchemaExplainCommand:
 
     def test_explain_latest_version(self, runner: CliRunner, seeded_registry: SchemaRegistry) -> None:
         with _patch_registry(seeded_registry):
-            result = _invoke_devtools(["lab", "schema", "explain", "--provider", "test-provider"])
+            result = _invoke_devtools(["workspace", "schema", "explain", "--provider", "test-provider"])
 
         assert result.exit_code == 0, f"CLI failed: {result.output}"
         # Latest is v2, which has "status" and "tags"
@@ -500,7 +504,7 @@ class TestSchemaExplainCommand:
     def test_explain_specific_version(self, runner: CliRunner, seeded_registry: SchemaRegistry) -> None:
         with _patch_registry(seeded_registry):
             result = _invoke_devtools(
-                ["lab", "schema", "explain", "--provider", "test-provider", "--version", "v1"],
+                ["workspace", "schema", "explain", "--provider", "test-provider", "--version", "v1"],
             )
 
         assert result.exit_code == 0, f"CLI failed: {result.output}"
@@ -511,14 +515,14 @@ class TestSchemaExplainCommand:
     def test_explain_nonexistent_fails(self, runner: CliRunner, seeded_registry: SchemaRegistry) -> None:
         with _patch_registry(seeded_registry):
             result = _invoke_devtools(
-                ["lab", "schema", "explain", "--provider", "nonexistent"],
+                ["workspace", "schema", "explain", "--provider", "nonexistent"],
             )
 
         assert result.exit_code != 0
 
     def test_explain_shows_metadata(self, runner: CliRunner, seeded_registry: SchemaRegistry) -> None:
         with _patch_registry(seeded_registry):
-            result = _invoke_devtools(["lab", "schema", "explain", "--provider", "test-provider"])
+            result = _invoke_devtools(["workspace", "schema", "explain", "--provider", "test-provider"])
 
         assert result.exit_code == 0, f"CLI failed: {result.output}"
         assert "Metadata" in result.output
@@ -543,7 +547,7 @@ class TestSchemaExplainCommand:
         )
 
         with _patch_registry(registry):
-            result = _invoke_devtools(["lab", "schema", "explain", "--provider", "ann-prov", "--format", "json"])
+            result = _invoke_devtools(["workspace", "schema", "explain", "--provider", "ann-prov", "--format", "json"])
 
         assert result.exit_code == 0, f"CLI failed: {result.output}"
         outer = _extract_json(result.output)
@@ -683,7 +687,7 @@ class TestFullOperatorWorkflow:
         # Step 2: List — verify archive is visible
         with _patch_registry(registry):
             result = _invoke_devtools(
-                ["lab", "schema", "list", "--provider", "workflow-prov", "--format", "json"],
+                ["workspace", "schema", "list", "--provider", "workflow-prov", "--format", "json"],
             )
         assert result.exit_code == 0
         outer = _extract_json(result.output)
@@ -709,7 +713,7 @@ class TestFullOperatorWorkflow:
         with _patch_registry(registry):
             result = _invoke_devtools(
                 [
-                    "lab",
+                    "workspace",
                     "schema",
                     "compare",
                     "--provider",
@@ -757,7 +761,17 @@ class TestFullOperatorWorkflow:
         # Step 6: Explain the promoted version
         with _patch_registry(registry):
             result = _invoke_devtools(
-                ["lab", "schema", "explain", "--provider", "workflow-prov", "--version", "v3", "--format", "json"],
+                [
+                    "workspace",
+                    "schema",
+                    "explain",
+                    "--provider",
+                    "workflow-prov",
+                    "--version",
+                    "v3",
+                    "--format",
+                    "json",
+                ],
             )
         assert result.exit_code == 0
         outer = _extract_json(result.output)
@@ -772,7 +786,7 @@ class TestFullOperatorWorkflow:
         # Step 7: Final list shows all 3 versions
         with _patch_registry(registry):
             result = _invoke_devtools(
-                ["lab", "schema", "list", "--provider", "workflow-prov", "--format", "json"],
+                ["workspace", "schema", "list", "--provider", "workflow-prov", "--format", "json"],
             )
         assert result.exit_code == 0
         outer = _extract_json(result.output)


### PR DESCRIPTION
## Summary

Update schema-operator integration coverage to invoke the supported `devtools workspace schema` inspection surface.

## Problem

The complete corpus had 17 failures because this integration module still invoked the retired `devtools lab schema` command path, while current command catalog entries expose schema inspection under `workspace schema`.

## Solution

Migrate list, compare, and explain invocations to the supported command path while retaining the existing output and end-to-end assertions.

## Verification

- `env -u VIRTUAL_ENV direnv exec . devtools test tests/integration/test_schema_operator_workflow.py` — `25 passed in 2.57s`
- `env -u VIRTUAL_ENV direnv exec . devtools verify --quick` — success
