### PR TITLE
fix(verify): finalize interrupted receipts

### DIFF
--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -7,6 +7,7 @@ import contextlib
 import json
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import time
@@ -57,6 +58,18 @@ PYTEST_JUNIT_REPORT_DIR = PYTEST_REPORT_DIR / "junit"
 SERIAL_LANE_MAX_WORKERS = 4
 STORAGE_SCALE_LANE_MAX_WORKERS = 1
 _AGENTCTL_OPERATION_ARGV = {"verify_affected": (), "verify_quick": ("--quick",), "verify_all": ("--all",)}
+
+
+class VerificationInterrupted(KeyboardInterrupt):
+    """A terminal signal reached the verifier after its receipt was created."""
+
+    def __init__(self, signum: int) -> None:
+        super().__init__()
+        self.signum = signum
+
+
+def _raise_verification_interruption(signum: int, _frame: Any) -> None:
+    raise VerificationInterrupted(signum)
 
 
 def _declared_agentctl_operation(raw_argv: Sequence[str]) -> str | None:
@@ -369,6 +382,41 @@ def _emit(payload: Mapping[str, Any], *, use_json: bool, operation: str | None) 
         print(json.dumps(result, sort_keys=True, ensure_ascii=False))
 
 
+def _finish_interrupted_verification(
+    *,
+    run: VerifyRun,
+    started: float,
+    scope: VerificationScope,
+    args: argparse.Namespace,
+    agentctl_operation: str | None,
+    exit_code: int,
+    termination_reason: str,
+) -> int:
+    """Persist the terminal state when an outer runtime ends verification."""
+    run.finish_interrupted_steps(
+        exit_code=exit_code,
+        diagnosis="verification_interrupted",
+        termination_reason=termination_reason,
+    )
+    payload = run.finish(
+        exit_code=exit_code,
+        duration_s=time.monotonic() - started,
+        diagnosis="verification_interrupted",
+        verification_scope=scope.value,
+        final_git_head=git_head(ROOT),
+        pytest_aggregate={
+            "selection_mode": "all" if args.all_tests else "affected",
+            "outcomes": {},
+            "terminal_green": False,
+            "complete_corpus_covered": False,
+            "termination_reason": termination_reason,
+        },
+    )
+    append_verify_history(payload)
+    _emit(payload, use_json=args.json, operation=agentctl_operation)
+    return exit_code
+
+
 def _main(argv: list[str] | None = None, *, agentctl_operation: str | None = None) -> int:
     parser = argparse.ArgumentParser(description="Run project semantic verification.")
     parser.add_argument("--quick", action="store_true")
@@ -454,12 +502,33 @@ def _main(argv: list[str] | None = None, *, agentctl_operation: str | None = Non
     )
     results: list[dict[str, Any]] = []
     exit_code = 0
-    for label, command in steps:
-        rc, elapsed, metadata = _run(label, command, run=run)
-        results.append({"name": label, "duration_s": round(elapsed, 2), "exit": rc, **metadata})
-        if rc:
-            exit_code = rc
-            break
+    try:
+        for label, command in steps:
+            rc, elapsed, metadata = _run(label, command, run=run)
+            results.append({"name": label, "duration_s": round(elapsed, 2), "exit": rc, **metadata})
+            if rc:
+                exit_code = rc
+                break
+    except VerificationInterrupted as exc:
+        return _finish_interrupted_verification(
+            run=run,
+            started=started,
+            scope=scope,
+            args=args,
+            agentctl_operation=agentctl_operation,
+            exit_code=128 + exc.signum,
+            termination_reason=signal.Signals(exc.signum).name.lower(),
+        )
+    except KeyboardInterrupt:
+        return _finish_interrupted_verification(
+            run=run,
+            started=started,
+            scope=scope,
+            args=args,
+            agentctl_operation=agentctl_operation,
+            exit_code=130,
+            termination_reason="operator_interrupt",
+        )
     aggregate = {
         "selection_mode": mode,
         "outcomes": {
@@ -487,10 +556,18 @@ def _main(argv: list[str] | None = None, *, agentctl_operation: str | None = Non
 
 def main(argv: list[str] | None = None) -> int:
     raw_argv = list(sys.argv[1:] if argv is None else argv)
+    handlers = {
+        signum: signal.signal(signum, _raise_verification_interruption) for signum in (signal.SIGINT, signal.SIGTERM)
+    }
     try:
         return _main(raw_argv, agentctl_operation=_declared_agentctl_operation(raw_argv))
+    except VerificationInterrupted as exc:
+        return 128 + exc.signum
     except KeyboardInterrupt:
         return 130
+    finally:
+        for signum, previous in handlers.items():
+            signal.signal(signum, previous)
 
 
 if __name__ == "__main__":

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import signal
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -87,3 +89,39 @@ def test_agentctl_verify_run_omits_mutable_current_receipt(tmp_path: Path) -> No
     VerifyRun(tier="all", argv=["--all"], git_head="head", root=tmp_path, mirror_current=False)
 
     assert not (tmp_path / CURRENT_RUN_PATH).exists()
+
+
+def test_verify_persists_terminal_receipt_when_outer_deadline_sends_sigterm(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    history: dict[str, Any] = {}
+
+    def interrupt(
+        label: str,
+        command: list[str],
+        *,
+        run: VerifyRun,
+    ) -> tuple[int, float, dict[str, object]]:
+        run.start_step(label=label, cmd=command)
+        raise verify.VerificationInterrupted(signal.SIGTERM)
+
+    monkeypatch.setattr(verify, "ROOT", tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(verify, "assert_polylogue_matches_checkout", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(verify, "git_head", lambda _root: "head")
+    monkeypatch.setattr(verify, "build_verify_steps", lambda **_kwargs: [("pytest native parallel (all)", ["pytest"])])
+    monkeypatch.setattr(verify, "_run", interrupt)
+    monkeypatch.setattr(verify, "append_verify_history", lambda payload: history.update(payload))
+
+    assert verify._main(["--quick"]) == 143
+
+    run_payload = json.loads((tmp_path / str(history["artifact_dir"]) / "run.json").read_text())
+    current_payload = json.loads((tmp_path / CURRENT_RUN_PATH).read_text())
+    for payload in (history, run_payload, current_payload):
+        assert payload["status"] == "failed"
+        assert payload["diagnosis"] == "verification_interrupted"
+        assert payload["exit_code"] == 143
+        assert payload["pytest_aggregate"]["termination_reason"] == "sigterm"
+        assert payload["steps"][0]["status"] == "failed"
+        assert payload["steps"][0]["termination_reason"] == "sigterm"


### PR DESCRIPTION
## Summary

Persist terminal verification receipts when an outer runtime interrupts a run.

## Problem

Full verification run `20260823T144002Z-all-951463-294cd855` stopped after 10,958 of 20,138 tests at the one-hour boundary, leaving its receipt in `running`. AgentCTL’s Polylogue project declaration has no one-hour operation timeout, so an external supervisor can end a run without a locally classified outcome.

## Solution

- Translate SIGTERM and SIGINT into a verifier interruption after receipt creation.
- Finalize active steps and the run receipt as `verification_interrupted`, including signal reason and conventional exit code.
- Cover SIGTERM during the pytest step with a receipt persistence test.

SIGKILL cannot be handled by any process; normal terminating signals now leave durable evidence for an operator to extend or retry the declared AgentCTL operation.

## Verification

- `devtools test tests/unit/devtools/test_verify.py` → `7 passed`
- `devtools verify --quick` → success (49.26s)
- Pre-push `devtools verify --quick` → success

## Bead disposition

| Bead | Disposition |
| --- | --- |
| polylogue-012fi | Satisfied by this PR after merge |

## Scope carrier

- `devtools/verify.py`: terminal-signal receipt finalization
- `tests/unit/devtools/test_verify.py`: SIGTERM regression coverage

Ref polylogue-012fi