### PR TITLE
test(bench): align performance-floor workload tiers

### DIFF
--- a/tests/benchmarks/perf_floors.py
+++ b/tests/benchmarks/perf_floors.py
@@ -60,8 +60,8 @@ _GIT_TIMEOUT_S = 2.0
 
 # Quick mode shrinks corpora for a fast smoke check (local dev / CI dry runs);
 # it still exercises every measured surface, just at a smaller scale.
-_ACTION_PAIRS_TARGET_MESSAGES = 3000
-_ACTION_PAIRS_TARGET_MESSAGES_QUICK = 600
+_ACTION_PAIRS_TARGET_MESSAGES = 5000
+_ACTION_PAIRS_TARGET_MESSAGES_QUICK = 1000
 _ACTION_PAIRS_SAMPLE_SESSIONS = 20
 _REPLAY_RAW_COUNT = 200
 _REPLAY_RAW_COUNT_QUICK = 40


### PR DESCRIPTION
## Summary

Align the action-pair performance-floor targets with the named workloads exposed by the shared artifact registry.

## Problem

The quick floor requested a 600-message corpus and the normal floor requested 3,000 messages. The registry supports 1,000, 5,000, 10,000, and 50,000-message profiles, so the quick metric raised `ValueError` before collecting its measurement.

## Solution

`tests/benchmarks/perf_floors.py` now uses the 1,000-message smoke profile in quick mode and the 5,000-message representative profile in normal mode. Both sizes are existing semantic workload tiers.

## Verification

- `env -u VIRTUAL_ENV direnv exec . devtools test tests/unit/infra/test_perf_floors.py`
  - `8 passed in 29.90s`
- `env -u VIRTUAL_ENV direnv exec . devtools verify --quick`
  - completed successfully, including mypy, generated-surface, layering, schema, and oracle-integrity checks.