### PR TITLE
fix(agentctl): honor browser and archive runtime contracts

### DIFF
--- a/.agentctl/project.toml
+++ b/.agentctl/project.toml
@@ -8,7 +8,7 @@ root_markers = ["pyproject.toml", "polylogue"]
 [environment]
 kind = "nix-develop"
 command = ["nix", "develop", "--accept-flake-config", "--command"]
-inherit = ["HOME", "USER", "LANG", "TERM", "SSH_AUTH_SOCK", "XDG_RUNTIME_DIR", "DBUS_SESSION_BUS_ADDRESS", "POLYLOGUE_ARCHIVE_ROOT", "XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_STATE_HOME"]
+inherit = ["HOME", "USER", "LANG", "TERM", "SSH_AUTH_SOCK", "XDG_RUNTIME_DIR", "DBUS_SESSION_BUS_ADDRESS", "WAYLAND_DISPLAY", "DISPLAY", "POLYLOGUE_ARCHIVE_ROOT", "XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_STATE_HOME"]
 unset = ["PYTHONPATH", "PYTHONHOME", "VIRTUAL_ENV", "_PYTHON_SYSCONFIGDATA_NAME", "_PYTHON_HOST_PLATFORM", "PYTHONPYCACHEPREFIX"]
 
 [workspace]

--- a/devtools/dev_loop_service.py
+++ b/devtools/dev_loop_service.py
@@ -21,7 +21,7 @@ from urllib.parse import quote, urlencode
 
 from devtools.sinnixd_service_context import require_declared_service_context, terminate_process_group
 from polylogue.browser_capture.server import make_server
-from polylogue.storage.sqlite.archive_tiers.archive_init import initialize_archive_tier_files
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
 
 _API_PORT_ENV = "POLYLOGUE_API_PORT"
 _BROWSER_CAPTURE_PORT_ENV = "POLYLOGUE_BROWSER_CAPTURE_PORT"
@@ -324,7 +324,7 @@ def run_proof(*, repo_root: Path | None = None, readiness_timeout_s: float = 45.
     cdp_port = ports[_BROWSER_CDP_PORT_ENV]
     archive_root, artifact_root = _service_paths()
     artifact_root.mkdir(parents=True, exist_ok=True)
-    initialize_archive_tier_files(archive_root=archive_root, replace_existing=True)
+    initialize_active_archive_root(archive_root)
     environment = _proof_environment(
         archive_root=archive_root,
         artifact_root=artifact_root,

--- a/tests/unit/devtools/test_dev_loop_service.py
+++ b/tests/unit/devtools/test_dev_loop_service.py
@@ -29,6 +29,7 @@ def test_declared_operation_has_fixed_json_service_contract() -> None:
         },
     }
     assert descriptor["operations"]["verify_all"]["timeout_seconds"] == 14400
+    assert {"WAYLAND_DISPLAY", "DISPLAY"} <= set(descriptor["environment"]["inherit"])
     assert all(spec.module != "devtools.dev_loop_service" for spec in COMMAND_SPECS)
     assert all(spec.module != "devtools.deployment_browser_smoke_service" for spec in COMMAND_SPECS)
 
@@ -49,7 +50,8 @@ def test_run_proof_uses_only_agentctl_injected_ports_and_product_convergence(
 ) -> None:
     _fixed_service_context(monkeypatch)
     monkeypatch.setenv("TMPDIR", str(tmp_path / "scratch"))
-    monkeypatch.setattr(dev_loop_service, "initialize_archive_tier_files", lambda **_kwargs: object())
+    initialized: list[Path] = []
+    monkeypatch.setattr(dev_loop_service, "initialize_active_archive_root", initialized.append)
     monkeypatch.setattr(dev_loop_service, "run_receiver_smoke", lambda **_kwargs: {"ok": True})
     started: dict[str, object] = {}
     monkeypatch.setattr(dev_loop_service, "_start_daemon", lambda **kwargs: started.update(kwargs))
@@ -80,6 +82,7 @@ def test_run_proof_uses_only_agentctl_injected_ports_and_product_convergence(
     }
     assert started["api_port"] == 48801
     assert started["capture_port"] == 48865
+    assert initialized == [tmp_path / "scratch" / "polylogue-dev-loop-proof" / "archive"]
     environment = started["environment"]
     assert isinstance(environment, dict)
     assert environment["POLYLOGUE_API_PORT"] == "48801"


### PR DESCRIPTION
Live AgentCTL proofs exposed two integration defects: browser operations lost the desktop display variables under Sinnixd’s clean environment, and the dev-loop proof created current-schema tier files without the canonical durable fresh-bootstrap evidence. Inherit `WAYLAND_DISPLAY`/`DISPLAY` and bootstrap the disposable archive through `initialize_active_archive_root`.\n\nVerification: focused AgentCTL service tests (9 passed), `devtools verify --quick`, pre-push quick gate, and `git diff --check`. Live failures reproduced before the change: Chrome core dump before CDP; daemon rejection for missing durable train evidence.