### PR TITLE
fix(agentctl): probe the public daemon liveness route

### DIFF
--- a/browser-extension/scripts/live_provider_proof.mjs
+++ b/browser-extension/scripts/live_provider_proof.mjs
@@ -285,7 +285,7 @@ async function runLiveProviderProof() {
   const chrome = launchFixedChrome(chromeBinary, [
     `--user-data-dir=${profile}`,
     `--remote-debugging-port=${cdpPort}`,
-    "--no-first-run", "--disable-default-apps", "--no-default-browser-check", "--enable-unsafe-extension-debugging",
+    "--disable-gpu", "--no-first-run", "--disable-default-apps", "--no-default-browser-check", "--enable-unsafe-extension-debugging",
     `--unsafely-treat-insecure-origin-as-secure=${receiverBaseUrl}`,
     `--disable-extensions-except=${extensionRoot}`, `--load-extension=${extensionRoot}`, "--new-window", "about:blank",
   ], { detached: true, stdio: "ignore" });

--- a/devtools/dev_loop_service.py
+++ b/devtools/dev_loop_service.py
@@ -172,11 +172,11 @@ def _await_api(*, base_url: str, timeout_s: float) -> None:
     last_error = "API did not answer"
     while time.monotonic() <= deadline:
         try:
-            status, payload = _http_get_json(f"{base_url}/api/status", timeout_s=2.0)
+            status, payload = _http_get_json(f"{base_url}/healthz/live", timeout_s=2.0)
         except OSError as error:
             last_error = f"{type(error).__name__}: {error}"
         else:
-            if status == 200 and payload.get("ok") is True:
+            if status == 200 and payload.get("status") == "alive":
                 return
             last_error = f"HTTP {status}"
         time.sleep(0.1)

--- a/tests/unit/devtools/test_dev_loop_service.py
+++ b/tests/unit/devtools/test_dev_loop_service.py
@@ -132,6 +132,24 @@ def test_receiver_smoke_proves_auth_rejection_and_accepted_capture(tmp_path: Pat
     assert isinstance(payload["artifact_ref"], str)
 
 
+def test_api_readiness_uses_the_unauthenticated_liveness_contract(monkeypatch: pytest.MonkeyPatch) -> None:
+    observed: list[str] = []
+
+    def live(url: str, **_kwargs: object) -> tuple[int, dict[str, str]]:
+        observed.append(url)
+        return 200, {"status": "alive"}
+
+    monkeypatch.setattr(
+        dev_loop_service,
+        "_http_get_json",
+        live,
+    )
+
+    dev_loop_service._await_api(base_url="http://127.0.0.1:48801", timeout_s=0.1)
+
+    assert observed == ["http://127.0.0.1:48801/healthz/live"]
+
+
 def test_main_emits_one_bounded_json_error(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
     monkeypatch.setattr(dev_loop_service, "run_proof", lambda: (_ for _ in ()).throw(ValueError("x" * 600)))
 


### PR DESCRIPTION
The live three-port AgentCTL proof reached the API after canonical archive bootstrap, but its stale `/api/status` readiness probe correctly received 401 under the current auth contract. Probe the explicitly unauthenticated `/healthz/live` route and require its typed `status: alive` response.\n\nVerification: focused service tests (9 passed), `devtools verify --quick`, pre-push quick gate, and live pre-fix HTTP 401 evidence.