### PR TITLE
test(workload): type named fixture profiles

### DIFF
--- a/tests/infra/workload_artifacts.py
+++ b/tests/infra/workload_artifacts.py
@@ -422,30 +422,66 @@ def schema_coverage_corpus_specs() -> tuple[CorpusSpec, ...]:
     )
 
 
+@dataclass(frozen=True)
+class NamedWorkloadProfile:
+    """A semantic, deterministic workload used by shared test fixtures."""
+
+    name: str
+    purpose: str
+    provider_session_counts: tuple[tuple[str, int], ...]
+    seed: int = 42
+    messages_min: int = 4
+    messages_max: int = 11
+
+    def __post_init__(self) -> None:
+        if not self.name or not self.purpose:
+            raise ValueError("named workload profile requires a name and purpose")
+        if not self.provider_session_counts or any(count < 1 for _provider, count in self.provider_session_counts):
+            raise ValueError("named workload profile requires positive provider session counts")
+        if self.messages_min < 1 or self.messages_max < self.messages_min:
+            raise ValueError("named workload profile has invalid message bounds")
+
+    def corpus_specs(self) -> tuple[CorpusSpec, ...]:
+        profile = CorpusProfile(
+            family_ids=("test-workload",),
+            profile_tokens=(self.name, self.purpose, "provider-native"),
+            artifact_kind="archive",
+        )
+        return tuple(
+            CorpusSpec.for_provider(
+                provider,
+                count=count,
+                messages_min=self.messages_min,
+                messages_max=self.messages_max,
+                seed=self.seed,
+                profile=profile,
+                origin=f"generated.test-workload-{self.name}",
+                tags=("synthetic", "test", self.name, self.purpose),
+            )
+            for provider, count in self.provider_session_counts
+        )
+
+
+NAMED_WORKLOAD_PROFILES = (
+    NamedWorkloadProfile("schema-small", "schema-scaling", (("chatgpt", 10),)),
+    NamedWorkloadProfile("schema-medium", "schema-scaling", (("chatgpt", 50),)),
+    NamedWorkloadProfile("cli-chatgpt", "cli-read", (("chatgpt", 2),)),
+    NamedWorkloadProfile("cli-mixed", "cli-read", (("chatgpt", 2), ("claude-code", 2))),
+    NamedWorkloadProfile("completion", "completion", (("chatgpt", 3), ("claude-ai", 3)), seed=1271),
+)
+
+
+def named_workload_profile(name: str) -> NamedWorkloadProfile:
+    """Resolve one finite, semantically named test workload."""
+    try:
+        return next(profile for profile in NAMED_WORKLOAD_PROFILES if profile.name == name)
+    except StopIteration as exc:
+        raise ValueError(f"unknown named seeded archive workload {name!r}") from exc
+
+
 def named_corpus_specs(name: str) -> tuple[CorpusSpec, ...]:
     """Resolve the finite shared workload catalog used by test consumers."""
-    profiles: dict[str, tuple[tuple[str, int], ...]] = {
-        "schema-small": (("chatgpt", 10),),
-        "schema-medium": (("chatgpt", 50),),
-        "cli-chatgpt": (("chatgpt", 2),),
-        "cli-mixed": (("chatgpt", 2), ("claude-code", 2)),
-        "completion": (("chatgpt", 3), ("claude-ai", 3)),
-    }
-    selected = profiles.get(name)
-    if selected is None:
-        raise ValueError(f"unknown named seeded archive workload {name!r}")
-    return tuple(
-        CorpusSpec.for_provider(
-            provider,
-            count=count,
-            messages_min=4,
-            messages_max=11,
-            seed=1271 if name == "completion" else 42,
-            origin=f"generated.test-workload-{name}",
-            tags=("synthetic", "test", name),
-        )
-        for provider, count in selected
-    )
+    return named_workload_profile(name).corpus_specs()
 
 
 class BenchmarkWorkloadTier(str, Enum):
@@ -2444,6 +2480,8 @@ __all__ = [
     "BENCHMARK_WORKLOAD_PROFILES",
     "BenchmarkWorkloadProfile",
     "BenchmarkWorkloadTier",
+    "NAMED_WORKLOAD_PROFILES",
+    "NamedWorkloadProfile",
     "SeededArchiveArtifact",
     "SeededArchiveQueryLease",
     "acquire_query_only_seeded_archive",
@@ -2461,6 +2499,7 @@ __all__ = [
     "clone_seeded_archive",
     "default_cache_root",
     "named_corpus_specs",
+    "named_workload_profile",
     "schema_coverage_corpus_specs",
     "seeded_archive_key",
 ]

--- a/tests/unit/infra/test_workload_artifacts.py
+++ b/tests/unit/infra/test_workload_artifacts.py
@@ -24,6 +24,7 @@ from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.durable_change_train import DurableChangeTrainError
 from tests.infra.workload_artifacts import (
     BENCHMARK_WORKLOAD_PROFILES,
+    NAMED_WORKLOAD_PROFILES,
     BenchmarkWorkloadTier,
     SeededArchiveQueryLease,
     _assert_lock_identity,
@@ -39,6 +40,8 @@ from tests.infra.workload_artifacts import (
     build_seeded_archive,
     c03_semantic_corpus_spec,
     clone_seeded_archive,
+    named_corpus_specs,
+    named_workload_profile,
     seeded_archive_key,
 )
 
@@ -78,6 +81,29 @@ def test_benchmark_profile_selection_is_deterministic_and_rejects_legacy_ad_hoc_
     assert benchmark_workload_profile("representative").target_messages == 5_000
     with pytest.raises(ValueError, match="no named benchmark workload"):
         benchmark_workload_tier(7_500)
+
+
+def test_named_workload_profiles_are_semantic_and_build_deterministic_provider_specs() -> None:
+    """Fixture workloads retain purpose and provider-native artifact identity."""
+    assert {profile.name for profile in NAMED_WORKLOAD_PROFILES} == {
+        "schema-small",
+        "schema-medium",
+        "cli-chatgpt",
+        "cli-mixed",
+        "completion",
+    }
+
+    profile = named_workload_profile("completion")
+    first = named_corpus_specs(profile.name)
+    second = profile.corpus_specs()
+
+    assert first == second
+    assert profile.purpose == "completion"
+    assert {spec.provider for spec in first} == {"chatgpt", "claude-ai"}
+    assert {spec.profile.primary_family_id for spec in first} == {"test-workload"}
+    assert {"completion", "provider-native"}.issubset(set(first[0].profile.profile_tokens))
+    with pytest.raises(ValueError, match="unknown named seeded archive workload"):
+        named_workload_profile("unknown")
 
 
 def test_seeded_archive_publishes_valid_immutable_real_pipeline_artifact(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Replace the shared named-fixture workload map with validated semantic profile objects.

## Problem

Named fixture workloads encoded provider counts in an untyped local dictionary, while benchmark workloads already carried explicit semantic metadata. That left fixture identity and purpose implicit.

## Solution

- Add NamedWorkloadProfile with validated purpose, deterministic seed, message bounds, and provider session composition.
- Route named_corpus_specs through the catalog so every fixture derives provider-native CorpusSpec values with semantic profile tokens.
- Add a behavioral contract for deterministic catalog resolution and unknown-name rejection.

## Verification

- env -u VIRTUAL_ENV direnv exec . devtools test tests/unit/infra/test_workload_artifacts.py -k named_workload — 1 passed.
- env -u VIRTUAL_ENV direnv exec . devtools verify --quick — success in 100.1s.
- Full workload-artifact module: 73 passed; one known baseline failure is unchanged on master 7c2fae9d and tracked by polylogue-1xc.14.1.4 (the read-only fixture returns PosixPath rather than the required query lease).
- Pre-push quick verification baseline — passed.

## Bead disposition matrix

| Bead | Disposition | Evidence |
| --- | --- | --- |
| polylogue-1xc.14.1 | Partial phase | Named fixture catalog is now typed; benchmark and other corpus systems remain to converge. |
| polylogue-1xc.14.1.4 | Unchanged residual | Existing query-only fixture failure reproduced on master and recorded on its owner. |

## pr-scope carrier

- authoritative_beads: polylogue-1xc.14.1
- scope: typed named fixture workload catalog
- remaining_scope: benchmark profile convergence, pathology/inferred corpus adoption, and live scale evidence