### PR TITLE
test(workload): prove append collector stays synchronous

### DIFF
--- a/tests/integration/test_append_cohort_memory.py
+++ b/tests/integration/test_append_cohort_memory.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import hashlib
 import sqlite3
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -171,7 +172,17 @@ def _seed_partially_classified_cohort_and_append_plan(archive_root: Path) -> _Ap
 def test_watcher_append_uses_durable_replay_metadata_without_historical_full_reads(tmp_path: Path) -> None:
     """An established append cohort replays only its selected full and tail."""
     plan = _seed_cohort_and_append_plan(tmp_path)
-    with append_cohort_memory_counter() as counter:
+
+    def unexpected_worker_start(_worker: threading.Thread, *_args: object, **_kwargs: object) -> None:
+        raise AssertionError("append-cohort collection must not start a parallel reader")
+
+    # The canary measures the same synchronous call stack it exercises.  A
+    # collector refactor that starts a background reader would make this fail
+    # before it can hide historical reads from the route assertions below.
+    with (
+        patch.object(threading.Thread, "start", autospec=True, side_effect=unexpected_worker_start),
+        append_cohort_memory_counter() as counter,
+    ):
         result = ingest_append_plans(cast(Any, _owner(tmp_path)), [plan])
         counter.snapshot("quiescent")
 


### PR DESCRIPTION
## Summary

Make the watcher append/cohort canary fail if measured collection starts a worker thread.

## Problem

The workload receipt requires a bounded, non-perturbing collector. The append counter documented its synchronous process boundary, but the production canary did not prove that a refactor could not introduce a background historical reader.

## Solution

Patch `threading.Thread.start` only around the established durable-replay append route. Any worker start fails before route assertions can pass, while the existing canary continues to verify bounded historical reads and process/cgroup receipt fields.

## Verification

- `devtools test tests/integration/test_append_cohort_memory.py -k durable_replay_metadata` — 1 passed in 53.52s.
- `devtools test tests/unit/scenarios/test_workload_receipts.py tests/integration/test_append_cohort_memory.py` — 12 passed in 17.63s.
- `devtools verify --quick` — success (92.09s).
- Pre-push quick baseline — success (47.42s).

## Bead disposition

| Bead | Disposition | Evidence |
| --- | --- | --- |
| polylogue-1xc.14.2 | Partial | The append canary now proves its collector does not start parallel reader work; final child closure still requires updating the parent AC matrix. |
| polylogue-1xc.14 | Remaining | This provides direct AC6 evidence for its named append/cohort canary. |

## Scope carrier

Ref polylogue-1xc.14.2

Remaining polylogue-1xc.14.2 scope: record this evidence against the parent AC5/AC6 matrix and close only after the full matrix is verified.