### PR TITLE
fix(agentctl): align the dev-loop receiver token

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -384,20 +384,6 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
-        "workspace dev-loop-service",
-        "workspace",
-        "Run the fixed Polylogue browser-capture proof inside an AgentCTL service lease.",
-        "devtools.dev_loop_service",
-        use_when=(
-            "AgentCTL invokes this fixed command through the declared dev_loop_proof operation. "
-            "Start that operation with agentctl so exact checkout binding, ports, lifecycle, cancellation, and results stay canonical."
-        ),
-        examples=(
-            "agentctl job start polylogue dev_loop_proof --workspace <workspace-id>",
-            "agentctl job result <job-id>",
-        ),
-    ),
-    CommandSpec(
         "workspace deployment-smoke",
         "workspace",
         "Probe deployed Polylogue binaries, daemon/web routes, and browser-capture archive flow.",

--- a/devtools/dev_loop_service.py
+++ b/devtools/dev_loop_service.py
@@ -207,6 +207,8 @@ def _start_daemon(
         str(capture_port),
         "--root",
         str(spool),
+        "--browser-capture-auth-token",
+        _RECEIVER_TOKEN,
         "--no-source-catchup",
     ]
     with log_path.open("w", encoding="utf-8") as log_file:

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -147,7 +147,6 @@ These are the commands worth remembering during normal repo work:
 | `devtools workspace binary-artifact-sweep` | Find raw_sessions rows whose bytes are a non-session binary format (SQLite, etc). |
 | `devtools workspace continuity-evidence` | Replay continuity scenarios and verify their query routes are discoverable. |
 | `devtools workspace deployment-smoke` | Probe deployed Polylogue binaries, daemon/web routes, and browser-capture archive flow. |
-| `devtools workspace dev-loop-service` | Run the fixed Polylogue browser-capture proof inside an AgentCTL service lease. |
 | `devtools workspace failure-context` | Join testmon, git history, and fixtures for a pytest failure ID into a JSON envelope. |
 | `devtools workspace index-fast-forward` | Plan and prove a declared index fast-forward against retained raw replay. |
 | `devtools workspace lineage-validation` | Validate lineage-count evidence before citing archive counts externally. |

--- a/tests/unit/devtools/test_dev_loop_service.py
+++ b/tests/unit/devtools/test_dev_loop_service.py
@@ -89,6 +89,31 @@ def test_run_proof_uses_only_agentctl_injected_ports_and_product_convergence(
     assert environment["POLYLOGUE_BROWSER_CAPTURE_PORT"] == "48865"
 
 
+def test_started_daemon_uses_the_proof_receiver_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    launched: dict[str, object] = {}
+
+    def fake_popen(command: list[str], **kwargs: object) -> object:
+        launched.update(command=command, kwargs=kwargs)
+        return object()
+
+    monkeypatch.setattr(dev_loop_service.subprocess, "Popen", fake_popen)
+
+    dev_loop_service._start_daemon(
+        repo_root=tmp_path,
+        environment={},
+        artifact_root=artifact_root,
+        api_port=48801,
+        capture_port=48865,
+    )
+
+    command = launched["command"]
+    assert isinstance(command, list)
+    token_index = command.index("--browser-capture-auth-token")
+    assert command[token_index + 1] == dev_loop_service._RECEIVER_TOKEN
+
+
 @pytest.mark.parametrize(
     ("environment", "value", "message"),
     [

--- a/tests/unit/devtools/test_dev_loop_service.py
+++ b/tests/unit/devtools/test_dev_loop_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -98,7 +99,7 @@ def test_started_daemon_uses_the_proof_receiver_token(tmp_path: Path, monkeypatc
         launched.update(command=command, kwargs=kwargs)
         return object()
 
-    monkeypatch.setattr(dev_loop_service.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
 
     dev_loop_service._start_daemon(
         repo_root=tmp_path,


### PR DESCRIPTION
The declared dev-loop proof sent a fixed bearer token, while its child daemon auto-minted a different token because the launch omitted the matching option. Pass the same fixed token into the daemon, cover the exact launch argv, and remove the private dev-loop module from the devtools command catalog as required by the AgentCTL migration.\n\nVerification: focused dev-loop tests: 10 passed; full pre-push quick verification: green.