### PR TITLE
Fix AgentCTL dev-loop shared Chrome proof

### DIFF
--- a/browser-extension/scripts/deployment_shared_chrome_smoke.mjs
+++ b/browser-extension/scripts/deployment_shared_chrome_smoke.mjs
@@ -5,6 +5,7 @@
 import { pathToFileURL } from "node:url";
 
 import { assertAgentWindow, firstControlJson, runChromeControlBytes } from "./shared_chrome_control.mjs";
+import { createOwnedTargetCleanup } from "./shared_chrome_proof_cleanup.mjs";
 
 const DEPLOYED_ROOT_URL = "http://127.0.0.1:8766/";
 const RENDER_TIMEOUT_S = 30;
@@ -19,10 +20,12 @@ export function assertDeployedRoot(dom) {
 export async function runDeploymentSharedChromeSmoke({ control = runChromeControlBytes } = {}) {
   await control(["status"]);
   let targetId = null;
+  let cleanup = null;
   try {
     const target = firstControlJson(await control(["agent-window", "--url", DEPLOYED_ROOT_URL]));
     if (target === null) throw new Error("shared Chrome control returned invalid agent-window JSON");
     if (typeof target.id === "string" && /^[A-F0-9]{32}$/i.test(target.id)) targetId = target.id;
+    if (targetId !== null) cleanup = createOwnedTargetCleanup({ control, targetId });
     targetId = assertAgentWindow(target, DEPLOYED_ROOT_URL);
     await control([
       "await",
@@ -46,7 +49,7 @@ export async function runDeploymentSharedChromeSmoke({ control = runChromeContro
       },
     };
   } finally {
-    if (targetId !== null) await control(["close", targetId]);
+    if (cleanup !== null) await cleanup.finish();
   }
 }
 

--- a/browser-extension/scripts/dev_loop_shared_chrome_proof.mjs
+++ b/browser-extension/scripts/dev_loop_shared_chrome_proof.mjs
@@ -8,6 +8,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { assertAgentWindow, firstControlJson, runChromeControlBytes } from "./shared_chrome_control.mjs";
+import { createOwnedTargetCleanup } from "./shared_chrome_proof_cleanup.mjs";
 
 function requiredEnvironment(name) {
   const value = process.env[name];
@@ -52,13 +53,15 @@ export async function runSharedChromeControlWorkflow({ extensionRoot, control = 
   await control(["status"]);
   await control(["load-extension", "--path", extensionRoot]);
   let createdTargetId = null;
+  let cleanup = null;
   try {
     const target = await control(["agent-window", "--url", "about:blank"]);
     if (typeof target?.id === "string" && /^[A-F0-9]{32}$/i.test(target.id)) createdTargetId = target.id;
+    if (createdTargetId !== null) cleanup = createOwnedTargetCleanup({ control, targetId: createdTargetId });
     assertAgentWindow(target, "about:blank");
     return { ok: true, shared_chrome: { extension_loaded: true, target_closed: true } };
   } finally {
-    if (createdTargetId !== null) await control(["close", createdTargetId]);
+    if (cleanup !== null) await cleanup.finish();
   }
 }
 

--- a/browser-extension/scripts/shared_chrome_control.mjs
+++ b/browser-extension/scripts/shared_chrome_control.mjs
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 
 const CONTROL_COMMAND = "/home/sinity/.local/bin/sinnix-chrome-control";
 const AGENT_WORKSPACE = "agentbrowser";
-const CONTROL_TIMEOUT_MS = 10_000;
+const CONTROL_TIMEOUT_MS = 30_000;
 
 export function firstControlJson(bytes) {
   for (const line of Buffer.from(bytes).toString("utf8").split("\n")) {

--- a/browser-extension/scripts/shared_chrome_proof_cleanup.mjs
+++ b/browser-extension/scripts/shared_chrome_proof_cleanup.mjs
@@ -1,0 +1,60 @@
+const DEFAULT_CLEANUP_TIMEOUT_MS = 2000;
+
+function boundedCleanup(cleanup, timeoutMs) {
+  let timeout = null;
+  const deadline = new Promise((resolve) => {
+    timeout = setTimeout(resolve, timeoutMs);
+    timeout.unref?.();
+  });
+  return Promise.race([Promise.resolve().then(cleanup), deadline]).finally(() => {
+    if (timeout !== null) clearTimeout(timeout);
+  });
+}
+
+export function createOwnedTargetCleanup({
+  control,
+  targetId,
+  processLike = process,
+  timeoutMs = DEFAULT_CLEANUP_TIMEOUT_MS,
+}) {
+  let cleanupPromise = null;
+  let signalReceived = false;
+  const handlers = new Map();
+
+  const removeSignalHandlers = () => {
+    for (const [signalName, handler] of handlers) processLike.off(signalName, handler);
+    handlers.clear();
+  };
+
+  const close = () => {
+    if (cleanupPromise === null) {
+      cleanupPromise = boundedCleanup(() => control(["close", targetId]), timeoutMs);
+    }
+    return cleanupPromise;
+  };
+
+  for (const signalName of ["SIGINT", "SIGTERM"]) {
+    const handler = () => {
+      if (signalReceived) return;
+      signalReceived = true;
+      void close()
+        .catch(() => undefined)
+        .finally(() => {
+          removeSignalHandlers();
+          processLike.kill(processLike.pid, signalName);
+        });
+    };
+    handlers.set(signalName, handler);
+    processLike.on(signalName, handler);
+  }
+
+  return {
+    async finish() {
+      try {
+        await close();
+      } finally {
+        if (!signalReceived) removeSignalHandlers();
+      }
+    },
+  };
+}

--- a/devtools/dev_loop_service.py
+++ b/devtools/dev_loop_service.py
@@ -35,6 +35,7 @@ _RECEIVER_TOKEN = "polylogue-agentctl-proof-token"
 _API_TOKEN = "polylogue-agentctl-proof-api-token"
 _SHARED_CHROME_TIMEOUT_S = 30
 _CHILD_ERROR_TAIL_CHARS = 384
+_DETERMINISTIC_PROVIDERS = ("chatgpt", "claude-ai")
 
 
 def _leased_port(name: str, bounds: tuple[int, int]) -> int:
@@ -276,7 +277,7 @@ def _run_shared_chrome_control(*, repo_root: Path, timeout_s: float = _SHARED_CH
 def _submit_deterministic_captures(*, capture_port: int, session_id: str) -> dict[str, dict[str, str]]:
     """Keep receiver, archive, and API convergence deterministic and browser-free."""
     captures: dict[str, dict[str, str]] = {}
-    for provider in ("chatgpt", "claude-ai"):
+    for provider in _DETERMINISTIC_PROVIDERS:
         provider_session_id = f"{session_id}-{provider}"
         status, _accepted = _receiver_post(
             port=capture_port,
@@ -310,7 +311,71 @@ def _fetch_api_messages(*, api_url: str, session_id: str) -> bool:
         f"{api_url}/api/sessions/{quote(session_id, safe='')}/messages?limit=5",
         bearer_token=_API_TOKEN,
     )
-    return status == 200 and isinstance(payload.get("messages"), list) and bool(payload["messages"])
+    messages = payload.get("messages")
+    if status != 200 or payload.get("session_id") != session_id or not isinstance(messages, list) or not messages:
+        return False
+    return all(
+        isinstance(message, dict)
+        and isinstance(message.get("id"), str)
+        and bool(message["id"])
+        and isinstance(message.get("role"), str)
+        and bool(message["role"])
+        and "text" in message
+        and (message["text"] is None or isinstance(message["text"], str))
+        and isinstance(message.get("target_ref"), dict)
+        and message["target_ref"]
+        == {
+            "target_type": "message",
+            "target_id": message["id"],
+            "session_id": session_id,
+            "message_id": message["id"],
+            "identity_key": f"message:{session_id}:{message['id']}",
+        }
+        for message in messages
+    )
+
+
+def _validated_provider_captures(captures: object) -> dict[str, dict[str, str]]:
+    """Validate the complete deterministic capture contract before polling."""
+    if not isinstance(captures, dict):
+        raise RuntimeError("deterministic provider captures were not a provider mapping")
+    expected = set(_DETERMINISTIC_PROVIDERS)
+    actual = set(captures)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        unexpected_count = len(actual - expected)
+        raise RuntimeError(
+            "deterministic provider capture set mismatch: "
+            + json.dumps({"missing": missing, "unexpected_count": unexpected_count}, sort_keys=True)
+        )
+    validated: dict[str, dict[str, str]] = {}
+    invalid: list[str] = []
+    for provider in _DETERMINISTIC_PROVIDERS:
+        item = captures[provider]
+        if (
+            not isinstance(item, dict)
+            or set(item) != {"provider", "provider_session_id"}
+            or item.get("provider") != provider
+            or not isinstance(item.get("provider_session_id"), str)
+            or not item["provider_session_id"]
+        ):
+            invalid.append(provider)
+            continue
+        validated[provider] = {"provider": provider, "provider_session_id": item["provider_session_id"]}
+    if invalid:
+        raise RuntimeError("deterministic provider capture entries were malformed: " + ", ".join(invalid))
+    return validated
+
+
+def _redacted_convergence(convergence: dict[str, dict[str, object]]) -> dict[str, dict[str, bool]]:
+    return {
+        provider: {
+            "archive": row.get("archive") is True,
+            "api": row.get("api") is True,
+            "indexed_session_id_present": isinstance(row.get("indexed_session_id"), str),
+        }
+        for provider, row in convergence.items()
+    }
 
 
 def run_proof(*, repo_root: Path | None = None, readiness_timeout_s: float = 45.0) -> dict[str, object]:
@@ -344,17 +409,15 @@ def run_proof(*, repo_root: Path | None = None, readiness_timeout_s: float = 45.
         _await_api(base_url=api_url, timeout_s=readiness_timeout_s)
         session_id = f"polylogue-agentctl-proof-{api_port}-{capture_port}"
         _run_shared_chrome_control(repo_root=checkout)
-        providers = _submit_deterministic_captures(capture_port=capture_port, session_id=session_id)
+        providers = _validated_provider_captures(
+            _submit_deterministic_captures(capture_port=capture_port, session_id=session_id)
+        )
         archive_ok = False
         api_ok = False
         convergence: dict[str, dict[str, object]] = {}
-        for item in providers.values():
-            if not isinstance(item, dict):
-                continue
-            provider = item.get("provider")
-            provider_session_id = item.get("provider_session_id")
-            if not isinstance(provider, str) or not isinstance(provider_session_id, str):
-                continue
+        for provider in _DETERMINISTIC_PROVIDERS:
+            item = providers[provider]
+            provider_session_id = item["provider_session_id"]
             archive_state = _poll_archive_state(
                 receiver_url=receiver_url,
                 provider=provider,
@@ -374,7 +437,10 @@ def run_proof(*, repo_root: Path | None = None, readiness_timeout_s: float = 45.
         archive_ok = bool(convergence) and all(row["archive"] is True for row in convergence.values())
         api_ok = bool(convergence) and all(row["api"] is True for row in convergence.values())
         if not archive_ok or not api_ok:
-            raise RuntimeError("archive/API convergence proof failed: " + json.dumps(convergence, sort_keys=True))
+            raise RuntimeError(
+                "archive/API convergence proof failed: "
+                + json.dumps(_redacted_convergence(convergence), sort_keys=True)
+            )
         return {
             "ok": True,
             "ports": {"api": api_port, "browser_capture": capture_port},

--- a/devtools/dev_loop_service.py
+++ b/devtools/dev_loop_service.py
@@ -280,7 +280,9 @@ def _submit_deterministic_captures(*, capture_port: int, session_id: str) -> dic
     return captures
 
 
-def _poll_archive_state(*, receiver_url: str, provider: str, provider_session_id: str, timeout_s: float) -> bool:
+def _poll_archive_state(
+    *, receiver_url: str, provider: str, provider_session_id: str, timeout_s: float
+) -> dict[str, object] | None:
     query = urlencode({"provider": provider, "provider_session_id": provider_session_id})
     deadline = time.monotonic() + timeout_s
     while time.monotonic() <= deadline:
@@ -289,17 +291,9 @@ def _poll_archive_state(*, receiver_url: str, provider: str, provider_session_id
         except OSError:
             status, payload = 0, {}
         if status == 200 and payload.get("raw_row_exists") is True and payload.get("indexed_session_exists") is True:
-            return True
+            return payload
         time.sleep(0.25)
-    return False
-
-
-def _session_id_for_provider(provider: str, provider_session_id: str) -> str:
-    return (
-        {"chatgpt": "chatgpt-export", "claude-ai": "claude-ai-export"}.get(provider, provider)
-        + ":"
-        + provider_session_id
-    )
+    return None
 
 
 def _fetch_api_messages(*, api_url: str, session_id: str) -> bool:
@@ -342,8 +336,7 @@ def run_proof(*, repo_root: Path | None = None, readiness_timeout_s: float = 45.
         archive_ok = False
         api_ok = False
         if isinstance(providers, dict):
-            archive_rows: list[bool] = []
-            api_rows: list[bool] = []
+            convergence: dict[str, dict[str, object]] = {}
             for item in providers.values():
                 if not isinstance(item, dict):
                     continue
@@ -351,24 +344,29 @@ def run_proof(*, repo_root: Path | None = None, readiness_timeout_s: float = 45.
                 provider_session_id = item.get("provider_session_id")
                 if not isinstance(provider, str) or not isinstance(provider_session_id, str):
                     continue
-                archive_rows.append(
-                    _poll_archive_state(
-                        receiver_url=receiver_url,
-                        provider=provider,
-                        provider_session_id=provider_session_id,
-                        timeout_s=readiness_timeout_s,
-                    )
+                archive_state = _poll_archive_state(
+                    receiver_url=receiver_url,
+                    provider=provider,
+                    provider_session_id=provider_session_id,
+                    timeout_s=readiness_timeout_s,
                 )
-                api_rows.append(
-                    _fetch_api_messages(
-                        api_url=api_url,
-                        session_id=_session_id_for_provider(provider, provider_session_id),
-                    )
+                indexed_session_id = archive_state.get("indexed_session_id") if archive_state is not None else None
+                provider_api_ok = isinstance(indexed_session_id, str) and _fetch_api_messages(
+                    api_url=api_url,
+                    session_id=indexed_session_id,
                 )
-            archive_ok = bool(archive_rows) and all(archive_rows)
-            api_ok = bool(api_rows) and all(api_rows)
+                convergence[provider] = {
+                    "archive": archive_state is not None,
+                    "api": provider_api_ok,
+                    "indexed_session_id": indexed_session_id,
+                }
+            archive_ok = bool(convergence) and all(row["archive"] is True for row in convergence.values())
+            api_ok = bool(convergence) and all(row["api"] is True for row in convergence.values())
         if not archive_ok or not api_ok:
-            raise RuntimeError("archive/API convergence proof failed")
+            raise RuntimeError(
+                "archive/API convergence proof failed: "
+                + json.dumps(convergence if isinstance(providers, dict) else {}, sort_keys=True)
+            )
         return {
             "ok": True,
             "ports": {"api": api_port, "browser_capture": capture_port},

--- a/devtools/dev_loop_service.py
+++ b/devtools/dev_loop_service.py
@@ -33,6 +33,7 @@ _MAX_ERROR_MESSAGE = 512
 _RECEIVER_ORIGIN = "chrome-extension://polylogue-agentctl-proof"
 _RECEIVER_TOKEN = "polylogue-agentctl-proof-token"
 _SHARED_CHROME_TIMEOUT_S = 30
+_CHILD_ERROR_TAIL_CHARS = 384
 
 
 def _leased_port(name: str, bounds: tuple[int, int]) -> int:
@@ -256,7 +257,8 @@ def _run_shared_chrome_control(*, repo_root: Path, timeout_s: float = _SHARED_CH
         terminate_process_group(process)
     completed = subprocess.CompletedProcess(process.args, process.returncode, stdout, stderr)
     if completed.returncode != 0:
-        raise RuntimeError("shared-Chrome control proof did not produce a successful result")
+        detail = " ".join(stderr.split())[-_CHILD_ERROR_TAIL_CHARS:] or f"exit {completed.returncode}"
+        raise RuntimeError(f"shared-Chrome control proof failed: {detail}")
     payload = json.loads(stdout)
     if not isinstance(payload, dict) or payload.get("ok") is not True:
         raise RuntimeError("shared-Chrome control proof reported failure")

--- a/devtools/dev_loop_service.py
+++ b/devtools/dev_loop_service.py
@@ -347,38 +347,34 @@ def run_proof(*, repo_root: Path | None = None, readiness_timeout_s: float = 45.
         providers = _submit_deterministic_captures(capture_port=capture_port, session_id=session_id)
         archive_ok = False
         api_ok = False
-        if isinstance(providers, dict):
-            convergence: dict[str, dict[str, object]] = {}
-            for item in providers.values():
-                if not isinstance(item, dict):
-                    continue
-                provider = item.get("provider")
-                provider_session_id = item.get("provider_session_id")
-                if not isinstance(provider, str) or not isinstance(provider_session_id, str):
-                    continue
-                archive_state = _poll_archive_state(
-                    receiver_url=receiver_url,
-                    provider=provider,
-                    provider_session_id=provider_session_id,
-                    timeout_s=readiness_timeout_s,
-                )
-                indexed_session_id = archive_state.get("indexed_session_id") if archive_state is not None else None
-                provider_api_ok = isinstance(indexed_session_id, str) and _fetch_api_messages(
-                    api_url=api_url,
-                    session_id=indexed_session_id,
-                )
-                convergence[provider] = {
-                    "archive": archive_state is not None,
-                    "api": provider_api_ok,
-                    "indexed_session_id": indexed_session_id,
-                }
-            archive_ok = bool(convergence) and all(row["archive"] is True for row in convergence.values())
-            api_ok = bool(convergence) and all(row["api"] is True for row in convergence.values())
-        if not archive_ok or not api_ok:
-            raise RuntimeError(
-                "archive/API convergence proof failed: "
-                + json.dumps(convergence if isinstance(providers, dict) else {}, sort_keys=True)
+        convergence: dict[str, dict[str, object]] = {}
+        for item in providers.values():
+            if not isinstance(item, dict):
+                continue
+            provider = item.get("provider")
+            provider_session_id = item.get("provider_session_id")
+            if not isinstance(provider, str) or not isinstance(provider_session_id, str):
+                continue
+            archive_state = _poll_archive_state(
+                receiver_url=receiver_url,
+                provider=provider,
+                provider_session_id=provider_session_id,
+                timeout_s=readiness_timeout_s,
             )
+            indexed_session_id = archive_state.get("indexed_session_id") if archive_state is not None else None
+            provider_api_ok = isinstance(indexed_session_id, str) and _fetch_api_messages(
+                api_url=api_url,
+                session_id=indexed_session_id,
+            )
+            convergence[provider] = {
+                "archive": archive_state is not None,
+                "api": provider_api_ok,
+                "indexed_session_id": indexed_session_id,
+            }
+        archive_ok = bool(convergence) and all(row["archive"] is True for row in convergence.values())
+        api_ok = bool(convergence) and all(row["api"] is True for row in convergence.values())
+        if not archive_ok or not api_ok:
+            raise RuntimeError("archive/API convergence proof failed: " + json.dumps(convergence, sort_keys=True))
         return {
             "ok": True,
             "ports": {"api": api_port, "browser_capture": capture_port},

--- a/devtools/dev_loop_service.py
+++ b/devtools/dev_loop_service.py
@@ -32,6 +32,7 @@ _DECLARED_PORTS = {
 _MAX_ERROR_MESSAGE = 512
 _RECEIVER_ORIGIN = "chrome-extension://polylogue-agentctl-proof"
 _RECEIVER_TOKEN = "polylogue-agentctl-proof-token"
+_API_TOKEN = "polylogue-agentctl-proof-api-token"
 _SHARED_CHROME_TIMEOUT_S = 30
 _CHILD_ERROR_TAIL_CHARS = 384
 
@@ -90,13 +91,19 @@ def _proof_environment(*, archive_root: Path, artifact_root: Path, api_port: int
     return environment
 
 
-def _http_get_json(url: str, *, timeout_s: float = 5.0) -> tuple[int, dict[str, object]]:
+def _http_get_json(
+    url: str,
+    *,
+    timeout_s: float = 5.0,
+    bearer_token: str | None = None,
+) -> tuple[int, dict[str, object]]:
     from urllib.parse import urlsplit
 
     parts = urlsplit(url)
     connection = HTTPConnection(parts.hostname or "127.0.0.1", parts.port or 80, timeout=timeout_s)
     try:
-        connection.request("GET", parts.path + (f"?{parts.query}" if parts.query else ""))
+        headers = {"Authorization": f"Bearer {bearer_token}"} if bearer_token is not None else {}
+        connection.request("GET", parts.path + (f"?{parts.query}" if parts.query else ""), headers=headers)
         response = connection.getresponse()
         body = json.loads(response.read().decode("utf-8"))
         return response.status, body if isinstance(body, dict) else {"body": body}
@@ -215,6 +222,8 @@ def _start_daemon(
         str(spool),
         "--browser-capture-auth-token",
         _RECEIVER_TOKEN,
+        "--api-auth-token",
+        _API_TOKEN,
         "--no-source-catchup",
     ]
     with log_path.open("w", encoding="utf-8") as log_file:
@@ -287,7 +296,7 @@ def _poll_archive_state(
     deadline = time.monotonic() + timeout_s
     while time.monotonic() <= deadline:
         try:
-            status, payload = _http_get_json(f"{receiver_url}/v1/archive-state?{query}")
+            status, payload = _http_get_json(f"{receiver_url}/v1/archive-state?{query}", bearer_token=_RECEIVER_TOKEN)
         except OSError:
             status, payload = 0, {}
         if status == 200 and payload.get("raw_row_exists") is True and payload.get("indexed_session_exists") is True:
@@ -297,7 +306,10 @@ def _poll_archive_state(
 
 
 def _fetch_api_messages(*, api_url: str, session_id: str) -> bool:
-    status, payload = _http_get_json(f"{api_url}/api/sessions/{quote(session_id, safe='')}/messages?limit=5")
+    status, payload = _http_get_json(
+        f"{api_url}/api/sessions/{quote(session_id, safe='')}/messages?limit=5",
+        bearer_token=_API_TOKEN,
+    )
     return status == 200 and isinstance(payload.get("messages"), list) and bool(payload["messages"])
 
 

--- a/devtools/sinnixd_service_context.py
+++ b/devtools/sinnixd_service_context.py
@@ -117,7 +117,7 @@ def require_declared_service_context(
 
 
 def terminate_process_group(process: subprocess.Popen[Any], *, timeout_s: float = 2.0) -> None:
-    """Terminate a launcher and all children in its dedicated process group."""
+    """Boundedly signal a process group; systemd remains final cgroup reaper."""
     try:
         os.killpg(process.pid, signal.SIGTERM)
     except ProcessLookupError:
@@ -132,4 +132,5 @@ def terminate_process_group(process: subprocess.Popen[Any], *, timeout_s: float 
     except ProcessLookupError:
         return
     if process.poll() is None:
-        process.wait(timeout=timeout_s)
+        with suppress(subprocess.TimeoutExpired):
+            process.wait(timeout=timeout_s)

--- a/flake.nix
+++ b/flake.nix
@@ -461,7 +461,7 @@
           pyc_should_clean=1
           if [ -f "$pyc_stamp" ]; then
             last_clean=$(stat -c %Y "$pyc_stamp" 2>/dev/null || echo 0)
-            newest_src=$(find polylogue tests devtools -name '*.py' -printf '%T@\n' 2>/dev/null | sort -rn | head -1 | cut -d. -f1)
+            newest_src=$(find polylogue tests devtools -name '*.py' -printf '%T@\n' 2>/dev/null | sort -rn | sed -n '1p' | cut -d. -f1)
             if [ -n "$newest_src" ] && [ "$last_clean" -ge "$newest_src" ]; then
               pyc_should_clean=0
             fi

--- a/polylogue/browser_capture/receiver.py
+++ b/polylogue/browser_capture/receiver.py
@@ -339,7 +339,10 @@ def _open_readonly_sqlite(path: Path) -> sqlite3.Connection | None:
 
 
 def _columns(conn: sqlite3.Connection, table_name: str) -> set[str]:
-    return {str(row["name"]) for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()}
+    # ``sessions.session_id`` is a generated canonical identity. SQLite's
+    # table_info projection omits generated columns, while table_xinfo includes
+    # both ordinary and generated columns with the same ``name`` field.
+    return {str(row["name"]) for row in conn.execute(f"PRAGMA table_xinfo({table_name})").fetchall()}
 
 
 def _origin_candidates_for_provider(provider: str) -> tuple[str, ...]:

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -4646,6 +4646,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             lineage=lineage,
         )
         return {
+            "session_id": session_id,
             "messages": [
                 {
                     "id": str(msg.id),
@@ -4723,6 +4724,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         total = envelope.total_message_count if envelope.total_message_count is not None else len(page)
         placement = self._archive_semantic_card_placement(envelope)
         return {
+            "session_id": envelope.session_id,
             "messages": [
                 self._archive_message_payload(
                     envelope.session_id,

--- a/tests/unit/browser_capture/test_receiver.py
+++ b/tests/unit/browser_capture/test_receiver.py
@@ -144,7 +144,8 @@ def _seed_browser_capture_archive(
         conn.execute(
             """
             CREATE TABLE sessions (
-                session_id TEXT,
+                origin TEXT NOT NULL,
+                session_id TEXT GENERATED ALWAYS AS (origin || ':' || native_id) STORED UNIQUE,
                 raw_id TEXT,
                 native_id TEXT,
                 message_count INTEGER,
@@ -154,10 +155,10 @@ def _seed_browser_capture_archive(
         )
         conn.execute(
             """
-            INSERT INTO sessions (session_id, raw_id, native_id, message_count, updated_at_ms)
+            INSERT INTO sessions (origin, raw_id, native_id, message_count, updated_at_ms)
             VALUES (?, ?, ?, ?, ?)
             """,
-            (f"chatgpt-export:{native_id}", raw_id, native_id, message_count, updated_at_ms),
+            ("chatgpt-export", raw_id, native_id, message_count, updated_at_ms),
         )
 
 
@@ -754,6 +755,7 @@ def test_receiver_archive_state_reports_archived_only_with_raw_index_and_message
     assert state.captured is True
     assert state.raw_row_exists is True
     assert state.indexed_session_exists is True
+    assert state.indexed_session_id == "chatgpt-export:conv-123"
     assert state.indexed_message_count == 1
 
 

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -1417,6 +1417,7 @@ class TestReaderSessionState:
         with _running_server(workspace_env) as (_, base_url):
             payload = _get_json(base_url, "/api/sessions/claude-code-session:c1/messages")
         assert isinstance(payload, dict)
+        assert payload["session_id"] == C1
         assert payload["total"] == 1
         message = payload["messages"][0]
         assert message["text"] == "Hello reader"

--- a/tests/unit/devtools/test_deployment_browser_smoke_service.py
+++ b/tests/unit/devtools/test_deployment_browser_smoke_service.py
@@ -344,3 +344,34 @@ try {
     payload = json.loads(completed.stdout)
     assert payload["message"] == "shared Chrome deployment render did not contain the Polylogue root marker"
     assert payload["calls"][-1] == ["close", "C" * 32]
+
+
+def test_shared_chrome_signal_cleanup_closes_only_the_owned_target_once() -> None:
+    program = r"""
+import { createOwnedTargetCleanup } from './scripts/shared_chrome_proof_cleanup.mjs';
+
+const targetId = 'D'.repeat(32);
+const unrelatedTargetId = 'E'.repeat(32);
+const cleanup = createOwnedTargetCleanup({
+  targetId,
+  control: async (args) => {
+    if (args[0] !== 'close' || args[1] !== targetId) throw new Error('attempted to close an unowned target');
+    process.stdout.write(JSON.stringify({ closed: args[1] }) + '\n');
+  },
+});
+process.stdout.write(JSON.stringify({ ready: true, unrelatedTargetId }) + '\n');
+setInterval(() => {}, 1000);
+setTimeout(() => process.kill(process.pid, 'SIGTERM'), 10);
+await new Promise(() => {});
+"""
+    completed = subprocess.run(
+        ["node", "--input-type=module", "--eval", program],
+        cwd="browser-extension",
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == -15, completed.stderr
+    events = [json.loads(line) for line in completed.stdout.splitlines() if line]
+    assert events == [{"ready": True, "unrelatedTargetId": "E" * 32}, {"closed": "D" * 32}]

--- a/tests/unit/devtools/test_dev_loop_service.py
+++ b/tests/unit/devtools/test_dev_loop_service.py
@@ -189,6 +189,25 @@ def test_shared_chrome_control_is_the_only_dev_loop_browser_handoff(
     assert not {name for name in environment if name.startswith("POLYLOGUE_") and ("CDP" in name or "PROFILE" in name)}
 
 
+def test_shared_chrome_control_preserves_bounded_child_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    process = type(
+        "Process",
+        (),
+        {
+            "args": ["node", "scripts/dev_loop_shared_chrome_proof.mjs"],
+            "returncode": 1,
+            "communicate": lambda self, **_kwargs: ("", "first line\ncontrol boundary rejected the window\n"),
+        },
+    )()
+    monkeypatch.setattr(subprocess, "Popen", lambda *_args, **_kwargs: process)
+    monkeypatch.setattr(dev_loop_service, "terminate_process_group", lambda _process: None)
+
+    with pytest.raises(RuntimeError, match="control boundary rejected the window") as failure:
+        dev_loop_service._run_shared_chrome_control(repo_root=tmp_path)
+
+    assert "\n" not in str(failure.value)
+
+
 def test_deterministic_captures_still_exercise_receiver_provider_identity(monkeypatch: pytest.MonkeyPatch) -> None:
     observed: list[dict[str, object]] = []
 

--- a/tests/unit/devtools/test_dev_loop_service.py
+++ b/tests/unit/devtools/test_dev_loop_service.py
@@ -131,7 +131,23 @@ def test_convergence_reads_use_the_matching_service_tokens(monkeypatch: pytest.M
         observed.append({"url": url, **kwargs})
         if "archive-state" in url:
             return 200, {"raw_row_exists": True, "indexed_session_exists": True, "indexed_session_id": "indexed"}
-        return 200, {"messages": [{"role": "user", "text": "proof"}]}
+        return 200, {
+            "session_id": "indexed",
+            "messages": [
+                {
+                    "id": "message-1",
+                    "role": "user",
+                    "text": "proof",
+                    "target_ref": {
+                        "target_type": "message",
+                        "target_id": "message-1",
+                        "session_id": "indexed",
+                        "message_id": "message-1",
+                        "identity_key": "message:indexed:message-1",
+                    },
+                }
+            ],
+        }
 
     monkeypatch.setattr(dev_loop_service, "_http_get_json", fake_get)
 
@@ -155,6 +171,51 @@ def test_convergence_reads_use_the_matching_service_tokens(monkeypatch: pytest.M
             "bearer_token": dev_loop_service._API_TOKEN,
         },
     ]
+
+
+def test_run_proof_rejects_one_malformed_expected_provider_before_convergence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _fixed_service_context(monkeypatch)
+    monkeypatch.setenv("TMPDIR", str(tmp_path / "scratch"))
+    monkeypatch.setattr(dev_loop_service, "initialize_active_archive_root", lambda _root: None)
+    monkeypatch.setattr(dev_loop_service, "run_receiver_smoke", lambda **_kwargs: {"ok": True})
+    monkeypatch.setattr(dev_loop_service, "_start_daemon", lambda **_kwargs: object())
+    monkeypatch.setattr(dev_loop_service, "terminate_process_group", lambda _process: None)
+    monkeypatch.setattr(dev_loop_service, "_await_api", lambda **_kwargs: None)
+    monkeypatch.setattr(dev_loop_service, "_run_shared_chrome_control", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        dev_loop_service,
+        "_submit_deterministic_captures",
+        lambda **_kwargs: {
+            "chatgpt": {"provider": "chatgpt", "provider_session_id": "capture-id"},
+            "claude-ai": {"provider": "claude-ai"},
+        },
+    )
+    monkeypatch.setattr(
+        dev_loop_service,
+        "_poll_archive_state",
+        lambda **_kwargs: pytest.fail("malformed captures must fail before convergence polling"),
+    )
+
+    with pytest.raises(RuntimeError, match="entries were malformed: claude-ai"):
+        dev_loop_service.run_proof()
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"session_id": "wrong", "messages": [{"id": "message-1", "role": "user", "target_ref": {}}]},
+        {"session_id": "indexed", "messages": [{}]},
+        {"session_id": "indexed", "messages": []},
+    ],
+)
+def test_api_message_convergence_rejects_wrong_or_malformed_response(
+    monkeypatch: pytest.MonkeyPatch, payload: dict[str, object]
+) -> None:
+    monkeypatch.setattr(dev_loop_service, "_http_get_json", lambda *_args, **_kwargs: (200, payload))
+
+    assert dev_loop_service._fetch_api_messages(api_url="http://api", session_id="indexed") is False
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/devtools/test_dev_loop_service.py
+++ b/tests/unit/devtools/test_dev_loop_service.py
@@ -68,7 +68,11 @@ def test_run_proof_uses_only_agentctl_injected_ports_and_product_convergence(
             "claude-ai": {"provider": "claude-ai", "provider_session_id": "agentctl-proof-claude-ai"},
         },
     )
-    monkeypatch.setattr(dev_loop_service, "_poll_archive_state", lambda **_kwargs: True)
+    monkeypatch.setattr(
+        dev_loop_service,
+        "_poll_archive_state",
+        lambda **kwargs: {"indexed_session_id": f"indexed:{kwargs['provider_session_id']}"},
+    )
     monkeypatch.setattr(dev_loop_service, "_fetch_api_messages", lambda **_kwargs: True)
 
     payload = dev_loop_service.run_proof()

--- a/tests/unit/devtools/test_dev_loop_service.py
+++ b/tests/unit/devtools/test_dev_loop_service.py
@@ -97,7 +97,7 @@ def test_run_proof_uses_only_agentctl_injected_ports_and_product_convergence(
     assert environment["POLYLOGUE_BROWSER_CAPTURE_PORT"] == "48865"
 
 
-def test_started_daemon_uses_the_proof_receiver_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_started_daemon_uses_fixed_proof_tokens(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     artifact_root = tmp_path / "artifacts"
     artifact_root.mkdir()
     launched: dict[str, object] = {}
@@ -120,6 +120,41 @@ def test_started_daemon_uses_the_proof_receiver_token(tmp_path: Path, monkeypatc
     assert isinstance(command, list)
     token_index = command.index("--browser-capture-auth-token")
     assert command[token_index + 1] == dev_loop_service._RECEIVER_TOKEN
+    api_token_index = command.index("--api-auth-token")
+    assert command[api_token_index + 1] == dev_loop_service._API_TOKEN
+
+
+def test_convergence_reads_use_the_matching_service_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
+    observed: list[dict[str, object]] = []
+
+    def fake_get(url: str, **kwargs: object) -> tuple[int, dict[str, object]]:
+        observed.append({"url": url, **kwargs})
+        if "archive-state" in url:
+            return 200, {"raw_row_exists": True, "indexed_session_exists": True, "indexed_session_id": "indexed"}
+        return 200, {"messages": [{"role": "user", "text": "proof"}]}
+
+    monkeypatch.setattr(dev_loop_service, "_http_get_json", fake_get)
+
+    assert (
+        dev_loop_service._poll_archive_state(
+            receiver_url="http://receiver",
+            provider="chatgpt",
+            provider_session_id="proof",
+            timeout_s=0.1,
+        )
+        is not None
+    )
+    assert dev_loop_service._fetch_api_messages(api_url="http://api", session_id="indexed") is True
+    assert observed == [
+        {
+            "url": "http://receiver/v1/archive-state?provider=chatgpt&provider_session_id=proof",
+            "bearer_token": dev_loop_service._RECEIVER_TOKEN,
+        },
+        {
+            "url": "http://api/api/sessions/indexed/messages?limit=5",
+            "bearer_token": dev_loop_service._API_TOKEN,
+        },
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/devtools/test_sinnixd_service_context.py
+++ b/tests/unit/devtools/test_sinnixd_service_context.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import os
+import signal
 import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 
@@ -119,3 +121,26 @@ def test_terminate_process_group_reaps_descendants(tmp_path: Path) -> None:
             os.kill(descendant, 0)
     finally:
         terminate_process_group(process, timeout_s=0.2)
+
+
+def test_terminate_process_group_leaves_final_reap_to_systemd_after_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    signals: list[tuple[int, signal.Signals]] = []
+
+    class StubbornProcess:
+        pid = 4242
+
+        @staticmethod
+        def poll() -> None:
+            return None
+
+        @staticmethod
+        def wait(*, timeout: float) -> None:
+            raise subprocess.TimeoutExpired(cmd=["stubborn"], timeout=timeout)
+
+    monkeypatch.setattr(os, "killpg", lambda pid, sig: signals.append((pid, sig)))
+
+    terminate_process_group(cast(Any, StubbornProcess()), timeout_s=0.01)
+
+    assert signals == [(4242, signal.SIGTERM), (4242, signal.SIGKILL)]


### PR DESCRIPTION
## What changed

- make the AgentCTL dev-loop proof use the existing shared Chrome profile and hidden agent workspace
- authenticate convergence reads and follow the indexed archive session identity through the API proof
- bound process cleanup and preserve browser-proof failures
- cover the receiver, service-context, and convergence contracts with focused tests

## Verification

- `devtools test tests/unit/browser_capture/test_receiver.py tests/unit/devtools/test_dev_loop_service.py tests/unit/devtools/test_sinnixd_service_context.py -n 0`: 70 passed
- AgentCTL `dev_loop_proof` job `c8d01c27-9157-4e17-a0f8-6094b271f33d`: succeeded with authenticated ChatGPT and Claude captures, archive convergence, API convergence, and released leases
- AgentCTL `verify_quick` job `71b0714b-2ffa-414b-8eb0-7a2c82666c88`: succeeded at `cdc86b2f0`
- pre-push quick verification baseline: passed

## Operator isolation

The live proof did not create an agent-private browser process or profile. It used the existing Chrome instance, left the operator's workspace-5 window untouched, and left no visible `agentbrowser` client after completion.
