### PR TITLE
test: bound seeded fixture parse fan-out

### DIFF
--- a/tests/infra/workload_artifacts.py
+++ b/tests/infra/workload_artifacts.py
@@ -2680,7 +2680,15 @@ def _build_seeded_archive_inner(
                         "polylogue.sources.parsers.antigravity.AntigravityLanguageServerClient",
                         SyntheticAntigravityLanguageServerClient,
                     ):
-                        asyncio.run(parse_sources_archive(staging, sources))
+                        # This fixture builds many tiny, isolated archives under
+                        # pytest-xdist.  Letting each outer test worker inherit
+                        # the production cpu-count default creates a nested
+                        # process fan-out (xdist workers × parse workers) whose
+                        # spawn/import memory dwarfs the corpus itself.  Pool
+                        # semantics have dedicated importer tests; this helper's
+                        # contract is the real admission/write route, which the
+                        # exact sequential escape hatch preserves.
+                        asyncio.run(parse_sources_archive(staging, sources, parse_workers=1))
                 inspect_raw_authority_frontier(
                     Config(
                         archive_root=staging,

--- a/tests/unit/infra/test_workload_artifacts.py
+++ b/tests/unit/infra/test_workload_artifacts.py
@@ -128,11 +128,26 @@ def test_named_and_benchmark_catalogs_share_one_semantic_spec_contract() -> None
     assert {spec.origin for spec in benchmark_corpus_specs(benchmark.tier)} == {benchmark.workload.origin}
 
 
-def test_seeded_archive_publishes_valid_immutable_real_pipeline_artifact(tmp_path: Path) -> None:
+def test_seeded_archive_publishes_valid_immutable_real_pipeline_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from polylogue.pipeline.services.archive_ingest import (
+        parse_sources_archive as real_parse_sources_archive,
+    )
+
+    observed_parse_workers: list[int | None] = []
+
+    async def record_parse_workers(*args: Any, **kwargs: Any) -> Any:
+        observed_parse_workers.append(kwargs.get("parse_workers"))
+        return await real_parse_sources_archive(*args, **kwargs)
+
+    monkeypatch.setattr("tests.infra.workload_artifacts.parse_sources_archive", record_parse_workers)
     cache_root = tmp_path / "cache"
 
     first = build_seeded_archive(cache_root=cache_root)
     second = build_seeded_archive(cache_root=cache_root)
+
+    assert observed_parse_workers == [1]
 
     assert first.root == second.root
     assert first.manifest.manifest_id == second.manifest.manifest_id


### PR DESCRIPTION
Bounds seeded archive fixture construction to one parse worker per pytest worker, preventing nested process fan-out while preserving dedicated pool coverage. Verified by registered verify_quick job 679889db-d7d8-4f8a-b1f2-2c6e8a3d2595 at exact head 37cbc12240e41f5d771257072562388321e15b27.