### PR TITLE
fix(devtools): normalize focused pytest collection

### DIFF
--- a/devtools/run_tests.py
+++ b/devtools/run_tests.py
@@ -34,6 +34,11 @@ from devtools.checkout_guard import (
     CheckoutImportMismatchError,
     assert_polylogue_matches_checkout,
 )
+from devtools.pytest_collection_contract import (
+    CLEAR_CONFIGURED_ADDOPTS,
+    IGNORED_COLLECTION_ARGS,
+    MANAGED_PLUGIN_ARGS,
+)
 from devtools.verify_runs import (
     VerifyRun,
     append_verify_history,
@@ -237,19 +242,28 @@ def _xdist_distribution_args(selection: list[str], worker_args: list[str]) -> li
 def build_pytest_cmd(selection: list[str]) -> list[str]:
     """Compose the pytest command for a focused selection."""
     worker_args = _worker_args(selection)
+    collection_args = () if _selection_targets_benchmarks(selection) else IGNORED_COLLECTION_ARGS
     return [
         sys.executable,
         "-m",
         "pytest",
         "-p",
         "devtools.pytest_progress_plugin",
+        *MANAGED_PLUGIN_ARGS,
+        CLEAR_CONFIGURED_ADDOPTS,
         "--json-report",
         "--json-report-omit=collectors,log,streams,warnings",
         f"--json-report-file={PYTEST_REPORT_PATH}",
+        *collection_args,
         *selection,
         *worker_args,
         *_xdist_distribution_args(selection, worker_args),
     ]
+
+
+def _selection_targets_benchmarks(selection: list[str]) -> bool:
+    """Keep benchmark collection available only when the caller asks for it."""
+    return any("tests/benchmarks" in argument for argument in selection)
 
 
 def _clear_pytest_report(_cmd: list[str]) -> None:
@@ -288,6 +302,13 @@ def _run(
         time.monotonic() - started,
         {"diagnosis": "pytest_passed" if completed.returncode == 0 else "pytest_failed"},
     )
+
+
+def _normalize_managed_pytest_environment(env: dict[str, str]) -> None:
+    """Make focused collection independent of ambient pytest plugins/options."""
+    env.pop("PYTEST_ADDOPTS", None)
+    env.pop("PYTEST_PLUGINS", None)
+    env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -340,6 +361,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         pytest_env = env_for_pytest_step(dict(os.environ), run=run, artifacts=artifacts)
         pytest_env.pop("POLYLOGUE_PYTEST_CONTAINMENT_PATH", None)
+        _normalize_managed_pytest_environment(pytest_env)
         rc, elapsed, metadata = _run(
             "pytest focused",
             cmd,

--- a/tests/unit/devtools/test_run_tests.py
+++ b/tests/unit/devtools/test_run_tests.py
@@ -12,6 +12,11 @@ from typing import Any, cast
 import pytest
 
 from devtools import run_tests
+from devtools.pytest_collection_contract import (
+    CLEAR_CONFIGURED_ADDOPTS,
+    IGNORED_COLLECTION_ARGS,
+    MANAGED_PLUGIN_ARGS,
+)
 from devtools.verify_runs import (
     CURRENT_RUN_PATH,
     CURRENT_STATISTICS_PATH,
@@ -31,6 +36,22 @@ def test_build_pytest_cmd_defaults_to_single_process() -> None:
     ]
     assert "tests/unit/pipeline" in cmd
     assert cmd[-2:] == ["-n", "0"]
+
+
+def test_build_pytest_cmd_uses_the_managed_plugin_contract() -> None:
+    cmd = run_tests.build_pytest_cmd(["tests/unit/pipeline"])
+
+    managed_start = cmd.index("devtools.pytest_progress_plugin") + 1
+    assert [*MANAGED_PLUGIN_ARGS] == cmd[managed_start : managed_start + len(MANAGED_PLUGIN_ARGS)]
+    assert CLEAR_CONFIGURED_ADDOPTS in cmd
+    ignored_start = cmd.index(IGNORED_COLLECTION_ARGS[0])
+    assert [*IGNORED_COLLECTION_ARGS] == cmd[ignored_start : ignored_start + len(IGNORED_COLLECTION_ARGS)]
+
+
+def test_build_pytest_cmd_keeps_benchmark_collection_for_explicit_target() -> None:
+    cmd = run_tests.build_pytest_cmd(["tests/benchmarks/test_scale_tiers.py"])
+
+    assert IGNORED_COLLECTION_ARGS[0] not in cmd
 
 
 def test_build_pytest_cmd_respects_explicit_worker_flag() -> None:
@@ -105,6 +126,9 @@ def test_main_strips_dispatch_json_flag(monkeypatch: pytest.MonkeyPatch) -> None
     assert "--json" not in captured["cmd"]
     assert "tests/unit/pipeline" in captured["cmd"]
     assert captured["env"]["POLYLOGUE_PYTEST_EVENTS_DIR"].endswith("/events")
+    assert captured["env"]["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] == "1"
+    assert "PYTEST_ADDOPTS" not in captured["env"]
+    assert "PYTEST_PLUGINS" not in captured["env"]
     assert captured["history"]["git_head"] == "abc123"
     assert isinstance(captured["history"]["git_dirty"], bool)
     assert captured["history"]["verification_scope"] == "affected"


### PR DESCRIPTION
## Summary

Restore the focused devtools test runner’s closed-world pytest configuration after the verifier cutover.

## Problem

On master 947b8e6, devtools test -k archive_verification failed in collection because a unit test’s benchmark fixture plugin was registered twice. The focused route no longer disabled ambient plugin loading or applied the verifier’s explicit plugin contract.

## Solution

- Apply the managed plugin list, neutralized addopts, and normalized pytest environment to devtools/run_tests.py.
- Exclude benchmark collection for non-benchmark focused selections, while preserving explicit benchmark targets.
- Add runner-contract regression coverage.

## Verification

- env -u VIRTUAL_ENV direnv exec . devtools test tests/unit/devtools/test_run_tests.py — 26 passed.
- env -u VIRTUAL_ENV direnv exec . devtools test -k archive_verification — 166 selected tests passed in 87.9s.
- env -u VIRTUAL_ENV direnv exec . devtools verify --quick — success in 92.9s.
- Pre-push quick verification baseline — passed.

## Bead disposition matrix

| Bead | Disposition | Evidence |
| --- | --- | --- |
| polylogue-n235p | Addressed by this PR | Focused archive-verification collection and execution are green. |

## pr-scope carrier

- authoritative_beads: polylogue-n235p
- scope: focused pytest collection normalization
- remaining_scope: none