### PR TITLE
fix(tests): restore append cohort authority fixture

### DIFF
--- a/tests/infra/append_cohort_memory_counter.py
+++ b/tests/infra/append_cohort_memory_counter.py
@@ -124,6 +124,7 @@ class AppendCohortMemoryCounter:
                         write_io_bytes=phase.io_write_bytes,
                         progress_completed=phase.plan_count,
                         progress_total=self.plan_count,
+                        cleanup_complete=True if phase.name == "quiescent" else None,
                         quiescent=phase.name == "quiescent",
                     ),
                     WorkloadPhaseObservation(
@@ -133,6 +134,7 @@ class AppendCohortMemoryCounter:
                         file_cache_bytes=phase.cgroup_file_bytes,
                         progress_completed=phase.plan_count,
                         progress_total=self.plan_count,
+                        cleanup_complete=True if phase.name == "quiescent" else None,
                         quiescent=phase.name == "quiescent",
                     ),
                 )

--- a/tests/integration/test_append_cohort_memory.py
+++ b/tests/integration/test_append_cohort_memory.py
@@ -26,11 +26,13 @@ from unittest.mock import patch
 
 from polylogue.archive.revision_authority import RawRevisionAuthority, RawRevisionEnvelope, RawRevisionKind
 from polylogue.core.enums import Provider
+from polylogue.core.sources import origin_from_provider
 from polylogue.sources.live.append_ingest import ingest_append_plans
 from polylogue.sources.live.batch_support import _AppendPlan
 from polylogue.sources.live.cursor import CursorStore
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from polylogue.storage.sqlite.archive_tiers.source_write import write_source_raw_session
 from tests.infra.append_cohort_memory_counter import append_cohort_memory_counter
 
 
@@ -73,11 +75,17 @@ def _seed_cohort_and_append_plan(
     source_path.write_bytes(snapshots[-1] + append_payload)
     with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
         for index, payload in enumerate(snapshots):
-            archive.write_raw_payload(
-                provider=Provider.CODEX,
+            blob_hash, _blob_size = archive._blob_publisher.write_from_bytes(payload)
+            archive._blob_publisher.flush()
+            write_source_raw_session(
+                archive._ensure_source_conn(),
+                origin=origin_from_provider(Provider.CODEX),
+                capture_mode=Provider.CODEX,
                 payload=payload,
                 source_path=str(source_path),
+                source_index=0,
                 acquired_at_ms=index + 1,
+                blob_publication_receipt_id=archive._blob_publisher.receipt_id(blob_hash),
                 revision=RawRevisionEnvelope(
                     f"codex:{session_id}",
                     RawRevisionKind.FULL,
@@ -116,11 +124,17 @@ def _seed_partially_classified_cohort_and_append_plan(archive_root: Path) -> _Ap
     source_path.write_bytes(snapshots[-1] + append_payload)
     with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
         for index, payload in enumerate(snapshots):
-            archive.write_raw_payload(
-                provider=Provider.CODEX,
+            blob_hash, _blob_size = archive._blob_publisher.write_from_bytes(payload)
+            archive._blob_publisher.flush()
+            write_source_raw_session(
+                archive._ensure_source_conn(),
+                origin=origin_from_provider(Provider.CODEX),
+                capture_mode=Provider.CODEX,
                 payload=payload,
                 source_path=str(source_path),
+                source_index=0,
                 acquired_at_ms=index + 1,
+                blob_publication_receipt_id=archive._blob_publisher.receipt_id(blob_hash),
                 revision=RawRevisionEnvelope(
                     f"codex:{session_id}",
                     RawRevisionKind.FULL,

--- a/tests/integration/test_append_cohort_memory.py
+++ b/tests/integration/test_append_cohort_memory.py
@@ -74,9 +74,11 @@ def _seed_cohort_and_append_plan(
     )
     source_path.write_bytes(snapshots[-1] + append_payload)
     with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+        publisher = archive._blob_publisher
+        assert publisher is not None
         for index, payload in enumerate(snapshots):
-            blob_hash, _blob_size = archive._blob_publisher.write_from_bytes(payload)
-            archive._blob_publisher.flush()
+            blob_hash, _blob_size = publisher.write_from_bytes(payload)
+            publisher.flush()
             write_source_raw_session(
                 archive._ensure_source_conn(),
                 origin=origin_from_provider(Provider.CODEX),
@@ -85,7 +87,7 @@ def _seed_cohort_and_append_plan(
                 source_path=str(source_path),
                 source_index=0,
                 acquired_at_ms=index + 1,
-                blob_publication_receipt_id=archive._blob_publisher.receipt_id(blob_hash),
+                blob_publication_receipt_id=publisher.receipt_id(blob_hash),
                 revision=RawRevisionEnvelope(
                     f"codex:{session_id}",
                     RawRevisionKind.FULL,
@@ -123,9 +125,11 @@ def _seed_partially_classified_cohort_and_append_plan(archive_root: Path) -> _Ap
     )
     source_path.write_bytes(snapshots[-1] + append_payload)
     with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+        publisher = archive._blob_publisher
+        assert publisher is not None
         for index, payload in enumerate(snapshots):
-            blob_hash, _blob_size = archive._blob_publisher.write_from_bytes(payload)
-            archive._blob_publisher.flush()
+            blob_hash, _blob_size = publisher.write_from_bytes(payload)
+            publisher.flush()
             write_source_raw_session(
                 archive._ensure_source_conn(),
                 origin=origin_from_provider(Provider.CODEX),
@@ -134,7 +138,7 @@ def _seed_partially_classified_cohort_and_append_plan(archive_root: Path) -> _Ap
                 source_path=str(source_path),
                 source_index=0,
                 acquired_at_ms=index + 1,
-                blob_publication_receipt_id=archive._blob_publisher.receipt_id(blob_hash),
+                blob_publication_receipt_id=publisher.receipt_id(blob_hash),
                 revision=RawRevisionEnvelope(
                     f"codex:{session_id}",
                     RawRevisionKind.FULL,


### PR DESCRIPTION
## Summary

Restore append-cohort test fixtures to write the explicit raw-revision chain required by durable replay tests.

## Problem

Typed raw admission now validates full revisions against canonical payload authority. The fixture used synthetic revision identifiers through the public ingestion path, so its intended durable-replay route failed before workload observation could begin.

## Solution

Seed fixture rows with the source-tier writer and published blobs, preserving the explicit full revision chain that the replay plan is designed to inspect. Bind the optional blob publisher once per archive fixture before using it.

## Verification

- `devtools test tests/integration/test_append_cohort_memory.py` — 4 passed in 76.72s.
- `devtools verify --quick` — success (52.55s).
- Pre-push quick baseline — success (58.46s).

## Bead disposition

| Bead | Disposition | Evidence |
| --- | --- | --- |
| polylogue-n83sk | Satisfied | Fixture revisions now retain internally consistent authority and source-revision evidence; the append-cohort integration module passes. |
| polylogue-1xc.14.2 | Remaining | Resume the bounded, non-perturbing collector proof after this fixture repair lands. |

## Scope carrier

Ref polylogue-n83sk

Remaining polylogue-1xc.14.2 scope: prove the collector does not introduce parallel historical readers, then complete the workload receipt evidence matrix.