### PR TITLE
fix(agentctl): ignore external task authority state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,7 @@ polylogue/_build_info.py
 _site/
 
 # Beads / Dolt files (added by bd init)
+/.beads/
 .dolt/
 *.db
 .beads-credential-key


### PR DESCRIPTION
## Summary

- ignore the checkout-local `.beads/` redirect and external-authority metadata

## Problem

After #4098 removed tracked Beads state, the canonical external task authority’s local `.beads/redirect` made the main checkout appear dirty. That contradicted the migration invariant that ordinary task operations do not affect Git status.

## Solution

Root-ignore `/.beads/`. Historical Beads exports remain available through Git history and product evidence parsers; live task state stays under the external authority.

## Verification

```text
git check-ignore -v --no-index .beads/redirect
.gitignore:115:/.beads/ .beads/redirect

git diff --check
clean
```
