### PR TITLE
test(daemon): align FTS startup contracts

### DIFF
--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -1430,7 +1430,7 @@ def test_periodic_raw_materialization_convergence_starts_without_catch_up(
 
     asyncio.run(exercise())
 
-    assert calls == ["drain", "fts"]
+    assert calls == ["drain"]
 
 
 def test_periodic_raw_materialization_convergence_waits_for_watcher_catch_up(
@@ -1463,7 +1463,7 @@ def test_periodic_raw_materialization_convergence_waits_for_watcher_catch_up(
 
     asyncio.run(exercise())
 
-    assert calls == ["drain", "fts"]
+    assert calls == ["drain"]
 
 
 def test_periodic_drive_source_catchup_waits_for_watcher_catch_up(
@@ -2946,8 +2946,10 @@ def test_archive_message_fts_startup_records_known_stale_ledger_without_global_c
             if query.startswith("SELECT name FROM sqlite_master WHERE type='trigger'"):
                 triggers: list[tuple[object, ...]] = [("messages_fts_ai",), ("messages_fts_ad",), ("messages_fts_au",)]
                 return FakeCursor(triggers[0], rows=triggers)
+            if query == "PRAGMA user_version":
+                return FakeCursor((0,))
             if query.startswith("SELECT state, source_rows, indexed_rows"):
-                return FakeCursor(("stale", 250_000, 100_000, 150_000, 0, 0, 0))
+                return FakeCursor(("stale", 250_000, 100_000, 150_000, 0, 0, 0, "unknown", None, 0))
             raise AssertionError(f"unexpected query: {query}")
 
     conn = FakeConnection()
@@ -3016,8 +3018,10 @@ def test_archive_message_fts_startup_downgrades_inconsistent_ready_ledger_withou
             if query.startswith("SELECT name FROM sqlite_master WHERE type='trigger'"):
                 triggers: list[tuple[object, ...]] = [("messages_fts_ai",), ("messages_fts_ad",), ("messages_fts_au",)]
                 return FakeCursor(triggers[0], rows=triggers)
+            if query == "PRAGMA user_version":
+                return FakeCursor((0,))
             if query.startswith("SELECT state, source_rows, indexed_rows"):
-                return FakeCursor(("ready", 250_000, 100_000, 0, 0, 0, 0))
+                return FakeCursor(("ready", 250_000, 100_000, 0, 0, 0, 0, "unknown", None, 0))
             raise AssertionError(f"unexpected query: {query}")
 
     conn = FakeConnection()
@@ -3105,8 +3109,10 @@ def test_archive_message_fts_startup_records_poisoned_stale_zero_ledger_without_
             if query.startswith("SELECT name FROM sqlite_master WHERE type='trigger'"):
                 triggers: list[tuple[object, ...]] = [("messages_fts_ai",), ("messages_fts_ad",), ("messages_fts_au",)]
                 return FakeCursor(triggers[0], rows=triggers)
+            if query == "PRAGMA user_version":
+                return FakeCursor((0,))
             if query.startswith("SELECT state, source_rows, indexed_rows"):
-                return FakeCursor(("stale", 0, 0, 0, 0, 0, 0))
+                return FakeCursor(("stale", 0, 0, 0, 0, 0, 0, "unknown", None, 0))
             if query == "SELECT 1 FROM blocks WHERE search_text != '' LIMIT 1":
                 return FakeCursor((1,))
             if query == "SELECT 1 FROM messages_fts_docsize LIMIT 1":
@@ -3277,7 +3283,10 @@ def test_ensure_fts_startup_readiness_trusts_ready_freshness_without_counts(
                         (6, "excess_rows"),
                         (7, "duplicate_rows"),
                         (8, "identity_mismatch_rows"),
-                        (9, "detail"),
+                        (9, "verification_kind"),
+                        (10, "exact_checked_at"),
+                        (11, "exact_generation"),
+                        (12, "detail"),
                     ],
                 )
             if query == "SELECT 1 FROM sqlite_master WHERE type='table' AND name=? LIMIT 1":
@@ -3293,7 +3302,9 @@ def test_ensure_fts_startup_readiness_trusts_ready_freshness_without_counts(
                 ]
                 return FakeCursor(None, rows=triggers)
             if query.startswith("SELECT state, source_rows, indexed_rows, missing_rows, excess_rows, duplicate_rows"):
-                return FakeCursor(("ready", 10, 10, 0, 0, 0, 0))
+                return FakeCursor(("ready", 10, 10, 0, 0, 0, 0, "exact", "2026-08-23T00:00:00+00:00", 0))
+            if query == "PRAGMA user_version":
+                return FakeCursor((0,))
             raise AssertionError(f"unexpected query: {query}")
 
         def commit(self) -> None:
@@ -3651,7 +3662,7 @@ def test_ensure_fts_startup_readiness_handles_archive(
             WHERE surface = 'messages_fts'
             """
         ).fetchone()
-    assert row == ("ready", 1, 1)
+    assert row == ("stale", 1, 1)
 
 
 def test_ensure_fts_startup_readiness_uses_extended_write_timeout(
@@ -4784,7 +4795,7 @@ def test_daemon_shutdown_marks_interrupted_attempts_only_without_signal(
     with (
         patch.object(daemon_cli, "make_server", return_value=browser_server),
         patch.object(daemon_cli, "_ensure_embedding_lifecycle_startup_sync", noop_sync),
-        patch.object(daemon_cli, "_ensure_fts_startup_readiness_sync", noop_sync),
+        patch.object(daemon_cli, "_run_startup_fts_readiness", lambda _coordinator: noop()),
         patch.object(daemon_cli, "_ensure_lineage_startup_readiness_sync", noop_sync),
         patch.object(daemon_cli, "_reconcile_blob_publications", noop),
         patch.object(daemon_cli, "_configure_fts_automerge", noop),


### PR DESCRIPTION
## Summary

Update daemon CLI tests to reflect the extracted FTS convergence owner and the exact, generation-bound freshness ledger contract.

## Problem

The controlled full-corpus baseline reported stale daemon fixtures: raw materialization still expected an FTS pass, startup-ledger mocks returned the retired seven-column shape, and shutdown tests patched a removed synchronous seam.

## Solution

`tests/unit/daemon/test_daemon_cli.py` now asserts the raw drain alone, supplies the current ten-field freshness row and generation probe, expects a bounded startup record to remain stale, and patches `_run_startup_fts_readiness`, the live daemon startup seam.

## Verification

- `env -u VIRTUAL_ENV direnv exec . devtools test tests/unit/daemon/test_daemon_cli.py::test_periodic_raw_materialization_convergence_waits_for_watcher_catch_up tests/unit/daemon/test_daemon_cli.py::test_periodic_raw_materialization_convergence_starts_without_catch_up tests/unit/daemon/test_daemon_cli.py::test_daemon_shutdown_marks_interrupted_attempts_only_without_signal tests/unit/daemon/test_daemon_cli.py::test_ensure_fts_startup_readiness_trusts_ready_freshness_without_counts tests/unit/daemon/test_daemon_cli.py::test_ensure_fts_startup_readiness_handles_archive tests/unit/daemon/test_daemon_cli.py::test_archive_message_fts_startup_records_known_stale_ledger_without_global_counts tests/unit/daemon/test_daemon_cli.py::test_archive_message_fts_startup_downgrades_inconsistent_ready_ledger_without_global_counts tests/unit/daemon/test_daemon_cli.py::test_archive_message_fts_startup_records_poisoned_stale_zero_ledger_without_global_counts` reported `9 passed in 8.47s`.
- Pre-push `devtools verify --quick` passed all 12 checks.

A whole-module run twice stalled in shutdown-test setup after substantial progress, while the identical focused selection completed successfully once. This PR does not claim to resolve that test-isolation problem; the upcoming controlled current-master corpus will classify it.