### PR TITLE
fix(agentctl): bypass the shared Chrome launcher

### DIFF
--- a/browser-extension/scripts/live_provider_proof.mjs
+++ b/browser-extension/scripts/live_provider_proof.mjs
@@ -5,7 +5,7 @@
 import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { once } from "node:events";
-import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -58,12 +58,32 @@ function requireExpectedServiceContext() {
   }
 }
 
-function resolveChromeBinary() {
-  for (const candidate of ["google-chrome", "google-chrome-stable", "chromium", "chromium-browser", "chrome-for-testing"]) {
+function nixStoreChromiumCandidates() {
+  const storeRoot = "/nix/store";
+  if (!existsSync(storeRoot)) return [];
+  return readdirSync(storeRoot)
+    .map((entry) => {
+      const match = entry.match(/-chromium-(\d+(?:\.\d+)+)$/);
+      if (!match) return null;
+      const binary = path.join(storeRoot, entry, "bin", "chromium");
+      return existsSync(binary) ? { binary, version: match[1].split(".").map(Number) } : null;
+    })
+    .filter(Boolean)
+    .sort((left, right) => right.version.join(".").localeCompare(left.version.join("."), undefined, { numeric: true }))
+    .map((candidate) => candidate.binary);
+}
+
+export function resolveChromeBinary() {
+  // The operator's google-chrome command is intentionally a shared-profile
+  // launcher. It injects its own profile and CDP port, so it is not a valid
+  // executable boundary for this isolated copied-profile proof.
+  for (const candidate of ["chromium", "chromium-browser", "chrome-for-testing"]) {
     const resolved = spawnSync("sh", ["-c", `command -v ${candidate}`], { encoding: "utf8" });
     if (resolved.status === 0 && resolved.stdout.trim()) return resolved.stdout.trim();
   }
-  throw new Error("no fixed Chrome/Chromium executable is available on the declared service PATH");
+  const storeCandidate = nixStoreChromiumCandidates()[0];
+  if (storeCandidate) return storeCandidate;
+  throw new Error("no unconfigured Chromium executable is available for the copied-profile proof");
 }
 
 function fixedInputs() {

--- a/tests/unit/devtools/test_deployment_browser_smoke_service.py
+++ b/tests/unit/devtools/test_deployment_browser_smoke_service.py
@@ -122,6 +122,25 @@ def test_private_live_provider_module_imports_without_launching_chrome() -> None
     assert completed.stdout == ""
 
 
+def test_live_provider_uses_an_unconfigured_chromium_binary() -> None:
+    completed = subprocess.run(
+        [
+            "node",
+            "--input-type=module",
+            "--eval",
+            "import('./scripts/live_provider_proof.mjs').then(m => console.log(m.resolveChromeBinary()))",
+        ],
+        cwd="browser-extension",
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "google-chrome" not in completed.stdout
+    assert "chromium" in completed.stdout
+
+
 def test_live_provider_module_rejects_forged_environment_before_node_can_launch(tmp_path: Path) -> None:
     environment = os.environ | {
         "SINNIXD_JOB_ID": "123e4567-e89b-42d3-a456-426614174000",


### PR DESCRIPTION
The live-provider proof must own its copied profile and leased CDP port. The managed google-chrome command injects the operator profile and port 9222, which produces duplicate profile/port flags and a Chrome TRAP inside the AgentCTL job. Reuse the existing unconfigured Chromium discovery path and exclude shared-profile launchers.\n\nVerification: direnv exec . pytest tests/unit/devtools/test_deployment_browser_smoke_service.py -q (10 passed).