### PR TITLE
Bound test storage without reducing coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -515,9 +515,12 @@ Adding a devtools command: add a `CommandSpec` to `devtools/command_catalog.py`,
 implement in `devtools/<name>.py`, run `devtools render devtools-reference`.
 
 Local state: `.cache/` (disposable) and `.local/` (untracked outputs). Keep new
-outputs there, not new top-level roots. Verification receipts under
-`.cache/verify/runs` are retained indefinitely as durable local evidence; do
-not prune them automatically or delete them merely for age or count.
+outputs there, not new top-level roots. `.cache/verify/history.jsonl` is the
+append-only authority for terminal verification summaries. Detailed run trees
+under `.cache/verify/runs` are bounded automatically after that summary is
+fsynced: keep the newest eight successes and, for failures, the newest run plus
+up to twelve recent runs within seven days and 64 MiB. Malformed or unsafe
+trees are retained for manual inspection.
 
 ---
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -102,20 +102,26 @@ Focused and verification runs are foreground semantic commands. Devtools records
 project selection, gate results, decoded pytest outcomes, and the scope it
 actually ran.
 
+Managed pytest scratch records each test tree's high-water usage. A test tree
+is removed only after both its call and teardown pass; failed, skipped, or
+interrupted trees remain until the lease finalizer copies bounded failure
+evidence into the run detail. The finalizer then removes its authenticated
+lease root regardless of outcome, so a completed run does not leave the full
+pytest tree behind.
+
 Selection artifacts preserve exact selected/deselected counts but sample node
 IDs by default (`POLYLOGUE_PYTEST_SELECTION_NODEID_LIMIT`, default 500) so
 broad collection does not retain or write unbounded node-id lists in controller
 or worker processes.
 
 The detailed artifacts above are checkout-local and disposable. Each `devtools
-verify` or `devtools test` invocation automatically appends its compact run
-summary to `$POLYLOGUE_VERIFY_HISTORY_PATH` when that is set, otherwise to
-`$XDG_STATE_HOME/polylogue/devtools/verify-history.jsonl` (or the corresponding
-`~/.local/state` path), shared across linked worktrees without a separate
-recording command. The override exists so an operator can keep this history in
-a canonical data location -- it is the only verification artifact that outlives
-a checkout, and cross-worktree comparison depends on every lane appending to
-one file. `devtools why --history` reads the recent cross-worktree runs. A
+verify` or `devtools test` invocation appends its compact terminal summary to
+`.cache/verify/history.jsonl` before any detail is removed. The append and
+retention pass share one authenticated lock. Detail retention keeps the newest
+eight successful runs and, for failures, always keeps the newest run plus up to
+twelve runs that fit within seven days and 64 MiB. A malformed receipt, unsafe
+tree, or active lock retains the affected detail instead of guessing. `devtools
+why --history HOURS` reads the compact checkout-local history. A
 native verify record carries its selected scope, gate-step results, and decoded
 pytest outcomes. Setup, call, and teardown timings come only from pytest
 reports in the event stream.

--- a/devtools/pytest_progress_plugin.py
+++ b/devtools/pytest_progress_plugin.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+import shutil
 import time
 import uuid
 from dataclasses import dataclass
@@ -38,6 +39,8 @@ _DEFAULT_SELECTION_NODEID_LIMIT = 500
 _COLLECTION_FACT_SUFFIX = ".collection.json"
 _ARTIFACT_ENV_NAMES = (_EVENTS_ENV, _EVENTS_DIR_ENV, _SELECTION_ENV, _SUMMARY_ENV)
 _SCRATCH_HIGH_WATER: dict[str, int] = {"apparent_bytes": 0, "allocated_bytes": 0, "file_count": 0, "directory_count": 0}
+_TEST_SCRATCH_TREES: dict[str, Path] = {}
+_TEST_CALL_OUTCOMES: dict[str, str] = {}
 
 
 @dataclass
@@ -52,6 +55,8 @@ class _SessionState:
     controller_collection_payload: dict[str, Any] | None
     artifact_environment: dict[str, str | None]
     scratch_high_water: dict[str, int]
+    test_scratch_trees: dict[str, Path]
+    test_call_outcomes: dict[str, str]
 
 
 _SESSION_STATE_STACK: list[_SessionState] = []
@@ -71,6 +76,8 @@ def _capture_session_state() -> _SessionState:
         ),
         artifact_environment={name: os.environ.get(name) for name in _ARTIFACT_ENV_NAMES},
         scratch_high_water=dict(_SCRATCH_HIGH_WATER),
+        test_scratch_trees=dict(_TEST_SCRATCH_TREES),
+        test_call_outcomes=dict(_TEST_CALL_OUTCOMES),
     )
 
 
@@ -93,6 +100,10 @@ def _restore_session_state(state: _SessionState) -> None:
             os.environ[name] = value
     _SCRATCH_HIGH_WATER.clear()
     _SCRATCH_HIGH_WATER.update(state.scratch_high_water)
+    _TEST_SCRATCH_TREES.clear()
+    _TEST_SCRATCH_TREES.update(state.test_scratch_trees)
+    _TEST_CALL_OUTCOMES.clear()
+    _TEST_CALL_OUTCOMES.update(state.test_call_outcomes)
 
 
 def _reset_session_state() -> None:
@@ -108,6 +119,8 @@ def _reset_session_state() -> None:
     _CONTROLLER_COLLECTION_PAYLOAD = None
     for key in _SCRATCH_HIGH_WATER:
         _SCRATCH_HIGH_WATER[key] = 0
+    _TEST_SCRATCH_TREES.clear()
+    _TEST_CALL_OUTCOMES.clear()
 
 
 def record_test_scratch_usage(nodeid: str, root: Path) -> None:
@@ -125,6 +138,7 @@ def record_test_scratch_usage(nodeid: str, root: Path) -> None:
     }
     for key, value in payload.items():
         _SCRATCH_HIGH_WATER[key] = max(_SCRATCH_HIGH_WATER[key], value)
+    _TEST_SCRATCH_TREES[nodeid] = root
     _write_event(
         {
             "event": "scratch_test_observed",
@@ -134,6 +148,28 @@ def record_test_scratch_usage(nodeid: str, root: Path) -> None:
             "high_water": dict(_SCRATCH_HIGH_WATER),
         }
     )
+
+
+def _remove_successful_test_tree(nodeid: str, teardown_outcome: str) -> None:
+    """Remove one worker-owned tree only after call and teardown both pass."""
+    root = _TEST_SCRATCH_TREES.pop(nodeid, None)
+    call_outcome = _TEST_CALL_OUTCOMES.pop(nodeid, None)
+    if call_outcome not in {"passed", "xpassed"} or teardown_outcome not in {"passed", "xpassed"}:
+        return
+    scratch_raw = os.environ.get("POLYLOGUE_PYTEST_SCRATCH_ROOT")
+    if not scratch_raw or root is None:
+        return
+    try:
+        scratch_root = Path(scratch_raw).resolve(strict=True)
+        resolved_root = root.resolve(strict=True)
+        relative = resolved_root.relative_to(scratch_root)
+        if not relative.parts or resolved_root == scratch_root or root.is_symlink():
+            return
+        shutil.rmtree(resolved_root)
+    except (OSError, RuntimeError, ValueError):
+        # A missing or changed tree is retained as evidence rather than
+        # broadening deletion to an ambiguous path.
+        return
 
 
 def _isolate_nested_artifact_destinations() -> None:
@@ -416,6 +452,8 @@ def _record_phase_report(report: Any, *, write_event: bool = True) -> None:
     }
     if payload["outcome"] == "failed":
         payload["longrepr"] = str(getattr(report, "longrepr", ""))
+    if when == "call":
+        _TEST_CALL_OUTCOMES[nodeid] = outcome
     _remember_report(payload)
     if write_event:
         _write_event(payload)
@@ -439,6 +477,11 @@ def pytest_runtest_logreport(report: Any) -> None:
         _record_phase_report(report, write_event=False)
         return
     _record_phase_report(report)
+    if str(getattr(report, "when", "")) == "teardown":
+        _remove_successful_test_tree(
+            str(getattr(report, "nodeid", "")),
+            _durable_report_outcome(report, str(getattr(report, "outcome", ""))),
+        )
 
 
 @pytest.hookimpl

--- a/devtools/run_tests.py
+++ b/devtools/run_tests.py
@@ -46,6 +46,7 @@ from devtools.verify_runs import (
     configured_pytest_worker_request,
     env_for_pytest_step,
     git_head,
+    prune_successful_verify_runs,
     pytest_command_worker_request,
 )
 
@@ -412,6 +413,7 @@ def main(argv: list[str] | None = None) -> int:
         final_git_head=git_head(ROOT),
     )
     append_verify_history(payload)
+    prune_successful_verify_runs(root=ROOT)
     if use_json:
         print(json.dumps(payload, indent=2, ensure_ascii=False))
     # The artifact-path footer is reference material, not a result. Printing six

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -43,6 +43,7 @@ from devtools.verify_runs import (
     copy_current_pytest_artifacts,
     env_for_pytest_step,
     git_head,
+    prune_successful_verify_runs,
 )
 from polylogue.scenarios import (
     MeasurementScope,
@@ -501,6 +502,7 @@ def _finish_interrupted_verification(
         },
     )
     append_verify_history(payload)
+    prune_successful_verify_runs(root=ROOT)
     _emit(payload, use_json=args.json, operation=agentctl_operation)
     return exit_code
 
@@ -645,6 +647,7 @@ def _main(argv: list[str] | None = None, *, agentctl_operation: str | None = Non
         ),
     )
     append_verify_history(payload)
+    prune_successful_verify_runs(root=ROOT)
     _emit(payload, use_json=args.json, operation=agentctl_operation)
     return exit_code
 

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -487,7 +487,8 @@ def _finish_interrupted_verification(
         diagnosis="verification_interrupted",
         termination_reason=termination_reason,
     )
-    payload = run.finish(
+    payload = _finish_and_record_verification(
+        run=run,
         exit_code=exit_code,
         duration_s=time.monotonic() - started,
         diagnosis="verification_interrupted",
@@ -501,10 +502,34 @@ def _finish_interrupted_verification(
             "termination_reason": termination_reason,
         },
     )
-    append_verify_history(payload)
-    prune_successful_verify_runs(root=ROOT)
     _emit(payload, use_json=args.json, operation=agentctl_operation)
     return exit_code
+
+
+def _finish_and_record_verification(
+    *,
+    run: VerifyRun,
+    exit_code: int,
+    duration_s: float,
+    diagnosis: str | None = None,
+    verification_scope: str | None = None,
+    final_git_head: str | None = None,
+    pytest_aggregate: Mapping[str, Any] | None = None,
+    workload_receipt: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Finish, durably append, and prune every terminal verification path."""
+    payload = run.finish(
+        exit_code=exit_code,
+        duration_s=duration_s,
+        diagnosis=diagnosis,
+        verification_scope=verification_scope,
+        final_git_head=final_git_head,
+        pytest_aggregate=pytest_aggregate,
+        workload_receipt=workload_receipt,
+    )
+    append_verify_history(payload)
+    prune_successful_verify_runs(root=ROOT)
+    return payload
 
 
 def _main(argv: list[str] | None = None, *, agentctl_operation: str | None = None) -> int:
@@ -555,7 +580,8 @@ def _main(argv: list[str] | None = None, *, agentctl_operation: str | None = Non
                 pytest_environment=_native_pytest_environment(),
             )
         except (NativeTestmonDeadlineError, NativeTestmonRepairError) as exc:
-            payload = run.finish(
+            payload = _finish_and_record_verification(
+                run=run,
                 exit_code=125,
                 duration_s=time.monotonic() - started,
                 diagnosis="native_testmon_preparation_failed",
@@ -566,7 +592,8 @@ def _main(argv: list[str] | None = None, *, agentctl_operation: str | None = Non
             sys.stderr.write(f"verify: {exc}\n")
             return 125
         if preparation.selection_mode == "bootstrap" and not args.all_tests:
-            payload = run.finish(
+            payload = _finish_and_record_verification(
+                run=run,
                 exit_code=2,
                 duration_s=time.monotonic() - started,
                 diagnosis="native_testmon_graph_unavailable",
@@ -632,7 +659,8 @@ def _main(argv: list[str] | None = None, *, agentctl_operation: str | None = Non
         "complete_corpus_covered": False,
     }
     diagnosis = next((str(result["diagnosis"]) for result in reversed(results) if result["exit"] != 0), None)
-    payload = run.finish(
+    payload = _finish_and_record_verification(
+        run=run,
         exit_code=exit_code,
         duration_s=time.monotonic() - started,
         diagnosis=diagnosis,
@@ -646,8 +674,6 @@ def _main(argv: list[str] | None = None, *, agentctl_operation: str | None = Non
             exit_code=exit_code,
         ),
     )
-    append_verify_history(payload)
-    prune_successful_verify_runs(root=ROOT)
     _emit(payload, use_json=args.json, operation=agentctl_operation)
     return exit_code
 

--- a/devtools/verify_runs.py
+++ b/devtools/verify_runs.py
@@ -36,8 +36,18 @@ FAILED_VERIFY_DETAIL_LIMIT = 12
 FAILED_VERIFY_DETAIL_MAX_AGE_S = 7 * 24 * 60 * 60
 FAILED_VERIFY_DETAIL_MAX_BYTES = 64 * 1024 * 1024
 _RETENTION_LOCK_NAME = ".retention.lock"
+_DETAIL_NODE_BUDGET = 100_000
 _O_DIRECTORY = getattr(os, "O_DIRECTORY", 0)
 _O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+
+
+@dataclass
+class _NodeBudget:
+    remaining: int
+
+    def consume(self) -> bool:
+        self.remaining -= 1
+        return self.remaining >= 0
 
 
 def utc_now() -> str:
@@ -510,17 +520,22 @@ def _read_history_pinned(path: Path) -> list[dict[str, Any]]:
         raise
 
 
-def _tree_size_without_links(root: Path) -> tuple[int, bool]:
+def _tree_size_without_links(root: Path, *, budget: _NodeBudget | None = None, depth: int = 0) -> tuple[int, bool]:
     """Measure a run tree while treating links and special nodes as corrupt."""
+    budget = budget or _NodeBudget(_DETAIL_NODE_BUDGET)
+    if depth > 256:
+        return 0, False
     total = 0
     try:
         with os.scandir(root) as entries:
             for entry in entries:
+                if not budget.consume():
+                    return total, False
                 info = entry.stat(follow_symlinks=False)
                 if stat.S_ISLNK(info.st_mode):
                     return total, False
                 if stat.S_ISDIR(info.st_mode):
-                    nested, safe = _tree_size_without_links(Path(entry.path))
+                    nested, safe = _tree_size_without_links(Path(entry.path), budget=budget, depth=depth + 1)
                     total += nested
                     if not safe:
                         return total, False
@@ -533,10 +548,11 @@ def _tree_size_without_links(root: Path) -> tuple[int, bool]:
     return total, True
 
 
-def _remove_tree_at(parent_fd: int, name: str, *, budget: int = 100_000) -> None:
+def _remove_tree_at(parent_fd: int, name: str, *, budget: _NodeBudget | None = None) -> None:
     """Remove one run directory through pinned descriptors only."""
-    if budget <= 0:
-        raise ValueError("verification detail deletion budget must be positive")
+    budget = budget or _NodeBudget(_DETAIL_NODE_BUDGET)
+    if not budget.consume():
+        raise RuntimeError("verification detail deletion exceeded bounded node budget")
     info = os.lstat(name, dir_fd=parent_fd)
     if stat.S_ISLNK(info.st_mode):
         raise OSError("refusing to delete a symlinked verification detail tree")
@@ -544,18 +560,16 @@ def _remove_tree_at(parent_fd: int, name: str, *, budget: int = 100_000) -> None
         os.unlink(name, dir_fd=parent_fd)
         return
     child_fd = os.open(name, os.O_RDONLY | _O_DIRECTORY | _O_NOFOLLOW, dir_fd=parent_fd)
-    inspected = 0
     try:
         with os.scandir(child_fd) as entries:
             for entry in entries:
-                inspected += 1
-                if inspected > budget:
+                if not budget.consume():
                     raise RuntimeError("verification detail deletion exceeded bounded node budget")
                 child_info = entry.stat(follow_symlinks=False)
                 if stat.S_ISLNK(child_info.st_mode):
                     raise OSError("refusing to traverse a symlinked verification detail node")
                 if stat.S_ISDIR(child_info.st_mode):
-                    _remove_tree_at(child_fd, entry.name, budget=budget - inspected)
+                    _remove_tree_at(child_fd, entry.name, budget=budget)
                 elif stat.S_ISREG(child_info.st_mode):
                     os.unlink(entry.name, dir_fd=child_fd)
                 else:

--- a/devtools/verify_runs.py
+++ b/devtools/verify_runs.py
@@ -29,6 +29,7 @@ CURRENT_RUN_PATH = VERIFY_CACHE / "current-run.json"
 CURRENT_STATISTICS_PATH = VERIFY_CACHE / "current-pytest-statistics.json"
 CURRENT_EVENTS_DIR = VERIFY_CACHE / "current-pytest-events"
 PYTEST_CANONICAL_REPORT_NAME = "pytest-report.json"
+SUCCESSFUL_VERIFY_DETAIL_LIMIT = 8
 
 
 def utc_now() -> str:
@@ -44,8 +45,19 @@ def make_run_id(*, tier: str) -> str:
 def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = path.with_name(f"{path.name}.{os.getpid()}.{time.monotonic_ns()}.tmp")
-    temporary.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    with temporary.open("w", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
+        handle.flush()
+        os.fsync(handle.fileno())
     temporary.replace(path)
+    try:
+        directory_fd = os.open(path.parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    except OSError:
+        return
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
 
 
 def _read_only_git_env() -> dict[str, str]:
@@ -372,3 +384,60 @@ def append_verify_history(entry: Mapping[str, Any], *, path: Path = VERIFY_HISTO
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(dict(entry), ensure_ascii=False, sort_keys=True) + "\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def prune_successful_verify_runs(
+    *,
+    root: Path,
+    history_path: Path | None = None,
+    max_successful: int = SUCCESSFUL_VERIFY_DETAIL_LIMIT,
+) -> dict[str, object]:
+    """Bound only successful detail trees after history is durably appended.
+
+    The history ledger is the authority for pruning: a run whose summary was
+    never captured there is retained, as are every failed/cancelled/crashed
+    run. Malformed or symlinked run directories are also retained for manual
+    inspection. This keeps the compact durable record while reclaiming the
+    large per-step detail trees from successful repetition.
+    """
+    if max_successful < 0:
+        raise ValueError("successful verify detail limit must be non-negative")
+    root = root.resolve()
+    resolved_history = history_path or (root / VERIFY_HISTORY_PATH)
+    if not resolved_history.is_absolute():
+        resolved_history = root / resolved_history
+    durable_successes: set[str] = set()
+    try:
+        lines = resolved_history.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return {"retained_run_ids": [], "pruned_run_ids": [], "history_durable": False}
+    for line in lines:
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict) and payload.get("status") == "success" and isinstance(payload.get("run_id"), str):
+            durable_successes.add(payload["run_id"])
+    runs_root = root / VERIFY_RUNS_DIR
+    candidates: list[tuple[str, str, Path]] = []
+    if runs_root.is_dir():
+        for run_dir in runs_root.iterdir():
+            if not run_dir.is_dir() or run_dir.is_symlink():
+                continue
+            payload = _read_json(run_dir / "run.json")
+            run_id = payload.get("run_id")
+            if payload.get("status") != "success" or not isinstance(run_id, str) or run_id not in durable_successes:
+                continue
+            candidates.append((str(payload.get("finished_at", "")), run_id, run_dir))
+    candidates.sort(key=lambda item: (item[0], item[1]), reverse=True)
+    retained = [run_id for _, run_id, _ in candidates[:max_successful]]
+    pruned: list[str] = []
+    for _, run_id, run_dir in candidates[max_successful:]:
+        try:
+            shutil.rmtree(run_dir)
+        except OSError:
+            continue
+        pruned.append(run_id)
+    return {"retained_run_ids": retained, "pruned_run_ids": pruned, "history_durable": True}

--- a/devtools/verify_runs.py
+++ b/devtools/verify_runs.py
@@ -9,10 +9,12 @@ scope.
 from __future__ import annotations
 
 import contextlib
+import fcntl
 import json
 import os
 import re
 import shutil
+import stat
 import subprocess
 import time
 import uuid
@@ -30,6 +32,12 @@ CURRENT_STATISTICS_PATH = VERIFY_CACHE / "current-pytest-statistics.json"
 CURRENT_EVENTS_DIR = VERIFY_CACHE / "current-pytest-events"
 PYTEST_CANONICAL_REPORT_NAME = "pytest-report.json"
 SUCCESSFUL_VERIFY_DETAIL_LIMIT = 8
+FAILED_VERIFY_DETAIL_LIMIT = 12
+FAILED_VERIFY_DETAIL_MAX_AGE_S = 7 * 24 * 60 * 60
+FAILED_VERIFY_DETAIL_MAX_BYTES = 64 * 1024 * 1024
+_RETENTION_LOCK_NAME = ".retention.lock"
+_O_DIRECTORY = getattr(os, "O_DIRECTORY", 0)
+_O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 
 
 def utc_now() -> str:
@@ -42,6 +50,96 @@ def make_run_id(*, tier: str) -> str:
     return f"{stamp}-{safe_tier}-{os.getpid()}-{uuid.uuid4().hex[:8]}"
 
 
+def _absolute_path(path: Path) -> Path:
+    """Make a lexical absolute path without resolving any symlink."""
+    return Path(os.path.abspath(os.fspath(path)))
+
+
+def _open_pinned_dir(path: Path) -> int:
+    """Open every directory component with O_NOFOLLOW."""
+    absolute = _absolute_path(path)
+    parts = tuple(part for part in absolute.parts if part not in ("", os.sep))
+    fd = os.open(os.sep, os.O_RDONLY | _O_DIRECTORY | _O_NOFOLLOW)
+    try:
+        for part in parts:
+            next_fd = os.open(part, os.O_RDONLY | _O_DIRECTORY | _O_NOFOLLOW, dir_fd=fd)
+            os.close(fd)
+            fd = next_fd
+        return fd
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.close(fd)
+        raise
+
+
+def _mkdir_pinned(path: Path, mode: int = 0o700) -> None:
+    """Create directory components without following an existing symlink."""
+    absolute = _absolute_path(path)
+    parts = tuple(part for part in absolute.parts if part not in ("", os.sep))
+    fd = os.open(os.sep, os.O_RDONLY | _O_DIRECTORY | _O_NOFOLLOW)
+    try:
+        for part in parts:
+            with contextlib.suppress(FileExistsError):
+                os.mkdir(part, mode, dir_fd=fd)
+            next_fd = os.open(part, os.O_RDONLY | _O_DIRECTORY | _O_NOFOLLOW, dir_fd=fd)
+            os.close(fd)
+            fd = next_fd
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(fd)
+
+
+def _fsync_directory(path: Path) -> None:
+    fd = _open_pinned_dir(path)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _open_retention_lock(verify_dir: Path, *, nonblocking: bool) -> int | None:
+    directory_fd = _open_pinned_dir(verify_dir)
+    try:
+        fd = os.open(
+            _RETENTION_LOCK_NAME,
+            os.O_RDWR | os.O_CREAT | _O_NOFOLLOW,
+            0o600,
+            dir_fd=directory_fd,
+        )
+    except BaseException:
+        os.close(directory_fd)
+        raise
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | (fcntl.LOCK_NB if nonblocking else 0))
+    except BlockingIOError:
+        os.close(fd)
+        os.close(directory_fd)
+        return None
+    except BaseException:
+        os.close(fd)
+        os.close(directory_fd)
+        raise
+    try:
+        named = os.stat(_RETENTION_LOCK_NAME, dir_fd=directory_fd, follow_symlinks=False)
+        opened = os.fstat(fd)
+        if (named.st_dev, named.st_ino) != (opened.st_dev, opened.st_ino):
+            raise OSError("verification retention lock pathname was replaced while locked")
+    except BaseException:
+        with contextlib.suppress(OSError):
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+        raise
+    finally:
+        os.close(directory_fd)
+    return fd
+
+
+def _close_retention_lock(fd: int) -> None:
+    with contextlib.suppress(OSError):
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    os.close(fd)
+
+
 def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = path.with_name(f"{path.name}.{os.getpid()}.{time.monotonic_ns()}.tmp")
@@ -50,14 +148,7 @@ def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
         handle.flush()
         os.fsync(handle.fileno())
     temporary.replace(path)
-    try:
-        directory_fd = os.open(path.parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
-    except OSError:
-        return
-    try:
-        os.fsync(directory_fd)
-    finally:
-        os.close(directory_fd)
+    _fsync_directory(path.parent)
 
 
 def _read_only_git_env() -> dict[str, str]:
@@ -380,12 +471,140 @@ def configured_pytest_worker_request(env: Mapping[str, str]) -> int | None:
         return None
 
 
+def _read_json_pinned(path: Path) -> dict[str, Any]:
+    parent_fd = _open_pinned_dir(path.parent)
+    try:
+        fd = os.open(path.name, os.O_RDONLY | _O_NOFOLLOW, dir_fd=parent_fd)
+    finally:
+        os.close(parent_fd)
+    try:
+        with os.fdopen(fd, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError, TypeError):
+        with contextlib.suppress(OSError):
+            os.close(fd)
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _read_history_pinned(path: Path) -> list[dict[str, Any]]:
+    parent_fd = _open_pinned_dir(path.parent)
+    try:
+        fd = os.open(path.name, os.O_RDONLY | _O_NOFOLLOW, dir_fd=parent_fd)
+    finally:
+        os.close(parent_fd)
+    try:
+        with os.fdopen(fd, "r", encoding="utf-8") as handle:
+            rows: list[dict[str, Any]] = []
+            for line in handle:
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(payload, dict):
+                    rows.append(payload)
+            return rows
+    except OSError:
+        with contextlib.suppress(OSError):
+            os.close(fd)
+        raise
+
+
+def _tree_size_without_links(root: Path) -> tuple[int, bool]:
+    """Measure a run tree while treating links and special nodes as corrupt."""
+    total = 0
+    try:
+        with os.scandir(root) as entries:
+            for entry in entries:
+                info = entry.stat(follow_symlinks=False)
+                if stat.S_ISLNK(info.st_mode):
+                    return total, False
+                if stat.S_ISDIR(info.st_mode):
+                    nested, safe = _tree_size_without_links(Path(entry.path))
+                    total += nested
+                    if not safe:
+                        return total, False
+                elif stat.S_ISREG(info.st_mode):
+                    total += info.st_size
+                else:
+                    return total, False
+    except OSError:
+        return total, False
+    return total, True
+
+
+def _remove_tree_at(parent_fd: int, name: str, *, budget: int = 100_000) -> None:
+    """Remove one run directory through pinned descriptors only."""
+    if budget <= 0:
+        raise ValueError("verification detail deletion budget must be positive")
+    info = os.lstat(name, dir_fd=parent_fd)
+    if stat.S_ISLNK(info.st_mode):
+        raise OSError("refusing to delete a symlinked verification detail tree")
+    if not stat.S_ISDIR(info.st_mode):
+        os.unlink(name, dir_fd=parent_fd)
+        return
+    child_fd = os.open(name, os.O_RDONLY | _O_DIRECTORY | _O_NOFOLLOW, dir_fd=parent_fd)
+    inspected = 0
+    try:
+        with os.scandir(child_fd) as entries:
+            for entry in entries:
+                inspected += 1
+                if inspected > budget:
+                    raise RuntimeError("verification detail deletion exceeded bounded node budget")
+                child_info = entry.stat(follow_symlinks=False)
+                if stat.S_ISLNK(child_info.st_mode):
+                    raise OSError("refusing to traverse a symlinked verification detail node")
+                if stat.S_ISDIR(child_info.st_mode):
+                    _remove_tree_at(child_fd, entry.name, budget=budget - inspected)
+                elif stat.S_ISREG(child_info.st_mode):
+                    os.unlink(entry.name, dir_fd=child_fd)
+                else:
+                    raise OSError("refusing to delete an unsupported verification detail node")
+        os.fchmod(child_fd, os.fstat(child_fd).st_mode | stat.S_IWUSR)
+    finally:
+        os.close(child_fd)
+    os.fchmod(parent_fd, os.fstat(parent_fd).st_mode | stat.S_IWUSR)
+    os.rmdir(name, dir_fd=parent_fd)
+
+
+def _history_path_for_root(root: Path, history_path: Path | None) -> tuple[Path, Path]:
+    root = _absolute_path(root)
+    history = _absolute_path(
+        history_path
+        if history_path is not None and history_path.is_absolute()
+        else root / (history_path or VERIFY_HISTORY_PATH)
+    )
+    try:
+        history.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("verification history must remain inside the repository root") from exc
+    return root, history
+
+
 def append_verify_history(entry: Mapping[str, Any], *, path: Path = VERIFY_HISTORY_PATH) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(dict(entry), ensure_ascii=False, sort_keys=True) + "\n")
-        handle.flush()
-        os.fsync(handle.fileno())
+    path = _absolute_path(path)
+    _mkdir_pinned(path.parent)
+    lock_fd = _open_retention_lock(path.parent, nonblocking=False)
+    if lock_fd is None:
+        raise RuntimeError("verification retention lock is busy")
+    parent_fd = _open_pinned_dir(path.parent)
+    try:
+        fd = os.open(path.name, os.O_WRONLY | os.O_CREAT | os.O_APPEND | _O_NOFOLLOW, 0o600, dir_fd=parent_fd)
+        try:
+            with os.fdopen(fd, "a", encoding="utf-8") as handle:
+                handle.write(json.dumps(dict(entry), ensure_ascii=False, sort_keys=True) + "\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            # The history record is the authority that permits detail
+            # pruning. Persist its directory entry before returning to the
+            # caller that immediately starts pruning.
+            os.fsync(parent_fd)
+        finally:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+    finally:
+        os.close(parent_fd)
+        _close_retention_lock(lock_fd)
 
 
 def prune_successful_verify_runs(
@@ -393,51 +612,159 @@ def prune_successful_verify_runs(
     root: Path,
     history_path: Path | None = None,
     max_successful: int = SUCCESSFUL_VERIFY_DETAIL_LIMIT,
+    max_failed: int = FAILED_VERIFY_DETAIL_LIMIT,
+    max_failed_age_s: float = FAILED_VERIFY_DETAIL_MAX_AGE_S,
+    max_failed_bytes: int = FAILED_VERIFY_DETAIL_MAX_BYTES,
+    now: float | None = None,
 ) -> dict[str, object]:
-    """Bound only successful detail trees after history is durably appended.
+    """Bound terminal verification detail after history is durably appended.
 
-    The history ledger is the authority for pruning: a run whose summary was
-    never captured there is retained, as are every failed/cancelled/crashed
-    run. Malformed or symlinked run directories are also retained for manual
-    inspection. This keeps the compact durable record while reclaiming the
-    large per-step detail trees from successful repetition.
+    Successful details retain the newest ``max_successful`` runs. Failed,
+    cancelled, and crashed details retain the newest run unconditionally, then
+    at most ``max_failed`` recent runs within ``max_failed_age_s`` and
+    ``max_failed_bytes``. The newest failure is the explicit exception to the
+    byte, age, and count caps so a single run cannot erase the only diagnostic
+    evidence. The append-only history remains the compact structured summary.
+    Any symlink, malformed receipt, unsafe path, or active retention lock
+    causes pruning to retain the affected evidence and report the refusal.
     """
-    if max_successful < 0:
+    if max_successful < 0 or max_failed < 0 or max_failed_age_s < 0 or max_failed_bytes < 0:
         raise ValueError("successful verify detail limit must be non-negative")
-    root = root.resolve()
-    resolved_history = history_path or (root / VERIFY_HISTORY_PATH)
-    if not resolved_history.is_absolute():
-        resolved_history = root / resolved_history
-    durable_successes: set[str] = set()
     try:
-        lines = resolved_history.read_text(encoding="utf-8").splitlines()
-    except OSError:
-        return {"retained_run_ids": [], "pruned_run_ids": [], "history_durable": False}
-    for line in lines:
+        root, resolved_history = _history_path_for_root(root, history_path)
+        root_fd = _open_pinned_dir(root)
+        verify_dir = root / VERIFY_CACHE
+        verify_fd = _open_pinned_dir(verify_dir)
+        runs_root = root / VERIFY_RUNS_DIR
+        runs_fd = _open_pinned_dir(runs_root)
+    except (OSError, ValueError) as exc:
+        return {
+            "retained_run_ids": [],
+            "retained_failure_run_ids": [],
+            "pruned_run_ids": [],
+            "history_durable": False,
+            "refused": True,
+            "reason": str(exc),
+        }
+    lock_fd = _open_retention_lock(verify_dir, nonblocking=True)
+    if lock_fd is None:
+        for fd in (runs_fd, verify_fd, root_fd):
+            os.close(fd)
+        return {
+            "retained_run_ids": [],
+            "retained_failure_run_ids": [],
+            "pruned_run_ids": [],
+            "history_durable": False,
+            "retention_locked": True,
+        }
+    try:
         try:
-            payload = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if isinstance(payload, dict) and payload.get("status") == "success" and isinstance(payload.get("run_id"), str):
-            durable_successes.add(payload["run_id"])
-    runs_root = root / VERIFY_RUNS_DIR
-    candidates: list[tuple[str, str, Path]] = []
-    if runs_root.is_dir():
-        for run_dir in runs_root.iterdir():
-            if not run_dir.is_dir() or run_dir.is_symlink():
+            history_rows = _read_history_pinned(resolved_history)
+        except (OSError, ValueError):
+            return {
+                "retained_run_ids": [],
+                "retained_failure_run_ids": [],
+                "pruned_run_ids": [],
+                "history_durable": False,
+                "refused": True,
+            }
+        durable: dict[str, dict[str, Any]] = {}
+        for row in history_rows:
+            run_id = row.get("run_id")
+            if isinstance(run_id, str) and row.get("status") != "running":
+                durable[run_id] = row
+
+        candidates: list[dict[str, Any]] = []
+        with os.scandir(runs_fd) as entries:
+            for entry in entries:
+                info = entry.stat(follow_symlinks=False)
+                if not stat.S_ISDIR(info.st_mode) or stat.S_ISLNK(info.st_mode):
+                    continue
+                run_dir = runs_root / entry.name
+                try:
+                    payload = _read_json_pinned(run_dir / "run.json")
+                except (OSError, ValueError):
+                    # A malformed or hostile detail tree is evidence, not a
+                    # pruning candidate.
+                    continue
+                run_id = payload.get("run_id")
+                history = durable.get(run_id) if isinstance(run_id, str) else None
+                if (
+                    not isinstance(run_id, str)
+                    or entry.name != run_id
+                    or history is None
+                    or payload.get("status") != history.get("status")
+                ):
+                    continue
+                finished_at = payload.get("finished_at")
+                try:
+                    finished_epoch = datetime.fromisoformat(str(finished_at).replace("Z", "+00:00")).timestamp()
+                except (TypeError, ValueError, OverflowError):
+                    continue
+                size, safe = _tree_size_without_links(run_dir)
+                if not safe:
+                    continue
+                candidates.append(
+                    {
+                        "run_id": run_id,
+                        "status": payload.get("status"),
+                        "finished_at": str(finished_at),
+                        "finished_epoch": finished_epoch,
+                        "size": size,
+                        "name": entry.name,
+                    }
+                )
+
+        successes = sorted(
+            (candidate for candidate in candidates if candidate["status"] == "success"),
+            key=lambda item: (item["finished_at"], item["run_id"]),
+            reverse=True,
+        )
+        failures = sorted(
+            (candidate for candidate in candidates if candidate["status"] != "success"),
+            key=lambda item: (item["finished_at"], item["run_id"]),
+            reverse=True,
+        )
+        retained = [candidate["run_id"] for candidate in successes[:max_successful]]
+        retained_failures: list[str] = []
+        keep_failure_names: set[str] = set()
+        if failures:
+            newest = failures[0]
+            retained_failures.append(newest["run_id"])
+            keep_failure_names.add(newest["name"])
+            used_bytes = newest["size"]
+            current_time = time.time() if now is None else now
+            for candidate in failures[1:]:
+                if len(retained_failures) >= max_failed:
+                    continue
+                if current_time - candidate["finished_epoch"] > max_failed_age_s:
+                    continue
+                if used_bytes + candidate["size"] > max_failed_bytes:
+                    continue
+                retained_failures.append(candidate["run_id"])
+                keep_failure_names.add(candidate["name"])
+                used_bytes += candidate["size"]
+
+        keep_names = {candidate["name"] for candidate in successes[:max_successful]} | keep_failure_names
+        pruned: list[str] = []
+        for candidate in candidates:
+            if candidate["name"] in keep_names:
                 continue
-            payload = _read_json(run_dir / "run.json")
-            run_id = payload.get("run_id")
-            if payload.get("status") != "success" or not isinstance(run_id, str) or run_id not in durable_successes:
+            try:
+                _remove_tree_at(runs_fd, candidate["name"])
+            except (OSError, RuntimeError, ValueError):
                 continue
-            candidates.append((str(payload.get("finished_at", "")), run_id, run_dir))
-    candidates.sort(key=lambda item: (item[0], item[1]), reverse=True)
-    retained = [run_id for _, run_id, _ in candidates[:max_successful]]
-    pruned: list[str] = []
-    for _, run_id, run_dir in candidates[max_successful:]:
-        try:
-            shutil.rmtree(run_dir)
-        except OSError:
-            continue
-        pruned.append(run_id)
-    return {"retained_run_ids": retained, "pruned_run_ids": pruned, "history_durable": True}
+            pruned.append(candidate["run_id"])
+        if pruned:
+            os.fsync(runs_fd)
+        return {
+            "retained_run_ids": retained,
+            "retained_failure_run_ids": retained_failures,
+            "pruned_run_ids": pruned,
+            "history_durable": True,
+            "retention_locked": False,
+        }
+    finally:
+        _close_retention_lock(lock_fd)
+        for fd in (runs_fd, verify_fd, root_fd):
+            os.close(fd)

--- a/tests/infra/archive_templates.py
+++ b/tests/infra/archive_templates.py
@@ -74,9 +74,25 @@ def _remove_partial_clone(destination: Path) -> None:
     shutil.rmtree(destination)
 
 
-def clone_archive_template(template: Path, destination: Path) -> None:
+def _assert_detached_tree(template: Path, destination: Path) -> None:
+    """Reject links and shared inodes after either clone implementation."""
+    for source in template.rglob("*"):
+        relative = source.relative_to(template)
+        target = destination / relative
+        if source.is_symlink() or target.is_symlink():
+            raise RuntimeError(f"archive template clone contains a symlink: {relative}")
+        if (
+            source.is_file()
+            and target.is_file()
+            and (source.stat().st_dev, source.stat().st_ino) == (target.stat().st_dev, target.stat().st_ino)
+        ):
+            raise RuntimeError(f"archive template clone contains a hardlink: {relative}")
+
+
+def clone_archive_template(template: Path, destination: Path, *, reject_links: bool = False) -> str:
     """Clone an immutable archive into a private writable destination."""
     destination.mkdir(parents=True, exist_ok=True)
+    method = "reflink"
     try:
         subprocess.run(
             # ``auto`` silently falls back to a byte-for-byte copy when the
@@ -95,6 +111,9 @@ def clone_archive_template(template: Path, destination: Path) -> None:
         # that partial tree before replacing it on a filesystem without CoW.
         _remove_partial_clone(destination)
         shutil.copytree(template, destination, symlinks=True)
+        method = "copy"
+    if reject_links:
+        _assert_detached_tree(template, destination)
     for path in destination.rglob("*"):
         if path.is_symlink():
             continue
@@ -106,6 +125,7 @@ def clone_archive_template(template: Path, destination: Path) -> None:
 
         bootstrap_marker.unlink()
         _record_fresh_durable_bootstrap(destination)
+    return method
 
 
 __all__ = ["clone_archive_template", "finalize_archive_template", "quiesce_archive_template"]

--- a/tests/infra/whale_fixtures.py
+++ b/tests/infra/whale_fixtures.py
@@ -24,6 +24,7 @@ from polylogue.product.raw_authority import (
     RAW_MATERIALIZATION_ORDINARY_BLOB_LIMIT_BYTES,
     RAW_MATERIALIZATION_WHALE_BLOB_LIMIT_BYTES,
 )
+from tests.infra.archive_templates import clone_archive_template
 
 _TERMINAL_WIRE_BYTES: Final = 90_822_451
 _REVISION_COUNT: Final = 804
@@ -38,6 +39,11 @@ def copy_sqlite_database(source: Path, destination: Path) -> None:
     """Copy live SQLite contents in place so archive identity inodes remain stable."""
     with sqlite3.connect(source) as source_conn, sqlite3.connect(destination) as destination_conn:
         source_conn.backup(destination_conn)
+
+
+def clone_blob_tree(source: Path, destination: Path) -> str:
+    """Clone Codex blob evidence with CoW first and detached-copy fallback."""
+    return clone_archive_template(source, destination, reject_links=True)
 
 
 def assert_planner_append_authority(
@@ -592,6 +598,7 @@ __all__ = [
     "WHALE_FIXTURE_DIMENSIONS",
     "WhaleFixtureDimensions",
     "acquire_codex_revision_chain",
+    "clone_blob_tree",
     "multi_million_codex_stream",
     "write_codex_whale_fixture_pack",
 ]

--- a/tests/infra/workload_artifacts.py
+++ b/tests/infra/workload_artifacts.py
@@ -1161,7 +1161,7 @@ def _assert_lock_identity(fd: int, path: Path) -> None:
         raise OSError("lock pathname was replaced while lock was held")
 
 
-def _open_authenticated_lock(path: Path, *, nonblocking: bool = False) -> int:
+def _open_authenticated_lock(path: Path, *, nonblocking: bool = False, shared: bool = False) -> int:
     """Open and flock a lock inode, rejecting pathname replacement.
 
     A flock authenticates an inode, not a pathname.  Comparing the opened
@@ -1171,7 +1171,7 @@ def _open_authenticated_lock(path: Path, *, nonblocking: bool = False) -> int:
     """
     fd = _open_no_follow(path, os.O_RDWR | os.O_CREAT, 0o600)
     try:
-        operation = fcntl.LOCK_EX | (fcntl.LOCK_NB if nonblocking else 0)
+        operation = (fcntl.LOCK_SH if shared else fcntl.LOCK_EX) | (fcntl.LOCK_NB if nonblocking else 0)
         fcntl.flock(fd, operation)
         try:
             _assert_lock_identity(fd, path)
@@ -1436,7 +1436,11 @@ def _remove_tree(path: Path, *, budget: int = _MAX_DELETE_NODES) -> None:
             elif not stat.S_ISREG(info.st_mode):
                 os.unlink(name, dir_fd=directory_fd)
             else:
-                _chmod_at(directory_fd, name, info.st_mode | stat.S_IWUSR)
+                # Unlinking needs a writable parent, not a writable file.
+                # Do not chmod regular files here: a rejected reflink/copy
+                # may contain hardlinks to the immutable source tree, and a
+                # chmod would mutate the source inode before removing the
+                # destination name.
                 os.unlink(name, dir_fd=directory_fd)
     finally:
         for entries in iterators:
@@ -2901,6 +2905,47 @@ def _authenticate_clone_copy(
             os.close(clone_manifest_fd)
 
 
+@contextlib.contextmanager
+def _shared_seeded_artifact_read_locks(artifact: SeededArchiveArtifact) -> Iterator[None]:
+    """Hold the cache, per-key, and source-root leases during a clone.
+
+    Lock order is cache root, per-key lock, then final artifact root.  GC
+    acquires the same sequence exclusively, so it cannot unlink the source
+    after validation and before the clone has finished reading it.
+    """
+    cache_root = artifact.root.parent.parent
+    cache_fd = _open_pinned_dir(cache_root)
+    key_fd = -1
+    root_fd = -1
+    try:
+        fcntl.flock(cache_fd, fcntl.LOCK_SH)
+        try:
+            key_fd = _open_authenticated_lock(cache_root / ".locks" / f"{artifact.root.name}.lock", shared=True)
+        except FileNotFoundError:
+            # Keep the small generic symlink-rejection fixture usable. Real
+            # seeded artifacts always have the cache lock domain, and GC
+            # safety for those artifacts uses all three locks above.
+            root_fd = _open_pinned_dir(artifact.root)
+            fcntl.flock(root_fd, fcntl.LOCK_SH)
+            yield
+            return
+        root_fd = _open_pinned_dir(artifact.root)
+        fcntl.flock(root_fd, fcntl.LOCK_SH)
+        yield
+    finally:
+        if root_fd >= 0:
+            with contextlib.suppress(OSError):
+                fcntl.flock(root_fd, fcntl.LOCK_UN)
+            os.close(root_fd)
+        if key_fd >= 0:
+            with contextlib.suppress(OSError):
+                fcntl.flock(key_fd, fcntl.LOCK_UN)
+            os.close(key_fd)
+        with contextlib.suppress(OSError):
+            fcntl.flock(cache_fd, fcntl.LOCK_UN)
+        os.close(cache_fd)
+
+
 def acquire_query_only_seeded_archive(
     artifact: SeededArchiveArtifact,
     key: SeededArchiveKey,
@@ -2927,65 +2972,78 @@ def clone_seeded_archive(artifact: SeededArchiveArtifact, destination: Path) -> 
     directories remain entirely caller-owned, so closing one clone cannot
     restore modes or release locks belonging to a sibling.
     """
-    _assert_no_symlinks(artifact.root)
-    disk_manifest = _read_manifest(artifact.root / "manifest.json")
-    if disk_manifest != artifact.manifest:
-        raise ValueError("published artifact manifest changed before clone")
-    if _is_symlink_node(destination):
-        _safe_unlink(destination)
-    _remove_tree(destination)
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    method = "reflink"
-    try:
-        subprocess.run(
-            ["cp", "-a", "--reflink=always", str(artifact.root), str(destination)],
-            check=True,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            timeout=30,
-        )
-    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+    with _shared_seeded_artifact_read_locks(artifact):
+        _assert_no_symlinks(artifact.root)
+        disk_manifest = _read_manifest(artifact.root / "manifest.json")
+        if disk_manifest != artifact.manifest:
+            raise ValueError("published artifact manifest changed before clone")
+        if _is_symlink_node(destination):
+            _safe_unlink(destination)
         _remove_tree(destination)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        method = "reflink"
         try:
-            _copy_tree(artifact.root, destination)
+            subprocess.run(
+                ["cp", "-a", "--reflink=always", str(artifact.root), str(destination)],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=30,
+            )
+        except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+            _remove_tree(destination)
+            try:
+                _copy_tree(artifact.root, destination)
+            except BaseException:
+                with contextlib.suppress(BaseException):
+                    _remove_tree(destination)
+                raise
+            method = "copy"
+        integrity_fd = -1
+        try:
+            _assert_no_symlinks(destination)
+            # Authenticate inode detachment before chmodding the writable
+            # clone. A hostile hardlink would otherwise receive the write bit
+            # through the destination path and mutate the source inode.
+            _authenticate_clone_copy(
+                artifact,
+                destination,
+                disk_manifest,
+                ignored_relatives=frozenset({".maintenance-state/durable-change-trains/.bootstrap"}),
+            )
+            for path in _pinned_paths(destination):
+                _safe_chmod(path, _safe_stat(path).st_mode | stat.S_IWUSR)
+            _safe_chmod(destination, _safe_stat(destination).st_mode | stat.S_IWUSR)
+            bootstrap_marker = destination / ".maintenance-state" / "durable-change-trains" / ".bootstrap"
+            if stat.S_ISREG(_safe_stat(bootstrap_marker).st_mode):
+                from polylogue.storage.sqlite.durable_change_train import _record_fresh_durable_bootstrap
+
+                _safe_unlink(bootstrap_marker)
+                _record_fresh_durable_bootstrap(destination)
+            integrity_fd = _open_pinned_dir(destination)
+            fcntl.flock(integrity_fd, fcntl.LOCK_SH)
+            _authenticate_clone_copy(
+                artifact,
+                destination,
+                disk_manifest,
+                ignored_relatives=frozenset({".maintenance-state/durable-change-trains/.bootstrap"}),
+            )
         except BaseException:
+            if integrity_fd >= 0:
+                with contextlib.suppress(OSError):
+                    os.close(integrity_fd)
+            # Cleanup is deliberately best-effort, but never touches the
+            # source tree.  _remove_tree unlinks residue without chmodding
+            # regular files, preserving source modes for hardlink failures.
             with contextlib.suppress(BaseException):
                 _remove_tree(destination)
             raise
-        method = "copy"
-    integrity_fd = -1
-    try:
-        _assert_no_symlinks(destination)
-        for path in _pinned_paths(destination):
-            _safe_chmod(path, _safe_stat(path).st_mode | stat.S_IWUSR)
-        _safe_chmod(destination, _safe_stat(destination).st_mode | stat.S_IWUSR)
-        bootstrap_marker = destination / ".maintenance-state" / "durable-change-trains" / ".bootstrap"
-        if stat.S_ISREG(_safe_stat(bootstrap_marker).st_mode):
-            from polylogue.storage.sqlite.durable_change_train import _record_fresh_durable_bootstrap
-
-            _safe_unlink(bootstrap_marker)
-            _record_fresh_durable_bootstrap(destination)
-        integrity_fd = _open_pinned_dir(destination)
-        fcntl.flock(integrity_fd, fcntl.LOCK_SH)
-        _authenticate_clone_copy(
-            artifact,
-            destination,
-            disk_manifest,
-            ignored_relatives=frozenset({".maintenance-state/durable-change-trains/.bootstrap"}),
+        return SeededArchiveClone(
+            root=destination,
+            source_manifest_id=disk_manifest.manifest_id,
+            clone_method=method,
+            _integrity_fd=integrity_fd,
         )
-    except BaseException:
-        if integrity_fd >= 0:
-            with contextlib.suppress(OSError):
-                os.close(integrity_fd)
-        with contextlib.suppress(BaseException):
-            _remove_tree(destination)
-        raise
-    return SeededArchiveClone(
-        root=destination,
-        source_manifest_id=disk_manifest.manifest_id,
-        clone_method=method,
-        _integrity_fd=integrity_fd,
-    )
 
 
 __all__ = [

--- a/tests/infra/workload_artifacts.py
+++ b/tests/infra/workload_artifacts.py
@@ -184,6 +184,80 @@ class SeededArchiveArtifact:
         return self.manifest.facts
 
 
+class ArtifactGcDisposition(str, Enum):
+    """The fail-closed result for one published seeded-artifact directory."""
+
+    REACHABLE = "reachable"
+    GRACE = "grace"
+    STALE = "stale"
+    ACTIVE_LOCK = "active-lock"
+    ACTIVE_LEASE = "active-lease"
+    ACTIVE_WORKTREE = "active-worktree"
+    CORRUPT = "corrupt"
+    DELETED = "deleted"
+    DELETION_FAILED = "deletion-failed"
+
+
+@dataclass(frozen=True)
+class ArtifactGcEntry:
+    """Receipt row for a final artifact considered by cache GC."""
+
+    name: str
+    path: str
+    key: str | None
+    manifest_id: str | None
+    size_bytes: int
+    age_seconds: float | None
+    disposition: ArtifactGcDisposition
+    detail: str | None = None
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "path": self.path,
+            "key": self.key,
+            "manifest_id": self.manifest_id,
+            "size_bytes": self.size_bytes,
+            "age_seconds": self.age_seconds,
+            "disposition": self.disposition.value,
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True)
+class ArtifactGcReport:
+    """Bounded, serializable preview/apply receipt for final-artifact GC."""
+
+    cache_root: Path
+    dry_run: bool
+    grace_period_s: float
+    reachable_keys: tuple[str, ...]
+    entries: tuple[ArtifactGcEntry, ...]
+
+    @property
+    def deleted_bytes(self) -> int:
+        return sum(entry.size_bytes for entry in self.entries if entry.disposition is ArtifactGcDisposition.DELETED)
+
+    @property
+    def reclaimable_bytes(self) -> int:
+        return sum(
+            entry.size_bytes
+            for entry in self.entries
+            if entry.disposition in {ArtifactGcDisposition.STALE, ArtifactGcDisposition.DELETED}
+        )
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "cache_root": str(self.cache_root),
+            "dry_run": self.dry_run,
+            "grace_period_s": self.grace_period_s,
+            "reachable_keys": list(self.reachable_keys),
+            "reclaimable_bytes": self.reclaimable_bytes,
+            "deleted_bytes": self.deleted_bytes,
+            "entries": [entry.to_payload() for entry in self.entries],
+        }
+
+
 @dataclass
 class SeededArchiveClone:
     root: Path
@@ -1843,6 +1917,358 @@ def _manifest_binds_to_key(manifest: SeededArchiveManifest, root: Path, key: See
     return manifest.receipt == dict(expected_receipt)
 
 
+_SEEDED_KEY = re.compile(r"seeded-archive:sha256:([0-9a-f]{64})\Z")
+_GC_WORKTREE_MARKERS = (".worktree", ".worktree.lock", ".artifact-worktree.lock")
+_GC_LEASE_MARKERS = (".lease", ".artifact.lease", ".query.lease")
+_GC_CONTROL_MARKERS = frozenset((*_GC_WORKTREE_MARKERS, *_GC_LEASE_MARKERS))
+
+
+def _gc_tree_size(root: Path) -> int:
+    """Measure regular files without following a corrupt link node."""
+    total = 0
+    try:
+        for path in _pinned_paths(root):
+            if _is_regular(path):
+                total += _safe_stat(path).st_size
+    except (OSError, RuntimeError, ValueError):
+        return total
+    return total
+
+
+def _gc_manifest_integrity(root: Path) -> tuple[SeededArchiveManifest | None, int, str | None]:
+    """Check only the authenticated final-tree shape needed before GC.
+
+    Full semantic validation remains the build/query authority. GC does not
+    rebuild or reinterpret an artifact; it merely refuses to delete anything
+    whose self-authenticated manifest or content-addressed file set is not
+    intact.
+    """
+    size = _gc_tree_size(root)
+    try:
+        manifest = _read_manifest(root / "manifest.json")
+        match = _SEEDED_KEY.fullmatch(manifest.key)
+        if match is None or root.name != match.group(1):
+            return manifest, size, "manifest key does not match final path"
+        expected = _manifest_file_entries(manifest.files)
+        expected_paths = {relative for relative, _, _ in expected}
+        actual_paths: set[str] = set()
+        for path in _pinned_paths(root):
+            relative = path.relative_to(root)
+            if relative.parts and relative.parts[0] in _GC_CONTROL_MARKERS:
+                continue
+            if _is_symlink_node(path):
+                return manifest, size, f"symlink node: {relative}"
+            if _is_regular(path) and not _is_reserved_root_file(path, root):
+                actual_paths.add(str(relative))
+        if actual_paths != expected_paths:
+            return manifest, size, "manifest file set does not match final tree"
+        for expected_relative, expected_size, expected_digest in expected:
+            path = root / expected_relative
+            if not _is_regular(path) or _safe_stat(path).st_size != expected_size or _sha256(path) != expected_digest:
+                return manifest, size, f"file digest mismatch: {expected_relative}"
+    except (OSError, RuntimeError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        return None, size, f"unreadable or malformed artifact: {type(exc).__name__}"
+    return manifest, size, None
+
+
+def _try_exclusive_path_lock(path: Path) -> tuple[int | None, bool]:
+    """Return ``(fd, True)`` for an acquired lock, ``(None, False)`` if busy."""
+    try:
+        fd = _open_authenticated_lock(path, nonblocking=True)
+    except BlockingIOError:
+        return None, False
+    except OSError as exc:
+        if getattr(exc, "errno", None) in {11, 13}:
+            return None, False
+        raise
+    return fd, True
+
+
+def _gc_active_marker(root: Path, names: tuple[str, ...]) -> bool:
+    for name in names:
+        marker = root / name
+        if not _safe_exists(marker):
+            continue
+        if name == ".worktree":
+            return True
+        if _is_symlink_node(marker):
+            return True
+        try:
+            fd = _open_no_follow(marker, os.O_RDONLY | os.O_NONBLOCK)
+        except OSError:
+            return True
+        try:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                return True
+        finally:
+            with contextlib.suppress(OSError):
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            os.close(fd)
+    return False
+
+
+def _write_gc_receipt(path: Path, report: ArtifactGcReport) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _write_private_text(path, json.dumps(report.to_payload(), sort_keys=True, indent=2) + "\n")
+
+
+def gc_seeded_archive_artifacts(
+    *,
+    cache_root: Path,
+    reachable_keys: Iterable[SeededArchiveKey | str],
+    grace_period_s: float = 24 * 60 * 60,
+    now: float | None = None,
+    dry_run: bool = True,
+    protected_worktrees: Iterable[Path] = (),
+    receipt_path: Path | None = None,
+) -> ArtifactGcReport:
+    """Preview or delete unreachable, aged final seeded-artifact trees.
+
+    ``reachable_keys`` is mandatory by design. It is the current workload
+    authority, not a build-id heuristic: a different checkout can publish the
+    same bytes and a current checkout can legitimately reuse an older build.
+    Missing, malformed, or corrupt artifacts are retained and reported. Every
+    destructive decision holds the cache, per-key, and final-root locks for
+    the complete inspect/delete interval, so active builders, query leases,
+    clones, and explicitly protected worktrees remain untouched.
+    """
+    if grace_period_s < 0:
+        raise ValueError("artifact GC grace period must be non-negative")
+    reachable_values = {item.value if isinstance(item, SeededArchiveKey) else str(item) for item in reachable_keys}
+    if any(_SEEDED_KEY.fullmatch(value) is None for value in reachable_values):
+        raise ValueError("artifact GC reachability must use complete seeded archive keys")
+    reachable = tuple(sorted(reachable_values))
+    if not reachable:
+        raise ValueError("artifact GC requires explicit current reachable keys")
+    cache_root = cache_root.expanduser()
+    artifacts_root = cache_root / "artifacts"
+    if not artifacts_root.is_dir():
+        report = ArtifactGcReport(cache_root, dry_run, grace_period_s, reachable, ())
+        if receipt_path is not None:
+            _write_gc_receipt(receipt_path, report)
+        return report
+
+    protected = tuple(path.expanduser().resolve(strict=False) for path in protected_worktrees)
+    current_time = time.time() if now is None else now
+    entries: list[ArtifactGcEntry] = []
+    cache_fd = -1
+    try:
+        cache_fd = _open_pinned_dir(cache_root)
+        try:
+            fcntl.flock(cache_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            report = ArtifactGcReport(
+                cache_root,
+                dry_run,
+                grace_period_s,
+                reachable,
+                (
+                    ArtifactGcEntry(
+                        name="<cache>",
+                        path=str(cache_root),
+                        key=None,
+                        manifest_id=None,
+                        size_bytes=0,
+                        age_seconds=None,
+                        disposition=ArtifactGcDisposition.ACTIVE_LOCK,
+                        detail="cache root is owned by an active builder",
+                    ),
+                ),
+            )
+            if receipt_path is not None:
+                _write_gc_receipt(receipt_path, report)
+            return report
+        candidates = sorted(artifacts_root.iterdir(), key=lambda item: item.name)
+        for root in candidates:
+            if root.name.startswith("."):
+                continue
+            if _is_symlink_node(root) or not root.is_dir():
+                entries.append(
+                    ArtifactGcEntry(
+                        root.name,
+                        str(root),
+                        None,
+                        None,
+                        _gc_tree_size(root),
+                        None,
+                        ArtifactGcDisposition.CORRUPT,
+                        "final entry is not a directory",
+                    )
+                )
+                continue
+            manifest, size, corruption = _gc_manifest_integrity(root)
+            key = manifest.key if manifest is not None else None
+            manifest_id = manifest.manifest_id if manifest is not None else None
+            try:
+                age = max(0.0, current_time - max(root.stat().st_mtime, (root / "manifest.json").stat().st_mtime))
+            except OSError:
+                age = None
+            if corruption is not None:
+                entries.append(
+                    ArtifactGcEntry(
+                        root.name, str(root), key, manifest_id, size, age, ArtifactGcDisposition.CORRUPT, corruption
+                    )
+                )
+                continue
+            assert manifest is not None and key is not None
+            if key in reachable:
+                entries.append(
+                    ArtifactGcEntry(root.name, str(root), key, manifest_id, size, age, ArtifactGcDisposition.REACHABLE)
+                )
+                continue
+            try:
+                resolved_root = root.resolve(strict=True)
+            except OSError:
+                resolved_root = root
+            if any(
+                resolved_root == protected_root or protected_root in resolved_root.parents
+                for protected_root in protected
+            ):
+                entries.append(
+                    ArtifactGcEntry(
+                        root.name,
+                        str(root),
+                        key,
+                        manifest_id,
+                        size,
+                        age,
+                        ArtifactGcDisposition.ACTIVE_WORKTREE,
+                        "explicitly protected worktree",
+                    )
+                )
+                continue
+            if _gc_active_marker(root, _GC_LEASE_MARKERS):
+                entries.append(
+                    ArtifactGcEntry(
+                        root.name,
+                        str(root),
+                        key,
+                        manifest_id,
+                        size,
+                        age,
+                        ArtifactGcDisposition.ACTIVE_LEASE,
+                        "active lease marker",
+                    )
+                )
+                continue
+            if _gc_active_marker(root, _GC_WORKTREE_MARKERS):
+                entries.append(
+                    ArtifactGcEntry(
+                        root.name,
+                        str(root),
+                        key,
+                        manifest_id,
+                        size,
+                        age,
+                        ArtifactGcDisposition.ACTIVE_WORKTREE,
+                        "active worktree marker",
+                    )
+                )
+                continue
+            lock_path = cache_root / ".locks" / f"{root.name}.lock"
+            if _is_symlink_node(lock_path):
+                entries.append(
+                    ArtifactGcEntry(
+                        root.name,
+                        str(root),
+                        key,
+                        manifest_id,
+                        size,
+                        age,
+                        ArtifactGcDisposition.CORRUPT,
+                        "per-key lock path is a symlink",
+                    )
+                )
+                continue
+            lock_fd, acquired = _try_exclusive_path_lock(lock_path)
+            if not acquired:
+                entries.append(
+                    ArtifactGcEntry(
+                        root.name,
+                        str(root),
+                        key,
+                        manifest_id,
+                        size,
+                        age,
+                        ArtifactGcDisposition.ACTIVE_LOCK,
+                        "per-key build lock is held",
+                    )
+                )
+                continue
+            root_fd = -1
+            try:
+                root_fd = _open_pinned_dir(root)
+                try:
+                    fcntl.flock(root_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except BlockingIOError:
+                    entries.append(
+                        ArtifactGcEntry(
+                            root.name,
+                            str(root),
+                            key,
+                            manifest_id,
+                            size,
+                            age,
+                            ArtifactGcDisposition.ACTIVE_LEASE,
+                            "artifact root is leased",
+                        )
+                    )
+                    continue
+                if age is None or age < grace_period_s:
+                    entries.append(
+                        ArtifactGcEntry(root.name, str(root), key, manifest_id, size, age, ArtifactGcDisposition.GRACE)
+                    )
+                elif dry_run:
+                    entries.append(
+                        ArtifactGcEntry(root.name, str(root), key, manifest_id, size, age, ArtifactGcDisposition.STALE)
+                    )
+                else:
+                    try:
+                        _remove_tree(root)
+                    except (OSError, RuntimeError, ValueError) as exc:
+                        entries.append(
+                            ArtifactGcEntry(
+                                root.name,
+                                str(root),
+                                key,
+                                manifest_id,
+                                size,
+                                age,
+                                ArtifactGcDisposition.DELETION_FAILED,
+                                str(exc),
+                            )
+                        )
+                    else:
+                        for memo_key, artifact in tuple(_VALIDATED_ARTIFACTS.items()):
+                            if artifact.root == root:
+                                _VALIDATED_ARTIFACTS.pop(memo_key, None)
+                        entries.append(
+                            ArtifactGcEntry(
+                                root.name, str(root), key, manifest_id, size, age, ArtifactGcDisposition.DELETED
+                            )
+                        )
+            finally:
+                if root_fd >= 0:
+                    with contextlib.suppress(OSError):
+                        fcntl.flock(root_fd, fcntl.LOCK_UN)
+                    os.close(root_fd)
+                if lock_fd is not None:
+                    with contextlib.suppress(OSError):
+                        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                    os.close(lock_fd)
+    finally:
+        if cache_fd >= 0:
+            with contextlib.suppress(OSError):
+                fcntl.flock(cache_fd, fcntl.LOCK_UN)
+            os.close(cache_fd)
+    report = ArtifactGcReport(cache_root, dry_run, grace_period_s, reachable, tuple(entries))
+    if receipt_path is not None:
+        _write_gc_receipt(receipt_path, report)
+    return report
+
+
 _VALIDATED_ARTIFACTS: dict[tuple[str, str], SeededArchiveArtifact] = {}
 
 
@@ -2563,6 +2989,9 @@ def clone_seeded_archive(artifact: SeededArchiveArtifact, destination: Path) -> 
 
 
 __all__ = [
+    "ArtifactGcDisposition",
+    "ArtifactGcEntry",
+    "ArtifactGcReport",
     "ImmutableTreeArtifact",
     "BENCHMARK_WORKLOAD_PROFILES",
     "BenchmarkWorkloadProfile",
@@ -2587,6 +3016,7 @@ __all__ = [
     "c03_semantic_corpus_spec",
     "clone_seeded_archive",
     "default_cache_root",
+    "gc_seeded_archive_artifacts",
     "named_corpus_specs",
     "named_workload_profile",
     "schema_coverage_corpus_specs",

--- a/tests/unit/devtools/test_pytest_progress_plugin.py
+++ b/tests/unit/devtools/test_pytest_progress_plugin.py
@@ -34,8 +34,12 @@ def _restore_plugin_state(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     collection_duration_s = pytest_progress_plugin._COLLECTION_DURATION_S
     controller_collection_payload = pytest_progress_plugin._CONTROLLER_COLLECTION_PAYLOAD
     recorded_report_keys = set(pytest_progress_plugin._RECORDED_REPORT_KEYS)
+    test_scratch_trees = dict(pytest_progress_plugin._TEST_SCRATCH_TREES)
+    test_call_outcomes = dict(pytest_progress_plugin._TEST_CALL_OUTCOMES)
     session_state_stack = list(pytest_progress_plugin._SESSION_STATE_STACK)
     pytest_progress_plugin._RECORDED_REPORT_KEYS.clear()
+    pytest_progress_plugin._TEST_SCRATCH_TREES.clear()
+    pytest_progress_plugin._TEST_CALL_OUTCOMES.clear()
     pytest_progress_plugin._SESSION_STATE_STACK.clear()
     yield
     pytest_progress_plugin._SELECTED_COUNT = selected_count
@@ -47,6 +51,10 @@ def _restore_plugin_state(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     pytest_progress_plugin._CONTROLLER_COLLECTION_PAYLOAD = controller_collection_payload
     pytest_progress_plugin._RECORDED_REPORT_KEYS.clear()
     pytest_progress_plugin._RECORDED_REPORT_KEYS.update(recorded_report_keys)
+    pytest_progress_plugin._TEST_SCRATCH_TREES.clear()
+    pytest_progress_plugin._TEST_SCRATCH_TREES.update(test_scratch_trees)
+    pytest_progress_plugin._TEST_CALL_OUTCOMES.clear()
+    pytest_progress_plugin._TEST_CALL_OUTCOMES.update(test_call_outcomes)
     pytest_progress_plugin._SESSION_STATE_STACK[:] = session_state_stack
 
 
@@ -278,6 +286,41 @@ def test_progress_plugin_write_failures_do_not_escape(monkeypatch: pytest.Monkey
     monkeypatch.setenv("POLYLOGUE_PYTEST_EVENTS_PATH", "/dev/null/events.jsonl")
 
     pytest_progress_plugin.pytest_runtest_logreport(_Report("test_body", "call", "failed", longrepr="boom"))
+
+
+def test_successful_test_tree_is_removed_only_after_passed_teardown(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    scratch = tmp_path / "scratch"
+    test_tree = scratch / "test-success"
+    test_tree.mkdir(parents=True)
+    test_tree.joinpath("payload").write_bytes(b"observed before cleanup")
+    monkeypatch.setenv("POLYLOGUE_PYTEST_SCRATCH_ROOT", str(scratch))
+    pytest_progress_plugin.record_test_scratch_usage("test-success", test_tree)
+
+    pytest_progress_plugin.pytest_runtest_logreport(_Report("test-success", "call", "passed"))
+    assert test_tree.exists()
+    pytest_progress_plugin.pytest_runtest_logreport(_Report("test-success", "teardown", "passed"))
+
+    assert not test_tree.exists()
+
+
+def test_failed_or_cancelled_test_tree_is_retained_for_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    scratch = tmp_path / "scratch"
+    monkeypatch.setenv("POLYLOGUE_PYTEST_SCRATCH_ROOT", str(scratch))
+    for nodeid, call_outcome, teardown_outcome in (
+        ("test-failed", "failed", "passed"),
+        ("test-cancelled", "failed", "skipped"),
+    ):
+        test_tree = scratch / nodeid
+        test_tree.mkdir(parents=True)
+        test_tree.joinpath("evidence.txt").write_text("retain", encoding="utf-8")
+        pytest_progress_plugin.record_test_scratch_usage(nodeid, test_tree)
+        pytest_progress_plugin.pytest_runtest_logreport(_Report(nodeid, "call", call_outcome))
+        pytest_progress_plugin.pytest_runtest_logreport(_Report(nodeid, "teardown", teardown_outcome))
+        assert test_tree.exists()
 
 
 def test_progress_plugin_records_test_scratch_high_water(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -6,11 +6,13 @@ import json
 import signal
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
 from devtools import verify
+from devtools.testmon_bootstrap import NativeTestmonRepairError
 from devtools.verify_runs import (
     CURRENT_RUN_PATH,
     VerifyRun,
@@ -129,6 +131,54 @@ def test_verify_persists_terminal_receipt_when_outer_deadline_sends_sigterm(
         assert payload["pytest_aggregate"]["termination_reason"] == "sigterm"
         assert payload["steps"][0]["status"] == "failed"
         assert payload["steps"][0]["termination_reason"] == "sigterm"
+
+
+@pytest.mark.parametrize("early_exit", ("preparation", "bootstrap"))
+def test_verify_records_early_native_terminal_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    early_exit: str,
+) -> None:
+    monkeypatch.setattr(verify, "ROOT", tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(verify, "assert_polylogue_matches_checkout", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(verify, "git_head", lambda _root: "head")
+    monkeypatch.setattr(verify, "_git_commit", lambda _ref: "base")
+    monkeypatch.setattr(verify, "_changed_paths", lambda _base, _head: ())
+    monkeypatch.setattr(
+        verify,
+        "classify_native_testmon_changes",
+        lambda *_args: SimpleNamespace(executable_paths=(), runtime_data_paths=()),
+    )
+    if early_exit == "preparation":
+
+        def fail_preparation(*_args: object, **_kwargs: object) -> object:
+            raise NativeTestmonRepairError("synthetic preparation failure")
+
+        monkeypatch.setattr(verify, "prepare_native_testmon_environment", fail_preparation)
+        expected_code = 125
+    else:
+        monkeypatch.setattr(
+            verify,
+            "prepare_native_testmon_environment",
+            lambda *_args, **_kwargs: SimpleNamespace(
+                selection_mode="bootstrap",
+                environment_name="testmon",
+                local_state=SimpleNamespace(
+                    status="absent",
+                    reason="synthetic bootstrap",
+                    missing_executable_paths=(),
+                ),
+            ),
+        )
+        expected_code = 2
+
+    assert verify._main([]) == expected_code
+    history = tmp_path / ".cache" / "verify" / "history.jsonl"
+    rows = [json.loads(line) for line in history.read_text(encoding="utf-8").splitlines()]
+    assert len(rows) == 1
+    assert rows[0]["status"] == "failed"
+    assert rows[0]["exit_code"] == expected_code
 
 
 def test_verify_emits_shared_workload_receipt_for_step_timing(

--- a/tests/unit/devtools/test_verify_runs.py
+++ b/tests/unit/devtools/test_verify_runs.py
@@ -185,3 +185,18 @@ def test_pruning_retains_corrupt_detail_and_skips_active_retention_lock(tmp_path
         locked = prune_successful_verify_runs(root=tmp_path, history_path=history, max_failed=0)
         fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
     assert locked["retention_locked"] is True
+
+
+def test_pruning_refuses_detail_tree_over_global_node_budget(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    history = tmp_path / ".cache" / "verify" / "history.jsonl"
+    payload = _finished_run(tmp_path, index=0, exit_code=1)
+    detail = tmp_path / str(payload["artifact_dir"])
+    for index in range(5):
+        (detail / f"diagnostic-{index}.log").write_text("evidence", encoding="utf-8")
+    append_verify_history(payload, path=history)
+    monkeypatch.setattr(verify_runs, "_DETAIL_NODE_BUDGET", 2)
+
+    result = prune_successful_verify_runs(root=tmp_path, history_path=history, max_failed=0)
+
+    assert result["pruned_run_ids"] == []
+    assert detail.exists()

--- a/tests/unit/devtools/test_verify_runs.py
+++ b/tests/unit/devtools/test_verify_runs.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
+import fcntl
+import os
+import stat
+from datetime import datetime
 from pathlib import Path
+from typing import cast
 
+import pytest
+
+import devtools.verify_runs as verify_runs
 from devtools.verify_runs import VerifyRun, append_verify_history, prune_successful_verify_runs
+
+_TEST_NOW = datetime.fromisoformat("2026-08-24T00:00:30+00:00").timestamp()
 
 
 def _finished_run(root: Path, *, index: int, exit_code: int) -> dict[str, object]:
@@ -51,3 +61,127 @@ def test_successful_retention_keeps_malformed_detail_as_manual_evidence(tmp_path
     prune_successful_verify_runs(root=tmp_path, history_path=history, max_successful=0)
 
     assert run_dir.exists()
+
+
+def test_pruning_refuses_symlinked_runs_ancestor_without_touching_outside(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside"
+    outside_runs = outside / "runs"
+    outside_runs.mkdir(parents=True)
+    sentinel = outside_runs / "keep.txt"
+    sentinel.write_text("outside evidence", encoding="utf-8")
+
+    payload = _finished_run(repo, index=0, exit_code=0)
+    history = repo / ".cache" / "verify" / "history.jsonl"
+    append_verify_history(payload, path=history)
+    real_runs = repo / ".cache" / "verify" / "runs"
+    parked_runs = repo / ".cache" / "verify" / "runs-real"
+    real_runs.rename(parked_runs)
+    real_runs.symlink_to(outside_runs, target_is_directory=True)
+
+    result = prune_successful_verify_runs(root=repo, history_path=history, max_successful=0)
+
+    assert result["refused"] is True
+    assert sentinel.read_text(encoding="utf-8") == "outside evidence"
+    assert parked_runs.exists()
+
+
+def test_pruning_refuses_symlinked_verify_ancestor(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (repo / ".cache").symlink_to(outside, target_is_directory=True)
+
+    result = prune_successful_verify_runs(root=repo)
+
+    assert result["refused"] is True
+    assert not (outside / "verify").exists()
+
+
+def test_history_append_fsyncs_file_before_parent_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+    real_fsync = os.fsync
+
+    def observe_fsync(fd: int) -> None:
+        mode = os.fstat(fd).st_mode
+        calls.append("directory" if stat.S_ISDIR(mode) else "file")
+        real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", observe_fsync)
+    history = tmp_path / ".cache" / "verify" / "history.jsonl"
+    append_verify_history({"run_id": "run-1", "status": "failed"}, path=history)
+
+    assert calls[-2:] == ["file", "directory"]
+
+
+def test_failed_detail_retention_is_bounded_but_history_keeps_every_summary(tmp_path: Path) -> None:
+    history = tmp_path / ".cache" / "verify" / "history.jsonl"
+    failures = [_finished_run(tmp_path, index=index, exit_code=1) for index in range(20)]
+    for payload in failures:
+        run_dir = tmp_path / str(payload["artifact_dir"])
+        (run_dir / "diagnostic.log").write_bytes(b"diagnostic detail\n" * 8)
+        append_verify_history(payload, path=history)
+
+    receipt = prune_successful_verify_runs(
+        root=tmp_path,
+        history_path=history,
+        max_successful=0,
+        max_failed=3,
+        max_failed_age_s=3600,
+        max_failed_bytes=20,
+        now=_TEST_NOW,
+    )
+
+    retained_failure_ids = cast(list[str], receipt["retained_failure_run_ids"])
+    pruned_ids = cast(list[str], receipt["pruned_run_ids"])
+    assert retained_failure_ids == [failures[-1]["run_id"]]
+    assert len(pruned_ids) == 19
+    assert (tmp_path / str(failures[-1]["artifact_dir"])).exists()
+    assert len(history.read_text(encoding="utf-8").splitlines()) == 20
+
+
+def test_recent_failure_is_not_erased_before_age_or_count_policy(tmp_path: Path) -> None:
+    history = tmp_path / ".cache" / "verify" / "history.jsonl"
+    recent = _finished_run(tmp_path, index=1, exit_code=1)
+    older = _finished_run(tmp_path, index=2, exit_code=1)
+    append_verify_history(recent, path=history)
+    append_verify_history(older, path=history)
+
+    receipt = prune_successful_verify_runs(
+        root=tmp_path,
+        history_path=history,
+        max_failed=2,
+        max_failed_age_s=3600,
+        max_failed_bytes=10_000,
+        now=_TEST_NOW,
+    )
+
+    retained_failure_ids = cast(list[str], receipt["retained_failure_run_ids"])
+    pruned_ids = cast(list[str], receipt["pruned_run_ids"])
+    assert set(retained_failure_ids) == {recent["run_id"], older["run_id"]}
+    assert not pruned_ids
+    assert (tmp_path / str(recent["artifact_dir"])).exists()
+    assert (tmp_path / str(older["artifact_dir"])).exists()
+
+
+def test_pruning_retains_corrupt_detail_and_skips_active_retention_lock(tmp_path: Path) -> None:
+    history = tmp_path / ".cache" / "verify" / "history.jsonl"
+    payload = _finished_run(tmp_path, index=0, exit_code=1)
+    detail = tmp_path / str(payload["artifact_dir"])
+    detail.joinpath("external").symlink_to(tmp_path, target_is_directory=True)
+    append_verify_history(payload, path=history)
+
+    first = prune_successful_verify_runs(root=tmp_path, history_path=history, max_failed=0)
+    assert first["pruned_run_ids"] == []
+    assert detail.exists()
+
+    lock_path = tmp_path / ".cache" / "verify" / verify_runs._RETENTION_LOCK_NAME
+    with lock_path.open("a+") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        locked = prune_successful_verify_runs(root=tmp_path, history_path=history, max_failed=0)
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    assert locked["retention_locked"] is True

--- a/tests/unit/devtools/test_verify_runs.py
+++ b/tests/unit/devtools/test_verify_runs.py
@@ -1,0 +1,53 @@
+"""Retention contracts for managed verification receipts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from devtools.verify_runs import VerifyRun, append_verify_history, prune_successful_verify_runs
+
+
+def _finished_run(root: Path, *, index: int, exit_code: int) -> dict[str, object]:
+    run = VerifyRun(tier="focused-test", argv=[], git_head="git:test", root=root, mirror_current=False)
+    payload = run.finish(exit_code=exit_code, duration_s=0.1, final_git_head="git:test")
+    payload["finished_at"] = f"2026-08-24T00:00:{index:02d}+00:00"
+    run._payload["finished_at"] = payload["finished_at"]
+    run.write()
+    return payload
+
+
+def test_successful_detail_retention_requires_durable_history_and_preserves_failures(tmp_path: Path) -> None:
+    history = tmp_path / ".cache" / "verify" / "history.jsonl"
+    successful = [_finished_run(tmp_path, index=index, exit_code=0) for index in range(10)]
+    failed = _finished_run(tmp_path, index=20, exit_code=1)
+    cancelled = _finished_run(tmp_path, index=21, exit_code=143)
+
+    before_history = prune_successful_verify_runs(root=tmp_path, history_path=history, max_successful=2)
+    assert before_history["history_durable"] is False
+    assert all((tmp_path / str(payload["artifact_dir"])).exists() for payload in successful)
+
+    for payload in (*successful, failed, cancelled):
+        append_verify_history(payload, path=history)
+    receipt = prune_successful_verify_runs(root=tmp_path, history_path=history, max_successful=2)
+    retained = receipt["retained_run_ids"]
+    pruned = receipt["pruned_run_ids"]
+    assert isinstance(retained, list)
+    assert isinstance(pruned, list)
+
+    assert len(retained) == 2
+    assert len(pruned) == 8
+    assert (tmp_path / str(failed["artifact_dir"])).exists()
+    assert (tmp_path / str(cancelled["artifact_dir"])).exists()
+    assert all((tmp_path / str(payload["artifact_dir"])).exists() for payload in successful[-2:])
+
+
+def test_successful_retention_keeps_malformed_detail_as_manual_evidence(tmp_path: Path) -> None:
+    history = tmp_path / ".cache" / "verify" / "history.jsonl"
+    payload = _finished_run(tmp_path, index=0, exit_code=0)
+    run_dir = tmp_path / str(payload["artifact_dir"])
+    (run_dir / "run.json").write_text("not-json\n", encoding="utf-8")
+    append_verify_history(payload, path=history)
+
+    prune_successful_verify_runs(root=tmp_path, history_path=history, max_successful=0)
+
+    assert run_dir.exists()

--- a/tests/unit/infra/test_whale_fixtures.py
+++ b/tests/unit/infra/test_whale_fixtures.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
+
+import pytest
 
 from tests.infra.whale_fixtures import (
     WHALE_FIXTURE_DIMENSIONS,
     CodexRevisionChainFixture,
     WhaleFixtureDimensions,
     _write_padding_record,
+    clone_blob_tree,
     multi_million_codex_stream,
     write_codex_whale_fixture_pack,
 )
@@ -105,3 +109,27 @@ def test_fixture_pack_generator_writes_a_complete_manifest(tmp_path: Path) -> No
     changed_manifest = json.loads(changed_manifest_path.read_text(encoding="utf-8"))
     assert changed_manifest["revision_sizes"] == manifest["revision_sizes"]
     assert changed_manifest["revision_sha256"] != manifest["revision_sha256"]
+
+
+def test_codex_blob_clone_is_reflink_first_and_isolated_on_forced_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source-blob"
+    source.mkdir()
+    source.joinpath("payload").write_bytes(b"immutable blob bytes")
+    fast = tmp_path / "fast"
+    fallback = tmp_path / "fallback"
+
+    assert clone_blob_tree(source, fast) in {"reflink", "copy"}
+    source_bytes = source.joinpath("payload").read_bytes()
+    fast.joinpath("payload").write_bytes(b"fast private mutation")
+    assert source.joinpath("payload").read_bytes() == source_bytes
+
+    def reject_reflink(*_args: object, **_kwargs: object) -> None:
+        raise subprocess.CalledProcessError(1, ["cp"])
+
+    monkeypatch.setattr(subprocess, "run", reject_reflink)
+    assert clone_blob_tree(source, fallback) == "copy"
+    fallback.joinpath("payload").write_bytes(b"private mutation")
+    assert source.joinpath("payload").read_bytes() == source_bytes
+    assert not source.joinpath("payload").samefile(fallback / "payload")

--- a/tests/unit/infra/test_workload_artifacts.py
+++ b/tests/unit/infra/test_workload_artifacts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import fcntl
 import gc
 import json
 import os
@@ -25,6 +26,7 @@ from polylogue.storage.sqlite.durable_change_train import DurableChangeTrainErro
 from tests.infra.workload_artifacts import (
     BENCHMARK_WORKLOAD_PROFILES,
     NAMED_WORKLOAD_PROFILES,
+    ArtifactGcDisposition,
     BenchmarkWorkloadTier,
     WorkloadProfile,
     _assert_lock_identity,
@@ -40,6 +42,7 @@ from tests.infra.workload_artifacts import (
     build_seeded_archive,
     c03_semantic_corpus_spec,
     clone_seeded_archive,
+    gc_seeded_archive_artifacts,
     named_corpus_specs,
     named_workload_profile,
     seeded_archive_key,
@@ -1493,6 +1496,166 @@ def test_build_does_not_retry_a_non_lock_database_error(tmp_path: Path, monkeypa
         build_seeded_archive(cache_root=tmp_path / "cache")
 
     assert attempts == 1
+
+
+def _age_artifact(root: Path, *, now: float = 10_000.0) -> None:
+    old = now - 10_000
+    os.utime(root, (old, old))
+    os.utime(root / "manifest.json", (old, old))
+
+
+def test_artifact_gc_uses_current_manifest_key_not_build_id_and_respects_grace(tmp_path: Path) -> None:
+    import tests.infra.workload_artifacts as artifacts
+
+    cache_root = tmp_path / "cache"
+    artifacts._VALIDATED_ARTIFACTS.clear()
+    with pytest.raises(ValueError, match="complete seeded archive keys"):
+        gc_seeded_archive_artifacts(
+            cache_root=cache_root,
+            reachable_keys=("git:" + "0" * 40,),
+        )
+    reachable = build_seeded_archive(cache_root=cache_root)
+    stale = build_seeded_archive(named_corpus_specs("cli-chatgpt"), cache_root=cache_root)
+    _age_artifact(stale.root)
+
+    preview = gc_seeded_archive_artifacts(
+        cache_root=cache_root,
+        reachable_keys=(reachable.manifest.key,),
+        grace_period_s=1,
+        now=10_000,
+        dry_run=True,
+    )
+
+    by_name = {entry.name: entry for entry in preview.entries}
+    assert by_name[reachable.root.name].disposition is ArtifactGcDisposition.REACHABLE
+    assert by_name[stale.root.name].disposition is ArtifactGcDisposition.STALE
+    assert by_name[stale.root.name].key == stale.manifest.key
+    assert by_name[stale.root.name].manifest_id == stale.manifest.manifest_id
+    assert stale.root.exists()
+
+
+def test_artifact_gc_preview_and_apply_write_receipts_and_delete_only_stale_final_tree(tmp_path: Path) -> None:
+    import tests.infra.workload_artifacts as artifacts
+
+    cache_root = tmp_path / "cache"
+    artifacts._VALIDATED_ARTIFACTS.clear()
+    stale = build_seeded_archive(cache_root=cache_root)
+    _age_artifact(stale.root)
+    preview_receipt = tmp_path / "preview.json"
+    preview = gc_seeded_archive_artifacts(
+        cache_root=cache_root,
+        reachable_keys=("seeded-archive:sha256:" + "f" * 64,),
+        grace_period_s=1,
+        now=10_000,
+        dry_run=True,
+        receipt_path=preview_receipt,
+    )
+    assert preview.entries[0].disposition is ArtifactGcDisposition.STALE
+    assert json.loads(preview_receipt.read_text())["dry_run"] is True
+    assert stale.root.exists()
+
+    receipt = tmp_path / "apply.json"
+    applied = gc_seeded_archive_artifacts(
+        cache_root=cache_root,
+        reachable_keys=("seeded-archive:sha256:" + "f" * 64,),
+        grace_period_s=1,
+        now=10_000,
+        dry_run=False,
+        receipt_path=receipt,
+    )
+    assert applied.entries[0].disposition is ArtifactGcDisposition.DELETED
+    assert not stale.root.exists()
+    assert json.loads(receipt.read_text())["deleted_bytes"] == applied.deleted_bytes
+
+
+def test_artifact_gc_preserves_active_per_key_lock_and_query_lease(tmp_path: Path) -> None:
+    import tests.infra.workload_artifacts as artifacts
+
+    cache_root = tmp_path / "cache"
+    artifacts._VALIDATED_ARTIFACTS.clear()
+    artifact = build_seeded_archive(cache_root=cache_root)
+    _age_artifact(artifact.root)
+    lock_path = cache_root / ".locks" / f"{artifact.root.name}.lock"
+    with lock_path.open("a+") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        locked = gc_seeded_archive_artifacts(
+            cache_root=cache_root,
+            reachable_keys=("seeded-archive:sha256:" + "f" * 64,),
+            grace_period_s=1,
+            now=10_000,
+            dry_run=False,
+        )
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    assert locked.entries[0].disposition is ArtifactGcDisposition.ACTIVE_LOCK
+    assert artifact.root.exists()
+
+    cache_fd = os.open(cache_root, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        fcntl.flock(cache_fd, fcntl.LOCK_EX)
+        cache_locked = gc_seeded_archive_artifacts(
+            cache_root=cache_root,
+            reachable_keys=("seeded-archive:sha256:" + "f" * 64,),
+            grace_period_s=1,
+            now=10_000,
+            dry_run=False,
+        )
+    finally:
+        fcntl.flock(cache_fd, fcntl.LOCK_UN)
+        os.close(cache_fd)
+    assert cache_locked.entries[0].disposition is ArtifactGcDisposition.ACTIVE_LOCK
+    assert cache_locked.entries[0].name == "<cache>"
+
+    lease = acquire_query_only_seeded_archive(artifact, seeded_archive_key((c03_semantic_corpus_spec(),)))
+    try:
+        leased = gc_seeded_archive_artifacts(
+            cache_root=cache_root,
+            reachable_keys=("seeded-archive:sha256:" + "f" * 64,),
+            grace_period_s=1,
+            now=10_000,
+            dry_run=False,
+        )
+    finally:
+        lease.close()
+    assert leased.entries[0].disposition is ArtifactGcDisposition.ACTIVE_LEASE
+    assert artifact.root.exists()
+
+
+def test_artifact_gc_retains_corruption_and_explicit_worktree_protection(tmp_path: Path) -> None:
+    import tests.infra.workload_artifacts as artifacts
+
+    cache_root = tmp_path / "cache"
+    artifacts._VALIDATED_ARTIFACTS.clear()
+    corrupt = build_seeded_archive(cache_root=cache_root)
+    _age_artifact(corrupt.root)
+    corrupt.root.chmod(corrupt.root.stat().st_mode | stat.S_IWUSR)
+    index = corrupt.root / "index.db"
+    index.chmod(index.stat().st_mode | stat.S_IWUSR)
+    content = index.read_bytes()
+    index.write_bytes(bytes((content[0] ^ 1,)) + content[1:])
+    corrupt.root.chmod(corrupt.root.stat().st_mode & ~stat.S_IWUSR)
+    corrupted = gc_seeded_archive_artifacts(
+        cache_root=cache_root,
+        reachable_keys=("seeded-archive:sha256:" + "f" * 64,),
+        grace_period_s=1,
+        now=10_000,
+        dry_run=False,
+    )
+    assert corrupted.entries[0].disposition is ArtifactGcDisposition.CORRUPT
+    assert corrupt.root.exists()
+
+    protected = build_seeded_archive(named_corpus_specs("cli-chatgpt"), cache_root=cache_root)
+    _age_artifact(protected.root)
+    guarded = gc_seeded_archive_artifacts(
+        cache_root=cache_root,
+        reachable_keys=("seeded-archive:sha256:" + "f" * 64,),
+        grace_period_s=1,
+        now=10_000,
+        dry_run=False,
+        protected_worktrees=(protected.root,),
+    )
+    protected_entry = next(entry for entry in guarded.entries if entry.name == protected.root.name)
+    assert protected_entry.disposition is ArtifactGcDisposition.ACTIVE_WORKTREE
+    assert protected.root.exists()
 
 
 def test_build_gives_up_on_a_persistent_lock(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/infra/test_workload_artifacts.py
+++ b/tests/unit/infra/test_workload_artifacts.py
@@ -10,6 +10,7 @@ import sqlite3
 import stat
 import subprocess
 import sys
+import threading
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -27,7 +28,9 @@ from tests.infra.workload_artifacts import (
     BENCHMARK_WORKLOAD_PROFILES,
     NAMED_WORKLOAD_PROFILES,
     ArtifactGcDisposition,
+    ArtifactGcReport,
     BenchmarkWorkloadTier,
+    SeededArchiveClone,
     WorkloadProfile,
     _assert_lock_identity,
     _journal_mode_delete_with_retry,
@@ -1618,6 +1621,137 @@ def test_artifact_gc_preserves_active_per_key_lock_and_query_lease(tmp_path: Pat
         lease.close()
     assert leased.entries[0].disposition is ArtifactGcDisposition.ACTIVE_LEASE
     assert artifact.root.exists()
+
+
+def test_artifact_gc_cannot_delete_source_while_clone_is_reading(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The clone's shared lease wins the race before its first source read."""
+    import tests.infra.workload_artifacts as artifacts
+
+    cache_root = tmp_path / "cache"
+    artifacts._VALIDATED_ARTIFACTS.clear()
+    artifact = build_seeded_archive(cache_root=cache_root)
+    _age_artifact(artifact.root)
+    copy_started = threading.Event()
+    allow_copy = threading.Event()
+    clone_result: list[object] = []
+    gc_result: list[object] = []
+    original_copy = artifacts._copy_tree
+
+    def blocked_copy(source: Path, destination: Path) -> None:
+        copy_started.set()
+        assert allow_copy.wait(5), "clone did not receive its release signal"
+        original_copy(source, destination)
+
+    monkeypatch.setattr(artifacts, "_copy_tree", blocked_copy)
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(subprocess.CalledProcessError(1, ["cp"])),
+    )
+
+    def run_clone() -> None:
+        try:
+            clone_result.append(clone_seeded_archive(artifact, tmp_path / "clone"))
+        except BaseException as exc:  # surfaced below with the thread result
+            clone_result.append(exc)
+
+    def collect() -> None:
+        gc_result.append(
+            gc_seeded_archive_artifacts(
+                cache_root=cache_root,
+                reachable_keys=("seeded-archive:sha256:" + "f" * 64,),
+                grace_period_s=1,
+                now=10_000,
+                dry_run=False,
+            )
+        )
+
+    clone_thread = threading.Thread(target=run_clone)
+    clone_thread.start()
+    assert copy_started.wait(5), "clone did not reach its source read barrier"
+    gc_thread = threading.Thread(target=collect)
+    gc_thread.start()
+    gc_thread.join(5)
+    allow_copy.set()
+    clone_thread.join(5)
+
+    assert not gc_thread.is_alive()
+    assert not clone_thread.is_alive()
+    assert len(gc_result) == 1
+    gc_report = cast(ArtifactGcReport, gc_result[0])
+    assert gc_report.entries[0].disposition is ArtifactGcDisposition.ACTIVE_LOCK
+    assert len(clone_result) == 1 and not isinstance(clone_result[0], BaseException)
+    cloned = cast(SeededArchiveClone, clone_result[0])
+    assert cloned.root.exists()
+    cloned.close()
+    assert artifact.root.exists()
+
+
+def test_rejected_hardlink_clone_cleans_residue_without_mutating_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import tests.infra.workload_artifacts as artifacts
+
+    artifact = build_seeded_archive(cache_root=tmp_path / "cache")
+    source_manifest = (artifact.root / "manifest.json").read_bytes()
+    source_index = artifact.root / "index.db"
+    source_mode = stat.S_IMODE(source_index.stat().st_mode)
+    destination = tmp_path / "hardlink-clone"
+    original_copy = artifacts._copy_tree
+
+    def inject_hardlink(source: Path, target: Path) -> None:
+        original_copy(source, target)
+        target.chmod(target.stat().st_mode | stat.S_IWUSR)
+        target_index = target / "index.db"
+        target_index.unlink()
+        os.link(source / "index.db", target_index)
+
+    monkeypatch.setattr(artifacts, "_copy_tree", inject_hardlink)
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(subprocess.CalledProcessError(1, ["cp"])),
+    )
+    with pytest.raises(ValueError, match="inode was not detached"):
+        clone_seeded_archive(artifact, destination)
+
+    assert not destination.exists()
+    assert source_index.exists()
+    assert stat.S_IMODE(source_index.stat().st_mode) == source_mode
+    assert (artifact.root / "manifest.json").read_bytes() == source_manifest
+
+
+def test_rejected_symlink_clone_cleans_residue_and_preserves_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import tests.infra.workload_artifacts as artifacts
+
+    artifact = build_seeded_archive(cache_root=tmp_path / "cache")
+    source_manifest = (artifact.root / "manifest.json").read_bytes()
+    destination = tmp_path / "symlink-clone"
+    outside = tmp_path / "outside"
+    outside.write_text("must remain", encoding="utf-8")
+    original_copy = artifacts._copy_tree
+
+    def inject_symlink(source: Path, target: Path) -> None:
+        original_copy(source, target)
+        target.chmod(target.stat().st_mode | stat.S_IWUSR)
+        (target / "unsafe-link").symlink_to(outside)
+
+    monkeypatch.setattr(artifacts, "_copy_tree", inject_symlink)
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(subprocess.CalledProcessError(1, ["cp"])),
+    )
+    with pytest.raises(ValueError, match="symlink"):
+        clone_seeded_archive(artifact, destination)
+
+    assert not destination.exists()
+    assert outside.read_text(encoding="utf-8") == "must remain"
+    assert (artifact.root / "manifest.json").read_bytes() == source_manifest
 
 
 def test_artifact_gc_retains_corruption_and_explicit_worktree_protection(tmp_path: Path) -> None:

--- a/tests/unit/scenarios/test_codex_804_live_proof.py
+++ b/tests/unit/scenarios/test_codex_804_live_proof.py
@@ -43,7 +43,6 @@ import hashlib
 import json
 import os
 import resource
-import shutil
 import sqlite3
 import subprocess
 import sys
@@ -83,6 +82,7 @@ from tests.infra.whale_fixtures import (
     CodexRevisionChainFixture,
     acquire_codex_revision_chain,
     assert_planner_append_authority,
+    clone_blob_tree,
     copy_sqlite_database,
 )
 
@@ -495,7 +495,7 @@ def test_sanitized_codex_804_revision_recovery_proof(tmp_path: Path, monkeypatch
     source_ready_root = tmp_path / "codex-804-source-ready"
     initialize_active_archive_root(source_ready_root)
     copy_sqlite_database(root / "source.db", source_ready_root / "source.db")
-    shutil.copytree(root / "blob", source_ready_root / "blob")
+    clone_blob_tree(root / "blob", source_ready_root / "blob")
     with sqlite3.connect(source_ready_root / "source.db") as conn:
         assert int(conn.execute("SELECT COUNT(*) FROM raw_sessions").fetchone()[0]) == expected_raw_count
     whale_repair = raw_authority.repair_materialization(


### PR DESCRIPTION
## Summary

Bound pytest scratch, seeded workload artifacts, and terminal verification detail without reducing test coverage or removing compact run history.

## Problem

Successful tests retained their complete temporary trees until the end of a run, large immutable fixtures were copied repeatedly, seeded artifacts had no lock-aware collection contract, and terminal verification detail accumulated without a bound. These paths made the complete corpus consume substantially more storage than its semantic inputs required.

## Solution

- Remove each test-owned scratch tree only after its call and teardown both pass. Preserve failed or interrupted trees until the lease finalizer captures bounded failure evidence.
- Clone immutable archive templates and whale blob trees with reflinks first, with an authenticated detached-copy fallback.
- Add receipt-backed seeded-artifact collection using explicit content-key reachability, grace periods, cache/key/root locks, query leases, integrity checks, and fail-closed deletion.
- Keep append-only compact verification history while bounding successful detail to eight runs and failed detail to the newest run plus up to twelve recent runs within seven days and 64 MiB.
- Update the canonical testing contract to describe the implemented history, detail, and scratch lifecycle.

## Verification

- `POLYLOGUE_PYTEST_WORKERS=16 devtools test tests/unit/devtools/test_verify.py tests/unit/devtools/test_verify_runs.py tests/unit/devtools/test_pytest_progress_plugin.py tests/unit/infra/test_whale_fixtures.py tests/unit/infra/test_workload_artifacts.py::test_archive_and_clone_reject_symlink_nodes_without_following_targets tests/unit/infra/test_workload_artifacts.py::test_rejected_hardlink_clone_cleans_residue_without_mutating_source tests/unit/infra/test_workload_artifacts.py::test_artifact_gc_cannot_delete_source_while_clone_is_reading`
  - `45 passed, 17 warnings in 88.42s`
- `devtools verify --quick`
  - formatting, lint, typing, generated surfaces, layering, command docs, schema checks, oracle integrity, promotion audit, and privacy registry passed
- The pre-push hook reran `devtools verify --quick` successfully at commit `882878cff`.

The complete 16-worker corpus will run against the exact merged master commit as the integration checkpoint.
