### PR TITLE
refactor(devtools): run focused tests without lifecycle authority

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -9,14 +9,11 @@ All commands below assume you are inside the project devshell. See
 # Normal repository verification
 devtools verify
 
-# Focused inner-loop runs: prefer `devtools test` over raw pytest. It runs the
-# selection through the managed harness (repo env, single-process by default,
-# live output, current-node progress artifacts, stall/runtime timeouts) and
-# serializes overlapping runs from the same checkout so two suites do not race.
-# It records direct CLI evidence in the managed run ledger. AgentCTL-declared
-# `devtools verify` jobs own workspace identity, lifecycle, logs, and result
-# capture; devtools retains testmon selection/graph evidence, import-root
-# validation, and before/after byte attestation.
+# Focused inner-loop runs: prefer `devtools test` over raw pytest. It provides
+# the project environment, a single-process default, live output, progress
+# artifacts, import-root validation, and a typed outcome receipt. AgentCTL
+# owns workspace identity, lifecycle, logs, scratch, and result capture for
+# declared verification jobs.
 # Any pytest arguments go after the command name.
 devtools test tests/unit/storage/test_hybrid_laws.py
 devtools test -k "test_name"
@@ -182,16 +179,15 @@ on completion or termination, with startup stale-root cleanup as recovery
 after an uncatchable process kill or reboot.
 
 The default path does not replay cached verify results. Every invocation runs
-the static gates and then invokes pytest-testmon over the complete corpus:
-changed-dependency, never-recorded, and previously-failing tests execute, and
-the rest is attested from unchanged recorded greens. There is no seed,
-repair, shard, or registry command, and no separate full-corpus flag.
+the static gates and then invokes pytest-testmon over the selected scope.
+Affected selection runs changed-dependency, never-recorded, and previously
+failing tests. A selected result reports only the tests it executed. There is
+no seed, repair, shard, or registry command.
 
-Direct `devtools verify` and `devtools test` invocations treat pytest as a
-bounded, supervised child workload, not an unowned shell. Each pytest step gets a run directory
-under `.cache/verify/runs/<run-id>/` with stdout/stderr, progress, selection,
-summary, merged worker events, raw per-worker event files, resource samples,
-and a postmortem diagnosis. The latest run is mirrored to
+A focused `devtools test` step gets a run directory under
+`.cache/verify/runs/<run-id>/` with progress, selection, summary, merged
+worker events, and decoded pytest outcomes. The latest focused result is
+mirrored to
 `.cache/verify/current-run.json`, and the latest pytest step is mirrored to:
 
 - `.cache/verify/current-pytest-progress.json`
@@ -199,43 +195,17 @@ and a postmortem diagnosis. The latest run is mirrored to
 - `.cache/verify/current-pytest-summary.json`
 - `.cache/verify/current-pytest-events.jsonl`
 - `.cache/verify/current-pytest-events/`
-- `.cache/verify/current-pytest-resources.jsonl`
-- `.cache/verify/current-pytest-postmortem.json`
-- `.cache/verify/current-pytest-containment.json`
-- `.cache/verify/current-pytest-statistics.json` — derived phase
-  distributions, worker count, storage, resource peaks, and cleanup outcome;
-  the same file is retained under each run's `steps/*/statistics.json`.
+- `.cache/verify/current-pytest-statistics.json` for decoded pytest outcomes
 - `.cache/verify/current-pytest-output.log`
 
-For direct invocations, the devtools process drains pytest output, prints
-periodic heartbeat lines, and samples the pytest process tree and host
-memory/pressure state. A separate supervisor owns the pytest controller's
-process group and watches the devtools owner process. One 3600-second deadline
-covers the complete direct `devtools verify` invocation. Each step, including both pytest lanes, receives only the time
-remaining from that same budget. Termination sends SIGTERM to that exact group,
-then SIGKILL after
-`POLYLOGUE_VERIFY_PYTEST_TERM_GRACE_S` (default 5 seconds). On Sinnix, the
-supervisor runs in a unique transient scope under the configured build slice;
-`KillMode=control-group` and a slightly later `RuntimeMaxSec` are the final
-boundary if ordinary cleanup cannot run. Other Linux hosts retain the external
-supervisor and process-group boundary and record that fallback honestly in the
-containment receipt. If transient scope creation fails in automatic mode, the
-runner records the failure and retries with that process-group boundary. The
-managed runner requires Linux process identities so it never substitutes an
-unsafe numeric-PGID kill on unsupported hosts. The devtools process
-independently enforces the same absolute deadline, including supervisor
-startup, and also requests group termination when
-pytest produces no output for
-`POLYLOGUE_VERIFY_PYTEST_STALL_TIMEOUT_S` (default 10 minutes).
-`POLYLOGUE_VERIFY_RESOURCE_INTERVAL_S` controls resource sampling cadence
-(default 2 seconds). Basetemp size is a recursive filesystem walk, so it is
-sampled less frequently; `POLYLOGUE_VERIFY_BASETEMP_SIZE_INTERVAL_S` controls
-that cadence (default 15 seconds, `0` disables the size walk). Focused
-`devtools test` runs retain their command-specific timeout control; it does not
-compose with or extend the verify invocation deadline. The three declared
-AgentCTL verification jobs receive their deadline, process-tree cancellation,
-logs, and typed result artifact from AgentCTL. Devtools does not start a second
-supervisor or write a parallel invocation receipt on that route.
+Direct focused runs are ordinary foreground subprocesses. AgentCTL verification
+jobs receive deadlines, process-tree cancellation, logs, scratch, and typed
+result artifacts from AgentCTL. Devtools does not create a second lifecycle on
+that route.
+
+The direct `devtools verify` compatibility path still owns its legacy
+supervisor, scratch, and resource evidence. It remains the isolated deletion
+blocker until its gate and CI/hook consumers use the AgentCTL route.
 
 Tests marked `storage_scale` move their private `tmp_path` tree to NVMe scratch
 and emit a periodic typed activity heartbeat while the marked node runs. The
@@ -266,16 +236,14 @@ read/write totals, and cleanup and containment.
 Setup, call, and teardown timings come only from pytest reports in the event
 stream.
 
-`devtools test` uses the same pytest progress plugin and process supervisor for
-focused selections. During or after a run, inspect
+`devtools test` uses the pytest progress plugin for focused selections. During
+or after a run, inspect
 `.cache/verify/current-pytest-progress.json`,
 `.cache/verify/current-pytest-selection.json`,
 `.cache/verify/current-pytest-summary.json`,
-`.cache/verify/current-pytest-events.jsonl`,
-`.cache/verify/current-pytest-containment.json`,
-and `.cache/verify/current-pytest-output.log` to see the active/latest test node,
-selected/deselected node IDs, collection duration, slowest setup/call/teardown
-phases, captured output, and termination reason if a focused run stalls.
+`.cache/verify/current-pytest-events.jsonl`, and
+`.cache/verify/current-pytest-output.log` to see selected/deselected node IDs,
+collection duration, slowest setup/call/teardown phases, and captured output.
 
 Optional lane, mutation-campaign, and benchmark commands remain discoverable
 through `devtools --help`; pytest and the concrete commands are the behavioral

--- a/devtools/run_tests.py
+++ b/devtools/run_tests.py
@@ -1,4 +1,4 @@
-"""``devtools test`` — focused pytest runner through the managed harness.
+"""``devtools test`` — focused pytest runner with project-owned semantics.
 
 Agents and humans should never invoke raw ``pytest`` for inner-loop checks.
 This command forwards a selection (paths, ``-k``/``-m`` expressions, ``-x``,
@@ -9,13 +9,12 @@ This command forwards a selection (paths, ``-k``/``-m`` expressions, ``-x``,
 - a single-process worker default (``-n 0``) for fast focused runs, overridable
   with ``-n`` in the selection or ``POLYLOGUE_PYTEST_WORKERS``;
 - live, streamed output (unlike ``devtools verify``, which captures);
-- the same pytest progress ledger, external deadline supervisor, owned process
-  group/cgroup containment, heartbeat, and stall timeout used by
-  ``devtools verify``;
-- a checkout-scoped lock that serializes overlapping runs so two suites from
-  the same checkout do not race and burn CPU. Concurrency is already
-  *correctness*-safe at the conftest level (#1785, per-run tmpfs basetemp); the
-  lock is the throughput guard. Set ``POLYLOGUE_TEST_NO_LOCK=1`` to bypass it.
+- the same pytest progress ledger, JSON report, and typed outcome receipt used
+  by ``devtools verify``.
+
+Process placement, cancellation, resource admission, and timeout authority
+belong to AgentCTL when a job needs them. A direct focused invocation is an
+ordinary foreground subprocess and does not create a second local lifecycle.
 
 For the full pre-PR gate use ``devtools verify``; this command is the inner
 loop, not a substitute for it.
@@ -23,40 +22,36 @@ loop, not a substitute for it.
 
 from __future__ import annotations
 
-import contextlib
-import fcntl
 import json
 import os
+import shutil
+import subprocess
 import sys
 import time
-from collections.abc import Iterator
 from pathlib import Path
 
 from devtools.checkout_guard import (
     CheckoutImportMismatchError,
     assert_polylogue_matches_checkout,
 )
-from devtools.verify import (
-    PYTEST_CONTAINMENT_PATH,
-    PYTEST_EVENTS_PATH,
-    PYTEST_OUTPUT_PATH,
-    PYTEST_PROGRESS_PATH,
-    PYTEST_REPORT_PATH,
-    PYTEST_SELECTION_PATH,
-    PYTEST_SUMMARY_PATH,
-    _clear_pytest_report,
-    _run,
-)
 from devtools.verify_runs import (
     VerifyRun,
     append_verify_history,
     configured_pytest_worker_request,
+    env_for_pytest_step,
     git_head,
     pytest_command_worker_request,
 )
 
 ROOT = Path(__file__).resolve().parent.parent
-_LOCK_PATH = ROOT / ".cache" / "test-run.lock"
+PYTEST_REPORT_DIR = Path(".cache/verify")
+PYTEST_REPORT_PATH = PYTEST_REPORT_DIR / "last-pytest.json"
+PYTEST_PROGRESS_PATH = PYTEST_REPORT_DIR / "current-pytest-progress.json"
+PYTEST_EVENTS_PATH = PYTEST_REPORT_DIR / "current-pytest-events.jsonl"
+PYTEST_EVENTS_DIR = PYTEST_REPORT_DIR / "current-pytest-events"
+PYTEST_SELECTION_PATH = PYTEST_REPORT_DIR / "current-pytest-selection.json"
+PYTEST_SUMMARY_PATH = PYTEST_REPORT_DIR / "current-pytest-summary.json"
+PYTEST_OUTPUT_PATH = PYTEST_REPORT_DIR / "current-pytest-output.log"
 _PATH_VALUE_OPTIONS = frozenset(
     {
         "-c",
@@ -257,33 +252,42 @@ def build_pytest_cmd(selection: list[str]) -> list[str]:
     ]
 
 
-@contextlib.contextmanager
-def _run_lock(*, enabled: bool) -> Iterator[None]:
-    """Serialize concurrent ``devtools test`` runs from the same checkout."""
-    if not enabled:
-        yield
-        return
-    _LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
-    with _LOCK_PATH.open("a+") as handle:
-        try:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except OSError:
-            handle.seek(0)
-            holder = handle.read().strip() or "another run"
-            sys.stderr.write(
-                f"devtools test: waiting for in-flight run ({holder}) — set POLYLOGUE_TEST_NO_LOCK=1 to skip\n"
-            )
-            sys.stderr.flush()
-            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
-        handle.seek(0)
-        handle.truncate()
-        handle.write(f"pid={os.getpid()}")
-        handle.flush()
-        try:
-            yield
-        finally:
-            handle.seek(0)
-            handle.truncate()
+def _clear_pytest_report(_cmd: list[str]) -> None:
+    """Remove this focused invocation's stale pytest-domain artifacts."""
+    for path in (
+        PYTEST_REPORT_PATH,
+        PYTEST_PROGRESS_PATH,
+        PYTEST_EVENTS_PATH,
+        PYTEST_EVENTS_DIR,
+        PYTEST_SELECTION_PATH,
+        PYTEST_SUMMARY_PATH,
+        PYTEST_OUTPUT_PATH,
+    ):
+        if not path.exists():
+            continue
+        if path.is_dir():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+
+
+def _run(
+    label: str,
+    command: list[str],
+    *,
+    cwd: str,
+    env: dict[str, str],
+    run: VerifyRun,
+) -> tuple[int, float, dict[str, str]]:
+    """Run focused pytest directly while preserving its project receipt."""
+    del label, run
+    started = time.monotonic()
+    completed = subprocess.run(command, cwd=cwd, env=env)
+    return (
+        completed.returncode,
+        time.monotonic() - started,
+        {"diagnosis": "pytest_passed" if completed.returncode == 0 else "pytest_failed"},
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -322,47 +326,54 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     cmd = build_pytest_cmd(selection)
-    no_lock = os.environ.get("POLYLOGUE_TEST_NO_LOCK") == "1"
-    with _run_lock(enabled=not no_lock):
-        _clear_pytest_report(cmd)
-        run = VerifyRun(
-            tier="focused-test",
-            argv=selection,
-            git_head=git_head(ROOT),
-            root=ROOT,
-            polylogue_import_path=str(polylogue_import_path),
-            environment_fingerprint=environment_fingerprint,
+    _clear_pytest_report(cmd)
+    run = VerifyRun(
+        tier="focused-test",
+        argv=selection,
+        git_head=git_head(ROOT),
+        root=ROOT,
+        polylogue_import_path=str(polylogue_import_path),
+        environment_fingerprint=environment_fingerprint,
+    )
+    artifacts = run.start_step(label="pytest focused", cmd=cmd)
+    started = time.monotonic()
+    try:
+        pytest_env = env_for_pytest_step(dict(os.environ), run=run, artifacts=artifacts)
+        pytest_env.pop("POLYLOGUE_PYTEST_CONTAINMENT_PATH", None)
+        rc, elapsed, metadata = _run(
+            "pytest focused",
+            cmd,
+            cwd=str(ROOT),
+            env=pytest_env,
+            run=run,
         )
-        started = time.monotonic()
-        try:
-            rc, _elapsed, metadata = _run("pytest focused", cmd, cwd=str(ROOT), run=run)
-        except KeyboardInterrupt:
-            rc = 130
-            metadata = {"diagnosis": "pytest_interrupted", "termination_reason": "operator_interrupt"}
-            run.finish_interrupted_steps(exit_code=rc, diagnosis=str(metadata["diagnosis"]))
-        except Exception as exc:
-            rc = 125
-            metadata = {
-                "diagnosis": "focused_test_runner_exception",
-                "exception_type": type(exc).__name__,
-                "error": str(exc),
-                "termination_reason": "runner_exception",
-            }
-            run.finish_interrupted_steps(
-                exit_code=rc,
-                diagnosis=str(metadata["diagnosis"]),
-                termination_reason="runner_exception",
-            )
-            sys.stderr.write(f"devtools test: unexpected runner exception: {exc}\n")
-        payload = run.finish(
-            exit_code=rc,
-            duration_s=time.monotonic() - started,
-            diagnosis=metadata.get("diagnosis"),
-            verification_scope="affected",
-            release_baseline_allowed=False,
-            final_git_head=git_head(ROOT),
-        )
-        append_verify_history(payload)
+    except KeyboardInterrupt:
+        rc = 130
+        elapsed = time.monotonic() - started
+        metadata = {"diagnosis": "pytest_interrupted", "termination_reason": "operator_interrupt"}
+    except Exception as exc:
+        rc = 125
+        metadata = {
+            "diagnosis": "focused_test_runner_exception",
+            "exception_type": type(exc).__name__,
+            "error": str(exc),
+            "termination_reason": "runner_exception",
+        }
+        elapsed = time.monotonic() - started
+        sys.stderr.write(f"devtools test: cannot start pytest: {exc}\n")
+    run.finish_step(
+        step_id=artifacts.step_id,
+        result={"duration_s": elapsed, "exit": rc, **metadata},
+    )
+    payload = run.finish(
+        exit_code=rc,
+        duration_s=elapsed,
+        diagnosis=metadata.get("diagnosis"),
+        verification_scope="affected",
+        release_baseline_allowed=False,
+        final_git_head=git_head(ROOT),
+    )
+    append_verify_history(payload)
     if use_json:
         print(json.dumps(payload, indent=2, ensure_ascii=False))
     # The artifact-path footer is reference material, not a result. Printing six
@@ -372,7 +383,7 @@ def main(argv: list[str] | None = None) -> int:
     if _verbose_output() or rc != 0:
         sys.stderr.write(
             f"\ndevtools test: progress={PYTEST_PROGRESS_PATH} selection={PYTEST_SELECTION_PATH} "
-            f"summary={PYTEST_SUMMARY_PATH} events={PYTEST_EVENTS_PATH} containment={PYTEST_CONTAINMENT_PATH} "
+            f"summary={PYTEST_SUMMARY_PATH} events={PYTEST_EVENTS_PATH} "
             f"output={PYTEST_OUTPUT_PATH}\n"
         )
     return rc

--- a/tests/unit/devtools/test_run_tests.py
+++ b/tests/unit/devtools/test_run_tests.py
@@ -11,7 +11,7 @@ from typing import Any, cast
 
 import pytest
 
-from devtools import run_tests, verify
+from devtools import run_tests
 from devtools.verify_runs import (
     CURRENT_RUN_PATH,
     CURRENT_STATISTICS_PATH,
@@ -82,17 +82,6 @@ def test_build_pytest_cmd_does_not_add_distribution_for_serial_run() -> None:
     assert not any(arg.startswith("--dist") for arg in cmd)
 
 
-def test_subprocess_env_anchors_pytest_artifacts_to_checkout(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.chdir(run_tests.ROOT / "tests")
-
-    env = verify._subprocess_env()
-
-    assert env["POLYLOGUE_PYTEST_EVENTS_DIR"] == str(run_tests.ROOT / verify.PYTEST_EVENTS_DIR)
-    assert env["POLYLOGUE_PYTEST_EVENTS_PATH"] == str(run_tests.ROOT / verify.PYTEST_EVENTS_PATH)
-    assert env["POLYLOGUE_PYTEST_SELECTION_PATH"] == str(run_tests.ROOT / verify.PYTEST_SELECTION_PATH)
-    assert env["POLYLOGUE_PYTEST_SUMMARY_PATH"] == str(run_tests.ROOT / verify.PYTEST_SUMMARY_PATH)
-
-
 def test_main_requires_a_selection(capsys: pytest.CaptureFixture[str]) -> None:
     assert run_tests.main([]) == 2
     err = capsys.readouterr().err
@@ -103,27 +92,23 @@ def test_main_requires_a_selection(capsys: pytest.CaptureFixture[str]) -> None:
 def test_main_strips_dispatch_json_flag(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, Any] = {}
 
-    def _fake_run(label: str, cmd: list[str], **kwargs: Any) -> tuple[int, float, dict[str, Any]]:
-        captured["label"] = label
+    def direct_subprocess(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
         captured["cmd"] = cmd
-        captured["run"] = kwargs["run"]
-        return 0, 0.01, {"diagnosis": "pytest_passed"}
+        captured["env"] = kwargs["env"]
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
-    monkeypatch.setenv("POLYLOGUE_TEST_NO_LOCK", "1")
     monkeypatch.setattr("devtools.run_tests._clear_pytest_report", lambda _cmd: None)
-    monkeypatch.setattr("devtools.run_tests._run", _fake_run)
+    monkeypatch.setattr("devtools.run_tests.subprocess.run", direct_subprocess)
     monkeypatch.setattr("devtools.run_tests.git_head", lambda _root: "abc123")
     monkeypatch.setattr("devtools.run_tests.append_verify_history", lambda payload: captured.update(history=payload))
     assert run_tests.main(["tests/unit/pipeline", "--json"]) == 0
     assert "--json" not in captured["cmd"]
     assert "tests/unit/pipeline" in captured["cmd"]
-    assert captured["label"] == "pytest focused"
-    assert captured["run"].run_id
-    assert captured["run"]._payload["git_head"] == "abc123"
-    assert isinstance(captured["run"]._payload["git_dirty"], bool)
-    assert captured["run"]._payload["verification_scope"] == "affected"
-    assert captured["run"]._payload["release_baseline_allowed"] is False
-    assert captured["history"]["run_id"] == captured["run"].run_id
+    assert captured["env"]["POLYLOGUE_PYTEST_EVENTS_DIR"].endswith("/events")
+    assert captured["history"]["git_head"] == "abc123"
+    assert isinstance(captured["history"]["git_dirty"], bool)
+    assert captured["history"]["verification_scope"] == "affected"
+    assert captured["history"]["release_baseline_allowed"] is False
     assert captured["history"]["status"] == "success"
 
 
@@ -137,7 +122,6 @@ def test_main_preserves_relative_selection_from_subdirectory(
         return 0, 0.01, {"diagnosis": "pytest_passed"}
 
     monkeypatch.chdir(run_tests.ROOT / "tests" / "unit")
-    monkeypatch.setenv("POLYLOGUE_TEST_NO_LOCK", "1")
     monkeypatch.setattr("devtools.run_tests._clear_pytest_report", lambda _cmd: None)
     monkeypatch.setattr("devtools.run_tests._run", _fake_run)
     monkeypatch.setattr("devtools.run_tests.append_verify_history", lambda _payload: None)
@@ -161,7 +145,6 @@ def test_main_preserves_path_valued_options_from_subdirectory(
     invocation.mkdir()
     (invocation / "fixtures").mkdir()
     monkeypatch.chdir(invocation)
-    monkeypatch.setenv("POLYLOGUE_TEST_NO_LOCK", "1")
     monkeypatch.setattr(run_tests, "_clear_pytest_report", lambda _cmd: None)
     monkeypatch.setattr(run_tests, "_run", _fake_run)
     monkeypatch.setattr(run_tests, "append_verify_history", lambda _payload: None)
@@ -208,7 +191,6 @@ def test_main_persists_interrupted_direct_cli_result_to_local_run_artifacts(
         "assert_polylogue_matches_checkout",
         lambda *_args, **_kwargs: SimpleNamespace(polylogue_import_path=tmp_path / "polylogue", as_dict=lambda: {}),
     )
-    monkeypatch.setenv("POLYLOGUE_TEST_NO_LOCK", "1")
     monkeypatch.setattr(run_tests, "_clear_pytest_report", lambda _cmd: None)
     monkeypatch.setattr(run_tests, "_run", interrupt)
     monkeypatch.setattr(run_tests, "git_head", lambda _root: "head")
@@ -309,7 +291,6 @@ def test_main_preserves_keyword_and_marker_values_from_tests_directory(
 ) -> None:
     captured: list[str] = []
     monkeypatch.chdir(run_tests.ROOT / "tests")
-    monkeypatch.setenv("POLYLOGUE_TEST_NO_LOCK", "1")
     monkeypatch.setattr(run_tests, "_clear_pytest_report", lambda _cmd: None)
 
     def capture(_label: str, command: list[str], **_kwargs: Any) -> tuple[int, float, dict[str, Any]]:
@@ -343,7 +324,6 @@ def test_main_finalizes_runner_exception_after_open_step(
         "assert_polylogue_matches_checkout",
         lambda *_args, **_kwargs: SimpleNamespace(polylogue_import_path=tmp_path / "polylogue", as_dict=lambda: {}),
     )
-    monkeypatch.setenv("POLYLOGUE_TEST_NO_LOCK", "1")
     monkeypatch.setattr(run_tests, "_clear_pytest_report", lambda _cmd: None)
     monkeypatch.setattr(run_tests, "git_head", lambda _root: "head")
     monkeypatch.setattr(run_tests, "append_verify_history", lambda payload: history.update(payload))
@@ -366,7 +346,6 @@ def test_main_returns_pytest_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
     def _fake_run(label: str, cmd: list[str], **kwargs: Any) -> tuple[int, float, dict[str, Any]]:
         return 5, 0.01, {"diagnosis": "pytest_failed"}
 
-    monkeypatch.setenv("POLYLOGUE_TEST_NO_LOCK", "1")
     monkeypatch.setattr("devtools.run_tests._clear_pytest_report", lambda _cmd: None)
     monkeypatch.setattr("devtools.run_tests._run", _fake_run)
     assert run_tests.main(["tests/unit/does_not_exist"]) == 5
@@ -381,7 +360,7 @@ def test_main_anchors_and_refreshes_root_artifacts_from_any_invocation_directory
     external_directory = tmp_path / "unrelated"
     subdirectory.mkdir(parents=True)
     external_directory.mkdir()
-    stale_report = root / verify.PYTEST_REPORT_PATH
+    stale_report = root / run_tests.PYTEST_REPORT_PATH
     stale_statistics = root / CURRENT_STATISTICS_PATH
     stale_report.parent.mkdir(parents=True)
     stale_statistics.parent.mkdir(parents=True, exist_ok=True)
@@ -391,11 +370,10 @@ def test_main_anchors_and_refreshes_root_artifacts_from_any_invocation_directory
 
     def fake_run(_label: str, _cmd: list[str], **kwargs: Any) -> tuple[int, float, dict[str, Any]]:
         captured["cwd"] = kwargs["cwd"]
-        Path(verify.PYTEST_REPORT_PATH).write_text('{"fresh": true}')
+        Path(run_tests.PYTEST_REPORT_PATH).write_text('{"fresh": true}')
         return 0, 0.01, {"diagnosis": "pytest_passed"}
 
     monkeypatch.setattr(run_tests, "ROOT", root)
-    monkeypatch.setattr(run_tests, "_LOCK_PATH", root / ".cache" / "test-run.lock")
     monkeypatch.setattr(
         run_tests,
         "assert_polylogue_matches_checkout",
@@ -404,7 +382,6 @@ def test_main_anchors_and_refreshes_root_artifacts_from_any_invocation_directory
     monkeypatch.setattr(run_tests, "git_head", lambda _root: "head")
     monkeypatch.setattr(run_tests, "_run", fake_run)
     monkeypatch.setattr(run_tests, "append_verify_history", lambda _payload: None)
-    monkeypatch.setenv("POLYLOGUE_TEST_NO_LOCK", "1")
     invocation_directory = subdirectory if invocation_location == "inside" else external_directory
     monkeypatch.chdir(invocation_directory)
 
@@ -412,7 +389,7 @@ def test_main_anchors_and_refreshes_root_artifacts_from_any_invocation_directory
 
     assert captured["cwd"] == str(root)
     assert stale_report.read_text() == '{"fresh": true}'
-    assert not stale_statistics.exists()
+    assert json.loads(stale_statistics.read_text())["canonical_report_status"] == "missing"
     assert not (invocation_directory / ".cache").exists()
 
 


### PR DESCRIPTION
## Summary

Run focused Polylogue tests as foreground pytest subprocesses while retaining project-owned selection, import-root validation, progress events, outcome decoding, and typed receipts.

## Problem

The focused test command still imported verifier lifecycle machinery and owned checkout locking, containment, supervision, resource evidence, and postmortems after AgentCTL became the host execution authority.

## Solution

Remove focused-run lifecycle authority and its compatibility flag. Keep the semantic receipt and pytest-domain artifacts. Document the primary verify compatibility route as the remaining deletion blocker.

## Verification

- `nix develop --command devtools test tests/unit/devtools/test_run_tests.py tests/unit/devtools/test_run_tests_output.py`: 29 passed in 1.30s
- AgentCTL declared `verify_quick` job `6057c2d5-3b86-4965-96b3-eccea5a84ea4`: succeeded at exact head `5f4deff7011563a0376189163792c6a11109e7af`

Ref polylogue-agentctl.2.1