### PR TITLE
test(devtools): track schema-versioning command label

### DIFF
--- a/tests/unit/devtools/test_durable_schema_policy_gate.py
+++ b/tests/unit/devtools/test_durable_schema_policy_gate.py
@@ -97,7 +97,7 @@ def test_schema_versioning_policy_runs_exactly_once_in_every_noncommit_fast_gate
                 testmon_environment="env-digest" if not quick else "",
             )
         ]
-        assert labels.count("lab policy schema-versioning") == 1
+        assert labels.count("verify schema-versioning") == 1
 
     commit_labels = [
         label
@@ -107,4 +107,4 @@ def test_schema_versioning_policy_runs_exactly_once_in_every_noncommit_fast_gate
             commit=True,
         )
     ]
-    assert "lab policy schema-versioning" not in commit_labels
+    assert "verify schema-versioning" not in commit_labels


### PR DESCRIPTION
## Summary

Update the durable-schema policy gate test to assert the current command-catalog label.

## Problem

The controlled full-corpus run failed because `test_schema_versioning_policy_runs_exactly_once_in_every_noncommit_fast_gate` still expected the retired `lab policy schema-versioning` label. The verification pipeline has invoked `verify schema-versioning` since the command-catalog migration.

## Solution

`tests/unit/devtools/test_durable_schema_policy_gate.py` now checks the current label in both non-commit and commit-mode assertions.

## Verification

- `env -u VIRTUAL_ENV direnv exec . devtools test tests/unit/devtools/test_durable_schema_policy_gate.py` reported `4 passed in 1.52s`.
- `env -u VIRTUAL_ENV direnv exec . devtools verify --quick` passed all 12 checks.