### PR TITLE
Own and bound managed pytest scratch

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -29,6 +29,15 @@ devtools verify
 nix flake check
 ```
 
+Managed pytest invocations allocate a unique Btrfs/NVMe scratch lease under
+`/realm/tmp/polylogue-pytest/runs`. The runner records apparent and allocated
+bytes, file counts, Btrfs exclusive/shared extent evidence where available,
+and per-worker/test observed high-water values in its verification receipt.
+The lease is removed after every terminal outcome. Failed runs retain at most
+64 MiB of small diagnostic files plus a manifest; abandoned leases are reclaimed
+only after their owner process is proven dead. Do not pass `--basetemp` to
+`devtools test` or `devtools verify`: the runner owns that isolation boundary.
+
 ### First-party browser credential journey
 
 The browser security journey launches the production daemon against a fresh,

--- a/TESTING.md
+++ b/TESTING.md
@@ -33,6 +33,8 @@ Managed pytest invocations allocate a unique Btrfs/NVMe scratch lease under
 `/realm/tmp/polylogue-pytest/runs`. The runner records apparent and allocated
 bytes, file counts, Btrfs exclusive/shared extent evidence where available,
 and per-worker/test observed high-water values in its verification receipt.
+The high-water record is explicitly scoped to observed test trees and the
+terminal lease scan; it does not claim a complete concurrent peak.
 The lease is removed after every terminal outcome. Failed runs retain at most
 64 MiB of small diagnostic files plus a manifest; abandoned leases are reclaimed
 only after their owner process is proven dead. Do not pass `--basetemp` to

--- a/devtools/pytest_progress_plugin.py
+++ b/devtools/pytest_progress_plugin.py
@@ -37,6 +37,7 @@ _SLOW_REPORT_LIMIT = 20
 _DEFAULT_SELECTION_NODEID_LIMIT = 500
 _COLLECTION_FACT_SUFFIX = ".collection.json"
 _ARTIFACT_ENV_NAMES = (_EVENTS_ENV, _EVENTS_DIR_ENV, _SELECTION_ENV, _SUMMARY_ENV)
+_SCRATCH_HIGH_WATER: dict[str, int] = {"apparent_bytes": 0, "allocated_bytes": 0, "file_count": 0, "directory_count": 0}
 
 
 @dataclass
@@ -50,6 +51,7 @@ class _SessionState:
     collection_duration_s: float | None
     controller_collection_payload: dict[str, Any] | None
     artifact_environment: dict[str, str | None]
+    scratch_high_water: dict[str, int]
 
 
 _SESSION_STATE_STACK: list[_SessionState] = []
@@ -68,6 +70,7 @@ def _capture_session_state() -> _SessionState:
             dict(_CONTROLLER_COLLECTION_PAYLOAD) if _CONTROLLER_COLLECTION_PAYLOAD else None
         ),
         artifact_environment={name: os.environ.get(name) for name in _ARTIFACT_ENV_NAMES},
+        scratch_high_water=dict(_SCRATCH_HIGH_WATER),
     )
 
 
@@ -88,6 +91,8 @@ def _restore_session_state(state: _SessionState) -> None:
             os.environ.pop(name, None)
         else:
             os.environ[name] = value
+    _SCRATCH_HIGH_WATER.clear()
+    _SCRATCH_HIGH_WATER.update(state.scratch_high_water)
 
 
 def _reset_session_state() -> None:
@@ -101,6 +106,34 @@ def _reset_session_state() -> None:
     _COLLECTION_STARTED_AT = None
     _COLLECTION_DURATION_S = None
     _CONTROLLER_COLLECTION_PAYLOAD = None
+    for key in _SCRATCH_HIGH_WATER:
+        _SCRATCH_HIGH_WATER[key] = 0
+
+
+def record_test_scratch_usage(nodeid: str, root: Path) -> None:
+    """Record the test-owned temp tree without scanning every worker root."""
+    if not os.environ.get("POLYLOGUE_PYTEST_SCRATCH_ROOT"):
+        return
+    from devtools.pytest_scratch import measure_tree
+
+    usage = measure_tree(root)
+    payload = {
+        "apparent_bytes": usage.apparent_bytes,
+        "allocated_bytes": usage.allocated_bytes,
+        "file_count": usage.file_count,
+        "directory_count": usage.directory_count,
+    }
+    for key, value in payload.items():
+        _SCRATCH_HIGH_WATER[key] = max(_SCRATCH_HIGH_WATER[key], value)
+    _write_event(
+        {
+            "event": "scratch_test_observed",
+            "nodeid": nodeid,
+            "lane": os.environ.get("POLYLOGUE_PYTEST_SCRATCH_LANE"),
+            "usage": payload,
+            "high_water": dict(_SCRATCH_HIGH_WATER),
+        }
+    )
 
 
 def _isolate_nested_artifact_destinations() -> None:
@@ -413,6 +446,13 @@ def pytest_sessionfinish(session: Any, exitstatus: int) -> None:
     """Write a compact post-run diagnosis artifact independent of pytest-json-report."""
     del session
     try:
+        _write_event(
+            {
+                "event": "scratch_worker_high_water",
+                "lane": os.environ.get("POLYLOGUE_PYTEST_SCRATCH_LANE"),
+                "high_water": dict(_SCRATCH_HIGH_WATER),
+            }
+        )
         # Worker processes have their own in-memory slowest lists. The controller
         # receives the forwarded timings and is the only writer for the shared
         # summary path, so an empty worker summary cannot overwrite it.

--- a/devtools/pytest_scratch.py
+++ b/devtools/pytest_scratch.py
@@ -1,0 +1,256 @@
+"""Owned, measured scratch leases for managed pytest invocations.
+
+Pytest deliberately retains a supplied ``--basetemp`` tree. The managed test
+runners therefore give every invocation a private lease and reclaim only that
+lease after recording its terminal footprint. A killed runner leaves a marker
+behind; a later invocation may reclaim it only after proving its owner process
+is gone.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import time
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from devtools.cloud_sentinels import cloud_sentinel_declined
+
+DEFAULT_SCRATCH_ROOT = Path("/realm/tmp/polylogue-pytest")
+FALLBACK_SCRATCH_ROOT = Path("/tmp/polylogue-pytest")
+_SUBPROCESS_RUN = subprocess.run
+_LEASE_FILE = "lease.json"
+_MAX_STALE_LEASES_PER_START = 32
+_MAX_FAILURE_ARTIFACT_BYTES = 64 * 1024 * 1024
+_MAX_FAILURE_ARTIFACT_FILE_BYTES = 8 * 1024 * 1024
+_MAX_FAILURE_ARTIFACT_FILES = 1_000
+
+
+@dataclass(frozen=True)
+class ScratchUsage:
+    apparent_bytes: int
+    allocated_bytes: int
+    file_count: int
+    directory_count: int
+
+
+def measure_tree(root: Path) -> ScratchUsage:
+    """Count a tree without following symlinks or failing a test teardown."""
+    apparent = allocated = files = directories = 0
+    pending = [root]
+    while pending:
+        directory = pending.pop()
+        try:
+            entries = tuple(os.scandir(directory))
+        except OSError:
+            continue
+        directories += 1
+        for entry in entries:
+            try:
+                info = entry.stat(follow_symlinks=False)
+            except OSError:
+                continue
+            if entry.is_dir(follow_symlinks=False):
+                pending.append(Path(entry.path))
+            elif entry.is_file(follow_symlinks=False):
+                files += 1
+                apparent += info.st_size
+                allocated += info.st_blocks * 512
+    return ScratchUsage(apparent, allocated, files, directories)
+
+
+def _size_bytes(raw: str) -> int | None:
+    match = re.fullmatch(r"([0-9.]+)(B|KiB|MiB|GiB|TiB)", raw)
+    if match is None:
+        return None
+    scale = {"B": 1, "KiB": 1024, "MiB": 1024**2, "GiB": 1024**3, "TiB": 1024**4}[match.group(2)]
+    return int(float(match.group(1)) * scale)
+
+
+def btrfs_extent_usage(root: Path) -> dict[str, int] | None:
+    """Return Btrfs exclusive/shared bytes when the local tool can prove them."""
+    try:
+        result = _SUBPROCESS_RUN(
+            ["btrfs", "filesystem", "du", "-s", str(root)], capture_output=True, text=True, timeout=5, check=False
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode:
+        return None
+    for line in result.stdout.splitlines():
+        fields = line.split()
+        if len(fields) < 4 or fields[0] == "Total":
+            continue
+        total, exclusive, shared = (_size_bytes(field) for field in fields[:3])
+        if total is not None and exclusive is not None and shared is not None:
+            return {
+                "btrfs_total_bytes": total,
+                "btrfs_exclusive_bytes": exclusive,
+                "btrfs_shared_bytes": shared,
+            }
+    return None
+
+
+def scratch_root_from_environment(environment: Mapping[str, str] | None = None) -> Path:
+    resolved_environment = os.environ if environment is None else environment
+    raw = resolved_environment.get("POLYLOGUE_PYTEST_BASETEMP_ROOT")
+    if raw and not cloud_sentinel_declined("POLYLOGUE_PYTEST_BASETEMP_ROOT", raw):
+        return Path(raw).expanduser()
+    return DEFAULT_SCRATCH_ROOT if DEFAULT_SCRATCH_ROOT.parent.is_dir() else FALLBACK_SCRATCH_ROOT
+
+
+def _process_start_ticks(pid: int) -> str | None:
+    try:
+        # Field 22 is the start time. Split after the only parenthesized field,
+        # whose command text may contain spaces.
+        return Path(f"/proc/{pid}/stat").read_text(encoding="utf-8").rsplit(") ", 1)[1].split()[19]
+    except (OSError, IndexError):
+        return None
+
+
+def _owner_is_alive(payload: dict[str, Any]) -> bool:
+    pid = payload.get("pid")
+    start = payload.get("process_start_ticks")
+    return isinstance(pid, int) and isinstance(start, str) and _process_start_ticks(pid) == start
+
+
+def _read_lease(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _prune_stale_leases(root: Path) -> tuple[str, ...]:
+    removed: list[str] = []
+    leases_root = root / "runs"
+    if not leases_root.is_dir():
+        return ()
+    for marker in sorted(leases_root.glob(f"*/*/{_LEASE_FILE}"))[:_MAX_STALE_LEASES_PER_START]:
+        payload = _read_lease(marker)
+        if payload is None or not _owner_is_alive(payload):
+            lease_root = marker.parent
+            shutil.rmtree(lease_root, ignore_errors=True)
+            removed.append(str(lease_root))
+    # A completed lane removes its leaf. Reclaim empty run containers later;
+    # active or sibling lanes keep their container non-empty and untouched.
+    for run_root in sorted(leases_root.iterdir()):
+        with contextlib.suppress(OSError):
+            run_root.rmdir()
+            removed.append(str(run_root))
+    return tuple(removed)
+
+
+def _capture_failure_artifacts(source: Path, destination: Path) -> dict[str, Any]:
+    """Keep small diagnostic files, never a second incident-scale corpus."""
+    copied: list[str] = []
+    skipped: list[dict[str, Any]] = []
+    total = 0
+    candidates = sorted(path for path in source.rglob("*") if path.is_file() and not path.is_symlink())
+    for path in candidates[:_MAX_FAILURE_ARTIFACT_FILES]:
+        relative = path.relative_to(source)
+        try:
+            size = path.stat().st_size
+        except OSError:
+            continue
+        if size > _MAX_FAILURE_ARTIFACT_FILE_BYTES or total + size > _MAX_FAILURE_ARTIFACT_BYTES:
+            skipped.append({"path": str(relative), "size": size, "reason": "artifact_budget"})
+            continue
+        target = destination / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with contextlib.suppress(OSError):
+            shutil.copy2(path, target, follow_symlinks=False)
+            total += size
+            copied.append(str(relative))
+    payload = {"copied_bytes": total, "copied_files": copied, "skipped": skipped}
+    destination.mkdir(parents=True, exist_ok=True)
+    (destination / "manifest.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return payload
+
+
+Outcome = Literal["success", "failure", "cancelled", "worker_crash"]
+
+
+@dataclass
+class PytestScratchLease:
+    root: Path
+    lease_root: Path
+    basetemp: Path
+    evidence_dir: Path
+    run_id: str
+    lane: str
+    stale_leases_reclaimed: tuple[str, ...]
+
+    @classmethod
+    def acquire(cls, *, root: Path, run_id: str, lane: str, evidence_dir: Path) -> PytestScratchLease:
+        root = root.resolve()
+        root.mkdir(parents=True, exist_ok=True)
+        stale = _prune_stale_leases(root)
+        safe_lane = re.sub(r"[^a-z0-9_.-]+", "-", lane.lower()).strip("-") or "pytest"
+        lease_root = root / "runs" / run_id / safe_lane
+        lease_root.mkdir(parents=True, exist_ok=False)
+        marker = {
+            "run_id": run_id,
+            "lane": safe_lane,
+            "pid": os.getpid(),
+            "process_start_ticks": _process_start_ticks(os.getpid()),
+            "created_monotonic_ns": time.monotonic_ns(),
+        }
+        (lease_root / _LEASE_FILE).write_text(json.dumps(marker, sort_keys=True) + "\n", encoding="utf-8")
+        return cls(root, lease_root, lease_root / "pytest", evidence_dir, run_id, safe_lane, stale)
+
+    def command(self, command: list[str]) -> list[str]:
+        if any(argument == "--basetemp" or argument.startswith("--basetemp=") for argument in command):
+            raise ValueError("managed pytest owns --basetemp; do not supply a shared path")
+        return [*command, f"--basetemp={self.basetemp}"]
+
+    def environment(self, environment: dict[str, str]) -> dict[str, str]:
+        return {
+            **environment,
+            "POLYLOGUE_PYTEST_SCRATCH_ROOT": str(self.basetemp),
+            "POLYLOGUE_PYTEST_SCRATCH_LANE": self.lane,
+        }
+
+    def finalize(self, outcome: Outcome) -> dict[str, Any]:
+        terminal = measure_tree(self.lease_root)
+        extent = btrfs_extent_usage(self.lease_root)
+        artifacts: dict[str, Any] | None = None
+        if outcome != "success" and self.basetemp.exists():
+            artifacts = _capture_failure_artifacts(self.basetemp, self.evidence_dir / "scratch-failure-artifacts")
+        cleanup_started = time.monotonic_ns()
+        shutil.rmtree(self.lease_root, ignore_errors=True)
+        # A verifier run can own several sequential lanes. Remove only this
+        # run's now-empty container, never the shared ``runs`` namespace or a
+        # sibling lane still in flight.
+        with contextlib.suppress(OSError):
+            self.lease_root.parent.rmdir()
+        payload: dict[str, Any] = {
+            "run_id": self.run_id,
+            "lane": self.lane,
+            "outcome": outcome,
+            "terminal_usage": asdict(terminal),
+            "high_water_usage": asdict(terminal),
+            "stale_leases_reclaimed": list(self.stale_leases_reclaimed),
+            "cleanup_complete": not self.lease_root.exists(),
+            "cleanup_started_monotonic_ns": cleanup_started,
+        }
+        if extent is not None:
+            payload["extent_usage"] = extent
+        if artifacts is not None:
+            payload["failure_artifacts"] = artifacts
+        self.evidence_dir.mkdir(parents=True, exist_ok=True)
+        (self.evidence_dir / "scratch-metrics.json").write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        return payload
+
+
+__all__ = ["PytestScratchLease", "ScratchUsage", "btrfs_extent_usage", "measure_tree", "scratch_root_from_environment"]

--- a/devtools/pytest_scratch.py
+++ b/devtools/pytest_scratch.py
@@ -10,18 +10,22 @@ is gone.
 from __future__ import annotations
 
 import contextlib
+import fcntl
 import json
 import os
 import re
 import shutil
+import signal
+import stat
 import subprocess
 import time
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Literal
+from uuid import uuid4
 
-from devtools.cloud_sentinels import cloud_sentinel_declined
+from devtools.cloud_sentinels import cloud_sentinel_declined, running_in_cloud_sandbox
 
 DEFAULT_SCRATCH_ROOT = Path("/realm/tmp/polylogue-pytest")
 FALLBACK_SCRATCH_ROOT = Path("/tmp/polylogue-pytest")
@@ -103,7 +107,11 @@ def scratch_root_from_environment(environment: Mapping[str, str] | None = None) 
     raw = resolved_environment.get("POLYLOGUE_PYTEST_BASETEMP_ROOT")
     if raw and not cloud_sentinel_declined("POLYLOGUE_PYTEST_BASETEMP_ROOT", raw):
         return Path(raw).expanduser()
-    return DEFAULT_SCRATCH_ROOT if DEFAULT_SCRATCH_ROOT.parent.is_dir() else FALLBACK_SCRATCH_ROOT
+    if DEFAULT_SCRATCH_ROOT.parent.is_dir():
+        return DEFAULT_SCRATCH_ROOT
+    if running_in_cloud_sandbox():
+        return FALLBACK_SCRATCH_ROOT
+    raise RuntimeError("managed pytest requires the workstation scratch mount at /realm/tmp")
 
 
 def _process_start_ticks(pid: int) -> str | None:
@@ -119,6 +127,18 @@ def _owner_is_alive(payload: dict[str, Any]) -> bool:
     pid = payload.get("pid")
     start = payload.get("process_start_ticks")
     return isinstance(pid, int) and isinstance(start, str) and _process_start_ticks(pid) == start
+
+
+@contextlib.contextmanager
+def _lease_lock(root: Path) -> Any:
+    """Serialize lease creation and stale cleanup within one scratch root."""
+    root.mkdir(parents=True, exist_ok=True)
+    with (root / ".lease.lock").open("a+") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
 def _read_lease(path: Path) -> dict[str, Any] | None:
@@ -149,29 +169,127 @@ def _prune_stale_leases(root: Path) -> tuple[str, ...]:
     return tuple(removed)
 
 
+_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+_DIRECTORY = getattr(os, "O_DIRECTORY", 0)
+
+
+def _open_directory_chain(root: Path, parts: tuple[str, ...], *, create: bool = False) -> int:
+    fd = os.open(root, os.O_RDONLY | _DIRECTORY | _NOFOLLOW)
+    try:
+        for part in parts:
+            if create:
+                with contextlib.suppress(FileExistsError):
+                    os.mkdir(part, mode=0o700, dir_fd=fd)
+            next_fd = os.open(part, os.O_RDONLY | _DIRECTORY | _NOFOLLOW, dir_fd=fd)
+            os.close(fd)
+            fd = next_fd
+        return fd
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def _copy_bounded_file(source: Path, destination: Path, relative: Path, limit: int) -> tuple[str, int] | None:
+    """Copy one regular file through no-following directory descriptors."""
+    source_fd = _open_directory_chain(source, tuple(relative.parts[:-1]))
+    try:
+        destination_fd = _open_directory_chain(destination, tuple(relative.parts[:-1]), create=True)
+        try:
+            target_name = relative.name
+            target_fd: int | None = None
+            source_file_fd = os.open(target_name, os.O_RDONLY | _NOFOLLOW, dir_fd=source_fd)
+            try:
+                source_stat = os.fstat(source_file_fd)
+                if not stat.S_ISREG(source_stat.st_mode):
+                    return None
+                size = source_stat.st_size
+                if size > _MAX_FAILURE_ARTIFACT_FILE_BYTES:
+                    return "artifact_budget", size
+                if size > limit:
+                    return "artifact_budget", size
+                target_fd = os.open(
+                    target_name,
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL | _NOFOLLOW,
+                    mode=0o600,
+                    dir_fd=destination_fd,
+                )
+                remaining = size
+                while remaining:
+                    chunk = os.read(source_file_fd, min(1024 * 1024, remaining))
+                    if not chunk:
+                        break
+                    view = memoryview(chunk)
+                    while view:
+                        written = os.write(target_fd, view)
+                        view = view[written:]
+                    remaining -= len(chunk)
+                if remaining:
+                    os.close(target_fd)
+                    target_fd = None
+                    os.unlink(target_name, dir_fd=destination_fd)
+                    return None
+                return "copied", size
+            finally:
+                os.close(source_file_fd)
+                if target_fd is not None:
+                    os.close(target_fd)
+        finally:
+            os.close(destination_fd)
+    except OSError:
+        return None
+    finally:
+        os.close(source_fd)
+
+
+def _iter_failure_files(source: Path) -> Any:
+    """Yield a bounded prefix without materializing or sorting the whole tree."""
+    pending = [source]
+    scanned = 0
+    scan_limit = _MAX_FAILURE_ARTIFACT_FILES * 16
+    while pending and scanned < scan_limit:
+        directory = pending.pop()
+        try:
+            entries = os.scandir(directory)
+        except OSError:
+            continue
+        with entries:
+            for entry in entries:
+                scanned += 1
+                if scanned > scan_limit:
+                    break
+                try:
+                    if entry.is_dir(follow_symlinks=False):
+                        pending.append(Path(entry.path))
+                    elif entry.is_file(follow_symlinks=False):
+                        yield Path(entry.path)
+                except OSError:
+                    continue
+
+
 def _capture_failure_artifacts(source: Path, destination: Path) -> dict[str, Any]:
     """Keep small diagnostic files, never a second incident-scale corpus."""
     copied: list[str] = []
     skipped: list[dict[str, Any]] = []
     total = 0
-    candidates = sorted(path for path in source.rglob("*") if path.is_file() and not path.is_symlink())
-    for path in candidates[:_MAX_FAILURE_ARTIFACT_FILES]:
+    try:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.mkdir(mode=0o700, exist_ok=False)
+    except FileExistsError:
+        return {"copied_bytes": 0, "copied_files": [], "skipped": [], "error": "destination_not_owned"}
+    for path in _iter_failure_files(source):
+        if len(copied) + len(skipped) >= _MAX_FAILURE_ARTIFACT_FILES:
+            break
         relative = path.relative_to(source)
-        try:
-            size = path.stat().st_size
-        except OSError:
+        result = _copy_bounded_file(source, destination, relative, _MAX_FAILURE_ARTIFACT_BYTES - total)
+        if result is None:
             continue
-        if size > _MAX_FAILURE_ARTIFACT_FILE_BYTES or total + size > _MAX_FAILURE_ARTIFACT_BYTES:
-            skipped.append({"path": str(relative), "size": size, "reason": "artifact_budget"})
+        status, size = result
+        if status == "artifact_budget":
+            skipped.append({"path": str(relative), "size": size, "reason": status})
             continue
-        target = destination / relative
-        target.parent.mkdir(parents=True, exist_ok=True)
-        with contextlib.suppress(OSError):
-            shutil.copy2(path, target, follow_symlinks=False)
-            total += size
-            copied.append(str(relative))
+        total += size
+        copied.append(str(relative))
     payload = {"copied_bytes": total, "copied_files": copied, "skipped": skipped}
-    destination.mkdir(parents=True, exist_ok=True)
     (destination / "manifest.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return payload
 
@@ -188,24 +306,32 @@ class PytestScratchLease:
     run_id: str
     lane: str
     stale_leases_reclaimed: tuple[str, ...]
+    lease_token: str
 
     @classmethod
     def acquire(cls, *, root: Path, run_id: str, lane: str, evidence_dir: Path) -> PytestScratchLease:
         root = root.resolve()
         root.mkdir(parents=True, exist_ok=True)
-        stale = _prune_stale_leases(root)
-        safe_lane = re.sub(r"[^a-z0-9_.-]+", "-", lane.lower()).strip("-") or "pytest"
-        lease_root = root / "runs" / run_id / safe_lane
-        lease_root.mkdir(parents=True, exist_ok=False)
-        marker = {
-            "run_id": run_id,
-            "lane": safe_lane,
-            "pid": os.getpid(),
-            "process_start_ticks": _process_start_ticks(os.getpid()),
-            "created_monotonic_ns": time.monotonic_ns(),
-        }
-        (lease_root / _LEASE_FILE).write_text(json.dumps(marker, sort_keys=True) + "\n", encoding="utf-8")
-        return cls(root, lease_root, lease_root / "pytest", evidence_dir, run_id, safe_lane, stale)
+        with _lease_lock(root):
+            stale = _prune_stale_leases(root)
+            safe_lane = re.sub(r"[^a-z0-9_.-]+", "-", lane.lower()).strip("-") or "pytest"
+            run_root = root / "runs" / run_id
+            run_root.mkdir(parents=True, exist_ok=True)
+            lease_root = run_root / safe_lane
+            staging_root = run_root / f".{safe_lane}.creating-{os.getpid()}-{uuid4().hex}"
+            staging_root.mkdir(parents=False)
+            lease_token = uuid4().hex
+            marker = {
+                "run_id": run_id,
+                "lane": safe_lane,
+                "lease_token": lease_token,
+                "pid": os.getpid(),
+                "process_start_ticks": _process_start_ticks(os.getpid()),
+                "created_monotonic_ns": time.monotonic_ns(),
+            }
+            (staging_root / _LEASE_FILE).write_text(json.dumps(marker, sort_keys=True) + "\n", encoding="utf-8")
+            staging_root.rename(lease_root)
+        return cls(root, lease_root, lease_root / "pytest", evidence_dir, run_id, safe_lane, stale, lease_token)
 
     def command(self, command: list[str]) -> list[str]:
         if any(argument == "--basetemp" or argument.startswith("--basetemp=") for argument in command):
@@ -220,24 +346,32 @@ class PytestScratchLease:
         }
 
     def finalize(self, outcome: Outcome) -> dict[str, Any]:
-        terminal = measure_tree(self.lease_root)
-        extent = btrfs_extent_usage(self.lease_root)
-        artifacts: dict[str, Any] | None = None
-        if outcome != "success" and self.basetemp.exists():
-            artifacts = _capture_failure_artifacts(self.basetemp, self.evidence_dir / "scratch-failure-artifacts")
-        cleanup_started = time.monotonic_ns()
-        shutil.rmtree(self.lease_root, ignore_errors=True)
-        # A verifier run can own several sequential lanes. Remove only this
-        # run's now-empty container, never the shared ``runs`` namespace or a
-        # sibling lane still in flight.
-        with contextlib.suppress(OSError):
-            self.lease_root.parent.rmdir()
+        with _lease_lock(self.root):
+            marker = _read_lease(self.lease_root / _LEASE_FILE)
+            owns_lease = isinstance(marker, dict) and marker.get("lease_token") == self.lease_token
+            terminal = measure_tree(self.lease_root) if owns_lease else ScratchUsage(0, 0, 0, 0)
+            high_water = _event_high_water(self.evidence_dir, terminal)
+            extent = btrfs_extent_usage(self.lease_root) if owns_lease else None
+            artifacts: dict[str, Any] | None = None
+            if owns_lease and outcome != "success" and self.basetemp.exists():
+                artifacts = _capture_failure_artifacts(self.basetemp, self.evidence_dir / "scratch-failure-artifacts")
+            cleanup_started = time.monotonic_ns()
+            if owns_lease:
+                shutil.rmtree(self.lease_root, ignore_errors=True)
+                # A verifier run can own several sequential lanes. Remove only this
+                # run's now-empty container, never the shared ``runs`` namespace or a
+                # sibling lane still in flight.
+                with contextlib.suppress(OSError):
+                    self.lease_root.parent.rmdir()
         payload: dict[str, Any] = {
             "run_id": self.run_id,
             "lane": self.lane,
             "outcome": outcome,
             "terminal_usage": asdict(terminal),
-            "high_water_usage": asdict(terminal),
+            "high_water_usage": asdict(high_water),
+            "high_water_scope": "observed_test_trees_and_terminal_lease",
+            "high_water_complete": False,
+            "owner_verified": owns_lease,
             "stale_leases_reclaimed": list(self.stale_leases_reclaimed),
             "cleanup_complete": not self.lease_root.exists(),
             "cleanup_started_monotonic_ns": cleanup_started,
@@ -253,4 +387,58 @@ class PytestScratchLease:
         return payload
 
 
-__all__ = ["PytestScratchLease", "ScratchUsage", "btrfs_extent_usage", "measure_tree", "scratch_root_from_environment"]
+def _event_high_water(evidence_dir: Path, terminal: ScratchUsage) -> ScratchUsage:
+    """Combine per-test and per-worker observations without inventing values."""
+    high_water = asdict(terminal)
+    event_paths = [evidence_dir / "events.jsonl"]
+    with contextlib.suppress(OSError):
+        event_paths.extend((evidence_dir / "events").glob("*.jsonl"))
+    for event_path in event_paths:
+        with contextlib.suppress(OSError):
+            for line in event_path.read_text(encoding="utf-8", errors="replace").splitlines():
+                with contextlib.suppress(json.JSONDecodeError):
+                    payload = json.loads(line)
+                    observed = payload.get("high_water") if isinstance(payload, dict) else None
+                    if isinstance(observed, dict):
+                        for key in high_water:
+                            value = observed.get(key)
+                            if isinstance(value, int):
+                                high_water[key] = max(high_water[key], value)
+    return ScratchUsage(**high_water)
+
+
+def run_managed_pytest(
+    command: list[str], *, cwd: Path, env: Mapping[str, str], stdout: Any = None, stderr: Any = None
+) -> subprocess.CompletedProcess[Any]:
+    """Run pytest in an owned process group and reap it before lease cleanup."""
+    process = subprocess.Popen(
+        command,
+        cwd=cwd,
+        env=dict(env),
+        stdout=stdout,
+        stderr=stderr,
+        start_new_session=True,
+    )
+    try:
+        process.wait()
+    except KeyboardInterrupt:
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(process.pid, signal.SIGTERM)
+        try:
+            process.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(process.pid, signal.SIGKILL)
+            process.wait()
+        raise
+    return subprocess.CompletedProcess(command, process.returncode)
+
+
+__all__ = [
+    "PytestScratchLease",
+    "ScratchUsage",
+    "btrfs_extent_usage",
+    "measure_tree",
+    "run_managed_pytest",
+    "scratch_root_from_environment",
+]

--- a/devtools/run_tests.py
+++ b/devtools/run_tests.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
-import subprocess
+import signal
 import sys
 import time
 from pathlib import Path
@@ -39,7 +39,7 @@ from devtools.pytest_collection_contract import (
     IGNORED_COLLECTION_ARGS,
     MANAGED_PLUGIN_ARGS,
 )
-from devtools.pytest_scratch import Outcome, PytestScratchLease, scratch_root_from_environment
+from devtools.pytest_scratch import Outcome, PytestScratchLease, run_managed_pytest, scratch_root_from_environment
 from devtools.verify_runs import (
     VerifyRun,
     append_verify_history,
@@ -90,6 +90,16 @@ _NON_PATH_VALUE_OPTIONS = frozenset(
         "-o",
     }
 )
+
+
+class ManagedTestInterrupted(KeyboardInterrupt):
+    def __init__(self, signum: int) -> None:
+        super().__init__()
+        self.signum = signum
+
+
+def _raise_managed_interruption(_signum: int, _frame: object) -> None:
+    raise ManagedTestInterrupted(_signum)
 
 
 def _verbose_output() -> bool:
@@ -281,7 +291,14 @@ def _run(
     """Run focused pytest directly while preserving its project receipt."""
     del label, run
     started = time.monotonic()
-    completed = subprocess.run(command, cwd=cwd, env=env)
+    handlers = {
+        signum: signal.signal(signum, _raise_managed_interruption) for signum in (signal.SIGINT, signal.SIGTERM)
+    }
+    try:
+        completed = run_managed_pytest(command, cwd=Path(cwd), env=env)
+    finally:
+        for signum, previous in handlers.items():
+            signal.signal(signum, previous)
     return (
         completed.returncode,
         time.monotonic() - started,
@@ -350,6 +367,13 @@ def main(argv: list[str] | None = None) -> int:
             env=pytest_env,
             run=run,
         )
+    except ManagedTestInterrupted as exc:
+        rc = 128 + exc.signum
+        elapsed = time.monotonic() - started
+        metadata = {
+            "diagnosis": "pytest_interrupted",
+            "termination_reason": signal.Signals(exc.signum).name.lower(),
+        }
     except KeyboardInterrupt:
         rc = 130
         elapsed = time.monotonic() - started

--- a/devtools/run_tests.py
+++ b/devtools/run_tests.py
@@ -39,6 +39,7 @@ from devtools.pytest_collection_contract import (
     IGNORED_COLLECTION_ARGS,
     MANAGED_PLUGIN_ARGS,
 )
+from devtools.pytest_scratch import Outcome, PytestScratchLease, scratch_root_from_environment
 from devtools.verify_runs import (
     VerifyRun,
     append_verify_history,
@@ -329,10 +330,19 @@ def main(argv: list[str] | None = None) -> int:
     )
     artifacts = run.start_step(label="pytest focused", cmd=cmd)
     started = time.monotonic()
+    lease: PytestScratchLease | None = None
     try:
         pytest_env = env_for_pytest_step(dict(os.environ), run=run, artifacts=artifacts)
         pytest_env.pop("POLYLOGUE_PYTEST_CONTAINMENT_PATH", None)
         _normalize_managed_pytest_environment(pytest_env)
+        lease = PytestScratchLease.acquire(
+            root=scratch_root_from_environment(pytest_env),
+            run_id=run.run_id,
+            lane="focused",
+            evidence_dir=artifacts.step_dir,
+        )
+        cmd = lease.command(cmd)
+        pytest_env = lease.environment(pytest_env)
         rc, elapsed, metadata = _run(
             "pytest focused",
             cmd,
@@ -354,6 +364,18 @@ def main(argv: list[str] | None = None) -> int:
         }
         elapsed = time.monotonic() - started
         sys.stderr.write(f"devtools test: cannot start pytest: {exc}\n")
+    finally:
+        if lease is not None:
+            outcome: Outcome = (
+                "success"
+                if "rc" in locals() and rc == 0
+                else "cancelled"
+                if "rc" in locals() and rc == 130
+                else "worker_crash"
+                if "rc" in locals() and rc == 3
+                else "failure"
+            )
+            lease.finalize(outcome)
     run.finish_step(
         step_id=artifacts.step_id,
         result={"duration_s": elapsed, "exit": rc, **metadata},

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -25,6 +25,7 @@ from devtools.pytest_collection_contract import (
     SERIAL_MARKER_EXPRESSION,
     STORAGE_SCALE_MARKER_EXPRESSION,
 )
+from devtools.pytest_scratch import PytestScratchLease, scratch_root_from_environment
 from devtools.testmon_bootstrap import (
     TESTMON_DATA_RELPATH,
     NativeTestmonDeadlineError,
@@ -326,7 +327,25 @@ def _run(label: str, command: list[str], *, run: VerifyRun) -> tuple[int, float,
         _clear_pytest_report(command)
         _normalize_managed_pytest_environment(env)
         env = env_for_pytest_step(env, run=run, artifacts=artifacts)
-        completed = subprocess.run(command, cwd=ROOT, env=env, stdout=sys.stderr, stderr=sys.stderr)
+        lane = label.removeprefix("pytest native ").split(" ", 1)[0]
+        lease = PytestScratchLease.acquire(
+            root=scratch_root_from_environment(env), run_id=run.run_id, lane=lane, evidence_dir=artifacts.step_dir
+        )
+        managed_command = lease.command(command)
+        try:
+            completed = subprocess.run(
+                managed_command, cwd=ROOT, env=lease.environment(env), stdout=sys.stderr, stderr=sys.stderr
+            )
+        except KeyboardInterrupt:
+            lease.finalize("cancelled")
+            raise
+        except BaseException:
+            lease.finalize("failure")
+            raise
+        else:
+            lease.finalize(
+                "success" if completed.returncode == 0 else "worker_crash" if completed.returncode == 3 else "failure"
+            )
     else:
         completed = subprocess.run(command, cwd=ROOT, env=env, capture_output=True, text=True)
     elapsed = time.monotonic() - started

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -25,7 +25,7 @@ from devtools.pytest_collection_contract import (
     SERIAL_MARKER_EXPRESSION,
     STORAGE_SCALE_MARKER_EXPRESSION,
 )
-from devtools.pytest_scratch import PytestScratchLease, scratch_root_from_environment
+from devtools.pytest_scratch import PytestScratchLease, run_managed_pytest, scratch_root_from_environment
 from devtools.testmon_bootstrap import (
     TESTMON_DATA_RELPATH,
     NativeTestmonDeadlineError,
@@ -333,7 +333,7 @@ def _run(label: str, command: list[str], *, run: VerifyRun) -> tuple[int, float,
         )
         managed_command = lease.command(command)
         try:
-            completed = subprocess.run(
+            completed = run_managed_pytest(
                 managed_command, cwd=ROOT, env=lease.environment(env), stdout=sys.stderr, stderr=sys.stderr
             )
         except KeyboardInterrupt:

--- a/devtools/verify_runs.py
+++ b/devtools/verify_runs.py
@@ -193,6 +193,12 @@ class VerifyRun:
                     step["statistics_path"] = str(self.relative_run_dir / "steps" / step_id / "statistics.json")
                     if self.mirror_current:
                         shutil.copyfile(step_dir / "statistics.json", self.root / CURRENT_STATISTICS_PATH)
+                scratch_metrics = _read_json(step_dir / "scratch-metrics.json")
+                if scratch_metrics:
+                    step["scratch_metrics"] = scratch_metrics
+                    step["scratch_metrics_path"] = str(
+                        self.relative_run_dir / "steps" / step_id / "scratch-metrics.json"
+                    )
             self.write()
             return dict(step)
         return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,6 +136,8 @@ _MANAGED_VERIFY_ENV = frozenset(
         "POLYLOGUE_PYTEST_SUMMARY_PATH",
         "POLYLOGUE_PYTEST_SELECTION_NODEID_LIMIT",
         "POLYLOGUE_VISUAL_EVIDENCE_DIR",
+        "POLYLOGUE_PYTEST_SCRATCH_ROOT",
+        "POLYLOGUE_PYTEST_SCRATCH_LANE",
     }
 )
 
@@ -265,7 +267,7 @@ def _clear_polylogue_env(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     request: pytest.FixtureRequest,
-) -> None:
+) -> Iterator[None]:
     # Close any cached SQLite connections to prevent WAL sidecar corruption
     # when tests create/move/delete temp database files.
     from polylogue.storage.sqlite.connection import _clear_connection_cache
@@ -395,6 +397,12 @@ def _clear_polylogue_env(
     # respond to in-process or subprocess CLI invocations. Port 1 is reserved
     # (TCPMUX) and reliably refuses on a developer host (#1325).
     monkeypatch.setenv("POLYLOGUE_DAEMON_URL", "http://127.0.0.1:1")
+    try:
+        yield
+    finally:
+        from devtools.pytest_progress_plugin import record_test_scratch_usage
+
+        record_test_scratch_usage(request.node.nodeid, tmp_path)
 
 
 @pytest.fixture

--- a/tests/unit/devtools/test_pytest_progress_plugin.py
+++ b/tests/unit/devtools/test_pytest_progress_plugin.py
@@ -201,6 +201,7 @@ def test_managed_event_ledger_survives_test_host_environment_scrub(tmp_path: Pat
     env = dict(os.environ)
     for name in ("POLYLOGUE_PYTEST_RUN_ID",):
         env.pop(name, None)
+    env.pop("PYTEST_DISABLE_PLUGIN_AUTOLOAD", None)
     env.update(
         {
             "POLYLOGUE_PYTEST_EVENTS_DIR": str(events_dir),
@@ -277,6 +278,26 @@ def test_progress_plugin_write_failures_do_not_escape(monkeypatch: pytest.Monkey
     monkeypatch.setenv("POLYLOGUE_PYTEST_EVENTS_PATH", "/dev/null/events.jsonl")
 
     pytest_progress_plugin.pytest_runtest_logreport(_Report("test_body", "call", "failed", longrepr="boom"))
+
+
+def test_progress_plugin_records_test_scratch_high_water(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    events_path = tmp_path / "events.jsonl"
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    scratch.joinpath("payload").write_bytes(b"x" * 4_097)
+    monkeypatch.setenv("POLYLOGUE_PYTEST_EVENTS_PATH", str(events_path))
+    monkeypatch.setenv("POLYLOGUE_PYTEST_SCRATCH_ROOT", str(tmp_path))
+    monkeypatch.setenv("POLYLOGUE_PYTEST_SCRATCH_LANE", "parallel")
+    pytest_progress_plugin.pytest_sessionstart(object())
+
+    pytest_progress_plugin.record_test_scratch_usage("tests/a.py::test_scratch", scratch)
+
+    event = json.loads(events_path.read_text().splitlines()[-1])
+    assert event["event"] == "scratch_test_observed"
+    assert event["nodeid"] == "tests/a.py::test_scratch"
+    assert event["lane"] == "parallel"
+    assert event["usage"]["apparent_bytes"] == 4_097
+    assert event["high_water"]["allocated_bytes"] >= 4_097
 
 
 class _Item:

--- a/tests/unit/devtools/test_pytest_scratch.py
+++ b/tests/unit/devtools/test_pytest_scratch.py
@@ -158,8 +158,11 @@ def test_managed_pytest_kills_its_process_group_before_propagating_interrupt(
 
     process = _Process()
     killed: list[tuple[int, signal.Signals]] = []
-    monkeypatch.setattr(pytest_scratch.subprocess, "Popen", lambda *args, **kwargs: process)
-    monkeypatch.setattr(pytest_scratch.os, "killpg", lambda pid, signum: killed.append((pid, signum)))
+    monkeypatch.setattr("devtools.pytest_scratch.subprocess.Popen", lambda *args, **kwargs: process)
+    monkeypatch.setattr(
+        "devtools.pytest_scratch.os.killpg",
+        lambda pid, signum: killed.append((pid, signum)),
+    )
 
     with pytest.raises(KeyboardInterrupt):
         run_managed_pytest(["pytest"], cwd=Path.cwd(), env={})

--- a/tests/unit/devtools/test_pytest_scratch.py
+++ b/tests/unit/devtools/test_pytest_scratch.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import json
+import signal
 from pathlib import Path
 
 import pytest
 
-from devtools.pytest_scratch import PytestScratchLease, measure_tree
+from devtools import pytest_scratch
+from devtools.pytest_scratch import PytestScratchLease, measure_tree, run_managed_pytest
 
 
 def test_measure_tree_reports_apparent_allocated_and_file_counts(tmp_path: Path) -> None:
@@ -88,3 +90,89 @@ def test_managed_command_rejects_unowned_shared_basetemp(tmp_path: Path) -> None
     assert command[-1] == f"--basetemp={lease.basetemp}"
     assert lease.environment({})["POLYLOGUE_PYTEST_SCRATCH_LANE"] == "parallel"
     lease.finalize("success")
+
+
+def test_failure_artifacts_do_not_follow_a_destination_symlink(tmp_path: Path) -> None:
+    scratch_root = tmp_path / "scratch"
+    evidence = tmp_path / "evidence"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    evidence.mkdir()
+    lease = PytestScratchLease.acquire(root=scratch_root, run_id="run", lane="parallel", evidence_dir=evidence)
+    lease.basetemp.mkdir(parents=True)
+    lease.basetemp.joinpath("diagnostic.txt").write_text("private", encoding="utf-8")
+    evidence.joinpath("scratch-failure-artifacts").symlink_to(outside, target_is_directory=True)
+
+    metrics = lease.finalize("failure")
+
+    assert metrics["failure_artifacts"]["error"] == "destination_not_owned"
+    assert not outside.joinpath("diagnostic.txt").exists()
+
+
+def test_high_water_metrics_use_worker_observations(tmp_path: Path) -> None:
+    scratch_root = tmp_path / "scratch"
+    evidence = tmp_path / "evidence"
+    events = evidence / "events"
+    events.mkdir(parents=True)
+    events.joinpath("gw0-1.jsonl").write_text(
+        json.dumps(
+            {
+                "event": "scratch_worker_high_water",
+                "high_water": {
+                    "apparent_bytes": 999,
+                    "allocated_bytes": 8_192,
+                    "file_count": 40,
+                    "directory_count": 30,
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    lease = PytestScratchLease.acquire(root=scratch_root, run_id="run", lane="parallel", evidence_dir=evidence)
+
+    metrics = lease.finalize("success")
+
+    assert metrics["terminal_usage"]["apparent_bytes"] < 999
+    assert metrics["high_water_scope"] == "observed_test_trees_and_terminal_lease"
+    assert metrics["high_water_complete"] is False
+    assert metrics["high_water_usage"] == {
+        "apparent_bytes": 999,
+        "allocated_bytes": 8_192,
+        "file_count": 40,
+        "directory_count": 30,
+    }
+
+
+def test_managed_pytest_kills_its_process_group_before_propagating_interrupt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Process:
+        pid = 42
+        returncode = 130
+
+        def wait(self, timeout: float | None = None) -> int:
+            if timeout is None:
+                raise KeyboardInterrupt
+            return self.returncode
+
+    process = _Process()
+    killed: list[tuple[int, signal.Signals]] = []
+    monkeypatch.setattr(pytest_scratch.subprocess, "Popen", lambda *args, **kwargs: process)
+    monkeypatch.setattr(pytest_scratch.os, "killpg", lambda pid, signum: killed.append((pid, signum)))
+
+    with pytest.raises(KeyboardInterrupt):
+        run_managed_pytest(["pytest"], cwd=Path.cwd(), env={})
+
+    assert killed == [(42, signal.SIGTERM)]
+
+
+def test_workstation_does_not_fallback_to_tmpfs_when_nvme_mount_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(pytest_scratch, "DEFAULT_SCRATCH_ROOT", tmp_path / "missing" / "scratch")
+    monkeypatch.setattr(pytest_scratch, "running_in_cloud_sandbox", lambda: False)
+
+    with pytest.raises(RuntimeError, match="workstation scratch mount"):
+        pytest_scratch.scratch_root_from_environment({})

--- a/tests/unit/devtools/test_pytest_scratch.py
+++ b/tests/unit/devtools/test_pytest_scratch.py
@@ -1,0 +1,90 @@
+"""Regression coverage for owned pytest scratch leases."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from devtools.pytest_scratch import PytestScratchLease, measure_tree
+
+
+def test_measure_tree_reports_apparent_allocated_and_file_counts(tmp_path: Path) -> None:
+    root = tmp_path / "scratch"
+    root.mkdir()
+    root.joinpath("payload").write_bytes(b"x" * 4_097)
+    root.joinpath("nested").mkdir()
+    root.joinpath("nested", "second").write_bytes(b"y")
+
+    usage = measure_tree(root)
+
+    assert usage.apparent_bytes == 4_098
+    assert usage.allocated_bytes >= usage.apparent_bytes
+    assert usage.file_count == 2
+    assert usage.directory_count == 2
+
+
+@pytest.mark.parametrize("outcome", ["success", "failure", "cancelled", "worker_crash"])
+def test_terminal_outcomes_reclaim_only_their_own_lease(tmp_path: Path, outcome: str) -> None:
+    scratch_root = tmp_path / "scratch"
+    evidence = tmp_path / "evidence"
+    owner = PytestScratchLease.acquire(
+        root=scratch_root, run_id=f"run-{outcome}", lane="parallel", evidence_dir=evidence
+    )
+    sibling = PytestScratchLease.acquire(
+        root=scratch_root, run_id=f"sibling-{outcome}", lane="parallel", evidence_dir=evidence
+    )
+    owner.basetemp.mkdir(parents=True)
+    owner.basetemp.joinpath("diagnostic.txt").write_text("keep bounded evidence", encoding="utf-8")
+    owner.basetemp.joinpath("incident-scale.bin").write_bytes(b"x" * (8 * 1024 * 1024 + 1))
+
+    receipt = owner.finalize(outcome)  # type: ignore[arg-type]
+
+    assert receipt["cleanup_complete"] is True
+    assert not owner.lease_root.exists()
+    assert sibling.lease_root.exists()
+    if outcome == "success":
+        assert not evidence.joinpath("scratch-failure-artifacts").exists()
+    else:
+        manifest = json.loads(evidence.joinpath("scratch-failure-artifacts", "manifest.json").read_text())
+        assert manifest["copied_files"] == ["diagnostic.txt"]
+        assert manifest["skipped"] == [
+            {"path": "incident-scale.bin", "reason": "artifact_budget", "size": 8 * 1024 * 1024 + 1}
+        ]
+    sibling.finalize("success")
+
+
+def test_new_lease_reclaims_only_dead_owner_markers(tmp_path: Path) -> None:
+    scratch_root = tmp_path / "scratch"
+    dead = scratch_root / "runs" / "abandoned" / "parallel"
+    dead.mkdir(parents=True)
+    dead.joinpath("lease.json").write_text(
+        json.dumps({"pid": 999_999_999, "process_start_ticks": "0"}), encoding="utf-8"
+    )
+    empty = scratch_root / "runs" / "empty-completed-run"
+    empty.mkdir(parents=True)
+    live = PytestScratchLease.acquire(
+        root=scratch_root, run_id="live", lane="parallel", evidence_dir=tmp_path / "evidence"
+    )
+
+    assert str(dead) in live.stale_leases_reclaimed
+    assert str(empty) in live.stale_leases_reclaimed
+    assert not dead.exists()
+    assert not empty.exists()
+    assert live.lease_root.exists()
+    live.finalize("success")
+
+
+def test_managed_command_rejects_unowned_shared_basetemp(tmp_path: Path) -> None:
+    lease = PytestScratchLease.acquire(
+        root=tmp_path / "scratch", run_id="run", lane="parallel", evidence_dir=tmp_path / "evidence"
+    )
+
+    with pytest.raises(ValueError, match="owns --basetemp"):
+        lease.command(["pytest", "--basetemp=/shared"])
+
+    command = lease.command(["pytest", "tests/unit"])
+    assert command[-1] == f"--basetemp={lease.basetemp}"
+    assert lease.environment({})["POLYLOGUE_PYTEST_SCRATCH_LANE"] == "parallel"
+    lease.finalize("success")

--- a/tests/unit/devtools/test_run_tests.py
+++ b/tests/unit/devtools/test_run_tests.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import signal
 import subprocess
 import sys
 from pathlib import Path
@@ -118,7 +119,7 @@ def test_main_strips_dispatch_json_flag(monkeypatch: pytest.MonkeyPatch) -> None
         return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
     monkeypatch.setattr("devtools.run_tests._clear_pytest_report", lambda _cmd: None)
-    monkeypatch.setattr("devtools.run_tests.subprocess.run", direct_subprocess)
+    monkeypatch.setattr("devtools.run_tests.run_managed_pytest", direct_subprocess)
     monkeypatch.setattr("devtools.run_tests.git_head", lambda _root: "abc123")
     monkeypatch.setattr("devtools.run_tests.append_verify_history", lambda payload: captured.update(history=payload))
     assert run_tests.main(["tests/unit/pipeline", "--json"]) == 0
@@ -225,6 +226,28 @@ def test_main_persists_interrupted_direct_cli_result_to_local_run_artifacts(
         assert payload["pytest_aggregate"]["selection_mode"] == "focused"
         assert payload["git_head"] == "head"
         assert payload["final_git_head"] == "head"
+
+
+def test_main_preserves_sigterm_for_managed_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    history: dict[str, Any] = {}
+    monkeypatch.setattr(run_tests, "ROOT", tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(run_tests, "assert_polylogue_matches_checkout", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(run_tests, "git_head", lambda _root: "head")
+    monkeypatch.setattr(run_tests, "append_verify_history", lambda payload: history.update(payload))
+    monkeypatch.setattr(run_tests, "_clear_pytest_report", lambda _cmd: None)
+
+    def interrupt(*_args: Any, **_kwargs: Any) -> tuple[int, float, dict[str, str]]:
+        raise run_tests.ManagedTestInterrupted(signal.SIGTERM)
+
+    monkeypatch.setattr(run_tests, "_run", interrupt)
+
+    assert run_tests.main(["tests/unit/example.py"]) == 143
+    assert history["exit_code"] == 143
+    assert history["steps"][0]["termination_reason"] == "sigterm"
 
 
 def test_normalize_selection_paths_preserves_pytest_path_option_semantics(

--- a/tests/unit/devtools/test_run_tests.py
+++ b/tests/unit/devtools/test_run_tests.py
@@ -176,7 +176,6 @@ def test_main_preserves_path_valued_options_from_subdirectory(
             [
                 "-k",
                 "proof",
-                "--basetemp=diagnostic",
                 "--rootdir",
                 ".",
                 "--ignore",
@@ -190,7 +189,6 @@ def test_main_preserves_path_valued_options_from_subdirectory(
     )
 
     command = cast(list[str], captured["cmd"])
-    assert f"--basetemp={invocation / 'diagnostic'}" in command
     assert command[command.index("--rootdir") + 1] == str(invocation)
     assert command[command.index("--ignore") + 1] == str(invocation / "fixtures")
     assert f"--ignore-glob={invocation / 'fixtures' / '*.json'}" in command
@@ -371,6 +369,53 @@ def test_main_returns_pytest_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("devtools.run_tests._clear_pytest_report", lambda _cmd: None)
     monkeypatch.setattr("devtools.run_tests._run", _fake_run)
     assert run_tests.main(["tests/unit/does_not_exist"]) == 5
+
+
+@pytest.mark.parametrize(
+    ("result", "expected_exit", "expected_outcome"),
+    [
+        ((0, 0.01, {"diagnosis": "pytest_passed"}), 0, "success"),
+        ((1, 0.01, {"diagnosis": "pytest_failed"}), 1, "failure"),
+        ((3, 0.01, {"diagnosis": "pytest_failed"}), 3, "worker_crash"),
+        (KeyboardInterrupt(), 130, "cancelled"),
+    ],
+)
+def test_managed_runner_reclaims_its_scratch_for_every_terminal_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    result: tuple[int, float, dict[str, str]] | KeyboardInterrupt,
+    expected_exit: int,
+    expected_outcome: str,
+) -> None:
+    """Mutation: removing the runner's ``finally`` leaks the private lease."""
+    scratch_root = tmp_path / "scratch"
+    monkeypatch.setattr(run_tests, "ROOT", tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(run_tests, "assert_polylogue_matches_checkout", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(run_tests, "git_head", lambda _root: "head")
+    monkeypatch.setattr(run_tests, "append_verify_history", lambda _payload: None)
+    monkeypatch.setattr(run_tests, "_clear_pytest_report", lambda _cmd: None)
+    monkeypatch.setattr(run_tests, "scratch_root_from_environment", lambda _env: scratch_root)
+
+    def fake_run(_label: str, command: list[str], **_kwargs: Any) -> tuple[int, float, dict[str, str]]:
+        basetemp = Path(next(part.split("=", 1)[1] for part in command if part.startswith("--basetemp=")))
+        basetemp.mkdir(parents=True)
+        basetemp.joinpath("small-diagnostic.txt").write_text("evidence", encoding="utf-8")
+        if isinstance(result, KeyboardInterrupt):
+            raise result
+        return result
+
+    monkeypatch.setattr(run_tests, "_run", fake_run)
+
+    assert run_tests.main(["tests/unit/example.py"]) == expected_exit
+
+    metrics = next((tmp_path / ".cache" / "verify" / "runs").glob("*/steps/*/scratch-metrics.json"))
+    payload = json.loads(metrics.read_text())
+    assert payload["outcome"] == expected_outcome
+    assert payload["cleanup_complete"] is True
+    runs = scratch_root / "runs"
+    assert not list(runs.rglob("lease.json"))
+    assert not list(runs.iterdir())
 
 
 @pytest.mark.parametrize("invocation_location", ["inside", "external"])

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -63,6 +63,9 @@ def test_pytest_receipt_decodes_report_and_selection(tmp_path: Path) -> None:
     (artifacts.events_dir / "gw0.jsonl").write_text(
         json.dumps({"event": "test_report", "updated_at": "2026-01-01T00:00:00Z"}) + "\n", encoding="utf-8"
     )
+    (artifacts.step_dir / "scratch-metrics.json").write_text(
+        json.dumps({"high_water_usage": {"apparent_bytes": 128}}), encoding="utf-8"
+    )
 
     result = run.finish_step(step_id=artifacts.step_id, result={"exit": 1, "duration_s": 0.1})
 
@@ -71,6 +74,7 @@ def test_pytest_receipt_decodes_report_and_selection(tmp_path: Path) -> None:
     assert statistics["outcomes"] == {"passed": 1, "failed": 1}
     assert statistics["selected_count"] == 2
     assert statistics["event_count"] == 1
+    assert result["scratch_metrics"]["high_water_usage"]["apparent_bytes"] == 128
 
 
 def test_step_environment_is_receipt_scoped(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- give every managed pytest invocation a unique NVMe-backed scratch lease
- measure apparent, allocated, file-count, high-water, and shared-extent usage in verification receipts
- reclaim successful runs and retain bounded, ownership-safe failure evidence
- terminate owned pytest process groups before releasing their scratch lease
- fail closed on workstation `/tmp` fallback while preserving explicit cloud-sandbox behavior

## Why

The prior shared scratch tree retained about 15.5 GB across runs and could not safely support tmpfs. A sampled recovery fixture was about 1.20 GB apparent/allocated with 1.12 GiB shared extents, so sparse-file assumptions were false and blindly copying fixtures would multiply storage. Managed per-run leases make cleanup deterministic without reducing test scope or fixture semantics.

The independent review found and fixed three high-severity lifecycle defects: interrupted runners could release a lease while pytest workers survived; concurrent stale cleanup could race PID reuse; and a missing NVMe root could silently spill onto `/tmp` tmpfs. It also bounded failure-artifact scanning/copying and made incomplete high-water scope explicit.

## Verification

- `pytest -q tests/unit/devtools/test_pytest_progress_plugin.py tests/unit/devtools/test_pytest_scratch.py tests/unit/devtools/test_run_tests.py tests/unit/devtools/test_verify.py` — 66 passed
- `pytest -q tests/unit/devtools/test_pytest_scratch.py` — 11 passed after the type-safe test-double correction
- pre-push maintained quick gate — green (Ruff format/check, mypy, render, layering, command/docs/schema/oracle/privacy gates)
- independent Luna review commit — focused suite 66 passed; signed commits verified

The complete 16-worker suite will run once on merged master so it covers this storage lifecycle together with the just-merged shared-Chrome work.

## Storage contract

- test coverage and incident-fixture semantics are unchanged
- old scratch is intentionally not deleted by this PR; it will be removed only after merged-master equivalence is green
- retained failure artifacts are capped at 64 MiB and copied without following symlinks
- raw test trees remain NVMe-backed; current evidence does not support tmpfs

Ref: `polylogue-k1o3t`.
