### PR TITLE
fix(workload): require cancellation and cleanup evidence

### DIFF
--- a/polylogue/scenarios/workload.py
+++ b/polylogue/scenarios/workload.py
@@ -317,6 +317,15 @@ class WorkloadReceipt:
         expected_budget_results = evaluate_budgets(self.spec, self.phases)
         if self.budget_results != expected_budget_results:
             raise ValueError("Workload receipt budget verdicts do not match its phase observations")
+        if self.cancellation_requested and not any(
+            phase.cancellation_latency_ms is not None or "cancellation_latency_ms" in phase.unavailable
+            for phase in self.phases
+        ):
+            raise ValueError("A cancellation request requires a latency observation or explicit unavailability")
+        if self.cleanup_complete and not any(
+            phase.quiescent and phase.cleanup_complete is True for phase in self.phases
+        ):
+            raise ValueError("Completed cleanup requires a quiescent cleanup observation")
 
     @classmethod
     def from_observations(

--- a/tests/unit/scenarios/test_workload_receipts.py
+++ b/tests/unit/scenarios/test_workload_receipts.py
@@ -125,6 +125,48 @@ def test_phase_rejects_measurement_reported_as_both_present_and_unavailable() ->
         )
 
 
+def test_receipt_rejects_cancellation_claim_without_latency_evidence() -> None:
+    with pytest.raises(ValueError, match="cancellation request requires a latency"):
+        WorkloadReceipt.from_observations(
+            spec=WorkloadEnvelopeSpec(
+                workload_id="cancelled-query",
+                family_id="query",
+                version=1,
+                inputs=(WorkloadInputRef(input_id="archive:test"),),
+                phases=("query",),
+            ),
+            status=WorkloadRunStatus.CANCELLED,
+            build_id=None,
+            runtime_id=None,
+            archive_id=None,
+            generation_id=None,
+            frame_id=None,
+            phases=(WorkloadPhaseObservation(name="query"),),
+            cancellation_requested=True,
+        )
+
+
+def test_receipt_rejects_cleanup_claim_without_quiescent_observation() -> None:
+    with pytest.raises(ValueError, match="Completed cleanup requires"):
+        WorkloadReceipt.from_observations(
+            spec=WorkloadEnvelopeSpec(
+                workload_id="cleanup-query",
+                family_id="query",
+                version=1,
+                inputs=(WorkloadInputRef(input_id="archive:test"),),
+                phases=("query",),
+            ),
+            status=WorkloadRunStatus.SUCCEEDED,
+            build_id=None,
+            runtime_id=None,
+            archive_id=None,
+            generation_id=None,
+            frame_id=None,
+            phases=(WorkloadPhaseObservation(name="query"),),
+            cleanup_complete=True,
+        )
+
+
 def test_budget_aggregation_is_dimension_aware_and_may_target_one_phase() -> None:
     spec = WorkloadEnvelopeSpec(
         workload_id="query:actions",


### PR DESCRIPTION
## Summary

Make cancellation and cleanup claims in shared workload receipts evidence-bearing.

## Problem

The workload receipt model allowed cancellation and cleanup to be claimed without a matching phase observation, leaving AC5 vulnerable to paper coverage.

## Solution

- Require a cancellation latency observation or explicit unavailability when cancellation is requested.
- Require a quiescent cleanup phase when cleanup is claimed complete.
- Add negative contracts for both unsupported claims.

## Verification

- `devtools test tests/unit/scenarios/test_workload_receipts.py` → `8 passed`
- `devtools verify --quick` → success (96.88s)
- Pre-push `devtools verify --quick` → success (55.21s)

## Bead disposition

| Bead | Disposition |
| --- | --- |
| polylogue-1xc.14.2 | Partial AC1; bounded collector proof remains |

## Scope carrier

- `polylogue/scenarios/workload.py`: receipt evidence invariants
- `tests/unit/scenarios/test_workload_receipts.py`: anti-vacuity contracts

Ref polylogue-1xc.14.2