### PR TITLE
fix(status): preserve unavailable convergence debt

### DIFF
--- a/polylogue/operations/daemon_workload_probe.py
+++ b/polylogue/operations/daemon_workload_probe.py
@@ -23,6 +23,7 @@ from typing import Any
 
 from polylogue.archive.topology.edge import TopologyEdgeStatus
 from polylogue.config import Config
+from polylogue.daemon.convergence_debt_status import convergence_debt_summary_info
 from polylogue.paths import archive_root
 from polylogue.storage.archive_identity import resolve_active_index_path
 from polylogue.storage.archive_readiness import probe_archive_tier
@@ -34,7 +35,7 @@ from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 
 # Bumped when the JSON shape gains new top-level keys or changes a field type.
 # The compare path uses this to refuse incompatible inputs loudly.
-REPORT_VERSION = 20
+REPORT_VERSION = 21
 UNKNOWN_TABLE_COUNT = -2
 
 _EXPECTED_FTS_TRIGGERS: tuple[str, ...] = ("messages_fts_ai", "messages_fts_ad", "messages_fts_au")
@@ -916,29 +917,40 @@ def _percentile_from_sorted(sorted_values: list[float], q: float) -> float:
     return float(sorted_values[lo]) * (1.0 - frac) + float(sorted_values[hi]) * frac
 
 
-def _convergence_debt(conn: sqlite3.Connection, *, ops_db: Path | None = None) -> dict[str, Any]:
-    ops_rows = _ops_convergence_debt_rows(ops_db)
-    if ops_rows:
+def _convergence_debt(
+    conn: sqlite3.Connection,
+    *,
+    db: Path,
+    ops_db: Path | None = None,
+) -> dict[str, Any]:
+    """Project authoritative ops debt, preserving only the legacy index fallback."""
+    if ops_db is not None:
+        summary = convergence_debt_summary_info(db, ops_db=ops_db)
         return {
-            "failed_count": sum(failed_count for _stage, failed_count, _deferred_count, _unresolved_count in ops_rows),
-            "deferred_count": sum(
-                deferred_count for _stage, _failed_count, deferred_count, _unresolved_count in ops_rows
-            ),
-            "unresolved_count": sum(
-                unresolved_count for _stage, _failed_count, _deferred_count, unresolved_count in ops_rows
-            ),
+            "available": summary.available,
+            "error": summary.error,
+            "failed_count": summary.failed_count,
+            "deferred_count": summary.deferred_count,
+            "unresolved_count": summary.failed_count + summary.deferred_count,
             "by_stage": [
                 {
-                    "stage": stage,
-                    "failed_count": failed_count,
-                    "deferred_count": deferred_count,
-                    "unresolved_count": unresolved_count,
+                    "stage": item.stage,
+                    "failed_count": item.failed_count,
+                    "deferred_count": item.deferred_count,
+                    "unresolved_count": item.failed_count + item.deferred_count,
                 }
-                for stage, failed_count, deferred_count, unresolved_count in ops_rows
+                for item in summary.stage_summaries
             ],
         }
     if not _table_exists(conn, "live_convergence_debt"):
-        return {"failed_count": 0, "deferred_count": 0, "unresolved_count": 0, "by_stage": []}
+        return {
+            "available": True,
+            "error": None,
+            "failed_count": 0,
+            "deferred_count": 0,
+            "unresolved_count": 0,
+            "by_stage": [],
+        }
     rows = conn.execute(
         """
         SELECT stage, COUNT(*) AS unresolved_count
@@ -950,6 +962,8 @@ def _convergence_debt(conn: sqlite3.Connection, *, ops_db: Path | None = None) -
     ).fetchall()
     unresolved_count = sum(int(row[1] or 0) for row in rows)
     return {
+        "available": True,
+        "error": None,
         "failed_count": unresolved_count,
         "deferred_count": 0,
         "unresolved_count": unresolved_count,
@@ -963,33 +977,6 @@ def _convergence_debt(conn: sqlite3.Connection, *, ops_db: Path | None = None) -
             for row in rows
         ],
     }
-
-
-def _ops_convergence_debt_rows(ops_db: Path | None) -> list[tuple[str, int, int, int]]:
-    if ops_db is None or not ops_db.exists():
-        return []
-    try:
-        conn = open_readonly_connection(ops_db)
-        try:
-            if not _table_exists(conn, "convergence_debt"):
-                return []
-            rows = conn.execute(
-                """
-                SELECT
-                    stage,
-                    SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failed_count,
-                    SUM(CASE WHEN status = 'deferred' THEN 1 ELSE 0 END) AS deferred_count,
-                    COUNT(*) AS unresolved_count
-                FROM convergence_debt
-                GROUP BY stage
-                ORDER BY failed_count DESC, deferred_count DESC, stage
-                """
-            ).fetchall()
-        finally:
-            conn.close()
-    except sqlite3.Error:
-        return []
-    return [(str(row[0] or "unknown"), int(row[1] or 0), int(row[2] or 0), int(row[3] or 0)) for row in rows]
 
 
 def _boundary_table_counts(
@@ -2411,7 +2398,7 @@ def probe(
             exact_derived_counts=exact_derived_counts,
             exact_table_counts=exact_table_counts,
         )
-        convergence_debt = _convergence_debt(conn, ops_db=ops_db)
+        convergence_debt = _convergence_debt(conn, db=db, ops_db=ops_db)
         return {
             "ok": True,
             "report_version": REPORT_VERSION,

--- a/tests/unit/operations/test_daemon_workload_probe.py
+++ b/tests/unit/operations/test_daemon_workload_probe.py
@@ -998,6 +998,8 @@ def test_probe_reads_ops_convergence_debt(tmp_path: Path) -> None:
     payload = probe(db)
 
     assert payload["convergence_debt"] == {
+        "available": True,
+        "error": None,
         "failed_count": 2,
         "deferred_count": 0,
         "unresolved_count": 2,
@@ -1033,6 +1035,8 @@ def test_probe_does_not_count_ops_deferred_convergence_debt_as_failed(tmp_path: 
     payload = probe(db)
 
     assert payload["convergence_debt"] == {
+        "available": True,
+        "error": None,
         "failed_count": 0,
         "deferred_count": 1,
         "unresolved_count": 1,
@@ -1045,6 +1049,22 @@ def test_probe_does_not_count_ops_deferred_convergence_debt_as_failed(tmp_path: 
             }
         ],
     }
+
+
+def test_probe_reports_unavailable_authoritative_convergence_ledger(tmp_path: Path) -> None:
+    db = tmp_path / "archive.sqlite"
+    _seed_minimal_archive(db, tmp_path / "session.jsonl")
+    db.with_name("ops.db").write_text("not a sqlite database")
+
+    payload = probe(db)
+
+    debt = payload["convergence_debt"]
+    assert debt["available"] is False
+    assert str(debt["error"]).startswith("convergence debt status unavailable:")
+    assert debt["failed_count"] == 0
+    assert debt["deferred_count"] == 0
+    assert debt["unresolved_count"] == 0
+    assert debt["by_stage"] == []
 
 
 def test_probe_reads_ops_cursor_lag_baselines(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Make workload diagnostics use the authoritative convergence-debt projection.

## Problem

The daemon and direct CLI report an unreadable authoritative `ops.db` convergence ledger as unavailable. Workload diagnostics independently queried that ledger and collapsed read failures into zero debt, producing a false healthy state.

## Solution

- Adapt `convergence_debt_summary_info` into the workload report.
- Preserve the legacy in-index fallback only when no ops path is supplied.
- Include availability and error state in the workload debt payload.
- Advance the workload report contract from v20 to v21.

## Verification

- `devtools test tests/unit/operations/test_daemon_workload_probe.py`
  - `31 passed`
- `devtools verify --quick`
  - `exit_code: 0`, `duration_s: 92.97`

## Bead disposition

| Bead | Disposition | Evidence |
| --- | --- | --- |
| polylogue-703 | Partial progress, remains open | Workload debt semantics now match daemon/CLI; the broader status assembly remains. |

## Scope carrier

`polylogue-703`: authoritative convergence-debt facts for workload diagnostics. Remaining scope: compose all shared status facts through one substrate snapshot.