### PR TITLE
test(neighbors): preserve historical fixture timelines

### DIFF
--- a/tests/unit/core/test_neighbor_candidates.py
+++ b/tests/unit/core/test_neighbor_candidates.py
@@ -53,16 +53,28 @@ async def test_same_title_different_body_is_explainable_candidate(db_path: Path)
         SessionBuilder(db_path, "target")
         .provider("claude-ai")
         .title("Vault Analysis")
+        .created_at("2026-04-22T10:00:00+00:00")
         .updated_at("2026-04-22T10:00:00+00:00")
-        .add_message("target-user", role="user", text="Map the archive verification roadmap.")
+        .add_message(
+            "target-user",
+            role="user",
+            text="Map the archive verification roadmap.",
+            timestamp="2026-04-22T10:00:00+00:00",
+        )
         .save()
     )
     (
         SessionBuilder(db_path, "candidate")
         .provider("claude-ai")
         .title("Vault Analysis")
+        .created_at("2026-04-20T10:00:00+00:00")
         .updated_at("2026-04-20T10:00:00+00:00")
-        .add_message("candidate-user", role="user", text="Discuss unrelated dashboard styling decisions.")
+        .add_message(
+            "candidate-user",
+            role="user",
+            text="Discuss unrelated dashboard styling decisions.",
+            timestamp="2026-04-20T10:00:00+00:00",
+        )
         .save()
     )
 
@@ -85,24 +97,42 @@ async def test_nearby_similar_content_gets_time_and_content_reasons(db_path: Pat
         SessionBuilder(db_path, "target")
         .provider("codex")
         .title("Checkpoint Failure")
+        .created_at("2026-04-22T12:00:00+00:00")
         .updated_at("2026-04-22T12:00:00+00:00")
-        .add_message("target-user", role="user", text="Debug sqlite checkpoint lock retry recovery in archive writes.")
+        .add_message(
+            "target-user",
+            role="user",
+            text="Debug sqlite checkpoint lock retry recovery in archive writes.",
+            timestamp="2026-04-22T12:00:00+00:00",
+        )
         .save()
     )
     (
         SessionBuilder(db_path, "candidate")
         .provider("codex")
         .title("Archive Lock Retries")
+        .created_at("2026-04-22T14:00:00+00:00")
         .updated_at("2026-04-22T14:00:00+00:00")
-        .add_message("candidate-user", role="user", text="Investigate sqlite checkpoint lock retry recovery behavior.")
+        .add_message(
+            "candidate-user",
+            role="user",
+            text="Investigate sqlite checkpoint lock retry recovery behavior.",
+            timestamp="2026-04-22T14:00:00+00:00",
+        )
         .save()
     )
     (
         SessionBuilder(db_path, "distractor")
         .provider("codex")
         .title("Visual Cleanup")
+        .created_at("2026-04-22T13:00:00+00:00")
         .updated_at("2026-04-22T13:00:00+00:00")
-        .add_message("distractor-user", role="user", text="Adjust typography and color spacing.")
+        .add_message(
+            "distractor-user",
+            role="user",
+            text="Adjust typography and color spacing.",
+            timestamp="2026-04-22T13:00:00+00:00",
+        )
         .save()
     )
 
@@ -125,16 +155,28 @@ async def test_source_content_seed_finds_similar_candidate_outside_time_window(d
         SessionBuilder(db_path, "target")
         .provider("codex")
         .title("Checkpoint Failure")
+        .created_at("2026-04-22T12:00:00+00:00")
         .updated_at("2026-04-22T12:00:00+00:00")
-        .add_message("target-user", role="user", text="Debug sqlite checkpoint lock retry recovery in archive writes.")
+        .add_message(
+            "target-user",
+            role="user",
+            text="Debug sqlite checkpoint lock retry recovery in archive writes.",
+            timestamp="2026-04-22T12:00:00+00:00",
+        )
         .save()
     )
     (
         SessionBuilder(db_path, "candidate")
         .provider("codex")
         .title("Different Title")
+        .created_at("2026-04-18T12:00:00+00:00")
         .updated_at("2026-04-18T12:00:00+00:00")
-        .add_message("candidate-user", role="user", text="Investigate sqlite checkpoint lock retry recovery behavior.")
+        .add_message(
+            "candidate-user",
+            role="user",
+            text="Investigate sqlite checkpoint lock retry recovery behavior.",
+            timestamp="2026-04-18T12:00:00+00:00",
+        )
         .save()
     )
 


### PR DESCRIPTION
## Summary

Preserve the intended historical timelines in neighbor-candidate fixtures.

## Problem

Fixtures set a historical `updated_at` but left `created_at` at the live clock. Timestamp normalization repaired that inverted interval by advancing the effective session time, causing outside-window candidates to receive `nearby_time`.

## Solution

Set matching historical session endpoints and explicit message times for the fixture corpus.

## Verification

- `env -u VIRTUAL_ENV direnv exec . devtools test tests/unit/core/test_neighbor_candidates.py`
  - `4 passed in 13.17s`
- `env -u VIRTUAL_ENV direnv exec . devtools verify --quick`
  - completed successfully
- pre-push quick verification
  - completed successfully