### PR TITLE
Bound failed-run scratch growth

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -102,12 +102,14 @@ Focused and verification runs are foreground semantic commands. Devtools records
 project selection, gate results, decoded pytest outcomes, and the scope it
 actually ran.
 
-Managed pytest scratch records each test tree's high-water usage. A test tree
-is removed only after both its call and teardown pass; failed, skipped, or
-interrupted trees remain until the lease finalizer copies bounded failure
-evidence into the run detail. The finalizer then removes its authenticated
-lease root regardless of outcome, so a completed run does not leave the full
-pytest tree behind.
+Managed pytest scratch records each test tree's high-water usage. Once a test's
+teardown report has durably recorded its outcome and failure details, its tree
+is removed regardless of outcome so completed failures cannot exhaust the
+bounded scratch filesystem and cascade into unrelated ENOSPC errors. A test
+interrupted before teardown keeps its tree until the lease finalizer copies
+bounded failure evidence into the run detail. The finalizer then removes its
+authenticated lease root regardless of outcome, so a completed run does not
+leave the full pytest tree behind.
 
 Selection artifacts preserve exact selected/deselected counts but sample node
 IDs by default (`POLYLOGUE_PYTEST_SELECTION_NODEID_LIMIT`, default 500) so

--- a/devtools/pytest_progress_plugin.py
+++ b/devtools/pytest_progress_plugin.py
@@ -40,7 +40,6 @@ _COLLECTION_FACT_SUFFIX = ".collection.json"
 _ARTIFACT_ENV_NAMES = (_EVENTS_ENV, _EVENTS_DIR_ENV, _SELECTION_ENV, _SUMMARY_ENV)
 _SCRATCH_HIGH_WATER: dict[str, int] = {"apparent_bytes": 0, "allocated_bytes": 0, "file_count": 0, "directory_count": 0}
 _TEST_SCRATCH_TREES: dict[str, Path] = {}
-_TEST_CALL_OUTCOMES: dict[str, str] = {}
 
 
 @dataclass
@@ -56,7 +55,6 @@ class _SessionState:
     artifact_environment: dict[str, str | None]
     scratch_high_water: dict[str, int]
     test_scratch_trees: dict[str, Path]
-    test_call_outcomes: dict[str, str]
 
 
 _SESSION_STATE_STACK: list[_SessionState] = []
@@ -77,7 +75,6 @@ def _capture_session_state() -> _SessionState:
         artifact_environment={name: os.environ.get(name) for name in _ARTIFACT_ENV_NAMES},
         scratch_high_water=dict(_SCRATCH_HIGH_WATER),
         test_scratch_trees=dict(_TEST_SCRATCH_TREES),
-        test_call_outcomes=dict(_TEST_CALL_OUTCOMES),
     )
 
 
@@ -102,8 +99,6 @@ def _restore_session_state(state: _SessionState) -> None:
     _SCRATCH_HIGH_WATER.update(state.scratch_high_water)
     _TEST_SCRATCH_TREES.clear()
     _TEST_SCRATCH_TREES.update(state.test_scratch_trees)
-    _TEST_CALL_OUTCOMES.clear()
-    _TEST_CALL_OUTCOMES.update(state.test_call_outcomes)
 
 
 def _reset_session_state() -> None:
@@ -120,7 +115,6 @@ def _reset_session_state() -> None:
     for key in _SCRATCH_HIGH_WATER:
         _SCRATCH_HIGH_WATER[key] = 0
     _TEST_SCRATCH_TREES.clear()
-    _TEST_CALL_OUTCOMES.clear()
 
 
 def record_test_scratch_usage(nodeid: str, root: Path) -> None:
@@ -150,12 +144,17 @@ def record_test_scratch_usage(nodeid: str, root: Path) -> None:
     )
 
 
-def _remove_successful_test_tree(nodeid: str, teardown_outcome: str) -> None:
-    """Remove one worker-owned tree only after call and teardown both pass."""
+def _remove_completed_test_tree(nodeid: str) -> None:
+    """Remove one worker-owned tree after its durable teardown report exists.
+
+    Failure details and measured scratch usage are written to the event ledger
+    before this hook runs.  Keeping completed failure trees until session end
+    lets a small number of failures exhaust the bounded scratch filesystem and
+    turn the rest of a run into unrelated ENOSPC errors.  An interrupted test
+    has no teardown report, so its tree remains available to the lease
+    finalizer as bounded crash evidence.
+    """
     root = _TEST_SCRATCH_TREES.pop(nodeid, None)
-    call_outcome = _TEST_CALL_OUTCOMES.pop(nodeid, None)
-    if call_outcome not in {"passed", "xpassed"} or teardown_outcome not in {"passed", "xpassed"}:
-        return
     scratch_raw = os.environ.get("POLYLOGUE_PYTEST_SCRATCH_ROOT")
     if not scratch_raw or root is None:
         return
@@ -167,7 +166,7 @@ def _remove_successful_test_tree(nodeid: str, teardown_outcome: str) -> None:
             return
         shutil.rmtree(resolved_root)
     except (OSError, RuntimeError, ValueError):
-        # A missing or changed tree is retained as evidence rather than
+        # A missing or changed tree is left alone rather than
         # broadening deletion to an ambiguous path.
         return
 
@@ -452,8 +451,6 @@ def _record_phase_report(report: Any, *, write_event: bool = True) -> None:
     }
     if payload["outcome"] == "failed":
         payload["longrepr"] = str(getattr(report, "longrepr", ""))
-    if when == "call":
-        _TEST_CALL_OUTCOMES[nodeid] = outcome
     _remember_report(payload)
     if write_event:
         _write_event(payload)
@@ -478,10 +475,7 @@ def pytest_runtest_logreport(report: Any) -> None:
         return
     _record_phase_report(report)
     if str(getattr(report, "when", "")) == "teardown":
-        _remove_successful_test_tree(
-            str(getattr(report, "nodeid", "")),
-            _durable_report_outcome(report, str(getattr(report, "outcome", ""))),
-        )
+        _remove_completed_test_tree(str(getattr(report, "nodeid", "")))
 
 
 @pytest.hookimpl

--- a/polylogue/daemon/uds.py
+++ b/polylogue/daemon/uds.py
@@ -33,16 +33,21 @@ class DaemonAPIUnixHTTPServer(socketserver.ThreadingMixIn, socketserver.UnixStre
         auth_token: str | None = None,
         write_bridge: DaemonWriteThreadBridge | None = None,
     ) -> None:
+        # UnixStreamServer may call server_close() while super().__init__ is
+        # unwinding a failed bind.  Establish every attribute that cleanup
+        # reads before crossing that boundary so the original OSError remains
+        # authoritative.
+        self.socket_path = socket_path
+        self.archive_query_executor: ThreadPoolExecutor | None = None
+        self._owned_write_runtime: _StandaloneWriteRuntime | None = None
         socket_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
         with __import__("contextlib").suppress(FileNotFoundError):
             socket_path.unlink()
         super().__init__(str(socket_path), handler_class)
-        self.socket_path = socket_path
         self.auth_token = auth_token
         self.api_host = "127.0.0.1"
         self.started_at = datetime.now(UTC).isoformat()
         self.web_credentials = WebCredentialRegistry()
-        self._owned_write_runtime: _StandaloneWriteRuntime | None = None
         if write_bridge is None:
             self._owned_write_runtime = _StandaloneWriteRuntime()
             write_bridge = self._owned_write_runtime.bridge
@@ -62,8 +67,9 @@ class DaemonAPIUnixHTTPServer(socketserver.ThreadingMixIn, socketserver.UnixStre
         executor = getattr(self, "archive_query_executor", None)
         if executor is not None:
             executor.shutdown(wait=False, cancel_futures=True)
-        if self._owned_write_runtime is not None:
-            self._owned_write_runtime.close()
+        owned_write_runtime = getattr(self, "_owned_write_runtime", None)
+        if owned_write_runtime is not None:
+            owned_write_runtime.close()
             self._owned_write_runtime = None
         super().server_close()
         with __import__("contextlib").suppress(FileNotFoundError):

--- a/tests/unit/cli/test_daemon_client.py
+++ b/tests/unit/cli/test_daemon_client.py
@@ -15,11 +15,25 @@ import pytest
 @pytest.fixture
 def _short_uds_runtime_dir() -> Iterator[Path]:
     """Keep UDS route tests under the operating system socket-path limit."""
-    runtime_dir = Path(tempfile.mkdtemp(prefix="plg-client-uds-"))
+    # Managed pytest deliberately puts TMPDIR under its deeply nested lease.
+    # AF_UNIX counts the complete encoded path, so choose a short socket-only
+    # root independently of fixture storage.
+    runtime_dir = Path(tempfile.mkdtemp(prefix="plg-uds-", dir="/tmp"))
     try:
         yield runtime_dir
     finally:
         shutil.rmtree(runtime_dir, ignore_errors=True)
+
+
+def test_uds_server_preserves_bind_error_during_partial_initialization(tmp_path: Path) -> None:
+    """A failed AF_UNIX bind is not masked by cleanup of uninitialized state."""
+    from http.server import BaseHTTPRequestHandler
+
+    from polylogue.daemon.uds import DaemonAPIUnixHTTPServer
+
+    overlong_socket = tmp_path / ("socket-" + "x" * 160)
+    with pytest.raises(OSError, match="AF_UNIX path too long"):
+        DaemonAPIUnixHTTPServer(overlong_socket, BaseHTTPRequestHandler)
 
 
 def test_daemon_client_import_does_not_load_storage() -> None:

--- a/tests/unit/core/test_synthetic_wire_support.py
+++ b/tests/unit/core/test_synthetic_wire_support.py
@@ -631,7 +631,10 @@ def test_parser_witness_rejects_messages_rehomed_to_another_raw_identity(
     )
 
 
-@pytest.mark.parametrize("returned_session", ["empty", "unrelated", "metadata", "id_only"])
+@pytest.mark.parametrize(
+    "returned_session",
+    ["empty", "unrelated", "metadata", pytest.param("id_only", marks=pytest.mark.load_sensitive)],
+)
 def test_parser_witness_requires_meaningful_evidence_from_its_own_artifact(
     monkeypatch: pytest.MonkeyPatch,
     returned_session: str,

--- a/tests/unit/devtools/test_oracle_integrity.py
+++ b/tests/unit/devtools/test_oracle_integrity.py
@@ -187,6 +187,7 @@ def test_allowlist_suppresses_only_the_named_subtree(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.load_sensitive
 def test_repository_is_clean_against_its_baseline() -> None:
     """The gate is green today; only NEW violations fail."""
     report = check_oracle_integrity(_REPO_ROOT)
@@ -408,6 +409,7 @@ def test_lambda_body_is_call_time_not_import_time(tmp_path: Path) -> None:
     assert scan_import_time_home_capture(Path("polylogue/sources/lazy.py"), *_parsed(path)) == ()
 
 
+@pytest.mark.load_sensitive
 def test_real_repository_has_exactly_one_import_time_capture_module() -> None:
     """Calibration against the live tree (y9106/hhg58 forensics agree).
 

--- a/tests/unit/devtools/test_pytest_progress_plugin.py
+++ b/tests/unit/devtools/test_pytest_progress_plugin.py
@@ -35,11 +35,9 @@ def _restore_plugin_state(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     controller_collection_payload = pytest_progress_plugin._CONTROLLER_COLLECTION_PAYLOAD
     recorded_report_keys = set(pytest_progress_plugin._RECORDED_REPORT_KEYS)
     test_scratch_trees = dict(pytest_progress_plugin._TEST_SCRATCH_TREES)
-    test_call_outcomes = dict(pytest_progress_plugin._TEST_CALL_OUTCOMES)
     session_state_stack = list(pytest_progress_plugin._SESSION_STATE_STACK)
     pytest_progress_plugin._RECORDED_REPORT_KEYS.clear()
     pytest_progress_plugin._TEST_SCRATCH_TREES.clear()
-    pytest_progress_plugin._TEST_CALL_OUTCOMES.clear()
     pytest_progress_plugin._SESSION_STATE_STACK.clear()
     yield
     pytest_progress_plugin._SELECTED_COUNT = selected_count
@@ -53,8 +51,6 @@ def _restore_plugin_state(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     pytest_progress_plugin._RECORDED_REPORT_KEYS.update(recorded_report_keys)
     pytest_progress_plugin._TEST_SCRATCH_TREES.clear()
     pytest_progress_plugin._TEST_SCRATCH_TREES.update(test_scratch_trees)
-    pytest_progress_plugin._TEST_CALL_OUTCOMES.clear()
-    pytest_progress_plugin._TEST_CALL_OUTCOMES.update(test_call_outcomes)
     pytest_progress_plugin._SESSION_STATE_STACK[:] = session_state_stack
 
 
@@ -305,7 +301,7 @@ def test_successful_test_tree_is_removed_only_after_passed_teardown(
     assert not test_tree.exists()
 
 
-def test_failed_or_cancelled_test_tree_is_retained_for_evidence(
+def test_completed_failed_or_skipped_test_tree_is_removed_after_durable_teardown(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     scratch = tmp_path / "scratch"
@@ -316,11 +312,24 @@ def test_failed_or_cancelled_test_tree_is_retained_for_evidence(
     ):
         test_tree = scratch / nodeid
         test_tree.mkdir(parents=True)
-        test_tree.joinpath("evidence.txt").write_text("retain", encoding="utf-8")
+        test_tree.joinpath("payload.txt").write_text("already measured", encoding="utf-8")
         pytest_progress_plugin.record_test_scratch_usage(nodeid, test_tree)
         pytest_progress_plugin.pytest_runtest_logreport(_Report(nodeid, "call", call_outcome))
         pytest_progress_plugin.pytest_runtest_logreport(_Report(nodeid, "teardown", teardown_outcome))
-        assert test_tree.exists()
+        assert not test_tree.exists()
+
+
+def test_interrupted_test_tree_without_teardown_is_retained_for_finalizer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    scratch = tmp_path / "scratch"
+    test_tree = scratch / "test-interrupted"
+    test_tree.mkdir(parents=True)
+    monkeypatch.setenv("POLYLOGUE_PYTEST_SCRATCH_ROOT", str(scratch))
+    pytest_progress_plugin.record_test_scratch_usage("test-interrupted", test_tree)
+    pytest_progress_plugin.pytest_runtest_logreport(_Report("test-interrupted", "call", "failed"))
+
+    assert test_tree.exists()
 
 
 def test_progress_plugin_records_test_scratch_high_water(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/infra/test_perf_floors.py
+++ b/tests/unit/infra/test_perf_floors.py
@@ -14,6 +14,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from tests.benchmarks.perf_floors import (
     FloorComparison,
     compare_to_floors,
@@ -177,6 +179,7 @@ def test_format_delta_table_marks_regressions_and_new_metrics() -> None:
     assert "NEW" in table
 
 
+@pytest.mark.load_sensitive
 def test_run_perf_floor_set_quick_measures_every_curated_metric(tmp_path: Path) -> None:
     """End-to-end smoke run in --quick shape over every measurement group.
 

--- a/tests/unit/maintenance/test_rebuild_parse_apply_split.py
+++ b/tests/unit/maintenance/test_rebuild_parse_apply_split.py
@@ -75,6 +75,7 @@ REINDEX_PRODUCTION_SEAMS = (
 )
 
 
+@pytest.mark.load_sensitive
 def test_selected_reindex_proof_tests_are_production_reachable() -> None:
     """The selected reindex proofs bind to replay and terminal convergence."""
     root = Path(__file__).resolve().parents[3]


### PR DESCRIPTION
Fixes the full-suite failure cascade observed on the 2 GiB pytest tmpfs.

- remove completed test trees after teardown evidence is emitted, including failed/skipped tests
- retain only interrupted trees for lease-finalizer evidence
- keep AF_UNIX fixtures independent of deep managed TMPDIR paths and preserve bind errors during partial server initialization
- route five measured wall-clock-bound tests through the existing isolated lane

Verification:
- 31 focused harness/UDS tests passed
- all five isolated tests passed in 163.15s total with the 120s per-test guard unchanged
- ruff passed
- pre-push quick baseline passed