### PR TITLE
Run full verification with 16 pytest workers

### DIFF
--- a/.agentctl/project.toml
+++ b/.agentctl/project.toml
@@ -46,7 +46,7 @@ cache = "tree+environment"
 
 [operations.verify_all]
 description = "Run Polylogue's explicit complete-corpus verification plan"
-exec = ["devtools", "verify", "--all"]
+exec = ["env", "POLYLOGUE_PYTEST_WORKERS=16", "devtools", "verify", "--all"]
 pool = "bulk"
 result = "pytest"
 cache = "tree+environment"

--- a/tests/unit/devtools/test_dev_loop_service.py
+++ b/tests/unit/devtools/test_dev_loop_service.py
@@ -29,7 +29,9 @@ def test_declared_operation_has_fixed_json_service_contract() -> None:
             "browser_capture": {"environment": "POLYLOGUE_BROWSER_CAPTURE_PORT", "range": [48864, 48927]},
         },
     }
-    assert descriptor["operations"]["verify_all"]["timeout_seconds"] == 14400
+    verify_all = descriptor["operations"]["verify_all"]
+    assert verify_all["timeout_seconds"] == 14400
+    assert verify_all["exec"] == ["env", "POLYLOGUE_PYTEST_WORKERS=16", "devtools", "verify", "--all"]
     assert {"WAYLAND_DISPLAY", "DISPLAY"} <= set(descriptor["environment"]["inherit"])
     assert all(spec.module != "devtools.dev_loop_service" for spec in COMMAND_SPECS)
     assert all(spec.module != "devtools.deployment_browser_smoke_service" for spec in COMMAND_SPECS)


### PR DESCRIPTION
Sets the declared AgentCTL verify_all operation to request 16 xdist workers. Serial and storage-scale lanes retain their existing safety caps.

Verification: exact-head verify_quick succeeded; focused descriptor contract 14 passed.