### PR TITLE
fix(agentctl): admit the live Chrome profile size

### DIFF
--- a/devtools/live_provider_profile_provision_service.py
+++ b/devtools/live_provider_profile_provision_service.py
@@ -22,7 +22,7 @@ from devtools.sinnixd_service_context import require_declared_operation_context
 _SOURCE_ROOT = Path.home() / ".config" / "chrome-ws"
 _DESTINATION_ROOT = Path("/realm/state/polylogue/live-provider-proof-profile")
 _MAX_FILES = 20_000
-_MAX_BYTES = 1_000_000_000
+_MAX_BYTES = 2_000_000_000
 _EXCLUDED_NAMES = frozenset({"SingletonLock", "SingletonCookie", "SingletonSocket", "lockfile"})
 _MAX_ERROR_MESSAGE = 512
 

--- a/tests/unit/devtools/test_live_provider_profile_provision_service.py
+++ b/tests/unit/devtools/test_live_provider_profile_provision_service.py
@@ -26,6 +26,19 @@ def test_profile_provision_reports_missing_source_paths(tmp_path: Path) -> None:
         provision._copy_selected_profile(source_root=tmp_path / "absent", destination_root=tmp_path / "destination")
 
 
+def test_profile_provision_rejects_profiles_above_the_copy_bound(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = _source_profile(tmp_path / "current-chrome")
+    destination = tmp_path / "proof-profile"
+    monkeypatch.setattr(provision, "_MAX_BYTES", 1)
+
+    with pytest.raises(ValueError, match="exceeds the declared provisioning bound"):
+        provision._copy_selected_profile(source_root=source, destination_root=destination)
+
+    assert not destination.exists()
+
+
 def test_profile_provision_copies_fixed_profile_without_live_locks(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
The live Sinnix Chrome Default profile is currently about 1.3 GB, above the provisioning operation’s 1 GB finite-copy bound. Raise the bound to 2 GB while retaining file-count and byte-count enforcement, and add a behavioral rejection/cleanup test.\n\nVerification: focused profile provision tests (4 passed), `devtools verify --quick`, and `git diff --check`.