### PR TITLE
refactor(agentctl): trust daemon workspace bindings

### DIFF
--- a/devtools/agentctl_verification_receipt.py
+++ b/devtools/agentctl_verification_receipt.py
@@ -49,6 +49,7 @@ def agentctl_verification_receipt(
         "job_id": _string(values.get(AGENTCTL_JOB_ID_ENV)),
         "run_id": _string(payload.get("run_id")),
         "workspace": {
+            "authority": "agentctl",
             "checkout_id": _string(values.get(AGENTCTL_CHECKOUT_ID_ENV)),
             "declared_head": _string(values.get(AGENTCTL_CHECKOUT_HEAD_ENV)),
             "observed_head": _string(payload.get("git_head")),

--- a/devtools/verify_runs.py
+++ b/devtools/verify_runs.py
@@ -118,7 +118,6 @@ def agentctl_declared_job_binding(
     env: Mapping[str, str] | None = None,
     cgroup_text: str | None = None,
     current_head: str | None = None,
-    git_common_dir: Path | None = None,
 ) -> AgentctlDeclaredJobBinding | None:
     """Prove that this process is the exact checkout-bound declared job."""
     values = os.environ if env is None else env
@@ -141,30 +140,8 @@ def agentctl_declared_job_binding(
     if observed_head != declared_head:
         return None
 
-    resolved_root = root.resolve()
-    common_dir = git_common_dir
-    if common_dir is None:
-        try:
-            result = subprocess.run(
-                ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
-                cwd=resolved_root,
-                check=True,
-                capture_output=True,
-                text=True,
-                timeout=2,
-            )
-            common_dir = Path(result.stdout.strip())
-        except (OSError, subprocess.SubprocessError):
-            return None
-    common_dir = common_dir.resolve()
-    project_root = common_dir.parent if common_dir.name == ".git" else None
-    expected_checkout_id = (
-        "default"
-        if project_root == resolved_root
-        else "worktree-" + hashlib.sha256(str(resolved_root).encode()).hexdigest()[:16]
-    )
     checkout_id = values.get("SINNIXD_CHECKOUT_ID", "")
-    if checkout_id != expected_checkout_id:
+    if not checkout_id:
         return None
 
     if cgroup_text is None:

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import contextlib
 import fcntl
-import hashlib
 import itertools
 import json
 import os
@@ -4694,10 +4693,9 @@ def test_verify_continues_after_failed_cheap_step(
 
 def test_agentctl_declared_job_binding_requires_outer_job_and_exact_checkout(tmp_path: Path) -> None:
     root = (tmp_path / "worktree").resolve()
-    common_dir = (tmp_path / "project" / ".git").resolve()
     head = "a" * 40
     job_id = "11111111-1111-1111-1111-111111111111"
-    checkout_id = "worktree-" + hashlib.sha256(str(root).encode()).hexdigest()[:16]
+    checkout_id = "managed-workspace-opaque-id"
     environment = {
         "SINNIXD_OPERATION": "verify_affected",
         "SINNIXD_JOB_ID": job_id,
@@ -4713,7 +4711,6 @@ def test_agentctl_declared_job_binding_requires_outer_job_and_exact_checkout(tmp
         env=environment,
         cgroup_text=cgroup,
         current_head=head,
-        git_common_dir=common_dir,
     )
 
     assert binding == AgentctlDeclaredJobBinding(
@@ -4728,7 +4725,6 @@ def test_agentctl_declared_job_binding_requires_outer_job_and_exact_checkout(tmp
             env={"SINNIXD_OPERATION": "verify_affected"},
             cgroup_text=cgroup,
             current_head=head,
-            git_common_dir=common_dir,
         )
         is None
     )
@@ -4738,7 +4734,6 @@ def test_agentctl_declared_job_binding_requires_outer_job_and_exact_checkout(tmp
             env=environment,
             cgroup_text="0::/user.slice/agent.slice/not-the-declared-job.service\n",
             current_head=head,
-            git_common_dir=common_dir,
         )
         is None
     )
@@ -4748,17 +4743,15 @@ def test_agentctl_declared_job_binding_requires_outer_job_and_exact_checkout(tmp
             env={**environment, "SINNIXD_CHECKOUT_HEAD": "b" * 40},
             cgroup_text=cgroup,
             current_head=head,
-            git_common_dir=common_dir,
         )
         is None
     )
     assert (
         agentctl_declared_job_binding(
             root,
-            env={**environment, "SINNIXD_CHECKOUT_ID": "default"},
+            env={**environment, "SINNIXD_CHECKOUT_ID": ""},
             cgroup_text=cgroup,
             current_head=head,
-            git_common_dir=common_dir,
         )
         is None
     )
@@ -4917,6 +4910,7 @@ def test_agentctl_verification_receipt_bounds_public_diagnostics_and_preserves_c
     assert receipt is not None
     assert receipt["operation"] == "verify_affected"
     assert receipt["workspace"] == {
+        "authority": "agentctl",
         "checkout_id": "workspace-1",
         "declared_head": "declared-head",
         "observed_head": "observed-head",
@@ -4988,6 +4982,7 @@ def test_verify_run_writes_typed_agentctl_invocation_receipt(
 
     persisted = json.loads(receipt_path.read_text())
     assert persisted["operation"] == "verify_affected"
+    assert persisted["workspace"]["authority"] == "agentctl"
     assert persisted["workspace"]["checkout_id"] == "workspace-1"
     assert persisted["workspace"]["observed_head"] == "observed-head"
     assert persisted["workspace"]["final_head"] == "final-head"


### PR DESCRIPTION
## Summary

Delegate declared-job workspace identity entirely to AgentCTL while retaining Polylogue verification semantics and local evidence.

## Problem

`agentctl_declared_job_binding` re-derived the workspace identifier from Git common-directory topology. The live AgentCTL contract already binds a daemon-owned service cgroup to a registered workspace and exact declared HEAD, so the local derivation duplicated authority and rejected valid opaque workspace identifiers.

Ref polylogue-agentctl.2.1.

## Solution

`devtools/verify_runs.py` now requires a nonempty AgentCTL checkout ID after validating the project, operation, UUIDs, cgroup, and exact HEAD. `devtools/agentctl_verification_receipt.py` records `workspace.authority = "agentctl"`. The receipt still includes Polylogue’s observed and final content evidence. Tests prove opaque-ID admission and preserve rejection of missing IDs, wrong cgroups, and mismatched heads.

## Verification

- `nix develop --accept-flake-config --command devtools test tests/unit/devtools/test_verify.py -k 'agentctl_declared_job_binding or agentctl_verification_receipt or typed_agentctl'`
  - `6 passed, 235 deselected in 1.45s`
- `nix develop --accept-flake-config --command devtools verify --quick`
  - all 12 gates passed in `43.45s`
- `nix develop --accept-flake-config --command git -C /realm/worktrees/polylogue-agentctl-verify-final push --set-upstream origin feature/refactor/agentctl-verify-final`
  - exact-head pre-push quick verification passed in `53.28s`

Anti-vacuity: the quick gate ran `verify oracle-integrity` successfully, covering production reachability and ambient-path constraints for the changed modules.

## Bead disposition matrix

| Assigned Bead | Whole-Bead disposition | Evidence refs | Named successor for residual work |
| --- | --- | --- | --- |
| `polylogue-agentctl.2.1` | partial | focused AgentCTL binding and receipt tests; quick verification | same open Bead, no Beads write authorized |

<!-- polylogue-pr-scope:v2
{
  "assigned_beads": ["polylogue-agentctl.2.1"],
  "dispositions": [
    {
      "bead_id": "polylogue-agentctl.2.1",
      "disposition": "partial",
      "evidence": [
        {"kind": "test", "ref": "devtools test tests/unit/devtools/test_verify.py -k agentctl_declared_job_binding or agentctl_verification_receipt or typed_agentctl"},
        {"kind": "command", "ref": "devtools verify --quick"}
      ],
      "successors": []
    }
  ],
  "mutated_beads": [],
  "scope_kind": "bead",
  "version": 2,
  "renderer": "retired by refactor(agentctl): delete local delivery protocols"
}
-->

## Risks and Follow-ups

Direct `devtools verify` and `devtools test` still own their process supervision, timeout, scratch placement, cleanup, resource sampling, and mutation monitoring. Declared AgentCTL jobs already own transient service lifecycle, cancellation, logs, typed result capture, and registered workspace identity, but AgentCTL does not yet attest unchanged checkout bytes at completion or provide a scratch-admission/cleanup contract. Polylogue therefore retains its import-root assertion and before/after worktree fingerprints for declared jobs, and keeps the complete direct-route lifecycle machinery until equivalent AgentCTL contracts exist. The retired PR-scope renderer is not restored; this archival carrier is transparent metadata because the template still references the removed command.