### PR TITLE
fix(agentctl): allow full verifier completion

### DIFF
--- a/.agentctl/project.toml
+++ b/.agentctl/project.toml
@@ -50,6 +50,7 @@ exec = ["devtools", "verify", "--all"]
 pool = "bulk"
 result = "pytest"
 cache = "tree+environment"
+timeout_seconds = 7200
 exclusive_keys = ["polylogue:testmon-graph"]
 scratch = "nvme"
 


### PR DESCRIPTION
Polylogue full verification remained CPU-active until AgentCTL terminated it at the prior 3,600-second default. Declare a 7,200-second limit only for verify_all; affected and quick verification retain the default. Sinnix keeps a 14,400-second hard maximum for declared operations and a 3,600-second cap for shell and attested-agent jobs.\n\nVerification: exact-head AgentCTL verify_quick job 172d58e0-c01b-4439-b35a-5ad86f92a533 succeeded at af059a789.