### PR TITLE
Fail closed on unprovable blob liveness instead of deleting

### DIFF
--- a/polylogue/cli/commands/maintenance/_blob_gc.py
+++ b/polylogue/cli/commands/maintenance/_blob_gc.py
@@ -74,6 +74,12 @@ def blob_gc_command(max_batch: int, output_format: str) -> None:
     click.echo("Blob GC dry-run (inspect, read-only)")
     click.echo(f"Archive DB: {result.db_path}")
     click.echo(f"Blob root:  {result.blob_dir}")
+    if result.blocked_reason is not None:
+        # A refused pass reports zero candidates for the same reason it
+        # refuses to delete any -- say why, rather than let it read as
+        # "nothing to reclaim".
+        click.echo(f"Blocked:    {result.blocked_reason}")
+        return
     click.echo(f"Candidates: {result.candidate_count:,}")
     click.echo(f"Inspected:  {result.inspected_count:,}")
     click.echo(f"Result:     would delete {result.would_delete_count:,} blob(s)")

--- a/polylogue/storage/blob_gc.py
+++ b/polylogue/storage/blob_gc.py
@@ -7,12 +7,17 @@ longer referenced by any archive row.
 Safety invariants
 -----------------
 1. Never delete a blob that still has a DB reference (message text,
-   content_blocks, attachments).
+   content_blocks, attachments). A reference surface that cannot be read is
+   a blocker, never an answer: an unavailable tier aborts the pass rather
+   than being treated as holding no references.
 2. Never delete a blob with a durable publication receipt. Archive
    orchestration commits per-publication receipt IDs before exposing final
    paths, and exact reference transactions consume only their own receipts.
-3. Serialize the final reference/reservation recheck and unlink under the
-   source-tier write lock.
+3. Serialize the final reference/reservation recheck and unlink under a
+   write lock on *every* tier the recheck reads -- the control tier and each
+   sibling reference tier -- so no concurrent writer can commit a reference
+   between the check and the unlink. Tiers are locked in a fixed order
+   (control, source, index).
 4. Only delete blobs older than the previous completed GC generation
    plus MIN_AGE seconds (defense-in-depth against clockskew and any
    uninstrumented writer path).
@@ -45,7 +50,7 @@ import logging
 import os
 import sqlite3
 import time
-from contextlib import closing
+from contextlib import closing, suppress
 from dataclasses import dataclass
 from pathlib import Path
 from uuid import uuid4
@@ -96,6 +101,7 @@ class BlobGCResult:
     generation_id: str | None = None
     generation_written: bool = False
     older_than_s: float = 0.0
+    blocked_reason: str | None = None
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -115,6 +121,7 @@ class BlobGCResult:
             "generation_id": self.generation_id,
             "generation_written": self.generation_written,
             "older_than_s": self.older_than_s,
+            "blocked_reason": self.blocked_reason,
         }
 
 
@@ -186,6 +193,40 @@ BLOB_REF_LIVENESS_JOIN: tuple[tuple[str, str, str], ...] = (
 
 # Private alias retained for the GC implementation's existing local naming.
 _BLOB_REF_LIVENESS_JOIN = BLOB_REF_LIVENESS_JOIN
+
+
+def _open_recheck_connection(path: Path, *, dry_run: bool) -> sqlite3.Connection:
+    """Open a sibling reference tier for the final recheck window.
+
+    A destructive pass takes a write transaction so no other process can
+    commit a new reference between the recheck and the unlink. A dry run
+    reads only and takes no lock, so it never blocks an ingest.
+    """
+    if dry_run:
+        return sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    conn = sqlite3.connect(str(path))
+    conn.execute("BEGIN IMMEDIATE")
+    return conn
+
+
+def _reference_tier_blockers(tier_paths: dict[str, Path]) -> tuple[str, ...]:
+    """Return a reason per reference tier that cannot be read.
+
+    A tier counts as available when its path resolves to a file that SQLite
+    can open read-only. A dangling symlink (the shape a reset or a swapped
+    generation leaves behind) is unavailable, not empty.
+    """
+    blockers: list[str] = []
+    for tier, path in tier_paths.items():
+        if not path.exists():
+            blockers.append(f"{tier} tier is unavailable at {path} (path does not resolve)")
+            continue
+        try:
+            with closing(sqlite3.connect(f"file:{path}?mode=ro", uri=True)) as probe:
+                probe.execute("SELECT 1").fetchone()
+        except sqlite3.Error as exc:
+            blockers.append(f"{tier} tier at {path} could not be opened for reading: {exc}")
+    return tuple(blockers)
 
 
 def _blob_refs_has_ref_type_column(conn: sqlite3.Connection) -> bool:
@@ -561,6 +602,31 @@ def run_blob_gc_report(
         if db_path_obj.name != "source.db" and _database_has_table(sibling_source_db, "gc_generations")
         else db_path_obj
     )
+
+    from polylogue.storage.archive_identity import ArchiveLocation
+
+    sibling_index_db = ArchiveLocation.resolve(db_path_obj.parent).active_index_path
+    # Fail closed on an unreadable reference tier before a single candidate is
+    # considered. Proceeding without one silently converts "cannot tell" into
+    # "not referenced" for every blob only that tier knows about.
+    #
+    # The index tier carries ``attachments.blob_hash``: on the live archive
+    # 1,240 distinct attachment payloads (~425 MB) are reachable through it and
+    # nowhere else. It is *rebuildable* and reached through a symlink into a
+    # generations directory, so a reset or an interrupted generation promotion
+    # leaves the path absent. This is the same fail-closed rule the
+    # per-ref-type join already applies to a missing referent table or column.
+    required_tiers: dict[str, Path] = {"index": sibling_index_db}
+    if db_path_obj.name == "index.db":
+        # A split file set names its durable source tier explicitly; a
+        # single-file fixture's control database *is* its source surface.
+        required_tiers["source"] = sibling_source_db
+    blockers = _reference_tier_blockers(required_tiers)
+    if blockers:
+        reason = "; ".join(blockers)
+        logger.error("Blob GC refused to run: %s", reason)
+        report.blocked_reason = reason
+        return report
     # Filesystem enumeration is deliberately outside the destructive source
     # lock. The lock protects only the bounded final recheck+unlink window.
     with closing(sqlite3.connect(f"file:{control_db_path}?mode=ro", uri=True)) as planning_conn:
@@ -574,9 +640,6 @@ def run_blob_gc_report(
     if not candidates:
         return report
 
-    from polylogue.storage.archive_identity import ArchiveLocation
-
-    sibling_index_db = ArchiveLocation.resolve(db_path_obj.parent).active_index_path
     evidence = GCRunEvidence(dry_run=dry_run, max_batch=max_batch)
     shortlist: list[tuple[str, float]] = []
 
@@ -593,9 +656,13 @@ def run_blob_gc_report(
     planning_source_legacy_hook_status = "not_applicable"
     planning_index_legacy_hook_status = "not_applicable"
     try:
+        # The source sibling is optional: for a single-file set the control
+        # database is itself the source surface. The index sibling is not --
+        # it was proven readable above, so it is opened unconditionally and a
+        # failure here aborts the pass rather than silently omitting the tier.
         if control_db_path != sibling_source_db and sibling_source_db.exists():
             planning_source_conn = sqlite3.connect(f"file:{sibling_source_db}?mode=ro", uri=True)
-        if control_db_path != sibling_index_db and sibling_index_db.exists():
+        if control_db_path != sibling_index_db:
             planning_index_conn = sqlite3.connect(f"file:{sibling_index_db}?mode=ro", uri=True)
         planning_legacy_hook_status = _legacy_hook_liveness_status(planning_conn)
         if planning_source_conn is not None:
@@ -665,12 +732,19 @@ def run_blob_gc_report(
     reclaimed_bytes = 0
     started_at_ms = int(time.time() * 1000)
     try:
+        # Invariant 3 spans every tier the recheck reads, not just the control
+        # tier. A read-only sibling connection excludes no writer, so a
+        # concurrent commit could create the very reference this pass is about
+        # to decide does not exist. Each sibling therefore takes its own
+        # BEGIN IMMEDIATE for the recheck+unlink window. Tiers are always
+        # locked in the same order (control, then source, then index) so two
+        # GC passes cannot deadlock against each other.
         if not dry_run:
             conn.execute("BEGIN IMMEDIATE")
         if control_db_path != sibling_source_db and sibling_source_db.exists():
-            source_conn = sqlite3.connect(f"file:{sibling_source_db}?mode=ro", uri=True)
-        if control_db_path != sibling_index_db and sibling_index_db.exists():
-            index_conn = sqlite3.connect(f"file:{sibling_index_db}?mode=ro", uri=True)
+            source_conn = _open_recheck_connection(sibling_source_db, dry_run=dry_run)
+        if control_db_path != sibling_index_db:
+            index_conn = _open_recheck_connection(sibling_index_db, dry_run=dry_run)
         legacy_hook_status = _legacy_hook_liveness_status(conn)
         if source_conn is not None:
             source_legacy_hook_status = _legacy_hook_liveness_status(source_conn)
@@ -750,10 +824,16 @@ def run_blob_gc_report(
             conn.rollback()
         raise
     finally:
-        if source_conn is not None:
-            source_conn.close()
-        if index_conn is not None:
-            index_conn.close()
+        # The sibling tiers are read during the recheck and never written, so
+        # their transactions are always rolled back; the lock existed only to
+        # exclude a concurrent reference commit.
+        for sibling in (index_conn, source_conn):
+            if sibling is None:
+                continue
+            if not dry_run:
+                with suppress(sqlite3.Error):
+                    sibling.rollback()
+            sibling.close()
         conn.close()
 
 

--- a/polylogue/storage/raw_retention.py
+++ b/polylogue/storage/raw_retention.py
@@ -74,6 +74,36 @@ class _RawRevisionAuthorityUnavailableError(RawRetentionSafetyError):
     """Raised when source-tier authority cannot be read, not when it is invalid."""
 
 
+# Row surfaces whose own ``blob_hash`` column is a first-class reference to the
+# CAS payload, independent of the ``blob_refs`` ledger. Retention cleanup must
+# consult these directly: on the live archive 399 raw payload hashes carry no
+# ledger row at all, so a ledger-only liveness test would read them as dead.
+_BLOB_HASH_ROW_SURFACES: tuple[str, ...] = ("raw_sessions", "attachments", "raw_hook_events")
+
+
+def _blob_hash_still_referenced(conn: sqlite3.Connection, blob_hash: bytes) -> bool:
+    """Return True if any surviving row still points at this CAS payload.
+
+    Blobs are content-addressed, so two raw snapshots of identical bytes share
+    one file. Deleting one snapshot's row must not unlink bytes another row
+    still names. The ``blob_refs`` ledger is checked first because it is the
+    intended catalog, but it is not treated as complete: each row surface that
+    carries its own ``blob_hash`` column is checked too, so a missing ledger
+    row cannot become evidence of death.
+    """
+    if (
+        _column_exists(conn, "blob_refs", "blob_hash")
+        and conn.execute("SELECT 1 FROM blob_refs WHERE blob_hash = ? LIMIT 1", (blob_hash,)).fetchone()
+    ):
+        return True
+    for table in _BLOB_HASH_ROW_SURFACES:
+        if not _table_exists(conn, table) or not _column_exists(conn, table, "blob_hash"):
+            continue
+        if conn.execute(f"SELECT 1 FROM {table} WHERE blob_hash = ? LIMIT 1", (blob_hash,)).fetchone():
+            return True
+    return False
+
+
 @dataclass(frozen=True)
 class RawSnapshotCleanupCandidate:
     raw_id: str
@@ -2162,7 +2192,7 @@ def cleanup_superseded_raw_snapshots(
             except ValueError as exc:
                 errors.append(str(exc))
                 continue
-            if conn.execute("SELECT 1 FROM blob_refs WHERE blob_hash = ? LIMIT 1", (blob_hash,)).fetchone():
+            if _blob_hash_still_referenced(conn, blob_hash):
                 continue
         else:
             # Without a reference catalog, row cleanup cannot prove that this

--- a/tests/unit/storage/test_blob_gc.py
+++ b/tests/unit/storage/test_blob_gc.py
@@ -28,9 +28,29 @@ from polylogue.storage.blob_store import BlobStore
 # ---------------------------------------------------------------------------
 
 
+def _make_index_sibling(db_path: str | Path) -> Path:
+    """Create the minimal index tier GC requires beside a file-based fixture.
+
+    GC refuses to run when a reference tier it must consult cannot be read,
+    so a file-set fixture has to carry one. The table matters: the index tier
+    is where ``attachments.blob_hash`` lives, and it is the only surface that
+    knows about 1,240 of the live archive's attachment payloads.
+    """
+    index_path = Path(db_path).with_name("index.db")
+    conn = sqlite3.connect(str(index_path))
+    try:
+        conn.execute("CREATE TABLE IF NOT EXISTS attachments (blob_hash BLOB)")
+        conn.commit()
+    finally:
+        conn.close()
+    return index_path
+
+
 def _make_db(path: str | Path | None = None) -> sqlite3.Connection:
     """Create an in-memory or file-based SQLite database with GC schema."""
     target = str(path) if path else ":memory:"
+    if path is not None:
+        _make_index_sibling(path)
     conn = sqlite3.connect(target)
     conn.row_factory = sqlite3.Row
     conn.execute(
@@ -396,7 +416,10 @@ def test_run_blob_gc_does_not_stage_again_when_all_candidates_are_referenced(
 
     assert report.deleted_count == 0
     assert report.skipped_referenced == 1
-    assert stage_calls == 1
+    # One stage per reference tier the planning pass consults (control tier +
+    # index tier), and none from a second destructive pass -- an empty
+    # shortlist must not re-enter the lock. Re-staging would double this.
+    assert stage_calls == 2
 
 
 def test_run_blob_gc_nonexistent_blob_dir(tmp_path: Path) -> None:
@@ -605,3 +628,89 @@ def test_read_gc_history_returns_recent_passes(tmp_path: Path) -> None:
     assert len(history) == 3
     assert all(row.reclaimed_count == 1 for row in history)
     assert all(row.generation_id.startswith("gc-") for row in history)
+
+
+@pytest.mark.uses_real_clock(
+    "backdates a real blob mtime via os.utime; blob_gc.py's age gate compares it against a real time.time() call"
+)
+def test_run_blob_gc_refuses_when_the_index_tier_cannot_be_read(tmp_path: Path) -> None:
+    """An unavailable reference tier is a blocker, never proof of non-reference.
+
+    ``attachments.blob_hash`` lives in the index tier and nowhere else -- 1,240
+    distinct attachment payloads (~425 MB) on the live archive are reachable
+    only that way. The tier is rebuildable and reached through a symlink into
+    a generations directory, so a reset or an interrupted generation promotion
+    leaves the path absent. Reading that absence as "unreferenced" unlinks
+    durable bytes that every other surface agrees nothing else holds.
+    """
+    db_path = tmp_path / "source.db"
+    blob_root = tmp_path / "blobs"
+    store = BlobStore(blob_root)
+    index_path = tmp_path / "index.db"
+
+    attachment_hash, _size = store.write_from_bytes(b"attachment payload")
+    _backdate(store, attachment_hash)
+    conn = _make_db(db_path)
+    conn.commit()
+    conn.close()
+
+    # The only reference to these bytes anywhere in the archive.
+    index_conn = sqlite3.connect(str(index_path))
+    index_conn.execute("INSERT INTO attachments (blob_hash) VALUES (?)", (bytes.fromhex(attachment_hash),))
+    index_conn.commit()
+    index_conn.close()
+
+    assert run_blob_gc(db_path, blob_root, max_batch=10) == 0
+    assert store.exists(attachment_hash)
+
+    # Now the index tier is gone -- the shape a reset or a swapped generation
+    # leaves behind. Nothing else in the archive names this blob.
+    index_path.unlink()
+
+    report = run_blob_gc_report(db_path, blob_root, max_batch=10)
+
+    assert report.blocked_reason is not None
+    assert "index tier" in report.blocked_reason
+    assert report.deleted_count == 0
+    assert report.generation_written is False
+    assert store.exists(attachment_hash), "unlinked a blob whose only reference tier was unreadable"
+
+
+@pytest.mark.uses_real_clock(
+    "backdates a real blob mtime via os.utime; blob_gc.py's age gate compares it against a real time.time() call"
+)
+def test_run_blob_gc_serializes_the_recheck_against_an_index_tier_writer(tmp_path: Path) -> None:
+    """The recheck+unlink window must exclude writers on every tier it reads.
+
+    Invariant 3 claims the final reference recheck and the unlink are
+    serialized under a write lock. A read-only sibling connection excludes
+    nobody, so a concurrent commit could create the very reference the pass is
+    about to decide does not exist. Holding an index-tier write transaction
+    here must therefore make the destructive pass fail rather than delete.
+    """
+    db_path = tmp_path / "source.db"
+    blob_root = tmp_path / "blobs"
+    store = BlobStore(blob_root)
+
+    orphan_hash, _size = store.write_from_bytes(b"orphan payload")
+    _backdate(store, orphan_hash)
+    conn = _make_db(db_path)
+    conn.commit()
+    conn.close()
+
+    # Stand in for a concurrent process mid-write on the index tier.
+    writer = sqlite3.connect(str(tmp_path / "index.db"), timeout=0.1)
+    writer.execute("BEGIN IMMEDIATE")
+    try:
+        with pytest.raises(sqlite3.OperationalError, match="locked"):
+            run_blob_gc(db_path, blob_root, max_batch=10)
+    finally:
+        writer.rollback()
+        writer.close()
+
+    assert store.exists(orphan_hash), "unlinked while an index-tier writer held the reference table"
+
+    # With no competing writer the same pass reclaims the blob, so the
+    # assertion above is about serialization, not a blanket refusal.
+    assert run_blob_gc(db_path, blob_root, max_batch=10) == 1
+    assert not store.exists(orphan_hash)

--- a/tests/unit/storage/test_blob_gc.py
+++ b/tests/unit/storage/test_blob_gc.py
@@ -649,31 +649,45 @@ def test_run_blob_gc_refuses_when_the_index_tier_cannot_be_read(tmp_path: Path) 
     index_path = tmp_path / "index.db"
 
     attachment_hash, _size = store.write_from_bytes(b"attachment payload")
+    control_hash, _control_size = store.write_from_bytes(b"nothing references me")
     _backdate(store, attachment_hash)
+    _backdate(store, control_hash)
     conn = _make_db(db_path)
     conn.commit()
     conn.close()
 
-    # The only reference to these bytes anywhere in the archive.
+    # The only reference to the attachment bytes anywhere in the archive.
     index_conn = sqlite3.connect(str(index_path))
     index_conn.execute("INSERT INTO attachments (blob_hash) VALUES (?)", (bytes.fromhex(attachment_hash),))
     index_conn.commit()
     index_conn.close()
 
-    assert run_blob_gc(db_path, blob_root, max_batch=10) == 0
+    # The control blob proves this pass reaches the liveness check at all: it
+    # clears the same age gate and the same candidate scan, and it is
+    # collected. Without it, a blob retained for an unrelated reason (age,
+    # an empty candidate walk) would satisfy every assertion below.
+    assert run_blob_gc(db_path, blob_root, max_batch=10) == 1
+    assert not store.exists(control_hash)
     assert store.exists(attachment_hash)
 
     # Now the index tier is gone -- the shape a reset or a swapped generation
-    # leaves behind. Nothing else in the archive names this blob.
+    # leaves behind. Nothing else in the archive names the attachment blob.
+    second_control_hash, _second_size = store.write_from_bytes(b"nothing references me either")
+    _backdate(store, second_control_hash)
     index_path.unlink()
 
     report = run_blob_gc_report(db_path, blob_root, max_batch=10)
 
+    # The data-loss claim first: without the gate this is the assertion that
+    # fails, and it fails because the bytes are gone.
+    assert store.exists(attachment_hash), "unlinked a blob whose only reference tier was unreadable"
     assert report.blocked_reason is not None
     assert "index tier" in report.blocked_reason
     assert report.deleted_count == 0
     assert report.generation_written is False
-    assert store.exists(attachment_hash), "unlinked a blob whose only reference tier was unreadable"
+    # The refusal is total, not selective: even a blob that was provably
+    # collectable a moment ago is left alone while a tier cannot be read.
+    assert store.exists(second_control_hash)
 
 
 @pytest.mark.uses_real_clock(

--- a/tests/unit/storage/test_blob_gc_ref_type_liveness.py
+++ b/tests/unit/storage/test_blob_gc_ref_type_liveness.py
@@ -469,3 +469,53 @@ def test_census_orphaned_blob_refs_counts_by_ref_type(tmp_path: Path) -> None:
             "schema_unavailable_count": 0,
             "deferred_by_ref_type": {},
         }
+
+
+def test_gc_retains_a_raw_payload_named_only_by_the_raw_row_hash(tmp_path: Path) -> None:
+    """A raw payload stays protected when the ledger has no row for it.
+
+    Liveness must not depend on ``blob_refs`` being complete. On the live
+    archive 399 raw payload hashes (~1 GB of irreplaceable acquired bytes)
+    carry no ledger row of any type, so a ledger-only test would read them as
+    collectable. Removing the ``raw_sessions`` branch from
+    ``_archive_reference_surfaces`` makes the retention assertion below fail.
+    """
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+    blob_store = BlobStore(archive_root / "blob")
+    blob_store.write_from_bytes(b"ledgerless raw payload")
+
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        raw_id = write_source_raw_session(
+            conn,
+            origin=Origin.CODEX_SESSION,
+            source_path="/ledgerless.jsonl",
+            source_index=0,
+            native_id="raw-ledgerless",
+            payload=b"ledgerless raw payload",
+            acquired_at_ms=1,
+        )
+        raw_hash = bytes(
+            conn.execute("SELECT blob_hash FROM raw_sessions WHERE raw_id = ?", (raw_id,)).fetchone()[0]
+        ).hex()
+        # Drop the ledger row, leaving raw_sessions.blob_hash as the only
+        # reference -- the shape measured on the live archive.
+        conn.execute("DELETE FROM blob_refs WHERE ref_id = ?", (raw_id,))
+        assert (
+            conn.execute("SELECT COUNT(*) FROM blob_refs WHERE blob_hash = ?", (bytes.fromhex(raw_hash),)).fetchone()[0]
+            == 0
+        )
+
+    _backdate(blob_store, raw_hash)
+
+    assert run_blob_gc(archive_root / "source.db", archive_root / "blob", max_batch=10) == 0
+    assert blob_store.exists(raw_hash)
+
+    # Once the raw row itself is gone, nothing names the payload and GC may
+    # reclaim it -- so the assertion above is about the raw-row surface, not a
+    # blanket refusal to collect.
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        conn.execute("DELETE FROM raw_sessions WHERE raw_id = ?", (raw_id,))
+
+    assert run_blob_gc(archive_root / "source.db", archive_root / "blob", max_batch=10) == 1
+    assert not blob_store.exists(raw_hash)

--- a/tests/unit/storage/test_raw_retention.py
+++ b/tests/unit/storage/test_raw_retention.py
@@ -3104,3 +3104,74 @@ def test_stale_supersession_reissue_refuses_when_head_is_in_progress_append(tmp_
             "SELECT COUNT(*) FROM raw_revision_applications WHERE raw_id = 'raw-baseline'"
         ).fetchone()[0]
     assert count == 1
+
+
+def test_superseded_cleanup_keeps_blob_named_by_a_ledgerless_surviving_raw(tmp_path: Path) -> None:
+    """A shared CAS payload survives when only another raw row's hash names it.
+
+    Blobs are content-addressed, so two raw snapshots of identical bytes share
+    one file. On the live archive 399 raw payload hashes carry no ``blob_refs``
+    row at all, so proving deadness from the ledger alone unlinks bytes a
+    surviving ``raw_sessions`` row still points at.
+    """
+    db_path = tmp_path / "source.db"
+    superseded_source = tmp_path / "superseded.jsonl"
+    superseded_source.write_text('{"type":"message"}\n', encoding="utf-8")
+    other_source = tmp_path / "other.jsonl"
+    other_source.write_text('{"type":"message"}\n', encoding="utf-8")
+    blob_store = BlobStore(tmp_path / "blob")
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    _ensure_archive_source_schema(conn)
+
+    shared_hash, shared_size = _write_blob(blob_store, b"deduplicated payload")
+    current_hash, current_size = _write_blob(blob_store, b"current payload")
+
+    # The superseded snapshot on one source path: a GC candidate, and the only
+    # holder of a ledger row for the shared payload.
+    _insert_archive_raw_session(
+        conn,
+        raw_id=shared_hash,
+        source_path=superseded_source,
+        source_index=0,
+        blob_hash=shared_hash,
+        blob_size=shared_size,
+        acquired_at_ms=1_000,
+    )
+    _insert_archive_raw_session(
+        conn,
+        raw_id=current_hash,
+        source_path=superseded_source,
+        source_index=0,
+        blob_hash=current_hash,
+        blob_size=current_size,
+        acquired_at_ms=2_000,
+    )
+    # A live raw snapshot of the same bytes on a different source path, with no
+    # ledger row -- its own ``blob_hash`` column is the whole reference.
+    conn.execute(
+        """
+        INSERT INTO raw_sessions (
+            raw_id, origin, native_id, source_path, source_index,
+            blob_hash, blob_size, acquired_at_ms
+        ) VALUES (?, 'codex', ?, ?, 0, ?, ?, ?)
+        """,
+        ("ledgerless-raw", "ledgerless-raw", str(other_source), bytes.fromhex(shared_hash), shared_size, 3_000),
+    )
+    conn.commit()
+
+    candidates = superseded_raw_snapshot_candidates(conn, limit=100)
+    assert {candidate.raw_id for candidate in candidates} == {shared_hash}
+
+    result = cleanup_superseded_raw_snapshots(conn, dry_run=False, blob_store=blob_store)
+
+    assert result.deleted_raw_count == 1
+    assert result.deleted_blob_count == 0
+    assert blob_store.exists(shared_hash), "unlinked a payload a surviving raw row still names"
+    assert {str(row[0]) for row in conn.execute("SELECT raw_id FROM raw_sessions")} == {
+        current_hash,
+        "ledgerless-raw",
+    }
+    conn.close()


### PR DESCRIPTION
## Summary

Three ways the blob collectors could unlink irreplaceable bytes while believing
nothing referenced them. All three share one root: a liveness check that treats
*cannot tell* as *not referenced*. This PR makes each of them fail closed.

1. **Retention ignored raw rows.** Superseded-raw cleanup unlinked a
   content-addressed payload whenever no ledger row named its hash, without
   checking whether a surviving raw session row still pointed at the same bytes.
2. **GC read an absent reference tier as proof of non-reference.** The sibling
   index database was opened only `if ...exists()`; when it did not, every blob
   reachable only through that tier read as unreferenced, with no blocker and no
   warning.
3. **The final recheck was not atomic across tiers.** The write lock covered the
   control tier only; the sibling tiers were read through read-only connections
   that excluded no writer.

## Problem

**Ledger incompleteness (class 1).** Blobs are content-addressed, so two raw
snapshots of identical bytes share one file — 6,996 hashes on the live archive
are named by more than one raw session row. `cleanup_superseded_raw_snapshots`
deleted the candidate rows and their ledger rows, then unlinked the blob if no
`blob_refs` row still carried that hash, never asking whether a surviving raw
row named the same bytes. The ledger is not a complete oracle: of 33,757
distinct hashes named by `raw_sessions`, **399 have no `blob_refs` row of any
type** (~971 MB by recorded size), all from one acquisition route — the Gemini
Drive cache, acquired 2026-06-29 to 2026-07-18. Two hashes are in the exposed
mixed state today; the count grows with the ledger gap.

**Tier unavailability (class 2).** `attachments.blob_hash` lives in the index
tier. Live measurement: 1,446 distinct attachment hashes there, 206 also
reachable from the source tier, **1,240 reachable only through the index tier,
all present on disk, 425,523,021 bytes.** That tier is *rebuildable* and reached
through a symlink into a generations directory, so `exists()` is false on a
dangling symlink — the shape a reset or an interrupted generation promotion
leaves behind. Reset the index, run a collection, and 425 MB of durable bytes
pass every liveness check and are unlinked. This was the one unknown the module
answered instead of refusing: it already fails closed on a missing referent
table, a missing key column, an unknown ref type and a legacy table shape.

**Non-atomic recheck (class 3).** The module docstring claimed the final
reference recheck and the unlink are serialized under the source-tier write
lock. That held for the control database only. The sibling source and index
databases were opened as separate read-only connections and consulted inside the
per-blob loop, so a concurrent writer committing a new reference between the
check and the unlink was excluded by nothing. Since the writer lease is shared
rather than exclusive, an ordinary command-line process is exactly such a writer.
Classes 2 and 3 compound: closing the missing reference class still leaves the
check racing the commit that would create one.

## Solution

`polylogue/storage/raw_retention.py` gains `_blob_hash_still_referenced`, which
checks the ledger first (it is the intended catalog) and then every row surface
carrying its own `blob_hash`. The unlink loop calls it in place of the bare
`blob_refs` membership query. Behaviour changes only ever *retain* bytes.

`polylogue/storage/blob_gc.py` resolves the active index path before any
candidate is considered and refuses the whole pass when a required reference
tier cannot be opened read-only, recording the reason on a new
`BlobGCResult.blocked_reason` and logging at error level. The index tier is
always required; the source tier is required only for a split file set that
names it separately (for a single-file set the control database *is* the source
surface). Because the tier is now proven readable, the `exists()` guard on the
index connection is gone: a failure to open it aborts the pass rather than
silently omitting the tier.

For class 3, each sibling tier takes its own `BEGIN IMMEDIATE` for the
recheck+unlink window, in a fixed lock order (control, source, index) so two
passes cannot deadlock. The siblings are only read, so their transactions are
always rolled back — the lock exists solely to exclude a concurrent reference
commit. Dry runs stay read-only and take no lock, so a preview never blocks an
ingest. The daemon's periodic GC already retries on transient lock errors, so
contention degrades to "next tick" rather than an error.

`polylogue/cli/commands/maintenance/_blob_gc.py` prints the blocked reason, so a
refused pass does not read as "nothing to reclaim".

### Deliberate scope limits

Two further problems in the same span are **not** fixed here, and neither is a
data-loss class:

- The entire unlink loop — every stat and unlink, up to a full batch — runs
  inside the immediate transaction. This PR makes that worse in kind by adding
  a second and third tier to the lock. Narrowing the locked window is a
  restructuring of the batch loop, not a guard, and mixing it into a
  fail-closed change would make both harder to review.
- The generation record is inserted last, so a crash mid-loop deletes blobs
  with no durable record the batch ran. It fails safe — the next age gate
  becomes stricter, not looser — so it is audit-trail loss rather than
  corruption, but that table is the only durable answer to what a collection
  destroyed and when.

Backfilling the 399 missing ledger rows is also deliberately excluded. Ten of
those raws carry a ledger row under their own id pointing at a *different* hash,
consistent with a re-acquisition updating the raw row's hash in place without
minting a new row. A backfill against a writer that still does that would only
postpone the gap, so the Drive-cache import path needs investigating first.

## Verification

```
devtools test tests/unit/storage tests/unit/daemon/test_blob_gc_periodic.py \
  tests/unit/cli/test_archive_maintenance_cli.py \
  tests/unit/cli/test_blob_ref_liveness_cli.py \
  tests/unit/pipeline/test_acquisition_blob_gc_age_gate.py
================= 863 passed, 3 warnings in 362.82s (0:06:02) ==================

devtools render all --check   # no "out of sync" lines
```

All three new tests were confirmed non-vacuous by reverting the code they cover:

- `test_superseded_cleanup_keeps_blob_named_by_a_ledgerless_surviving_raw`, with
  the ledger-only query restored: `assert result.deleted_blob_count == 0` →
  `assert 1 == 0`.
- `test_run_blob_gc_refuses_when_the_index_tier_cannot_be_read`, with the tier
  gate disabled: `unlinked a blob whose only reference tier was unreadable` —
  the attachment blob was gone from the store.
- `test_run_blob_gc_serializes_the_recheck_against_an_index_tier_writer`, with
  the sibling connections read-only again: `DID NOT RAISE OperationalError`.

Each test also pins that it reaches the code it means to exercise, which is
the vacuity mode that matters here — a blob retained for an unrelated reason
(the age gate, an empty candidate walk, a candidate query that stopped
selecting the row) would otherwise satisfy every assertion:

- The tier-blocker test collects a control blob in the same pass, through the
  same age gate and candidate scan, and pins a second control blob as retained
  once the tier is unreadable — so the refusal is total, not selective.
- The serialization test reclaims the same blob on a second pass with no
  competing writer.
- The retention test asserts the candidate set and the deleted row count
  before checking that the shared blob survived, and pins the exact surviving
  row set.

One existing assertion changed meaning rather than breaking: the stage-call
counter in `test_run_blob_gc_does_not_stage_again_when_all_candidates_are_referenced`
now sees one stage per reference tier (2, not 1) because the fixture carries an
index tier. Its intent — that an empty shortlist does not re-enter the lock — is
unchanged and would show as 4.

No garbage collection, dry run or otherwise, was executed against the live
archive; every live measurement was read-only over `mode=ro` URIs.

