### PR TITLE
docs(agent): record deferred-scope closure discipline

### DIFF
--- a/.agent/CONVENTIONS.md
+++ b/.agent/CONVENTIONS.md
@@ -68,6 +68,14 @@ substep is a checkpoint, not a publishing trigger; split only at a genuine
 boundary (risk, reviewability, dependency, ownership, deployment, or failure
 isolation).
 
+## Deferred Scope at Closure
+
+When closing a Bead while any acceptance criterion, root cause, or repair scope
+remains deferred, create the successor Bead first and link it with a structured
+`related` or dependency edge in the same batch. The close reason must name that
+successor. Review this as a judgment call at close time; do not add a lint or
+gate that pattern-matches close-reason prose.
+
 ## Scratch, Demos, Git Boundary
 
 `.agent/scratch/` is gitignored thinking space (README + research notes);


### PR DESCRIPTION
## Summary

Records the close-time convention for deferred Bead scope and links the three historical deferred-scope successors to their closed source Beads.

## Problem

Three closed campaign records deferred repair or verification scope without a structured successor edge. The successor work existed after later archaeology, but the relationship was not queryable from the original records.

## Solution

Adds the convention to `.agent/CONVENTIONS.md`: create and link the successor before closing a Bead that defers acceptance, root-cause, or repair scope, then name it in the close reason. Adds related links for gysk3 to slshy, 8b10 to m73wk, and mvq8 to s8s54 in the authoritative Beads workspace. The rule remains a close-time judgment; it deliberately adds no prose-pattern lint.

## Verification

- `bd dep list polylogue-gysk3 --json`, `bd dep list polylogue-8b10 --json`, and `bd dep list polylogue-mvq8 --json` each report the intended `relates-to` successor.
- `devtools verify --quick` completed successfully in 87.0s.
- Pre-push `devtools verify --quick` completed successfully in 40.3s.

## Bead disposition

| Bead | Status |
| --- | --- |
| polylogue-aagkt | Satisfied by the documented convention and three structured historical successor links. |

Ref polylogue-aagkt.
